### PR TITLE
fix(wallet): Network Placeholder Icons

### DIFF
--- a/components/brave_wallet_ui/components/shared/create-network-icon/index.tsx
+++ b/components/brave_wallet_ui/components/shared/create-network-icon/index.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../../utils/rewards_utils'
 
 // Styled components
-import { IconWrapper, Placeholder, NetworkIcon } from './style'
+import { IconWrapper, Placeholder, NetworkIcon, IconSize } from './style'
 
 // Options
 import { getNetworkLogo } from '../../../options/asset-options'
@@ -42,7 +42,7 @@ type SimpleNetwork = Pick<
 interface Props {
   network?: SimpleNetwork | null
   marginRight?: number
-  size?: 'huge' | 'big' | 'small' | 'tiny' | 'extra-small'
+  size?: IconSize
 }
 
 const isStorybook = isComponentInStorybook()
@@ -54,6 +54,7 @@ export const CreateNetworkIcon = ({ network, marginRight, size }: Props) => {
       <NetworkPlaceholderIcon
         marginRight={marginRight}
         network={network}
+        size={size}
       />
     )
   }
@@ -110,6 +111,7 @@ export const CreateNetworkIcon = ({ network, marginRight, size }: Props) => {
       <NetworkPlaceholderIcon
         marginRight={marginRight}
         network={network}
+        size={size}
       />
     )
   }
@@ -132,10 +134,12 @@ export default CreateNetworkIcon
 
 function NetworkPlaceholderIcon({
   marginRight,
-  network
+  network,
+  size
 }: {
   marginRight: number | undefined
   network?: SimpleNetwork | null
+  size?: IconSize
 }) {
   // custom hooks
   const orb = useNetworkOrb(network)
@@ -145,8 +149,12 @@ function NetworkPlaceholderIcon({
     <IconWrapper
       marginRight={marginRight ?? 0}
       isTestnet={false}
+      size={size}
     >
-      <Placeholder orb={orb} />
+      <Placeholder
+        size={size}
+        orb={orb}
+      />
     </IconWrapper>
   )
 }

--- a/components/brave_wallet_ui/components/shared/create-network-icon/style.ts
+++ b/components/brave_wallet_ui/components/shared/create-network-icon/style.ts
@@ -34,15 +34,7 @@ export const IconWrapper = styled.div<{
   padding: ${(p) => (p.externalProvider ? '2px' : '0px')};
 `
 
-export const Placeholder = styled.div<{ orb: string }>`
-  width: 10px;
-  height: 10px;
-  border-radius: 100%;
-  background: ${(p) => p.orb};
-  background-size: cover;
-`
-
-type IconSize = 'huge' | 'big' | 'small' | 'tiny' | 'extra-small'
+export type IconSize = 'huge' | 'big' | 'small' | 'tiny' | 'extra-small'
 
 interface IconProps extends AssetIconProps {
   size?: IconSize
@@ -89,3 +81,14 @@ export const NetworkIcon = AssetIconFactory<IconProps>((props) => ({
     : getNetworkIconWidthFromSize(props.size),
   height: 'auto'
 }))
+
+export const Placeholder = styled.div<{
+  orb: string
+  size?: IconSize
+}>`
+  min-width: ${(p) => (p.size ? getNetworkIconWidthFromSize(p.size) : '15px')};
+  min-height: ${(p) => (p.size ? getNetworkIconWidthFromSize(p.size) : '15px')};
+  border-radius: 100%;
+  background: ${(p) => p.orb};
+  background-size: cover;
+`


### PR DESCRIPTION
## Description 
Fixes the network `Placeholder` icon sizes

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/34194>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Add a custom network and then open the `Network Selector`
   2. The `Placeholder` icon should be the same size as the rest of the network icons

Before:

![Screenshot 66](https://github.com/brave/brave-core/assets/40611140/d3ecfe12-0c7d-4afd-9255-0da6f75ae86e)

After:

![Screenshot 71](https://github.com/brave/brave-core/assets/40611140/91217f9a-1332-451d-8a01-489610b3576c)
