### PR TITLE
Include synced history entries into P3A

### DIFF
--- a/browser/sync/brave_sync_service_impl_delegate.h
+++ b/browser/sync/brave_sync_service_impl_delegate.h
@@ -6,14 +6,17 @@
 #ifndef BRAVE_BROWSER_SYNC_BRAVE_SYNC_SERVICE_IMPL_DELEGATE_H_
 #define BRAVE_BROWSER_SYNC_BRAVE_SYNC_SERVICE_IMPL_DELEGATE_H_
 
-#include "brave/components/sync/service/sync_service_impl_delegate.h"
+#include <utility>
 
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/scoped_observation.h"
+#include "brave/components/sync/service/sync_service_impl_delegate.h"
 #include "components/sync_device_info/device_info_tracker.h"
 
-class Profile;
+namespace history {
+class HistoryService;
+}  // namespace history
 
 namespace syncer {
 
@@ -29,7 +32,8 @@ class BraveSyncServiceImplDelegate
       public syncer::DeviceInfoTracker::Observer {
  public:
   explicit BraveSyncServiceImplDelegate(
-      DeviceInfoSyncService* device_info_sync_service);
+      DeviceInfoSyncService* device_info_sync_service,
+      history::HistoryService* history_service);
   ~BraveSyncServiceImplDelegate() override;
 
   void SuspendDeviceObserverForOwnReset() override;
@@ -37,6 +41,9 @@ class BraveSyncServiceImplDelegate
 
   void SetLocalDeviceAppearedCallback(
       base::OnceCallback<void()> local_device_appeared_callback) override;
+
+  void GetKnownToSyncHistoryCount(
+      base::OnceCallback<void(std::pair<bool, int>)> callback) override;
 
  private:
   // syncer::DeviceInfoTracker::Observer:
@@ -54,6 +61,7 @@ class BraveSyncServiceImplDelegate
       device_info_observer_{this};
 
   raw_ptr<DeviceInfoSyncService> device_info_sync_service_ = nullptr;
+  raw_ptr<history::HistoryService> history_service_ = nullptr;
 
   // This is triggered once after SetLocalDeviceAppearedCallback
   // when the local device first appears in the changed synced devices list

--- a/chromium_src/chrome/browser/sync/sync_service_factory.cc
+++ b/chromium_src/chrome/browser/sync/sync_service_factory.cc
@@ -5,13 +5,16 @@
 
 #include "brave/browser/sync/brave_sync_service_impl_delegate.h"
 #include "brave/components/sync/service/brave_sync_service_impl.h"
+#include "chrome/browser/history/history_service_factory.h"
 #include "chrome/browser/sync/device_info_sync_service_factory.h"
 
-#define BRAVE_BUILD_SERVICE_INSTANCE_FOR                      \
-  std::make_unique<syncer::BraveSyncServiceImpl>(             \
-      std::move(init_params),                                 \
-      std::make_unique<syncer::BraveSyncServiceImplDelegate>( \
-          DeviceInfoSyncServiceFactory::GetForProfile(profile)));
+#define BRAVE_BUILD_SERVICE_INSTANCE_FOR                        \
+  std::make_unique<syncer::BraveSyncServiceImpl>(               \
+      std::move(init_params),                                   \
+      std::make_unique<syncer::BraveSyncServiceImplDelegate>(   \
+          DeviceInfoSyncServiceFactory::GetForProfile(profile), \
+          HistoryServiceFactory::GetForProfile(                 \
+              profile, ServiceAccessType::IMPLICIT_ACCESS)));
 
 #include "src/chrome/browser/sync/sync_service_factory.cc"
 

--- a/chromium_src/components/history/core/browser/history_backend.cc
+++ b/chromium_src/components/history/core/browser/history_backend.cc
@@ -1,0 +1,15 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/history/core/browser/history_backend.cc"
+
+namespace history {
+
+HistoryCountResult HistoryBackend::GetKnownToSyncCount() {
+  int count = 0;
+  return {db_ && db_->GetKnownToSyncCount(&count), count};
+}
+
+}  // namespace history

--- a/chromium_src/components/history/core/browser/history_backend.h
+++ b/chromium_src/components/history/core/browser/history_backend.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_HISTORY_BACKEND_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_HISTORY_BACKEND_H_
+
+#define GetHistoryCount  \
+  GetKnownToSyncCount(); \
+  HistoryCountResult GetHistoryCount
+
+#include "src/components/history/core/browser/history_backend.h"  // IWYU pragma: export
+
+#undef GetHistoryCount
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_HISTORY_BACKEND_H_

--- a/chromium_src/components/history/core/browser/history_service.cc
+++ b/chromium_src/components/history/core/browser/history_service.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/history/core/browser/history_service.cc"
+
+namespace history {
+
+void HistoryService::GetKnownToSyncCount(
+    base::OnceCallback<void(HistoryCountResult)> callback) {
+  backend_task_runner_->PostTaskAndReplyWithResult(
+      FROM_HERE,
+      base::BindOnce(&HistoryBackend::GetKnownToSyncCount, history_backend_),
+      std::move(callback));
+}
+
+}  // namespace history

--- a/chromium_src/components/history/core/browser/history_service.cc
+++ b/chromium_src/components/history/core/browser/history_service.cc
@@ -5,6 +5,8 @@
 
 #include "src/components/history/core/browser/history_service.cc"
 
+#include "base/task/bind_post_task.h"
+
 namespace history {
 
 void HistoryService::GetKnownToSyncCount(
@@ -12,7 +14,7 @@ void HistoryService::GetKnownToSyncCount(
   backend_task_runner_->PostTaskAndReplyWithResult(
       FROM_HERE,
       base::BindOnce(&HistoryBackend::GetKnownToSyncCount, history_backend_),
-      std::move(callback));
+      base::BindPostTaskToCurrentDefault(std::move(callback)));
 }
 
 }  // namespace history

--- a/chromium_src/components/history/core/browser/history_service.cc
+++ b/chromium_src/components/history/core/browser/history_service.cc
@@ -5,8 +5,6 @@
 
 #include "src/components/history/core/browser/history_service.cc"
 
-#include "base/task/bind_post_task.h"
-
 namespace history {
 
 void HistoryService::GetKnownToSyncCount(
@@ -14,7 +12,7 @@ void HistoryService::GetKnownToSyncCount(
   backend_task_runner_->PostTaskAndReplyWithResult(
       FROM_HERE,
       base::BindOnce(&HistoryBackend::GetKnownToSyncCount, history_backend_),
-      base::BindPostTaskToCurrentDefault(std::move(callback)));
+      std::move(callback));
 }
 
 }  // namespace history

--- a/chromium_src/components/history/core/browser/history_service.h
+++ b/chromium_src/components/history/core/browser/history_service.h
@@ -15,7 +15,14 @@ class BraveHistoryQuickProviderTest;
   friend class ::BraveHistoryQuickProviderTest; \
   void CleanupUnused
 
+#define AddRelatedSearchesForVisit                                     \
+  GetKnownToSyncCount(                                                 \
+      base::OnceCallback<void(history::HistoryCountResult)> callback); \
+  void AddRelatedSearchesForVisit
+
 #include "src/components/history/core/browser/history_service.h"  // IWYU pragma: export
+
+#undef AddRelatedSearchesForVisit
 
 #undef Cleanup
 

--- a/chromium_src/components/history/core/browser/visit_database.cc
+++ b/chromium_src/components/history/core/browser/visit_database.cc
@@ -13,3 +13,21 @@
 #include "src/components/history/core/browser/visit_database.cc"
 
 #undef SOURCE_SAFARI_IMPORTED
+
+namespace history {
+
+bool VisitDatabase::GetKnownToSyncCount(int* count) {
+  sql::Statement statement(
+      GetDB().GetCachedStatement(SQL_FROM_HERE,
+                                 "SELECT COUNT(*) "
+                                 "FROM visits "
+                                 "WHERE is_known_to_sync == TRUE"));
+
+  *count = 0;
+  if (statement.Step()) {
+    *count = statement.ColumnInt(0);
+  }
+  return true;
+}
+
+}  // namespace history

--- a/chromium_src/components/history/core/browser/visit_database.h
+++ b/chromium_src/components/history/core/browser/visit_database.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_VISIT_DATABASE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_VISIT_DATABASE_H_
+
+#define GetHistoryCount            \
+  GetKnownToSyncCount(int* count); \
+  bool GetHistoryCount
+
+#include "src/components/history/core/browser/visit_database.h"  // IWYU pragma: export
+
+#undef GetHistoryCount
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_HISTORY_CORE_BROWSER_VISIT_DATABASE_H_

--- a/chromium_src/ios/chrome/browser/sync/model/sync_service_factory.mm
+++ b/chromium_src/ios/chrome/browser/sync/model/sync_service_factory.mm
@@ -5,13 +5,16 @@
 
 #include "brave/browser/sync/brave_sync_service_impl_delegate.h"
 #include "brave/components/sync/service/brave_sync_service_impl.h"
+#include "ios/chrome/browser/history/model/history_service_factory.h"
 #include "ios/chrome/browser/sync/model/device_info_sync_service_factory.h"
 
-#define BRAVE_BUILD_SERVICE_INSTANCE_FOR                      \
-  std::make_unique<syncer::BraveSyncServiceImpl>(             \
-      std::move(init_params),                                 \
-      std::make_unique<syncer::BraveSyncServiceImplDelegate>( \
-          DeviceInfoSyncServiceFactory::GetForBrowserState(browser_state)));
+#define BRAVE_BUILD_SERVICE_INSTANCE_FOR                                   \
+  std::make_unique<syncer::BraveSyncServiceImpl>(                          \
+      std::move(init_params),                                              \
+      std::make_unique<syncer::BraveSyncServiceImplDelegate>(              \
+          DeviceInfoSyncServiceFactory::GetForBrowserState(browser_state), \
+          ios::HistoryServiceFactory::GetForBrowserState(                  \
+              browser_state, ServiceAccessType::IMPLICIT_ACCESS)));
 
 #include "src/ios/chrome/browser/sync/model/sync_service_factory.mm"
 

--- a/components/brave_sync/brave_sync_p3a.cc
+++ b/components/brave_sync/brave_sync_p3a.cc
@@ -51,7 +51,7 @@ void RecordSyncedObjectsCount(int total_entities) {
   // 1 - 1001..10000
   // 2 - 10001..49000
   // 3 - >= 49001
-  p3a_utils::RecordToHistogramBucket(kSyncedObjectsCountHistogramName,
+  p3a_utils::RecordToHistogramBucket(kSyncedObjectsCountHistogramNameV2,
                                      {1000, 10000, 49000}, total_entities);
 }
 

--- a/components/brave_sync/brave_sync_p3a.cc
+++ b/components/brave_sync/brave_sync_p3a.cc
@@ -46,7 +46,7 @@ void RecordEnabledTypes(bool sync_everything_enabled,
 }
 
 void RecordSyncedObjectsCount(int total_entities) {
-  // "Brave.Sync.SyncedObjectsCount"
+  // "Brave.Sync.SyncedObjectsCount.2"
   // 0 - 0..1000
   // 1 - 1001..10000
   // 2 - 10001..49000

--- a/components/brave_sync/brave_sync_p3a.h
+++ b/components/brave_sync/brave_sync_p3a.h
@@ -14,6 +14,11 @@ namespace p3a {
 // TODO(alexeybarabash): move here also "Brave.Sync.Status.2" and
 // "Brave.Sync.ProgressTokenEverReset"
 inline constexpr char kEnabledTypesHistogramName[] = "Brave.Sync.EnabledTypes";
+inline constexpr char kSyncedObjectsCountHistogramNameV2[] =
+    "Brave.Sync.SyncedObjectsCount.2";
+
+// Obsolete metric name, with a new History datatype contains wrong data for
+// synced History objects count
 inline constexpr char kSyncedObjectsCountHistogramName[] =
     "Brave.Sync.SyncedObjectsCount";
 

--- a/components/brave_sync/brave_sync_p3a.h
+++ b/components/brave_sync/brave_sync_p3a.h
@@ -14,13 +14,9 @@ namespace p3a {
 // TODO(alexeybarabash): move here also "Brave.Sync.Status.2" and
 // "Brave.Sync.ProgressTokenEverReset"
 inline constexpr char kEnabledTypesHistogramName[] = "Brave.Sync.EnabledTypes";
+// Improved version of metric which includes count of synced History objects
 inline constexpr char kSyncedObjectsCountHistogramNameV2[] =
     "Brave.Sync.SyncedObjectsCount.2";
-
-// Obsolete metric name, with a new History datatype contains wrong data for
-// synced History objects count
-inline constexpr char kSyncedObjectsCountHistogramName[] =
-    "Brave.Sync.SyncedObjectsCount";
 
 enum class EnabledTypesAnswer {
   kEmptyOrBookmarksOnly = 0,

--- a/components/brave_sync/brave_sync_p3a_unittest.cc
+++ b/components/brave_sync/brave_sync_p3a_unittest.cc
@@ -58,22 +58,22 @@ TEST(BraveSyncP3ATest, TestSyncedObjectsCount) {
   base::HistogramTester histogram_tester;
 
   RecordSyncedObjectsCount(0);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 0, 1);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 0, 1);
   RecordSyncedObjectsCount(1000);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 0, 2);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 0, 2);
 
   RecordSyncedObjectsCount(1001);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 1, 1);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 1, 1);
   RecordSyncedObjectsCount(10000);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 1, 2);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 1, 2);
 
   RecordSyncedObjectsCount(10001);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 2, 1);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 2, 1);
   RecordSyncedObjectsCount(49000);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 2, 2);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 2, 2);
 
   RecordSyncedObjectsCount(49001);
