### PR TITLE
Fixed wrong search provider is used for Paste and search in omnibox

### DIFF
--- a/browser/ui/views/omnibox/brave_omnibox_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.cc
@@ -11,12 +11,22 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/ui/browser_commands.h"
+#include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_navigator.h"
+#include "chrome/browser/ui/omnibox/clipboard_utils.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "chrome/grit/generated_resources.h"
+#include "components/omnibox/browser/autocomplete_match.h"
+#include "components/omnibox/browser/omnibox_client.h"
+#include "components/omnibox/browser/omnibox_controller.h"
 #include "components/omnibox/browser/omnibox_edit_model.h"
+#include "components/search_engines/template_url_service.h"
+#include "ui/base/clipboard/clipboard.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/window_open_disposition.h"
+#include "ui/gfx/text_elider.h"
 
 namespace {
 void BraveUpdateContextMenu(ui::SimpleMenuModel* menu_contents, GURL url) {
@@ -28,6 +38,13 @@ void BraveUpdateContextMenu(ui::SimpleMenuModel* menu_contents, GURL url) {
     return;
   menu_contents->InsertItemWithStringIdAt(
       copy_position.value() + 1, IDC_COPY_CLEAN_LINK, IDS_COPY_CLEAN_LINK);
+}
+
+std::u16string GetClipboardText() {
+  return ui::Clipboard::GetForCurrentThread()
+                 ->IsMarkedByOriginatorAsConfidential()
+             ? std::u16string()
+             : ::GetClipboardText(/*notify_if_restricted=*/false);
 }
 }  // namespace
 
@@ -120,6 +137,48 @@ void BraveOmniboxViewViews::ExecuteTextEditCommand(
   OmniboxViewViews::ExecuteTextEditCommand(command);
 }
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
+
+void BraveOmniboxViewViews::ExecuteCommand(int command_id, int event_flags) {
+  // Early return if |location_bar_view_| is null as it's used to get Browser
+  // instance pointer.
+  if (!location_bar_view_ || command_id != IDC_PASTE_AND_GO ||
+      !ShouldExecuteForPasteAndSearch()) {
+    return OmniboxViewViews::ExecuteCommand(command_id, event_flags);
+  }
+
+  // Do paste and search here instead of delegating to
+  // OmniboxEditModel::PasteAndGo(). In OmniboxEditModel, only normal
+  // profile's search provider is used because same AutocompleteClassifier is
+  // shared between normal and private profile.
+  constexpr size_t kMaxSelectionTextLength = 50;
+  const std::u16string clipboard_text = GetClipboardText();
+  CHECK(!clipboard_text.empty());
+  std::u16string selection_text = gfx::TruncateString(
+      clipboard_text, kMaxSelectionTextLength, gfx::WORD_BREAK);
+
+  const auto* service = controller()->client()->GetTemplateURLService();
+  const auto url =
+      service->GenerateSearchURLForDefaultSearchProvider(selection_text);
+  if (!url.is_valid()) {
+    return OmniboxViewViews::ExecuteCommand(command_id, event_flags);
+  }
+
+  NavigateParams params(location_bar_view_->browser(), url,
+                        ui::PAGE_TRANSITION_GENERATED);
+  params.disposition = WindowOpenDisposition::CURRENT_TAB;
+  Navigate(&params);
+}
+
+bool BraveOmniboxViewViews::ShouldExecuteForPasteAndSearch() {
+  const std::u16string clipboard_text = GetClipboardText();
+  if (clipboard_text.empty()) {
+    return false;
+  }
+
+  AutocompleteMatch match;
+  model()->ClassifyString(clipboard_text, &match, nullptr);
+  return AutocompleteMatch::IsSearchType(match.type);
+}
 
 void BraveOmniboxViewViews::UpdateContextMenu(
     ui::SimpleMenuModel* menu_contents) {

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -48,7 +48,7 @@ class BraveOmniboxViewViews : public OmniboxViewViews {
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveOmniboxViewViewsTest, PasteAndSearchTest);
 
-  bool ShouldExecuteForPasteAndSearch();
+  std::optional<std::u16string> GetClipboardTextForPasteAndSearch();
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_

--- a/browser/ui/views/omnibox/brave_omnibox_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views.h
@@ -36,12 +36,19 @@ class BraveOmniboxViewViews : public OmniboxViewViews {
   bool GetAcceleratorForCommandId(int command_id,
                                   ui::Accelerator* accelerator) const override;
 
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
   // ui::views::Textfield
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)
   void ExecuteTextEditCommand(ui::TextEditCommand command) override;
 #endif
+  void ExecuteCommand(int command_id, int event_flags) override;
+
   // ui::views::TextfieldController:
   void UpdateContextMenu(ui::SimpleMenuModel* menu_contents) override;
+
+ private:
+  FRIEND_TEST_ALL_PREFIXES(BraveOmniboxViewViewsTest, PasteAndSearchTest);
+
+  bool ShouldExecuteForPasteAndSearch();
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_VIEW_VIEWS_H_

--- a/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_view_views_browsertest.cc
@@ -4,21 +4,56 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/brave_browser_features.h"
+#include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
 #include "brave/components/url_sanitizer/browser/url_sanitizer_service.h"
 #include "build/build_config.h"
+#include "chrome/app/chrome_command_ids.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/location_bar/location_bar_view.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/search_test_utils.h"
 #include "chrome/test/base/ui_test_utils.h"
+#include "components/search_engines/template_url.h"
+#include "components/search_engines/template_url_service.h"
 #include "content/public/test/browser_test.h"
 #include "ui/base/clipboard/clipboard.h"
+#include "ui/base/clipboard/scoped_clipboard_writer.h"
 #include "ui/strings/grit/ui_strings.h"
 #include "ui/views/controls/textfield/textfield.h"
 #include "url/gurl.h"
+
+namespace {
+
+void SetClipboardText(ui::ClipboardBuffer buffer, const std::u16string& text) {
+  ui::ScopedClipboardWriter(buffer).WriteText(text);
+}
+
+testing::AssertionResult VerifyTemplateURLServiceLoad(
+    TemplateURLService* service) {
+  if (service->loaded()) {
+    return testing::AssertionSuccess();
+  }
+  search_test_utils::WaitForTemplateURLServiceToLoad(service);
+  if (service->loaded()) {
+    return testing::AssertionSuccess();
+  }
+  return testing::AssertionFailure() << "TemplateURLService isn't loaded";
+}
+
+TemplateURLData CreateTestSearchEngine() {
+  TemplateURLData result;
+  result.SetShortName(u"test1");
+  result.SetKeyword(u"test.com");
+  result.SetURL("http://test.com/search?t={searchTerms}");
+  return result;
+}
+
+}  // namespace
 
 class BraveOmniboxViewViewsTest : public InProcessBrowserTest {
  public:
@@ -52,6 +87,56 @@ class BraveOmniboxViewViewsDisabledFeatureTest
  private:
   base::test::ScopedFeatureList features_;
 };
+
+IN_PROC_BROWSER_TEST_F(BraveOmniboxViewViewsTest, PasteAndSearchTest) {
+  // Put a search term on the clipboard to enable paste and search.
+  SetClipboardText(ui::ClipboardBuffer::kCopyPaste, u"Brave browser");
+
+  auto* brave_omnibox_view =
+      static_cast<BraveOmniboxViewViews*>(omnibox_view());
+  EXPECT_TRUE(brave_omnibox_view->ShouldExecuteForPasteAndSearch());
+
+  // Paste and search for normal window.
+  brave_omnibox_view->ExecuteCommand(IDC_PASTE_AND_GO, ui::EF_NONE);
+  TabStripModel* tab_strip = browser()->tab_strip_model();
+  auto* active_web_contents = tab_strip->GetActiveWebContents();
+  content::WaitForLoadStop(active_web_contents);
+
+  // Check loaded url's host and search provider's url host are same in normal
+  // window.
+  auto* service =
+      TemplateURLServiceFactory::GetForProfile(browser()->profile());
+  EXPECT_EQ(active_web_contents->GetVisibleURL().host(),
+            GURL(service->GetDefaultSearchProvider()->url()).host());
+
+  // Create private window.
+  Browser* private_browser = CreateIncognitoBrowser();
+  auto* private_service =
+      TemplateURLServiceFactory::GetForProfile(private_browser->profile());
+  EXPECT_TRUE(VerifyTemplateURLServiceLoad(private_service));
+
+  // Set custom search provider.
+  TemplateURLData test_data = CreateTestSearchEngine();
+  std::unique_ptr<TemplateURL> test_url(new TemplateURL(test_data));
+  private_service->SetUserSelectedDefaultSearchProvider(test_url.get());
+
+  auto* private_browser_view =
+      BrowserView::GetBrowserViewForBrowser(private_browser);
+  auto* private_brave_omnibox_view = static_cast<BraveOmniboxViewViews*>(
+      private_browser_view->toolbar()->location_bar()->omnibox_view());
+  EXPECT_TRUE(private_brave_omnibox_view->ShouldExecuteForPasteAndSearch());
+
+  // Paste and search for private window
+  private_brave_omnibox_view->ExecuteCommand(IDC_PASTE_AND_GO, ui::EF_NONE);
+  TabStripModel* private_tab_strip = private_browser->tab_strip_model();
+  auto* private_active_web_contents = private_tab_strip->GetActiveWebContents();
+  content::WaitForLoadStop(private_active_web_contents);
+
+  // Check loaded url's host and search provider's url host are same in private
+  // window.
+  EXPECT_EQ(private_active_web_contents->GetVisibleURL().host(),
+            GURL(private_service->GetDefaultSearchProvider()->url()).host());
+}
 
 // Load brave url and check copied url also has brave scheme.
 IN_PROC_BROWSER_TEST_F(BraveOmniboxViewViewsTest,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/35308

So far, normal window's search provider was used for "Paste and search`
command in omnibox context menu because OmniboxEditModel refers normal
profile's AutocompleteClassifier. To get proper search provider url,
use current profile's template url service directlry from
BraveOmniboxViewViews.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveOmniboxViewViewsTest.PasteAndSearchTest`

1. Launch browser
2. Set google as normal profile's search provider
3. Set brave as private profile's search provider
4. Open private window and copy any terms in clipboard
5. Run `Paste and search...` from private window's omnibox context menu
6. Check brave search is used