### PR TITLE
Implement timestamp and seeker bar for PIP window

### DIFF
--- a/browser/ui/views/overlay/brave_video_overlay_window_views.cc
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.cc
@@ -5,8 +5,15 @@
 
 #include "brave/browser/ui/views/overlay/brave_video_overlay_window_views.h"
 
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <utility>
 #include <vector>
 
+#include "base/strings/strcat.h"
+#include "base/strings/utf_string_conversions.h"
+#include "brave/browser/ui/color/leo/colors.h"
 #include "brave/browser/ui/views/overlay/brave_back_to_tab_label_button.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
@@ -18,10 +25,141 @@
 #include "chrome/browser/ui/views/overlay/simple_overlay_window_image_button.h"
 #include "chrome/browser/ui/views/overlay/toggle_camera_button.h"
 #include "chrome/browser/ui/views/overlay/toggle_microphone_button.h"
+#include "ui/gfx/canvas.h"
 
 namespace {
 
 constexpr int kTopControlIconSize = 20;
+
+std::u16string ToString(const base::TimeDelta& time) {
+  const int time_in_seconds = time.InSecondsF();
+  const int hours = time_in_seconds / 3600;
+  const int minutes = (time_in_seconds % 3600) / 60;
+  const int seconds = (time_in_seconds % 60);
+  std::ostringstream oss;
+  if (hours) {
+    oss << std::setw(2) << std::setfill('0') << hours << ":";
+  }
+
+  oss << std::setw(2) << std::setfill('0') << minutes << ":" << std::setw(2)
+      << std::setfill('0') << seconds;
+  return base::ASCIIToUTF16(oss.str());
+}
+
+std::u16string ToString(const media_session::MediaPosition& position) {
+  return base::StrCat({ToString(position.GetPosition()), u" / ",
+                       ToString(position.duration())});
+}
+
+class Seeker : public views::Slider, public views::SliderListener {
+ public:
+  static constexpr int kThumbRadius = 6;
+  static constexpr int kPreferredHeight = kThumbRadius * 2;
+  static constexpr int kLineHeight = 4;
+
+  explicit Seeker(views::SliderListener* listener)
+      : Slider(this), listener_(listener) {
+    SetValueIndicatorRadius(0);
+    SetPaintToLayer();
+    layer()->SetFillsBoundsOpaquely(false);
+    layer()->SetName("Seeker");
+    SetRenderingStyle(RenderingStyle::kMinimalStyle);
+    SetPreferredSize(gfx::Size(kPreferredHeight, kPreferredHeight));
+    thumb_animation_.SetSlideDuration(base::Milliseconds(150));
+  }
+  ~Seeker() override = default;
+
+  // views::Slider:
+  void OnPaint(gfx::Canvas* canvas) override {
+    // Paint the background for progress line
+    cc::PaintFlags flags;
+    flags.setColor(leo::kColorWhite);
+    flags.setStyle(cc::PaintFlags::kFill_Style);
+    flags.setAlphaf(0.4f);
+    auto line_bounds = gfx::RectF(GetLocalBounds());
+    line_bounds.Inset(
+        gfx::InsetsF::VH((kPreferredHeight - kLineHeight) / 2, 0));
+    canvas->DrawRect(line_bounds, flags);
+
+    // Paint the progress line
+    flags.setColor(leo::kColorPrimitivePrimary60);
+    line_bounds.set_width(line_bounds.width() * GetAnimatingValue());
+    flags.setAlphaf(1.0f);
+    canvas->DrawRect(line_bounds, flags);
+
+    if (ShouldShowThumb() || thumb_animation_.is_animating()) {
+      // Paint the thumb button only when user is interacting with this seeker.
+      canvas->DrawCircle(
+          gfx::Point(line_bounds.right(), line_bounds.CenterPoint().y() - 1),
+          thumb_animation_.is_animating()
+              ? thumb_animation_.CurrentValueBetween(kLineHeight / 2,
+                                                     kThumbRadius)
+              : kThumbRadius,
+          flags);
+    }
+  }
+
+  void OnMouseEntered(const ui::MouseEvent& event) override {
+    Slider::OnMouseEntered(event);
+    mouse_hovered_ = true;
+    thumb_animation_.Show();
+  }
+
+  void OnMouseExited(const ui::MouseEvent& event) override {
+    Slider::OnMouseExited(event);
+    mouse_hovered_ = false;
+    if (!ShouldShowThumb()) {
+      thumb_animation_.Hide();
+    }
+  }
+
+  void AnimationProgressed(const gfx::Animation* animation) override {
+    if (animation == &thumb_animation_) {
+      SchedulePaint();
+      return;
+    }
+
+    Slider::AnimationProgressed(animation);
+  }
+
+  void AnimationEnded(const gfx::Animation* animation) override {
+    if (animation == &thumb_animation_) {
+      return;
+    }
+    Slider::AnimationEnded(animation);
+  }
+
+  // views::SliderListener:
+  void SliderValueChanged(views::Slider* sender,
+                          float value,
+                          float old_value,
+                          views::SliderChangeReason reason) override {
+    listener_->SliderValueChanged(sender, value, old_value, reason);
+  }
+
+  void SliderDragStarted(views::Slider* sender) override {
+    dragging_ = true;
+    listener_->SliderDragStarted(sender);
+  }
+
+  void SliderDragEnded(views::Slider* sender) override {
+    dragging_ = false;
+    if (!ShouldShowThumb()) {
+      thumb_animation_.Hide();
+    }
+    listener_->SliderDragEnded(sender);
+  }
+
+ private:
+  bool ShouldShowThumb() const { return dragging_ || mouse_hovered_; }
+
+  raw_ptr<views::SliderListener> listener_;
+
+  bool dragging_ = false;
+  bool mouse_hovered_ = false;
+
+  gfx::SlideAnimation thumb_animation_{this};
+};
 
 }  // namespace
 
