### PR TITLE
[Brave News]: Miscellaneous fixes

### DIFF
--- a/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
@@ -92,15 +92,6 @@ export default function FeedV2() {
     ref.current?.scrollIntoView()
   }, [feedV2?.items])
 
-  // For some reason |createGlobalStyle| doesn't seem to work in Brave Core
-  // To get the background blur effect looking nice, we need to set the body
-  // background to black - unfortunately we can't do this in root HTML file
-  // because we want to avoid the background flash effect.
-  React.useEffect(() => {
-    // Note: This is always black because this doesn't support light mode.
-    document.body.style.backgroundColor = 'black';
-  }, [])
-
   return <Root ref={ref as any} data-theme="dark">
     <SidebarContainer>
       <FeedNavigation />

--- a/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
@@ -11,8 +11,10 @@ import * as React from 'react'
 import styled from 'styled-components'
 import Feed from '../../../../brave_news/browser/resources/Feed'
 import FeedNavigation from '../../../../brave_news/browser/resources/FeedNavigation'
+import NewsButton from '../../../../brave_news/browser/resources/NewsButton'
 import Variables from '../../../../brave_news/browser/resources/Variables'
 import { useBraveNews } from '../../../../brave_news/browser/resources/shared/Context'
+import { isPublisherEnabled } from '../../../../brave_news/browser/resources/shared/api'
 import { CLASSNAME_PAGE_STUCK } from '../page'
 
 const Root = styled(Variables)`
@@ -56,19 +58,13 @@ const ButtonsContainer = styled.div`
   background: var(--bn-glass-container);
 `
 
-const NewsButton = styled(Button)`
+const SettingsButton = styled(Button)`
   --leo-button-color: var(--bn-glass-50);
   --leo-button-radius: ${radius.s};
   --leo-button-padding: ${spacing.m};
 `
 
-const LoadNewContentButton = styled(Button)`
-  --leo-button-color: var(--bn-glass-10);
-
-  border-radius: 20px;
-  overflow: hidden;
-  backdrop-filter: brightness(0.8) blur(32px);
-
+const LoadNewContentButton = styled(NewsButton)`
   position: fixed;
   z-index: 1;
   top: ${spacing['3Xl']};
