### PR TITLE
Runs initMiscAndroidMetrics from an UI thread in case of connection failure (uplift to 1.62.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -2053,7 +2053,9 @@ public abstract class BraveActivity extends ChromeActivity
                             mMiscAndroidMetrics = miscAndroidMetrics;
                             mMiscAndroidMetrics.recordPrivacyHubEnabledStatus(
                                     OnboardingPrefManager.getInstance().isBraveStatsEnabled());
-                            mUsageMonitor = new UsageMonitor(mMiscAndroidMetrics);
+                            if (mUsageMonitor == null) {
+                                mUsageMonitor = UsageMonitor.getInstance(mMiscAndroidMetrics);
+                            }
                             mUsageMonitor.start();
                         });
     }
@@ -2100,6 +2102,9 @@ public abstract class BraveActivity extends ChromeActivity
 
     @Override
     public void cleanUpMiscAndroidMetrics() {
+        if (mUsageMonitor != null) {
+            mUsageMonitor.stop();
+        }
         if (mMiscAndroidMetrics != null) mMiscAndroidMetrics.close();
         mMiscAndroidMetrics = null;
     }

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -2029,7 +2029,15 @@ public abstract class BraveActivity extends ChromeActivity
     }
 
     @Override
-    public void initMiscAndroidMetrics() {
+    public void initMiscAndroidMetricsFromAWorkerThread() {
+        runOnUiThread(
+                () -> {
+                    initMiscAndroidMetrics();
+                });
+    }
+
+    private void initMiscAndroidMetrics() {
+        ThreadUtils.assertOnUiThread();
         if (mMiscAndroidMetrics != null) {
             return;
         }

--- a/android/java/org/chromium/chrome/browser/misc_metrics/MiscAndroidMetricsConnectionErrorHandler.java
+++ b/android/java/org/chromium/chrome/browser/misc_metrics/MiscAndroidMetricsConnectionErrorHandler.java
@@ -16,7 +16,8 @@ public class MiscAndroidMetricsConnectionErrorHandler implements ConnectionError
      *This is a delegate that is implemented in the object where the connection is created
      */
     public interface MiscAndroidMetricsConnectionErrorHandlerDelegate {
-        default void initMiscAndroidMetrics() {}
+        default void initMiscAndroidMetricsFromAWorkerThread() {}
+
         default void cleanUpMiscAndroidMetrics() {}
     }
 
@@ -31,6 +32,6 @@ public class MiscAndroidMetricsConnectionErrorHandler implements ConnectionError
     @Override
     public void onConnectionError(MojoException e) {
         mDelegate.cleanUpMiscAndroidMetrics();
-        mDelegate.initMiscAndroidMetrics();
+        mDelegate.initMiscAndroidMetricsFromAWorkerThread();
     }
 }


### PR DESCRIPTION
Uplift of #21171
Uplift of https://github.com/brave/brave-core/pull/21219
Resolves https://github.com/brave/brave-browser/issues/34649
Resolves https://github.com/brave/brave-browser/issues/34698

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.