### PR TITLE
Revert ffmpeg to acb78dc0f416f6ef009192d94dc07c05effabfda

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -130,6 +130,11 @@ hooks = [
                '--source-dir', '.',
                '--filter', '^[0-9]\{{1,\}}\.[0-9]\{{1,\}}\.[0-9]\{{1,\}}$'],
   },
+  {
+    'name': 'patch_ffmpeg',
+    'pattern': '.',
+    'action': ['vpython3', 'script/patch_ffmpeg.py'],
+  },
 ]
 
 include_rules = [

--- a/script/patch_ffmpeg.py
+++ b/script/patch_ffmpeg.py
@@ -27,7 +27,6 @@ def main():
     current_rev = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
                                           cwd=FFMPEG_DIR,
                                           universal_newlines=True).rstrip()
-    print(current_rev)
 
     if current_rev == STABLE_REVISION:
         return 0

--- a/script/patch_ffmpeg.py
+++ b/script/patch_ffmpeg.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env vpython3
+
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+A temporary fix for FFMpeg perf bug:
+https://github.com/brave/brave-browser/issues/34639
+
+The script re-checkouts the good ffmpeg revision used in CR119.
+Consider removing after FFMpeg is updated.
+"""
+
+import os
+import sys
+import subprocess
+
+from lib.config import SOURCE_ROOT
+
+FFMPEG_DIR = os.path.join(SOURCE_ROOT, '..', 'third_party', 'ffmpeg')
+STABLE_REVISION = 'acb78dc0f416f6ef009192d94dc07c05effabfda'
+BAD_REVISION = 'e1ca3f06adec15150a171bc38f550058b4bbb23b'
+
+
+def main():
+    current_rev = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+                                          cwd=FFMPEG_DIR,
+                                          universal_newlines=True).rstrip()
+    print(current_rev)
+
+    if current_rev == STABLE_REVISION:
+        return 0
+
+    # FFMpeg is updated. The perf bug is probably fixed.
+    # Consider removing this file.
+    assert current_rev == BAD_REVISION
+
+    subprocess.check_call(['git', 'checkout', '--force', STABLE_REVISION],
+                          cwd=FFMPEG_DIR)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34639

<img width="1176" alt="Screenshot 2023-11-30 at 18 22 39" src="https://github.com/brave/brave-core/assets/45488748/94533be7-7732-41de-a257-c29d43ffd764">

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

