### PR TITLE
[Android] move youtube options to media

### DIFF
--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
@@ -68,7 +68,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
     private static final String PREF_CLEAR_DATA_SECTION = "clear_data_section";
     private static final String PREF_BRAVE_SOCIAL_BLOCKING_SECTION =
             "brave_social_blocking_section";
-    private static final String PREF_YOUTUBE_SECTION = "youtube_section";
     private static final String PREF_OTHER_PRIVACY_SETTINGS_SECTION =
             "other_privacy_settings_section";
 
@@ -91,10 +90,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
     private static final String PREF_SHOW_AUTOCOMPLETE_IN_ADDRESS_BAR =
             "show_autocomplete_in_address_bar";
     private static final String PREF_AUTOCOMPLETE_TOP_SITES = "autocomplete_top_sites";
-    private static final String PREF_HIDE_YOUTUBE_RECOMMENDED_CONTENT =
-            "hide_youtube_recommended_content";
-    private static final String PREF_HIDE_YOUTUBE_DISTRACTING_ELEMENTS =
-            "hide_youtube_distracting_elements";
 
     private static final String PREF_SOCIAL_BLOCKING_GOOGLE = "social_blocking_google";
     private static final String PREF_SOCIAL_BLOCKING_FACEBOOK = "social_blocking_facebook";
@@ -139,9 +134,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         PREF_SOCIAL_BLOCKING_FACEBOOK,
         PREF_SOCIAL_BLOCKING_TWITTER,
         PREF_SOCIAL_BLOCKING_LINKEDIN,
-        PREF_YOUTUBE_SECTION, // Youtube section
-        PREF_HIDE_YOUTUBE_RECOMMENDED_CONTENT,
-        PREF_HIDE_YOUTUBE_DISTRACTING_ELEMENTS,
         PREF_OTHER_PRIVACY_SETTINGS_SECTION, // other section
         PREF_APP_LINKS,
         PREF_WEBRTC_POLICY,
@@ -200,8 +192,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
     private ChromeSwitchPreference mIpfsGatewayPref;
     private ChromeSwitchPreference mBlockCookieConsentNoticesPref;
     private ChromeSwitchPreference mBlockSwitchToAppNoticesPref;
-    private ChromeSwitchPreference mHideYoutubeRecommendedContentPref;
-    private ChromeSwitchPreference mHideYoutubeDistractingElementsPref;
     private PreferenceCategory mSocialBlockingCategory;
     private ChromeSwitchPreference mSocialBlockingGoogle;
     private ChromeSwitchPreference mSocialBlockingFacebook;
@@ -289,14 +279,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         mBlockSwitchToAppNoticesPref =
                 (ChromeSwitchPreference) findPreference(PREF_BLOCK_SWITCH_TO_APP_NOTICES);
         mBlockSwitchToAppNoticesPref.setOnPreferenceChangeListener(this);
-
-        mHideYoutubeRecommendedContentPref =
-                (ChromeSwitchPreference) findPreference(PREF_HIDE_YOUTUBE_RECOMMENDED_CONTENT);
-        mHideYoutubeRecommendedContentPref.setOnPreferenceChangeListener(this);
-
-        mHideYoutubeDistractingElementsPref =
-                (ChromeSwitchPreference) findPreference(PREF_HIDE_YOUTUBE_DISTRACTING_ELEMENTS);
-        mHideYoutubeDistractingElementsPref.setOnPreferenceChangeListener(this);
 
         mBlockCrosssiteCookies =
                 (BraveDialogPreference) findPreference(PREF_BLOCK_CROSS_SITE_COOKIES);
