### PR TITLE
[Brave News]: Fix scroll restore bug & error message with no feeds (uplift to 1.62.x)

### DIFF
--- a/components/brave_news/browser/resources/shared/useFeedV2.ts
+++ b/components/brave_news/browser/resources/shared/useFeedV2.ts
@@ -76,7 +76,7 @@ const maybeLoadFeed = (view?: FeedView) => {
   }
 
   // Don't load errored feeds.
-  if (feed.error !== undefined) {
+  if (typeof feed.error !== 'number') {
     return undefined
   }
 


### PR DESCRIPTION
Uplift of #21557
Resolves https://github.com/brave/brave-browser/issues/35059
Resolves https://github.com/brave/brave-browser/issues/35274

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.