### PR TITLE
[Uplift 1.62] [Brave News]: FeedV2 default to opening articles in a new tab and add setting for old behavior (#21302)

### DIFF
--- a/browser/ui/webui/brave_webui_source.cc
+++ b/browser/ui/webui/brave_webui_source.cc
@@ -245,6 +245,9 @@ void CustomizeWebUIHTMLSource(content::WebUI* web_ui,
         { "braveNewsNoArticles", IDS_BRAVE_NEWS_NO_ARTICLES},
         { "braveNewsCustomizeFeed", IDS_BRAVE_NEWS_CUSTOMIZE_FEED},
         { "braveNewsRefreshFeed", IDS_BRAVE_NEWS_REFRESH_FEED},
+        { "braveNewsOpenArticlesIn", IDS_BRAVE_NEWS_OPEN_ARTICLES_IN},
+        { "braveNewsOpenArticlesInNewTab", IDS_BRAVE_NEWS_OPEN_ARTICLES_IN_NEW_TAB},
+        { "braveNewsOpenArticlesInCurrentTab", IDS_BRAVE_NEWS_OPEN_ARTICLES_IN_CURRENT_TAB},
 
         // Brave News Channels
         { "braveNewsChannel-Brave", IDS_BRAVE_NEWS_CHANNEL_BRAVE},

--- a/components/brave_new_tab_ui/components/default/braveNews/customize/Configure.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/customize/Configure.tsx
@@ -19,6 +19,8 @@ import Discover from './Discover'
 import { PopularPage } from './Popular'
 import SourcesList from './SourcesList'
 import { SuggestionsPage } from './Suggestions'
+import Dropdown from '@brave/leo/react/dropdown'
+import { defaultState } from '../../../../storage/new_tab_storage'
 
 const Grid = styled.div`
   width: 100%;
@@ -54,6 +56,7 @@ const BackButtonContainer = styled.div`
   display: flex;
   padding: 12px;
   padding-left: 34px;
+  & > leo-button { max-width: max-content; }
 `
 
 const CloseButton = styled(Button)`
@@ -94,13 +97,19 @@ const Content = styled.div`
   padding: 20px 64px;
 `
 
+const OpenArticlesDropdown = styled(Dropdown)`
+  margin-left: ${spacing['3Xl']};
+`
+
 export default function Configure() {
   const {
     setCustomizePage,
     customizePage,
     toggleBraveNewsOnNTP,
     isOptInPrefEnabled,
-    isShowOnNTPPrefEnabled
+    isShowOnNTPPrefEnabled,
+    openArticlesInNewTab,
+    setOpenArticlesInNewTab
   } = useBraveNews()
 
   // TODO(petemill): We'll probably need to have 2 toggles, or some other
@@ -123,7 +132,7 @@ export default function Configure() {
     <Grid id='brave-news-configure'>
       <BackButtonContainer>
         <Button onClick={() => setCustomizePage(null)} kind='plain-faint'>
-          <Flex direction='row' align='center' gap={spacing[8]}>
+          <Flex direction='row' align='center' gap={spacing.m}>
             {BackArrow}
             <span>
               {formatMessage(getLocale('braveNewsBackToDashboard'), {
@@ -142,6 +151,14 @@ export default function Configure() {
         {isBraveNewsFullyEnabled && <Flex direction="row" align="center" gap={8}>
           <HeaderText>{getLocale('braveNewsTitle')}</HeaderText>
           <Toggle checked={isShowOnNTPPrefEnabled} onChange={e => toggleBraveNewsOnNTP(e.detail.checked)} />
+          {defaultState.featureFlagBraveNewsFeedV2Enabled && <OpenArticlesDropdown size='small' value={openArticlesInNewTab ? 'true' : 'false'} onChange={e => setOpenArticlesInNewTab(e.detail.value === 'true')}>
+            <span slot="label">{getLocale('braveNewsOpenArticlesIn')}</span>
+            <span slot='value'>
+              {openArticlesInNewTab ? getLocale('braveNewsOpenArticlesInNewTab') : getLocale('braveNewsOpenArticlesInCurrentTab')}
+            </span>
+            <leo-option value={'true'}>{getLocale('braveNewsOpenArticlesInNewTab')}</leo-option>
+            <leo-option value={'false'}>{getLocale('braveNewsOpenArticlesInCurrentTab')}</leo-option>
+          </OpenArticlesDropdown>}
         </Flex>}
       </Header>
       <Hr />

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -78,6 +78,7 @@ void BraveNewsController::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterDictionaryPref(prefs::kBraveNewsSources);
   registry->RegisterDictionaryPref(prefs::kBraveNewsChannels);
   registry->RegisterDictionaryPref(prefs::kBraveNewsDirectFeeds);
+  registry->RegisterBooleanPref(prefs::kBraveNewsOpenArticlesInNewTab, true);
 
   p3a::RegisterProfilePrefs(registry);
 }
@@ -550,6 +551,8 @@ void BraveNewsController::SetConfiguration(
     SetConfigurationCallback callback) {
   prefs_->SetBoolean(prefs::kBraveNewsOptedIn, configuration->isOptedIn);
   prefs_->SetBoolean(prefs::kNewTabPageShowToday, configuration->showOnNTP);
+  prefs_->SetBoolean(prefs::kBraveNewsOpenArticlesInNewTab,
+                     configuration->openArticlesInNewTab);
   std::move(callback).Run();
 }
 
@@ -560,6 +563,8 @@ void BraveNewsController::AddConfigurationListener(
   auto event = mojom::Configuration::New();
   event->isOptedIn = prefs_->GetBoolean(prefs::kBraveNewsOptedIn);
   event->showOnNTP = prefs_->GetBoolean(prefs::kNewTabPageShowToday);
+  event->openArticlesInNewTab =
+      prefs_->GetBoolean(prefs::kBraveNewsOpenArticlesInNewTab);
   configuration_listeners_.Get(id)->Changed(std::move(event));
 }
 
@@ -727,6 +732,8 @@ void BraveNewsController::OnOptInChange() {
   auto event = mojom::Configuration::New();
   event->isOptedIn = prefs_->GetBoolean(prefs::kBraveNewsOptedIn);
   event->showOnNTP = prefs_->GetBoolean(prefs::kNewTabPageShowToday);
+  event->openArticlesInNewTab =
+      prefs_->GetBoolean(prefs::kBraveNewsOpenArticlesInNewTab);
   for (const auto& listener : configuration_listeners_) {
     listener->Changed(event->Clone());
   }

--- a/components/brave_news/browser/resources/feed/Ad.tsx
+++ b/components/brave_news/browser/resources/feed/Ad.tsx
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import SecureLink, { handleOpenURLClick } from '$web-common/SecureLink';
+import { getLocale } from '$web-common/locale';
 import { useOnVisibleCallback } from '$web-common/useVisible';
 import VisibilityTimer from '$web-common/visibilityTimer';
 import Button from '@brave/leo/react/button';
@@ -14,7 +15,6 @@ import getBraveNewsController from '../shared/api';
 import { useUnpaddedImageUrl } from '../shared/useUnpaddedImageUrl';
 import { MetaInfoContainer } from './ArticleMetaRow';
 import Card, { LargeImage, Title } from './Card';
-import { getLocale } from '$web-common/locale';
 
 interface Props {
   info: FeedV2Ad

--- a/components/brave_news/browser/resources/feed/Article.tsx
+++ b/components/brave_news/browser/resources/feed/Article.tsx
@@ -3,14 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import Flex from '$web-common/Flex';
-import SecureLink, { linkClickHandler } from '$web-common/SecureLink';
 import { spacing } from '@brave/leo/tokens/css';
 import { Article as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
 import * as React from 'react';
 import styled from 'styled-components';
 import { useLazyUnpaddedImageUrl } from '../shared/useUnpaddedImageUrl';
 import ArticleMetaRow from './ArticleMetaRow';
-import Card, { SmallImage, Title } from './Card';
+import Card, { BraveNewsLink, SmallImage, Title, braveNewsCardClickHandler } from './Card';
 
 interface Props {
   info: Info
@@ -26,11 +25,11 @@ export default function Article({ info, hideChannel }: Props) {
   const { url: imageUrl, setElementRef } = useLazyUnpaddedImageUrl(info.data.image.paddedImageUrl?.url ?? info.data.image.imageUrl?.url, { useCache: true })
   const url = info.data.url.url;
 
-  return <Container ref={setElementRef} onClick={linkClickHandler(url)}>
+  return <Container ref={setElementRef} onClick={braveNewsCardClickHandler(url)}>
     <ArticleMetaRow article={info.data} hideChannel={hideChannel} />
     <Flex direction='row' gap={spacing.m} justify='space-between'>
       <Title>
-        <SecureLink onClick={e => e.stopPropagation()} href={url}>{info.data.title}</SecureLink>
+        <BraveNewsLink href={url}>{info.data.title}</BraveNewsLink>
       </Title>
       <SmallImage src={imageUrl} />
     </Flex>

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -5,6 +5,9 @@
 
 import { color, effect, font, radius, spacing } from '@brave/leo/tokens/css';
 import styled from "styled-components";
+import SecureLink, { SecureLinkProps, validateScheme } from '$web-common/SecureLink';
+import * as React from 'react';
+import { configurationCache, useBraveNews } from '../shared/Context';
 
 export const Header = styled.h2`
   margin: 0;
@@ -70,3 +73,18 @@ export default styled.div`
 
   ${p => p.onClick && 'cursor: pointer'}
 `
+
+export const braveNewsCardClickHandler = (href: string | undefined) => (e: React.MouseEvent) => {
+  validateScheme(href)
+
+  if (configurationCache.value.openArticlesInNewTab || e.ctrlKey || e.metaKey || e.buttons & 4) {
+    window.open(href, '_blank', 'noopener noreferrer')
+  } else {
+    window.location.href = href!
+  }
+}
+
+export function BraveNewsLink(props: SecureLinkProps) {
+  const { openArticlesInNewTab } = useBraveNews()
+  return <SecureLink {...props} onClick={e => e.stopPropagation()} target={openArticlesInNewTab ? '_blank' : undefined} />
+}

--- a/components/brave_news/browser/resources/feed/Hero.tsx
+++ b/components/brave_news/browser/resources/feed/Hero.tsx
@@ -2,12 +2,11 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
-import SecureLink, { linkClickHandler } from '$web-common/SecureLink';
 import { HeroArticle as Info } from 'gen/brave/components/brave_news/common/brave_news.mojom.m';
 import * as React from 'react';
 import { useLazyUnpaddedImageUrl } from '../shared/useUnpaddedImageUrl';
 import ArticleMetaRow from './ArticleMetaRow';
-import Card, { LargeImage, Title } from './Card';
+import Card, { BraveNewsLink, LargeImage, Title, braveNewsCardClickHandler } from './Card';
 
 interface Props {
   info: Info
@@ -19,11 +18,11 @@ export default function HeroArticle({ info }: Props) {
     rootElement: document.body,
     rootMargin: '0px 0px 200px 0px'
   })
-  return <Card onClick={linkClickHandler(info.data.url.url)} ref={setElementRef}>
+  return <Card onClick={braveNewsCardClickHandler(info.data.url.url)} ref={setElementRef}>
     <LargeImage src={url} />
     <ArticleMetaRow article={info.data} />
     <Title>
-      <SecureLink onClick={e => e.stopPropagation()} href={info.data.url.url}>{info.data.title}</SecureLink>
+      <BraveNewsLink href={info.data.url.url}>{info.data.title}</BraveNewsLink>
     </Title>
   </Card>
 }

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -39,6 +39,8 @@ interface BraveNewsContext {
   isOptInPrefEnabled: boolean | undefined
   isShowOnNTPPrefEnabled: boolean | undefined
   toggleBraveNewsOnNTP: (enabled: boolean) => void
+  openArticlesInNewTab: boolean,
+  setOpenArticlesInNewTab: (newTab: boolean) => void
 }
 
 export const BraveNewsContext = React.createContext<BraveNewsContext>({
@@ -58,12 +60,14 @@ export const BraveNewsContext = React.createContext<BraveNewsContext>({
   updateSuggestedPublisherIds: () => { },
   isOptInPrefEnabled: undefined,
   isShowOnNTPPrefEnabled: undefined,
-  toggleBraveNewsOnNTP: (enabled: boolean) => { }
+  toggleBraveNewsOnNTP: (enabled: boolean) => { },
+  openArticlesInNewTab: true,
+  setOpenArticlesInNewTab: () => {}
 })
 
 export const publishersCache = new PublishersCachingWrapper()
 const channelsCache = new ChannelsCachingWrapper()
-const configurationCache = new ConfigurationCachingWrapper()
+export const configurationCache = new ConfigurationCachingWrapper()
 
 export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
   const [locale, setLocale] = useState('')
@@ -131,6 +135,10 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     configurationCache.set({ showOnNTP: false })
   }
 
+  const setOpenArticlesInNewTab = useCallback((inNewTab: boolean) => {
+    configurationCache.set({ openArticlesInNewTab: inNewTab })
+  }, [])
+
   const context = useMemo<BraveNewsContext>(() => ({
     locale,
     feedView,
@@ -148,7 +156,9 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     updateSuggestedPublisherIds,
     isOptInPrefEnabled: configuration.isOptedIn,
     isShowOnNTPPrefEnabled: configuration.showOnNTP,
-    toggleBraveNewsOnNTP
+    toggleBraveNewsOnNTP,
+    openArticlesInNewTab: configuration.openArticlesInNewTab,
+    setOpenArticlesInNewTab
   }), [customizePage, setFeedView, feedV2, channels, publishers, suggestedPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP])
 
   return <BraveNewsContext.Provider value={context}>

--- a/components/brave_news/browser/resources/shared/configurationCache.ts
+++ b/components/brave_news/browser/resources/shared/configurationCache.ts
@@ -22,7 +22,8 @@ export class ConfigurationCachingWrapper
   constructor() {
     super({
       isOptedIn: false,
-      showOnNTP: false
+      showOnNTP: false,
+      openArticlesInNewTab: true,
     })
 
     this.controller = getBraveNewsController()

--- a/components/brave_news/common/brave_news.mojom
+++ b/components/brave_news/common/brave_news.mojom
@@ -248,6 +248,7 @@ struct ChannelsEvent {
 struct Configuration {
   bool isOptedIn;
   bool showOnNTP;
+  bool openArticlesInNewTab;
 };
 
 interface ChannelsListener {

--- a/components/brave_news/common/pref_names.h
+++ b/components/brave_news/common/pref_names.h
@@ -43,6 +43,8 @@ inline constexpr char kBraveNewsLastSessionTime[] =
     "brave.today.p3a_last_session_time";
 inline constexpr char kBraveNewsWasEverEnabled[] =
     "brave.today.p3a_was_ever_enabled";
+inline constexpr char kBraveNewsOpenArticlesInNewTab[] =
+    "brave.news.open-articles-in-new-tab";
 
 // Dictionary value keys
 inline constexpr char kBraveNewsDirectFeedsKeyTitle[] = "title";

--- a/components/common/SecureLink.tsx
+++ b/components/common/SecureLink.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 
 export const defaultAllowedSchemes = ['http:', 'https:']
 
-type Props = React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> & {
+export type SecureLinkProps = React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement> & {
   allowedSchemes?: string[]
 }
 
@@ -50,7 +50,7 @@ export const linkClickHandler = (href: string | undefined) => (e: React.MouseEve
  * to an allowed scheme. By default, allowed schemes are http: or https:,
  * but this can be overridden.
  */
-export default function SecureLink({ href, allowedSchemes, ...rest }: Props) {
+export default function SecureLink({ href, allowedSchemes, ...rest }: SecureLinkProps) {
   validateScheme(href, allowedSchemes ?? defaultAllowedSchemes)
   return <a href={href} {...rest} />
 }

--- a/components/resources/brave_news_strings.grdp
+++ b/components/resources/brave_news_strings.grdp
@@ -222,4 +222,13 @@
   <message name="IDS_BRAVE_NEWS_REFRESH_FEED" desc="Text of button for refreshing the feed">
     Refresh
   </message>
+  <message name="IDS_BRAVE_NEWS_OPEN_ARTICLES_IN" desc="Question for how the user would like to open their articles">
+    Open articles in
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPEN_ARTICLES_IN_NEW_TAB" desc="Indicates the user would like to open articles in a new tab">
+    New tab
+  </message>
+  <message name="IDS_BRAVE_NEWS_OPEN_ARTICLES_IN_CURRENT_TAB" desc="Indicates the user would like to open articles in the current tab">
+    Current tab
+  </message>
 </grit-part>


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/21302
Resolves https://github.com/brave/brave-browser/issues/34782