### PR TITLE
Enable Widevine on all Linux archs

### DIFF
--- a/browser/brave_drm_tab_helper.cc
+++ b/browser/brave_drm_tab_helper.cc
@@ -76,6 +76,13 @@ void BraveDrmTabHelper::BindBraveDRM(
 }
 
 bool BraveDrmTabHelper::ShouldShowWidevineOptIn() const {
+#if BUILDFLAG(IS_LINUX) && !defined(ARCH_CPU_X86_64)
+  // On non-x64 Linux, Widevine is not publicly available. This point is a
+  // convenient single place for turning this class into a no-op:
+  return false;
+  // Users on non-x64 Linux may still install Widevine manually and enable it in
+  // brave://settings.
+#else
   // If the user already opted in, don't offer it.
   PrefService* prefs =
       static_cast<Profile*>(web_contents()->GetBrowserContext())->GetPrefs();
@@ -84,6 +91,7 @@ bool BraveDrmTabHelper::ShouldShowWidevineOptIn() const {
   }
 
   return is_widevine_requested_;
+#endif  // BUILDFLAG(IS_LINUX) && !defined(ARCH_CPU_X86_64)
 }
 
 void BraveDrmTabHelper::DidStartNavigation(

--- a/browser/widevine/widevine_utils.cc
+++ b/browser/widevine/widevine_utils.cc
@@ -80,6 +80,9 @@ void RegisterWidevineLocalstatePrefs(PrefRegistrySimple* registry) {
 }
 
 bool IsWidevineEnabled() {
+  // N.B.: As of this writing, kWidevineEnabled is also queried in other places.
+  // If you want to change the logic for enabling Widevine, then you need to
+  // change those other places as well.
   return g_browser_process->local_state()->GetBoolean(kWidevineEnabled);
 }
 

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -518,10 +518,6 @@ Config.prototype.buildArgs = function () {
       args.use_vaapi = true
 
     }
-    if (this.targetArch === 'arm64') {
-      // We don't yet support Widevine on Arm64 Linux.
-      args.enable_widevine = false
-    }
   }
 
   if (['android', 'linux', 'mac'].includes(this.getTargetOS())) {

--- a/patches/third_party-widevine-cdm-widevine.gni.patch
+++ b/patches/third_party-widevine-cdm-widevine.gni.patch
@@ -1,0 +1,12 @@
+diff --git a/third_party/widevine/cdm/widevine.gni b/third_party/widevine/cdm/widevine.gni
+index 58f073ca562ca40c3165f4dd0f650dc467b43d5c..735a99c71e5086e146ec0bdbf2090d56bd5f08ca 100644
+--- a/third_party/widevine/cdm/widevine.gni
++++ b/third_party/widevine/cdm/widevine.gni
+@@ -31,6 +31,7 @@ library_widevine_cdm_available =
+     (target_os == "mac" && (target_cpu == "x64" || target_cpu == "arm64")) ||
+     (target_os == "win" &&
+      (target_cpu == "x86" || target_cpu == "x64" || target_cpu == "arm64"))
++if (target_os == "linux") { library_widevine_cdm_available = true } # Let Linux users manually supply Widevine on architectures where it isn't publicly available.
+ 
+ # Widevine CDM is available as a library CDM and it's supported by Chromium.
+ # This does not define how the CDM will be deployed. It can be bundled or


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/33081.

After this PR, Arm64 Linux users can set up Widevine as follows:

1. Obtain a copy of Widevine. This is a folder with the files `manifest.json` and `_platform_specific/linux_arm64/libwidevinecdm.so`. Some Linux distributions such as Raspberry Pi OS ship with a copy of Widevine somewhere in `/opt`.
2. In Brave's User Data Directory, create the file `WidevineCdm/latest-component-updated-widevine-cdm` with the following contents: `{"Path":"/path/to/the/folder/from/step/1"}`. The default User Data Directory for the Release version of Brave is `~/.config/BraveSoftware/Brave-Browser`.
3. Enable Widevine in `brave://settings`.
4. Restart Brave.

The instructions can also be used on architectures other than Arm64. In those cases, the path that mentions `linux_arm64` above will differ.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] **Update brave.com with the instructions above.**
- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

At a minimum, it should be tested that Widevine can now be used on Arm64 Linux. The expected behavior is that Widevine should "just work" when users follow the steps at the top of this PR description. The only real feasible platform I have found for testing the functionality is on a Raspberry Pi 4B.

If you don't have a physical Raspberry Pi, then it is also possible to emulate it with QEMU. [This article](https://interrupt.memfault.com/blog/emulating-raspberry-pi-in-qemu) gives good instructions. Note the `-nographic` comment at the bottom. However, setting this up is very tedious and the emulation is extremely slow. I would advise to buy a physical Raspberry Pi for testing instead.

The changes may also affect Widevine on other platforms. If there is time, then it would be good to test that Widevine can still be installed and used to play DRM-protected content on other platforms.