### PR TITLE
Launch dev channel deprecation infobar at startup (uplift to 1.61.x)

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -456,7 +456,10 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           With a Directory
         </message>
       </if>
-
+      <!-- Dev channel deprecation infobar -->
+      <message name="IDS_DEV_CHANNEL_DEPRECATION_INFOBAR_MESSAGE" desc="The text label of dev channel deprecation announcement.">
+        Beginning on December 1, 2023, Brave Dev channel will no longer receive browser updates. We recommend users migrate to the Nightly, Beta, or Release versions of Brave.
+      </message>
       <!-- Mac Menubar Menus -->
       <if expr="is_macosx">
         <message name="IDS_REPORT_BROKEN_SITE_MAC" desc="The Mac menu item to report a broken site in the Help menu.">

--- a/browser/infobars/dev_channel_deprecation_infobar_delegate.cc
+++ b/browser/infobars/dev_channel_deprecation_infobar_delegate.cc
@@ -1,0 +1,65 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/infobars/dev_channel_deprecation_infobar_delegate.h"
+
+#include <memory>
+
+#include "brave/browser/infobars/brave_confirm_infobar_creator.h"
+#include "brave/components/constants/url_constants.h"
+#include "brave/grit/brave_generated_resources.h"
+#include "chrome/common/channel_info.h"
+#include "components/infobars/core/infobar.h"
+#include "components/strings/grit/components_strings.h"
+#include "components/version_info/channel.h"
+#include "ui/base/l10n/l10n_util.h"
+
+// static
+void DevChannelDeprecationInfoBarDelegate::CreateIfNeeded(
+    infobars::InfoBarManager* infobar_manager) {
+  if (chrome::GetChannel() == version_info::Channel::DEV) {
+    infobar_manager->AddInfoBar(
+        CreateBraveConfirmInfoBar(std::unique_ptr<BraveConfirmInfoBarDelegate>(
+            new DevChannelDeprecationInfoBarDelegate())));
+  }
+}
+
+DevChannelDeprecationInfoBarDelegate::~DevChannelDeprecationInfoBarDelegate() =
+    default;
+
+DevChannelDeprecationInfoBarDelegate::DevChannelDeprecationInfoBarDelegate() =
+    default;
+
+infobars::InfoBarDelegate::InfoBarIdentifier
+DevChannelDeprecationInfoBarDelegate::GetIdentifier() const {
+  return DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE;
+}
+
+std::u16string DevChannelDeprecationInfoBarDelegate::GetMessageText() const {
+  return l10n_util::GetStringUTF16(IDS_DEV_CHANNEL_DEPRECATION_INFOBAR_MESSAGE);
+}
+
+int DevChannelDeprecationInfoBarDelegate::GetButtons() const {
+  return BUTTON_NONE;
+}
+
+std::vector<int> DevChannelDeprecationInfoBarDelegate::GetButtonsOrder() const {
+  return {};
+}
+
+bool DevChannelDeprecationInfoBarDelegate::ShouldExpire(
+    const NavigationDetails& details) const {
+  // Since deprecation infobar communicates critical state, it should persist
+  // until explicitly dismissed.
+  return false;
+}
+
+std::u16string DevChannelDeprecationInfoBarDelegate::GetLinkText() const {
+  return l10n_util::GetStringUTF16(IDS_LEARN_MORE);
+}
+
+GURL DevChannelDeprecationInfoBarDelegate::GetLinkURL() const {
+  return GURL(kDevChannelDeprecationLearnMoreUrl);
+}