@@ -29,9 +167,31 @@ BraveVideoOverlayWindowViews::BraveVideoOverlayWindowViews(
     content::VideoPictureInPictureWindowController* controller)
     : VideoOverlayWindowViews(controller) {}
 
+BraveVideoOverlayWindowViews::~BraveVideoOverlayWindowViews() = default;
+
 void BraveVideoOverlayWindowViews::SetUpViews() {
   VideoOverlayWindowViews::SetUpViews();
   UpdateControlIcons();
+
+  timestamp_ =
+      controls_container_view_->AddChildView(std::make_unique<views::Label>());
+  timestamp_->SetEnabledColorId(kColorPipWindowForeground);
+  timestamp_->SetSubpixelRenderingEnabled(false);
+  timestamp_->SetAutoColorReadabilityEnabled(false);
+  timestamp_->SetElideBehavior(gfx::NO_ELIDE);
+  timestamp_->SetPaintToLayer(ui::LAYER_TEXTURED);
+  timestamp_->layer()->SetFillsBoundsOpaquely(false);
+  timestamp_->layer()->SetName("Timestamp");
+
+  // Unlike other controls, seeker should be visible even when mouse is not
+  // hovered on this window. So seeker is attached to the root view directly.
+  auto seeker = std::make_unique<Seeker>(this);
+  seeker_ = seeker.get();
+
+  // views in |view_holder_| will be added as child of contents view in
+  // VideoOverlayWindowViews::OnRootViewReady(). As a result, the view will
+  // be visible even when
+  view_holder_.push_back(std::move(seeker));
 }
 
 void BraveVideoOverlayWindowViews::OnUpdateControlsBounds() {
@@ -110,6 +270,13 @@ void BraveVideoOverlayWindowViews::OnUpdateControlsBounds() {
                                    kCenterControlSize);
     x += kCenterControlSize + kCenterControlSpacing;
   }