@@ -77,8 +73,16 @@ const LoadNewContentButton = styled(Button)`
 `
 
 export default function FeedV2() {
-  const { feedV2, setCustomizePage, refreshFeedV2, feedV2UpdatesAvailable } = useBraveNews()
+  const { feedV2, setCustomizePage, refreshFeedV2, feedV2UpdatesAvailable, publishers, channels } = useBraveNews()
 
+  // This is a bit of an interesting |useMemo| - we only want it to be updated
+  // when the feed changes so as to not break the case where:
+  // 1. The user has no feeds (we show the NoFeeds card)
+  // 2. The user subscribes to a feed (we should still show the NoFeeds card,
+  //    not the "Empty Feed")
+  // To achieve this, |hasSubscriptions| is only updated when the feed changes.
+  const hasSubscriptions = React.useMemo(() => Object.values(publishers).some(isPublisherEnabled)
+    || Object.values(channels).some(c => c.subscribedLocales.length), [feedV2])
   const ref = React.useRef<HTMLDivElement>()
 
   // Note: Whenever the feed is updated, if we're viewing the feed, scroll to
@@ -100,16 +104,16 @@ export default function FeedV2() {
       {feedV2UpdatesAvailable && <LoadNewContentButton onClick={refreshFeedV2}>
         {getLocale('braveNewsNewContentAvailable')}
       </LoadNewContentButton>}
-      <Feed feed={feedV2} />
+      <Feed feed={feedV2} hasSubscriptions={hasSubscriptions} />
     </Flex>
 
     <ButtonsContainer>
-      <NewsButton fab kind='outline' onClick={() => setCustomizePage('news')} title={getLocale('braveNewsCustomizeFeed')}>
+      <SettingsButton fab kind='outline' onClick={() => setCustomizePage('news')} title={getLocale('braveNewsCustomizeFeed')}>
         <Icon name="settings" />
-      </NewsButton>
-      <NewsButton fab isLoading={!feedV2} kind='outline' title={getLocale('braveNewsRefreshFeed')} onClick={() => {
+      </SettingsButton>
+      <SettingsButton fab isLoading={!feedV2} kind='outline' title={getLocale('braveNewsRefreshFeed')} onClick={() => {
         refreshFeedV2()
-      }}><Icon name="refresh" /></NewsButton>
+      }}><Icon name="refresh" /></SettingsButton>
     </ButtonsContainer>
   </Root>
 }

--- a/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/FeedV2.tsx
@@ -75,14 +75,21 @@ const LoadNewContentButton = styled(NewsButton)`
 export default function FeedV2() {
   const { feedV2, setCustomizePage, refreshFeedV2, feedV2UpdatesAvailable, publishers, channels } = useBraveNews()
 
+  // We don't want to decide whether we have subscriptions until the publishers
+  // and channels have loaded.
+  const loaded = React.useMemo(() => !!Object.values(publishers).length && !!Object.values(channels).length, [publishers, channels])
+
   // This is a bit of an interesting |useMemo| - we only want it to be updated
   // when the feed changes so as to not break the case where:
   // 1. The user has no feeds (we show the NoFeeds card)
   // 2. The user subscribes to a feed (we should still show the NoFeeds card,
   //    not the "Empty Feed")
-  // To achieve this, |hasSubscriptions| is only updated when the feed changes.
-  const hasSubscriptions = React.useMemo(() => Object.values(publishers).some(isPublisherEnabled)
-    || Object.values(channels).some(c => c.subscribedLocales.length), [feedV2])
+  // To achieve this, |hasSubscriptions| is only updated when the feed changes,
+  // or the opt-in status is changed.
+  const hasSubscriptions = React.useMemo(() => !loaded
+    || Object.values(publishers).some(isPublisherEnabled)
+    || Object.values(channels).some(c => c.subscribedLocales.length), [feedV2, loaded])
+
   const ref = React.useRef<HTMLDivElement>()
 
   // Note: Whenever the feed is updated, if we're viewing the feed, scroll to

--- a/components/brave_new_tab_ui/components/default/braveNews/cards/cardOptIn.tsx
+++ b/components/brave_new_tab_ui/components/default/braveNews/cards/cardOptIn.tsx
@@ -8,6 +8,7 @@ import { getLocale, getLocaleWithTag } from '../../../../../common/locale'
 import * as Card from '../cardIntro'
 import BraveNewsLogoUrl from '../braveNewsLogo.svg'
 import { CardButton, TertiaryButton } from '../default'
+import { NEWS_FEED_CLASS } from '../../../../../brave_news/browser/resources/Feed'
 
 type Props = {
   onOptIn: () => unknown
@@ -19,7 +20,7 @@ const descriptionTwoTextParts = getLocaleWithTag('braveNewsIntroDescriptionTwo')
 export default function IntroCard (props: Props) {
   const introElementRef = React.useRef(null)
   return (
-    <Card.Intro ref={introElementRef}>
+    <Card.Intro ref={introElementRef} className={NEWS_FEED_CLASS}>
       <Card.Image src={BraveNewsLogoUrl} />
       <Card.Title>{getLocale('braveNewsIntroTitle')}</Card.Title>
       <div>

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -307,6 +307,12 @@ void BraveNewsController::SetChannelSubscribed(
     SetChannelSubscribedCallback callback) {
   auto result =
       channels_controller_.SetChannelSubscribed(locale, channel_id, subscribed);
+
+  // When channels are changed, see if it affects the feed.
+  if (MaybeInitFeedV2()) {
+    feed_v2_builder_->RecheckFeedHash();
+  }
+
   std::move(callback).Run(std::move(result));
 }
 

--- a/components/brave_news/browser/channels_controller.cc
+++ b/components/brave_news/browser/channels_controller.cc
@@ -172,6 +172,11 @@ bool ChannelsController::GetChannelSubscribed(const std::string& locale,
 }
 
 void ChannelsController::OnPublishersUpdated(PublishersController* controller) {
+  // Don't notify updates until the pref is initialized.
+  if (!prefs_->HasPrefPath(prefs::kBraveNewsChannels)) {
+    return;
+  }
+
   GetAllChannels(base::BindOnce(
       [](ChannelsController* controller, Channels channels) {
         auto event = mojom::ChannelsEvent::New();

--- a/components/brave_news/browser/feed_v2_builder.cc
+++ b/components/brave_news/browser/feed_v2_builder.cc
@@ -900,8 +900,7 @@ void FeedV2Builder::GetSignals(GetSignalsCallback callback) {
                  weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
 }
 
-void FeedV2Builder::OnPublishersUpdated(
-    PublishersController* publishers_controller) {
+void FeedV2Builder::RecheckFeedHash() {
   const auto& publishers = publishers_controller_->GetLastPublishers();
   auto channels =
       channels_controller_->GetChannelsFromPublishers(publishers, &*prefs_);
@@ -909,6 +908,11 @@ void FeedV2Builder::OnPublishersUpdated(
   for (const auto& listener : listeners_) {
     listener->OnUpdateAvailable(hash_);
   }
+}
+
+void FeedV2Builder::OnPublishersUpdated(
+    PublishersController* publishers_controller) {
+  RecheckFeedHash();
 }
 
 void FeedV2Builder::UpdateData(UpdateSettings settings,

--- a/components/brave_news/browser/feed_v2_builder.cc
+++ b/components/brave_news/browser/feed_v2_builder.cc
@@ -88,6 +88,12 @@ std::string GetFeedHash(const Channels& channels,
     if (publisher->user_enabled_status == mojom::UserEnabled::ENABLED) {
       hash_items.push_back(id);
     }
+
+    // Disabling a publisher should also change the hash, as it will affect what
+    // articles can be shown.
+    if (publisher->user_enabled_status == mojom::UserEnabled::DISABLED) {
+      hash_items.push_back(id + "_disabled");
+    }
   }
 
   for (const auto& [region, etag] : etags) {

--- a/components/brave_news/browser/feed_v2_builder.cc
+++ b/components/brave_news/browser/feed_v2_builder.cc
@@ -85,7 +85,8 @@ std::string GetFeedHash(const Channels& channels,
   }
 
   for (const auto& [id, publisher] : publishers) {
-    if (publisher->user_enabled_status == mojom::UserEnabled::ENABLED) {
+    if (publisher->user_enabled_status == mojom::UserEnabled::ENABLED ||
+        publisher->type == mojom::PublisherType::DIRECT_SOURCE) {
       hash_items.push_back(id);
     }
 

--- a/components/brave_news/browser/feed_v2_builder.h
+++ b/components/brave_news/browser/feed_v2_builder.h
@@ -59,6 +59,8 @@ class FeedV2Builder : public PublishersController::Observer {
 
   void GetSignals(GetSignalsCallback callback);
 
+  void RecheckFeedHash();
+
   // PublishersController::Observer:
   void OnPublishersUpdated(PublishersController* controller) override;
 

--- a/components/brave_news/browser/resources/Feed.tsx
+++ b/components/brave_news/browser/resources/Feed.tsx
@@ -3,19 +3,20 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import { spacing } from "@brave/leo/tokens/css";
 import { FeedItemV2, FeedV2 } from "gen/brave/components/brave_news/common/brave_news.mojom.m";
 import * as React from 'react';
 import styled from "styled-components";
 import Advert from "./feed/Ad";
 import Article from "./feed/Article";
+import CaughtUp from "./feed/CaughtUp";
 import Cluster from "./feed/Cluster";
 import Discover from "./feed/Discover";
 import HeroArticle from "./feed/Hero";
-import { getHistoryValue, setHistoryState } from "./shared/history";
-import NoArticles from "./feed/NoArticles";
 import LoadingCard from "./feed/LoadingCard";
-import { spacing } from "@brave/leo/tokens/css";
-import CaughtUp from "./feed/CaughtUp";
+import NoArticles from "./feed/NoArticles";
+import NoFeeds from "./feed/NoFeeds";
+import { getHistoryValue, setHistoryState } from "./shared/history";
 
 // Restoring scroll position is complicated - we have two available strategies:
 // 1. Scroll to the same position - as long as the window hasn't been resized,
@@ -44,6 +45,7 @@ const FeedContainer = styled.div`
 
 interface Props {
   feed: FeedV2 | undefined;
+  hasSubscriptions: boolean;
 }
 
 const getKey = (feedItem: FeedItemV2, index: number): React.Key => {
@@ -74,7 +76,7 @@ const saveScrollPos = (itemId: React.Key) => () => {
   })
 }
 
