### PR TITLE
Fixed dereferencing of the nullptr. (uplift to 1.62.x)

### DIFF
--- a/components/speedreader/rust/ffi/speedreader.cc
+++ b/components/speedreader/rust/ffi/speedreader.cc
@@ -19,7 +19,12 @@ SpeedReader::~SpeedReader() {
 }
 
 std::unique_ptr<Rewriter> SpeedReader::MakeRewriter(const std::string& url) {
-  return std::make_unique<Rewriter>(raw_, url);
+  std::unique_ptr<Rewriter> rewriter(new Rewriter(raw_, url));
+  if (rewriter->raw_ == nullptr) {
+    // Underlying implementation failed to create a rewriter for some reason.
+    return nullptr;
+  }
+  return rewriter;
 }
 
 Rewriter::Rewriter(C_SpeedReader* speedreader, const std::string& url)

--- a/components/speedreader/rust/ffi/speedreader.h
+++ b/components/speedreader/rust/ffi/speedreader.h
@@ -19,7 +19,7 @@
 #else
 #define SPEEDREADER_EXPORT __declspec(dllimport)
 #endif  // defined(SPEEDREADER_IMPLEMENTATION)
-#else  // defined(WIN32)
+#else   // defined(WIN32)
 #if defined(SPEEDREADER_IMPLEMENTATION)
 #define SPEEDREADER_EXPORT __attribute__((visibility("default")))
 #else
@@ -34,19 +34,6 @@ namespace speedreader {
 
 class SPEEDREADER_EXPORT Rewriter {
  public:
-  /// Create a buffering `Rewriter`. Output will be accumulated internally,
-  /// retrievable via `GetOutput`. Expected to only be instantiated by
-  /// `SpeedReader`.
-  Rewriter(C_SpeedReader* speedreader, const std::string& url);
-
-  /// Create a streaming `Rewriter`. Provided callback will be called with every
-  /// new chunk of output available. Output availability is not strictly related
-  /// to when more input is `Written`. Expected to only be instantiated by
-  /// `SpeedReader`.
-  Rewriter(C_SpeedReader* speedreader,
-           const std::string& url,
-           void (*output_sink)(const char*, size_t, void*),
-           void* output_sink_user_data);
   ~Rewriter();
 
   Rewriter(const Rewriter&) = delete;
@@ -75,6 +62,22 @@ class SPEEDREADER_EXPORT Rewriter {
   const std::string& GetOutput();
 
  private:
+  friend class SpeedReader;
+
+  /// Create a buffering `Rewriter`. Output will be accumulated internally,
+  /// retrievable via `GetOutput`. Expected to only be instantiated by
+  /// `SpeedReader`.
+  Rewriter(C_SpeedReader* speedreader, const std::string& url);
+
+  /// Create a streaming `Rewriter`. Provided callback will be called with every
+  /// new chunk of output available. Output availability is not strictly related
+  /// to when more input is `Written`. Expected to only be instantiated by
+  /// `SpeedReader`.
+  Rewriter(C_SpeedReader* speedreader,
+           const std::string& url,
+           void (*output_sink)(const char*, size_t, void*),
+           void* output_sink_user_data);
+
   std::string output_;
   bool ended_;
   bool poisoned_;

--- a/components/speedreader/speedreader_rewriter_service.cc
+++ b/components/speedreader/speedreader_rewriter_service.cc
@@ -171,6 +171,9 @@ std::unique_ptr<Rewriter> SpeedreaderRewriterService::MakeRewriter(
     const std::string& font_size,
     const std::string& column_width) {
   auto rewriter = speedreader_->MakeRewriter(url.spec());
+  if (!rewriter) {
+    return nullptr;
+  }
   rewriter->SetMinOutLength(speedreader::kSpeedreaderMinOutLengthParam.Get());
   rewriter->SetTheme(theme);
   rewriter->SetFontFamily(font_family);

--- a/components/speedreader/speedreader_util.cc
+++ b/components/speedreader/speedreader_util.cc
@@ -193,6 +193,11 @@ void DistillPage(const GURL& url,
                                      speedreader_service->GetFontFamilyName(),
                                      speedreader_service->GetFontSizeName(),
                                      speedreader_service->GetColumnWidth());
+  if (!rewriter) {
+    std::move(callback).Run(DistillationResult::kFail, std::move(body),
+                            std::string());
+    return;
+  }
 
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::TaskPriority::USER_BLOCKING, base::MayBlock()},


### PR DESCRIPTION
Uplift of #21338
Resolves https://github.com/brave/brave-browser/issues/34836

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.