### PR TITLE
Optimize brave ads javascript requests for non rewards users

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -8,8 +8,10 @@
 #include <string>
 
 #include "brave/browser/brave_ads/ads_service_factory.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
+#include "components/prefs/pref_service.h"
 #include "components/sessions/content/session_tab_helper.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
@@ -31,6 +33,10 @@ constexpr char16_t kGetDocumentHTMLScript[] =
     u"new XMLSerializer().serializeToString(document)";
 
 constexpr char16_t kGetInnerTextScript[] = u"document?.body?.innerText";
+
+bool UserHasOptedInToBraveRewards(const PrefService* prefs) {
+  return prefs->GetBoolean(brave_rewards::prefs::kEnabled);
+}
 
 }  // namespace
 
@@ -77,17 +83,26 @@ void AdsTabHelper::RunIsolatedJavaScript(
     content::RenderFrameHost* render_frame_host) {
   CHECK(render_frame_host);
 
+  const PrefService* prefs =
+      Profile::FromBrowserContext(web_contents()->GetBrowserContext())
+          ->GetPrefs();
+  if (!prefs) {
+    return;
+  }
+
   render_frame_host->ExecuteJavaScriptInIsolatedWorld(
       kGetDocumentHTMLScript,
       base::BindOnce(&AdsTabHelper::OnJavaScriptHtmlResult,
                      weak_factory_.GetWeakPtr()),
       ISOLATED_WORLD_ID_BRAVE_INTERNAL);
 
-  render_frame_host->ExecuteJavaScriptInIsolatedWorld(
-      kGetInnerTextScript,
-      base::BindOnce(&AdsTabHelper::OnJavaScriptTextResult,
-                     weak_factory_.GetWeakPtr()),
-      ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+  if (UserHasOptedInToBraveRewards(prefs)) {
+    render_frame_host->ExecuteJavaScriptInIsolatedWorld(
+        kGetInnerTextScript,
+        base::BindOnce(&AdsTabHelper::OnJavaScriptTextResult,
+                       weak_factory_.GetWeakPtr()),
+        ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+  }
 }
 
 void AdsTabHelper::OnJavaScriptHtmlResult(base::Value value) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35205

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Start with a fresh profile
* Open some web page
* Make sure that the HTML content change event occurred. There should be the line in the rewards log `Tab id HTML content changed`
* Make sure that the text content change event does NOT occur. Following line shouldn't be presented in the rewards log `Tab id text content changed`
* Join Brave Rewards
* Open some web page
* Make sure that the HTML content change event occurred. There should be the line in the rewards log `Tab id HTML content changed`
* Make sure that the text content change event occurred. There should be the line in the rewards log `Tab id text content changed`
