### PR TITLE
[Brave News]: FeedV2 Performance

### DIFF
--- a/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
@@ -57,13 +57,13 @@ export default function FeedV2() {
 
   // Note: Whenever the feed is updated, if we're viewing the feed, scroll to
   // the top.
-  React.useEffect(() => {
-    const root = document.querySelector<HTMLElement>('#root:not(.bn-scroll-restored)')
+  React.useLayoutEffect(() => {
+    const root = document.querySelector<HTMLElement>('#root')
     if (!root?.classList.contains(CLASSNAME_PAGE_STUCK)) {
       return
     }
 
-    // ref.current?.scrollIntoView()
+    ref.current?.scrollIntoView()
   }, [feedV2?.items])
 
   // For some reason |createGlobalStyle| doesn't seem to work in Brave Core

--- a/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
@@ -58,12 +58,12 @@ export default function FeedV2() {
   // Note: Whenever the feed is updated, if we're viewing the feed, scroll to
   // the top.
   React.useEffect(() => {
-    const root = document.querySelector<HTMLElement>('#root')
+    const root = document.querySelector<HTMLElement>('#root:not(.bn-scroll-restored)')
     if (!root?.classList.contains(CLASSNAME_PAGE_STUCK)) {
       return
     }
 
-    ref.current?.scrollIntoView()
+    // ref.current?.scrollIntoView()
   }, [feedV2?.items])
 
   // For some reason |createGlobalStyle| doesn't seem to work in Brave Core

--- a/components/brave_new_tab_ui/components/default/braveNews/index.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/index.tsx
@@ -13,9 +13,15 @@ import CardLoading from './cards/cardLoading'
 import CardOptIn from './cards/cardOptIn'
 import * as BraveNewsElement from './default'
 
-import FeedV2 from './FeedV2'
 const Content = React.lazy(() => import('./content'))
-// const FeedV2 = React.lazy(() => import('./FeedV2'))
+const FeedV2 = React.lazy(() => import('./FeedV2'))
+
+// When FeedV2 is enabled, immediately start loading the Brave News chunk,
+// rather than waiting for the parent component to render.
+if (defaultState.featureFlagBraveNewsFeedV2Enabled) {
+  import('./FeedV2')
+}
+
 export type OnReadFeedItem = (args: TodayActions.ReadFeedItemPayload) => any
 export type OnSetPublisherPref = (publisherId: string, enabled: boolean) => any
 export type OnPromotedItemViewed = (args: TodayActions.PromotedItemViewedPayload) => any

--- a/components/brave_new_tab_ui/components/default/braveNews/index.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/index.tsx
@@ -13,9 +13,9 @@ import CardLoading from './cards/cardLoading'
 import CardOptIn from './cards/cardOptIn'
 import * as BraveNewsElement from './default'
 
+import FeedV2 from './FeedV2'
 const Content = React.lazy(() => import('./content'))
-const FeedV2 = React.lazy(() => import('./FeedV2'))
-
+// const FeedV2 = React.lazy(() => import('./FeedV2'))
 export type OnReadFeedItem = (args: TodayActions.ReadFeedItemPayload) => any
 export type OnSetPublisherPref = (publisherId: string, enabled: boolean) => any
 export type OnPromotedItemViewed = (args: TodayActions.PromotedItemViewedPayload) => any

--- a/components/brave_news/browser/resources/Feed.tsx
+++ b/components/brave_news/browser/resources/Feed.tsx
@@ -86,7 +86,7 @@ export default function Component({ feed }: Props) {
       const scroll = scrollData.innerHeight === window.innerHeight && scrollData.innerWidth === window.innerWidth
         ? () => document.scrollingElement?.scrollTo({ top: scrollData.scrollPos })
         : () => document.querySelector(`[data-id="${scrollData.itemId}"]`)?.scrollIntoView()
-      setTimeout(scroll)
+      scroll()
     }
   }, [])
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34749

This PR makes two changes which increase the Brave News performance:
1. Eagerly load the Brave News V2 chunk when the feature is enabled, rather than waiting for something which needs it to render and then loading. 
2. Remove the `setTimeout` from restoring the scroll position (this makes back navigations instant).

(note: We're interested in the perf from the NTP loading, to the feed being scrolled to the last position)

Before:
[Screencast from 2023-12-07 14-16-45.webm](https://github.com/brave/brave-core/assets/7678024/2f0a5c2c-40b8-4863-b64e-5cbe373a95b9)

After:
[Screencast from 2023-12-07 14-18-51.webm](https://github.com/brave/brave-core/assets/7678024/9e193278-c5ea-401d-a7eb-e58b677b8e17)

(the difference is significantly better when I'm not screen recording)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

