### PR TITLE
Skip brave specific uninstall logic if user cancelled uninstall (uplift to 1.62.x)

### DIFF
--- a/chromium_src/chrome/installer/setup/uninstall.cc
+++ b/chromium_src/chrome/installer/setup/uninstall.cc
@@ -69,6 +69,14 @@ InstallStatus UninstallProduct(const ModifyParams& modify_params,
                                bool remove_all,
                                bool force_uninstall,
                                const base::CommandLine& cmd_line) {
+  InstallStatus ret = UninstallProduct_ChromiumImpl(modify_params, remove_all,
+                                                    force_uninstall, cmd_line);
+
+  // Early return if user cancelled.
+  if (ret == installer::UNINSTALL_CANCELLED) {
+    return ret;
+  }
+
   DeleteBraveFileKeys(HKEY_CURRENT_USER);
 
   const auto installer_state = modify_params.installer_state;
@@ -100,8 +108,8 @@ InstallStatus UninstallProduct(const ModifyParams& modify_params,
   }
   brave_vpn::ras::RemoveEntry(brave_vpn::GetBraveVPNConnectionName());
 #endif
-  return UninstallProduct_ChromiumImpl(modify_params, remove_all,
-                                       force_uninstall, cmd_line);
+
+  return ret;
 }
 
 }  // namespace installer


### PR DESCRIPTION
Uplift of #21478
fix https://github.com/brave/brave-browser/issues/35006

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.