### PR TITLE
Force the referrer to always be 'no-referrer' while in speedreader mode. (uplift to 1.62.x)

### DIFF
--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -317,6 +317,9 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SmokeTest) {
   const std::string kGetFontsExists =
       "!!(document.getElementById('atkinson_hyperligible_font') && "
       "document.getElementById('open_dyslexic_font'))";
+  const std::string kCheckReferrer =
+      R"js(document.querySelector('meta[name="referrer"]')
+             .getAttribute('content') === 'no-referrer')js";
 
   // Check that the document became much smaller and that non-empty speedreader
   // style is injected.
@@ -328,6 +331,11 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SmokeTest) {
                               content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
                               ISOLATED_WORLD_ID_BRAVE_INTERNAL)
                   .ExtractBool());
+  EXPECT_TRUE(content::EvalJs(ActiveWebContents(), kCheckReferrer,
+                              content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,
+                              ISOLATED_WORLD_ID_BRAVE_INTERNAL)
+                  .ExtractBool());
+
   const auto speedreaded_length =
       content::EvalJs(ActiveWebContents(), kGetContentLength,
                       content::EXECUTE_SCRIPT_DEFAULT_OPTIONS,

--- a/components/speedreader/speedreader_rewriter_service.cc
+++ b/components/speedreader/speedreader_rewriter_service.cc
@@ -44,6 +44,7 @@ std::string WrapStylesheetWithCSP(const std::string& stylesheet,
   };
 
   constexpr const char kCSP[] = R"html(
+    <meta name="referrer" content="no-referrer">
     <meta http-equiv="Content-Security-Policy"
       content="script-src 'none';
                style-src-elem 'sha256-%s' 'sha256-%s' 'sha256-%s'"


### PR DESCRIPTION
Uplift of #21481
Resolves https://github.com/brave/brave-browser/issues/35095

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.