### PR TITLE
Fixed crash when running extension item from app menu in private window

### DIFF
--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -192,7 +192,6 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
 #endif
     &features::kDigitalGoodsApi,
     &features::kDIPS,
-    &features::kExtensionsMenuInAppMenu,
     &features::kFedCm,
     &features::kFedCmWithoutThirdPartyCookies,
     &features::kFirstPartySets,

--- a/browser/ui/toolbar/app_menu_icons.cc
+++ b/browser/ui/toolbar/app_menu_icons.cc
@@ -37,6 +37,7 @@ const std::map<int, const gfx::VectorIcon&>& GetCommandIcons() {
           {IDC_VIEW_PASSWORDS, kLeoKeyIcon},
           {IDC_SHOW_DOWNLOADS, kLeoDownloadIcon},
           {IDC_MANAGE_EXTENSIONS, kLeoBrowserExtensionsIcon},
+          {IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS, kLeoBrowserExtensionsIcon},
           {IDC_ZOOM_MENU, kLeoSearchZoomInIcon},
           {IDC_PRINT, kLeoPrintIcon},
           {IDC_MORE_TOOLS_MENU, kLeoWindowScrewdriverIcon},

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -297,10 +297,22 @@ void BraveAppMenuModel::BuildBrowserSection() {
                              IDS_SHOW_DOWNLOADS);
   }
 
+  // Use this command's enabled state to not having it in guest window.
+  // It's disabled in guest window. Upstream's guest window has extensions
+  // menu in app menu, but we hide it.
   if (IsCommandIdEnabled(IDC_MANAGE_EXTENSIONS)) {
+    // Upstream enabled extensions submenu by default.
+    CHECK(features::IsExtensionMenuInRootAppMenu());
+
+    // Use IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS instead of
+    // IDC_MANAGE_EXTENSIONS because executing it from private(tor) window
+    // causes crash as LogSafetyHubInteractionMetrics() tries to refer
+    // SafetyHubMenuNotificationService. But it's not instantiated in private
+    // window. Upstream also has this crash if ExtensionsMenuInAppMenu feature
+    // is disabled.
     InsertItemWithStringIdAt(
         GetIndexOfCommandId(IDC_SHOW_DOWNLOADS).value() + 1,
-        IDC_MANAGE_EXTENSIONS, IDS_SHOW_EXTENSIONS);
+        IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS, IDS_SHOW_EXTENSIONS);
   }
 }
 
@@ -385,19 +397,11 @@ void BraveAppMenuModel::RemoveUpstreamMenus() {
   DCHECK(more_tools_model);
 
   // Remove upstream's extensions item. It'll be added into top level third
-  // section.
-  if (base::FeatureList::IsEnabled(features::kExtensionsMenuInAppMenu) ||
-      features::IsChromeRefresh2023()) {
-    // Hide extensions sub menu.
-    DCHECK(GetIndexOfCommandId(IDC_EXTENSIONS_SUBMENU).has_value());
-    RemoveItemAt(GetIndexOfCommandId(IDC_EXTENSIONS_SUBMENU).value());
-  } else {
-    // Hide extensions item from more tools sub menu.
-    DCHECK(more_tools_model->GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS)
-               .has_value());
-    more_tools_model->RemoveItemAt(
-        more_tools_model->GetIndexOfCommandId(IDC_MANAGE_EXTENSIONS).value());
-  }
+  // section. Upstream enabled extensions submenu by default.
+  CHECK(features::IsExtensionMenuInRootAppMenu());
+  // Hide extensions sub menu.
+  DCHECK(GetIndexOfCommandId(IDC_EXTENSIONS_SUBMENU).has_value());
+  RemoveItemAt(GetIndexOfCommandId(IDC_EXTENSIONS_SUBMENU).value());
 
   // Remove upstream's cast item. It'll be added into more tools sub menu.
   if (media_router::MediaRouterEnabled(browser()->profile())) {
@@ -495,6 +499,11 @@ bool BraveAppMenuModel::IsCommandIdEnabled(int id) const {
              IsIpfsServiceLaunched(browser_context);
   }
 #endif
+  if (id == IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS) {
+    // Always returns true as this command id is only added when it could be
+    // used.
+    return true;
+  }
   return AppMenuModel::IsCommandIdEnabled(id);
 }
 

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -37,6 +37,7 @@ class BraveAppMenuModel : public AppMenuModel {
 
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveAppMenuModelBrowserTest, BraveIpfsMenuTest);
+  friend class BraveAppMenuModelBrowserTest;
 
   // AppMenuModel overrides:
   void Build() override;

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -90,6 +90,13 @@ class BraveAppMenuModelBrowserTest : public InProcessBrowserTest {
     ipfs_service_->GetIpnsKeysManager()->SetKeysForTest(keys);
   }
 #endif
