### PR TITLE
Fixed new tab button's plus icon is mis-aligned with horizontal tab (uplift to 1.63.x)

### DIFF
--- a/browser/ui/views/tabs/brave_new_tab_button.cc
+++ b/browser/ui/views/tabs/brave_new_tab_button.cc
@@ -85,8 +85,9 @@ void BraveNewTabButton::PaintIcon(gfx::Canvas* canvas) {
     // the canvas in the center of the view.
     constexpr int kIconSize = 18;
     gfx::Rect bounds = GetContentsBounds();
-    canvas->Translate(gfx::Vector2d((bounds.width() - kIconSize) / 2,
-                                    (bounds.height() - kIconSize) / 2));
+    canvas->Translate(
+        gfx::Vector2d((bounds.width() - kIconSize) / 2 + bounds.x(),
+                      (bounds.height() - kIconSize) / 2 + bounds.y()));
     gfx::PaintVectorIcon(canvas, kLeoPlusAddIcon, kIconSize,
                          GetForegroundColor());
     return;


### PR DESCRIPTION
Uplift of #21584
fix https://github.com/brave/brave-browser/issues/35300

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.