### PR TITLE
fix: remove all-networks opt from hardware import

### DIFF
--- a/components/brave_wallet_ui/components/desktop/network-filter-selector/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/network-filter-selector/index.tsx
@@ -49,6 +49,7 @@ interface Props {
     'accountId' | 'address' | 'name'
   >
   isV2?: boolean
+  disableAllAccountsOption?: boolean
   onSelectNetwork?: (network: BraveWallet.NetworkInfo) => void
 }
 
@@ -57,7 +58,8 @@ export const NetworkFilterSelector = ({
   onSelectNetwork,
   selectedNetwork = AllNetworksOption,
   isV2,
-  selectedAccount
+  selectedAccount,
+  disableAllAccountsOption
 }: Props) => {
   // state
   const [showNetworkFilter, setShowNetworkFilter] =
@@ -88,7 +90,8 @@ export const NetworkFilterSelector = ({
 
   const { primaryNetworks, secondaryNetworks, testNetworks } =
     React.useMemo(() => {
-      const primaryNetworks: BraveWallet.NetworkInfo[] = [AllNetworksOption]
+      const primaryNetworks: BraveWallet.NetworkInfo[] =
+        disableAllAccountsOption ? [] : [AllNetworksOption]
       const secondaryNetworks: BraveWallet.NetworkInfo[] = []
       const testNetworks: BraveWallet.NetworkInfo[] = []
 
@@ -119,7 +122,7 @@ export const NetworkFilterSelector = ({
         secondaryNetworks,
         testNetworks
       }
-    }, [filteredNetworks])
+    }, [filteredNetworks, disableAllAccountsOption])
 
   const toggleShowNetworkFilter = React.useCallback(() => {
     setShowNetworkFilter((prev) => !prev)

--- a/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/accounts-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/add-account-modal/hardware-wallet-connect/accounts-list.tsx
@@ -207,6 +207,7 @@ export const HardwareWalletAccountsList = ({
             networkListSubset={networksSubset}
             selectedNetwork={networksRegistry?.entities[selectedNetworkId]}
             onSelectNetwork={onSelectNetwork}
+            disableAllAccountsOption
           />
           {coin === BraveWallet.CoinType.ETH ? (
             <Select


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/30484

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The "All networks" option should no longer appear during hardware wallet import.

<img width="595" alt="Screenshot 2023-11-07 at 1 04 53 PM" src="https://github.com/brave/brave-core/assets/30185185/b2bbec3f-7180-4f44-ab3b-ff204ec28d6b">

<img width="606" alt="Screenshot 2023-11-07 at 1 04 20 PM" src="https://github.com/brave/brave-core/assets/30185185/be57bf99-9321-4184-9f6f-6dd9fe35ffe6">

<img width="611" alt="Screenshot 2023-11-07 at 1 03 43 PM" src="https://github.com/brave/brave-core/assets/30185185/d00a0f88-96d1-46a7-a611-49a47c50ee8b">



