### PR TITLE
perf: reduce function declaration in wallet panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-hardware-wallet-panel/index.tsx
@@ -47,10 +47,18 @@ import {
 } from './style'
 
 export interface Props {
-  onCancel: (account: BraveWallet.AccountInfo) => void
   account: BraveWallet.AccountInfo
   hardwareWalletCode: HardwareWalletResponseCodeType | undefined
-  onClickInstructions: () => void
+}
+
+const onClickInstructions = () => {
+  const url = 'https://support.brave.com/hc/en-us/articles/4409309138701'
+
+  chrome.tabs.create({ url }, () => {
+    if (chrome.runtime.lastError) {
+      console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
+    }
+  })
 }
 
 function getAppName(coinType: BraveWallet.CoinType): string {
@@ -65,10 +73,8 @@ function getAppName(coinType: BraveWallet.CoinType): string {
 }
 
 export const ConnectHardwareWalletPanel = ({
-  onCancel,
   account,
-  hardwareWalletCode,
-  onClickInstructions
+  hardwareWalletCode
 }: Props) => {
   // redux
   const dispatch = useDispatch<ThunkDispatch<any, any, any>>()
@@ -128,8 +134,8 @@ export const ConnectHardwareWalletPanel = ({
 
   // methods
   const onCancelConnect = React.useCallback(() => {
-    onCancel(account)
-  }, [onCancel, account])
+    dispatch(PanelActions.cancelConnectHardwareWallet(account))
+  }, [account])
 
   const onSignData = React.useCallback(() => {
     if (!messageAccount || !request) {

--- a/components/brave_wallet_ui/components/extension/encryption-key-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/encryption-key-panel/index.tsx
@@ -4,6 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import { useDispatch } from 'react-redux'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
@@ -11,6 +12,7 @@ import { BraveWallet } from '../../../constants/types'
 // Utils
 import { reduceAccountDisplayName } from '../../../utils/reduce-account-name'
 import { getLocale, splitStringForTag } from '../../../../common/locale'
+import { PanelActions } from '../../../panel/actions'
 
 // Components
 import { NavButton } from '../buttons/nav-button/index'
@@ -37,12 +39,13 @@ import { useAccountQuery } from '../../../common/slices/api.slice.extra'
 
 export interface ProvidePubKeyPanelProps {
   payload: BraveWallet.GetEncryptionPublicKeyRequest
-  onProvide: (requestId: string) => void
-  onCancel: (requestId: string) => void
 }
 
-export function ProvidePubKeyPanel(props: ProvidePubKeyPanelProps) {
-  const { payload, onProvide: onProvideOrAllow, onCancel } = props
+export function ProvidePubKeyPanel({ payload }: ProvidePubKeyPanelProps) {
+  // redux
+  const dispatch = useDispatch()
+
+  // queries
   const { account } = useAccountQuery(payload.accountId)
 
   const orb = useAccountOrb(account)
@@ -52,6 +55,26 @@ export function ProvidePubKeyPanel(props: ProvidePubKeyPanelProps) {
   ).replace('$url', payload.originInfo.originSpec)
   const { duringTag, afterTag } = splitStringForTag(descriptionString)
 
+  // methods
+  const onProvideOrAllow = () => {
+    dispatch(
+      PanelActions.getEncryptionPublicKeyProcessed({
+        requestId: payload.requestId,
+        approved: true
+      })
+    )
+  }
+
+  const onCancel = (requestId: string) => {
+    dispatch(
+      PanelActions.getEncryptionPublicKeyProcessed({
+        requestId,
+        approved: false
+      })
+    )
+  }
+
+  // render
   return (
     <StyledWrapper>
       <AccountCircle orb={orb} />
@@ -85,7 +108,7 @@ export function ProvidePubKeyPanel(props: ProvidePubKeyPanelProps) {
         <NavButton
           buttonType='primary'
           text={getLocale('braveWalletProvideEncryptionKeyButton')}
-          onSubmit={() => onProvideOrAllow(payload.requestId)}
+          onSubmit={onProvideOrAllow}
         />
       </ButtonRow>
     </StyledWrapper>
@@ -94,17 +117,39 @@ export function ProvidePubKeyPanel(props: ProvidePubKeyPanelProps) {
 
 interface DecryptRequestPanelProps {
   payload: BraveWallet.DecryptRequest
-  onAllow: (requestId: string) => void
-  onCancel: (requestId: string) => void
 }
 
-export function DecryptRequestPanel(props: DecryptRequestPanelProps) {
-  const { payload, onAllow, onCancel } = props
+export function DecryptRequestPanel({ payload }: DecryptRequestPanelProps) {
+  // redux
+  const dispatch = useDispatch()
+
+  // state
   const [isDecrypted, setIsDecrypted] = React.useState<boolean>(false)
 
+  // queries
   const { account } = useAccountQuery(payload.accountId)
 
+  // custom hooks
   const orb = useAccountOrb(account)
+
+  // methods
+  const onAllow = () => {
+    dispatch(
+      PanelActions.decryptProcessed({
+        requestId: payload.requestId,
+        approved: true
+      })
+    )
+  }
+
+  const onCancel = () => {
+    dispatch(
+      PanelActions.decryptProcessed({
+        requestId: payload.requestId,
+        approved: false
+      })
+    )
+  }
 
   const onDecryptMessage = () => {
     setIsDecrypted(true)
@@ -144,12 +189,12 @@ export function DecryptRequestPanel(props: DecryptRequestPanelProps) {
         <NavButton
           buttonType='secondary'
           text={getLocale('braveWalletButtonCancel')}
-          onSubmit={() => onCancel(payload.requestId)}
+          onSubmit={onCancel}
         />
         <NavButton
           buttonType='primary'
           text={getLocale('braveWalletReadEncryptedMessageButton')}
-          onSubmit={() => onAllow(payload.requestId)}
+          onSubmit={onAllow}
         />
       </ButtonRow>
     </StyledWrapper>

--- a/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
@@ -64,7 +64,6 @@ import {
 
 interface Props {
   signMessageData: BraveWallet.SignMessageRequest[]
-  onCancel: () => void
   showWarning: boolean
 }
 
@@ -82,7 +81,7 @@ const onClickLearnMore = () => {
 }
 
 export const SignPanel = (props: Props) => {
-  const { signMessageData, onCancel, showWarning } = props
+  const { signMessageData, showWarning } = props
 
   // redux
   const dispatch = useDispatch()
@@ -111,9 +110,20 @@ export const SignPanel = (props: Props) => {
   const ethSIWETypedData = selectedQueueData.signData.ethSiweData
   const solanaSignTypedData = selectedQueueData.signData.solanaSignData
 
-  // memos
+  // methods
+  const onCancel = () => {
+    dispatch(
+      PanelActions.signMessageProcessed({
+        approved: false,
+        id: signMessageData[0].id
+      })
+    )
+  }
+
+  // custom hooks
   const orb = useAccountOrb(account)
 
+  // memos
   const signMessageQueueInfo = React.useMemo(() => {
     return {
       queueLength: signMessageData.length,

--- a/components/brave_wallet_ui/components/extension/sign-panel/sign-panel.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/sign-panel.stories.tsx
@@ -65,7 +65,6 @@ export const _SignPanel = () => {
   return (
     <WalletPageStory>
       <SignPanel
-        onCancel={() => alert('canceled')}
         showWarning={true}
         signMessageData={[evilUnicodeSignMessageData, signMessageData]}
       />

--- a/components/brave_wallet_ui/components/extension/welcome-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/welcome-panel/index.tsx
@@ -4,9 +4,11 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import { useDispatch } from 'react-redux'
 
 // utils
 import { getLocale } from '../../../../common/locale'
+import { PanelActions } from '../../../panel/actions'
 
 // components
 import { NavButton } from '../buttons/nav-button/index'
@@ -15,11 +17,16 @@ import { NavButton } from '../buttons/nav-button/index'
 import { VerticalSpace, WalletWelcomeGraphic } from '../../shared/style'
 import { StyledWrapper, Title, Description } from './style'
 
-interface Props {
-  onSetup: () => void
-}
+export const WelcomePanel = () => {
+  // redux
+  const dispatch = useDispatch()
 
-export const WelcomePanel = ({ onSetup }: Props) => {
+  // methods
+  const onSetup = () => {
+    dispatch(PanelActions.setupWallet())
+  }
+
+  // render
   return (
     <StyledWrapper>
       <WalletWelcomeGraphic scale={0.9} />

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -39,7 +39,6 @@ import {
 } from '../stories/style'
 import { PanelWrapper, WelcomePanelWrapper } from './style'
 
-import * as WalletPanelActions from './actions/wallet_panel_actions'
 import { BraveWallet, WalletRoutes } from '../constants/types'
 
 import {
@@ -53,7 +52,6 @@ import { ConfirmSolanaTransactionPanel } from '../components/extension/confirm-t
 import { ConfirmBitcoinTransactionPanel } from '../components/extension/confirm-transaction-panel/confirm-bitcoin-transaction-panel'
 import { ConfirmZCashTransactionPanel } from '../components/extension/confirm-transaction-panel/confirm_zcash_transaction_panel'
 import { SignTransactionPanel } from '../components/extension/sign-panel/sign-transaction-panel'
-import { useDispatch } from 'react-redux'
 import { ConfirmSwapTransaction } from '../components/extension/confirm-transaction-panel/swap'
 import { TransactionStatus } from '../components/extension/post-confirmation'
 import {
@@ -91,9 +89,6 @@ let hasInitializedRouter = false
 function Container() {
   // routing
   const history = useHistory()
-
-  // redux
-  const dispatch = useDispatch()
 
   // wallet selectors (safe)
   const hasInitialized = useSafeWalletSelector(WalletSelectors.hasInitialized)
@@ -152,105 +147,6 @@ function Container() {
   // bundle and display that loading indicator ASAP.
   const { selectedPendingTransaction } = usePendingTransactions()
 
-  const onSetup = () => {
-    dispatch(WalletPanelActions.setupWallet())
-  }
-
-  const onCancelSigning = () => {
-    dispatch(
-      WalletPanelActions.signMessageProcessed({
-        approved: false,
-        id: signMessageData[0].id
-      })
-    )
-  }
-
-  const onApproveAddNetwork = () => {
-    dispatch(
-      WalletPanelActions.addEthereumChainRequestCompleted({
-        chainId: addChainRequest.networkInfo.chainId,
-        approved: true
-      })
-    )
-  }
-
-  const onCancelAddNetwork = () => {
-    dispatch(
-      WalletPanelActions.addEthereumChainRequestCompleted({
-        chainId: addChainRequest.networkInfo.chainId,
-        approved: false
-      })
-    )
-  }
-
-  const onApproveChangeNetwork = () => {
-    dispatch(
-      WalletPanelActions.switchEthereumChainProcessed({
-        requestId: switchChainRequest.requestId,
-        approved: true
-      })
-    )
-  }
-
-  const onCancelChangeNetwork = () => {
-    dispatch(
-      WalletPanelActions.switchEthereumChainProcessed({
-        requestId: switchChainRequest.requestId,
-        approved: false
-      })
-    )
-  }
-
-  const onCancelConnectHardwareWallet = (account: BraveWallet.AccountInfo) => {
-    dispatch(WalletPanelActions.cancelConnectHardwareWallet(account))
-  }
-
-  const onClickInstructions = () => {
-    const url = 'https://support.brave.com/hc/en-us/articles/4409309138701'
-
-    chrome.tabs.create({ url }, () => {
-      if (chrome.runtime.lastError) {
-        console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
-      }
-    })
-  }
-
-  const onProvideEncryptionKey = (requestId: string) => {
-    dispatch(
-      WalletPanelActions.getEncryptionPublicKeyProcessed({
-        requestId,
-        approved: true
-      })
-    )
-  }
-
-  const onCancelProvideEncryptionKey = (requestId: string) => {
-    dispatch(
-      WalletPanelActions.getEncryptionPublicKeyProcessed({
-        requestId,
-        approved: false
-      })
-    )
-  }
-
-  const onAllowReadingEncryptedMessage = (requestId: string) => {
-    dispatch(
-      WalletPanelActions.decryptProcessed({
-        requestId,
-        approved: true
-      })
-    )
-  }
-
-  const onCancelAllowReadingEncryptedMessage = (requestId: string) => {
-    dispatch(
-      WalletPanelActions.decryptProcessed({
-        requestId,
-        approved: false
-      })
-    )
-  }
-
   const canInitializePageRouter =
     !isWalletLocked &&
     !hasInitializedRouter &&
@@ -273,7 +169,7 @@ function Container() {
     return (
       <WelcomePanelWrapper>
         <LongWrapper>
-          <WelcomePanel onSetup={onSetup} />
+          <WelcomePanel />
         </LongWrapper>
       </WelcomePanelWrapper>
     )
@@ -309,10 +205,8 @@ function Container() {
       <PanelWrapper isLonger={false}>
         <StyledExtensionWrapper>
           <ConnectHardwareWalletPanel
-            onCancel={onCancelConnectHardwareWallet}
             account={selectedAccount}
             hardwareWalletCode={hardwareWalletCode}
-            onClickInstructions={onClickInstructions}
           />
         </StyledExtensionWrapper>
       </PanelWrapper>
@@ -374,9 +268,6 @@ function Container() {
         <LongWrapper>
           <AllowAddChangeNetworkPanel
             originInfo={addChainRequest.originInfo}
-            onApproveAddNetwork={onApproveAddNetwork}
-            onApproveChangeNetwork={onApproveChangeNetwork}
-            onCancel={onCancelAddNetwork}
             networkPayload={addChainRequest.networkInfo}
             panelType='add'
           />
@@ -391,9 +282,6 @@ function Container() {
         <LongWrapper>
           <AllowAddChangeNetworkPanel
             originInfo={switchChainRequest.originInfo}
-            onApproveAddNetwork={onApproveAddNetwork}
-            onApproveChangeNetwork={onApproveChangeNetwork}
-            onCancel={onCancelChangeNetwork}
             networkPayload={switchChainRequestNetwork}
             panelType='change'
           />
@@ -416,7 +304,6 @@ function Container() {
         <LongWrapper>
           <SignPanel
             signMessageData={signMessageData}
-            onCancel={onCancelSigning}
             // Pass a boolean here if the signing method is risky
             showWarning={false}
           />
@@ -449,11 +336,7 @@ function Container() {
     return (
       <PanelWrapper isLonger={true}>
         <LongWrapper>
-          <ProvidePubKeyPanel
-            payload={getEncryptionPublicKeyRequest}
-            onCancel={onCancelProvideEncryptionKey}
-            onProvide={onProvideEncryptionKey}
-          />
+          <ProvidePubKeyPanel payload={getEncryptionPublicKeyRequest} />
         </LongWrapper>
       </PanelWrapper>
     )
@@ -463,11 +346,7 @@ function Container() {
     return (
       <PanelWrapper isLonger={true}>
         <LongWrapper>
-          <DecryptRequestPanel
-            payload={decryptRequest}
-            onCancel={onCancelAllowReadingEncryptedMessage}
-            onAllow={onAllowReadingEncryptedMessage}
-          />
+          <DecryptRequestPanel payload={decryptRequest} />
         </LongWrapper>
       </PanelWrapper>
     )

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -469,22 +469,11 @@ _ConfirmErcApproveTransaction.story = {
 }
 
 export const _AllowAddChangeNetwork = () => {
-  const onApprove = () => {
-    alert('Will Approve adding or chainging networks')
-  }
-
-  const onCancel = () => {
-    alert('Canceled Adding Network')
-  }
-
   return (
     <StyledExtensionWrapperLonger>
       <AllowAddChangeNetworkPanel
         originInfo={originInfo}
         panelType='change'
-        onApproveAddNetwork={onApprove}
-        onApproveChangeNetwork={onApprove}
-        onCancel={onCancel}
         networkPayload={mockNetworks[0]}
       />
     </StyledExtensionWrapperLonger>
@@ -496,10 +485,6 @@ _AllowAddChangeNetwork.story = {
 }
 
 export const _SignData = () => {
-  const onCancel = () => {
-    alert('Canceled Signing Data')
-  }
-
   const signMessageDataPayload: BraveWallet.SignMessageRequest[] = [
     {
       id: 0,
@@ -527,7 +512,6 @@ export const _SignData = () => {
     <StyledExtensionWrapperLonger>
       <SignPanel
         signMessageData={signMessageDataPayload}
-        onCancel={onCancel}
         showWarning={true}
       />
     </StyledExtensionWrapperLonger>
@@ -539,21 +523,9 @@ _SignData.story = {
 }
 
 export const _ProvideEncryptionKey = () => {
-  const onProvide = () => {
-    alert('Will Provide Encryption Key')
-  }
-
-  const onCancel = () => {
-    alert('Will Cancel Providing Encryption Key')
-  }
-
   return (
     <StyledExtensionWrapperLonger>
-      <ProvidePubKeyPanel
-        payload={mockEncryptionKeyRequest}
-        onCancel={onCancel}
-        onProvide={onProvide}
-      />
+      <ProvidePubKeyPanel payload={mockEncryptionKeyRequest} />
     </StyledExtensionWrapperLonger>
   )
 }
@@ -563,21 +535,9 @@ _ProvideEncryptionKey.story = {
 }
 
 export const _ReadEncryptedMessage = () => {
-  const onAllow = () => {
-    alert('Will Allow Reading Encrypted Message')
-  }
-
-  const onCancel = () => {
-    alert('Will Not Allow Reading Encrypted Message')
-  }
-
   return (
     <StyledExtensionWrapperLonger>
-      <DecryptRequestPanel
-        payload={mockDecryptRequest}
-        onCancel={onCancel}
-        onAllow={onAllow}
-      />
+      <DecryptRequestPanel payload={mockDecryptRequest} />
     </StyledExtensionWrapperLonger>
   )
 }
@@ -604,13 +564,9 @@ _ConnectWithSite.story = {
 }
 
 export const _SetupWallet = () => {
-  const onSetup = () => {
-    alert('Will navigate to full wallet onboarding page')
-  }
-
   return (
     <StyledWelcomPanel>
-      <WelcomePanel onSetup={onSetup} />
+      <WelcomePanel />
     </StyledWelcomPanel>
   )
 }
@@ -620,25 +576,10 @@ _SetupWallet.story = {
 }
 
 export const _ConnectHardwareWallet = () => {
-  const onCancel = (account: BraveWallet.AccountInfo) => {
-    // Doesn't do anything in storybook
-  }
-
-  const onClickInstructions = () => {
-    // Open support link in new tab
-    window.open(
-      'https://support.brave.com/hc/en-us/articles/4409309138701',
-      '_blank',
-      'noreferrer'
-    )
-  }
-
   return (
     <StyledExtensionWrapper>
       <ConnectHardwareWalletPanel
         account={{ ...mockAccounts[0], name: 'Ledger 1' }}
-        onCancel={onCancel}
-        onClickInstructions={onClickInstructions}
         hardwareWalletCode={undefined}
       />
     </StyledExtensionWrapper>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34568

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The following Wallet panels should continue to work without regressions:
- Add Network
- Change network
- Connect hardware Wallet
- ProvidePubKeyPanel (encryption key panel)
- Sign Panel
- "Welcome" panel
