### PR TITLE
Display correct provider name in logged out notification (uplift to 1.62.x)

### DIFF
--- a/components/brave_rewards/core/wallet/wallet_util.cc
+++ b/components/brave_rewards/core/wallet/wallet_util.cc
@@ -382,7 +382,7 @@ bool LogOutWallet(RewardsEngineImpl& engine,
     engine.client()->ShowNotification(notification.empty()
                                           ? notifications::kWalletDisconnected
                                           : notification,
-                                      {}, base::DoNothing());
+                                      {wallet_type}, base::DoNothing());
   }
 
   return true;

--- a/components/brave_rewards/resources/rewards_panel/lib/notification_adapter.ts
+++ b/components/brave_rewards/resources/rewards_panel/lib/notification_adapter.ts
@@ -2,10 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-import {
-  ExternalWalletProvider,
-  externalWalletProviderFromString
-} from '../../shared/lib/external_wallet'
+import { externalWalletProviderFromString } from '../../shared/lib/external_wallet'
 
 import {
   Notification,
@@ -29,11 +26,6 @@ function parseGrantDetails (args: string[]) {
     claimableUntil: parseFloat(args[2]) || null,
     expiresAt: null
   }
-}
-
-function mapProvider (name: string): ExternalWalletProvider {
-  const provider = externalWalletProviderFromString(name.toLocaleLowerCase())
-  return provider || 'uphold'
 }
 
 enum ExtensionNotificationType {
@@ -103,25 +95,31 @@ export function mapNotification (
       }
     case ExtensionNotificationType.GENERAL:
       switch (obj.args[0]) {
-        case 'wallet_disconnected':
+        case 'wallet_disconnected': {
+          const provider = externalWalletProviderFromString(obj.args[1] || '')
+          if (!provider) {
+            return null
+          }
           return create<ExternalWalletDisconnectedNotification>({
             ...baseProps,
             type: 'external-wallet-disconnected',
-            // The provider is not currently recorded for this notification
-            provider: mapProvider('')
+            provider
           })
-        case 'uphold_bat_not_allowed':
+        }
+        case 'uphold_bat_not_allowed': {
           return create<UpholdBATNotAllowedNotification>({
             ...baseProps,
             type: 'uphold-bat-not-allowed',
             provider: 'uphold'
           })
-        case 'uphold_insufficient_capabilities':
+        }
+        case 'uphold_insufficient_capabilities': {
           return create<UpholdInsufficientCapabilitiesNotification>({
             ...baseProps,
             type: 'uphold-insufficient-capabilities',
             provider: 'uphold'
           })
+        }
       }
       break
   }


### PR DESCRIPTION
Uplift of #21212
Resolves https://github.com/brave/brave-browser/issues/34670

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.