### PR TITLE
Revert ffmpeg to acb78dc0f416f6ef009192d94dc07c05effabfda (uplift to 1.61.x)

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -130,6 +130,11 @@ hooks = [
                '--source-dir', '.',
                '--filter', '^[0-9]\{{1,\}}\.[0-9]\{{1,\}}\.[0-9]\{{1,\}}$'],
   },
+  {
+    'name': 'patch_ffmpeg',
+    'pattern': '.',
+    'action': ['vpython3', 'script/patch_ffmpeg.py'],
+  },
 ]
 
 include_rules = [

--- a/script/patch_ffmpeg.py
+++ b/script/patch_ffmpeg.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env vpython3
+
+# Copyright (c) 2023 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""
+A temporary fix for FFMpeg perf bug:
+https://github.com/brave/brave-browser/issues/34639
+
+The script re-checkouts the good ffmpeg revision used in CR119.
+Consider removing after FFMpeg is updated.
+"""
+
+import os
+import sys
+import subprocess
+
+from lib.config import SOURCE_ROOT
+
+FFMPEG_DIR = os.path.join(SOURCE_ROOT, '..', 'third_party', 'ffmpeg')
+STABLE_REVISION = 'acb78dc0f416f6ef009192d94dc07c05effabfda'
+BAD_REVISION = 'e1ca3f06adec15150a171bc38f550058b4bbb23b'
+
+
+def main():
+    current_rev = subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+                                          cwd=FFMPEG_DIR,
+                                          universal_newlines=True).rstrip()
+
+    if current_rev == STABLE_REVISION:
+        return 0
+
+    # FFMpeg is updated. The perf bug is probably fixed.
+    # Consider removing this file.
+    assert current_rev == BAD_REVISION
+
+    subprocess.check_call(['git', 'checkout', '--force', STABLE_REVISION],
+                          cwd=FFMPEG_DIR)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Uplift of #21160
Resolves https://github.com/brave/brave-browser/issues/34639

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.