### PR TITLE
Prevent Widevine Arm64 DLL incompatibilities

### DIFF
--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -134,7 +134,7 @@ class WidevineCdmComponentInstallerPolicy
   CrxInstaller::Result OnCustomInstall(
       const base::Value::Dict& manifest,
       const base::FilePath& install_dir) override;
-  const std::string GetArm64DllZipUrl(const std::string version);
+  const std::string GetArm64DllZipUrl(const std::string& version);
   CrxInstaller::Result InstallArm64Dll(const GURL zip_url,
                                        const base::FilePath& install_dir);
   bool IsHttp404(CrxInstaller::Result);
@@ -210,7 +210,7 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
 }
 
 const std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
-    const std::string version) {
+    const std::string& version) {
   const std::string format = kBraveWidevineArm64DllTemplateUrl.Get();
   size_t pos = format.find("%s");
   if (pos == std::string::npos) {

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -111,12 +111,9 @@ BASE_DECLARE_FEATURE(kBraveWidevineArm64DllFix);
 constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllUrl{
     &kBraveWidevineArm64DllFix, "widevine_arm64_dll_url",
     "https://dl.google.com/widevine-cdm/4.10.2710.0-win-arm64.zip"};
-constexpr char kVersionPlaceholder[] = "{version}";
 const base::FeatureParam<std::string> kBraveWidevineArm64DllTemplateUrl{
     &kBraveWidevineArm64DllFix, "widevine_arm64_dll_template_url",
-    ("https://dl.google.com/widevine-cdm/" + std::string(kVersionPlaceholder) +
-     "-win-arm64.zip")
-        .c_str()};
+    "https://dl.google.com/widevine-cdm/{version}-win-arm64.zip"};
 BASE_FEATURE(kBraveWidevineArm64DllFix,
              "BraveWidevineArm64DllFix",
              base::FEATURE_ENABLED_BY_DEFAULT);
@@ -214,8 +211,7 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
 std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
     const std::string& version) {
   std::string result = kBraveWidevineArm64DllTemplateUrl.Get();
-  base::ReplaceFirstSubstringAfterOffset(&result, 0, kVersionPlaceholder,
-                                         version);
+  base::ReplaceFirstSubstringAfterOffset(&result, 0, "{version}", version);
   return result;
 }
 

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -112,9 +112,12 @@ BASE_DECLARE_FEATURE(kBraveWidevineArm64DllFix);
 constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllUrl{
     &kBraveWidevineArm64DllFix, "widevine_arm64_dll_url",
     "https://dl.google.com/widevine-cdm/4.10.2710.0-win-arm64.zip"};
-constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllTemplateUrl{
+constexpr char kVersionPlaceholder[] = "{version}";
+const base::FeatureParam<std::string> kBraveWidevineArm64DllTemplateUrl{
     &kBraveWidevineArm64DllFix, "widevine_arm64_dll_template_url",
-    "https://dl.google.com/widevine-cdm/%s-win-arm64.zip"};
+    ("https://dl.google.com/widevine-cdm/" + std::string(kVersionPlaceholder) +
+     "-win-arm64.zip")
+        .c_str()};
 BASE_FEATURE(kBraveWidevineArm64DllFix,
              "BraveWidevineArm64DllFix",
              base::FEATURE_ENABLED_BY_DEFAULT);
@@ -211,13 +214,10 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
 
 std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
     const std::string& version) {
-  const std::string format = kBraveWidevineArm64DllTemplateUrl.Get();
-  size_t pos = format.find("%s");
-  if (pos == std::string::npos) {
-    // This can happen when `format` was set to a static URL via Griffin.
-    return format;
-  }
-  return base::StringPrintf(format.c_str(), version.c_str());
+  std::string result = kBraveWidevineArm64DllTemplateUrl.Get();
+  base::ReplaceFirstSubstringAfterOffset(&result, 0, kVersionPlaceholder,
+                                         version);
+  return result;
 }
 
 CrxInstaller::Result WidevineCdmComponentInstallerPolicy::InstallArm64Dll(

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -134,7 +134,7 @@ class WidevineCdmComponentInstallerPolicy
       const base::Value::Dict& manifest,
       const base::FilePath& install_dir) override;
   std::string GetArm64DllZipUrl(const std::string& version);