--- a/browser/infobars/dev_channel_deprecation_infobar_delegate.h
+++ b/browser/infobars/dev_channel_deprecation_infobar_delegate.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_INFOBARS_DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE_H_
+#define BRAVE_BROWSER_INFOBARS_DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE_H_
+
+#include <vector>
+
+#include "brave/components/infobars/core/brave_confirm_infobar_delegate.h"
+
+class DevChannelDeprecationInfoBarDelegate
+    : public BraveConfirmInfoBarDelegate {
+ public:
+  static void CreateIfNeeded(infobars::InfoBarManager* infobar_manager);
+
+  DevChannelDeprecationInfoBarDelegate(
+      const DevChannelDeprecationInfoBarDelegate&) = delete;
+  DevChannelDeprecationInfoBarDelegate& operator=(
+      const DevChannelDeprecationInfoBarDelegate&) = delete;
+
+  ~DevChannelDeprecationInfoBarDelegate() override;
+
+ private:
+  DevChannelDeprecationInfoBarDelegate();
+
+  // BraveConfirmInfoBarDelegate overrides:
+  infobars::InfoBarDelegate::InfoBarIdentifier GetIdentifier() const override;
+  std::u16string GetMessageText() const override;
+  int GetButtons() const override;
+  std::vector<int> GetButtonsOrder() const override;
+  bool ShouldExpire(const NavigationDetails& details) const override;
+  std::u16string GetLinkText() const override;
+  GURL GetLinkURL() const override;
+};
+
+#endif  // BRAVE_BROWSER_INFOBARS_DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE_H_

