### PR TITLE
Fix Shields usage status metric (uplift to 1.61.x)

### DIFF
--- a/browser/ui/brave_shields_data_controller.cc
+++ b/browser/ui/brave_shields_data_controller.cc
@@ -164,7 +164,8 @@ void BraveShieldsDataController::SetBraveShieldsEnabled(bool is_enabled) {
                                     nullptr) == is_enabled) {
     brave_shields::ResetBraveShieldsEnabled(map, GetCurrentSiteURL());
   } else {
-    brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL());
+    brave_shields::SetBraveShieldsEnabled(map, is_enabled, GetCurrentSiteURL(),
+                                          g_browser_process->local_state());
   }
   ReloadWebContents();
 }

--- a/browser/ui/webui/brave_shields/shields_panel_handler.cc
+++ b/browser/ui/webui/brave_shields/shields_panel_handler.cc
@@ -8,7 +8,9 @@
 #include <utility>
 
 #include "brave/browser/ui/brave_browser_window.h"
+#include "brave/components/brave_shields/browser/brave_shields_p3a.h"
 #include "brave/components/constants/pref_names.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
@@ -32,6 +34,9 @@ void ShieldsPanelHandler::ShowUI() {
   if (embedder) {
     embedder->ShowUI();
   }
+  brave_shields::MaybeRecordShieldsUsageP3A(
+      brave_shields::ShieldsIconUsage::kClicked,
+      g_browser_process->local_state());
 }
 
 void ShieldsPanelHandler::CloseUI() {


### PR DESCRIPTION
Uplift of #20885
Resolves https://github.com/brave/brave-browser/issues/34168

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.