### PR TITLE
Fix android wallet page routes

### DIFF
--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -253,6 +253,28 @@ bool HandleURLReverseOverrideRewrite(GURL* url,
     return true;
   }
 
+// For wallet pages, return true to update the displayed URL to react-routed
+// URL rather than showing brave://wallet for everything. This is needed
+// because of a side effect from rewriting brave:// to chrome:// in
+// HandleURLRewrite handler which makes brave://wallet the virtual URL here
+// unless we return true to trigger an update of virtual URL here to the routed
+// URL. For example, we will display brave://wallet/send instead of
+// brave://wallet with this. This is Android only because currently both
+// virtual and real URLs are chrome:// on desktop, so it doesn't have this
+// issue.
+#if BUILDFLAG(IS_ANDROID)
+  if ((url->SchemeIs(content::kBraveUIScheme) ||
+       url->SchemeIs(content::kChromeUIScheme)) &&
+      url->host() == kWalletPageHost) {
+    if (url->SchemeIs(content::kChromeUIScheme)) {
+      GURL::Replacements replacements;
+      replacements.SetSchemeStr(content::kBraveUIScheme);
+      *url = url->ReplaceComponents(replacements);
+    }
+    return true;
+  }
+#endif
+
   return false;
 }
 
@@ -261,6 +283,21 @@ bool HandleURLRewrite(GURL* url, content::BrowserContext* browser_context) {
                                                           browser_context)) {
     return true;
   }
+
+// For wallet pages, return true so we can handle it in the reverse handler.
+// Also update the real URL from brave:// to chrome://.
+#if BUILDFLAG(IS_ANDROID)
+  if ((url->SchemeIs(content::kBraveUIScheme) ||
+       url->SchemeIs(content::kChromeUIScheme)) &&
+      url->host() == kWalletPageHost) {
+    if (url->SchemeIs(content::kBraveUIScheme)) {
+      GURL::Replacements replacements;
+      replacements.SetSchemeStr(content::kChromeUIScheme);
+      *url = url->ReplaceComponents(replacements);
+    }
+    return true;
+  }
+#endif
 
   return false;
 }

--- a/components/brave_wallet/browser/android_page_appearing_browsertest.cc
+++ b/components/brave_wallet/browser/android_page_appearing_browsertest.cc
@@ -7,7 +7,9 @@
 #include <string_view>
 
 #include "base/files/scoped_temp_dir.h"
+#include "base/no_destructor.h"
 #include "base/strings/pattern.h"
+#include "base/strings/strcat.h"
 #include "base/test/bind.h"
 #include "base/test/scoped_run_loop_timeout.h"
 #include "brave/browser/brave_wallet/asset_ratio_service_factory.h"
@@ -35,6 +37,7 @@
 #include "chrome/test/base/chrome_test_utils.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
+#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/web_ui_controller_factory.h"
 #include "content/public/browser/web_ui_controller_interface_binder.h"
 #include "content/public/browser/web_ui_data_source.h"
@@ -310,7 +313,8 @@ class AndroidPageAppearingBrowserTest : public PlatformBrowserTest {
     }
   }
 