-export default function Component({ feed }: Props) {
+export default function Component({ feed, hasSubscriptions }: Props) {
   const [cardCount, setCardCount] = React.useState(getHistoryValue(HISTORY_CARD_COUNT, PAGE_SIZE));
 
   // Store the number of cards we've loaded in history - otherwise when we
@@ -144,12 +146,15 @@ export default function Component({ feed }: Props) {
   }, [cardCount, feed?.items])
 
   return <FeedContainer className={NEWS_FEED_CLASS}>
-    {feed
-      ? !feed.items.length ? <NoArticles />
-      : <>
-          {cards}
-          <CaughtUp />
-      </>
-      : <LoadingCard />}
+    {!hasSubscriptions
+      ? <NoFeeds />
+      : feed
+        ? !feed.items.length
+          ? <NoArticles />
+          : <>
+            {cards}
+            <CaughtUp />
+          </>
+        : <LoadingCard />}
   </FeedContainer>
 }

--- a/components/brave_news/browser/resources/FeedPage.tsx
+++ b/components/brave_news/browser/resources/FeedPage.tsx
@@ -23,6 +23,6 @@ export default function FeedPage() {
   const { feedV2 } = useBraveNews()
   return <Container>
     <h2>The Feed ({feedV2?.items.length} items. Truncated at {truncate})</h2>
-    <Feed feed={feedV2} />
+    <Feed feed={feedV2} hasSubscriptions />
   </Container>
 }

