### PR TITLE
Added the ability to override the .desktop file location in official Linux builds (uplift to 1.61.x)

### DIFF
--- a/chromium_src/chrome/common/channel_info_posix.cc
+++ b/chromium_src/chrome/common/channel_info_posix.cc
@@ -54,6 +54,10 @@ std::string GetChannelSuffixForExtraFlagsEnvVarName() {
 
 #if BUILDFLAG(IS_LINUX)
 std::string GetDesktopName(base::Environment* env) {
+  std::string brave_snap;
+  if (env->GetVar("BRAVE_SNAP", &brave_snap) && brave_snap == "1") {
+    return "brave.desktop";
+  }
 #if defined(OFFICIAL_BUILD)
   version_info::Channel product_channel(chrome::GetChannel());
   switch (product_channel) {


### PR DESCRIPTION
Uplift of #20892
Resolves https://github.com/brave/brave-browser/issues/34053

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.