### PR TITLE
Avoid P3AServiceTest.EphemeralMetricOnlySentOnce test timeout on macOS (uplift to 1.63.x)

### DIFF
--- a/components/p3a/p3a_service_unittest.cc
+++ b/components/p3a/p3a_service_unittest.cc
@@ -44,6 +44,8 @@ constexpr char kTestP3AJsonHost[] = "https://p3a-json.brave.com";
 constexpr char kTestP2AJsonHost[] = "https://p2a-json.brave.com";
 constexpr char kTestP3ACreativeHost[] = "https://p3a-creative.brave.com";
 
+constexpr char kTestEphemeralMetric[] = "Brave.Wallet.UsageWeekly";
+
 }  // namespace
 
 class P3AServiceTest : public testing::Test {
@@ -383,25 +385,22 @@ TEST_F(P3AServiceTest, ShouldNotSendIfDisabled) {
 }
 
 TEST_F(P3AServiceTest, EphemeralMetricOnlySentOnce) {
-  // Increase upload interval to reduce test time (less tasks to execute)
-  base::CommandLine* cmdline = base::CommandLine::ForCurrentProcess();
-  cmdline->AppendSwitchASCII(switches::kP3AUploadIntervalSeconds, "13000");
   SetUpP3AService();
 
-  std::string test_histogram = std::string(*p3a::kEphemeralHistograms.begin());
-  base::UmaHistogramExactLinear(test_histogram, 1, 8);
-  p3a_service_->OnHistogramChanged(test_histogram.c_str(), 0, 8);
+  base::UmaHistogramExactLinear(kTestEphemeralMetric, 1, 8);
+  p3a_service_->OnHistogramChanged(kTestEphemeralMetric, 0, 8);
 
   EXPECT_EQ(p3a_json_sent_metrics_.size(), 0U);
 
-  task_environment_.FastForwardBy(base::Seconds(kUploadIntervalSeconds * 400));
+  task_environment_.FastForwardBy(base::Seconds(kUploadIntervalSeconds * 10));
 
   EXPECT_EQ(p3a_json_sent_metrics_.size(), 1U);
   EXPECT_EQ(p2a_json_sent_metrics_.size(), 0U);
   EXPECT_EQ(p3a_creative_sent_metrics_.size(), 0U);
 
   ResetInterceptorStores();
-  task_environment_.FastForwardBy(base::Days(15));
+  task_environment_.FastForwardBy(base::Days(7) +
+                                  base::Seconds(kUploadIntervalSeconds * 10));
 
   EXPECT_EQ(p3a_json_sent_metrics_.size(), 0U);
   EXPECT_EQ(p2a_json_sent_metrics_.size(), 0U);


### PR DESCRIPTION
Uplift of #21589

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.