### PR TITLE
Avoid `base::` replacements for c++20 `std::`

### DIFF
--- a/browser/brave_shields/brave_shields_web_contents_observer.cc
+++ b/browser/brave_shields/brave_shields_web_contents_observer.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/containers/cxx20_erase_vector.h"
 #include "base/feature_list.h"
@@ -261,7 +262,7 @@ void BraveShieldsWebContentsObserver::BlockAllowedScripts(
   for (const auto& script : scripts) {
     auto origin = url::Origin::Create(GURL(script));
     bool is_origin = origin.Serialize() == script;
-    base::EraseIf(allowed_scripts_, [is_origin, script,
+    std::erase_if(allowed_scripts_, [is_origin, script,
                                      origin](const std::string& value) {
       // scripts array may have both origins or full scripts paths.
       return is_origin ? url::Origin::Create(GURL(value)) == origin

--- a/browser/brave_wallet/solana_provider_impl_unittest.cc
+++ b/browser/brave_wallet/solana_provider_impl_unittest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include <memory>
+#include <vector>
 
 #include "base/containers/cxx20_erase_vector.h"
 #include "brave/components/brave_wallet/browser/solana_provider_impl.h"
@@ -230,7 +231,7 @@ class SolanaProviderImplUnitTest : public testing::Test {
       mojom::KeyringId keyring_id = mojom::kSolanaKeyringId) {
     CHECK(!keyring_service_->IsLockedSync());
     auto all_accounts = keyring_service_->GetAllAccountsSync();
-    base::EraseIf(all_accounts->accounts, [&](auto& acc) {
+    std::erase_if(all_accounts->accounts, [&](auto& acc) {
       return acc->account_id->keyring_id != keyring_id;
     });
     return all_accounts->accounts[index].Clone();

--- a/browser/permissions/mock_permission_lifetime_prompt_factory.cc
+++ b/browser/permissions/mock_permission_lifetime_prompt_factory.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/permissions/mock_permission_lifetime_prompt_factory.h"
 
+#include <vector>
+
 #include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "base/memory/ptr_util.h"
@@ -65,7 +67,7 @@ void MockPermissionLifetimePromptFactory::WaitForPermissionBubble() {
 
 void MockPermissionLifetimePromptFactory::HideView(
     MockPermissionLifetimePrompt* prompt) {
-  base::Erase(prompts_, prompt);
+  std::erase(prompts_, prompt);
 }
 
 }  // namespace permissions

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -283,7 +283,7 @@ std::vector<int> AcceleratorService::AssignAccelerator(
 
   // Find any other commands with this accelerator and remove it from them.
   for (auto& [other_command_id, accelerators] : accelerators_) {
-    if (base::EraseIf(
+    if (std::erase_if(
             accelerators, [&accelerator, &system_managed, &default_accelerators,
                            other_command_id](const auto& other) {
               bool is_default_accelerator =
@@ -308,7 +308,7 @@ std::vector<int> AcceleratorService::AssignAccelerator(
 void AcceleratorService::UnassignAccelerator(
     int command_id,
     const ui::Accelerator& accelerator) {
-  base::Erase(accelerators_[command_id], accelerator);
+  std::erase(accelerators_[command_id], accelerator);
   pref_manager_.RemoveAccelerator(command_id, accelerator);
 }
 

--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
@@ -6,6 +6,7 @@
 #include "chrome/browser/ui/webui/settings/site_settings_helper.h"
 
 #include <string_view>
+#include <vector>
 
 #include "base/containers/cxx20_erase_vector.h"
 #include "brave/components/brave_shields/common/brave_shield_constants.h"
@@ -106,7 +107,7 @@ const std::vector<ContentSettingsType>& GetVisiblePermissionCategories() {
     types->insert(types->end(), base_types.begin(), base_types.end());
 
     if (!base::FeatureList::IsEnabled(blink::features::kBraveWebSerialAPI)) {
-      base::Erase(*types, ContentSettingsType::SERIAL_GUARD);
+      std::erase(*types, ContentSettingsType::SERIAL_GUARD);
     }
 
     initialized = true;

--- a/chromium_src/components/content_settings/core/common/content_settings.cc
+++ b/chromium_src/components/content_settings/core/common/content_settings.cc
@@ -5,6 +5,8 @@
 
 #include "components/content_settings/core/common/content_settings.h"
 
+#include <vector>
+
 #define RendererContentSettingRules RendererContentSettingRules_ChromiumImpl
 
 #include "src/components/content_settings/core/common/content_settings.cc"
@@ -47,12 +49,12 @@ void RendererContentSettingRules::FilterRulesByOutermostMainFrameURL(
   FilterRulesForType(brave_shields_rules, outermost_main_frame_url);
   // FilterRulesForType has a DCHECK on the size and these fail (for now)
   // because they incorrectly use CONTENT_SETTINGS_DEFAULT as a distinct setting
-  base::EraseIf(
+  std::erase_if(
       cosmetic_filtering_rules,
       [&outermost_main_frame_url](const ContentSettingPatternSource& source) {
         return !source.primary_pattern.Matches(outermost_main_frame_url);
       });
-  base::EraseIf(
+  std::erase_if(
       fingerprinting_rules,
       [&outermost_main_frame_url](const ContentSettingPatternSource& source) {
         return !source.primary_pattern.Matches(outermost_main_frame_url);

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -419,7 +419,7 @@ void APIRequestHelper::URLLoaderHandler::ParseSSE(
   // TODO(@nullhook): Parse both JSON and string values. The below currently
   // only identifies JSON values.
   static constexpr char kDataPrefix[] = "data: {";
-  base::EraseIf(stream_data, [](std::string_view item) {
+  std::erase_if(stream_data, [](std::string_view item) {
     DVLOG(3) << "Received chunk: " << item;
     if (!base::StartsWith(item, kDataPrefix)) {
       // This is useful to log in case an API starts

--- a/components/brave_rewards/core/contribution/contribution_monthly.cc
+++ b/components/brave_rewards/core/contribution/contribution_monthly.cc
@@ -5,6 +5,7 @@
 
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/containers/cxx20_erase.h"
 #include "base/functional/bind.h"
@@ -37,7 +38,7 @@ void ContributionMonthly::AdvanceContributionDates(
     LegacyResultCallback callback,
     std::vector<mojom::PublisherInfoPtr> publishers) {
   // Remove any contributions whose next contribution date is in the future.
-  base::EraseIf(publishers,
+  std::erase_if(publishers,
                 [cutoff_time](const mojom::PublisherInfoPtr& publisher) {
                   if (!publisher || publisher->id.empty()) {
                     return true;
@@ -72,7 +73,7 @@ void ContributionMonthly::OnNextContributionDateAdvanced(
   // Remove entries for zero contribution amounts or unverified creators. Note
   // that in previous versions, pending contributions would be created if the
   // creator was unverified.
-  base::EraseIf(publishers, [](const mojom::PublisherInfoPtr& publisher) {
+  std::erase_if(publishers, [](const mojom::PublisherInfoPtr& publisher) {
     DCHECK(publisher);
     return publisher->weight <= 0 ||
            publisher->status == mojom::PublisherStatus::NOT_VERIFIED;

--- a/components/brave_vpn/common/wireguard/win/service_details.cc
+++ b/components/brave_vpn/common/wireguard/win/service_details.cc
@@ -7,6 +7,8 @@
 
 #include <guiddef.h>
 
+#include <vector>
+
 #include "base/containers/cxx20_erase.h"
 #include "base/path_service.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
@@ -98,7 +100,7 @@ std::wstring GetBraveVpnWireguardServiceDisplayName() {
 
 std::wstring GetBraveVpnWireguardServiceName() {
   std::wstring name = GetBraveVpnWireguardServiceDisplayName();
-  base::EraseIf(name, isspace);
+  std::erase_if(name, isspace);
   return name;
 }
 

--- a/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.cc
@@ -9,6 +9,7 @@
 #include <deque>
 #include <map>
 #include <set>
+#include <vector>
 
 #include "base/check.h"
 #include "base/check_op.h"
@@ -202,7 +203,7 @@ void GetBalanceTask::OnGetAddressStats(
   auto mempool_balance = GetChainBalance(stats->mempool_stats);
   balances_[address->address_string] = chain_balance + mempool_balance;
 
-  CHECK(base::Erase(addresses_, address));
+  CHECK(std::erase(addresses_, address));
   if (addresses_.empty()) {
     result_ = mojom::BitcoinBalance::New();
     for (auto& balance : balances_) {
@@ -292,7 +293,7 @@ void GetUtxosTask::OnGetUtxoList(
 
   utxos_[address->address_string] = std::move(utxos.value());
 
-  CHECK(base::Erase(addresses_, address));
+  CHECK(std::erase(addresses_, address));
   if (addresses_.empty()) {
     result_ = std::move(utxos_);
   }

--- a/components/brave_wallet/browser/brave_wallet_auto_pin_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_auto_pin_service.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_wallet/browser/brave_wallet_auto_pin_service.h"
 
+#include <vector>
+
 #include "brave/components/brave_wallet/browser/pref_names.h"
 
 namespace brave_wallet {
@@ -120,7 +122,7 @@ void BraveWalletAutoPinService::OnTokenAdded(BlockchainTokenPtr token) {
     return;
   }
   tokens_.insert(token_str.value());
-  base::EraseIf(queue_, [&token_str](const auto& intent) {
+  std::erase_if(queue_, [&token_str](const auto& intent) {
     return GetTokenStringValue(intent->token) == token_str;
   });
   AddOrExecute(
@@ -139,7 +141,7 @@ void BraveWalletAutoPinService::OnTokenRemoved(BlockchainTokenPtr token) {
     return;
   }
   tokens_.erase(token_str.value());
-  base::EraseIf(queue_, [&token_str](const auto& intent) {
+  std::erase_if(queue_, [&token_str](const auto& intent) {
     return GetTokenStringValue(intent->token) == token_str;
   });
   AddOrExecute(

--- a/components/brave_wallet/browser/brave_wallet_pin_service.h
+++ b/components/brave_wallet/browser/brave_wallet_pin_service.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "base/containers/cxx20_erase_deque.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/task/sequenced_task_runner.h"

--- a/components/brave_wallet/browser/ethereum_provider_impl.cc
+++ b/components/brave_wallet/browser/ethereum_provider_impl.cc
@@ -8,6 +8,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include "base/containers/contains.h"
 #include "base/json/json_reader.h"
@@ -560,7 +561,7 @@ bool EthereumProviderImpl::UnsubscribeBlockObserver(
 
 bool EthereumProviderImpl::UnsubscribeLogObserver(
     const std::string& subscription_id) {
-  if (base::Erase(eth_log_subscriptions_, subscription_id)) {
+  if (std::erase(eth_log_subscriptions_, subscription_id)) {
     eth_logs_tracker_.RemoveSubscriber(subscription_id);
     if (eth_log_subscriptions_.empty()) {
       eth_logs_tracker_.Stop();

--- a/components/brave_wallet/browser/json_rpc_service.cc
+++ b/components/brave_wallet/browser/json_rpc_service.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "base/base64.h"
 #include "base/check.h"
@@ -777,8 +778,8 @@ void JsonRpcService::GetHiddenNetworks(mojom::CoinType coin,
   auto hidden_networks = brave_wallet::GetHiddenNetworks(prefs_, coin);
 
   // Currently selected chain is never hidden for coin.
-  base::Erase(hidden_networks,
-              base::ToLowerASCII(GetChainIdSync(coin, absl::nullopt)));
+  std::erase(hidden_networks,
+             base::ToLowerASCII(GetChainIdSync(coin, absl::nullopt)));
 
   std::move(callback).Run(hidden_networks);
 }

--- a/components/brave_wallet/browser/solana_provider_impl.cc
+++ b/components/brave_wallet/browser/solana_provider_impl.cc
@@ -140,7 +140,7 @@ void SolanaProviderImpl::Connect(absl::optional<base::Value::Dict> arg,
     const auto allowed_accounts =
         delegate_->GetAllowedAccounts(mojom::CoinType::SOL, addresses);
     if (allowed_accounts) {
-      base::EraseIf(addresses, [&allowed_accounts](const auto& address) {
+      std::erase_if(addresses, [&allowed_accounts](const auto& address) {
         return base::Contains(*allowed_accounts, address);
       });
     }

--- a/vendor/brave_base/random.cc
+++ b/vendor/brave_base/random.cc
@@ -5,6 +5,7 @@
 
 #include "brave_base/random.h"
 
+#include <bit>
 #include <cmath>
 
 #include "base/bits.h"
@@ -51,10 +52,10 @@ double Uniform_01() {
   //
   // If we stopped at e >= 1088, this means our RNG is broken.  In
   // that case, we could just as well abort the process.  But it is
-  // also safe to call CountLeadingZeroBits at this point; it will
+  // also safe to call std::countl_zero at this point; it will
   // just return 64, and the exponent will be even more improbably
   // larger.
-  e += base::bits::CountLeadingZeroBits(x);
+  e += std::countl_zero(x);
 
   u = Uniform64();
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Chromium upstream is set to remove `base::Erase`, `base::EraseIf`, as well as `base::bits::CountLeadingZeroBits`. This PR removes the occurrences of these constructs in anticipation for the upstream deletions.

Resolves https://github.com/brave/brave-browser/issues/34452

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

