### PR TITLE
[Brave News] Fix P2 issue: Brave news card peek covering other parts of the UI

### DIFF
--- a/components/brave_new_tab_ui/components/default/braveNews/default.ts
+++ b/components/brave_new_tab_ui/components/default/braveNews/default.ts
@@ -26,7 +26,6 @@ export const Section = styled('section')`
   flex-direction: column;
   transition: margin-top 2s ease-out;
   max-width: calc(max(min(680px, 80vw - 380px), 380px));
-  
   & > div {
     max-width: 100%;
   }

--- a/components/brave_new_tab_ui/components/default/braveNews/default.ts
+++ b/components/brave_new_tab_ui/components/default/braveNews/default.ts
@@ -20,13 +20,33 @@ export const Section = styled('section')`
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   min-height: 100vh;
-  margin: 100px 30px;
+  margin: 100px 30px 100px calc(max(50vw - 360px, 190px));
   display: flex;
   align-items: center;
   flex-direction: column;
-  transition: margin 2s ease-out;
+  transition: margin-top 2s ease-out;
+  max-width: calc(max(min(680px, 80vw - 380px), 380px));
+  
+  & > div {
+    max-width: 100%;
+  }
+
   [data-show-news-prompt] & {
     margin-top: -100px;
+  }
+
+
+  @media screen and (max-width: 980px) {
+    margin-left: calc(max(50vw - 200px, 15px));
+    [data-show-news-prompt] & {
+      margin-top: -16px;
+    }
+  }
+
+  @media screen and (max-width: 650px) {
+    [data-show-news-prompt] & {
+      margin-top: -6px;
+    }
   }
 `
 

--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -276,6 +276,20 @@ export const GridItemNavigationBraveNews = styled('div') <{}>`
   [data-show-news-prompt] & {
     bottom: 120px;
   }
+
+  @media screen and (max-width: 980px) {
+    [data-show-news-prompt] & {
+      bottom: 50px;
+    }
+  }
+  @media screen and (max-width: 650px) {
+    [data-show-news-prompt] & {
+      bottom: -22px;
+    }
+    & > div {
+      font-size: 13px;
+    }
+  }
 `
 
 export const Footer = styled('footer') <{}>`


### PR DESCRIPTION
Resolves brave/brave-browser#34384 

Currently, the "scroll for brave news" peeking component extends significantly farther in the DOM than it does visually, making other buttons on the new tab landing page UI un-clickable. This PR makes the component appropriately sized to its visual dimensions. In addition it makes the component responsive to avoid covering the UI as the screen size changes.

Current problem dom element:
![Screenshot 2023-12-01 145821](https://github.com/brave/brave-core/assets/1338468/637d7769-c97c-42b3-8d02-6d3e88434f69)

Current problem mobile experience:
![Screenshot 2023-12-01 145914](https://github.com/brave/brave-core/assets/1338468/09e6a68f-e549-46cd-a9eb-0c0abfbc1de9)


Fixed component size new experience:
![Screenshot 2023-12-01 144306](https://github.com/brave/brave-core/assets/1338468/f4f64731-73dd-45a1-93f8-6e2fbdecd6fb)

Fixed smaller screen peeking experience:
![Screenshot 2023-12-01 145156](https://github.com/brave/brave-core/assets/1338468/36ae99e4-ed5e-4a37-a6a6-49bc5947a6ff)



## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review is not needed
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