--- a/components/brave_news/browser/resources/NewsButton.tsx
+++ b/components/brave_news/browser/resources/NewsButton.tsx
@@ -1,0 +1,14 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import Button from '@brave/leo/react/button'
+import styled from 'styled-components'
+
+export default styled(Button)`
+  --leo-button-color: var(--bn-glass-10);
+
+  border-radius: 20px;
+  overflow: hidden;
+  backdrop-filter: brightness(0.8) blur(32px);
+`

--- a/components/brave_news/browser/resources/Peek.tsx
+++ b/components/brave_news/browser/resources/Peek.tsx
@@ -98,26 +98,35 @@ const scrollToNews = () => {
 }
 
 export default function Peek() {
-  const { feedV2 } = useBraveNews()
+  const { feedV2, isShowOnNTPPrefEnabled, isOptInPrefEnabled } = useBraveNews()
   const top = feedV2?.items?.find(a => a.article || a.hero)
   const data = (top?.hero ?? top?.article)?.data
   const imageUrl = useUnpaddedImageUrl(data?.image.paddedImageUrl?.url ?? data?.image.imageUrl?.url, undefined, true)
 
-  if (!data) return null
+  // For some reason |createGlobalStyle| doesn't seem to work in Brave Core
+  // To get the background blur effect looking nice, we need to set the body
+  // background to black - unfortunately we can't do this in root HTML file
+  // because we want to avoid the background flash effect.
+  React.useEffect(() => {
+    // Note: This is always black because this doesn't support light mode.
+    document.body.style.backgroundColor = 'black';
+  }, [])
 
-  return <Container>
-    <NewsButton onClick={scrollToNews}>
-      <Icon name='news-default' />
-      {getLocale('braveNewsNewsPeek')}
-      <Icon name='carat-down' />
-    </NewsButton>
-    <PeekingCard onClick={scrollToNews}>
-      <div>
-        <MetaInfo article={data} />
-        <Title>{data.title}</Title>
-      </div>
-      <SmallImage src={imageUrl} />
-    </PeekingCard>
-  </Container>
+  return isShowOnNTPPrefEnabled
+    ? <Container>
+      {(!isOptInPrefEnabled || data) && <NewsButton onClick={scrollToNews}>
+        <Icon name='news-default' />
+        {getLocale('braveNewsNewsPeek')}
+        <Icon name='carat-down' />
+      </NewsButton>}
+      {data && <PeekingCard onClick={scrollToNews}>
+        <div>
+          <MetaInfo article={data} />
+          <Title>{data.title}</Title>
+        </div>
+        <SmallImage src={imageUrl} />
+      </PeekingCard>}
+    </Container>
+    : null
 }
 

