### PR TITLE
fix(wallet): Wallet Settings Link Route

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
@@ -33,6 +33,7 @@ import { CreateAccountOptions } from '../../../options/nav-options'
 // utils
 import { getLocale } from '../../../../common/locale'
 import { useGetSelectedChainQuery } from '../../../common/slices/api.slice'
+import { openWalletSettings } from '../../../utils/routes-utils'
 
 // Styled Components
 import {
@@ -115,11 +116,7 @@ export const DefaultPanelMenu = (props: Props) => {
   }, [onClosePopup])
 
   const onClickSettings = React.useCallback(() => {
-    chrome.tabs.create({ url: 'chrome://settings/wallet' }, () => {
-      if (chrome.runtime.lastError) {
-        console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
-      }
-    })
+    openWalletSettings()
     if (onClosePopup) {
       onClosePopup()
     }

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wallet-settings-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wallet-settings-menu.tsx
@@ -15,6 +15,7 @@ import { WalletActions } from '../../../common/actions'
 // utils
 import { getLocale } from '../../../../common/locale'
 import { useGetSelectedChainQuery } from '../../../common/slices/api.slice'
+import { openWalletSettings } from '../../../utils/routes-utils'
 
 // Styled Components
 import {
@@ -84,11 +85,7 @@ export const WalletSettingsMenu = (props: Props) => {
   }, [onClosePopup])
 
   const onClickSettings = React.useCallback(() => {
-    chrome.tabs.create({ url: 'chrome://settings/wallet' }, () => {
-      if (chrome.runtime.lastError) {
-        console.error('tabs.create failed: ' + chrome.runtime.lastError.message)
-      }
-    })
+    openWalletSettings()
     if (onClosePopup) {
       onClosePopup()
     }

--- a/components/brave_wallet_ui/utils/routes-utils.ts
+++ b/components/brave_wallet_ui/utils/routes-utils.ts
@@ -197,7 +197,7 @@ export const openWalletRouteTab = (route: WalletRoutes) => {
 
 // Settings tabs
 export function openWalletSettings() {
-  openTab('chrome://settings/wallet')
+  openTab('chrome://settings/web3')
 }
 
 export function openNetworkSettings() {


### PR DESCRIPTION
## Description 
Wallet `Settings` button now directs to brave://settings/web3 instead of brave://settings/wallet

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/34647>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Go to the `Wallet` and open the `Wallet Menu` and click on `Settings`
   2. You should be directed to brave://settings/web3

Before:

https://github.com/brave/brave-core/assets/40611140/bbc6c478-592a-4487-a747-ec875ac10d19

After:

https://github.com/brave/brave-core/assets/40611140/6b553a7b-c392-4a93-a8ba-f7c545d59b7e
