### PR TITLE
fix(wallet): Remove Hardware Icon from Blockies

### DIFF
--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.style.ts
@@ -4,8 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import styled from 'styled-components'
-import * as leo from '@brave/leo/tokens/css'
-import Icon from '@brave/leo/react/icon'
 
 // Utils
 import { getRewardsProviderBackground } from '../../../utils/rewards_utils'
@@ -33,18 +31,6 @@ export const AccountBox = styled.div<{
   background-image: url(${(p) => p.orb});
   background-size: cover;
   margin-right: ${(p) => (p.marginRight !== undefined ? p.marginRight : 0)}px;
-`
-
-export const AccountIcon = styled(Icon)<{
-  size?: 'big' | 'medium' | 'small' | 'tiny'
-}>`
-  --icon-big: 24px;
-  --icon-medium: 20px;
-  --icon-small: 16px;
-  --icon-tiny: 14px;
-  --leo-icon-size: ${(p) =>
-    p.size ? `var(--icon-${p.size})` : 'var(--icon-medium)'};
-  color: ${leo.color.white};
 `
 
 export const ExternalAccountBox = styled(AccountBox)<{

--- a/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.tsx
+++ b/components/brave_wallet_ui/components/shared/create-account-icon/create-account-icon.tsx
@@ -16,7 +16,6 @@ import {
 // styles
 import {
   AccountBox,
-  AccountIcon,
   ExternalAccountBox,
   ExternalAccountIcon
 } from './create-account-icon.style'
@@ -58,13 +57,6 @@ export const CreateAccountIcon = (props: Props) => {
       size={size}
       marginRight={marginRight}
       round={round}
-    >
-      {account?.accountId.kind === BraveWallet.AccountKind.kHardware && (
-        <AccountIcon
-          name='flashdrive'
-          size={size}
-        />
-      )}
-    </AccountBox>
+    />
   )
 }


### PR DESCRIPTION
## Description 
Removes the `Thumbdrive` icon for hardware wallets now that we have updated the `blockies` package

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/34193>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go the `Accounts` tab and import a `Hardware Wallet`
2. There should not be a `Thumbdrive` icon on the blockie

Before:

![Screenshot 65](https://github.com/brave/brave-core/assets/40611140/675c7805-af04-42ca-bcd4-4a21852be27d)

After:

![Screenshot 70](https://github.com/brave/brave-core/assets/40611140/1f989b61-84fb-4f0b-974f-d87b3d479a3f)
