### PR TITLE
Hides `Open in Reading Mode` context menu item. (uplift to 1.63.x)

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -137,6 +137,7 @@ source_set("browser_tests") {
       "//extensions/common",
       "//services/device/public/cpp:device_features",
       "//testing/gtest",
+      "//ui/accessibility:ax_base",
     ]
 
     if (is_linux || is_win || is_mac) {

--- a/app/DEPS
+++ b/app/DEPS
@@ -37,5 +37,6 @@ include_rules = [
   "+third_party/blink/public/common",
   "+third_party/blink/public/mojom",
   "+third_party/blink/public/public_buildflags.h",
+  "+ui/accessibility/accessibility_features.h",
   "+ui/base",
 ]

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -70,6 +70,7 @@
 #include "chrome/test/base/in_process_browser_test.h"
 #include "components/translate/core/common/translate_util.h"
 #include "extensions/common/extension_features.h"
+#include "ui/accessibility/accessibility_features.h"
 #endif
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
@@ -212,6 +213,9 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, DisabledFeatures) {
       &features::kPrivacyGuidePreloadAndroid,
 #endif
       &features::kPrivacySandboxAdsAPIsOverride,
+#if !BUILDFLAG(IS_ANDROID)
+      &features::kReadAnything,
+#endif
       &features::kResourceTimingForCancelledNavigationInFrame,
       &features::kSCTAuditing,
       &features::kServiceWorkerAutoPreload,

--- a/chromium_src/ui/accessibility/accessibility_features.cc
+++ b/chromium_src/ui/accessibility/accessibility_features.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/ui/accessibility/accessibility_features.cc"
+
+#include "base/feature_override.h"
+
+namespace features {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+#if !BUILDFLAG(IS_ANDROID)
+    {kReadAnything, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
+}});
+
+}  // namespace features


### PR DESCRIPTION
Uplift of #21628
Resolves https://github.com/brave/brave-browser/issues/35411

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.