### PR TITLE
Apply contents rounded corners to normal window only (uplift to 1.61.x)

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/lifetime/browser_close_manager.h"
@@ -36,6 +37,12 @@ bool g_suppress_dialog_for_testing = false;
 // static
 void BraveBrowser::SuppressBrowserWindowClosingDialogForTesting(bool suppress) {
   g_suppress_dialog_for_testing = suppress;
+}
+
+// static
+bool BraveBrowser::ShouldUseBraveWebViewRoundedCorners(Browser* browser) {
+  return base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners) &&
+         browser->is_type_normal();
 }
 
 BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -30,6 +30,8 @@ class BraveBrowser : public Browser {
   BraveBrowser(const BraveBrowser&) = delete;
   BraveBrowser& operator=(const BraveBrowser&) = delete;
 
+  static bool ShouldUseBraveWebViewRoundedCorners(Browser* browser);
+
   // Browser overrides:
   void ScheduleUIUpdate(content::WebContents* source,
                         unsigned changed_flags) override;

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -15,7 +15,6 @@
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
-#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/sparkle_buildflags.h"
 #include "brave/browser/translate/brave_translate_utils.h"
@@ -196,7 +195,7 @@ class BraveBrowserView::TabCyclingEventHandler : public ui::EventObserver,
 
 BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
     : BrowserView(std::move(browser)) {
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
     // Collapse the separator line between the toolbar or bookmark bar and the
     // views below.
     contents_separator_->SetPreferredSize(gfx::Size());
@@ -248,7 +247,7 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
             std::move(original_side_panel)));
     unified_side_panel_ = sidebar_container_view_->side_panel();
 
-    if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
       sidebar_separator_view_ =
           AddChildView(std::make_unique<SidebarSeparator>());
     }
@@ -435,6 +434,10 @@ void BraveBrowserView::ShowReaderModeToolbar() {
   if (!reader_mode_toolbar_view_) {
     reader_mode_toolbar_view_ =
         std::make_unique<ReaderModeToolbarView>(GetProfile());
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
+      SetBorder(views::CreateThemedSolidSidedBorder(
+          gfx::Insets::TLBR(0, 0, 1, 0), kColorToolbarContentAreaSeparator));
+    }
     AddChildView(reader_mode_toolbar_view_.get());
     GetBrowserViewLayout()->set_reader_mode_toolbar(
         reader_mode_toolbar_view_.get());
@@ -728,7 +731,7 @@ BraveBrowser* BraveBrowserView::GetBraveBrowser() const {
 }
 
 void BraveBrowserView::UpdateWebViewRoundedCorners() {
-  if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())) {
     return;
   }
 

--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <limits>
 
-#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
@@ -292,7 +292,8 @@ void BraveBrowserViewLayout::LayoutReaderModeToolbar(
 }
 
 gfx::Insets BraveBrowserViewLayout::GetContentsMargins() const {
-  if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+          browser_view_->browser())) {
     return {};
   }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "brave/app/vector_icons/vector_icons.h"
-#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -1159,7 +1158,7 @@ void VerticalTabStripRegionView::UpdateBorder() {
       return false;
     }
 
-    if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
       return true;
     }
 

--- a/browser/ui/views/side_panel/brave_side_panel.cc
+++ b/browser/ui/views/side_panel/brave_side_panel.cc
@@ -7,7 +7,7 @@
 
 #include "base/functional/bind.h"
 #include "base/ranges/algorithm.h"
-#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
@@ -34,7 +34,8 @@ BraveSidePanel::BraveSidePanel(BrowserView* browser_view,
   OnSidePanelWidthChanged();
   AddObserver(this);
 
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+          browser_view_->browser())) {
     shadow_ = BraveContentsViewUtil::CreateShadow(this);
     SetBackground(
         views::CreateThemedSolidBackground(kColorSidebarPanelHeaderBackground));
@@ -59,7 +60,8 @@ bool BraveSidePanel::IsRightAligned() {
 }
 
 void BraveSidePanel::UpdateBorder() {
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+          browser_view_->browser())) {
     // Use a negative top border to hide the separator inserted by the upstream
     // side panel implementation.
     SetBorder(views::CreateEmptyBorder(gfx::Insets::TLBR(-1, 0, 0, 0)));

--- a/browser/ui/views/sidebar/sidebar_control_view.cc
+++ b/browser/ui/views/sidebar/sidebar_control_view.cc
@@ -6,7 +6,6 @@
 #include "brave/browser/ui/views/sidebar/sidebar_control_view.h"
 
 #include "brave/app/brave_command_ids.h"
-#include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
@@ -87,7 +86,7 @@ void SidebarControlView::UpdateBackgroundAndBorder() {
   if (const ui::ColorProvider* color_provider = GetColorProvider()) {
     SetBackground(
         views::CreateSolidBackground(color_provider->GetColor(kColorToolbar)));
-    if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+    if (!BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
       constexpr int kBorderThickness = 1;
       SetBorder(views::CreateSolidSidedBorder(
           gfx::Insets::TLBR(0, sidebar_on_left_ ? 0 : kBorderThickness, 0,

--- a/browser/ui/views/speedreader/reader_mode_toolbar_view.cc
+++ b/browser/ui/views/speedreader/reader_mode_toolbar_view.cc
@@ -7,7 +7,6 @@
 
 #include <memory>
 
-#include "brave/browser/brave_browser_features.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "content/public/browser/browser_context.h"
@@ -45,12 +44,6 @@ class Toolbar : public views::WebView {
 ReaderModeToolbarView::ReaderModeToolbarView(
     content::BrowserContext* browser_context) {
   SetBackground(views::CreateThemedSolidBackground(kColorToolbar));
-
-  if (!base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
-    SetBorder(views::CreateThemedSolidSidedBorder(
-        gfx::Insets::TLBR(0, 0, 1, 0), kColorToolbarContentAreaSeparator));
-  }
-
   toolbar_ = std::make_unique<Toolbar>(browser_context);
   AddChildView(toolbar_.get());
 }

--- a/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/speedreader/speedreader_service_factory.h"
 #include "brave/browser/speedreader/speedreader_tab_helper.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/ai_chat/common/buildflags/buildflags.h"
@@ -302,7 +303,7 @@ void SpeedreaderToolbarDataHandlerImpl::OnThemeChanged() {
   colors->foreground =
       color_provider->GetColor(kColorSpeedreaderToolbarForeground);
   colors->border = color_provider->GetColor(kColorSpeedreaderToolbarBorder);
-  if (base::FeatureList::IsEnabled(features::kBraveWebViewRoundedCorners)) {
+  if (BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_)) {
     // The border is rendered in HTML. Hide the border by giving it the same
     // color as the background. When this feature flag is removed, consider
     // removing the border in HTML.


### PR DESCRIPTION
Uplift of #21108
fix https://github.com/brave/brave-browser/issues/34475

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.