+
+  void RunCommandFromAppMenuModel(Browser* browser, int command_id) {
+    auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser);
+    BraveAppMenuModel model(browser_view->toolbar(), browser);
+    model.Init();
+    model.ExecuteCommand(command_id, /*event_flags=*/0);
+  }
 };
 
 void CheckCommandsAreDisabledInMenuModel(
@@ -190,6 +197,11 @@ void CheckHistoryCommandsAreInOrderInMenuModel(
   CheckCommandsAreInOrderInMenuModel(history_model, history_commands_in_order);
 }
 
+IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, CommandsExecutionTest) {
+  RunCommandFromAppMenuModel(CreateIncognitoBrowser(),
+                             IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS);
+}
+
 // Test brave menu order test.
 // Brave menu is inserted based on corresponding commands enable status.
 // So, this doesn't test for each profiles(normal, private, tor and guest).
@@ -209,7 +221,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
     IDC_RECENT_TABS_MENU,
     IDC_BOOKMARKS_MENU,
     IDC_SHOW_DOWNLOADS,
-    IDC_MANAGE_EXTENSIONS,
+    IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS,
     IDC_ZOOM_MENU,
     IDC_PRINT,
     IDC_FIND,
@@ -263,7 +275,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
     IDC_SHOW_BRAVE_WALLET,
     IDC_BOOKMARKS_MENU,
     IDC_SHOW_DOWNLOADS,
-    IDC_MANAGE_EXTENSIONS,
+    IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS,
     IDC_ZOOM_MENU,
     IDC_PRINT,
     IDC_FIND,
@@ -316,7 +328,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
 #endif
     IDC_RECENT_TABS_MENU,
     IDC_BOOKMARKS_MENU,
-    IDC_MANAGE_EXTENSIONS,
+    IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS,
   };
 
   CheckCommandsAreDisabledInMenuModel(guest_browser,
@@ -355,7 +367,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
       IDC_SHOW_BRAVE_WALLET,
       IDC_BOOKMARKS_MENU,
       IDC_SHOW_DOWNLOADS,
-      IDC_MANAGE_EXTENSIONS,
+      IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS,
       IDC_ZOOM_MENU,
       IDC_PRINT,
       IDC_FIND,

--- a/chromium_src/chrome/browser/ui/ui_features.cc
+++ b/chromium_src/chrome/browser/ui/ui_features.cc
@@ -16,7 +16,6 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kHaTSWebUI, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
     {kTabHoverCardImages, base::FEATURE_DISABLED_BY_DEFAULT},
-    {kExtensionsMenuInAppMenu, base::FEATURE_DISABLED_BY_DEFAULT},
 }});
 
 }  // namespace features


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/34811

Use `IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS` command instead of `IDC_MANAGE_EXTENSIONS`
as it refers uninitialized service(`SafetyHubMenuNotificationService`) in private(tor) window.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`BraveAppMenuModelBrowserTest.*`
Running `Extensions` menu item from app menu in private(tor) and check it doesn't have any crash.