### PR TITLE
Fix CommanderServiceBrowserTest

### DIFF
--- a/browser/ui/commander/commander_service.h
+++ b/browser/ui/commander/commander_service.h
@@ -41,7 +41,7 @@ class CommanderService : public CommanderFrontendDelegate, public KeyedService {
   void Hide() override;
   void AddObserver(Observer* observer) override;
   void RemoveObserver(Observer* observer) override;
-  void UpdateText(bool force = false) override;
+  void UpdateText(const std::u16string& text) override;
   void SelectCommand(uint32_t command_index, uint32_t result_set_id) override;
   std::vector<CommandItemModel> GetItems() override;
   int GetResultSetId() override;
@@ -51,6 +51,9 @@ class CommanderService : public CommanderFrontendDelegate, public KeyedService {
   void Shutdown() override;
 
  private:
+  void UpdateTextFromCurrentBrowserOmnibox();
+  void UpdateText(const std::u16string& text, bool force);
+
   OmniboxView* GetOmnibox() const;
   void UpdateCommands();
   void NotifyObservers();

--- a/browser/ui/commander/commander_service_browsertest.cc
+++ b/browser/ui/commander/commander_service_browsertest.cc
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <string>
+
 #include "base/functional/callback_forward.h"
 #include "base/location.h"
 #include "base/run_loop.h"
@@ -199,7 +200,7 @@ IN_PROC_BROWSER_TEST_F(CommanderServiceBrowserTest,
   auto items = commander()->GetItems();
   ASSERT_EQ(3u, items.size());
   EXPECT_EQ(u"Pin tab", items[0].title);
-  EXPECT_EQ(u"Pin tab…", items[1].title);
+  EXPECT_EQ(u"Pin tab …", items[1].title);
   EXPECT_EQ(u"Close unpinned tabs", items[2].title);
 
   commander()->SelectCommand(1, 1);

--- a/components/commander/browser/commander_frontend_delegate.h
+++ b/components/commander/browser/commander_frontend_delegate.h
@@ -29,7 +29,7 @@ class COMPONENT_EXPORT(COMMANDER_BROWSER) CommanderFrontendDelegate {
   virtual void RemoveObserver(Observer* observer) = 0;
   virtual void SelectCommand(uint32_t command_index,
                              uint32_t result_set_id) = 0;
-  virtual void UpdateText(bool force = false) = 0;
+  virtual void UpdateText(const std::u16string& text) = 0;
   virtual std::vector<CommandItemModel> GetItems() = 0;
   virtual int GetResultSetId() = 0;
   virtual const std::u16string& GetPrompt() = 0;

--- a/components/omnibox/browser/commander_provider.cc
+++ b/components/omnibox/browser/commander_provider.cc
@@ -44,7 +44,7 @@ void CommanderProvider::Start(const AutocompleteInput& input,
   last_input_ = input.text();
 
   if (auto* delegate = client_->GetCommanderDelegate()) {
-    delegate->UpdateText();
+    delegate->UpdateText(input.text());
   }
 }
 
@@ -123,6 +123,10 @@ void CommanderProvider::OnCommanderUpdated() {
     matches_.push_back(match);
   }
 
-  NotifyListeners(/* updated_matches= */ true);
+  // Only call NotifyListeners if the update was triggered asynchronously, to
+  // avoid triggering a DCHECK in AutocompleteController.
+  if (!done()) {
+    NotifyListeners(/* updated_matches= */ true);
+  }
 }
 }  // namespace commander

--- a/components/omnibox/browser/commander_provider_unittest.cc
+++ b/components/omnibox/browser/commander_provider_unittest.cc
@@ -71,7 +71,7 @@ class FakeCommanderDelegate : public commander::CommanderFrontendDelegate {
     NOTIMPLEMENTED();
   }
 
-  void UpdateText(bool force = false) override { NOTIMPLEMENTED(); }
+  void UpdateText(const std::u16string& text) override { NOTIMPLEMENTED(); }
 
  private:
   base::ObserverList<Observer> observers_;


### PR DESCRIPTION
There was a refactoring of the AutocompleteController which caused some tests to fail. There were two causes:
1. A DCHECK that we weren't NotifyListeners wasn't called if the Provider was done in the controller.
2. OmniboxView->SetText isn't immediately reflected in GetText, so there is a small refactor for making the Provider pass the current text.
3. There's a weird going on where the `...` has a space before it. I think that's fine to address separately, it doesn't look like the string has changed.