-  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramName, 3, 1);
+  histogram_tester.ExpectBucketCount(kSyncedObjectsCountHistogramNameV2, 3, 1);
 }
 
 }  // namespace p3a

--- a/components/history/core/browser/BUILD.gn
+++ b/components/history/core/browser/BUILD.gn
@@ -1,18 +1,16 @@
-# Copyright (c) 2020 The Brave Authors. All rights reserved.
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-source_set("sync") {
+source_set("unit_tests") {
+  testonly = true
   sources = [
-    "brave_sync_service_impl_delegate.cc",
-    "brave_sync_service_impl_delegate.h",
+    "//brave/components/history/core/browser/brave_visit_database_unittest.cc",
   ]
-
   deps = [
     "//base",
     "//components/history/core/browser",
-    "//components/sync/service",
-    "//components/sync_device_info",
+    "//testing/gtest",
   ]
 }

--- a/components/history/core/browser/brave_visit_database_unittest.cc
+++ b/components/history/core/browser/brave_visit_database_unittest.cc
@@ -1,0 +1,83 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/time/time.h"
+#include "components/history/core/browser/url_database.h"
+#include "components/history/core/browser/visit_database.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "testing/platform_test.h"
+
+using base::Time;
+
+namespace history {
+
+// Inspired by Chromium's VisitDatabaseTest.IsKnownToSync
+class BraveVisitDatabaseTest : public PlatformTest,
+                               public URLDatabase,
+                               public VisitDatabase {
+ public:
+  BraveVisitDatabaseTest() {}
+
+ private:
+  // Test setup.
+  void SetUp() override {
+    PlatformTest::SetUp();
+
+    EXPECT_TRUE(db_.OpenInMemory());
+
+    // Initialize the tables for this test.
+    CreateURLTable(false);
+    CreateMainURLIndex();
+    InitVisitTable();
+  }
+  void TearDown() override {
+    db_.Close();
+    PlatformTest::TearDown();
+  }
+
+  // Provided for URL/VisitDatabase.
+  sql::Database& GetDB() override { return db_; }
+
+  sql::Database db_;
+};
+
+TEST_F(BraveVisitDatabaseTest, BraveGetKnownToSyncCount) {
+  // Insert three rows, VisitIDs 1, 2, and 3.
+  for (VisitID i = 1; i <= 3; i++) {
+    VisitRow original(i, Time::Now(), 23, ui::PageTransitionFromInt(0), 19,
+                      false, 0);
+    AddVisit(&original, SOURCE_BROWSED);
+    ASSERT_EQ(i, original.visit_id);  // Verifies that we added 1, 2, and 3
+  }
+
+  int known_to_sync_count = 0;
+  ASSERT_TRUE(GetKnownToSyncCount(&known_to_sync_count));
+  EXPECT_EQ(known_to_sync_count, 0);
+
+  // Set 2 and 3 to be `is_known_to_sync`.
+  VisitRow visit2;
+  ASSERT_TRUE(GetRowForVisit(2, &visit2));
+  EXPECT_FALSE(visit2.is_known_to_sync);
+  visit2.is_known_to_sync = true;
+  ASSERT_TRUE(UpdateVisitRow(visit2));
+
+  VisitRow visit3;
+  ASSERT_TRUE(GetRowForVisit(3, &visit3));
+  EXPECT_FALSE(visit3.is_known_to_sync);
+  visit3.is_known_to_sync = true;
+  ASSERT_TRUE(UpdateVisitRow(visit3));
+
+  ASSERT_TRUE(GetKnownToSyncCount(&known_to_sync_count));
+  EXPECT_EQ(known_to_sync_count, 2);
+
+  // Now clear out all `is_known_to_sync` bits and verify that we still count
+  // correctly.
+  SetAllVisitsAsNotKnownToSync();
+
+  ASSERT_TRUE(GetKnownToSyncCount(&known_to_sync_count));
+  EXPECT_EQ(known_to_sync_count, 0);
+}
+
+}  // namespace history

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -231,7 +231,7 @@ inline constexpr auto kCollectedSlowHistograms =
     "Brave.Rewards.PageViewCount",
     "Brave.Rewards.TipsSent.2",
     "Brave.Sync.EnabledTypes",
-    "Brave.Sync.SyncedObjectsCount",
+    "Brave.Sync.SyncedObjectsCount.2",
     "Brave.Today.UsageMonthly",
     "Brave.Toolbar.ForwardNavigationAction",
     "Brave.Wallet.UsageMonthly",

--- a/components/sync/service/BUILD.gn
+++ b/components/sync/service/BUILD.gn
@@ -20,6 +20,7 @@ source_set("unit_tests") {
     "//base/test:test_support",
     "//brave/components/brave_sync:crypto",
     "//brave/components/brave_sync:network_time_helper",
+    "//brave/components/brave_sync:p3a",
     "//brave/components/brave_sync:prefs",
     "//brave/components/constants",
     "//brave/components/sync/test:test_support",

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -78,6 +78,8 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, JoinActiveOrNewChain);
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, JoinDeletedChain);
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, HistoryPreconditions);
+  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,
+                           P3aForHistoryThroughDelegate);
 
   BraveSyncAuthManager* GetBraveSyncAuthManager();
   SyncServiceCrypto* GetCryptoForTests();

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -69,6 +69,8 @@ class SyncServiceImplDelegateMock : public SyncServiceImplDelegate {
   void ResumeDeviceObserver() override {}
   void SetLocalDeviceAppearedCallback(
       base::OnceCallback<void()> local_device_appeared_callback) override {}
+  void GetKnownToSyncHistoryCount(
+      base::OnceCallback<void(std::pair<bool, int>)> callback) override {}
 };
 
 class SyncServiceObserverMock : public SyncServiceObserver {

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -7,8 +7,11 @@
 
 #include "base/base64.h"
 #include "base/logging.h"
+#include "base/memory/raw_ptr.h"
 #include "base/test/gtest_util.h"
+#include "base/test/metrics/histogram_tester.h"
 #include "base/test/task_environment.h"
+#include "brave/components/brave_sync/brave_sync_p3a.h"
 #include "brave/components/history/core/browser/sync/brave_history_delete_directives_model_type_controller.h"
 #include "brave/components/history/core/browser/sync/brave_history_model_type_controller.h"
 #include "brave/components/sync/service/brave_sync_service_impl.h"
@@ -19,6 +22,7 @@
 #include "components/os_crypt/sync/os_crypt_mocker.h"
 #include "components/sync/engine/nigori/key_derivation_params.h"
 #include "components/sync/engine/nigori/nigori.h"
+#include "components/sync/model/type_entities_count.h"
 #include "components/sync/service/data_type_manager_impl.h"
 #include "components/sync/test/data_type_manager_mock.h"
 #include "components/sync/test/fake_data_type_controller.h"
@@ -65,12 +69,13 @@ class SyncServiceImplDelegateMock : public SyncServiceImplDelegate {
  public:
   SyncServiceImplDelegateMock() = default;
   ~SyncServiceImplDelegateMock() override = default;
-  void SuspendDeviceObserverForOwnReset() override {}
-  void ResumeDeviceObserver() override {}
-  void SetLocalDeviceAppearedCallback(
-      base::OnceCallback<void()> local_device_appeared_callback) override {}
-  void GetKnownToSyncHistoryCount(
-      base::OnceCallback<void(std::pair<bool, int>)> callback) override {}
+
+  MOCK_METHOD0(SuspendDeviceObserverForOwnReset, void());
+  MOCK_METHOD0(ResumeDeviceObserver, void());
+  MOCK_METHOD1(SetLocalDeviceAppearedCallback,
+               void(base::OnceCallback<void()>));
+  MOCK_METHOD1(GetKnownToSyncHistoryCount,
+               void(base::OnceCallback<void(std::pair<bool, int>)>));
 };
 
 class SyncServiceObserverMock : public SyncServiceObserver {
@@ -112,9 +117,12 @@ class BraveSyncServiceImplTest : public testing::Test {
     ON_CALL(*sync_client, CreateDataTypeControllers(_))
         .WillByDefault(Return(ByMove(std::move(controllers))));
 
+    auto sync_service_delegate(std::make_unique<SyncServiceImplDelegateMock>());
+    sync_service_delegate_ = sync_service_delegate.get();
+
     sync_service_impl_ = std::make_unique<BraveSyncServiceImpl>(
         sync_service_impl_bundle_.CreateBasicInitParams(std::move(sync_client)),
-        std::make_unique<SyncServiceImplDelegateMock>());
+        std::move(sync_service_delegate));
   }
 
   brave_sync::Prefs* brave_sync_prefs() { return &brave_sync_prefs_; }
@@ -143,6 +151,7 @@ class BraveSyncServiceImplTest : public testing::Test {
 
  protected:
   content::BrowserTaskEnvironment task_environment_;
+  raw_ptr<SyncServiceImplDelegateMock> sync_service_delegate_;
 
  private:
   SyncServiceImplBundle sync_service_impl_bundle_;
@@ -590,6 +599,50 @@ TEST_F(BraveSyncServiceImplTest, OnlyBookmarksAfterSetup) {
       brave_sync_service_impl()->GetUserSettings()->GetSelectedTypes();
   EXPECT_EQ(selected_types.Size(), 1u);
   EXPECT_TRUE(selected_types.Has(UserSelectableType::kBookmarks));
+
+  OSCryptMocker::TearDown();
+}
+
+TEST_F(BraveSyncServiceImplTest, P3aForHistoryThroughDelegate) {
+  OSCryptMocker::SetUp();
+  CreateSyncService(ModelTypeSet({BOOKMARKS, HISTORY}));
+
+  brave_sync_service_impl()->Initialize();
+  EXPECT_FALSE(engine());
+  brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
+  task_environment_.RunUntilIdle();
+
+  base::HistogramTester histogram_tester;
+
+  std::vector<syncer::TypeEntitiesCount> counts;
+  syncer::TypeEntitiesCount bookmarks_count(syncer::BOOKMARKS);
+  bookmarks_count.entities = bookmarks_count.non_tombstone_entities = 1;
+  counts.push_back(bookmarks_count);
+
+  brave_sync_service_impl()->OnGotEntityCounts(counts);
+  histogram_tester.ExpectBucketCount(
+      brave_sync::p3a::kSyncedObjectsCountHistogramNameV2, 0, 1);
+
+  // Enable History and pretend we got its number from delegate.
+  // We need to have setup handle, otherwise
+  // |SyncUserSettingsImpl::SetSelectedTypes| and
+  // |SyncUserSettingsImpl::GetSelectedTypes| work wrong
+  auto sync_blocker = brave_sync_service_impl()->GetSetupInProgressHandle();
+  auto selected_types =
+      brave_sync_service_impl()->GetUserSettings()->GetSelectedTypes();
+  selected_types.Put(UserSelectableType::kHistory);
+  brave_sync_service_impl()->GetUserSettings()->SetSelectedTypes(
+      false, selected_types);
+
+  ON_CALL(*sync_service_delegate_, GetKnownToSyncHistoryCount(_))
+      .WillByDefault(
+          [](base::OnceCallback<void(std::pair<bool, int>)> callback) {
+            std::move(callback).Run(std::pair<bool, int>(true, 10001));
+          });
+
+  brave_sync_service_impl()->OnGotEntityCounts(counts);
+  histogram_tester.ExpectBucketCount(
+      brave_sync::p3a::kSyncedObjectsCountHistogramNameV2, 2, 1);
 
   OSCryptMocker::TearDown();
 }

--- a/components/sync/service/sync_service_impl_delegate.h
+++ b/components/sync/service/sync_service_impl_delegate.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_SYNC_SERVICE_SYNC_SERVICE_IMPL_DELEGATE_H_
 #define BRAVE_COMPONENTS_SYNC_SERVICE_SYNC_SERVICE_IMPL_DELEGATE_H_
 
+#include <utility>
+
 #include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 
@@ -21,6 +23,9 @@ class SyncServiceImplDelegate {
 
   virtual void SetLocalDeviceAppearedCallback(
       base::OnceCallback<void()> local_device_appeared_callback) = 0;
+
+  virtual void GetKnownToSyncHistoryCount(
+      base::OnceCallback<void(std::pair<bool, int>)> callback) = 0;
 
   void set_profile_sync_service(BraveSyncServiceImpl* sync_service_impl) {
     sync_service_impl_ = sync_service_impl;

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -235,6 +235,7 @@ test("brave_unit_tests") {
     "//brave/components/de_amp/browser/test:unit_tests",
     "//brave/components/debounce/browser/test:unit_tests",
     "//brave/components/embedder_support:unit_tests",
+    "//brave/components/history/core/browser:unit_tests",
     "//brave/components/history/core/browser/sync:unit_tests",
     "//brave/components/ipfs/buildflags",
     "//brave/components/ipfs/test:brave_ipfs_unit_tests",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35579

This PR adds `VisitDatabase::GetKnownToSyncCount` and all the methods up till `HistoryService`. When History datatype is enabled, it is used to calculate synced objects count in addition to `SyncServiceImpl::GetEntityCountsForDebugging`

Also changed the tiem interval for P3A sync objects query.
Now it does the first update in ~5 minutes after sync start, and all the next each ~30 minutes.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a sync chain, enable History
2. Open brave://local-state/ , look for `SyncedObjectsCount`, there should be entries with `"value": "0"`
3. Open brave://inspect/#extensions , click `inspect` near the Brave extension
4. Paste
```
for (i=0;i<1100;++i) chrome.history.addUrl({url: 'https://search.brave.com/search?q='+i+'&source=web'}, function() {})
```
into the console
5. Wait ~3 min, to allow Sync send the records to the server
6. Close browser
7. Launch browser and wait ~5 min, to ensure P3A saved the synced objects count
8. Open againbrave://local-state/ , look for `SyncedObjectsCount`, there should be entries with `"value": "1"`