+
+  // Layout our own controls: timestamp and seeker
+  const auto slider_height = seeker_->GetPreferredSize().height();
+  seeker_->SetBounds(0, window_size.height() - slider_height,
+                     window_size.width(), slider_height);
+
+  UpdateTimestampPosition();
 }
 
 void BraveVideoOverlayWindowViews::UpdateControlIcons() {
@@ -129,4 +296,148 @@ void BraveVideoOverlayWindowViews::UpdateControlIcons() {
 
   previous_track_controls_view_->override_icon(kLeoPreviousOutlineIcon);
   next_track_controls_view_->override_icon(kLeoNextOutlineIcon);
+}
+
+void BraveVideoOverlayWindowViews::SetMediaPosition(
+    const absl::optional<media_session::MediaPosition>& media_position) {
+  CHECK(timestamp_);
+
+  media_position_ = media_position;
+
+  timestamp_update_timer_.Stop();
+  UpdateTimestampPeriodically();
+  UpdateTimestampPosition();
+}
+
+void BraveVideoOverlayWindowViews::SetPlaybackState(
+    PlaybackState playback_state) {
+  VideoOverlayWindowViews::SetPlaybackState(playback_state);
+  playback_state_ = playback_state;
+  if (playback_state != PlaybackState::kPlaying) {
+    timestamp_update_timer_.Stop();
+  }
+}
+
+bool BraveVideoOverlayWindowViews::ControlsHitTestContainsPoint(
+    const gfx::Point& point) {
+  if (seeker_->GetMirroredBounds().Contains(point)) {
+    return true;
+  }
+
+  return VideoOverlayWindowViews::ControlsHitTestContainsPoint(point);
+}
+
+void BraveVideoOverlayWindowViews::SetSeekerEnabled(bool enabled) {
+  seeker_->SetEnabled(enabled);
+}
+
+void BraveVideoOverlayWindowViews::ShowInactive() {
+  VideoOverlayWindowViews::ShowInactive();
+  UpdateTimestampPeriodically();
+}
+void BraveVideoOverlayWindowViews::Close() {
+  timestamp_update_timer_.Stop();
+  VideoOverlayWindowViews::Close();
+}
+
+void BraveVideoOverlayWindowViews::Hide() {
+  timestamp_update_timer_.Stop();
+  VideoOverlayWindowViews::Hide();
+}
+
+void BraveVideoOverlayWindowViews::SliderValueChanged(
+    views::Slider* sender,
+    float value,
+    float old_value,
+    views::SliderChangeReason reason) {
+  if (reason == views::SliderChangeReason::kByApi) {
+    return;
+  }
+
+  if (!media_position_) {
+    return;
+  }
+
+  controller_->SeekTo(media_position_->duration() * value);
+}
+
+void BraveVideoOverlayWindowViews::SliderDragStarted(views::Slider* sender) {
+  timestamp_update_timer_.Stop();
+  is_seeking_ = true;
+
+  if (was_playing_before_seeking_ = playback_state_ == PlaybackState::kPlaying;
+      was_playing_before_seeking_) {
+    controller_->TogglePlayPause();
+  }
+}
+
+void BraveVideoOverlayWindowViews::SliderDragEnded(views::Slider* sender) {
+  is_seeking_ = false;
+  UpdateTimestampPeriodically();
+  if (was_playing_before_seeking_ &&
+      playback_state_ == PlaybackState::kPaused) {
+    controller_->TogglePlayPause();
+  }
+}
+
+void BraveVideoOverlayWindowViews::UpdateTimestampPosition() {
+  CHECK(timestamp_);
+
+  timestamp_->SetVisible(media_position_.has_value());
+  if (!timestamp_->GetVisible()) {
+    return;
+  }
+
+  timestamp_->SetPosition(
+      {kPipWindowIconPadding, GetBounds().size().height() -
+                                  timestamp_->GetPreferredSize().height() -
+                                  seeker_->height()});
+}
+
+void BraveVideoOverlayWindowViews::UpdateTimestampPeriodically() {
+  // Update timestamp related UI controls
+  if (media_position_) {
+    auto new_time = ToString(*media_position_);
+    if (new_time != timestamp_->GetText()) {
+      timestamp_->SetText(ToString(*media_position_));
+      timestamp_->SetSize(timestamp_->GetPreferredSize());
+    }
+
+    if (!is_seeking_) {
+      seeker_->SetValue(media_position_->GetPosition().InSecondsF() /
+                        media_position_->duration().InSecondsF());
+    }
+
+    if (!seeker_->GetVisible()) {
+      seeker_->SetVisible(true);
+    }
+
+  } else {
+    timestamp_->SetText({});
+    seeker_->SetValue(0);
+    seeker_->SetVisible(false);
+  }
+
+  // Update repeating timer state.
+  const bool should_update_timestamp_periodically =
+      media_position_ && IsVisible() && !is_seeking_ &&
+      playback_state_ == PlaybackState::kPlaying;
+
+  if (should_update_timestamp_periodically ==
+      timestamp_update_timer_.IsRunning()) {
+    return;
+  }
+
+  if (should_update_timestamp_periodically) {
+    // 350 is the value defined by standard for progress event. This value
+    // would be good for updating timestamp too.
+    // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/html/media/html_media_element.cc;l=1838
+    timestamp_update_timer_.Start(
+        FROM_HERE, base::Milliseconds(350),
+        base::BindRepeating(
+            &BraveVideoOverlayWindowViews::UpdateTimestampPeriodically,
+            base::Unretained(this)));
+  } else {
+    timestamp_update_timer_.Stop();
+  }
 }

--- a/browser/ui/views/overlay/brave_video_overlay_window_views.cc
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.cc
@@ -5,13 +5,12 @@
 
 #include "brave/browser/ui/views/overlay/brave_video_overlay_window_views.h"
 
-#include <iomanip>
 #include <memory>
-#include <sstream>
 #include <utility>
 #include <vector>
 
 #include "base/strings/strcat.h"
+#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/color/leo/colors.h"
 #include "brave/browser/ui/views/overlay/brave_back_to_tab_label_button.h"
@@ -36,14 +35,10 @@ std::u16string ToString(const base::TimeDelta& time) {
   const int hours = time_in_seconds / 3600;
   const int minutes = (time_in_seconds % 3600) / 60;
   const int seconds = (time_in_seconds % 60);
-  std::ostringstream oss;
-  if (hours) {
-    oss << std::setw(2) << std::setfill('0') << hours << ":";
-  }
 
-  oss << std::setw(2) << std::setfill('0') << minutes << ":" << std::setw(2)
-      << std::setfill('0') << seconds;
-  return base::ASCIIToUTF16(oss.str());
+  return base::ASCIIToUTF16(
+      hours ? base::StringPrintf("%02d:%02d:%02d", hours, minutes, seconds)
+            : base::StringPrintf("%02d:%02d", minutes, seconds));
 }
 
 std::u16string ToString(const media_session::MediaPosition& position) {

--- a/browser/ui/views/overlay/brave_video_overlay_window_views.h
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.h
@@ -6,19 +6,61 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_OVERLAY_BRAVE_VIDEO_OVERLAY_WINDOW_VIEWS_H_
 #define BRAVE_BROWSER_UI_VIEWS_OVERLAY_BRAVE_VIDEO_OVERLAY_WINDOW_VIEWS_H_
 
+#include "base/timer/elapsed_timer.h"
+#include "base/timer/timer.h"
 #include "chrome/browser/ui/views/overlay/video_overlay_window_views.h"
+#include "services/media_session/public/cpp/media_position.h"
+#include "ui/views/controls/slider.h"
 
-class BraveVideoOverlayWindowViews : public VideoOverlayWindowViews {
+namespace views {
+class Label;
+}  // namespace views
+
+class BraveVideoOverlayWindowViews : public VideoOverlayWindowViews,
+                                     public views::SliderListener {
  public:
   explicit BraveVideoOverlayWindowViews(
       content::VideoPictureInPictureWindowController* controller);
-  ~BraveVideoOverlayWindowViews() override = default;
+  ~BraveVideoOverlayWindowViews() override;
 
   // VideoOverlayWindowViews:
   void SetUpViews() override;
   void OnUpdateControlsBounds() override;
+  void SetPlaybackState(PlaybackState playback_state) override;
+  void SetMediaPosition(const absl::optional<media_session::MediaPosition>&
+                            media_position) override;
+  bool ControlsHitTestContainsPoint(const gfx::Point& point) override;
+  void SetSeekerEnabled(bool enabled) override;
+  void ShowInactive() override;
+  void Close() override;
+  void Hide() override;
 
+  // views::SliderListener:
+  void SliderValueChanged(views::Slider* sender,
+                          float value,
+                          float old_value,
+                          views::SliderChangeReason reason) override;
+  void SliderDragStarted(views::Slider* sender) override;
+  void SliderDragEnded(views::Slider* sender) override;
+
+ private:
   void UpdateControlIcons();
+  void UpdateTimestampPosition();
+
+  // As SetMediaPosition() is called only when the position is changed due to
+  // playback state, not when it progresses, we should update timestamp by
+  // ourselves.
+  void UpdateTimestampPeriodically();
+
+  absl::optional<media_session::MediaPosition> media_position_;
+  base::RepeatingTimer timestamp_update_timer_;
+
+  PlaybackState playback_state_ = PlaybackState::kEndOfVideo;
+
+  raw_ptr<views::Label> timestamp_;
+  raw_ptr<views::Slider> seeker_;
+  bool is_seeking_ = false;
+  bool was_playing_before_seeking_ = false;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_OVERLAY_BRAVE_VIDEO_OVERLAY_WINDOW_VIEWS_H_

--- a/browser/ui/views/overlay/brave_video_overlay_window_views.h
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.h
@@ -27,7 +27,7 @@ class BraveVideoOverlayWindowViews : public VideoOverlayWindowViews,
   void SetUpViews() override;
   void OnUpdateControlsBounds() override;
   void SetPlaybackState(PlaybackState playback_state) override;
-  void SetMediaPosition(const absl::optional<media_session::MediaPosition>&
+  void SetMediaPosition(const std::optional<media_session::MediaPosition>&
                             media_position) override;
   bool ControlsHitTestContainsPoint(const gfx::Point& point) override;
   void SetSeekerEnabled(bool enabled) override;
@@ -52,13 +52,13 @@ class BraveVideoOverlayWindowViews : public VideoOverlayWindowViews,
   // ourselves.
   void UpdateTimestampPeriodically();
 
-  absl::optional<media_session::MediaPosition> media_position_;
+  std::optional<media_session::MediaPosition> media_position_;
   base::RepeatingTimer timestamp_update_timer_;
 
   PlaybackState playback_state_ = PlaybackState::kEndOfVideo;
 
-  raw_ptr<views::Label> timestamp_;
-  raw_ptr<views::Slider> seeker_;
+  raw_ptr<views::Label> timestamp_ = nullptr;
+  raw_ptr<views::Slider> seeker_ = nullptr;
   bool is_seeking_ = false;
   bool was_playing_before_seeking_ = false;
 };

--- a/chromium_src/chrome/browser/ui/views/overlay/video_overlay_window_views.h
+++ b/chromium_src/chrome/browser/ui/views/overlay/video_overlay_window_views.h
@@ -15,9 +15,11 @@ class BraveBackToTabLabelButton;
 
 #define OnUpdateControlsBounds virtual OnUpdateControlsBounds
 #define BackToTabLabelButton BraveBackToTabLabelButton
+#define ControlsHitTestContainsPoint virtual ControlsHitTestContainsPoint
 
 #include "src/chrome/browser/ui/views/overlay/video_overlay_window_views.h"  // IWYU pragma: export
 
+#undef ControlsHitTestContainsPoint
 #undef BackToTabLabelButton
 #undef OnUpdateControlsBounds
 #undef SetUpViews

--- a/chromium_src/content/browser/media/session/media_session_impl.cc
+++ b/chromium_src/content/browser/media/session/media_session_impl.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/content/browser/media/session/media_session_impl.cc"
+
+namespace content {
+
+absl::optional<media_session::MediaPosition>
+MediaSessionImpl::GetMediaPositionFromNormalPlayerIfPossible() {
+  if (normal_players_.size() == 1 && one_shot_players_.empty() &&
+      pepper_players_.empty()) {
+    auto& first = normal_players_.begin()->first;
+    return first.observer->GetPosition(first.player_id);
+  }
+
+  return {};
+}
+
+}  // namespace content

--- a/chromium_src/content/browser/media/session/media_session_impl.cc
+++ b/chromium_src/content/browser/media/session/media_session_impl.cc
@@ -7,7 +7,7 @@
 
 namespace content {
 
-absl::optional<media_session::MediaPosition>
+std::optional<media_session::MediaPosition>
 MediaSessionImpl::GetMediaPositionFromNormalPlayerIfPossible() {
   if (normal_players_.size() == 1 && one_shot_players_.empty() &&
       pepper_players_.empty()) {
@@ -15,7 +15,7 @@ MediaSessionImpl::GetMediaPositionFromNormalPlayerIfPossible() {
     return first.observer->GetPosition(first.player_id);
   }
 
-  return {};
+  return std::nullopt;
 }
 
 }  // namespace content

--- a/chromium_src/content/browser/media/session/media_session_impl.h
+++ b/chromium_src/content/browser/media/session/media_session_impl.h
@@ -9,7 +9,7 @@
 // Add a new method for video_picture_in_picture_window_controller_impl
 #define NotifyMediaSessionMetadataChange        \
   NotifyMediaSessionMetadataChange_Unused();    \
-  absl::optional<media_session::MediaPosition>  \
+  std::optional<media_session::MediaPosition>   \
   GetMediaPositionFromNormalPlayerIfPossible(); \
   void NotifyMediaSessionMetadataChange
 

--- a/chromium_src/content/browser/media/session/media_session_impl.h
+++ b/chromium_src/content/browser/media/session/media_session_impl.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CONTENT_BROWSER_MEDIA_SESSION_MEDIA_SESSION_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_CONTENT_BROWSER_MEDIA_SESSION_MEDIA_SESSION_IMPL_H_
+
+// Add a new method for video_picture_in_picture_window_controller_impl
+#define NotifyMediaSessionMetadataChange        \
+  NotifyMediaSessionMetadataChange_Unused();    \
+  absl::optional<media_session::MediaPosition>  \
+  GetMediaPositionFromNormalPlayerIfPossible(); \
+  void NotifyMediaSessionMetadataChange
+
+#include "src/content/browser/media/session/media_session_impl.h"  // IWYU pragma: export
+
+#undef NotifyMediaSessionMetadataChange
+
+#endif  // BRAVE_CHROMIUM_SRC_CONTENT_BROWSER_MEDIA_SESSION_MEDIA_SESSION_IMPL_H_

--- a/chromium_src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.cc
+++ b/chromium_src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.cc
@@ -1,0 +1,46 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "content/public/browser/overlay_window.h"
+#include "third_party/blink/public/mojom/mediasession/media_session.mojom.h"
+
+// Sets media position along with playback state.
+// Note that |media_position_| could be incorrect(suspecting timing issue
+// between service process), so we're getting more correct position from media
+// session.
+#define SetPlaybackState(PLAYBACK_STATE)                                  \
+  SetPlaybackState(PLAYBACK_STATE);                                       \
+  if (auto position = MediaSessionImpl::Get(web_contents())               \
+                          ->GetMediaPositionFromNormalPlayerIfPossible(); \
+      position) {                                                         \
+    window_->SetMediaPosition(position);                                  \
+  } else {                                                                \
+    window_->SetMediaPosition(media_position_);                           \
+  }
+
+// Update seeker enabled state whenever actions are updated.
+#define SetSkipAdButtonVisibility(SKIP_BUTTON_VISIBILITY)         \
+  SetSkipAdButtonVisibility(SKIP_BUTTON_VISIBILITY);              \
+  media_session_action_seek_to_handled_ =                         \
+      MediaSessionImpl::Get(web_contents())                       \
+          ->ShouldRouteAction(                                    \
+              media_session::mojom::MediaSessionAction::kSeekTo); \
+  window_->SetSeekerEnabled(media_session_action_seek_to_handled_)
+
+#include "src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.cc"
+
+#undef SetSkipAdButtonVisibility
+#undef SetPlaybackState
+
+namespace content {
+
+void VideoPictureInPictureWindowControllerImpl::SeekTo(
+    base::TimeDelta seek_time) {
+  if (media_session_action_seek_to_handled_) {
+    MediaSession::Get(web_contents())->SeekTo(seek_time);
+  }
+}
+
+}  // namespace content

--- a/chromium_src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.h
+++ b/chromium_src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CONTENT_BROWSER_PICTURE_IN_PICTURE_VIDEO_PICTURE_IN_PICTURE_WINDOW_CONTROLLER_IMPL_H_
+#define BRAVE_CHROMIUM_SRC_CONTENT_BROWSER_PICTURE_IN_PICTURE_VIDEO_PICTURE_IN_PICTURE_WINDOW_CONTROLLER_IMPL_H_
+
+#include "content/public/browser/video_picture_in_picture_window_controller.h"
+
+#define NextSlide                             \
+  SeekTo(base::TimeDelta seek_time) override; \
+  void NextSlide
+#define media_session_action_next_slide_handled_    \
+  media_session_action_next_slide_handled_ = false; \
+  bool media_session_action_seek_to_handled_
+
+#include "src/content/browser/picture_in_picture/video_picture_in_picture_window_controller_impl.h"  // IWYU pragma: export
+
+#undef media_session_action_next_slide_handled_
+#undef NextSlide
+
+#endif  // BRAVE_CHROMIUM_SRC_CONTENT_BROWSER_PICTURE_IN_PICTURE_VIDEO_PICTURE_IN_PICTURE_WINDOW_CONTROLLER_IMPL_H_

--- a/chromium_src/content/public/browser/overlay_window.h
+++ b/chromium_src/content/public/browser/overlay_window.h
@@ -6,16 +6,16 @@
 #ifndef BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_OVERLAY_WINDOW_H_
 #define BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_OVERLAY_WINDOW_H_
 
-#include "third_party/abseil-cpp/absl/types/optional.h"
+#include <optional>
 
 namespace media_session {
 struct MediaPosition;
 }  // namespace media_session
 
-#define SetPlaybackState                                                     \
-  SetMediaPosition(                                                          \
-      const absl::optional<media_session::MediaPosition>& media_position) {} \
-  virtual void SetSeekerEnabled(bool enabled) {}                             \
+#define SetPlaybackState                                                    \
+  SetMediaPosition(                                                         \
+      const std::optional<media_session::MediaPosition>& media_position) {} \
+  virtual void SetSeekerEnabled(bool enabled) {}                            \
   virtual void SetPlaybackState
 
 #include "src/content/public/browser/overlay_window.h"  // IWYU pragma: export

--- a/chromium_src/content/public/browser/overlay_window.h
+++ b/chromium_src/content/public/browser/overlay_window.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_OVERLAY_WINDOW_H_
+#define BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_OVERLAY_WINDOW_H_
+
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
+namespace media_session {
+struct MediaPosition;
+}  // namespace media_session
+
+#define SetPlaybackState                                                     \
+  SetMediaPosition(                                                          \
+      const absl::optional<media_session::MediaPosition>& media_position) {} \
+  virtual void SetSeekerEnabled(bool enabled) {}                             \
+  virtual void SetPlaybackState
+
+#include "src/content/public/browser/overlay_window.h"  // IWYU pragma: export
+
+#undef SetPlaybackState
+
+#endif  // BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_OVERLAY_WINDOW_H_

--- a/chromium_src/content/public/browser/video_picture_in_picture_window_controller.h
+++ b/chromium_src/content/public/browser/video_picture_in_picture_window_controller.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_VIDEO_PICTURE_IN_PICTURE_WINDOW_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_VIDEO_PICTURE_IN_PICTURE_WINDOW_CONTROLLER_H_
+
+#define NextSlide                      \
+  SeekTo(base::TimeDelta seek_time) {} \
+  virtual void NextSlide
+
+#include "src/content/public/browser/video_picture_in_picture_window_controller.h"  // IWYU pragma: export
+
+#undef NextSlide
+
+#endif  // BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_VIDEO_PICTURE_IN_PICTURE_WINDOW_CONTROLLER_H_

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1183,6 +1183,10 @@
 # This test fails because we disable kVisualQuerySuggestions
 -VisualQuerySuggestionsServiceBrowserTest.VisualQuerySuggestionsServiceEnabled
 
+# Fails because we customized PIP UI.
+# https://github.com/brave/brave-browser/issues/35263
+-PictureInPicturePixelComparisonBrowserTest.VideoPlay
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -_/WebrtcLoggingPrivateApiStartEventLoggingTestFeatureAndPolicyEnabled.*
 -AccessCodeCastHandlerBrowserTest.*


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35263


https://github.com/brave/brave-core/assets/5474642/eb33c44a-8775-4fe5-bdb4-18b6044ca99a



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* When entering PIP window and move mouse over it, timestamp should be vibile
* Seeker should be visible on the window regardless of mouse position
* When dragging or clicking seeker, video should move to the position
