### PR TITLE
[reclient] Add ccache support for reclient

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -64,6 +64,11 @@ hooks = [
     'action': ['vpython3', 'build/mac/download_hermetic_xcode.py'],
   },
   {
+    'name': 'download_ccache',
+    'pattern': '.',
+    'action': ['python3', 'build/ccache/download_ccache.py', '4.8.3'],
+  },
+  {
     'name': 'configure_reclient',
     'pattern': '.',
     'action': ['python3', 'third_party/reclient_configs/src/configure_reclient.py',

--- a/build/ccache/.gitignore
+++ b/build/ccache/.gitignore
@@ -1,0 +1,2 @@
+_unpack/
+bin/

--- a/build/ccache/download_ccache.py
+++ b/build/ccache/download_ccache.py
@@ -10,6 +10,7 @@ import os
 import sys
 import shutil
 
+from deps_config import DEPS_PACKAGES_URL
 import deps
 
 UNPACK_DIR = os.path.join(os.path.dirname(__file__), '_unpack')
@@ -24,8 +25,7 @@ def main():
     if os.path.exists(CCACHE_DIR):
         shutil.rmtree(CCACHE_DIR)
 
-    url = ('https://github.com/ccache/ccache/releases/download/'
-           f'v{args.version}/ccache-{args.version}-')
+    url = f'{DEPS_PACKAGES_URL}/ccache/ccache-{args.version}-'
     if sys.platform == 'linux':
         url += 'linux-x86_64.tar.xz'
     elif sys.platform == 'darwin':

--- a/build/ccache/download_ccache.py
+++ b/build/ccache/download_ccache.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import argparse
+import glob
+import os
+import sys
+import shutil
+
+import deps
+
+UNPACK_DIR = os.path.join(os.path.dirname(__file__), '_unpack')
+CCACHE_DIR = os.path.join(os.path.dirname(__file__), 'bin')
+
+
+def main():
+    args = parse_args()
+    if args.version == get_current_version():
+        return
+
+    if os.path.exists(CCACHE_DIR):
+        shutil.rmtree(CCACHE_DIR)
+
+    url = ('https://github.com/ccache/ccache/releases/download/'
+           f'v{args.version}/ccache-{args.version}-')
+    if sys.platform == 'linux':
+        url += 'linux-x86_64.tar.xz'
+    elif sys.platform == 'darwin':
+        url += 'darwin.tar.gz'
+    else:
+        url += 'windows-x86_64.zip'
+    deps.DownloadAndUnpack(url, UNPACK_DIR)
+    ccache_extracted_dir = glob.glob(f'{UNPACK_DIR}/ccache-*')
+    if not ccache_extracted_dir:
+        raise RuntimeError(f"Can't find extracted ccache at {UNPACK_DIR}")
+    ccache_extracted_dir = ccache_extracted_dir[0]
+    os.rename(ccache_extracted_dir, CCACHE_DIR)
+    shutil.rmtree(UNPACK_DIR)
+    set_current_version(args.version)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Download ccache binaries.')
+    parser.add_argument('version')
+    return parser.parse_args()
+
+
+def get_current_version():
+    try:
+        with open(os.path.join(CCACHE_DIR, '.version')) as f:
+            return f.read()
+    except FileNotFoundError:
+        return None
+
+
+def set_current_version(value):
+    with open(os.path.join(CCACHE_DIR, '.version'), 'w') as f:
+        f.write(value)
+
+
+if __name__ == '__main__':
+    main()

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -1245,6 +1245,9 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
           env.CCACHE_DIR = path.join(env.RBE_cache_dir, 'ccache')
         }
         env.CCACHE_BASEDIR = this.rbeExecRoot
+        env.CCACHE_FILECLONE = '1'
+        env.CCACHE_DEPEND = '1'
+        env.CCACHE_SLOPPINESS = 'time_macros'
       }
     }
 

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -226,6 +226,7 @@ const Config = function () {
   this.nativeRedirectCCDir = path.join(this.srcDir, 'out', 'redirect_cc')
   this.use_goma = getNPMConfig(['brave_use_goma']) || false
   this.useRemoteExec = getNPMConfig(['use_remoteexec']) || false
+  this.useRemoteExecWithCcache = getNPMConfig(['use_remoteexec_with_ccache'], process.platform !== 'win32')
   this.offline = getNPMConfig(['offline']) || false
   this.use_libfuzzer = false
   this.androidAabToApk = false
@@ -1236,6 +1237,14 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
         env.RBE_service_no_auth = env.RBE_service_no_auth || true
         env.RBE_use_application_default_credentials =
           env.RBE_use_application_default_credentials || true
+      }
+
+      if (this.useRemoteExecWithCcache) {
+        env.USE_REMOTEEXEC_WITH_CCACHE = true
+        if (env.RBE_cache_dir !== undefined && env.CCACHE_DIR === undefined) {
+          env.CCACHE_DIR = path.join(env.RBE_cache_dir, 'ccache')
+        }
+        env.CCACHE_BASEDIR = this.rbeExecRoot
       }
     }
 

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -575,6 +575,7 @@ const util = {
       rbe_exec_root: config.rbeExecRoot,
       rbe_bin_dir: config.realRewrapperDir,
       real_rewrapper: path.join(config.realRewrapperDir, 'rewrapper'),
+      ccache_executable: path.join(config.braveCoreDir, 'build', 'ccache', 'bin', 'ccache'),
     }
 
     const buildArgsStr = util.buildArgsToString(gnArgs)

