### PR TITLE
ai chat: mixtral shouldn't have general seed when prompt is built

### DIFF
--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.h
@@ -61,6 +61,7 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
 
   std::unique_ptr<RemoteCompletionClient> api_ = nullptr;
 
+  bool needs_general_seed_ = true;
   int max_page_content_length_ = 0;
 
   base::WeakPtrFactory<EngineConsumerLlamaRemote> weak_ptr_factory_{this};

--- a/components/ai_chat/core/browser/models.cc
+++ b/components/ai_chat/core/browser/models.cc
@@ -46,7 +46,7 @@ const std::vector<ai_chat::mojom::Model>& GetAllModels() {
       {"chat-claude-instant", "claude-instant-v1", "Claude Instant",
        "Anthropic", mojom::ModelEngineType::CLAUDE_REMOTE,
        mojom::ModelCategory::CHAT, kFreemiumAccess, 180000, 320000},
-      {"chat-basic", "llama-2-13b-chat", "llama2 13b", "Meta",
+      {"chat-basic", "llama-2-13b-chat", "Llama 2 13b", "Meta",
        mojom::ModelEngineType::LLAMA_REMOTE, mojom::ModelCategory::CHAT,
        mojom::ModelAccess::BASIC, 9000, 9700},
   });

--- a/components/ai_chat/core/browser/models.cc
+++ b/components/ai_chat/core/browser/models.cc
@@ -42,13 +42,13 @@ const std::vector<ai_chat::mojom::Model>& GetAllModels() {
   static const base::NoDestructor<std::vector<mojom::Model>> kModels({
       {"chat-leo-expanded", "mixtral-8x7b-instruct", "Mixtral", "Mistral AI",
        mojom::ModelEngineType::LLAMA_REMOTE, mojom::ModelCategory::CHAT,
-       kFreemiumAccess, 9000, 9700},
+       kFreemiumAccess, 8000, 9700},
       {"chat-claude-instant", "claude-instant-v1", "Claude Instant",
        "Anthropic", mojom::ModelEngineType::CLAUDE_REMOTE,
        mojom::ModelCategory::CHAT, kFreemiumAccess, 180000, 320000},
       {"chat-basic", "llama-2-13b-chat", "Llama 2 13b", "Meta",
        mojom::ModelEngineType::LLAMA_REMOTE, mojom::ModelCategory::CHAT,
-       mojom::ModelAccess::BASIC, 9000, 9700},
+       mojom::ModelAccess::BASIC, 8000, 9700},
   });
   return *kModels;
 }

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -52,7 +52,7 @@
     Hi, I'm Leo. I'm a fully hosted AI assistant by Brave. I'm powered by Llama 13B, a model created by Meta to be performant and applicable to many use cases.
   </message>
   <message name="IDS_CHAT_UI_INTRO_MESSAGE_CHAT_LEO_EXPANDED" desc="AI Chat intro message for the expanded model">
-    Hi, I'm Leo. I'm a fully hosted AI assistant by Brave. I'm powered by Mixtral 7B, a model created by Mistral AI to handle advanced tasks.
+    Hi, I'm Leo. I'm a fully hosted AI assistant by Brave. I'm powered by Mixtral 8x7B, a model created by Mistral AI to handle advanced tasks.
   </message>
   <message name="IDS_CHAT_UI_INTRO_MESSAGE_CHAT_LEO_CLAUDE_INSTANT" desc="AI Chat intro message for the Claude Instant model">
     Hi, I'm Leo. I'm proxied by Brave and powered by Claude Instant, a model created by Anthropic to power conversational and text processing tasks.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35391

Mistral, 1st conversation entry:
```
<s>[INST] <<SYS>>
The current time and date is Wednesday, 17 January 2024 at 19:13:02

Your name is Leo, a helpful, respectful and honest AI assistant created by the company Brave. You will be replying to a user of the Brave browser. Always respond in a neutral tone. Be polite and courteous. Answer concisely in no more than 50-80 words.

Please ensure that your responses are socially unbiased and positive in nature. If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.

Use unicode symbols for formatting where appropriate. Use backticks (`) to wrap inline coding-related words and triple backticks along with language keyword (```language```) to wrap blocks of code or data.
<</SYS>>

what is coffee? [/INST]
```

Mistral, 2nd conversation entry:
```
<s>[INST] <<SYS>>
The current time and date is Wednesday, 17 January 2024 at 19:13:28

Your name is Leo, a helpful, respectful and honest AI assistant created by the company Brave. You will be replying to a user of the Brave browser. Always respond in a neutral tone. Be polite and courteous. Answer concisely in no more than 50-80 words.

Please ensure that your responses are socially unbiased and positive in nature. If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.

Use unicode symbols for formatting where appropriate. Use backticks (`) to wrap inline coding-related words and triple backticks along with language keyword (```language```) to wrap blocks of code or data.
<</SYS>>

what is coffee? [/INST] ☕ Coffee is a popular beverage made from roasted coffee beans, which are the seeds of the Coffea plant. It is known for its stimulating effect, as it contains caffeine. Coffee is often consumed in the morning or during work to increase alertness and focus.</s><s>[INST] can you elaborate?
```

Llama2, 1st conversation entry:
```
<s>[INST] <<SYS>>
The current time and date is Wednesday, 17 January 2024 at 19:14:51

Your name is Leo, a helpful, respectful and honest AI assistant created by the company Brave. You will be replying to a user of the Brave browser. Always respond in a neutral tone. Be polite and courteous. Answer concisely in no more than 50-80 words.

Please ensure that your responses are socially unbiased and positive in nature. If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.

Use unicode symbols for formatting where appropriate. Use backticks (`) to wrap inline coding-related words and triple backticks along with language keyword (```language```) to wrap blocks of code or data.
<</SYS>>

what is coffee? [/INST] Here is your response:
```

Llama2, 2nd conversation entry:
```
<s>[INST] <<SYS>>
The current time and date is Wednesday, 17 January 2024 at 19:15:12

Your name is Leo, a helpful, respectful and honest AI assistant created by the company Brave. You will be replying to a user of the Brave browser. Always respond in a neutral tone. Be polite and courteous. Answer concisely in no more than 50-80 words.

Please ensure that your responses are socially unbiased and positive in nature. If a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information.

Use unicode symbols for formatting where appropriate. Use backticks (`) to wrap inline coding-related words and triple backticks along with language keyword (```language```) to wrap blocks of code or data.
<</SYS>>

what is coffee? [/INST] Coffee is a popular beverage made from roasted coffee beans, which are brewed or steeped in hot water to create a flavorful and stimulating drink. It has a rich aroma and can be enjoyed hot or cold, with various flavors and additives. 😊</s><s>[INST] can you elaborate? [/INST] Here is your response:
```

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

