### PR TITLE
Do not show web3 button if web3 URL is invalid

### DIFF
--- a/components/brave_rewards/resources/tip_panel/components/creator_view.tsx
+++ b/components/brave_rewards/resources/tip_panel/components/creator_view.tsx
@@ -64,10 +64,10 @@ export function CreatorView () {
 
   if (creatorBanner.web3Url) {
     if (renderedLinks.length > 0) {
-      renderedLinks.push(<style.linkDivider />)
+      renderedLinks.push(<style.linkDivider key='divider' />)
     }
     renderedLinks.push(
-      <NewTabLink href={creatorBanner.web3Url}>
+      <NewTabLink key='web3' href={creatorBanner.web3Url}>
         <LaunchIcon />
       </NewTabLink>
     )

--- a/components/brave_rewards/resources/tip_panel/lib/webui_model.ts
+++ b/components/brave_rewards/resources/tip_panel/lib/webui_model.ts
@@ -61,17 +61,34 @@ export function createModel (): Model {
         : false
     }
 
-    function mapBanner () {
-      return banner || {
-        name: '',
-        provider: '',
-        title: '',
-        description: '',
-        logo: '',
-        background: '',
-        links: {},
-        web3Url: ''
+    function mapURL (url: string) {
+      try {
+        return new URL(url).toString()
+      } catch {
+        return ''
       }
+    }
+
+    function mapBanner () {
+      if (!banner) {
+        return {
+          name: '',
+          provider: '',
+          title: '',
+          description: '',
+          logo: '',
+          background: '',
+          links: {},
+          web3Url: ''
+        }
+      }
+
+      banner.web3Url = mapURL(banner.web3Url)
+      for (const [key, value] of Object.entries(banner.links)) {
+        banner.links[key] = mapURL(String(value || ''))
+      }
+
+      return banner
     }
 
     function mapCreatorVerified () {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34843

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- With a new profile, enable Rewards
- Visit a publisher site in order to load publisher data into the database
- Close the browser
- Open the `publisher_info_db` database file
- Browse the data within the "server_publisher_banner" table
- Edit the "web3_url" value for the visited publisher, setting it to an invalid URL (e.g. `publishers.basicattentiontoken.org/c/xyz`)
- Save the changes
- Restart the browser
- Visit the publisher site and open the tipping panel
- Verify that the "Use Web3" button is not displayed
- Close the browser
- Edit the `publisher_info_db` database once again, this time setting "web3_url" to a valid absolute URL
- Save the changes and restart the browser
- Visit the publisher site and open the tipping panel
- Verify the the "Use Web3" button is displayed