### PR TITLE
perf: use less hooks in page container

### DIFF
--- a/components/brave_wallet_ui/components/desktop/lock-screen/lock-screen.stories.tsx
+++ b/components/brave_wallet_ui/components/desktop/lock-screen/lock-screen.stories.tsx
@@ -4,17 +4,17 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import LockScreen from '.'
+
+import {
+  WalletPageStory //
+} from '../../../stories/wrappers/wallet-page-story-wrapper'
+import { LockScreen } from '.'
 
 export const _LockScreen: React.FC = () => {
   return (
-    <LockScreen
-      disabled={false}
-      hasPasswordError={false}
-      onPasswordChanged={() => null}
-      onShowRestore={() => null}
-      onSubmit={() => null}
-    />
+    <WalletPageStory>
+      <LockScreen />
+    </WalletPageStory>
   )
 }
 

--- a/components/brave_wallet_ui/page/actions/wallet_page_actions.ts
+++ b/components/brave_wallet_ui/page/actions/wallet_page_actions.ts
@@ -9,7 +9,6 @@ import { PageActions } from '../reducers/page_reducer'
 export const {
   addHardwareAccounts,
   agreeToWalletTerms,
-  openWalletSettings,
   recoveryWordsAvailable,
   selectAsset,
   selectCoinMarket,

--- a/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
+++ b/components/brave_wallet_ui/page/async/wallet_page_async_handler.ts
@@ -30,12 +30,4 @@ handler.on(
   }
 )
 
-handler.on(WalletPageActions.openWalletSettings.type, async (store) => {
-  chrome.tabs.create({ url: 'chrome://settings/wallet' }, () => {
-    if (chrome.runtime.lastError) {
-      console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
-    }
-  })
-})
-
 export default handler.middleware

--- a/components/brave_wallet_ui/page/reducers/page_reducer.ts
+++ b/components/brave_wallet_ui/page/reducers/page_reducer.ts
@@ -40,7 +40,6 @@ export const WalletPageAsyncActions = {
   importAccountFromJson: createAction<ImportAccountFromJsonPayloadType>(
     'importAccountFromJson'
   ),
-  openWalletSettings: createAction('openWalletSettings'),
   selectAsset: createAction<UpdateSelectedAssetType>('selectAsset')
 }
 

--- a/components/brave_wallet_ui/utils/routes-utils.ts
+++ b/components/brave_wallet_ui/utils/routes-utils.ts
@@ -7,7 +7,8 @@ import {
   AccountPageTabs,
   BraveWallet,
   WalletRoutes,
-  SendPageTabHashes
+  SendPageTabHashes,
+  WalletOrigin
 } from '../constants/types'
 import { LOCAL_STORAGE_KEYS } from '../common/constants/local-storage-keys'
 
@@ -150,4 +151,15 @@ export const makeSendRoute = (
   }
 
   return `${WalletRoutes.Send}?${params.toString()}${SendPageTabHashes.token}`
+}
+
+export const openWalletRouteTab = (route: WalletRoutes) => {
+  chrome.tabs.create({ url: `${WalletOrigin}${route}` }, () => {
+    if (chrome.runtime.lastError) {
+      console.error(
+        'tabs.create failed: ' + //
+          chrome.runtime.lastError.message
+      )
+    }
+  })
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34455

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Locking/unlocking wallet should continue to function without regressions.
- Wallet backup warning banner should continue to work
- Set default wallet banner should continue to work
- "open settings" button in wallet banner should continue to work
