### PR TITLE
[ads] Brave News ad orphaned served events are not purged when closing a tab (uplift to 1.61.x)

### DIFF
--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -21,7 +21,6 @@
 #include "brave/components/brave_ads/core/internal/legacy_migration/client/legacy_client_migration.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/confirmations/legacy_confirmation_migration.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/rewards/legacy_rewards_migration.h"
-#include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_cache_util.h"
 #include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_events.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"  // IWYU pragma: keep
 #include "brave/components/brave_ads/core/public/history/ad_content_info.h"
@@ -203,13 +202,11 @@ void AdsImpl::PurgeOrphanedAdEventsForType(
              const bool success) {
             if (!success) {
               BLOG(0, "Failed to purge orphaned ad events for " << ad_type);
-              return std::move(callback).Run(/*success=*/false);
+            } else {
+              BLOG(1, "Successfully purged orphaned ad events for " << ad_type);
             }
 
-            RebuildAdEventCache();
-
-            BLOG(1, "Successfully purged orphaned ad events for " << ad_type);
-            std::move(callback).Run(/*success=*/true);
+            std::move(callback).Run(success);
           },
           ad_type, std::move(callback)));
 }
@@ -321,8 +318,6 @@ void AdsImpl::PurgeOrphanedAdEventsCallback(mojom::WalletInfoPtr wallet,
     BLOG(0, "Failed to purge orphaned ad events");
     return FailedToInitialize(std::move(callback));
   }
-
-  RebuildAdEventCache();
 
   rewards::Migrate(base::BindOnce(&AdsImpl::MigrateRewardsStateCallback,
                                   weak_factory_.GetWeakPtr(), std::move(wallet),

--- a/components/brave_ads/core/internal/serving/inline_content_ad_serving.cc
+++ b/components/brave_ads/core/internal/serving/inline_content_ad_serving.cc
@@ -49,10 +49,12 @@ void InlineContentAdServing::MaybeServeAd(
     return FailedToServeAd(dimensions, std::move(callback));
   }
 
-  NotifyOpportunityAroseToServeInlineContentAd();
-
   const absl::optional<TabInfo> tab = TabManager::GetInstance().GetVisible();
-  CHECK(tab);
+  if (!tab) {
+    return FailedToServeAd(dimensions, std::move(callback));
+  }
+
+  NotifyOpportunityAroseToServeInlineContentAd();
 
   GetEligibleAds(tab->id, dimensions, std::move(callback));
 }

--- a/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_events.cc
+++ b/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_events.cc
@@ -55,6 +55,10 @@ void PurgeOrphanedAdEvents(const mojom::AdType ad_type,
   database_table.PurgeOrphaned(
       ad_type, base::BindOnce(
                    [](AdEventCallback callback, const bool success) {
+                     if (success) {
+                       RebuildAdEventCache();
+                     }
+
                      std::move(callback).Run(success);
                    },
                    std::move(callback)));
@@ -66,6 +70,10 @@ void PurgeOrphanedAdEvents(const std::vector<std::string>& placement_ids,
   database_table.PurgeOrphaned(
       placement_ids, base::BindOnce(
                          [](AdEventCallback callback, const bool success) {
+                           if (success) {
+                             RebuildAdEventCache();
+                           }
+
                            std::move(callback).Run(success);
                          },
                          std::move(callback)));
@@ -75,6 +83,10 @@ void PurgeAllOrphanedAdEvents(AdEventCallback callback) {
   const database::table::AdEvents database_table;
   database_table.PurgeAllOrphaned(base::BindOnce(
       [](AdEventCallback callback, const bool success) {
+        if (success) {
+          RebuildAdEventCache();
+        }
+
         std::move(callback).Run(success);
       },
       std::move(callback)));


### PR DESCRIPTION
Uplift of #20954
Resolves https://github.com/brave/brave-browser/issues/34279

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.