### PR TITLE
Fixed crash from tab's context menu

### DIFF
--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -24,6 +24,11 @@ BraveBrowserTabStripController::~BraveBrowserTabStripController() {
     context_menu_contents_->Cancel();
 }
 
+const std::optional<int> BraveBrowserTabStripController::GetModelIndexOf(
+    Tab* tab) {
+  return tabstrip_->GetModelIndexOf(tab);
+}
+
 void BraveBrowserTabStripController::ShowContextMenuForTab(
     Tab* tab,
     const gfx::Point& p,

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_BROWSER_TAB_STRIP_CONTROLLER_H_
 
 #include <memory>
+#include <optional>
 
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 
@@ -23,6 +24,8 @@ class BraveBrowserTabStripController : public BrowserTabStripController {
   BraveBrowserTabStripController& operator=(
       const BraveBrowserTabStripController&) = delete;
   ~BraveBrowserTabStripController() override;
+
+  const std::optional<int> GetModelIndexOf(Tab* tab);
 
   // BrowserTabStripController overrides:
   void ShowContextMenuForTab(Tab* tab,

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -64,6 +64,10 @@ void BraveTabContextMenuContents::RunMenuAt(const gfx::Point& point,
 }
 
 bool BraveTabContextMenuContents::IsCommandIdChecked(int command_id) const {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (command_id == BraveTabMenuModel::CommandShowVerticalTabs) {
     return tabs::utils::ShouldShowVerticalTabs(browser_);
   }
@@ -72,6 +76,11 @@ bool BraveTabContextMenuContents::IsCommandIdChecked(int command_id) const {
 }
 
 bool BraveTabContextMenuContents::IsCommandIdEnabled(int command_id) const {
+  // This could be called after tab is closed.
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (IsBraveCommandId(command_id))
     return IsBraveCommandIdEnabled(command_id);
 
@@ -80,6 +89,10 @@ bool BraveTabContextMenuContents::IsCommandIdEnabled(int command_id) const {
 }
 
 bool BraveTabContextMenuContents::IsCommandIdVisible(int command_id) const {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (command_id == BraveTabMenuModel::CommandShowVerticalTabs) {
     return tabs::utils::SupportsVerticalTabs(browser_);
   }
@@ -90,6 +103,10 @@ bool BraveTabContextMenuContents::IsCommandIdVisible(int command_id) const {
 bool BraveTabContextMenuContents::GetAcceleratorForCommandId(
     int command_id,
     ui::Accelerator* accelerator) const {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (IsBraveCommandId(command_id))
     return false;
 
@@ -103,6 +120,10 @@ bool BraveTabContextMenuContents::GetAcceleratorForCommandId(
 
 void BraveTabContextMenuContents::ExecuteCommand(int command_id,
                                                  int event_flags) {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return;
+  }
+
   if (IsBraveCommandId(command_id))
     return ExecuteBraveCommand(command_id);
 
@@ -114,6 +135,8 @@ void BraveTabContextMenuContents::ExecuteCommand(int command_id,
 
 bool BraveTabContextMenuContents::IsBraveCommandIdEnabled(
     int command_id) const {
+  CHECK(controller_->GetModelIndexOf(tab_));
+
   switch (command_id) {
     case BraveTabMenuModel::CommandRestoreTab:
       return restore_service_ && (!restore_service_->IsLoaded() ||
@@ -143,6 +166,8 @@ bool BraveTabContextMenuContents::IsBraveCommandIdEnabled(
 }
 
 void BraveTabContextMenuContents::ExecuteBraveCommand(int command_id) {
+  CHECK(controller_->GetModelIndexOf(tab_));
+
   switch (command_id) {
     case BraveTabMenuModel::CommandRestoreTab:
       chrome::RestoreTab(browser_);

--- a/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
+
+#define CloseContextMenuForTesting             \
+  CloseContextMenuForTesting_UnUsed() {}       \
+  friend class BraveBrowserTabStripController; \
+  void CloseContextMenuForTesting
+
+#include "src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"  // IWYU pragma: export
+
+#undef CloseContextMenuForTesting
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/34785

Crash happened at TabStripModel::IsTabSelected().
Maybe this method was called after tab is closed already.
If target tab is not included in tab strip model,
this method should not be called with that tab.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

