### PR TITLE
Fixed crash when new window is created

### DIFF
--- a/browser/ui/views/view_shadow.cc
+++ b/browser/ui/views/view_shadow.cc
@@ -58,6 +58,7 @@ ViewShadow::ViewShadow(views::View* view,
 
   view_->AddLayerToRegion(shadow_layer(), views::LayerRegion::kBelow);
   view_->AddObserver(this);
+  layer_owner_observation_.Observe(&layer_owner_);
 
   OnViewLayerBoundsSet(view_);
 }
@@ -84,8 +85,21 @@ void ViewShadow::OnViewLayerBoundsSet(views::View* view) {
 }
 
 void ViewShadow::OnViewIsDeleting(views::View* view) {
+  layer_owner_observation_.Reset();
   view_->RemoveObserver(this);
   view_ = nullptr;
+}
+
+void ViewShadow::OnLayerRecreated(ui::Layer* old_layer) {
+  if (!view_) {
+    return;
+  }
+
+  // During the window closing, shadow layer seems destroyed first
+  // before |view_| is destroying in some situation.
+  // Crash happens when view tree layouts w/o removing it from layer tree.
+  view_->RemoveLayerFromRegionsKeepInLayerTree(old_layer);
+  layer_owner_observation_.Reset();
 }
 
 void ViewShadow::OnPaintLayer(const ui::PaintContext& context) {

--- a/browser/ui/views/view_shadow.h
+++ b/browser/ui/views/view_shadow.h
@@ -8,6 +8,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/raw_ref.h"
+#include "base/scoped_observation.h"
 #include "ui/compositor/layer_delegate.h"
 #include "ui/compositor/layer_owner.h"
 #include "ui/gfx/geometry/insets.h"
@@ -34,7 +35,9 @@
 //     ViewShadow shadow_{this, kCornerRadius, kShadow};
 //   };
 //
-class ViewShadow : public ui::LayerDelegate, public views::ViewObserver {
+class ViewShadow : public ui::LayerDelegate,
+                   public ui::LayerOwner::Observer,
+                   public views::ViewObserver {
  public:
   struct ShadowParameters {
     int offset_x;
@@ -67,6 +70,9 @@ class ViewShadow : public ui::LayerDelegate, public views::ViewObserver {
   void OnViewLayerBoundsSet(views::View* view) override;
   void OnViewIsDeleting(views::View* view) override;
 
+  // ui::LayerOwner::Observer,
+  void OnLayerRecreated(ui::Layer* old_layer) override;
+
   // LayerDelegate:
   void OnPaintLayer(const ui::PaintContext& context) override;
   void OnDeviceScaleFactorChanged(float old_device_scale_factor,
@@ -80,6 +86,9 @@ class ViewShadow : public ui::LayerDelegate, public views::ViewObserver {
   int corner_radius_ = 0;
   raw_ref<const gfx::ShadowValues> shadow_values_;
   gfx::Insets insets_;
+
+  base::ScopedObservation<ui::LayerOwner, ui::LayerOwner::Observer>
+      layer_owner_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_VIEW_SHADOW_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/34385

Crashed when new window that created by tab detaching is closed. We need to remove shadow layer from layer tree when it's destroyed before view tree is still live.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

