### PR TITLE
Force only dapp accounts in dapp panel

### DIFF
--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
@@ -14,16 +14,18 @@ import { WalletSelectors } from '../../../common/selectors'
 
 // Types
 import { DAppConnectionOptionsType } from './dapp-connection-settings'
-import { BraveWallet } from '../../../constants/types'
+import { BraveWallet, DAppSupportedCoinTypes } from '../../../constants/types'
 
 // Queries
 import {
   useGetDefaultFiatCurrencyQuery,
   useGetSelectedChainQuery,
   useRemoveSitePermissionMutation,
-  useRequestSitePermissionMutation
+  useRequestSitePermissionMutation,
+  useSetSelectedAccountMutation
 } from '../../../common/slices/api.slice'
 import {
+  useAccountsQuery,
   useSelectedAccountQuery //
 } from '../../../common/slices/api.slice.extra'
 
@@ -76,10 +78,12 @@ export const DAppConnectionMain = (props: Props) => {
   const { data: selectedNetwork } = useGetSelectedChainQuery()
   const { data: selectedAccount } = useSelectedAccountQuery()
   const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
+  const { accounts } = useAccountsQuery()
 
   // Mutations
   const [requestSitePermission] = useRequestSitePermissionMutation()
   const [removeSitePermission] = useRemoveSitePermissionMutation()
+  const [setSelectedAccount] = useSetSelectedAccountMutation()
 
   // Memos
   const connectionStatusText = React.useMemo((): string => {
@@ -110,6 +114,21 @@ export const DAppConnectionMain = (props: Props) => {
       await removeSitePermission(selectedAccount.accountId)
     }
   }, [selectedAccount, removeSitePermission])
+
+  React.useEffect(() => {
+    if (!selectedAccount) return
+
+    if (DAppSupportedCoinTypes.includes(selectedAccount.accountId.coin)) {
+      return
+    }
+
+    const dappAccount = accounts.find((acc) =>
+      DAppSupportedCoinTypes.includes(acc.accountId.coin)
+    )
+    if (dappAccount) {
+      setSelectedAccount(dappAccount.accountId)
+    }
+  }, [selectedAccount, accounts])
 
   return (
     <>

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-networks.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-networks.tsx
@@ -15,7 +15,12 @@ import {
 } from '../../../common/slices/api.slice'
 
 // Types
-import { BraveWallet, SupportedTestNetworks } from '../../../constants/types'
+import {
+  BraveWallet,
+  DAppSupportedCoinTypes,
+  DAppSupportedPrimaryChains,
+  SupportedTestNetworks
+} from '../../../constants/types'
 import { DAppConnectionOptionsType } from './dapp-connection-settings'
 
 // Components
@@ -29,16 +34,6 @@ import {
   BackIcon
 } from './dapp-connection-settings.style'
 import { Row, VerticalSpace, ScrollableColumn } from '../../shared/style'
-
-const DAppSupportedCoinTypes = [
-  BraveWallet.CoinType.SOL,
-  BraveWallet.CoinType.ETH
-]
-
-const DAppSupportedPrimaryChains = [
-  BraveWallet.MAINNET_CHAIN_ID,
-  BraveWallet.SOLANA_MAINNET
-]
 
 interface Props {
   onSelectOption: (option: DAppConnectionOptionsType) => void

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -803,6 +803,16 @@ export const SupportedTestNetworkEntityIds: EntityId[] = [
   BraveWallet.Z_CASH_TESTNET
 ]
 
+export const DAppSupportedCoinTypes = [
+  BraveWallet.CoinType.SOL,
+  BraveWallet.CoinType.ETH
+]
+
+export const DAppSupportedPrimaryChains = [
+  BraveWallet.MAINNET_CHAIN_ID,
+  BraveWallet.SOLANA_MAINNET
+]
+
 /**
  * Should match BraveWallet.CoinType defined with "as const" to allow for use
  * as a type-guard.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Dapps panel should only show EVM and Solana accounts. Switch to some of them if currently selected one is a Bitcoin or a Filecoin account.

Resolves https://github.com/brave/brave-browser/issues/35289

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

