### PR TITLE
Remove dynamic allocation of ffmpeg ff_tx tables.

### DIFF
--- a/patches/third_party/ffmpeg/libavutil-tx_template.c.patch
+++ b/patches/third_party/ffmpeg/libavutil-tx_template.c.patch
@@ -1,38 +1,8 @@
 diff --git a/libavutil/tx_template.c b/libavutil/tx_template.c
-index a2c27465cbcabe242325f4126b74b4aa53f1aae8..1685bbdc425c6c9588d5ab68c515b52635bfe801 100644
+index a2c27465cbcabe242325f4126b74b4aa53f1aae8..c6cf1c2ddb3ca9a84ed344748ba560a5647edac8 100644
 --- a/libavutil/tx_template.c
 +++ b/libavutil/tx_template.c
-@@ -27,6 +27,29 @@
- #define TABLE_DEF(name, size) \
-     DECLARE_ALIGNED(32, TXSample, TX_TAB(ff_tx_tab_ ##name))[size]
- 
-+#ifdef _WIN32
-+
-+#include <malloc.h>
-+
-+// Declares aligned ff_tx_tab_* pointer.
-+#define TABLE_DEF_PTR(name, size) \
-+  DECLARE_ALIGNED(32, TXSample*, TX_TAB(ff_tx_tab_##name))
-+
-+// Allocates aligned memory for ff_tx_tab_* variable.
-+#define ALLOCATE_FF_TX_TABLE(len)                              \
-+  if (!TX_TAB(ff_tx_tab_##len)) {                              \
-+    TX_TAB(ff_tx_tab_##len) =                                  \
-+        _aligned_malloc((len / 4 + 1) * sizeof(TXSample), 32); \
-+  }
-+
-+#else
-+
-+// Use static arrays on non-Windows targets as usual.
-+#define TABLE_DEF_PTR(name, size) TABLE_DEF(name, size)
-+#define ALLOCATE_FF_TX_TABLE(len)
-+
-+#endif
-+
- #define SR_POW2_TABLES \
-     SR_TABLE(8)        \
-     SR_TABLE(16)       \
-@@ -43,13 +66,9 @@
+@@ -43,10 +43,6 @@
      SR_TABLE(32768)    \
      SR_TABLE(65536)    \
      SR_TABLE(131072)   \
@@ -42,20 +12,8 @@ index a2c27465cbcabe242325f4126b74b4aa53f1aae8..1685bbdc425c6c9588d5ab68c515b526
 -    SR_TABLE(2097152)   \
  
  #define SR_TABLE(len) \
--    TABLE_DEF(len, len/4 + 1);
-+    TABLE_DEF_PTR(len, len/4 + 1);
- /* Power of two tables */
- SR_POW2_TABLES
- #undef SR_TABLE
-@@ -68,6 +87,7 @@ typedef struct FFTabInitData {
- static av_cold void TX_TAB(ff_tx_init_tab_ ##len)(void)            \
- {                                                                  \
-     double freq = 2*M_PI/len;                                      \
-+    ALLOCATE_FF_TX_TABLE(len);                                     \
-     TXSample *tab = TX_TAB(ff_tx_tab_ ##len);                      \
-                                                                    \
-     for (int i = 0; i < len/4; i++)                                \
-@@ -722,10 +742,6 @@ DECL_SR_CODELET(16384,8192,4096)
+     TABLE_DEF(len, len/4 + 1);
+@@ -722,10 +718,6 @@ DECL_SR_CODELET(16384,8192,4096)
  DECL_SR_CODELET(32768,16384,8192)
  DECL_SR_CODELET(65536,32768,16384)
  DECL_SR_CODELET(131072,65536,32768)
@@ -66,7 +24,7 @@ index a2c27465cbcabe242325f4126b74b4aa53f1aae8..1685bbdc425c6c9588d5ab68c515b526
  
  static av_cold int TX_NAME(ff_tx_fft_init)(AVTXContext *s,
                                             const FFTXCodelet *cd,
-@@ -2158,10 +2174,6 @@ const FFTXCodelet * const TX_NAME(ff_tx_codelet_list)[] = {
+@@ -2158,10 +2150,6 @@ const FFTXCodelet * const TX_NAME(ff_tx_codelet_list)[] = {
      &TX_NAME(ff_tx_fft32768_ns_def),
      &TX_NAME(ff_tx_fft65536_ns_def),
      &TX_NAME(ff_tx_fft131072_ns_def),


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Remove dynamic allocation to fix failed AAC decoding.

These variables are referenced in asm files, so it's impossible to allocate them in such way.

Confirmed all `media_unittests` passed.

Resolves https://github.com/brave/brave-browser/issues/35318

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

