### PR TITLE
Expose APIs that allow better indication of when a premium user is rate limited

### DIFF
--- a/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoCMHelper.java
+++ b/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoCMHelper.java
@@ -63,7 +63,7 @@ public class BraveLeoCMHelper implements ConnectionErrorHandler {
 
     public void getPremiumStatus(CredentialManagerHelper.GetPremiumStatus_Response callback) {
         if (mCredentialManagerHelper == null) {
-            callback.call(PremiumStatus.INACTIVE);
+            callback.call(PremiumStatus.INACTIVE, null);
             return;
         }
         mCredentialManagerHelper.getPremiumStatus(callback);

--- a/android/java/org/chromium/chrome/browser/settings/BraveLeoPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveLeoPreferences.java
@@ -44,7 +44,7 @@ public class BraveLeoPreferences extends BravePreferenceFragment {
     private void checkLinkPurchase() {
         BraveLeoCMHelper.getInstance(getProfile())
                 .getPremiumStatus(
-                        status -> {
+                        (status, info) -> {
                             if (status == PremiumStatus.ACTIVE
                                     || !BraveLeoPrefUtils.getIsSubscriptionActive(getProfile())) {
                                 return;

--- a/browser/ai_chat/android/ai_chat_cm_helper_android.cc
+++ b/browser/ai_chat/android/ai_chat_cm_helper_android.cc
@@ -60,8 +60,9 @@ void AIChatCMHelperAndroid::GetPremiumStatus(
 
 void AIChatCMHelperAndroid::OnPremiumStatusReceived(
     mojom::PageHandler::GetPremiumStatusCallback parent_callback,
-    mojom::PremiumStatus premium_status) {
-  std::move(parent_callback).Run(premium_status);
+    mojom::PremiumStatus premium_status,
+    mojom::PremiumInfoPtr premium_info) {
+  std::move(parent_callback).Run(premium_status, std::move(premium_info));
 }
 
 }  // namespace ai_chat

--- a/browser/ai_chat/android/ai_chat_cm_helper_android.h
+++ b/browser/ai_chat/android/ai_chat_cm_helper_android.h
@@ -31,7 +31,8 @@ class AIChatCMHelperAndroid : public mojom::CredentialManagerHelper {
  private:
   void OnPremiumStatusReceived(
       mojom::PageHandler::GetPremiumStatusCallback parent_callback,
-      mojom::PremiumStatus premium_status);
+      mojom::PremiumStatus premium_status,
+      mojom::PremiumInfoPtr premium_info);
   std::unique_ptr<AIChatCredentialManager> credential_manager_;
   mojo::ReceiverSet<mojom::CredentialManagerHelper> receivers_;
   base::WeakPtrFactory<AIChatCMHelperAndroid> weak_ptr_factory_{this};

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -389,7 +389,7 @@ void AIChatUIPageHandler::OnVisibilityChanged(content::Visibility visibility) {
 void AIChatUIPageHandler::GetPremiumStatus(GetPremiumStatusCallback callback) {
   if (!active_chat_tab_helper_) {
     VLOG(2) << "Chat tab helper is not set";
-    std::move(callback).Run(mojom::PremiumStatus::Inactive);
+    std::move(callback).Run(mojom::PremiumStatus::Inactive, nullptr);
     return;
   }
 
@@ -402,9 +402,10 @@ void AIChatUIPageHandler::GetPremiumStatus(GetPremiumStatusCallback callback) {
 
 void AIChatUIPageHandler::OnGetPremiumStatus(
     GetPremiumStatusCallback callback,
-    ai_chat::mojom::PremiumStatus status) {
+    ai_chat::mojom::PremiumStatus status,
+    ai_chat::mojom::PremiumInfoPtr info) {
   if (page_.is_bound()) {
-    std::move(callback).Run(status);
+    std::move(callback).Run(status, std::move(info));
   }
 }
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -101,7 +101,8 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   void GetFaviconImageData(GetFaviconImageDataCallback callback) override;
 
   void OnGetPremiumStatus(GetPremiumStatusCallback callback,
-                          ai_chat::mojom::PremiumStatus status);
+                          ai_chat::mojom::PremiumStatus status,
+                          ai_chat::mojom::PremiumInfoPtr info);
 
   mojo::Remote<ai_chat::mojom::ChatUIPage> page_;
 

--- a/components/ai_chat/core/browser/ai_chat_credential_manager.h
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager.h
@@ -39,8 +39,7 @@ class AIChatCredentialManager {
   AIChatCredentialManager& operator=(const AIChatCredentialManager&) = delete;
   ~AIChatCredentialManager();
 
-  void GetPremiumStatus(
-      ai_chat::mojom::PageHandler::GetPremiumStatusCallback callback);
+  void GetPremiumStatus(mojom::PageHandler::GetPremiumStatusCallback callback);
 
   void FetchPremiumCredential(
       base::OnceCallback<void(std::optional<CredentialCacheEntry> credential)>
@@ -54,14 +53,16 @@ class AIChatCredentialManager {
   void OnMojoConnectionError();
 
   void OnCredentialSummary(
-      ai_chat::mojom::PageHandler::GetPremiumStatusCallback callback,
+      mojom::PageHandler::GetPremiumStatusCallback callback,
       const std::string& domain,
+      const bool credential_in_cache,
       const std::string& summary_string);
 
   void OnGetPremiumStatus(
       base::OnceCallback<void(std::optional<CredentialCacheEntry> credential)>
           callback,
-      ai_chat::mojom::PremiumStatus);
+      mojom::PremiumStatus,
+      mojom::PremiumInfoPtr);
 
   void OnPrepareCredentialsPresentation(
       base::OnceCallback<void(std::optional<CredentialCacheEntry> credential)>

--- a/components/ai_chat/core/browser/ai_chat_credential_manager_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager_unittest.cc
@@ -7,10 +7,15 @@
 
 #include <memory>
 #include <optional>
+#include <utility>
+#include <vector>
 
+#include "base/i18n/time_formatting.h"
 #include "base/json/values_util.h"
+#include "base/strings/stringprintf.h"
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
+#include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/skus/browser/pref_names.h"
@@ -25,20 +30,128 @@
 #include "services/network/test/test_url_loader_factory.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
+namespace {
+
+constexpr char kSkusStateValueTemplate[] = R"({
+  "credentials": {
+    "items": {
+      "b7114ccc-b3a5-4951-9a5d-8b7a28731111": {
+        "creds": [
+          "fbdoW1uxsxUuQrPBrk20jS7BdyfOEh8NJHLcVhutzkgaJ8UcKyMw/nkOaMXTsme5XSW/uxJ0H+H14996nBEpYXgJJBYJrBlpL8gmQGgwQA2hbKZDBIwS+5fpU5Yo5RkG",
+          "v2X4t5GuttVpz/oEx+jAxI66e+qFBSAD5VvoD8W7l+/vUX4mOODwizoilNDQ8zW3UKjHgevuInJNA+fmNQTbFQELvrhfSlkDBW/NBbMXW9JlPZcv4RIBL+SFuz3TTLAH"
+        ],
+        "item_id": "b7114ccc-b3a5-4951-9a5d-8b7a28731111",
+        "state": "ActiveCredentials",
+        "type": "time-limited-v2",
+        "unblinded_creds": [
+          {
+            "issuer_id": "bfd1ad9e-e9cf-4c46-96d7-7350c52de34f",
+            "unblinded_creds": [
+              {
+                "spent": false,
+                "unblinded_cred": "e0ysOdVNd7ZMBhW8m+aZLAROZjRQosITScYvJ1StwOsjyENfroQZ/6BOdGSKSTlSc/Yhz0L+p/pemStozGDHsoIsDfYpGXxTX/aODh6TCZWOORXPSy6t5+h5iJajRakb"
+              },
+              {
+                "spent": false,
+                "unblinded_cred": "iUgmZwALkPgGmKOyjkf13edV1rpMuuPcePhFIPTCuzR9Vqt3kxmhfAXXUrvF+zFaCb8n5AbeUeeXD2lzNCN6tDKf1OYAWQjDA173p+pVZ7kF8tGa5lSR1pd4YccWQn4O"
+              }
+            ],
+            "valid_from": "$1",
+            "valid_to": "$2"
+          },
+          {
+            "issuer_id": "bfd1ad9e-e9cf-4c46-96d7-7350c52de34f",
+            "unblinded_creds": [
+              {
+                "spent": false,
+                "unblinded_cred": "T3WTO/6P7TeHk7BWPuWDpjc9mSZSWGwvdtYxhSNvWRSg4u+P4UkHDYakdOJxelW338UqconXonwDhp9CIkM0iXRVUN6QzBa55HkB+HKJlEbKcrKbrilYP+PcSxVChHYl"
+              },
+              {
+                "spent": false,
+                "unblinded_cred": "UTvHRpo0ySNO4wv59E/h64AvArHkJ7sWvNAL4KadBre/kBKNCNTTB183/DWWgWgwmDG1YkqfTZb2T32wpnOe+OjXjBxx1/z68b5BMWMcXfKsfpAlGPGG2cZ4FrPQTiB2"
+              }
+            ],
+            "valid_from": "$3",
+            "valid_to": "$4"
+          }
+        ]
+      }
+    }
+  },
+  "orders": {
+    "e24787ab-7bc3-46b9-bc05-65befb361111": {
+      "created_at": "$1",
+      "currency": "USD",
+      "expires_at": "$5",
+      "id": "e24787ab-7bc3-46b9-bc05-65befb361111",
+      "items": [
+        {
+          "created_at": "$1",
+          "credential_type": "time-limited-v2",
+          "currency": "USD",
+          "description": "brave-leo-premium",
+          "id": "b7114ccc-b3a5-4951-9a5d-8b7a28731111",
+          "location": "leo.brave.com",
+          "order_id": "e24787ab-7bc3-46b9-bc05-65befb361111",
+          "price": 15,
+          "quantity": 1,
+          "sku": "brave-leo-premium",
+          "subtotal": 15,
+          "updated_at": "$1"
+        }
+      ],
+      "last_paid_at": "$1",
+      "location": "leo.brave.com",
+      "merchant_id": "brave.com",
+      "metadata": {
+        "num_intervals": 3,
+        "num_per_interval": 192,
+        "payment_processor": "stripe",
+        "stripe_checkout_session_id": "cs_live_b1lZu8rs8O0CvxymIK5W0zeEVhaYqq6H5SvXMwAkkv5PDxiN4g2cSGlCNH"
+      },
+      "status": "paid",
+      "total_price": 15,
+      "updated_at": "$1"
+    }
+  },
+  "promotions": null,
+  "wallet": null
+})";
+
+std::string formatSkusStateValue(const base::Time start_time,
+                                 int shift_days = 0) {
+  std::vector<std::string> replacements;
+  base::Time shifted_start_time = start_time + base::Days(shift_days);
+  for (int i = 0; i < 5; ++i) {
+    base::Time incremented_time = shifted_start_time + base::Days(i);
+    base::Time::Exploded exploded;
+    incremented_time.UTCExplode(&exploded);
+    std::string formatted_time = base::StringPrintf(
+        "%04d-%02d-%02dT%02d:%02d:%02d", exploded.year, exploded.month,
+        exploded.day_of_month, exploded.hour, exploded.minute, exploded.second);
+
+    replacements.push_back(formatted_time);
+  }
+
+  const std::string result = base::ReplaceStringPlaceholders(
+      kSkusStateValueTemplate, replacements, nullptr);
+  return result;
+}
+
+}  // namespace
+
 namespace ai_chat {
 
 class AIChatCredentialManagerUnitTest : public testing::Test {
  public:
-  AIChatCredentialManagerUnitTest()
-      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME) {
+  AIChatCredentialManagerUnitTest() {
     scoped_feature_list_.InitWithFeatures({skus::features::kSkusFeature}, {});
   }
 
   void SetUp() override {
     auto* registry = prefs_service_.registry();
-    ai_chat::prefs::RegisterLocalStatePrefs(registry);
+    prefs::RegisterLocalStatePrefs(registry);
     skus::RegisterLocalStatePrefs(registry);
-
     shared_url_loader_factory_ =
         base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
             &url_loader_factory_);
@@ -59,11 +172,26 @@ class AIChatCredentialManagerUnitTest : public testing::Test {
         ->MakeRemote();
   }
 
-  void TestGetPremiumStatus(ai_chat::mojom::PremiumStatus expected_status) {
+  void TestGetPremiumStatus(mojom::PremiumStatus expected_status,
+                            mojom::PremiumInfoPtr expected_info) {
     base::RunLoop run_loop;
-    ai_chat_credential_manager_->GetPremiumStatus(
-        base::BindLambdaForTesting([&](ai_chat::mojom::PremiumStatus status) {
+    ai_chat_credential_manager_->GetPremiumStatus(base::BindLambdaForTesting(
+        [&](mojom::PremiumStatus status, mojom::PremiumInfoPtr info) {
           EXPECT_EQ(status, expected_status);
+          if (expected_info) {
+            ASSERT_TRUE(info);
+            EXPECT_EQ(info->remaining_credential_count,
+                      expected_info->remaining_credential_count);
+
+            if (expected_info->next_active_at) {
+              ASSERT_TRUE(info->next_active_at);
+              EXPECT_EQ(info->next_active_at, expected_info->next_active_at);
+            } else {
+              EXPECT_FALSE(info->next_active_at);
+            }
+          } else {
+            ASSERT_FALSE(info);
+          }
           run_loop.Quit();
         }));
     run_loop.Run();
@@ -88,6 +216,8 @@ class AIChatCredentialManagerUnitTest : public testing::Test {
     run_loop.Run();
   }
 
+  PrefService* prefs() { return &prefs_service_; }
+
  protected:
   content::BrowserTaskEnvironment task_environment_;
   TestingPrefServiceSimple prefs_service_;
@@ -100,9 +230,8 @@ class AIChatCredentialManagerUnitTest : public testing::Test {
 
 TEST_F(AIChatCredentialManagerUnitTest, CacheDefault) {
   // Should be an empty dictionary by default
-  EXPECT_EQ(
-      prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache),
-      base::Value::Dict());
+  EXPECT_EQ(prefs_service_.GetDict(prefs::kBraveChatPremiumCredentialCache),
+            base::Value::Dict());
 }
 
 TEST_F(AIChatCredentialManagerUnitTest, PutCredentialInCache) {
@@ -111,28 +240,108 @@ TEST_F(AIChatCredentialManagerUnitTest, PutCredentialInCache) {
   entry.expires_at = base::Time::Now();
   ai_chat_credential_manager_->PutCredentialInCache(entry);
   const auto& cached_creds_dict =
-      prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache);
+      prefs_service_.GetDict(prefs::kBraveChatPremiumCredentialCache);
   EXPECT_EQ(cached_creds_dict.size(), 1u);
   EXPECT_EQ(base::ValueToTime(*(cached_creds_dict.Find("credential"))),
             entry.expires_at);
 }
-
-TEST_F(AIChatCredentialManagerUnitTest, GetPremiumStatus) {
+TEST_F(AIChatCredentialManagerUnitTest, GetPremiumStatusInactive) {
   // By default there should be no credentials.
-  TestGetPremiumStatus(ai_chat::mojom::PremiumStatus::Inactive);
+  TestGetPremiumStatus(mojom::PremiumStatus::Inactive, nullptr);
 
   // Add an expired credential to the cache, should return false.
   CredentialCacheEntry entry;
   entry.credential = "credential";
   entry.expires_at = base::Time::Now() - base::Hours(1);  // Expired
   ai_chat_credential_manager_->PutCredentialInCache(entry);
-  TestGetPremiumStatus(ai_chat::mojom::PremiumStatus::Inactive);
+  TestGetPremiumStatus(mojom::PremiumStatus::Inactive, nullptr);
+}
 
-  // Add valid credential to the cache, GetPremiumStatus should
-  // return ai_chat::mojom::PremiumStatus::Active.
+TEST_F(AIChatCredentialManagerUnitTest, GetPremiumStatusActive) {
+  // By default there should be no credentials.
+  TestGetPremiumStatus(mojom::PremiumStatus::Inactive, nullptr);
+
+  // Add an expired credential to the cache, status should be Inactive
+  CredentialCacheEntry entry;
+  entry.credential = "credential";
+  entry.expires_at = base::Time::Now() - base::Hours(1);  // Expired
+  ai_chat_credential_manager_->PutCredentialInCache(entry);
+  TestGetPremiumStatus(mojom::PremiumStatus::Inactive, nullptr);
+
+  // Add valid credential to the cache with an empty SkusState, GetPremiumStatus
+  // should return Active status, but next_active_at is null.
   entry.expires_at = base::Time::Now() + base::Hours(1);  // Valid
   ai_chat_credential_manager_->PutCredentialInCache(entry);
-  TestGetPremiumStatus(ai_chat::mojom::PremiumStatus::Active);
+  mojom::PremiumInfoPtr expected_premium_info =
+      mojom::PremiumInfo::New(1, std::nullopt);
+  TestGetPremiumStatus(mojom::PremiumStatus::Active,
+                       std::move(expected_premium_info));
+
+  // Add a valid SKUs state, which has 2 valid credentials. Including the 1 in
+  // the cache, there should be 3 total. next_active_at should be the
+  // second batch valid_from.
+  base::Time start_time = base::Time::Now();
+  base::Time::Exploded exploded;
+  start_time.UTCExplode(&exploded);
+  exploded.millisecond = 0;  // Trim off milliseconds because they are not
+                             // included in the skusState.
+  ASSERT_TRUE(base::Time::FromUTCExploded(exploded, &start_time));
+  base::Value::Dict state;
+  std::string skusStateValue = formatSkusStateValue(start_time);
+  state.Set("skus:production", skusStateValue);
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
+  base::Time expected_next_active_at = start_time + base::Days(2);
+  expected_premium_info = mojom::PremiumInfo::New(3, expected_next_active_at);
+  TestGetPremiumStatus(mojom::PremiumStatus::Active,
+                       std::move(expected_premium_info));
+
+  // Remove the valid credential from the cache, and check status again.
+  // next_active_at should be the same, but remaining_credential_count
+  // should be one less.
+  TestFetchPremiumCredential(entry);
+  expected_premium_info = mojom::PremiumInfo::New(2, expected_next_active_at);
+  TestGetPremiumStatus(mojom::PremiumStatus::Active,
+                       std::move(expected_premium_info));
+
+  // Set the SKUs state to be on the final batch. There will be remaining valid
+  // credentials, but next_active_at will be null.
+  skusStateValue = formatSkusStateValue(start_time, -2);
+  state.Set("skus:production", skusStateValue);
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
+  expected_premium_info = mojom::PremiumInfo::New(2, std::nullopt);
+  TestGetPremiumStatus(mojom::PremiumStatus::Active,
+                       std::move(expected_premium_info));
+
+  // ActiveDisconnected
+  start_time += base::Days(30);
+  skusStateValue = formatSkusStateValue(start_time);
+  state.Set("skus:production", skusStateValue);
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
+  expected_premium_info = mojom::PremiumInfo::New(0, std::nullopt);
+  TestGetPremiumStatus(mojom::PremiumStatus::ActiveDisconnected,
+                       std::move(expected_premium_info));
+
+  // Add a credential to the cache - would other wise be ActiveDisconnected
+  // state based on the SKUs state, however, since there's a credential in the
+  // cache, it's Active.
+  ai_chat_credential_manager_->PutCredentialInCache(entry);
+  expected_premium_info = mojom::PremiumInfo::New(1, std::nullopt);
+  TestGetPremiumStatus(mojom::PremiumStatus::Active,
+                       std::move(expected_premium_info));
+}
+
+TEST_F(AIChatCredentialManagerUnitTest, GetPremiumStatusActiveDisconnected) {
+  // Would other wise be ActiveDisconnected state based on the SKUs state,
+  // however, since there's a credential in the cache, it's Active.
+  base::Value::Dict state;
+  const std::string skusStateValue =
+      formatSkusStateValue(base::Time::Now() + base::Days(30));
+  state.Set("skus:production", skusStateValue);
+  prefs()->SetDict(skus::prefs::kSkusState, std::move(state));
+  mojom::PremiumInfoPtr expected_premium_info =
+      mojom::PremiumInfo::New(0, std::nullopt);
+  TestGetPremiumStatus(mojom::PremiumStatus::ActiveDisconnected,
+                       std::move(expected_premium_info));
 }
 
 TEST_F(AIChatCredentialManagerUnitTest, FetchPremiumCredential) {
@@ -146,11 +355,11 @@ TEST_F(AIChatCredentialManagerUnitTest, FetchPremiumCredential) {
   entry.expires_at = base::Time::Now() - base::Hours(1);
   ai_chat_credential_manager_->PutCredentialInCache(entry);
   const auto& cached_creds_dict =
-      prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache);
+      prefs_service_.GetDict(prefs::kBraveChatPremiumCredentialCache);
   EXPECT_EQ(cached_creds_dict.size(), 1u);
   TestFetchPremiumCredential(std::nullopt);
   const auto& cached_creds_list2 =
-      prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache);
+      prefs_service_.GetDict(prefs::kBraveChatPremiumCredentialCache);
   EXPECT_EQ(cached_creds_list2.size(), 0u);
 
   // Add a valid credential to the cache. FetchPremiumCredential should
@@ -159,7 +368,7 @@ TEST_F(AIChatCredentialManagerUnitTest, FetchPremiumCredential) {
   ai_chat_credential_manager_->PutCredentialInCache(entry);
   TestFetchPremiumCredential(entry);
   const auto& cached_creds_list3 =
-      prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache);
+      prefs_service_.GetDict(prefs::kBraveChatPremiumCredentialCache);
   EXPECT_EQ(cached_creds_list3.size(), 0u);
 
   // Add two valid credentials to the cache. FetchPremiumCredential should
@@ -171,7 +380,7 @@ TEST_F(AIChatCredentialManagerUnitTest, FetchPremiumCredential) {
   ai_chat_credential_manager_->PutCredentialInCache(entry2);
   TestFetchPremiumCredential(entry2);
   const auto& cached_creds_list4 =
-      prefs_service_.GetDict(ai_chat::prefs::kBraveChatPremiumCredentialCache);
+      prefs_service_.GetDict(prefs::kBraveChatPremiumCredentialCache);
   EXPECT_EQ(cached_creds_list4.size(), 1u);
   TestFetchPremiumCredential(entry);
 

--- a/components/ai_chat/core/browser/ai_chat_metrics.cc
+++ b/components/ai_chat/core/browser/ai_chat_metrics.cc
@@ -94,9 +94,9 @@ void AIChatMetrics::RecordReset() {
                              std::numeric_limits<int>::max() - 1, 2);
 }
 
-void AIChatMetrics::OnPremiumStatusUpdated(
-    bool is_new_user,
-    mojom::PremiumStatus premium_status) {
+void AIChatMetrics::OnPremiumStatusUpdated(bool is_new_user,
+                                           mojom::PremiumStatus premium_status,
+                                           mojom::PremiumInfoPtr) {
   is_premium_ = premium_status == mojom::PremiumStatus::Active ||
                 premium_status == mojom::PremiumStatus::ActiveDisconnected;
   local_state_->SetBoolean(prefs::kBraveChatP3ALastPremiumStatus, is_premium_);

--- a/components/ai_chat/core/browser/ai_chat_metrics.h
+++ b/components/ai_chat/core/browser/ai_chat_metrics.h
@@ -65,7 +65,8 @@ class AIChatMetrics {
   void HandleOpenViaSidebar();
 
   void OnPremiumStatusUpdated(bool is_new_user,
-                              mojom::PremiumStatus premium_status);
+                              mojom::PremiumStatus premium_status,
+                              mojom::PremiumInfoPtr);
 
  private:
   void ReportAllMetrics();

--- a/components/ai_chat/core/browser/ai_chat_metrics_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_metrics_unittest.cc
@@ -46,7 +46,8 @@ class AIChatMetricsUnitTest : public testing::Test {
     return base::BindLambdaForTesting(
         [is_premium](mojom::PageHandler::GetPremiumStatusCallback callback) {
           std::move(callback).Run(is_premium ? mojom::PremiumStatus::Active
-                                             : mojom::PremiumStatus::Inactive);
+                                             : mojom::PremiumStatus::Inactive,
+                                  nullptr);
         });
   }
 
@@ -66,7 +67,8 @@ TEST_F(AIChatMetricsUnitTest, Enabled) {
   histogram_tester_.ExpectUniqueSample(kEnabledHistogramName, 1, 2);
 
   is_premium_ = true;
-  ai_chat_metrics_->OnPremiumStatusUpdated(false, mojom::PremiumStatus::Active);
+  ai_chat_metrics_->OnPremiumStatusUpdated(false, mojom::PremiumStatus::Active,
+                                           nullptr);
   histogram_tester_.ExpectBucketCount(kEnabledHistogramName, 2, 1);
 
   is_premium_ = false;
@@ -154,7 +156,8 @@ TEST_F(AIChatMetricsUnitTest, UsageDailyAndMonthly) {
   histogram_tester_.ExpectUniqueSample(kUsageMonthlyHistogramName, 1, 1);
 
   is_premium_ = true;
-  ai_chat_metrics_->OnPremiumStatusUpdated(false, mojom::PremiumStatus::Active);
+  ai_chat_metrics_->OnPremiumStatusUpdated(false, mojom::PremiumStatus::Active,
+                                           nullptr);
   RecordPrompts(true, 1);
   histogram_tester_.ExpectBucketCount(kUsageDailyHistogramName, 2, 1);
   histogram_tester_.ExpectBucketCount(kUsageMonthlyHistogramName, 2, 1);

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -145,7 +145,8 @@ class ConversationDriver {
   void OnPageHasContentChanged(mojom::SiteInfoPtr site_info);
   void OnPremiumStatusReceived(
       mojom::PageHandler::GetPremiumStatusCallback parent_callback,
-      mojom::PremiumStatus premium_status);
+      mojom::PremiumStatus premium_status,
+      mojom::PremiumInfoPtr premium_info);
   void OnConversationEntryPending();
 
   void SetAPIError(const mojom::APIError& error);

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -5,6 +5,7 @@
 
 module ai_chat.mojom;
 
+import "mojo/public/mojom/base/time.mojom";
 import "url/mojom/url.mojom";
 
 enum CharacterType {
@@ -39,6 +40,15 @@ enum PremiumStatus {
   Inactive,
   Active,
   ActiveDisconnected,
+};
+
+struct PremiumInfo {
+  // How many credentials in the current batch are remaining
+  uint32 remaining_credential_count;
+
+  // When their next batch of credentials is active. If null, there is no
+  // next batch.
+  mojo_base.mojom.Time? next_active_at;
 };
 
 enum SuggestionGenerationStatus {
@@ -137,7 +147,7 @@ interface PageHandler {
   SendFeedback(string category,
       string feedback,
           string rating_id) => (bool is_success);
-  GetPremiumStatus() => (PremiumStatus result);
+  GetPremiumStatus() => (PremiumStatus status, PremiumInfo? info);
 };
 
 interface ChatUIPage {

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -172,7 +172,7 @@ interface ChatUIPage {
 
 [EnableIf=is_android]
 interface CredentialManagerHelper {
-  GetPremiumStatus() => (PremiumStatus result);
+  GetPremiumStatus() => (PremiumStatus status, PremiumInfo? info);
 };
 
 [EnableIf=is_android]

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -137,9 +137,10 @@ function DataContextProvider (props: DataContextProviderProps) {
 
   const updateCurrentPremiumStatus = async () => {
     console.debug('Getting premium status...')
-    const premiumStatus = await getPageHandlerInstance().pageHandler.getPremiumStatus()
-    console.debug('got premium status: ', premiumStatus.result)
-    setPremiumStatus(premiumStatus.result)
+    const { status } = await getPageHandlerInstance()
+      .pageHandler.getPremiumStatus()
+    console.debug('got premium status: ', status)
+    setPremiumStatus(status)
   }
 
   const userRefreshPremiumSession = () => {

--- a/components/skus/browser/rs/lib/src/models.rs
+++ b/components/skus/browser/rs/lib/src/models.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
@@ -165,6 +170,7 @@ pub struct CredentialSummary {
     pub remaining_credential_count: usize,
     pub expires_at: Option<NaiveDateTime>,
     pub active: bool,
+    pub next_active_at: Option<NaiveDateTime>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/components/skus/browser/rs/lib/src/sdk/credentials/mod.rs
+++ b/components/skus/browser/rs/lib/src/sdk/credentials/mod.rs
@@ -1,7 +1,12 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 mod fetch;
 mod present;
 
-use chrono::Utc;
+use chrono::{NaiveDateTime, Utc};
 use tracing::{debug, instrument};
 
 use crate::errors::{InternalError, SkusError};
@@ -49,6 +54,7 @@ where
                         .await?
                         .map(|cred| cred.valid_to)
                         .or(expires_at);
+
                     if let Some(creds) = self.matching_time_limited_v2_credential(&item.id).await? {
                         let unblinded_creds =
                             creds.unblinded_creds.ok_or(InternalError::NotFound)?;
@@ -56,11 +62,14 @@ where
                             unblinded_creds.into_iter().filter(|cred| !cred.spent).count();
 
                         let active = remaining_credential_count > 0;
+
+                        let next_active_at = self.next_active_at(&item.id).await?;
                         return Ok(Some(CredentialSummary {
                             order,
                             remaining_credential_count, // number unspent
                             expires_at,
                             active,
+                            next_active_at,
                         }));
                     }
 
@@ -82,6 +91,7 @@ where
                             remaining_credential_count,
                             expires_at,
                             active,
+                            next_active_at: None,
                         }));
                     } else {
                         continue;
@@ -100,6 +110,7 @@ where
                             remaining_credential_count: 1,
                             expires_at,
                             active: true,
+                            next_active_at: None,
                         }));
                     }
 
@@ -120,6 +131,38 @@ where
                 Utc::now().naive_utc() < cred.valid_to && Utc::now().naive_utc() > cred.valid_from
             })
         }))
+    }
+
+    #[instrument]
+    pub async fn next_active_at(&self, item_id: &str) -> Result<Option<NaiveDateTime>, SkusError> {
+        let now = Utc::now().naive_utc();
+        let creds = self.client.get_time_limited_v2_creds(item_id).await?;
+        // Of the TimeLimitedV2Credentials, find the TimeLimitedV2Credential that has
+        // the smallest valid_from that's greater than the current time, and also
+        // has at least one unspent SingleUseCredential.
+        match creds {
+            Some(tlv2_creds) => {
+                // Check if unblinded_creds is present and filter out unspent credentials with
+                // valid_from greater than now
+                let next_valid_from = tlv2_creds
+                    .unblinded_creds
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter_map(|tlv2_cred| {
+                        tlv2_cred
+                            .unblinded_creds
+                            .unwrap_or_default()
+                            .into_iter()
+                            .filter(|single_cred| !single_cred.spent && tlv2_cred.valid_from > now)
+                            .map(|_| tlv2_cred.valid_from)
+                            .next()
+                    })
+                    .min(); // Find the smallest valid_from among them
+
+                Ok(next_valid_from)
+            }
+            None => Ok(None), // No credentials found for the item
+        }
     }
 
     #[instrument]
@@ -184,6 +227,7 @@ where
                                 remaining_credential_count: 0,
                                 expires_at: None,
                                 active: false,
+                                next_active_at: None,
                             }));
                         }
                     }

--- a/ios/browser/api/ai_chat/ai_chat.mm
+++ b/ios/browser/api/ai_chat/ai_chat.mm
@@ -160,7 +160,8 @@
 - (void)getPremiumStatus:(void (^)(AiChatPremiumStatus))completion {
   driver_->GetPremiumStatus(base::BindOnce(
       [](void (^completion)(AiChatPremiumStatus),
-         ai_chat::mojom::PremiumStatus status) {
+         ai_chat::mojom::PremiumStatus status,
+         ai_chat::mojom::PremiumInfoPtr info) {
         if (completion) {
           completion(static_cast<AiChatPremiumStatus>(status));
         }


### PR DESCRIPTION
Related to https://github.com/brave/brave-browser/issues/34261 

Updates the ai chat GetPremiumStatus mojom interface to returns an additional PremiumInfo object, with additional details about the user's premium status:

```
struct PremiumInfo {
  // How many credentials in the current batch are remaining
  uint32 remaining_credential_count;

  // When their next batch of credentials is active. If null, there is no
  // next batch.
  mojo_base.mojom.Time? next_active_at;
};

  GetPremiumStatus() => (PremiumStatus status, PremiumInfo? info);
```

The new PremiumInfo object can be used to display to premium users that have used all their credentials for the current period when premium models will be available again.  It can also be used to show how many credentials (chats) remaining the premium user has before they run out for the current period.

* When PremiumStatus is Inactive, PremiumInfo will be null
* When PremiumStatus is Active, PremiumInfo will be present
    * If PremiumStatus is only active because there is a valid credential in the cache (and otherwise the call to SkusService::CredentialSummary would have resulted in Inactive, then PremiumInfo.next_active_at will be null)
* When PremiumStatus is ActiveDisconnected, PremiumInfo will be present, but it should have 0 remaining credentails and null next_active_at

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

