### PR TITLE
[Uplift 1.62] [Brave News]: Flip FeedV2 flag by default (#21144)

### DIFF
--- a/components/brave_news/common/features.cc
+++ b/components/brave_news/common/features.cc
@@ -16,7 +16,7 @@ BASE_FEATURE(kBraveNewsCardPeekFeature,
 
 BASE_FEATURE(kBraveNewsFeedUpdate,
              "BraveNewsFeedUpdate",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 const base::FeatureParam<int> kBraveNewsMinBlockCards{&kBraveNewsFeedUpdate,
                                                       "min-block-cards", 1};
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/21144
Resolves https://github.com/brave/brave-browser/issues/34593