### PR TITLE
Fixed sync unit tests tests for cr121

### DIFF
--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -207,7 +207,7 @@ TEST_F(BraveSyncServiceImplTest, ValidPassphraseLeadingTrailingWhitespace) {
   OSCryptMocker::TearDown();
 }
 
-// Google test doc strongly recommends to use ``*DeathTest` naming
+// Google test doc strongly recommends to use `*DeathTest` naming
 // for test suite
 using BraveSyncServiceImplDeathTest = BraveSyncServiceImplTest;
 
@@ -269,18 +269,6 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
   EXPECT_FALSE(engine());
   brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
 
-  // By default Brave enables Bookmarks datatype when sync is enabled.
-  // This caused DCHECK at DataTypeManagerImpl::DataTypeManagerImpl
-  // after OnEngineInitialized(true, false) call.
-  // Current unit test is intended to verify fix for brave/brave-browser#22898
-  // and is about set encryption passphrase later setup after right after
-  // enabling sync, for example when internet connection is unstable. Related
-  // Chromium commit 3241d114b8036bb6d53931ba34b3bf819258c29d Prior to this
-  // commit DataTypeManagerImpl wasn't created for bookmarks at
-  // ForcedSetDecryptionPassphrase test.
-  brave_sync_service_impl()->GetUserSettings()->SetSelectedTypes(
-      false, syncer::UserSelectableTypeSet());
-
   task_environment_.RunUntilIdle();
 
   brave_sync_service_impl()
@@ -298,6 +286,22 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
 
   EXPECT_TRUE(
       brave_sync_service_impl()->GetUserSettings()->IsPassphraseRequired());
+
+  // By default Brave enables Bookmarks datatype when sync is enabled.
+  // This caused DCHECK at DataTypeManagerImpl::DataTypeManagerImpl
+  // after OnEngineInitialized(true, false) call.
+  // Current unit test is intended to verify fix for brave/brave-browser#22898
+  // and is about set encryption passphrase later setup after right after
+  // enabling sync, for example when internet connection is unstable. Related
+  // Chromium commit 3241d114b8036bb6d53931ba34b3bf819258c29d Prior to this
+  // commit DataTypeManagerImpl wasn't created for bookmarks at
+  // ForcedSetDecryptionPassphrase test.
+  // Update Dec 2023: moved this workaround closer to OnEngineInitialized,
+  // with Chromium commit 33441a0f3f9a591693157f2fd16852ce072e6f9d the logic of
+  // SyncUserSettingsImpl::GetSelectedTypes had been changed and affected this
+  // test.
+  brave_sync_service_impl()->GetUserSettings()->SetSelectedTypes(
+      false, syncer::UserSelectableTypeSet());
 
   brave_sync_service_impl()->OnEngineInitialized(true, false);
   EXPECT_FALSE(

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -227,6 +227,15 @@ TEST_F(BraveSyncServiceImplDeathTest, MAYBE_EmulateGetOrCreateSyncCodeCHECK) {
   brave_sync_service_impl()->Initialize();
   EXPECT_FALSE(engine());
 
+  // Since Chromium commit 33441a0f3f9a591693157f2fd16852ce072e6f9d
+  // we cannot change datatypes if we are not signed to sync, see changes
+  // around SyncUserSettingsImpl::SetSelectedTypes.
+  // Call pref_service()->SetString() below triggers
+  // BraveSyncServiceImpl::OnBraveSyncPrefsChanged which sets kBookmarks type.
+  // To workaround this, first set valid sync code to pretend we are signed in.
+  bool set_code_result = brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
+  EXPECT_TRUE(set_code_result);
+
   std::string wrong_seed = "123";
   std::string encrypted_wrong_seed;
   EXPECT_TRUE(OSCrypt::EncryptString(wrong_seed, &encrypted_wrong_seed));


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves N/A

This PR fixes `BraveSyncServiceImplTest.ForcedSetDecryptionPassphrase` and `BraveSyncServiceImplDeathTest.EmulateGetOrCreateSyncCodeCHECK` tests on CR121

Related Chromium change is https://source.chromium.org/chromium/chromium/src/+/33441a0f3f9a591693157f2fd16852ce072e6f9d

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

```
npm run test -- brave_unit_tests --filter=BraveSyncServiceImplTest.ForcedSetDecryptionPassphrase

npm run test -- brave_unit_tests --filter=BraveSyncServiceImplDeathTest.EmulateGetOrCreateSyncCodeCHECK
```
