### PR TITLE
Fixed crash from tab's context menu (uplift to 1.62.x)

### DIFF
--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.cc
@@ -24,6 +24,11 @@ BraveBrowserTabStripController::~BraveBrowserTabStripController() {
     context_menu_contents_->Cancel();
 }
 
+const std::optional<int> BraveBrowserTabStripController::GetModelIndexOf(
+    Tab* tab) {
+  return tabstrip_->GetModelIndexOf(tab);
+}
+
 void BraveBrowserTabStripController::ShowContextMenuForTab(
     Tab* tab,
     const gfx::Point& p,

--- a/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
+++ b/browser/ui/views/tabs/brave_browser_tab_strip_controller.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_BROWSER_TAB_STRIP_CONTROLLER_H_
 
 #include <memory>
+#include <optional>
 
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 
@@ -23,6 +24,8 @@ class BraveBrowserTabStripController : public BrowserTabStripController {
   BraveBrowserTabStripController& operator=(
       const BraveBrowserTabStripController&) = delete;
   ~BraveBrowserTabStripController() override;
+
+  const std::optional<int> GetModelIndexOf(Tab* tab);
 
   // BrowserTabStripController overrides:
   void ShowContextMenuForTab(Tab* tab,

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -64,6 +64,10 @@ void BraveTabContextMenuContents::RunMenuAt(const gfx::Point& point,
 }
 
 bool BraveTabContextMenuContents::IsCommandIdChecked(int command_id) const {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (command_id == BraveTabMenuModel::CommandShowVerticalTabs) {
     return tabs::utils::ShouldShowVerticalTabs(browser_);
   }
@@ -72,6 +76,11 @@ bool BraveTabContextMenuContents::IsCommandIdChecked(int command_id) const {
 }
 
 bool BraveTabContextMenuContents::IsCommandIdEnabled(int command_id) const {
+  // This could be called after tab is closed.
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (IsBraveCommandId(command_id))
     return IsBraveCommandIdEnabled(command_id);
 
@@ -80,6 +89,10 @@ bool BraveTabContextMenuContents::IsCommandIdEnabled(int command_id) const {
 }
 
 bool BraveTabContextMenuContents::IsCommandIdVisible(int command_id) const {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (command_id == BraveTabMenuModel::CommandShowVerticalTabs) {
     return tabs::utils::SupportsVerticalTabs(browser_);
   }
@@ -90,6 +103,10 @@ bool BraveTabContextMenuContents::IsCommandIdVisible(int command_id) const {
 bool BraveTabContextMenuContents::GetAcceleratorForCommandId(
     int command_id,
     ui::Accelerator* accelerator) const {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return false;
+  }
+
   if (IsBraveCommandId(command_id))
     return false;
 
@@ -103,6 +120,10 @@ bool BraveTabContextMenuContents::GetAcceleratorForCommandId(
 
 void BraveTabContextMenuContents::ExecuteCommand(int command_id,
                                                  int event_flags) {
+  if (!controller_->GetModelIndexOf(tab_)) {
+    return;
+  }
+
   if (IsBraveCommandId(command_id))
     return ExecuteBraveCommand(command_id);
 
@@ -114,6 +135,8 @@ void BraveTabContextMenuContents::ExecuteCommand(int command_id,
 
 bool BraveTabContextMenuContents::IsBraveCommandIdEnabled(
     int command_id) const {
+  CHECK(controller_->GetModelIndexOf(tab_));
+
   switch (command_id) {
     case BraveTabMenuModel::CommandRestoreTab:
       return restore_service_ && (!restore_service_->IsLoaded() ||
@@ -143,6 +166,8 @@ bool BraveTabContextMenuContents::IsBraveCommandIdEnabled(
 }
 
 void BraveTabContextMenuContents::ExecuteBraveCommand(int command_id) {
+  CHECK(controller_->GetModelIndexOf(tab_));
+
   switch (command_id) {
     case BraveTabMenuModel::CommandRestoreTab:
       chrome::RestoreTab(browser_);

--- a/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_
+
+#define CloseContextMenuForTesting             \
+  CloseContextMenuForTesting_UnUsed() {}       \
+  friend class BraveBrowserTabStripController; \
+  void CloseContextMenuForTesting
+
+#include "src/chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"  // IWYU pragma: export
+
+#undef CloseContextMenuForTesting
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TABS_BROWSER_TAB_STRIP_CONTROLLER_H_


### PR DESCRIPTION
Uplift of #21326
fix https://github.com/brave/brave-browser/issues/34785

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.