### PR TITLE
Bump wallet standard to fix `Signature verification error` in signTransaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@brave/brave-ui": "0.40.4",
         "@brave/leo": "github:brave/leo#857181f3d314e1c55bb2e19e21924acb0b54c587",
         "@brave/react-virtualized-auto-sizer": "^1.0.4",
-        "@brave/wallet-standard-brave": "~0.0.11",
+        "@brave/wallet-standard-brave": "0.0.12",
         "@dnd-kit/core": "6.0.5",
         "@dnd-kit/sortable": "7.0.1",
         "@glif/filecoin-wallet-provider": "2.0.0-beta.12",
@@ -2533,9 +2533,9 @@
       }
     },
     "node_modules/@brave/wallet-standard-brave": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@brave/wallet-standard-brave/-/wallet-standard-brave-0.0.11.tgz",
-      "integrity": "sha512-GazfXfrEPhIlz6TCbyi3C/+oLlC63YaINZ/WnhmGcMs5lFGi1Y+zbEpx3WS+7csIu7RbFJ+ojUpAuTE+SsiIcA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@brave/wallet-standard-brave/-/wallet-standard-brave-0.0.12.tgz",
+      "integrity": "sha512-y6P//YoyPXlbgcdmX7mA/NmqJJVh/8Tnj3wS6p9qDF+wvF5iNsQwns8qi0GCYs6kFw3U14Ea3JubJJKOhxQWww==",
       "dependencies": {
         "@solana/wallet-standard-features": "^1.0.0",
         "@solana/web3.js": "1.58.0",
@@ -29610,9 +29610,9 @@
       "requires": {}
     },
     "@brave/wallet-standard-brave": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/@brave/wallet-standard-brave/-/wallet-standard-brave-0.0.11.tgz",
-      "integrity": "sha512-GazfXfrEPhIlz6TCbyi3C/+oLlC63YaINZ/WnhmGcMs5lFGi1Y+zbEpx3WS+7csIu7RbFJ+ojUpAuTE+SsiIcA==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@brave/wallet-standard-brave/-/wallet-standard-brave-0.0.12.tgz",
+      "integrity": "sha512-y6P//YoyPXlbgcdmX7mA/NmqJJVh/8Tnj3wS6p9qDF+wvF5iNsQwns8qi0GCYs6kFw3U14Ea3JubJJKOhxQWww==",
       "requires": {
         "@solana/wallet-standard-features": "^1.0.0",
         "@solana/web3.js": "1.58.0",

--- a/package.json
+++ b/package.json
@@ -368,7 +368,7 @@
     "@brave/brave-ui": "0.40.4",
     "@brave/leo": "github:brave/leo#857181f3d314e1c55bb2e19e21924acb0b54c587",
     "@brave/react-virtualized-auto-sizer": "^1.0.4",
-    "@brave/wallet-standard-brave": "~0.0.11",
+    "@brave/wallet-standard-brave": "0.0.12",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/sortable": "7.0.1",
     "@glif/filecoin-wallet-provider": "2.0.0-beta.12",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34842

Bump version to include https://github.com/brave/wallet-standard-brave/pull/39.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Mint https://magiceden.io/launchpad/ryder_one should be successful, if it is not live, could try others. (Make sure you're on mainnet.)
- `Sign transaction` in https://solana-labs.github.io/wallet-adapter/example/ should work fine. (Make sure you're on devnet.)
