### PR TITLE
[ads] Optimize epsilon greedy bandit arms initialization to only initialize if the feature is enabled

### DIFF
--- a/components/brave_ads/core/internal/analytics/p2a/opportunities/p2a_opportunity_util_unittest.cc
+++ b/components/brave_ads/core/internal/analytics/p2a/opportunities/p2a_opportunity_util_unittest.cc
@@ -5,7 +5,6 @@
 
 #include "brave/components/brave_ads/core/internal/analytics/p2a/opportunities/p2a_opportunity_util.h"
 
-#include "brave/components/brave_ads/core/public/units/ad_type.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*

--- a/components/brave_ads/core/internal/serving/targeting/user_model/latent_interest/latent_interest_segments_unittest.cc
+++ b/components/brave_ads/core/internal/serving/targeting/user_model/latent_interest/latent_interest_segments_unittest.cc
@@ -24,8 +24,6 @@ class BraveAdsLatentInterestSegmentsTest : public UnitTestBase {
     UnitTestBase::SetUp();
 
     targeting_ = std::make_unique<test::TargetingHelper>();
-
-    NotifyDidInitializeAds();
   }
 
   std::unique_ptr<test::TargetingHelper> targeting_;
@@ -36,6 +34,8 @@ TEST_F(BraveAdsLatentInterestSegmentsTest, BuildLatentInterestSegments) {
   base::test::ScopedFeatureList scoped_feature_list;
   scoped_feature_list.InitAndEnableFeatureWithParameters(
       kEpsilonGreedyBanditFeature, {{"epsilon_value", "0.0"}});
+
+  NotifyDidInitializeAds();
 
   targeting_->MockLatentInterest();
 
@@ -51,6 +51,8 @@ TEST_F(BraveAdsLatentInterestSegmentsTest,
   const base::test::ScopedFeatureList scoped_feature_list(
       kEpsilonGreedyBanditFeature);
 
+  NotifyDidInitializeAds();
+
   // Act
   const SegmentList segments = BuildLatentInterestSegments();
 
@@ -63,6 +65,8 @@ TEST_F(BraveAdsLatentInterestSegmentsTest,
   // Arrange
   base::test::ScopedFeatureList scoped_feature_list;
   scoped_feature_list.InitAndDisableFeature(kEpsilonGreedyBanditFeature);
+
+  NotifyDidInitializeAds();
 
   targeting_->MockLatentInterest();
 

--- a/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_processor.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_processor.cc
@@ -10,6 +10,7 @@
 
 #include "base/check_op.h"
 #include "base/containers/contains.h"
+#include "base/feature_list.h"
 #include "base/notreached.h"
 #include "brave/components/brave_ads/core/internal/client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
@@ -18,6 +19,7 @@
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_arm_info.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_arm_util.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_arms_alias.h"
+#include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_feature.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_feedback_info.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_segments.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
@@ -32,7 +34,8 @@ constexpr double kDefaultArmValue = 1.0;
 constexpr int kDefaultArmPulls = 0;
 
 bool DoesRequireResource() {
-  return UserHasOptedInToBraveNewsAds() || UserHasOptedInToNotificationAds();
+  return base::FeatureList::IsEnabled(kEpsilonGreedyBanditFeature) &&
+         UserHasOptedInToNotificationAds();
 }
 
 void MaybeAddOrResetArms(EpsilonGreedyBanditArmMap& arms) {

--- a/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_processor_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_processor_unittest.cc
@@ -7,15 +7,26 @@
 
 #include <string>
 
+#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/common/unittest/unittest_base.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_arm_util.h"
+#include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_feature.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_feedback_info.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
 namespace brave_ads {
 
-class BraveAdsEpsilonGreedyBanditProcessorTest : public UnitTestBase {};
+class BraveAdsEpsilonGreedyBanditProcessorTest : public UnitTestBase {
+ protected:
+  void SetUp() override {
+    UnitTestBase::SetUp();
+
+    scoped_feature_list_.InitAndEnableFeature(kEpsilonGreedyBanditFeature);
+  }
+
+  base::test::ScopedFeatureList scoped_feature_list_;
+};
 
 TEST_F(BraveAdsEpsilonGreedyBanditProcessorTest, InitializeArmsFromResource) {
   // Arrange

--- a/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/resource/epsilon_greedy_bandit_resource.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/resource/epsilon_greedy_bandit_resource.cc
@@ -5,12 +5,14 @@
 
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/resource/epsilon_greedy_bandit_resource.h"
 
+#include "base/feature_list.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_info.h"
 #include "brave/components/brave_ads/core/internal/client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/segments/segment_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings.h"
+#include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_feature.h"
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/resource/epsilon_greedy_bandit_resource_util.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "brave/components/brave_news/common/pref_names.h"
@@ -21,7 +23,8 @@ namespace brave_ads {
 namespace {
 
 bool DoesRequireResource() {
-  return UserHasOptedInToBraveNewsAds() || UserHasOptedInToNotificationAds();
+  return base::FeatureList::IsEnabled(kEpsilonGreedyBanditFeature) &&
+         UserHasOptedInToNotificationAds();
 }
 
 }  // namespace

--- a/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/resource/epsilon_greedy_bandit_resource_unittest.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/resource/epsilon_greedy_bandit_resource_unittest.cc
@@ -8,11 +8,13 @@
 #include <memory>
 
 #include "base/strings/strcat.h"
+#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/unittest/unittest_base.h"
 #include "brave/components/brave_ads/core/internal/common/unittest/unittest_mock_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_unittest_util.h"
+#include "brave/components/brave_ads/core/internal/targeting/behavioral/multi_armed_bandits/epsilon_greedy_bandit_feature.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"
 #include "net/http/http_status_code.h"
 
@@ -24,6 +26,8 @@ class BraveAdsEpsilonGreedyBanditResourceTest : public UnitTestBase {
  protected:
   void SetUp() override {
     UnitTestBase::SetUp();
+
+    scoped_feature_list_.InitAndEnableFeature(kEpsilonGreedyBanditFeature);
 
     catalog_ = std::make_unique<Catalog>();
     resource_ = std::make_unique<EpsilonGreedyBanditResource>(*catalog_);
@@ -38,6 +42,8 @@ class BraveAdsEpsilonGreedyBanditResourceTest : public UnitTestBase {
 
     NotifyDidInitializeAds();
   }
+
+  base::test::ScopedFeatureList scoped_feature_list_;
 
   std::unique_ptr<Catalog> catalog_;
 
@@ -67,7 +73,7 @@ TEST_F(BraveAdsEpsilonGreedyBanditResourceTest,
   LoadResource("catalog.json");
 
   // Assert
-  EXPECT_TRUE(resource_->IsInitialized());
+  EXPECT_FALSE(resource_->IsInitialized());
 }
 
 TEST_F(BraveAdsEpsilonGreedyBanditResourceTest,

--- a/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_builder.cc
+++ b/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_builder.cc
@@ -7,7 +7,6 @@
 
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_info.h"
-#include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 #include "brave/components/brave_ads/core/public/units/ad_info.h"
 
 namespace brave_ads {

--- a/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_builder_unittest.cc
+++ b/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_builder_unittest.cc
@@ -10,7 +10,6 @@
 #include "brave/components/brave_ads/core/internal/units/ad_unittest_constants.h"
 #include "brave/components/brave_ads/core/internal/units/ad_unittest_util.h"
 #include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_info.h"
-#include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 #include "brave/components/brave_ads/core/public/units/ad_info.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*

--- a/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_handler_util.cc
+++ b/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_handler_util.cc
@@ -6,7 +6,6 @@
 #include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_handler_util.h"
 
 #include "base/ranges/algorithm.h"
-#include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 #include "brave/components/brave_ads/core/public/units/ad_info.h"
 
 namespace brave_ads {

--- a/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_unittest_util.cc
+++ b/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_unittest_util.cc
@@ -19,7 +19,6 @@
 #include "brave/components/brave_ads/core/internal/units/ad_unittest_constants.h"
 #include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_event_info.h"
 #include "brave/components/brave_ads/core/internal/user/user_interaction/ad_events/ad_events.h"
-#include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 
 namespace brave_ads::test {
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34414

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm epsilon greedy bandits are not initialized if the feature is disabled when a user has opted-in to notification ads. Greedy bandits should not be initialized for any other creative ad type.