### PR TITLE
Removed 'Enter reader mode' menu item from app menu. (uplift to 1.62.x)

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -439,6 +439,11 @@ void BraveAppMenuModel::RemoveUpstreamMenus() {
   if (const auto index = GetIndexOfCommandId(IDC_ABOUT)) {
     RemoveItemAt(*index);
   }
+
+  // Remove upstream's distill menu. It's replaced with speedreader.
+  if (const auto index = GetIndexOfCommandId(IDC_DISTILL_PAGE)) {
+    RemoveItemAt(*index);
+  }
 }
 
 void BraveAppMenuModel::ExecuteCommand(int id, int event_flags) {


### PR DESCRIPTION
Uplift of #21270
Resolves https://github.com/brave/brave-browser/issues/34707

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.