### PR TITLE
Fixed crash accessing 'send to devices' in share menu via Sync (uplift to 1.62.x)

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -646,6 +646,7 @@
 
 -keep class org.chromium.chrome.browser.share.send_tab_to_self.ManageAccountDevicesLinkView {
     public <init>(...);
+    *** getSharingAccountInfo(...);
 }
 
 -keep class org.chromium.chrome.browser.share.send_tab_to_self.BraveManageAccountDevicesLinkView {

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -131,6 +131,7 @@ import org.chromium.components.favicon.LargeIconBridge;
 import org.chromium.components.omnibox.AutocompleteMatch;
 import org.chromium.components.omnibox.action.OmniboxActionDelegate;
 import org.chromium.components.permissions.PermissionDialogController;
+import org.chromium.components.signin.base.AccountInfo;
 import org.chromium.content_public.browser.BrowserContextHandle;
 import org.chromium.ui.ViewProvider;
 import org.chromium.ui.base.ActivityWindowAndroid;
@@ -560,6 +561,13 @@ public class BytecodeTest {
                         "calculateButtonData",
                         true,
                         void.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/share/"
+                                + "send_tab_to_self/ManageAccountDevicesLinkView",
+                        "getSharingAccountInfo",
+                        true,
+                        AccountInfo.class));
     }
 
     @Test

--- a/browser/share/android/java/src/org/chromium/chrome/browser/share/send_tab_to_self/BraveManageAccountDevicesLinkView.java
+++ b/browser/share/android/java/src/org/chromium/chrome/browser/share/send_tab_to_self/BraveManageAccountDevicesLinkView.java
@@ -10,10 +10,25 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.widget.LinearLayout;
 
+import org.chromium.components.signin.base.AccountCapabilities;
+import org.chromium.components.signin.base.AccountInfo;
+import org.chromium.components.signin.base.CoreAccountId;
+
 public class BraveManageAccountDevicesLinkView extends LinearLayout {
     public BraveManageAccountDevicesLinkView(Context context, AttributeSet attrs) {
         super(context, attrs);
 
         setVisibility(View.GONE);
+    }
+
+    public static AccountInfo getSharingAccountInfo() {
+        return new AccountInfo(
+                new CoreAccountId(""),
+                "",
+                "",
+                null,
+                null,
+                null,
+                new AccountCapabilities(new String[0], new boolean[0]));
     }
 }

--- a/build/android/bytecode/java/org/brave/bytecode/BraveManageAccountDevicesLinkViewClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveManageAccountDevicesLinkViewClassAdapter.java
@@ -17,5 +17,10 @@ public class BraveManageAccountDevicesLinkViewClassAdapter extends BraveClassVis
         super(visitor);
 
         changeSuperName(sManageAccountDevicesLinkView, sBraveManageAccountDevicesLinkView);
+
+        changeMethodOwner(
+                sManageAccountDevicesLinkView,
+                "getSharingAccountInfo",
+                sBraveManageAccountDevicesLinkView);
     }
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1286,6 +1286,7 @@ if (is_android) {
       "//components/password_manager/core/browser:password_manager_java_enums",
       "//components/permissions/android:java",
       "//components/search_engines/android:java",
+      "//components/signin/public/android:java",
       "//components/sync/android:sync_java",
       "//components/variations/android:variations_java",
       "//content/public/android:content_full_java",


### PR DESCRIPTION
Uplift of #21168
Resolves https://github.com/brave/brave-browser/issues/34636

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.