### PR TITLE
Remove YouTube and Instagram share ID parameters from URLs

### DIFF
--- a/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
+++ b/browser/net/brave_site_hacks_network_delegate_helper_unittest.cc
@@ -227,7 +227,7 @@ TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringExempted) {
 
 TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringFiltered) {
   const std::vector<const std::pair<const std::string, const std::string>> urls(
-      {// { original url, expected url after filtering }
+      {// { original url, expected url after filtering ("" means unchanged) }
        {"https://example.com/?fbclid=1234", "https://example.com/"},
        {"https://example.com/?fbclid=1234&", "https://example.com/"},
        {"https://example.com/?&fbclid=1234", "https://example.com/"},
@@ -253,6 +253,9 @@ TEST(BraveSiteHacksNetworkDelegateHelperTest, QueryStringFiltered) {
        // Conditional query parameter stripping
        {"https://example.com/?igshid=1234", ""},
        {"https://www.instagram.com/?igshid=1234", "https://www.instagram.com/"},
+       {"https://brave.com/?ref_src=example.com", ""},
+       {"https://twitter.com/?ref_src=example.com", "https://twitter.com/"},
+       {"https://x.com/?ref_src=example.com", "https://x.com/"},
        {"https://example.com/?mkt_tok=123&foo=bar&mkt_unsubscribe=1", ""},
        {"https://example.com/index.php/email/emailWebview?mkt_tok=1234&foo=bar",
         ""},

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/strings/string_split.h"
@@ -117,6 +118,7 @@ static constexpr auto kConditionalQueryStringTrackers =
         {"mkt_tok", "([uU]nsubscribe|emailWebview)"},
     });
 
+// The second parameter is a comma-separated list of domains.
 // The domain comparison will also match on subdomains. So if the
 // parameter is scoped to example.com below, it will be removed from
 // https://example.com/index.php and from http://www.example.com/ for
@@ -126,9 +128,31 @@ static constexpr auto kScopedQueryStringTrackers =
         // https://github.com/brave/brave-browser/issues/11580
         {"igshid", "instagram.com"},
         // https://github.com/brave/brave-browser/issues/26966
-        {"ref_src", "twitter.com"},
-        {"ref_url", "twitter.com"},
+        {"ref_src", "twitter.com,x.com"},
+        {"ref_url", "twitter.com,x.com"},
     });
+
+bool IsScopedTracker(const std::string_view param_name,
+                     const std::string& spec) {
+  if (!base::Contains(trackers, param_name)) {
+    return false;
+  }
+
+  const std::vector<std::string_view> domain_strings =
+      SplitStringPiece(kScopedQueryStringTrackers.at(param_name).data(), ",",
+                       base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  if (domain_strings.empty()) {
+    return false;
+  }
+  const GURL original_url = GURL(spec);
+  for (const auto& domain : domain_strings) {
+    if (original_url.DomainIs(domain)) {
+      return true;
+    }
+  }
+
+  return false;
+}
 
 // Remove tracking query parameters from a GURL, leaving all
 // other parts untouched.
@@ -151,8 +175,7 @@ std::optional<std::string> StripQueryParameter(const std::string_view query,
     const std::string_view key = pieces.empty() ? "" : pieces[0];
     if (pieces.size() >= 2 &&
         (kSimpleQueryStringTrackers.count(key) == 1 ||
-         (kScopedQueryStringTrackers.count(key) == 1 &&
-          GURL(spec).DomainIs(kScopedQueryStringTrackers.at(key).data())) ||
+         IsScopedTracker(key, spec) ||
          (kConditionalQueryStringTrackers.count(key) == 1 &&
           !re2::RE2::PartialMatch(
               spec, kConditionalQueryStringTrackers.at(key).data())))) {

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -130,6 +130,8 @@ static constexpr auto kScopedQueryStringTrackers =
         // https://github.com/brave/brave-browser/issues/26966
         {"ref_src", "twitter.com,x.com"},
         {"ref_url", "twitter.com,x.com"},
+        // https://github.com/brave/brave-browser/issues/34719
+        {"si", "youtube.com,youtu.be"},
     });
 
 bool IsScopedTracker(const std::string_view param_name,

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -18,7 +18,7 @@
 #include "net/base/registry_controlled_domains/registry_controlled_domain.h"
 #include "third_party/re2/src/re2/re2.h"
 
-namespace query_filter {
+namespace {
 
 static constexpr auto kSimpleQueryStringTrackers =
     base::MakeFixedFlatSetSorted<std::string_view>({
@@ -156,13 +156,6 @@ bool IsScopedTracker(
   return false;
 }
 
-bool IsScopedTrackerForTesting(
-    const std::string_view param_name,
-    const std::string& spec,
-    const std::map<std::string_view, std::vector<std::string_view>>& trackers) {
-  return IsScopedTracker(param_name, spec, trackers);
-}
-
 // Remove tracking query parameters from a GURL, leaving all
 // other parts untouched.
 std::optional<std::string> StripQueryParameter(const std::string_view query,
@@ -198,6 +191,9 @@ std::optional<std::string> StripQueryParameter(const std::string_view query,
   }
   return std::nullopt;
 }
+}  // namespace
+
+namespace query_filter {
 
 std::optional<GURL> ApplyQueryFilter(const GURL& original_url) {
   const auto& query = original_url.query_piece();
@@ -256,5 +252,12 @@ std::optional<GURL> MaybeApplyQueryStringFilter(
   }
 
   return ApplyQueryFilter(request_url);
+}
+
+bool IsScopedTrackerForTesting(
+    const std::string_view param_name,
+    const std::string& spec,
+    const std::map<std::string_view, std::vector<std::string_view>>& trackers) {
+  return IsScopedTracker(param_name, spec, trackers);
 }
 }  // namespace query_filter

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -117,6 +117,10 @@ static constexpr auto kConditionalQueryStringTrackers =
         {"mkt_tok", "([uU]nsubscribe|emailWebview)"},
     });
 
+// The domain comparison will also match on subdomains. So if the
+// parameter is scoped to example.com below, it will be removed from
+// https://example.com/index.php and from http://www.example.com/ for
+// example.
 static constexpr auto kScopedQueryStringTrackers =
     base::MakeFixedFlatMapSorted<std::string_view, std::string_view>({
         // https://github.com/brave/brave-browser/issues/11580

--- a/components/query_filter/utils.cc
+++ b/components/query_filter/utils.cc
@@ -125,6 +125,8 @@ static constexpr auto kConditionalQueryStringTrackers =
 // example.
 static const auto kScopedQueryStringTrackers =
     std::map<std::string_view, std::vector<std::string_view>>({
+        // https://github.com/brave/brave-browser/issues/35094
+        {"igsh", {"instagram.com"}},
         // https://github.com/brave/brave-browser/issues/11580
         {"igshid", {"instagram.com"}},
         // https://github.com/brave/brave-browser/issues/26966

--- a/components/query_filter/utils.h
+++ b/components/query_filter/utils.h
@@ -6,8 +6,10 @@
 #ifndef BRAVE_COMPONENTS_QUERY_FILTER_UTILS_H_
 #define BRAVE_COMPONENTS_QUERY_FILTER_UTILS_H_
 
+#include <map>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "url/gurl.h"
 
@@ -31,5 +33,10 @@ std::optional<GURL> MaybeApplyQueryStringFilter(
     const GURL& request_url,
     const std::string& request_method,
     const bool internal_redirect);
+
+bool IsScopedTrackerForTesting(
+    const std::string_view param_name,
+    const std::string& spec,
+    const std::map<std::string_view, std::vector<std::string_view>>& trackers);
 }  // namespace query_filter
 #endif  // BRAVE_COMPONENTS_QUERY_FILTER_UTILS_H_

--- a/components/query_filter/utils_unittest.cc
+++ b/components/query_filter/utils_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/query_filter/utils.h"
 
+#include <vector>
+
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
@@ -97,4 +99,49 @@ TEST(BraveQueryFilter, FilterQueryTrackers) {
   EXPECT_FALSE(query_filter::MaybeApplyQueryStringFilter(
       GURL("https://brave.com"), GURL("https://brave.com"),
       GURL("https://test.com/?gclid=123"), "GET", true));
+}
+
+TEST(BraveQueryFilter, IsScopedTracker) {
+  auto trackers = std::map<std::string_view, std::vector<std::string_view>>({
+      {"igshid", {"instagram.com"}},
+      {"ref_src", {"twitter.com", "x.com", "y.com"}},
+      {"sample1", {"", " ", "brave.com", ""}},
+      {"sample2", {" "}},
+      {"sample3", {""}},
+      {"sample4", {}},
+  });
+
+  // Normal case for a parameter that's not on the list
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "t", "https://twitter.com/", trackers));
+
+  // Normal case with a single domain
+  EXPECT_TRUE(query_filter::IsScopedTrackerForTesting(
+      "igshid", "https://instagram.com/", trackers));
+  EXPECT_TRUE(query_filter::IsScopedTrackerForTesting(
+      "igshid", "http://www.instagram.com/", trackers));
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "igshid", "https://example.com/", trackers));
+
+  // Normal case with more than one domain
+  EXPECT_TRUE(query_filter::IsScopedTrackerForTesting(
+      "ref_src", "https://twitter.com/", trackers));
+  EXPECT_TRUE(query_filter::IsScopedTrackerForTesting(
+      "ref_src", "https://x.com/", trackers));
+  EXPECT_TRUE(query_filter::IsScopedTrackerForTesting(
+      "ref_src", "https://y.com/", trackers));
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "ref_src", "https://z.com/", trackers));
+
+  // Edge cases
+  EXPECT_TRUE(query_filter::IsScopedTrackerForTesting(
+      "sample1", "https://brave.com/", trackers));
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "sample1", "https://example.com/", trackers));
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "sample2", "https://brave.com/", trackers));
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "sample3", "https://brave.com/", trackers));
+  EXPECT_FALSE(query_filter::IsScopedTrackerForTesting(
+      "sample4", "https://brave.com/", trackers));
 }