-  void VerifyPage(const GURL url,
+  void VerifyPage(const GURL& url,
+                  const GURL& expected_url,
                   const std::vector<std::string> ignore_patterns) {
     content::NavigationController::LoadURLParams params(url);
     params.transition_type = ui::PageTransitionFromInt(
@@ -323,8 +327,8 @@ class AndroidPageAppearingBrowserTest : public PlatformBrowserTest {
     web_contents->GetController().LoadURLWithParams(params);
     web_contents->GetOutermostWebContents()->Focus();
     EXPECT_TRUE(WaitForLoadStop(web_contents));
-    EXPECT_TRUE(web_contents->GetLastCommittedURL() == url)
-        << "Expected URL " << url << " but observed "
+    EXPECT_TRUE(web_contents->GetLastCommittedURL() == expected_url)
+        << "Expected URL " << expected_url << " but observed "
         << web_contents->GetLastCommittedURL();
 
     auto result = content::EvalJs(
@@ -341,6 +345,12 @@ class AndroidPageAppearingBrowserTest : public PlatformBrowserTest {
                                 ignore_patterns);
   }
 
+  const std::vector<std::string>& GetWebUISchemes() {
+    static base::NoDestructor<std::vector<std::string>> kWebUISchemes(
+        {"chrome://", "brave://"});
+    return *kWebUISchemes;
+  }
+
   base::ScopedTempDir temp_dir_;
   int64_t file_size_;
   std::optional<std::string> file_digest_;
@@ -354,45 +364,78 @@ class AndroidPageAppearingBrowserTest : public PlatformBrowserTest {
   network::TestURLLoaderFactory url_loader_factory_;
 };
 
+IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestWalletPageRoute) {
+  const GURL expected_real_url =
+      GURL("chrome://wallet/crypto/portfolio/assets");
+  const GURL expected_virtual_url =
+      GURL("brave://wallet/crypto/portfolio/assets");
+  for (const std::string& scheme : GetWebUISchemes()) {
+    GURL url = GURL(base::StrCat({scheme, "wallet/"}));
+
+    auto* web_contents = GetActiveWebContents();
+    content::NavigateToURLBlockUntilNavigationsComplete(web_contents, url, 2);
+    EXPECT_EQ(web_contents->GetController().GetLastCommittedEntry()->GetURL(),
+              expected_real_url);
+    EXPECT_EQ(
+        web_contents->GetController().GetLastCommittedEntry()->GetVirtualURL(),
+        expected_virtual_url);
+  }
+}
+
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
                        TestPortfolioPageAppearing) {
-  GURL url = GURL("chrome://wallet/crypto/portfolio/assets");
-  const std::vector<std::string> ignore_patterns = {
-      "TypeError: Cannot read properties of undefined (reading "
-      "'onCompleteReset')",
-      "Error calling jsonRpcService.getERC20TokenBalances"};
-  VerifyPage(url, ignore_patterns);
+  const GURL expected_url = GURL("brave://wallet/crypto/portfolio/assets");
+  for (const std::string& scheme : GetWebUISchemes()) {
+    GURL url = GURL(base::StrCat({scheme, "wallet/crypto/portfolio/assets"}));
+    const std::vector<std::string> ignore_patterns = {
+        "TypeError: Cannot read properties of undefined (reading "
+        "'onCompleteReset')",
+        "Error calling jsonRpcService.getERC20TokenBalances"};
+    VerifyPage(url, expected_url, ignore_patterns);
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSwapPageAppearing) {
-  GURL url = GURL("chrome://wallet/swap");
-  const std::vector<std::string> ignore_patterns = {
-      "TypeError: Cannot read properties of undefined (reading 'forEach')",
-      "Error calling jsonRpcService.getERC20TokenBalances",
-      "Error querying balance:", "Error: An internal error has occurred",
-      "Unable to fetch getTokenBalancesForChainId"};
-  VerifyPage(url, ignore_patterns);
+  const GURL expected_url = GURL("brave://wallet/swap");
+  for (const std::string& scheme : GetWebUISchemes()) {
+    GURL url = GURL(base::StrCat({scheme, "wallet/swap"}));
+    const std::vector<std::string> ignore_patterns = {
+        "TypeError: Cannot read properties of undefined (reading 'forEach')",
+        "Error calling jsonRpcService.getERC20TokenBalances",
+        "Error querying balance:", "Error: An internal error has occurred",
+        "Unable to fetch getTokenBalancesForChainId"};
+    VerifyPage(url, expected_url, ignore_patterns);
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSendPageAppearing) {
-  GURL url = GURL("chrome://wallet/send");
-  const std::vector<std::string> ignore_patterns = {
-      "TypeError: Cannot read properties of undefined (reading 'forEach')"};
-  VerifyPage(url, ignore_patterns);
+  const GURL expected_url = GURL("brave://wallet/send");
+  for (const std::string& scheme : GetWebUISchemes()) {
+    GURL url = GURL(base::StrCat({scheme, "wallet/send"}));
+    const std::vector<std::string> ignore_patterns = {
+        "TypeError: Cannot read properties of undefined (reading 'forEach')"};
+    VerifyPage(url, expected_url, ignore_patterns);
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
                        TestDepositPageAppearing) {
-  GURL url = GURL("chrome://wallet/crypto/deposit-funds");
-  const std::vector<std::string> ignore_patterns = {
-      "TypeError: Cannot read properties of undefined (reading 'forEach')"};
-  VerifyPage(url, ignore_patterns);
+  const GURL expected_url = GURL("brave://wallet/crypto/deposit-funds");
+  for (const std::string& scheme : GetWebUISchemes()) {
+    GURL url = GURL(base::StrCat({scheme, "wallet/crypto/deposit-funds"}));
+    const std::vector<std::string> ignore_patterns = {
+        "TypeError: Cannot read properties of undefined (reading 'forEach')"};
+    VerifyPage(url, expected_url, ignore_patterns);
+  }
 }
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestBuyPageAppearing) {
-  GURL url = GURL("chrome://wallet/crypto/fund-wallet");
-  const std::vector<std::string> ignore_patterns = {
-      "TypeError: Cannot read properties of undefined (reading 'forEach')"};
-  VerifyPage(url, ignore_patterns);
+  const GURL expected_url = GURL("brave://wallet/crypto/fund-wallet");
+  for (const std::string& scheme : GetWebUISchemes()) {
+    GURL url = GURL(base::StrCat({scheme, "wallet/crypto/fund-wallet"}));
+    const std::vector<std::string> ignore_patterns = {
+        "TypeError: Cannot read properties of undefined (reading 'forEach')"};
+    VerifyPage(url, expected_url, ignore_patterns);
+  }
 }
 }  // namespace brave_wallet


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/31153

https://github.com/brave/brave-core/assets/4730197/fd00b2a3-3cb2-4fe8-b330-a7d738c0b20e

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Just play with wallet on Android and do some navigations in the wallet page and observe the addresses in URL bar.
