### PR TITLE
Apply contents rounded corners to normal window only

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/lifetime/browser_close_manager.h"
@@ -36,6 +37,12 @@ bool g_suppress_dialog_for_testing = false;
 // static
 void BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(bool suppress) {
   g_suppress_dialog_for_testing = suppress;
+}
+
+// static
+bool BraveBrowser::ShouldUseBraveWebViewRoundedCorners(Browser* browser) {
+  return base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners) &&
+         browser->is_type_normal();
 }
 
 BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -30,6 +30,8 @@ class BraveBrowser : public Browser {
   BraveBrowser(const BraveBrowser&) = delete;
   BraveBrowser& operator=(const BraveBrowser&) = delete;
 
+  static bool ShouldUseBraveWebViewRoundedCorners(Browser* browser);
+
   // Browser overrides:
   void ScheduleUIUpdate(content::WebContents* source,
                         unsigned changed_flags) override;

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -15,7 +15,6 @@
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
-#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/sparkle_buildflags.h"
 #include "brave/browser/translate/brave_translate_utils.h"
@@ -196,7 +195,7 @@ class BraveBrowserView::TabCyclingEventHandler : public ui::EventObserver,
 
 BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
     : BrowserView(std::move(browser)) {
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
     // Collapse the separator line between the toolbar or bookmark bar and the
     // views below.
     contents_separator_->SetPreferredSize(gfx::Size());
@@ -248,7 +247,7 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
             std::move(original_side_panel)));
     unified_side_panel_ = sidebar_container_view_->side_panel();
 
-    if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
       sidebar_separator_view_ =
           AddChildView(std::make_unique<SidebarSeparator>());
     }
@@ -435,6 +434,10 @@ void BraveBrowserView::ShowReaderModeToolbar() {
   if (!reader_mode_toolbar_view_) {
     reader_mode_toolbar_view_ =
         std::make_unique<ReaderModeToolbarView>(GetProfile());
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
+      SetBorder(views::CreateThemedSolidSidedBorder(
+          gfx::Insets::TLBR(0, 0, 1, 0), kColorToolbarContentAreaSeparator));
+    }
     AddChildView(reader_mode_toolbar_view_.get());
     GetBrowserViewLayout()->set_reader_mode_toolbar(
         reader_mode_toolbar_view_.get());
@@ -728,7 +731,7 @@ BraveBrowser* BraveBrowserView::GetBraveBrowser() const {
 }
 
 void BraveBrowserView::UpdateWebViewRoundedCorners() {
-  if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
     return;
   }
 

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <limits>
 
-#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
@@ -292,7 +292,8 @@ void BraveBrowserViewLayout::LayoutReaderModeToolbar(
 }
 
 gfx::Insets BraveBrowserViewLayout::GetContentsMargins() const {
-  if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+          browser_view_->browser())) {
     return {};
   }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "brave/app/vector_icons/vector_icons.h"
-#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -1145,7 +1144,7 @@ void VerticalTabStripRegionView::UpdateBorder() {
       return false;
     }
 
-    if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
       return true;
     }
 

--- a/browser/ui/views/side_panel/brave_side_panel.cc
+++ b/browser/ui/views/side_panel/brave_side_panel.cc
@@ -7,7 +7,7 @@
 
 #include "base/functional/bind.h"
 #include "base/ranges/algorithm.h"
-#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
@@ -34,7 +34,8 @@ BraveSidePanel::BraveSidePanel(BrowserView* browser_view,
   OnSidePanelWidthChanged();
   AddObserver(this);
 
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+          browser_view_->browser())) {
     shadow_ = BraveContentsViewUtil::CreateShadow(this);
     SetBackground(
         views::CreateThemedSolidBackground(kColorSidebarPanelHeaderBackground));
@@ -59,7 +60,8 @@ bool BraveSidePanel::IsRightAligned() {
 }
 
 void BraveSidePanel::UpdateBorder() {
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+          browser_view_->browser())) {
     // Use a negative top border to hide the separator inserted by the upstream
     // side panel implementation.
     SetBorder(views::CreateEmptyBorder(gfx::Insets::TLBR(-1, 0, 0, 0)));

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
 
 #include "brave/app/brave_command_ids.h"
-#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
@@ -87,7 +86,7 @@ void SidebarControlView::UpdateBackgroundAndBorder() {
   if (const ui::ColorProvider* color_provider = GetColorProvider()) {
     SetBackground(
         views::CreateSolidBackground(color_provider->GetColor(kColorToolbar)));
-    if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
       constexpr int kBorderThickness = 1;
       SetBorder(views::CreateSolidSidedBorder(
           gfx::Insets::TLBR(0, sidebar_on_left_ ? 0 : kBorderThickness, 0,

--- a/browser/ui/views/speedreader/reader_mode_toolbar_view.cc
+++ b/browser/ui/views/speedreader/reader_mode_toolbar_view.cc
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "brave/browser/brave_browser_features.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "content/public/browser/browser_context.h"
@@ -45,12 +44,6 @@ class Toolbar : public views::WebView {
 ReaderModeToolbarView::ReaderModeToolbarView(
     content::BrowserContext* browser_context) {
   SetBackground(views::CreateThemedSolidBackground(kColorToolbar));
-
-  if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
-    SetBorder(views::CreateThemedSolidSidedBorder(
-        gfx::Insets::TLBR(0, 0, 1, 0), kColorToolbarContentAreaSeparator));
-  }
-
   toolbar_ = std::make_unique<Toolbar>(browser_context);
   AddChildView(toolbar_.get());
 }

--- a/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/speedreader/speedreader_service_factory.h"
 #include "brave/browser/speedreader/speedreader_tab_helper.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -293,7 +294,7 @@ void SpeedreaderToolbarDataHandlerImpl::OnThemeChanged() {
   colors->foreground =
       color_provider->GetColor(kColorSpeedreaderToolbarForeground);
   colors->border = color_provider->GetColor(kColorSpeedreaderToolbarBorder);
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
     // The border is rendered in HTML. Hide the border by giving it the same
     // color as the background. When this feature flag is removed, consider
     // removing the border in HTML.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/34475

<img width="890" alt="Screenshot 2023-11-24 at 2 35 59 PM" src="https://github.com/brave/brave-core/assets/6786187/2e5d1886-8424-4bbf-b699-b696e600ecad">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable rounded corners feature
2. Re-launch and open inspector as a popup
3. Check popup doesn't have any padding for rounded corners