### PR TITLE
Fix Rewards verified badge in dark mode (uplift to 1.63.x)

### DIFF
--- a/browser/ui/views/brave_actions/brave_rewards_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_rewards_action_view.cc
@@ -117,11 +117,11 @@ class RewardsBadgeImageSource : public brave::BraveIconWithBadgeImageSource {
     gfx::Rect image_rect(badge_rect);
     gfx::Outsets outsets;
     outsets.set_left(2);
-    outsets.set_right(1);
+    outsets.set_bottom(2);
     image_rect.Outset(outsets);
 
     gfx::RectF check_rect(image_rect);
-    check_rect.Inset(4);
+    check_rect.Inset(3);
     cc::PaintFlags check_flags;
     check_flags.setStyle(cc::PaintFlags::kFill_Style);
     check_flags.setColor(SK_ColorWHITE);


### PR DESCRIPTION
Uplift of #21635
Resolves https://github.com/brave/brave-browser/issues/35423

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.