### PR TITLE
AI Chat retrieves page text whenever a new human message is submitted

### DIFF
--- a/browser/ai_chat/android/ai_chat_utils.cc
+++ b/browser/ai_chat/android/ai_chat_utils.cc
@@ -31,7 +31,7 @@ static void JNI_BraveLeoUtils_OpenLeoQuery(
       ai_chat::mojom::CharacterType::HUMAN,
       ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
       base::android::ConvertJavaStringToUTF8(query)};
-  chat_tab_helper->MakeAPIRequestWithConversationHistoryUpdate(std::move(turn));
+  chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
 #endif
 }
 }  // namespace ai_chat

--- a/browser/ai_chat/page_content_fetcher_browsertest.cc
+++ b/browser/ai_chat/page_content_fetcher_browsertest.cc
@@ -79,10 +79,11 @@ class PageContentFetcherBrowserTest : public InProcessBrowserTest {
                         bool expected_is_video) {
     base::RunLoop run_loop;
     ai_chat::FetchPageContent(
-        browser()->tab_strip_model()->GetActiveWebContents(),
+        browser()->tab_strip_model()->GetActiveWebContents(), "",
         base::BindLambdaForTesting([&run_loop, &expected_text,
-                                    &expected_is_video](std::string text,
-                                                        bool is_video) {
+                                    &expected_is_video](
+                                       std::string text, bool is_video,
+                                       std::string invalidation_token) {
           ASSERT_EQ(expected_text, base::TrimWhitespaceASCII(
                                        text, base::TrimPositions::TRIM_ALL));
           ASSERT_EQ(expected_is_video, is_video);

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -97,7 +97,7 @@ void AIChatUIPageHandler::SetClientPage(
   // ex. A user may ask a question from the location bar
   if (active_chat_tab_helper_ &&
       active_chat_tab_helper_->HasPendingConversationEntry()) {
-    OnConversationEntryPending();
+    OnHistoryUpdate();
   }
 }
 
@@ -120,8 +120,7 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
     const std::string& input) {
   mojom::ConversationTurn turn = {CharacterType::HUMAN,
                                   ConversationTurnVisibility::VISIBLE, input};
-  active_chat_tab_helper_->MakeAPIRequestWithConversationHistoryUpdate(
-      std::move(turn));
+  active_chat_tab_helper_->SubmitHumanConversationEntry(std::move(turn));
 }
 
 void AIChatUIPageHandler::SubmitSummarizationRequest() {
@@ -336,12 +335,6 @@ void AIChatUIPageHandler::OnFaviconImageDataChanged() {
 void AIChatUIPageHandler::OnPageHasContent(mojom::SiteInfoPtr site_info) {
   if (page_.is_bound()) {
     page_->OnSiteInfoChanged(std::move(site_info));
-  }
-}
-
-void AIChatUIPageHandler::OnConversationEntryPending() {
-  if (page_.is_bound()) {
-    page_->OnConversationEntryPending();
   }
 }
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -118,6 +118,9 @@ void AIChatUIPageHandler::ChangeModel(const std::string& model_key) {
 
 void AIChatUIPageHandler::SubmitHumanConversationEntry(
     const std::string& input) {
+  DCHECK(!active_chat_tab_helper_->IsRequestInProgress())
+      << "Should not be able to submit more"
+      << "than a single human conversation turn at a time.";
   mojom::ConversationTurn turn = {CharacterType::HUMAN,
                                   ConversationTurnVisibility::VISIBLE, input};
   active_chat_tab_helper_->SubmitHumanConversationEntry(std::move(turn));

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -96,7 +96,6 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
       mojom::SuggestionGenerationStatus suggestion_generation_status) override;
   void OnFaviconImageDataChanged() override;
   void OnPageHasContent(mojom::SiteInfoPtr site_info) override;
-  void OnConversationEntryPending() override;
 
   void GetFaviconImageData(GetFaviconImageDataCallback callback) override;
 

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
@@ -69,7 +69,7 @@ void ChromeAutocompleteProviderClient::OpenLeo(const std::u16string& query) {
       ai_chat::mojom::CharacterType::HUMAN,
       ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
       base::UTF16ToUTF8(query)};
-  chat_tab_helper->MakeAPIRequestWithConversationHistoryUpdate(std::move(turn));
+  chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
   ai_chat::AIChatMetrics* metrics =
       g_brave_browser_process->process_misc_metrics()->ai_chat_metrics();
   CHECK(metrics);

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -121,16 +121,9 @@ GURL AIChatTabHelper::GetPageURL() const {
 }
 
 void AIChatTabHelper::GetPageContent(
-    base::OnceCallback<void(std::string, bool is_video)> callback) const {
-  FetchPageContent(web_contents(), std::move(callback));
-}
-
-bool AIChatTabHelper::HasPrimaryMainFrame() const {
-  return web_contents()->GetPrimaryMainFrame() != nullptr;
-}
-
-bool AIChatTabHelper::IsDocumentOnLoadCompletedInPrimaryMainFrame() const {
-  return web_contents()->IsDocumentOnLoadCompletedInPrimaryMainFrame();
+    GetPageContentCallback callback,
+    std::string_view invalidation_token) const {
+  FetchPageContent(web_contents(), invalidation_token, std::move(callback));
 }
 
 std::u16string AIChatTabHelper::GetPageTitle() const {

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -89,8 +89,8 @@ void AIChatTabHelper::DidFinishNavigation(
 void AIChatTabHelper::TitleWasSet(content::NavigationEntry* entry) {
   DVLOG(3) << __func__ << entry->GetTitle();
   if (is_same_document_navigation_) {
-    DVLOG(3)
-        << "Same document navigation detected new \"page\" - calling OnNewPage()";
+    DVLOG(3) << "Same document navigation detected new \"page\" - calling "
+                "OnNewPage()";
     // Page title modification after same-document navigation seems as good a
     // time as any to assume meaningful changes occured to the content.
     OnNewPage(pending_navigation_id_);

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -63,10 +63,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // ai_chat::ConversationDriver
   GURL GetPageURL() const override;
-  void GetPageContent(base::OnceCallback<void(std::string, bool is_video)>
-                          callback) const override;
-  bool HasPrimaryMainFrame() const override;
-  bool IsDocumentOnLoadCompletedInPrimaryMainFrame() const override;
+  void GetPageContent(GetPageContentCallback callback,
+                      std::string_view invalidation_token) const override;
   std::u16string GetPageTitle() const override;
 
   raw_ptr<AIChatMetrics> ai_chat_metrics_;

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -49,7 +49,6 @@ class AIChatTabHelper : public content::WebContentsObserver,
       const std::string& channel_name);
 
   // content::WebContentsObserver
-  void DocumentOnLoadCompletedInPrimaryMainFrame() override;
   void WebContentsDestroyed() override;
   void DidFinishNavigation(
       content::NavigationHandle* navigation_handle) override;
@@ -71,11 +70,6 @@ class AIChatTabHelper : public content::WebContentsObserver,
   std::u16string GetPageTitle() const override;
 
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
-
-  // Store the unique ID for each navigation so that
-  // we can ignore API responses for previous navigations.
-  int64_t current_navigation_id_;
-  bool is_same_document_navigation_ = false;
 
   base::WeakPtrFactory<AIChatTabHelper> weak_ptr_factory_{this};
   WEB_CONTENTS_USER_DATA_KEY_DECL();

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -69,6 +69,9 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
 
+  bool is_same_document_navigation_ = false;
+  int64_t pending_navigation_id_;
+
   base::WeakPtrFactory<AIChatTabHelper> weak_ptr_factory_{this};
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -82,6 +82,7 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
 class PageContentFetcher {
  public:
   void Start(mojo::Remote<mojom::PageContentExtractor> content_extractor,
+             std::string_view invalidation_token,
              scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
              FetchPageContentCallback callback) {
     url_loader_factory_ = url_loader_factory;
@@ -94,9 +95,9 @@ class PageContentFetcher {
     // after it is destroyed.
     content_extractor_.set_disconnect_handler(base::BindOnce(
         &PageContentFetcher::DeleteSelf, base::Unretained(this)));
-    content_extractor_->ExtractPageContent(
-        base::BindOnce(&PageContentFetcher::OnTabContentResult,
-                       base::Unretained(this), std::move(callback)));
+    content_extractor_->ExtractPageContent(base::BindOnce(
+        &PageContentFetcher::OnTabContentResult, base::Unretained(this),
+        std::move(callback), invalidation_token));
   }
 
  private:
@@ -104,12 +105,14 @@ class PageContentFetcher {
 
   void SendResultAndDeleteSelf(FetchPageContentCallback callback,
                                std::string content = "",
+                               std::string invalidation_token = "",
                                bool is_video = false) {
-    std::move(callback).Run(content, is_video);
+    std::move(callback).Run(content, is_video, invalidation_token);
     delete this;
   }
 
   void OnTabContentResult(FetchPageContentCallback callback,
+                          std::string_view invalidation_token,
                           mojom::PageContentPtr data) {
     if (!data) {
       VLOG(1) << __func__ << " no data.";
@@ -125,7 +128,7 @@ class PageContentFetcher {
       auto content = data->content->get_content();
       DVLOG(1) << __func__ << ": Got content with char length of "
                << content.length();
-      SendResultAndDeleteSelf(std::move(callback), content, false);
+      SendResultAndDeleteSelf(std::move(callback), content, "", false);
       return;
     }
     // If it's video, we expect content url
@@ -134,7 +137,16 @@ class PageContentFetcher {
     if (content_url.is_empty() || !content_url.is_valid() ||
         !content_url.SchemeIs(url::kHttpsScheme)) {
       VLOG(1) << "Invalid content_url";
-      SendResultAndDeleteSelf(std::move(callback), "", true);
+      SendResultAndDeleteSelf(std::move(callback), "", "", true);
+      return;
+    }
+    // Subsequent calls do not need to re-fetch if the url stays the same
+    auto new_invalidation_token = content_url.spec();
+    if (new_invalidation_token == invalidation_token) {
+      VLOG(2) << "Not fetching content since invalidation token matches: "
+              << invalidation_token;
+      SendResultAndDeleteSelf(std::move(callback), "", new_invalidation_token,
+                              true);
       return;
     }
     DVLOG(1) << "Making video transcript fetch to " << content_url.spec();
@@ -156,13 +168,14 @@ class PageContentFetcher {
     auto on_response =
         base::BindOnce(&PageContentFetcher::OnTranscriptFetchResponse,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback),
-                       std::move(loader), is_youtube);
+                       std::move(loader), is_youtube, new_invalidation_token);
     loader_ptr->DownloadToString(url_loader_factory_.get(),
                                  std::move(on_response), 2 * 1024 * 1024);
   }
 
   void OnYoutubeTranscriptXMLParsed(
       FetchPageContentCallback callback,
+      std::string invalidation_token,
       base::expected<base::Value, std::string> result) {
     // Example Youtube transcript XML:
     //
@@ -206,13 +219,15 @@ class PageContentFetcher {
       transcript_text += text;
     }
 
-    SendResultAndDeleteSelf(std::move(callback), transcript_text, true);
+    SendResultAndDeleteSelf(std::move(callback), transcript_text,
+                            invalidation_token, true);
   }
 
   void OnTranscriptFetchResponse(
       FetchPageContentCallback callback,
       std::unique_ptr<network::SimpleURLLoader> loader,
       bool is_youtube,
+      std::string invalidation_token,
       std::unique_ptr<std::string> response_body) {
     auto response_code = -1;
     base::flat_map<std::string, std::string> headers;
@@ -239,11 +254,13 @@ class PageContentFetcher {
           data_decoder::mojom::XmlParser::WhitespaceBehavior::
               kPreserveSignificant,
           base::BindOnce(&PageContentFetcher::OnYoutubeTranscriptXMLParsed,
-                         weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+                         weak_ptr_factory_.GetWeakPtr(), std::move(callback),
+                         invalidation_token));
       return;
     }
 
-    SendResultAndDeleteSelf(std::move(callback), transcript_content, true);
+    SendResultAndDeleteSelf(std::move(callback), transcript_content,
+                            invalidation_token, true);
   }
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
@@ -297,6 +314,7 @@ void OnScreenshot(base::OnceCallback<void(std::string, bool is_video)> callback,
 }  // namespace
 
 void FetchPageContent(content::WebContents* web_contents,
+                      std::string_view invalidation_token,
                       FetchPageContentCallback callback) {
   VLOG(2) << __func__ << " Extracting page content from renderer...";
 
@@ -307,7 +325,7 @@ void FetchPageContent(content::WebContents* web_contents,
     LOG(ERROR)
         << "Content extraction request submitted for a WebContents without "
            "a primary main frame";
-    std::move(callback).Run("", false);
+    std::move(callback).Run("", false, "");
     return;
   }
 
@@ -337,7 +355,8 @@ void FetchPageContent(content::WebContents* web_contents,
                      ->GetDefaultStoragePartition()
                      ->GetURLLoaderFactoryForBrowserProcess()
                      .get();
-  fetcher->Start(std::move(extractor), loader, std::move(callback));
+  fetcher->Start(std::move(extractor), invalidation_token, loader,
+                 std::move(callback));
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -270,10 +270,10 @@ class PageContentFetcher {
 
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
 void OnGetTextFromImage(
-    base::OnceCallback<void(std::string, bool is_video)> callback,
+    FetchPageContentCallback callback,
     const std::pair<bool, std::vector<std::string>>& supported_strs) {
   if (!supported_strs.first) {
-    std::move(callback).Run("", false);
+    std::move(callback).Run("", false, "");
     return;
   }
 
@@ -285,11 +285,10 @@ void OnGetTextFromImage(
       ss << "\n";
     }
   }
-  std::move(callback).Run(ss.str(), false);
+  std::move(callback).Run(ss.str(), false, "");
 }
 
-void OnScreenshot(base::OnceCallback<void(std::string, bool is_video)> callback,
-                  const SkBitmap& image) {
+void OnScreenshot(FetchPageContentCallback callback, const SkBitmap& image) {
 #if BUILDFLAG(IS_MAC)
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE,

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -17,8 +17,11 @@ class WebContents;
 namespace ai_chat {
 
 using FetchPageContentCallback =
-    base::OnceCallback<void(std::string, bool is_video)>;
+    base::OnceCallback<void(std::string page_content,
+                            bool is_video,
+                            std::string invalidation_token)>;
 void FetchPageContent(content::WebContents* web_contents,
+                      std::string_view invalidation_token,
                       FetchPageContentCallback callback);
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/conversation_driver.cc
+++ b/components/ai_chat/core/browser/conversation_driver.cc
@@ -607,10 +607,9 @@ void ConversationDriver::SubmitHumanConversationEntry(
     // This is possible (on desktop) if user submits multiple location bar
     // messages before an entry is complete. But that should be obvious from the
     // UI that the 1 in-progress + 1 pending message is the limit.
-    if(pending_conversation_entry_) {
-      VLOG(1)
-        << "Should not be able to add a pending conversation entry "
-        << "when there is already a pending conversation entry.";
+    if (pending_conversation_entry_) {
+      VLOG(1) << "Should not be able to add a pending conversation entry "
+              << "when there is already a pending conversation entry.";
       return;
     }
     pending_conversation_entry_ =

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -42,7 +42,6 @@ class ConversationDriver {
         mojom::SuggestionGenerationStatus suggestion_generation_status) {}
     virtual void OnFaviconImageDataChanged() {}
     virtual void OnPageHasContent(mojom::SiteInfoPtr site_info) {}
-    virtual void OnConversationEntryPending() {}
   };
 
   ConversationDriver(
@@ -69,9 +68,8 @@ class ConversationDriver {
   void OnConversationActiveChanged(bool is_conversation_active);
   void AddToConversationHistory(mojom::ConversationTurn turn);
   void UpdateOrCreateLastAssistantEntry(std::string text);
-  void MakeAPIRequestWithConversationHistoryUpdate(
-      mojom::ConversationTurn turn,
-      bool needs_page_content = false);
+  void SubmitHumanConversationEntry(mojom::ConversationTurn turn,
+                                    bool has_latest_content = false);
   void RetryAPIRequest();
   bool IsRequestInProgress();
   void AddObserver(Observer* observer);
@@ -117,7 +115,7 @@ class ConversationDriver {
 
   virtual void OnFaviconImageDataChanged();
 
-  void MaybeGeneratePageText();
+  bool MaybeGeneratePageText();
   void CleanUp();
 
   int64_t GetNavigationId() const;
@@ -129,8 +127,8 @@ class ConversationDriver {
  private:
   void InitEngine();
   void OnUserOptedIn();
-  bool MaybePopPendingRequests();
-  void MaybeGenerateQuestions();
+  bool MaybePopPendingRequests(bool content_was_retrieved);
+  void MaybeSeedOrClearSuggestions();
 
   void OnPageContentRetrieved(int64_t navigation_id,
                               std::string contents_text,
@@ -147,7 +145,6 @@ class ConversationDriver {
       mojom::PageHandler::GetPremiumStatusCallback parent_callback,
       mojom::PremiumStatus premium_status,
       mojom::PremiumInfoPtr premium_info);
-  void OnConversationEntryPending();
 
   void SetAPIError(const mojom::APIError& error);
   bool IsContentAssociationPossible();
@@ -186,7 +183,6 @@ class ConversationDriver {
   mojom::PremiumStatus last_premium_status_ = mojom::PremiumStatus::Inactive;
 
   std::unique_ptr<mojom::ConversationTurn> pending_conversation_entry_;
-  bool pending_message_needs_page_content_ = false;
 
   base::WeakPtrFactory<ConversationDriver> weak_ptr_factory_{this};
 };

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -176,8 +176,6 @@ interface ChatUIPage {
   // |is_fetching| will be |true|.
   OnSiteInfoChanged(SiteInfo info);
   OnFaviconImageDataChanged(array<uint8> favicon_image_data);
-  // This reports if there are any pending entries to be sent to the remote LLM.
-  OnConversationEntryPending();
 };
 
 [EnableIf=is_android]

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -141,10 +141,12 @@ function Main() {
         onScroll={handleScroll}
       >
         <AlertCenter position='top-left' className={styles.alertCenter} />
-        {context.hasAcceptedAgreement && <ModelIntro />}
-        <ConversationList
-          onLastElementHeightChange={handleLastElementHeightChange}
-        />
+        {context.hasAcceptedAgreement && <>
+          <ModelIntro />
+          <ConversationList
+            onLastElementHeightChange={handleLastElementHeightChange}
+          />
+        </>}
         {currentErrorElement && (
           <div className={styles.promptContainer}>{currentErrorElement}</div>
         )}

--- a/components/ai_chat/resources/page/state/data-context-provider.tsx
+++ b/components/ai_chat/resources/page/state/data-context-provider.tsx
@@ -75,6 +75,14 @@ function DataContextProvider (props: DataContextProviderProps) {
       .then((res) => setConversationHistory(res.conversationHistory))
   }
 
+  // If a conversation entry is submitted but we haven't yet
+  // accepted the policy, show the policy.
+  React.useEffect(() => {
+    if (conversationHistory.length && !hasAcceptedAgreement) {
+      setShowAgreementModal(true)
+    }
+  }, [conversationHistory?.length, hasAcceptedAgreement])
+
   const getSuggestedQuestions = () => {
     getPageHandlerInstance()
       .pageHandler.getSuggestedQuestions()
@@ -249,12 +257,6 @@ function DataContextProvider (props: DataContextProviderProps) {
 
     getPageHandlerInstance().callbackRouter.onModelChanged.addListener((modelKey: string) => {
       setCurrentModelKey(modelKey)
-    })
-
-    getPageHandlerInstance().callbackRouter.onConversationEntryPending.addListener(() => {
-      if (!hasAcceptedAgreement) {
-        setShowAgreementModal(true)
-      }
     })
 
     // Since there is no server-side event for premium status changing,

--- a/ios/browser/api/ai_chat/ai_chat.mm
+++ b/ios/browser/api/ai_chat/ai_chat.mm
@@ -99,7 +99,7 @@
 }
 
 - (void)submitHumanConversationEntry:(NSString*)text {
-  driver_->MakeAPIRequestWithConversationHistoryUpdate(
+  driver_->SubmitHumanConversationEntry(
       {ai_chat::mojom::CharacterType::HUMAN,
        ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
        base::SysNSStringToUTF8(text)});

--- a/ios/browser/api/ai_chat/conversation_driver_ios.h
+++ b/ios/browser/api/ai_chat/conversation_driver_ios.h
@@ -41,10 +41,8 @@ class ConversationDriverIOS : public ConversationDriver,
  protected:
   std::u16string GetPageTitle() const override;
   GURL GetPageURL() const override;
-  void GetPageContent(base::OnceCallback<void(std::string, bool is_video)>
-                          callback) const override;
-  bool HasPrimaryMainFrame() const override;
-  bool IsDocumentOnLoadCompletedInPrimaryMainFrame() const override;
+  void GetPageContent(
+      ConversationDriver::GetPageContentCallback callback) const override;
 
   // Observer
   void OnHistoryUpdate() override;

--- a/ios/browser/api/ai_chat/conversation_driver_ios.h
+++ b/ios/browser/api/ai_chat/conversation_driver_ios.h
@@ -41,8 +41,8 @@ class ConversationDriverIOS : public ConversationDriver,
  protected:
   std::u16string GetPageTitle() const override;
   GURL GetPageURL() const override;
-  void GetPageContent(
-      ConversationDriver::GetPageContentCallback callback) const override;
+  void GetPageContent(ConversationDriver::GetPageContentCallback callback,
+                      std::string_view invalidation_token) const override;
 
   // Observer
   void OnHistoryUpdate() override;
@@ -53,7 +53,6 @@ class ConversationDriverIOS : public ConversationDriver,
       std::vector<std::string> questions,
       ai_chat::mojom::SuggestionGenerationStatus status) override;
   void OnPageHasContent(ai_chat::mojom::SiteInfoPtr site_info) override;
-  void OnConversationEntryPending() override;
 
  private:
   base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>

--- a/ios/browser/api/ai_chat/conversation_driver_ios.mm
+++ b/ios/browser/api/ai_chat/conversation_driver_ios.mm
@@ -52,7 +52,8 @@ GURL ConversationDriverIOS::GetPageURL() const {
 }
 
 void ConversationDriverIOS::GetPageContent(
-    ConversationDriver::GetPageContentCallback) const {
+    ConversationDriver::GetPageContentCallback,
+    std::string_view invalidation_token) const {
   [bridge_
       getPageContentWithCompletion:[callback =
                                         std::make_shared<decltype(callback)>(
@@ -61,7 +62,7 @@ void ConversationDriverIOS::GetPageContent(
         if (callback) {
           std::move(*callback).Run(
               content ? base::SysNSStringToUTF8(content) : std::string(),
-              isVideo);
+              isVideo, std::string());
         }
       }];
 }
@@ -96,10 +97,6 @@ void ConversationDriverIOS::OnPageHasContent(
     ai_chat::mojom::SiteInfoPtr site_info) {
   [bridge_ onPageHasContent:[[AiChatSiteInfo alloc]
                                 initWithSiteInfoPtr:std::move(site_info)]];
-}
-
-void ConversationDriverIOS::OnConversationEntryPending() {
-  [bridge_ onConversationEntryPending];
 }
 
 }  // namespace ai_chat

--- a/ios/browser/api/ai_chat/conversation_driver_ios.mm
+++ b/ios/browser/api/ai_chat/conversation_driver_ios.mm
@@ -6,6 +6,7 @@
 #include "brave/ios/browser/api/ai_chat/conversation_driver_ios.h"
 
 #import "ai_chat.mojom.objc+private.h"
+#include "brave/components/ai_chat/core/browser/conversation_driver.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/base/mac/conversions.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-shared.h"
@@ -51,7 +52,7 @@ GURL ConversationDriverIOS::GetPageURL() const {
 }
 
 void ConversationDriverIOS::GetPageContent(
-    base::OnceCallback<void(std::string, bool is_video)> callback) const {
+    ConversationDriver::GetPageContentCallback) const {
   [bridge_
       getPageContentWithCompletion:[callback =
                                         std::make_shared<decltype(callback)>(
@@ -63,15 +64,6 @@ void ConversationDriverIOS::GetPageContent(
               isVideo);
         }
       }];
-}
-
-bool ConversationDriverIOS::HasPrimaryMainFrame() const {
-  return true;
-}
-
-bool ConversationDriverIOS::IsDocumentOnLoadCompletedInPrimaryMainFrame()
-    const {
-  return [bridge_ isDocumentOnLoadCompletedInPrimaryFrame];
 }
 
 // MARK: - ConversationDriver::Observer

--- a/ios/browser/api/ai_chat/conversation_driver_ios.mm
+++ b/ios/browser/api/ai_chat/conversation_driver_ios.mm
@@ -6,9 +6,9 @@
 #include "brave/ios/browser/api/ai_chat/conversation_driver_ios.h"
 
 #import "ai_chat.mojom.objc+private.h"
-#include "brave/components/ai_chat/core/browser/conversation_driver.h"
 #include "base/strings/sys_string_conversions.h"
 #include "brave/base/mac/conversions.h"
+#include "brave/components/ai_chat/core/browser/conversation_driver.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/ios/browser/api/ai_chat/ai_chat_delegate.h"

--- a/ios/browser/api/ai_chat/conversation_driver_ios.mm
+++ b/ios/browser/api/ai_chat/conversation_driver_ios.mm
@@ -52,7 +52,7 @@ GURL ConversationDriverIOS::GetPageURL() const {
 }
 
 void ConversationDriverIOS::GetPageContent(
-    ConversationDriver::GetPageContentCallback,
+    ConversationDriver::GetPageContentCallback callback,
     std::string_view invalidation_token) const {
   [bridge_
       getPageContentWithCompletion:[callback =


### PR DESCRIPTION
On a page-connected conversation, every new conversation entry waits until page content is (re-)fetched. Also fixes bug for same-document navigations where class variables were being hidden by subclass variables left over from the iOS refactor.

Introduces `invalidation_token` which is optionally provided by `GetPageContent`'s callback in some cases. It should be provided on subsequent calls to `GetPageContent`.

<!-- Add brave-browser issue below that this PR will resolve -->
- Resolves https://github.com/brave/brave-browser/issues/34706
- Resolves https://github.com/brave/brave-browser/issues/34946

#### TODO
- [x] Separate "is page connected" with "have we retrieved content"
- [x] Fetch page content every time message is sent
- [x] Suggested questions should work again
- [ ] ~`is_video` should be decided independently so that conversation knows its a video before any messages are sent~ _not neccessary_
- [x] Do not re-fetch page content that is static (e.g. video transcript fetched via unchanged Url)
- [x] Change c++ flow - instead of `MaybeGetPageContent` + a pending message + `MaybePopPendingRequests`, use a function with a callback.
- [ ] Update iOS subclass

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