--- a/script/deps.py
+++ b/script/deps.py
@@ -82,10 +82,15 @@ def DownloadAndUnpack(url, output_dir, path_prefix=None):
         if url.endswith('.zip'):
             assert path_prefix is None
             zipfile.ZipFile(f).extractall(path=output_dir)
-        else:
+            return
+
+        if url.endswith('.gz'):
             t = tarfile.open(mode='r:gz', fileobj=f)
-            members = None
-            if path_prefix is not None:
-                members = [m for m in t.getmembers(
-                ) if m.name.startswith(path_prefix)]
-            t.extractall(path=output_dir, members=members)
+        elif url.endswith('.xz'):
+            t = tarfile.open(mode='r:xz', fileobj=f)
+        members = None
+        if path_prefix is not None:
+            members = [
+                m for m in t.getmembers() if m.name.startswith(path_prefix)
+            ]
+        t.extractall(path=output_dir, members=members)

--- a/tools/redirect_cc/BUILD.gn
+++ b/tools/redirect_cc/BUILD.gn
@@ -11,6 +11,7 @@ if (current_toolchain == host_toolchain) {
   declare_args() {
     real_gomacc = ""
     real_rewrapper = ""
+    ccache_executable = ""
   }
 
   executable("redirect_cc_executable") {
@@ -36,7 +37,16 @@ if (current_toolchain == host_toolchain) {
   buildflag_header("rewrapper_buildflags") {
     header = "rewrapper_buildflags.h"
     real_rewrapper_relative_to_out = rebase_path(real_rewrapper, root_out_dir)
-    flags = [ "REAL_REWRAPPER=\"$real_rewrapper_relative_to_out\"" ]
+    if (ccache_executable != "") {
+      ccache_executable_relative_to_out =
+          rebase_path(ccache_executable, root_out_dir)
+    } else {
+      ccache_executable_relative_to_out = ""
+    }
+    flags = [
+      "REAL_REWRAPPER=\"$real_rewrapper_relative_to_out\"",
+      "CCACHE_EXECUTABLE=\"$ccache_executable_relative_to_out\"",
+    ]
   }
 
   executable("gomacc_executable") {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
This PR adds support for ccache when doing builds via reclient. This is possible, because we use `redirect_cc` as a `rewrapper` proxy. I figured a way to run `rewrapper` via `CCACHE_PREFIX` with some environment variable tricks, because `CCACHE_PREFIX` cannot include args for some reason.

Unfortunately, ccache cannot be enabled on Windows, because it saves a command into a temporary file [when it exceeds 8192 chars](https://github.com/ccache/ccache/blob/e51e10edee8caf88256f6fcfcbfa5a06172443c4/src/execute.cpp#L229-L237), but this file is then passed as an argument to `rewrapper`, which doesn't make any sense to `rewrapper`. In the current state this is not fixable without ccache source code modification or some double-wrapped execution via `redirect_cc` with a custom logic for this exact case.

This PR doesn't set `CCACHE_SLOPPINESS=pch_defines,include_file_mtime`, because:
1. precompiled headers are disabled when RBE is enabled
2. `include_file_mtime` sloppiness will fail to detect `src/...` timestamp changes in `direct mode` when we add a new `chromium_src/...` file. We cannot enable it.

This PR doesn't set `CCACHE_CPP2`, because it's enabled by default in ccache.

This `ccache` integration should be considered as a temporary measure until we get a proper local disk cache support in Reclient/RBE.

Resolves https://github.com/brave/brave-browser/issues/34363

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