--- a/browser/infobars/sources.gni
+++ b/browser/infobars/sources.gni
@@ -17,6 +17,8 @@ if (!is_android) {
     "//brave/browser/infobars/brave_confirm_p3a_infobar_delegate.h",
     "//brave/browser/infobars/brave_sync_account_deleted_infobar_delegate.cc",
     "//brave/browser/infobars/brave_sync_account_deleted_infobar_delegate.h",
+    "//brave/browser/infobars/dev_channel_deprecation_infobar_delegate.cc",
+    "//brave/browser/infobars/dev_channel_deprecation_infobar_delegate.h",
     "//brave/browser/infobars/request_otr_infobar_delegate.cc",
     "//brave/browser/infobars/request_otr_infobar_delegate.h",
     "//brave/browser/infobars/sync_cannot_run_infobar_delegate.cc",

--- a/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
+++ b/chromium_src/chrome/browser/ui/startup/infobar_utils.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/infobars/dev_channel_deprecation_infobar_delegate.h"
 #include "brave/browser/ui/startup/brave_obsolete_system_infobar_delegate.h"
 #include "build/build_config.h"
 #include "chrome/browser/ui/session_crashed_bubble.h"
@@ -22,6 +23,7 @@ class BraveGoogleKeysInfoBarDelegate {
 
 #define ShowIfNotOffTheRecordProfile ShowIfNotOffTheRecordProfileBrave
 #define GoogleApiKeysInfoBarDelegate BraveGoogleKeysInfoBarDelegate
+#define AddInfoBarsIfNecessary AddInfoBarsIfNecessary_ChromiumImpl
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
 #define ObsoleteSystemInfoBarDelegate BraveObsoleteSystemInfoBarDelegate
@@ -33,5 +35,39 @@ class BraveGoogleKeysInfoBarDelegate {
 #undef ObsoleteSystemInfoBarDelegate
 #endif
 
+#undef AddInfoBarsIfNecessary
 #undef GoogleApiKeysInfoBarDelegate
 #undef ShowIfNotOffTheRecordProfile
+
+void AddInfoBarsIfNecessary(Browser* browser,
+                            Profile* profile,
+                            const base::CommandLine& startup_command_line,
+                            chrome::startup::IsFirstRun is_first_run,
+                            bool is_web_app) {
+  AddInfoBarsIfNecessary_ChromiumImpl(browser, profile, startup_command_line,
+                                      is_first_run, is_web_app);
+
+  if (!browser || !profile || browser->tab_strip_model()->count() == 0) {
+    return;
+  }
+
+  if (IsKioskModeEnabled()) {
+    return;
+  }
+
+  if (!startup_command_line.HasSwitch(switches::kTestType) &&
+      !IsAutomationEnabled()) {
+    static bool infobars_shown = false;
+    if (infobars_shown) {
+      return;
+    }
+    infobars_shown = true;
+
+    content::WebContents* web_contents =
+        browser->tab_strip_model()->GetActiveWebContents();
+    DCHECK(web_contents);
+    infobars::ContentInfoBarManager* infobar_manager =
+        infobars::ContentInfoBarManager::FromWebContents(web_contents);
+    DevChannelDeprecationInfoBarDelegate::CreateIfNeeded(infobar_manager);
+  }
+}

--- a/chromium_src/components/infobars/core/infobar_delegate.h
+++ b/chromium_src/components/infobars/core/infobar_delegate.h
@@ -12,14 +12,15 @@
 // When there will be too many items, redo java_cpp_enum.py to generate it
 // automatically
 
-#define BRAVE_INFOBAR_DELEGATE_IDENTIFIERS                                   \
-  BRAVE_CONFIRM_P3A_INFOBAR_DELEGATE = 500,                                  \
-  WAYBACK_MACHINE_INFOBAR_DELEGATE = 502,                                    \
-  SYNC_V2_MIGRATE_INFOBAR_DELEGATE = 503,                                    \
-  ANDROID_SYSTEM_SYNC_DISABLED_INFOBAR = 504, SYNC_CANNOT_RUN_INFOBAR = 505, \
-  WEB_DISCOVERY_INFOBAR_DELEGATE = 506,                                      \
-  BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR = 507,                                  \
-  BRAVE_REQUEST_OTR_INFOBAR_DELEGATE = 508, BRAVE_IPFS_INFOBAR_DELEGATE = 509,
+#define BRAVE_INFOBAR_DELEGATE_IDENTIFIERS                                     \
+  BRAVE_CONFIRM_P3A_INFOBAR_DELEGATE = 500,                                    \
+  WAYBACK_MACHINE_INFOBAR_DELEGATE = 502,                                      \
+  SYNC_V2_MIGRATE_INFOBAR_DELEGATE = 503,                                      \
+  ANDROID_SYSTEM_SYNC_DISABLED_INFOBAR = 504, SYNC_CANNOT_RUN_INFOBAR = 505,   \
+  WEB_DISCOVERY_INFOBAR_DELEGATE = 506,                                        \
+  BRAVE_SYNC_ACCOUNT_DELETED_INFOBAR = 507,                                    \
+  BRAVE_REQUEST_OTR_INFOBAR_DELEGATE = 508, BRAVE_IPFS_INFOBAR_DELEGATE = 509, \
+  DEV_CHANNEL_DEPRECATION_INFOBAR_DELEGATE = 510,
 
 #include "src/components/infobars/core/infobar_delegate.h"  // IWYU pragma: export
 

--- a/components/constants/url_constants.cc
+++ b/components/constants/url_constants.cc
@@ -30,3 +30,7 @@ const char kBraveSearchHost[] = "search.brave.com";
 const char kWidevineLearnMoreUrl[] =
     "https://support.brave.com/hc/en-us/articles/"
     "360023851591-How-do-I-view-DRM-protected-content-";
+const char kDevChannelDeprecationLearnMoreUrl[] =
+    "https://support.brave.com/hc/en-us/articles/"
+    "17924707453581-How-do-I-migrate-my-Brave-Dev-data-to-another-channel-"
+    "Nightly-Beta-Release-";

--- a/components/constants/url_constants.h
+++ b/components/constants/url_constants.h
@@ -21,6 +21,7 @@ extern const char kSpeedreaderLearnMoreUrl[];
 extern const char kWebDiscoveryLearnMoreUrl[];
 extern const char kBraveSearchHost[];
 extern const char kWidevineLearnMoreUrl[];
+extern const char kDevChannelDeprecationLearnMoreUrl[];
 
 // This is introduced to replace |kDownloadChromeUrl| in
 // outdated_upgrade_bubble_view.cc"


### PR DESCRIPTION
Uplift of #20633
Resolves https://github.com/brave/brave-browser/issues/33822

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.