--- a/components/brave_news/browser/resources/feed/NoArticles.tsx
+++ b/components/brave_news/browser/resources/feed/NoArticles.tsx
@@ -36,24 +36,24 @@ export default function NoArticles() {
       <rect x="9.5" y="75" width="64" height="4" rx="2" fill="url(#paint4_linear_5051_10730)" />
       <defs>
         <linearGradient id="paint0_linear_5051_10730" x1="49.5" y1="1" x2="49.5" y2="78.5" gradientUnits="userSpaceOnUse">
-          <stop stop-color="white" stop-opacity="0.15" />
-          <stop offset="1" stop-color="white" stop-opacity="0" />
+          <stop stopColor="white" stopOpacity="0.15" />
+          <stop offset="1" stopColor="white" stopOpacity="0" />
         </linearGradient>
         <linearGradient id="paint1_linear_5051_10730" x1="9.5" y1="33" x2="89.5" y2="33" gradientUnits="userSpaceOnUse">
-          <stop stop-color="white" stop-opacity="0.03" />
-          <stop offset="1" stop-color="white" stop-opacity="0.2" />
+          <stop stopColor="white" stopOpacity="0.03" />
+          <stop offset="1" stopColor="white" stopOpacity="0.2" />
         </linearGradient>
         <linearGradient id="paint2_linear_5051_10730" x1="9.5" y1="71.0426" x2="89.5" y2="71.0425" gradientUnits="userSpaceOnUse">
-          <stop stop-color="white" stop-opacity="0.03" />
-          <stop offset="1" stop-color="white" stop-opacity="0.2" />
+          <stop stopColor="white" stopOpacity="0.03" />
+          <stop offset="1" stopColor="white" stopOpacity="0.2" />
         </linearGradient>
         <linearGradient id="paint3_linear_5051_10730" x1="9.5" y1="60.0213" x2="57.5" y2="60.0213" gradientUnits="userSpaceOnUse">
-          <stop stop-color="white" stop-opacity="0.03" />
-          <stop offset="1" stop-color="white" stop-opacity="0.2" />
+          <stop stopColor="white" stopOpacity="0.03" />
+          <stop offset="1" stopColor="white" stopOpacity="0.2" />
         </linearGradient>
         <linearGradient id="paint4_linear_5051_10730" x1="9.5" y1="77.0426" x2="73.5" y2="77.0425" gradientUnits="userSpaceOnUse">
-          <stop stop-color="white" stop-opacity="0.03" />
-          <stop offset="1" stop-color="white" stop-opacity="0.2" />
+          <stop stopColor="white" stopOpacity="0.03" />
+          <stop offset="1" stopColor="white" stopOpacity="0.2" />
         </linearGradient>
       </defs>
     </svg>

--- a/components/brave_news/browser/resources/feed/NoFeeds.tsx
+++ b/components/brave_news/browser/resources/feed/NoFeeds.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import Flex from '$web-common/Flex';
+import { getLocale } from '$web-common/locale';
+import { spacing } from '@brave/leo/tokens/css';
+import * as React from 'react';
+import styled from 'styled-components';
+import NewsButton from '../NewsButton';
+import { useBraveNews } from '../shared/Context';
+import { Title } from './Card';
+
+const Container = styled(Flex)`
+  text-align: center;
+
+  padding: ${spacing['3Xl']};
+  gap: ${spacing.m};
+  color: var(--bn-glass-70);
+
+  & > svg {
+    margin-bottom: ${spacing.xl};
+    fill: none;
+  }
+`
+
+export default function NoFeeds() {
+  const { setCustomizePage } = useBraveNews()
+  return <Container align='center' direction='column' justify='center' gap={spacing.m}>
+    <svg xmlns='http://www.w3.org/2000/svg' fill='none' width="99" viewBox='0 0 64 46'>
+      <path
+        fill='#F0F2FF'
+        fillRule='evenodd'
+        d='M49.67 46H13.33C5.36 46 0 41.32 0 34.37c0-5.45 3.08-10.33 7.84-12.74l-.02-.84C7.82 9.69 16.92.67 28.1.67a20.3 20.3 0 0118.37 11.65c9.74.4 17.54 8.4 17.54 18.17C64 39.33 57.84 46 49.67 46zm-3.98-28.37c-.24 0-.47.02-.7.05-1.24.14-2.4-.6-2.81-1.77A14.94 14.94 0 0028.08 6a14.88 14.88 0 00-14.92 14.79c0 .68.06 1.37.18 2.11a2.67 2.67 0 01-1.8 2.96 8.95 8.95 0 00-6.2 8.5c0 5.85 6.12 6.3 8 6.3h36.33c4.47 0 9-3.5 9-10.17 0-7.1-5.83-12.86-12.98-12.86zM40 35.33c-.68 0-1.37-.26-1.89-.78-.05-.04-2.06-1.88-6.11-1.88-4.05 0-6.06 1.84-6.14 1.91-1.07 1-2.75.97-3.76-.07a2.65 2.65 0 01.01-3.73c.36-.35 3.63-3.45 9.89-3.45 6.26 0 9.53 3.1 9.89 3.45A2.66 2.66 0 0140 35.33zm-5.33-16H40v5.34h-5.33v-5.34zm-10.67 0h5.33v5.34H24v-5.34z'
+        clipRule='evenodd' />
+    </svg>
+    <Title>{getLocale('braveNewsNoContentHeading')}</Title>
+    <div>
+      {getLocale('braveNewsNoContentMessage')}
+    </div>
+    <NewsButton onClick={() => setCustomizePage('news')}>
+      {getLocale('braveNewsNoContentActionLabel')}
+    </NewsButton>
+  </Container>
+}

--- a/components/brave_news/browser/resources/shared/useFeedV2.ts
+++ b/components/brave_news/browser/resources/shared/useFeedV2.ts
@@ -15,6 +15,7 @@ const MAX_AGE_FOR_LOCAL_STORAGE_FEED = 1000 * 60 * 60
 const feedTypeToFeedView = (type: FeedV2Type | undefined): FeedView => {
   if (type?.channel) return `channels/${type.channel.channel}`
   if (type?.publisher) return `publishers/${type.publisher.publisherId}`
+  if (type?.following) return `following`
   return 'all'
 }
 
@@ -123,6 +124,8 @@ export const useFeedV2 = (enabled: boolean) => {
   const [feedView, setFeedView] = useState<FeedView>(feedTypeToFeedView(feedV2?.type))
   const [hash, setHash] = useState<string>()
 
+  window['feed'] = feedV2
+
   // Add a listener for the latest hash if Brave News is enabled. Note: We need
   // to re-add the listener when the enabled state changes because the backing
   // FeedV2Builder is created/destroyed.
@@ -144,8 +147,11 @@ export const useFeedV2 = (enabled: boolean) => {
 
     setFeedV2(undefined)
 
+    console.log("Attempting to load feed", feedView)
     const cachedFeed = maybeLoadFeed(feedView)
     if (cachedFeed) {
+      console.log("Got feed with", feedTypeToFeedView(cachedFeed?.type))
+      console.log(cachedFeed)
       setFeedV2(cachedFeed)
       return
     }

--- a/components/brave_news/browser/resources/shared/useFeedV2.ts
+++ b/components/brave_news/browser/resources/shared/useFeedV2.ts
@@ -124,8 +124,6 @@ export const useFeedV2 = (enabled: boolean) => {
   const [feedView, setFeedView] = useState<FeedView>(feedTypeToFeedView(feedV2?.type))
   const [hash, setHash] = useState<string>()
 
-  window['feed'] = feedV2
-
   // Add a listener for the latest hash if Brave News is enabled. Note: We need
   // to re-add the listener when the enabled state changes because the backing
   // FeedV2Builder is created/destroyed.
@@ -147,11 +145,8 @@ export const useFeedV2 = (enabled: boolean) => {
 
     setFeedV2(undefined)
 
-    console.log("Attempting to load feed", feedView)
     const cachedFeed = maybeLoadFeed(feedView)
     if (cachedFeed) {
-      console.log("Got feed with", feedTypeToFeedView(cachedFeed?.type))
-      console.log(cachedFeed)
       setFeedV2(cachedFeed)
       return
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35001
![image](https://github.com/brave/brave-core/assets/7678024/8aed84f8-e476-482d-81d0-799e00aa3076)

Resolves https://github.com/brave/brave-browser/issues/34975
![image](https://github.com/brave/brave-core/assets/7678024/2c1e9eeb-9861-489a-8ec5-f8668c9c97c8)

Resolves https://github.com/brave/brave-browser/issues/34973
[Screencast from 2023-12-21 13-22-54.webm](https://github.com/brave/brave-core/assets/7678024/b5fb20f1-78a6-44dc-aab8-e954115194cc)

Resolves https://github.com/brave/brave-browser/issues/35000

Additionally:
- Fixes some console warnings (no testing needed)
- Fixes a bug where selecting `Following`, then `For You` wouldn't update the feed.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Custom-Headers
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Select the `For You` feed
2. Select the `Following` feed
3. Select the `For You` feed again.
The feed should update (to what was originally in the `For You` feed

1. Create a new profile
2. On the New Tab page, there should be a hint that you can scroll down to view Brave News
3. Clicking the hint should scroll down
4. It should be possible to scroll down
5. The edges of the window when viewing the opt-in card should not have a weird whiteish tint 

1. Unsubscribe from all content & reload the feed
2. There should be a card showing saying we have no sources with a button to add more

1. After hiding a publisher with the `...` menu the `New content available. Reload?` button should show up