### PR DESCRIPTION
Fixes brave/brave-browser#34719 and https://github.com/brave/brave-browser/issues/35094

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [x] https://github.com/brave/brave-browser/wiki/Query-String-Filter

## Test Plan:

1. In a **new** browser profile with Shields set to **normal** adblocking (not aggressive).
2. Open the network tab of the devtools.
3. Paste <https://www.youtube.com/watch?v=dQw4w9WgXcQ&si=YjziZuccJeIE-b6z> in the URL bar.
4. Filter for just document requests and ensure that the `200 OK` request (ignore the `200 Internal Redirect` request) does not include the `si` parameter.
5. Delete the existing browser profile and create a new one.
6. Repeat the test with <https://youtu.be/watch?v=dQw4w9WgXcQ&si=YjziZuccJeIE-b6z>.
7. Repeat the test with <https://www.instagram.com/p/C1nNxSbsAzk/?utm_source=ig_web_button_share_sheet&igsh=ZDNl...IxNw==> confirming that the `igsh` parameter is only present in `Internal Redirect` requests.

Here's what it looks like **before the change in this PR**:
![Screenshot from 2023-12-05 13-29-23](https://github.com/brave/brave-core/assets/167821/bb4eedd7-b88b-4905-bf3a-d465b1639ef6)

and here's the **new expected result** as of this PR:
![Screenshot from 2023-12-05 16-47-58](https://github.com/brave/brave-core/assets/167821/dfe1ad7c-8cdd-4042-ba72-c9b2e4dfddce)
![Screenshot from 2023-12-05 16-48-04](https://github.com/brave/brave-core/assets/167821/8501b89b-4f4c-46ab-b9c0-d636dd9c4fe3)

The `youtu.be` URL will now show a `303 Internal Redirect` instead of a `303 See Other`:
![Screenshot from 2023-12-18 15-25-16](https://github.com/brave/brave-core/assets/167821/70b749a7-eed0-4cd3-8db0-3e231f210330)

Note: this test will only work the first time. You need to delete the profile or clear all data before testing this otherwise [service workers will interfere with the requests](https://github.com/brave/brave-browser/issues/23742).