### PR TITLE
[CodeHealth] Remove `FromValueDeprecated` uses

### DIFF
--- a/components/brave_news/browser/combined_feed_parsing.cc
+++ b/components/brave_news/browser/combined_feed_parsing.cc
@@ -29,12 +29,11 @@ namespace {
 
 base::expected<mojom::FeedItemPtr, std::string> ParseFeedItem(
     const base::Value& value) {
-  std::u16string error;
-  auto parsed_feed_item =
-      api::combined_feed::Item::FromValueDeprecated(value, &error);
-  if (!parsed_feed_item) {
-    return base::unexpected(base::StrCat(
-        {"Failed to parse feed item. ", base::UTF16ToASCII(error)}));
+  auto parsed_feed_item = api::combined_feed::Item::FromValue(value);
+  if (!parsed_feed_item.has_value()) {
+    return base::unexpected(
+        base::StrCat({"Failed to parse feed item. ",
+                      base::UTF16ToASCII(parsed_feed_item.error())}));
   }
   api::combined_feed::Item& feed_item = *parsed_feed_item;
 

--- a/components/brave_news/browser/publishers_parsing.cc
+++ b/components/brave_news/browser/publishers_parsing.cc
@@ -29,11 +29,10 @@ absl::optional<Publishers> ParseCombinedPublisherList(
   Publishers result;
 
   for (const base::Value& publisher_value : value.GetList()) {
-    std::u16string error;
-    auto parsed_publisher =
-        api::feed::Publisher::FromValueDeprecated(publisher_value, &error);
-    if (!parsed_publisher) {
-      LOG(ERROR) << "Invalid Brave Publisher data. error=" << error;
+    auto parsed_publisher = api::feed::Publisher::FromValue(publisher_value);
+    if (!parsed_publisher.has_value()) {
+      LOG(ERROR) << "Invalid Brave Publisher data. error="
+                 << parsed_publisher.error();
       return absl::nullopt;
     }
     auto& entry = *parsed_publisher;

--- a/components/brave_wallet/browser/asset_ratio_response_parser.cc
+++ b/components/brave_wallet/browser/asset_ratio_response_parser.cc
@@ -174,8 +174,7 @@ bool ParseAssetPriceHistory(const base::Value& json_value,
 mojom::BlockchainTokenPtr ParseTokenInfo(const base::Value& json_value,
                                          const std::string& chain_id,
                                          mojom::CoinType coin) {
-  auto token_info =
-      api::asset_ratio::TokenInfo::FromValueDeprecated(json_value);
+  auto token_info = api::asset_ratio::TokenInfo::FromValue(json_value);
   if (!token_info) {
     LOG(ERROR) << "Invalid response, could not parse JSON. ";
     return nullptr;
@@ -207,8 +206,7 @@ mojom::BlockchainTokenPtr ParseTokenInfo(const base::Value& json_value,
 
 absl::optional<std::vector<mojom::CoinMarketPtr>> ParseCoinMarkets(
     const base::Value& json_value) {
-  auto coin_market_data =
-      api::asset_ratio::CoinMarket::FromValueDeprecated(json_value);
+  auto coin_market_data = api::asset_ratio::CoinMarket::FromValue(json_value);
 
   if (!coin_market_data) {
     return absl::nullopt;

--- a/components/brave_wallet/browser/eth_response_parser.cc
+++ b/components/brave_wallet/browser/eth_response_parser.cc
@@ -289,7 +289,7 @@ bool ParseEthGetLogs(const base::Value& json_value, std::vector<Log>* logs) {
 
   for (const auto& logs_list_it : *result) {
     auto log_item_value =
-        json_rpc_responses::EthGetLogsResult::FromValueDeprecated(logs_list_it);
+        json_rpc_responses::EthGetLogsResult::FromValue(logs_list_it);
     if (!log_item_value) {
       return false;
     }

--- a/components/brave_wallet/browser/json_rpc_response_parser.h
+++ b/components/brave_wallet/browser/json_rpc_response_parser.h
@@ -40,8 +40,7 @@ void ParseErrorResult(const base::Value& json_value,
   *error = Error::kParsingError;
   *error_message = l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR);
 
-  auto response =
-      json_rpc_responses::RPCResponse::FromValueDeprecated(json_value);
+  auto response = json_rpc_responses::RPCResponse::FromValue(json_value);
   if (!response || !response->error) {
     return;
   }

--- a/components/brave_wallet/browser/sns_resolver_task.cc
+++ b/components/brave_wallet/browser/sns_resolver_task.cc
@@ -212,8 +212,7 @@ std::string getProgramAccounts(const SolanaAddress& mint_token) {
 // for mint. If parsing fails first element of pair is `false`.
 std::pair<bool, absl::optional<SolanaAddress>>
 GetTokenOwnerFromGetProgramAccountsResult(const base::Value& json_value) {
-  auto response =
-      json_rpc_responses::RPCResponse::FromValueDeprecated(json_value);
+  auto response = json_rpc_responses::RPCResponse::FromValue(json_value);
   if (!response || !response->result) {
     return {false, absl::nullopt};
   }

--- a/components/brave_wallet/browser/solana_response_parser.cc
+++ b/components/brave_wallet/browser/solana_response_parser.cc
@@ -259,8 +259,7 @@ bool ParseGetAccountInfo(const base::Value& json_value,
                          absl::optional<SolanaAccountInfo>* account_info_out) {
   DCHECK(account_info_out);
 
-  auto response =
-      json_rpc_responses::RPCResponse::FromValueDeprecated(json_value);
+  auto response = json_rpc_responses::RPCResponse::FromValue(json_value);
   if (!response) {
     return false;
   }

--- a/components/brave_wallet/browser/swap_response_parser.cc
+++ b/components/brave_wallet/browser/swap_response_parser.cc
@@ -120,7 +120,7 @@ mojom::SwapResponsePtr ParseSwapResponse(const base::Value& json_value,
   // }
 
   auto swap_response_value =
-      swap_responses::SwapResponse0x::FromValueDeprecated(json_value);
+      swap_responses::SwapResponse0x::FromValue(json_value);
   if (!swap_response_value) {
     return nullptr;
   }
@@ -205,7 +205,7 @@ mojom::SwapErrorResponsePtr ParseSwapErrorResponse(
   // }
 
   auto swap_error_response_value =
-      swap_responses::SwapErrorResponse0x::FromValueDeprecated(json_value);
+      swap_responses::SwapErrorResponse0x::FromValue(json_value);
   if (!swap_error_response_value) {
     return nullptr;
   }
@@ -271,7 +271,7 @@ mojom::JupiterQuotePtr ParseJupiterQuote(const base::Value& json_value) {
   //    }
 
   auto quote_value =
-      swap_responses::JupiterQuoteResponse::FromValueDeprecated(json_value);
+      swap_responses::JupiterQuoteResponse::FromValue(json_value);
   if (!quote_value) {
     return nullptr;
   }
@@ -370,8 +370,7 @@ mojom::JupiterQuotePtr ParseJupiterQuote(const base::Value& json_value) {
 
 mojom::JupiterSwapTransactionsPtr ParseJupiterSwapTransactions(
     const base::Value& json_value) {
-  auto value =
-      swap_responses::JupiterSwapTransactions::FromValueDeprecated(json_value);
+  auto value = swap_responses::JupiterSwapTransactions::FromValue(json_value);
   if (!value) {
     return nullptr;
   }
@@ -384,7 +383,7 @@ mojom::JupiterSwapTransactionsPtr ParseJupiterSwapTransactions(
 mojom::JupiterErrorResponsePtr ParseJupiterErrorResponse(
     const base::Value& json_value) {
   auto jupiter_error_response_value =
-      swap_responses::JupiterErrorResponse::FromValueDeprecated(json_value);
+      swap_responses::JupiterErrorResponse::FromValue(json_value);
   if (!jupiter_error_response_value) {
     return nullptr;
   }


### PR DESCRIPTION
Schema types have been migrated upstream to return optional/expected typed. This change corrects our remaining occurrences, to use the new version of `FromValue` provided upstream.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34324

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

