### PR TITLE
Optimizes an access to TemplateUrlService native implementation and fixes a crash on edit private tabs search engine

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/SearchEngineTabModelSelectorObserver.java
+++ b/android/java/org/chromium/chrome/browser/settings/SearchEngineTabModelSelectorObserver.java
@@ -29,7 +29,7 @@ public class SearchEngineTabModelSelectorObserver implements TabModelSelectorObs
         if (newModel.getProfile().isOffTheRecord()) {
             BraveSearchEngineUtils.initializeBraveSearchEngineStates(newModel.getProfile());
         } else {
-            BraveSearchEngineUtils.updateActiveDSE(newModel.getProfile());
+            BraveSearchEngineUtils.updateActiveDSE(newModel.getProfile(), null);
         }
     }
 

--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
@@ -36,7 +36,7 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
     private @Nullable BraveSearchBannerProcessor mBraveSearchBannerProcessor;
     private UrlBarEditingTextStateProvider mUrlBarEditingTextProvider;
     private @NonNull Supplier<Tab> mActivityTabSupplier;
-    private static final List<String> mBraveSearchEngineDefaultRegions =
+    private static final List<String> sBraveSearchEngineDefaultRegions =
             Arrays.asList("CA", "DE", "FR", "GB", "US", "AT", "ES", "MX");
     @Px
     private static final int DROPDOWN_HEIGHT_UNKNOWN = -1;
@@ -105,15 +105,15 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
         if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_SEARCH_OMNIBOX_BANNER)
                 && mUrlBarEditingTextProvider != null
                 && mUrlBarEditingTextProvider.getTextWithoutAutocomplete().length() > 0
-                && activeTab != null && !activeTab.isIncognito()
-                && mBraveSearchEngineDefaultRegions.contains(Locale.getDefault().getCountry())
-                && !BraveSearchEngineAdapter
-                            .getDSEShortName(
-                                    Profile.fromWebContents(activeTab.getWebContents()), false)
-                            .equals("Brave")
+                && activeTab != null
+                && !activeTab.isIncognito()
+                && sBraveSearchEngineDefaultRegions.contains(Locale.getDefault().getCountry())
+                && !BraveSearchEngineAdapter.getDSEShortName(
+                                Profile.fromWebContents(activeTab.getWebContents()), false, null)
+                        .equals("Brave")
                 && !OmniboxPrefManager.getInstance().isBraveSearchPromoBannerDismissed()
                 && !OmniboxPrefManager.getInstance()
-                            .isBraveSearchPromoBannerDismissedCurrentSession()) {
+                        .isBraveSearchPromoBannerDismissedCurrentSession()) {
             long expiredDate =
                     OmniboxPrefManager.getInstance().getBraveSearchPromoBannerExpiredDate();
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34826

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open Brave.
2. Make sure you don't have any private tab open.
3. Go to Settings->Search Engines and change a search engine for private tabs to any.
4. Close the dialog via X.
5. Make sure Brave doesn't crash.