### PR TITLE
[Brave News]: Advert chrome:// url fixes & Revert FeedNavigation heading  change (uplift to 1.62.x)

### DIFF
--- a/components/brave_news/browser/resources/FeedNavigation.tsx
+++ b/components/brave_news/browser/resources/FeedNavigation.tsx
@@ -33,7 +33,7 @@ const Container = styled(Card)`
   scrollbar-color: var(--bn-glass-10) var(--bn-glass-10);
 `
 
-const CustomButton = styled.button <{ selected?: boolean, faint?: boolean, large?: boolean, bold?: boolean }>`
+const CustomButton = styled.button <{ selected?: boolean, faint?: boolean, bold?: boolean }>`
   padding: ${spacing.m};
   padding-left: ${PAD_LEFT};
 
@@ -46,7 +46,7 @@ const CustomButton = styled.button <{ selected?: boolean, faint?: boolean, large
   width: 100%;
 
   color: ${p => p.faint ? `var(--bn-glass-50)` : `var(--bn-glass-100)`};
-  font: ${p => font[p.large ? 'default' : 'small'][p.bold ? 'semibold' : 'regular']};
+  font: ${p => font.small[p.bold ? 'semibold' : 'regular']};
   cursor: pointer;
 
   &:hover {
@@ -72,7 +72,7 @@ const Section = styled.details`
     align-items: center;
     gap: ${spacing.m};
     list-style: none;
-    font: ${font.default.semibold};
+    font: ${font.small.semibold};
 
     cursor: pointer;
 
@@ -115,7 +115,7 @@ const PlaceholderMarker = <Icon />
 export function Item(props: { id: FeedView, name: string }) {
   const { feedView, setFeedView } = useBraveNews()
   const topLevel = ['all', 'following'].includes(props.id)
-  return <CustomButton large={topLevel} selected={props.id === feedView} onClick={() => setFeedView(props.id)} bold={topLevel}>
+  return <CustomButton selected={props.id === feedView} onClick={() => setFeedView(props.id)} bold={topLevel}>
     {props.name}
   </CustomButton>
 }

--- a/components/brave_news/browser/resources/feed/Card.tsx
+++ b/components/brave_news/browser/resources/feed/Card.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import { color, effect, font, radius, spacing } from '@brave/leo/tokens/css';
 import styled from "styled-components";
-import SecureLink, { SecureLinkProps, validateScheme } from '$web-common/SecureLink';
+import SecureLink, { SecureLinkProps, defaultAllowedSchemes, validateScheme } from '$web-common/SecureLink';
 import { configurationCache, useBraveNews } from '../shared/Context';
 
 export const Header = styled.h2`
@@ -89,8 +89,8 @@ export default styled.div`
   ${p => p.onClick && 'cursor: pointer'}
 `
 
-export const braveNewsCardClickHandler = (href: string | undefined) => (e: React.MouseEvent) => {
-  validateScheme(href)
+export const braveNewsCardClickHandler = (href: string | undefined, allowedSchemes: string[] = defaultAllowedSchemes) => (e: React.MouseEvent) => {
+  validateScheme(href, allowedSchemes)
 
   if (configurationCache.value.openArticlesInNewTab || e.ctrlKey || e.metaKey || e.buttons & 4) {
     window.open(href, '_blank', 'noopener noreferrer')


### PR DESCRIPTION
Uplift of #21590
Resolves https://github.com/brave/brave-browser/issues/35346
Resolves https://github.com/brave/brave-browser/issues/35357
Resolves https://github.com/brave/brave-browser/issues/35353

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.