### PR TITLE
Fix #35186: Fixes crash when destructors are called off the main thread

### DIFF
--- a/ios/browser/api/web/web_state/web_state.mm
+++ b/ios/browser/api/web/web_state/web_state.mm
@@ -10,6 +10,7 @@
 
 #include "base/strings/sys_string_conversions.h"
 #include "ios/chrome/browser/shared/model/browser/browser.h"
+#include "ios/web/public/thread/web_task_traits.h"
 #include "ios/web/public/thread/web_thread.h"
 #include "ios/web/web_state/web_state_impl.h"
 
@@ -35,6 +36,15 @@
         std::make_unique<brave::NativeWebState>(browser, isOffTheRecord);
   }
   return self;
+}
+
+- (void)dealloc {
+  web::GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE, base::BindOnce(
+                     [](std::unique_ptr<brave::NativeWebState>&& web_state) {
+                       web_state.reset();
+                     },
+                     std::move(web_state_)));
 }
 
 - (void)setTitle:(NSString*)title {

--- a/ios/browser/api/web_image/image_downloader.h
+++ b/ios/browser/api/web_image/image_downloader.h
@@ -6,7 +6,9 @@
 #ifndef BRAVE_IOS_BROWSER_API_WEB_IMAGE_IMAGE_DOWNLOADER_H_
 #define BRAVE_IOS_BROWSER_API_WEB_IMAGE_IMAGE_DOWNLOADER_H_
 
+#include <memory>
 #include <vector>
+
 #import "components/image_fetcher/ios/ios_image_data_fetcher_wrapper.h"
 
 namespace network {
@@ -36,7 +38,7 @@ class ImageDownloader {
                             ImageDownloadCallback callback);
 
  private:
-  image_fetcher::IOSImageDataFetcherWrapper image_fetcher_;
+  std::unique_ptr<image_fetcher::IOSImageDataFetcherWrapper> image_fetcher_;
 };
 }  // namespace brave
 

--- a/ios/browser/favicon/brave_ios_web_favicon_driver.h
+++ b/ios/browser/favicon/brave_ios_web_favicon_driver.h
@@ -86,7 +86,7 @@ class BraveIOSWebFaviconDriver
                         bool icon_url_changed);
 
   // Image Fetcher used to fetch favicon.
-  brave::ImageDownloader image_fetcher_;
+  std::unique_ptr<brave::ImageDownloader> image_fetcher_;
   std::size_t max_image_width_;
   std::size_t max_image_height_;
 


### PR DESCRIPTION
- Fixes a crash when destructors are called off the main thread from the iOS side.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35186

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

