### PR TITLE
chore: create fiat currency endpoints file

### DIFF
--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -92,6 +92,7 @@ import { accountEndpoints } from './endpoints/account.endpoints'
 import { networkEndpoints } from './endpoints/network.endpoints'
 import { coinMarketEndpoints } from './endpoints/market.endpoints'
 import { tokenBalancesEndpoints } from './endpoints/token_balances.endpoints'
+import { fiatCurrencyEndpoints } from './endpoints/fiat_currency.endpoints'
 
 export interface IsEip1559ChangedMutationArg {
   id: string
@@ -120,53 +121,6 @@ export function createWalletApi() {
       .injectEndpoints({
         endpoints: ({ mutation, query }) => {
           return {
-            //
-            // Default Currencies
-            //
-            getDefaultFiatCurrency: query<string, void>({
-              queryFn: async (arg, { endpoint }, extraOptions, baseQuery) => {
-                try {
-                  const { braveWalletService } = baseQuery(undefined).data
-                  const { currency } =
-                    await braveWalletService.getDefaultBaseCurrency()
-                  const defaultFiatCurrency = currency.toLowerCase()
-                  return {
-                    data: defaultFiatCurrency
-                  }
-                } catch (error) {
-                  return handleEndpointError(
-                    endpoint,
-                    'Unable to fetch default fiat currency',
-                    error
-                  )
-                }
-              },
-              providesTags: ['DefaultFiatCurrency']
-            }),
-            setDefaultFiatCurrency: mutation<string, string>({
-              queryFn: async (
-                currencyArg,
-                { endpoint },
-                extraOptions,
-                baseQuery
-              ) => {
-                try {
-                  const { braveWalletService } = baseQuery(undefined).data
-                  braveWalletService.setDefaultBaseCurrency(currencyArg)
-                  return {
-                    data: currencyArg
-                  }
-                } catch (error) {
-                  return handleEndpointError(
-                    endpoint,
-                    `Unable to set default fiat currency to ${currencyArg}`,
-                    error
-                  )
-                }
-              },
-              invalidatesTags: ['DefaultFiatCurrency']
-            }),
-
             //
             // Transactions
             //
@@ -1979,6 +1933,8 @@ export function createWalletApi() {
       .injectEndpoints({ endpoints: tokenEndpoints })
       // Coin market endpoints
       .injectEndpoints({ endpoints: coinMarketEndpoints })
+      // Fiat currency endpoints
+      .injectEndpoints({ endpoints: fiatCurrencyEndpoints })
   )
 }
 

--- a/components/brave_wallet_ui/common/slices/endpoints/fiat_currency.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/fiat_currency.endpoints.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// types
+import { WalletApiEndpointBuilderParams } from '../api-base.slice'
+
+// utils
+import { handleEndpointError } from '../../../utils/api-utils'
+
+export const fiatCurrencyEndpoints = ({
+  mutation,
+  query
+}: WalletApiEndpointBuilderParams) => {
+  return {
+    getDefaultFiatCurrency: query<string, void>({
+      queryFn: async (arg, { endpoint }, extraOptions, baseQuery) => {
+        try {
+          const { braveWalletService } = baseQuery(undefined).data
+          const { currency } =
+            await braveWalletService.getDefaultBaseCurrency()
+          const defaultFiatCurrency = currency.toLowerCase()
+          return {
+            data: defaultFiatCurrency
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Unable to fetch default fiat currency',
+            error
+          )
+        }
+      },
+      providesTags: ['DefaultFiatCurrency']
+    }),
+    setDefaultFiatCurrency: mutation<string, string>({
+      queryFn: async (
+        currencyArg,
+        { endpoint },
+        extraOptions,
+        baseQuery
+      ) => {
+        try {
+          const { braveWalletService } = baseQuery(undefined).data
+          braveWalletService.setDefaultBaseCurrency(currencyArg)
+          return {
+            data: currencyArg
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            `Unable to set default fiat currency to ${currencyArg}`,
+            error
+          )
+        }
+      },
+      invalidatesTags: ['DefaultFiatCurrency']
+    }),
+  }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34202

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Fiat currency values should continue to render without regressions 