@@ -488,18 +470,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
             if (mFilterListAndroidHandler != null) {
                 mFilterListAndroidHandler.enableFilter(
                         FilterListConstants.SWITCH_TO_APP_UUID, (boolean) newValue);
-            }
-        } else if (PREF_HIDE_YOUTUBE_RECOMMENDED_CONTENT.equals(key)) {
-            if (mFilterListAndroidHandler != null) {
-                mFilterListAndroidHandler.enableFilter(
-                        FilterListConstants.HIDE_YOUTUBE_RECOMMENDED_CONTENT_UUID,
-                        (boolean) newValue);
-            }
-        } else if (PREF_HIDE_YOUTUBE_DISTRACTING_ELEMENTS.equals(key)) {
-            if (mFilterListAndroidHandler != null) {
-                mFilterListAndroidHandler.enableFilter(
-                        FilterListConstants.HIDE_YOUTUBE_DISTRACTING_ELEMENTS_UUID,
-                        (boolean) newValue);
             }
         } else if (PREF_FINGERPRINTING_PROTECTION.equals(key)) {
             if (newValue instanceof String) {
@@ -778,12 +748,6 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
                     isEnabled -> { mBlockCookieConsentNoticesPref.setChecked(isEnabled); });
             mFilterListAndroidHandler.isFilterListEnabled(FilterListConstants.SWITCH_TO_APP_UUID,
                     isEnabled -> { mBlockSwitchToAppNoticesPref.setChecked(isEnabled); });
-            mFilterListAndroidHandler.isFilterListEnabled(
-                    FilterListConstants.HIDE_YOUTUBE_RECOMMENDED_CONTENT_UUID,
-                    isEnabled -> { mHideYoutubeRecommendedContentPref.setChecked(isEnabled); });
-            mFilterListAndroidHandler.isFilterListEnabled(
-                    FilterListConstants.HIDE_YOUTUBE_DISTRACTING_ELEMENTS_UUID,
-                    isEnabled -> { mHideYoutubeDistractingElementsPref.setChecked(isEnabled); });
         }
         // Debounce
         if (mDebouncePref != null) {

--- a/android/java/res/xml/brave_privacy_preferences.xml
+++ b/android/java/res/xml/brave_privacy_preferences.xml
@@ -108,22 +108,6 @@
             android:defaultValue="false" />
 
     </PreferenceCategory>
-    <PreferenceCategory
-        android:key="youtube_section"
-        android:title="@string/youtube">
-            <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
-            android:key="hide_youtube_recommended_content"
-            android:title="@string/block_youtube_recommended_content"
-            android:order="25"
-            android:summary="@string/block_youtube_recommended_content_description"
-            android:defaultValue="true" />
-        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
-            android:key="hide_youtube_distracting_elements"
-            android:title="@string/block_youtube_distracting_elements"
-            android:order="25"
-            android:summary="@string/block_youtube_distracting_elements_description"
-            android:defaultValue="true" />
-    </PreferenceCategory>
         <PreferenceCategory
         android:key="other_privacy_settings_section"
         android:title="@string/prefs_section_other_privacy_settings"/>

--- a/android/java/res/xml/media_preferences.xml
+++ b/android/java/res/xml/media_preferences.xml
@@ -26,6 +26,16 @@
         <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
             android:key="play_yt_video_in_browser"
             android:title="@string/prefs_open_youtube_links_brave" />
+        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+            android:key="hide_youtube_recommended_content"
+            android:title="@string/block_youtube_recommended_content"
+            android:summary="@string/block_youtube_recommended_content_description"
+            android:defaultValue="true" />
+        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+            android:key="hide_youtube_distracting_elements"
+            android:title="@string/block_youtube_distracting_elements"
+            android:summary="@string/block_youtube_distracting_elements_description"
+            android:defaultValue="true" />
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java
@@ -44,7 +44,7 @@ public class BravePrivacySettingsTest {
     private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
     private static final String PREF_PHONE_AS_A_SECURITY_KEY = "phone_as_a_security_key";
 
-    private static final int BRAVE_PRIVACY_SETTINGS_NUMBER_OF_ITEMS = 30;
+    private static final int BRAVE_PRIVACY_SETTINGS_NUMBER_OF_ITEMS = 29;
 
     private int mItemsLeft;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34420

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Move `Block YouTube recommended content` to newly created `youtube` category in `Media`
- Move `Block YouTube distracting elements` to newly created `youtube` category in `Media`
- Check `Block YouTube recommended content` and `Block YouTube distracting elements` works as expected from `Media`