-  CrxInstaller::Result InstallArm64Dll(const GURL zip_url,
+  CrxInstaller::Result InstallArm64Dll(const GURL& zip_url,
                                        const base::FilePath& install_dir);
   bool IsHttp404(CrxInstaller::Result);
   std::unique_ptr<network::PendingSharedURLLoaderFactory>
@@ -145,7 +145,7 @@ class WidevineCdmComponentInstallerPolicy
 class WidevineArm64DllInstaller
     : public base::RefCountedThreadSafe<WidevineArm64DllInstaller> {
  public:
-  explicit WidevineArm64DllInstaller(const GURL zip_url,
+  explicit WidevineArm64DllInstaller(const GURL& zip_url,
                                      const base::FilePath& install_dir);
   void Start(std::unique_ptr<network::PendingSharedURLLoaderFactory>
                  pending_url_loader_factory);
@@ -216,7 +216,7 @@ std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
 }
 
 CrxInstaller::Result WidevineCdmComponentInstallerPolicy::InstallArm64Dll(
-    const GURL zip_url,
+    const GURL& zip_url,
     const base::FilePath& install_dir) {
   scoped_refptr<WidevineArm64DllInstaller> installer =
       base::MakeRefCounted<WidevineArm64DllInstaller>(zip_url, install_dir);
@@ -240,7 +240,7 @@ bool WidevineCdmComponentInstallerPolicy::IsHttp404(
 }
 
 WidevineArm64DllInstaller::WidevineArm64DllInstaller(
-    const GURL zip_url,
+    const GURL& zip_url,
     const base::FilePath& install_dir)
     : zip_url_(zip_url), install_dir_(install_dir) {
   DETACH_FROM_SEQUENCE(sequence_checker_);

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -35,7 +35,6 @@
 #include "base/memory/raw_ref.h"
 #include "base/metrics/field_trial_params.h"
 #include "base/sequence_checker.h"
-#include "base/strings/stringprintf.h"
 #include "base/synchronization/waitable_event.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/time/time.h"

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -134,7 +134,7 @@ class WidevineCdmComponentInstallerPolicy
   CrxInstaller::Result OnCustomInstall(
       const base::Value::Dict& manifest,
       const base::FilePath& install_dir) override;
-  const std::string GetArm64DllZipUrl(const std::string& version);
+  std::string GetArm64DllZipUrl(const std::string& version);
   CrxInstaller::Result InstallArm64Dll(const GURL zip_url,
                                        const base::FilePath& install_dir);
   bool IsHttp404(CrxInstaller::Result);
@@ -209,7 +209,7 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
   return result;
 }
 
-const std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
+std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
     const std::string& version) {
   const std::string format = kBraveWidevineArm64DllTemplateUrl.Get();
   size_t pos = format.find("%s");

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -285,7 +285,6 @@ CrxInstaller::Result WidevineArm64DllInstaller::WaitForCompletion() {
 void WidevineArm64DllInstaller::OnArm64DllDownloadComplete(
     base::FilePath zip_path) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  VLOG(2) << "Arm64 DLL download complete.";
   if (zip_path.empty()) {
     net::Error error = net::Error(loader_->NetError());
     VLOG(1) << "Arm64 DLL download failed. Error: "
@@ -299,6 +298,7 @@ void WidevineArm64DllInstaller::OnArm64DllDownloadComplete(
     }
     result_ = update_client::ToInstallerResult(error, extended_error);
   } else {
+    VLOG(2) << "Arm64 DLL download succeeded.";
     bool success = ExtractArm64Dll(zip_path) && AddArm64ArchToManifest();
     if (!success) {
       result_ =

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -111,10 +111,10 @@ constexpr net::NetworkTrafficAnnotationTag kTrafficAnnotation =
 BASE_DECLARE_FEATURE(kBraveWidevineArm64DllFix);
 constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllUrl{
     &kBraveWidevineArm64DllFix, "widevine_arm64_dll_url",
-    "https://dl.google.com/widevine-cdm/%s-win-arm64.zip"};
-constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllFallbackUrl{
-    &kBraveWidevineArm64DllFix, "widevine_arm64_dll_fallback_url",
     "https://dl.google.com/widevine-cdm/4.10.2710.0-win-arm64.zip"};
+constexpr base::FeatureParam<std::string> kBraveWidevineArm64DllTemplateUrl{
+    &kBraveWidevineArm64DllFix, "widevine_arm64_dll_template_url",
+    "https://dl.google.com/widevine-cdm/%s-win-arm64.zip"};
 BASE_FEATURE(kBraveWidevineArm64DllFix,
              "BraveWidevineArm64DllFix",
              base::FEATURE_ENABLED_BY_DEFAULT);
@@ -200,7 +200,7 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
   CrxInstaller::Result result = InstallArm64Dll(guessed_url, install_dir);
   if (IsHttp404(result)) {
     // Our guess failed. Fall back to a DLL version that is known to exist.
-    const GURL fallback_url = GURL(kBraveWidevineArm64DllFallbackUrl.Get());
+    const GURL fallback_url = GURL(kBraveWidevineArm64DllUrl.Get());
     LOG(WARNING) << "Guessed Widevine Arm64 ALL URL " << guessed_url
                  << " does not exist. Falling back to " << fallback_url
                  << ", which should exist but may not be compatible.";
@@ -211,7 +211,7 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
 
 const std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
     const std::string version) {
-  const std::string format = kBraveWidevineArm64DllUrl.Get();
+  const std::string format = kBraveWidevineArm64DllTemplateUrl.Get();
   size_t pos = format.find("%s");
   if (pos == std::string::npos) {
     // This can happen when `format` was set to a static URL via Griffin.

--- a/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
+++ b/chromium_src/chrome/browser/component_updater/widevine_cdm_component_installer.cc
@@ -118,6 +118,12 @@ BASE_FEATURE(kBraveWidevineArm64DllFix,
              "BraveWidevineArm64DllFix",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+std::string GetArm64DllZipUrl(const std::string& version) {
+  std::string result = kBraveWidevineArm64DllTemplateUrl.Get();
+  base::ReplaceFirstSubstringAfterOffset(&result, 0, "{version}", version);
+  return result;
+}
+
 }  // namespace
 
 namespace component_updater {
@@ -133,7 +139,6 @@ class WidevineCdmComponentInstallerPolicy
   CrxInstaller::Result OnCustomInstall(
       const base::Value::Dict& manifest,
       const base::FilePath& install_dir) override;
-  std::string GetArm64DllZipUrl(const std::string& version);
   CrxInstaller::Result InstallArm64Dll(const GURL& zip_url,
                                        const base::FilePath& install_dir);
   bool IsHttp404(CrxInstaller::Result);
@@ -205,13 +210,6 @@ CrxInstaller::Result WidevineCdmComponentInstallerPolicy::OnCustomInstall(
                  << ", which should exist but may not be compatible.";
     return InstallArm64Dll(fallback_url, install_dir);
   }
-  return result;
-}
-
-std::string WidevineCdmComponentInstallerPolicy::GetArm64DllZipUrl(
-    const std::string& version) {
-  std::string result = kBraveWidevineArm64DllTemplateUrl.Get();
-  base::ReplaceFirstSubstringAfterOffset(&result, 0, "{version}", version);
   return result;
 }
 


### PR DESCRIPTION
Resolves github.com/brave/brave-browser/issues/33595.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please test that Arm64 Brave on (Arm64) Windows can successfully install the Widevine component and play DRM-protected content at the highest quality. Do this twice: Once with no additional command-line parameters and once with `--enable-features="BraveWidevineArm64DllFix:widevine_arm64_dll_template_url/https%3A%2F%2Fbrave.com%2Fnonexistent"`.

All tests should be performed with a clean profile. On Windows for example, this means deleting (or temporarily renaming) the %LOCALAPPDATA%\BraveSoftware\Brave-Browser-<channel>\User Data directory. The reason why the profile should be clean is that an existing profile might have already installed the Widevine module.