### PR TITLE
Fix ParseSSE function causing Leo to get cut off (uplift to 1.61.x)

### DIFF
--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -453,7 +453,7 @@ void APIRequestHelper::URLLoaderHandler::ParseSSE(
         };
 
     DVLOG(2) << "Going to call ParseJson";
-    GetDataDecoder()->ParseJson(std::move(json.data()),
+    GetDataDecoder()->ParseJson(std::move(std::string(json)),
                                 base::BindOnce(std::move(on_json_parsed),
                                                weak_ptr_factory_.GetWeakPtr()));
   }


### PR DESCRIPTION
Uplift of #21018
Resolves https://github.com/brave/brave-browser/issues/34321

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.