### PR TITLE
chore(wallet): avoid chain/account switches in Send

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-nft-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-nft-asset.tsx
@@ -8,10 +8,11 @@ import { Redirect, useHistory, useParams } from 'react-router'
 import { skipToken } from '@reduxjs/toolkit/query/react'
 
 // types
-import { SendPageTabHashes, WalletRoutes } from '../../../../constants/types'
+import { WalletRoutes } from '../../../../constants/types'
 
 // Utils
 import { getBalance } from '../../../../utils/balance-utils'
+import { makeSendRoute } from '../../../../utils/routes-utils'
 import Amount from '../../../../utils/amount'
 
 // selectors
@@ -141,29 +142,12 @@ export const PortfolioNftAsset = () => {
   }, [selectedAssetFromParams, ownerAccount, tokenBalancesRegistry])
 
   const onSend = React.useCallback(() => {
-    if (!selectedAssetFromParams || !selectedAssetNetwork || !ownerAccount) {
+    if (!selectedAssetFromParams || !ownerAccount) {
       return
     }
 
-    const uniqueKeyOrAddress =
-      ownerAccount.address || ownerAccount.accountId.uniqueKey
-
-    history.push(
-      `${WalletRoutes.SendPage.replace(
-        ':chainId?',
-        selectedAssetNetwork.chainId
-      )
-        .replace(':uniqueKeyOrAddress?', uniqueKeyOrAddress)
-        .replace(
-          ':contractAddressOrSymbol?',
-          selectedAssetFromParams.contractAddress
-        )
-        .replace(':tokenId?', selectedAssetFromParams.tokenId)}${
-        //
-        SendPageTabHashes.nft
-      }`
-    )
-  }, [selectedAssetFromParams, ownerAccount, selectedAssetNetwork])
+    history.push(makeSendRoute(selectedAssetFromParams, ownerAccount))
+  }, [selectedAssetFromParams, ownerAccount])
 
   // asset not found
   if (

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
@@ -7,11 +7,7 @@ import * as React from 'react'
 import { useHistory } from 'react-router'
 
 // Types
-import {
-  BraveWallet,
-  SendPageTabHashes,
-  WalletRoutes
-} from '../../../constants/types'
+import { BraveWallet, WalletRoutes } from '../../../constants/types'
 
 // Queries
 import { useGetOnRampAssetsQuery } from '../../../common/slices/api.slice'
@@ -24,7 +20,10 @@ import {
 // Utils
 import { getLocale } from '../../../../common/locale'
 import Amount from '../../../utils/amount'
-import { makeDepositFundsRoute } from '../../../utils/routes-utils'
+import {
+  makeDepositFundsRoute,
+  makeSendRoute
+} from '../../../utils/routes-utils'
 
 // Components
 import {
@@ -101,21 +100,9 @@ export const AssetItemMenu = (props: Props) => {
 
   const onClickSend = React.useCallback(() => {
     if (account) {
-      const uniqueKeyOrAddress = account.address || account.accountId.uniqueKey
-
-      const contractAddressOrSymbol =
-        asset.contractAddress === '' ? asset.symbol : asset.contractAddress
-      history.push(
-        `${WalletRoutes.SendPage.replace(':chainId?', asset.chainId)
-          .replace(':uniqueKeyOrAddress?', uniqueKeyOrAddress)
-          .replace(':contractAddressOrSymbol?', contractAddressOrSymbol)
-          .replace('/:tokenId?', '')}${
-          //
-          SendPageTabHashes.token
-        }`
-      )
+      history.push(makeSendRoute(asset, account))
     } else {
-      history.push(WalletRoutes.SendPageStart)
+      history.push(WalletRoutes.Send)
     }
   }, [asset.chainId, asset.contractAddress, account?.address])
 

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -677,12 +677,7 @@ export enum WalletRoutes {
   Swap = '/swap',
 
   // send
-  SendPageStart = '/send',
-  SendPage = '/send/' +
-    ':chainId?/' +
-    ':uniqueKeyOrAddress?/' +
-    ':contractAddressOrSymbol?/' +
-    ':tokenId?',
+  Send = '/send',
 
   // dev bitcoin screen
   DevBitcoin = '/dev-bitcoin',

--- a/components/brave_wallet_ui/options/nav-options.ts
+++ b/components/brave_wallet_ui/options/nav-options.ts
@@ -56,7 +56,7 @@ export const BuySendSwapDepositOptions: NavOption[] = [
     id: 'send',
     name: 'braveWalletSend',
     icon: 'send',
-    route: WalletRoutes.SendPageStart
+    route: WalletRoutes.Send
   },
   {
     id: 'swap',

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -350,7 +350,7 @@ export const Container = () => {
 
             {!isWalletLocked && (
               <Route
-                path={WalletRoutes.SendPage}
+                path={WalletRoutes.SendPageStart}
                 exact
               >
                 <SendScreen />

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -199,7 +199,7 @@ export const Container = () => {
     if (toobarElement && rootElement) {
       if (
         walletLocation === WalletRoutes.Swap ||
-        walletLocation === WalletRoutes.SendPageStart ||
+        walletLocation === WalletRoutes.Send ||
         walletLocation.includes(WalletRoutes.DepositFundsPageStart) ||
         walletLocation.includes(WalletRoutes.FundWalletPageStart) ||
         walletLocation.includes(WalletRoutes.LocalIpfsNode) ||
@@ -350,7 +350,7 @@ export const Container = () => {
 
             {!isWalletLocked && (
               <Route
-                path={WalletRoutes.SendPageStart}
+                path={WalletRoutes.Send}
                 exact
               >
                 <SendScreen />

--- a/components/brave_wallet_ui/page/screens/send/components/account-selector/account-selector.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/account-selector/account-selector.tsx
@@ -14,9 +14,7 @@ import CaratDownIcon from '../../assets/carat-down-icon.svg'
 import { useOnClickOutside } from '../../../../../common/hooks/useOnClickOutside'
 import {
   useGenerateReceiveAddressMutation,
-  useGetFVMAddressQuery,
-  useGetSelectedAccountIdQuery,
-  useGetSelectedChainQuery //
+  useGetFVMAddressQuery
 } from '../../../../../common/slices/api.slice'
 import { useAccountsQuery } from '../../../../../common/slices/api.slice.extra'
 
@@ -34,6 +32,8 @@ import { BraveWallet } from '../../../../../constants/types'
 
 interface Props {
   asset: BraveWallet.BlockchainToken | undefined
+  selectedNetwork: BraveWallet.NetworkInfo | undefined
+  selectedAccountId: BraveWallet.AccountId | undefined
   onSelectAddress: (value: string) => void
   disabled: boolean
 }
@@ -41,12 +41,16 @@ interface Props {
 const ACCOUNT_SELECTOR_BUTTON_ID = 'account-selector-button-id'
 
 export const AccountSelector = (props: Props) => {
-  const { asset, onSelectAddress, disabled } = props
+  const {
+    asset,
+    selectedNetwork,
+    selectedAccountId,
+    onSelectAddress,
+    disabled
+  } = props
 
   // Queries
   const { accounts } = useAccountsQuery()
-  const { data: selectedNetwork } = useGetSelectedChainQuery()
-  const { data: selectedAccountId } = useGetSelectedAccountIdQuery()
 
   // State
   const [showAccountSelector, setShowAccountSelector] =

--- a/components/brave_wallet_ui/page/screens/send/components/select-token-modal/select-token-modal.tsx
+++ b/components/brave_wallet_ui/page/screens/send/components/select-token-modal/select-token-modal.tsx
@@ -37,9 +37,7 @@ import { getAssetIdKey } from '../../../../../utils/asset-utils'
 import {
   useGetDefaultFiatCurrencyQuery,
   useGetVisibleNetworksQuery,
-  useSetNetworkMutation,
   useGetTokenSpotPricesQuery,
-  useSetSelectedAccountMutation,
   useGetUserTokensRegistryQuery,
   useGetAccountInfosRegistryQuery
 } from '../../../../../common/slices/api.slice'
@@ -91,7 +89,10 @@ import {
 interface Props {
   onClose: () => void
   selectedSendOption: SendPageTabHashes
-  selectSendAsset: (asset: BraveWallet.BlockchainToken | undefined) => void
+  selectSendAsset: (
+    asset: BraveWallet.BlockchainToken,
+    account: BraveWallet.AccountInfo
+  ) => void
 }
 
 export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
@@ -107,8 +108,6 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
 
     // Queries & Mutations
     const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
-    const [setNetwork] = useSetNetworkMutation()
-    const [setSelectedAccount] = useSetSelectedAccountMutation()
     const { data: networks } = useGetVisibleNetworksQuery()
     const { accounts } = useGetAccountInfosRegistryQuery(undefined, {
       selectFromResult: (res) => ({
@@ -277,19 +276,14 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
     )
 
     const onSelectSendAsset = React.useCallback(
-      async (
+      (
         token: BraveWallet.BlockchainToken,
         account: BraveWallet.AccountInfo
       ) => {
-        selectSendAsset(token)
-        await setSelectedAccount(account.accountId)
-        await setNetwork({
-          chainId: token.chainId,
-          coin: token.coin
-        })
+        selectSendAsset(token, account)
         onClose()
       },
-      [selectSendAsset, onClose, setNetwork]
+      [selectSendAsset, onClose]
     )
 
     const onSearch = React.useCallback(

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -212,12 +212,12 @@ export const SendScreen = React.memo((props: Props) => {
           token.contractAddress.toLowerCase() ===
             contractOrSymbol.toLowerCase() &&
           token.tokenId === tokenId
-        : (token.contractAddress.toLowerCase() ===
-            contractOrSymbol.toLowerCase() &&
-            token.chainId === networkFromParams.chainId) ||
-          (token.symbol.toLowerCase() === contractOrSymbol.toLowerCase() &&
-            token.chainId === networkFromParams.chainId &&
-            token.contractAddress === '')
+        : (token.chainId === networkFromParams.chainId &&
+            token.contractAddress.toLowerCase() ===
+              contractOrSymbol.toLowerCase()) ||
+          (token.chainId === networkFromParams.chainId &&
+            token.contractAddress === '' &&
+            token.symbol.toLowerCase() === contractOrSymbol.toLowerCase())
     )
   }, [userVisibleTokensInfo, query, networkFromParams])
 

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -51,6 +51,7 @@ import {
   isValidFilAddress,
   isValidZecAddress
 } from '../../../../utils/address-utils'
+import { makeSendRoute } from '../../../../utils/routes-utils'
 import {
   selectAllVisibleUserAssetsFromQueryResult //
 } from '../../../../common/slices/entities/blockchain-token.entity'
@@ -495,25 +496,14 @@ export const SendScreen = React.memo((props: Props) => {
   // Methods
   const selectSendAsset = React.useCallback(
     (asset: BraveWallet.BlockchainToken, account: BraveWallet.AccountInfo) => {
-      if (asset.isErc721 || asset.isNft) {
+      const isNftTab = asset.isErc721 || asset.isNft
+      if (isNftTab) {
         setSendAmount('1')
       } else {
         setSendAmount('')
       }
       setToAddressOrUrl('')
-
-      const baseQueryParams = {
-        chainId: asset.chainId,
-        token: asset.contractAddress || asset.symbol.toUpperCase(),
-        account: account.accountId.uniqueKey
-      }
-      const params = new URLSearchParams(
-        asset.tokenId
-          ? { ...baseQueryParams, tokenId: asset.tokenId }
-          : baseQueryParams
-      )
-
-      history.push(`${WalletRoutes.SendPageStart}?${params.toString()}`)
+      history.push(makeSendRoute(asset, account))
     },
     []
   )
@@ -523,9 +513,9 @@ export const SendScreen = React.memo((props: Props) => {
     setSendAmount('')
 
     if (option) {
-      history.push(`${WalletRoutes.SendPageStart}${option}`)
+      history.push(`${WalletRoutes.Send}${option}`)
     } else {
-      history.push(WalletRoutes.SendPageStart)
+      history.push(WalletRoutes.Send)
     }
   }, [])
 

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
@@ -36,6 +36,7 @@ import { getPriceIdForToken } from '../../../../utils/api-utils'
 import { makeNetworkAsset } from '../../../../options/asset-options'
 import { getTokenPriceAmountFromRegistry } from '../../../../utils/pricing-utils'
 import { getBalance } from '../../../../utils/balance-utils'
+import { networkSupportsAccount } from '../../../../utils/network-utils'
 
 // Queries
 import {
@@ -695,7 +696,7 @@ export const useSwap = () => {
     return (
       !selectedNetwork ||
       !selectedAccount ||
-      selectedNetwork.coin !== selectedAccount.accountId.coin ||
+      !networkSupportsAccount(selectedNetwork, selectedAccount.accountId) ||
       // Prevent creating a swap transaction with stale parameters if fetching
       // of a new quote is in progress.
       zeroEx.loading ||

--- a/components/brave_wallet_ui/utils/account-utils.ts
+++ b/components/brave_wallet_ui/utils/account-utils.ts
@@ -99,7 +99,23 @@ export const findAccountByAccountId = (
   if (!accounts) {
     return undefined
   }
-  return accounts.entities[entityIdFromAccountId(accountId)]
+
+  for (const id of accounts.ids) {
+    const entity = accounts.entities[id]
+    if (!entity) {
+      continue
+    }
+    if (
+      entity.accountId.address.toLowerCase() ===
+        accountId.address.toLowerCase() ||
+      entity.accountId.uniqueKey.toLowerCase() ===
+        accountId.uniqueKey.toLowerCase()
+    ) {
+      return entity
+    }
+  }
+
+  return undefined
 }
 
 export const getAddressLabel = (

--- a/components/brave_wallet_ui/utils/routes-utils.ts
+++ b/components/brave_wallet_ui/utils/routes-utils.ts
@@ -3,7 +3,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { AccountPageTabs, BraveWallet, WalletRoutes } from '../constants/types'
+import {
+  AccountPageTabs,
+  BraveWallet,
+  WalletRoutes,
+  SendPageTabHashes
+} from '../constants/types'
 import { LOCAL_STORAGE_KEYS } from '../common/constants/local-storage-keys'
 
 /**
@@ -25,7 +30,7 @@ export function isPersistableSessionRoute(route?: string) {
     route.includes(WalletRoutes.PortfolioNFTAsset) ||
     route.includes(WalletRoutes.Market) ||
     route.includes(WalletRoutes.Swap) ||
-    route.includes(WalletRoutes.SendPageStart) ||
+    route.includes(WalletRoutes.Send) ||
     route.includes(WalletRoutes.LocalIpfsNode) ||
     route.includes(WalletRoutes.InspectNfts)
   )
@@ -122,4 +127,27 @@ export const makeDepositFundsRoute = (
   return `${WalletRoutes.DepositFundsPage}${
     paramsString ? `?${paramsString}` : ''
   }`
+}
+
+export const makeSendRoute = (
+  asset: BraveWallet.BlockchainToken,
+  account: BraveWallet.AccountInfo
+) => {
+  const isNftTab = asset.isErc721 || asset.isNft
+  const baseQueryParams = {
+    chainId: asset.chainId,
+    token: asset.contractAddress || asset.symbol.toUpperCase(),
+    account: account.accountId.uniqueKey
+  }
+  const params = new URLSearchParams(
+    asset.tokenId
+      ? { ...baseQueryParams, tokenId: asset.tokenId }
+      : baseQueryParams
+  )
+
+  if (isNftTab) {
+    return `${WalletRoutes.Send}?${params.toString()}${SendPageTabHashes.nft}`
+  }
+
+  return `${WalletRoutes.Send}?${params.toString()}${SendPageTabHashes.token}`
 }

--- a/components/brave_wallet_ui/utils/string-utils.ts
+++ b/components/brave_wallet_ui/utils/string-utils.ts
@@ -114,7 +114,7 @@ export const getWalletLocationTitle = (location: string) => {
   if (location === WalletRoutes.Swap) {
     return getLocale('braveWalletSwap')
   }
-  if (location === WalletRoutes.SendPageStart) {
+  if (location === WalletRoutes.Send) {
     return getLocale('braveWalletSend')
   }
   /** Wallet */


### PR DESCRIPTION
This PR does the following two refactorings:

1. Send screen no longer relies on `selectedNetwork` and `selectedAccount` backend states.
2. Field information in Send is encoded in the URL query params instead of relying on `React.useState`. This allowed us to cleanup the`useEffect` mess in Send screen.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34375

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Send flow in desktop and android should continue to work.
2. Must be tested for Ethereum, Solana, Filecoin.
3. Must be tested for ERC20s/SPL and NFTs.
4. Verify whether selecting an asset changes the query params in the URL.
5. Go to **Portfolio** and group entries by **Accounts**. Clicking on Send for an asset should populate it in the Send screen.
6. Open an account under the **Accounts** page. Clicking on Send for an asset should populate it in the Send screen.