### PR TITLE
Hide bouncing bars when media is paused

### DIFF
--- a/components/playlist/browser/resources/components/playlistItem.tsx
+++ b/components/playlist/browser/resources/components/playlistItem.tsx
@@ -50,7 +50,7 @@ const ThumbnailStyle = css`
 `
 const StyledThumbnail = styled.div<{ src: string }>`
   ${ThumbnailStyle}
-  background-image: url(${p => p.src});
+  background-image: url(${(p) => p.src});
   background-size: cover;
   background-position: center;
 `
@@ -89,20 +89,20 @@ const PlaylistItemContainer = styled.li<{
   gap: ${spacing.xl};
   user-select: none;
 
-  ${p =>
+  ${(p) =>
     p.shouldBeHidden &&
     css`
       visibility: hidden;
     `}
 
   align-self: stretch;
-  ${p =>
+  ${(p) =>
     p.isActive &&
     css`
       background: ${color.container.interactive};
     `}
 
-  ${p =>
+  ${(p) =>
     p.isHighlighted &&
     css`
       animation: highlightBackground 500ms 4 alternate;
@@ -145,8 +145,8 @@ const ProgressCircle = styled.div<{ progress: number }>`
   position: relative;
   background: conic-gradient(
     ${color.icon.default} 0%,
-    ${color.icon.default} ${p => p.progress + '%'},
-    ${color.primary[20]} ${p => p.progress + '%'},
+    ${color.icon.default} ${(p) => p.progress + '%'},
+    ${color.primary[20]} ${(p) => p.progress + '%'},
     ${color.primary[20]} 100%
   );
   clip-path: circle();
@@ -170,35 +170,39 @@ const ProgressCircle = styled.div<{ progress: number }>`
 `
 
 const ColoredSpan = styled.span<{ color: any }>`
-  color: ${p => p.color};
+  color: ${(p) => p.color};
 `
 
 const StyledCheckBox = styled(Icon)<{ checked: boolean }>`
   --leo-icon-size: 16px;
-  color: ${p => (p.checked ? color.icon.interactive : color.icon.default)};
+  color: ${(p) => (p.checked ? color.icon.interactive : color.icon.default)};
 `
 
-function Thumbnail ({
+function Thumbnail({
   thumbnailUrl,
+  isSelected,
   isPlaying,
   duration,
   lastPlayedPosition
 }: {
   thumbnailUrl?: string
+  isSelected: boolean
   isPlaying: boolean
   duration: string
   lastPlayedPosition: number
 }) {
-  const overlay = isPlaying ? (
+  const overlay = (
     <>
-      <BouncingBarsContainer>
-        <BouncingBars />
-      </BouncingBarsContainer>
-      {!!+duration && (
+      {isPlaying && (
+        <BouncingBarsContainer>
+          <BouncingBars />
+        </BouncingBarsContainer>
+      )}
+      {isSelected && !!+duration && (
         <ProgressBar progress={lastPlayedPosition / (+duration / 1e6)} />
       )}
     </>
-  ) : null
+  )
 
   return thumbnailUrl ? (
     <StyledThumbnail src={thumbnailUrl}>{overlay}</StyledThumbnail>
@@ -207,7 +211,7 @@ function Thumbnail ({
   )
 }
 
-export function PlaylistItem ({
+export function PlaylistItem({
   playlist,
   item,
   isEditing,
@@ -231,23 +235,30 @@ export function PlaylistItem ({
   const cachingProgress = useSelector<
     ApplicationState,
     CachingProgress | undefined
-  >(applicationState => applicationState.playlistData?.cachingProgress?.get(id))
+  >((applicationState) =>
+    applicationState.playlistData?.cachingProgress?.get(id)
+  )
 
   const currentItemId = useSelector<ApplicationState, string | undefined>(
-    applicationState =>
+    (applicationState) =>
       applicationState.playlistData?.lastPlayerState?.currentItem?.id
   )
-  const isPlaying = currentItemId === item.id
+  const playing = useSelector<ApplicationState, boolean | undefined>(
+    (applicationState) =>
+      applicationState.playlistData?.lastPlayerState?.playing
+  )
+  const isCurrentItem = currentItemId === item.id
+  const isPlayingItem = isCurrentItem && playing
 
   return (
     <PlaylistItemContainer
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      isActive={(isEditing && isSelected) || isPlaying}
+      isActive={(isEditing && isSelected) || isCurrentItem}
       isHighlighted={isHighlighted}
       shouldBeHidden={shouldBeHidden}
       tabIndex={0}
-      onKeyDown={e => e.key === 'Enter' && onClick(item)}
+      onKeyDown={(e) => e.key === 'Enter' && onClick(item)}
       onClick={() => onClick(item)}
     >
       {isEditing && (
@@ -258,7 +269,8 @@ export function PlaylistItem ({
       )}
       <Thumbnail
         thumbnailUrl={thumbnailUrl}
-        isPlaying={isPlaying}
+        isSelected={isCurrentItem}
+        isPlaying={!!isPlayingItem}
         duration={item.duration}
         lastPlayedPosition={item.lastPlayedPosition}
       />
@@ -340,7 +352,7 @@ export function PlaylistItem ({
 }
 
 export const SortablePlaylistItem = React.forwardRef(
-  function SortablePlaylistItem (
+  function SortablePlaylistItem(
     props: Props,
     forwardedRef?: React.ForwardedRef<HTMLAnchorElement>
   ) {


### PR DESCRIPTION
When it's paused we don't need to animate bars

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34885

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

