### PR TITLE
Fixed find-in-page bubble is behind the speedreader toolbar (uplift to 1.62.x)

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -439,6 +439,10 @@ void BraveBrowserView::ShowReaderModeToolbar() {
           gfx::Insets::TLBR(0, 0, 1, 0), kColorToolbarContentAreaSeparator));
     }
     AddChildView(reader_mode_toolbar_view_.get());
+
+    // See the comment of same code in ctor.
+    // TODO(simonhong): Find more better way instead of calling multiple times.
+    ReorderChildView(find_bar_host_view_, -1);
     GetBrowserViewLayout()->set_reader_mode_toolbar(
         reader_mode_toolbar_view_.get());
   } else {


### PR DESCRIPTION
Uplift of #21231
Resolves https://github.com/brave/brave-browser/issues/34708

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.