### PR TITLE
Update spacing between web page, sidebar and vertical tab

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_layout.h
+++ b/browser/ui/views/frame/brave_browser_view_layout.h
@@ -56,8 +56,10 @@ class BraveBrowserViewLayout : public BrowserViewLayout {
   gfx::Insets GetContentsMargins() const;
   bool IsReaderModeToolbarVisible() const;
   bool IsFullscreenForTab() const;
+  bool IsFullscreenForBrowser() const;
   bool ShouldPushBookmarkBarForVerticalTabs();
   gfx::Insets GetInsetsConsideringVerticalTabHost();
+  void UpdateContentsContainerInsets(gfx::Rect& contents_container_bounds);
 
 #if BUILDFLAG(IS_MAC)
   gfx::Insets AdjustInsetsConsideringFrameBorder(const gfx::Insets& insets);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/34249

As sidebar/vertical tab UI have sufficient internal padding,
we don't need additional margin for rounded corners feature around them.

W/o sidebar/vertical,
<img width="865" alt="Screenshot 2023-11-13 at 3 06 47 PM" src="https://github.com/brave/brave-core/assets/6786187/6a6813d9-5452-48df-b220-8f8e893d2890">

With sidebar,
<img width="816" alt="image" src="https://github.com/brave/brave-core/assets/6786187/e41051ea-3017-4448-9fdc-2c7e6c8b1676">
<img width="804" alt="image" src="https://github.com/brave/brave-core/assets/6786187/23897a65-c81b-45c2-9944-6d9d43037cac">
<img width="804" alt="image" src="https://github.com/brave/brave-core/assets/6786187/16859189-d3cb-4dee-b6af-d3a2e09d7cda">

With vertical tab,
<img width="811" alt="image" src="https://github.com/brave/brave-core/assets/6786187/2a65397e-59c5-4b45-a32a-611a37548c59">
<img width="813" alt="image" src="https://github.com/brave/brave-core/assets/6786187/b2c06157-8906-4cc2-ac88-f29cf6fed9cc">
<img width="807" alt="Screenshot 2023-11-13 at 3 11 20 PM" src="https://github.com/brave/brave-core/assets/6786187/e8e27e32-a201-48d5-9407-2b4747dd07c7">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

