### PR TITLE
Fixed wrong `Sync everything` initial state on Android (uplift to 1.62.x)

### DIFF
--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -144,6 +144,13 @@ void BraveSyncServiceImpl::OnBraveSyncPrefsChanged(const std::string& path) {
     if (!seed.empty()) {
       GetBraveSyncAuthManager()->DeriveSigningKeys(seed);
       // Default enabled types: Bookmarks
+
+      // Related Chromium change: 33441a0f3f9a591693157f2fd16852ce072e6f9d
+      // We need to acquire setup handle before change selected types.
+      // See changes at |SyncServiceImpl::GetSyncAccountStateForPrefs| and
+      // |SyncUserSettingsImpl::SetSelectedTypes|
+      auto sync_blocker = GetSetupInProgressHandle();
+
       syncer::UserSelectableTypeSet selected_types;
       selected_types.Put(UserSelectableType::kBookmarks);
       GetUserSettings()->SetSelectedTypes(false, selected_types);

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -567,4 +567,29 @@ TEST_F(BraveSyncServiceImplTest, HistoryPreconditions) {
   OSCryptMocker::TearDown();
 }
 
+TEST_F(BraveSyncServiceImplTest, OnlyBookmarksAfterSetup) {
+  OSCryptMocker::SetUp();
+  CreateSyncService();
+
+  brave_sync_service_impl()->Initialize();
+  EXPECT_FALSE(engine());
+  brave_sync_service_impl()->SetSyncCode(kValidSyncCode);
+  task_environment_.RunUntilIdle();
+
+  brave_sync_service_impl()
+      ->GetUserSettings()
+      ->SetInitialSyncFeatureSetupComplete(
+          syncer::SyncFirstSetupCompleteSource::ADVANCED_FLOW_CONFIRM);
+  EXPECT_TRUE(engine());
+
+  EXPECT_FALSE(
+      brave_sync_service_impl()->GetUserSettings()->IsSyncEverythingEnabled());
+  auto selected_types =
+      brave_sync_service_impl()->GetUserSettings()->GetSelectedTypes();
+  EXPECT_EQ(selected_types.Size(), 1u);
+  EXPECT_TRUE(selected_types.Has(UserSelectableType::kBookmarks));
+
+  OSCryptMocker::TearDown();
+}
+
 }  // namespace syncer


### PR DESCRIPTION
Uplift of #21597
Resolves https://github.com/brave/brave-browser/issues/35333

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.