### PR TITLE
Use updated rust toolchain to fix win-x86 builds in M120. (uplift to 1.62.x)

### DIFF
--- a/patches/tools-rust-update_rust.py.patch
+++ b/patches/tools-rust-update_rust.py.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/rust/update_rust.py b/tools/rust/update_rust.py
+index b7e32f0dc764f43535deb4d14f4e1fd2c310e074..d812d7eb5bad62288cd7baf9450fd30f98e146f2 100755
+--- a/tools/rust/update_rust.py
++++ b/tools/rust/update_rust.py
+@@ -35,7 +35,7 @@ sys.path.append(
+ # this back to its previous value _AND_ set `OVERRIDE_CLANG_REVISION` below
+ # to the `CLANG_REVISION` that was in place before the roll.
+ RUST_REVISION = '2e4e2a8f288f642cafcc41fff211955ceddc453d'
+-RUST_SUB_REVISION = 1
++RUST_SUB_REVISION = 3
+ 
+ # If not None, this overrides the `CLANG_REVISION` in
+ # //tools/clang/scripts/update.py in order to download a Rust toolchain that


### PR DESCRIPTION
Uplift of #21384
Resolves https://github.com/brave/brave-browser/issues/34854

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.