### PR TITLE
Fixed crash when account.brave.com is loaded

### DIFF
--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -111,6 +111,7 @@ BraveVpnService* BraveVpnServiceFactory::GetForProfile(Profile* profile) {
 void BraveVpnServiceFactory::BindForContext(
     content::BrowserContext* context,
     mojo::PendingReceiver<brave_vpn::mojom::ServiceHandler> receiver) {
+  CHECK(GetInstance());
   auto* service = static_cast<BraveVpnService*>(
       GetInstance()->GetServiceForBrowserContext(context, true));
   if (service) {

--- a/browser/brave_vpn/brave_vpn_service_factory.cc
+++ b/browser/brave_vpn/brave_vpn_service_factory.cc
@@ -89,20 +89,12 @@ std::unique_ptr<KeyedService> BuildVpnService(
 
 // static
 BraveVpnServiceFactory* BraveVpnServiceFactory::GetInstance() {
-  if (!IsBraveVPNFeatureEnabled()) {
-    return nullptr;
-  }
-
   static base::NoDestructor<BraveVpnServiceFactory> instance;
   return instance.get();
 }
 
 // static
 BraveVpnService* BraveVpnServiceFactory::GetForProfile(Profile* profile) {
-  if (!GetInstance()) {
-    return nullptr;
-  }
-
   return static_cast<BraveVpnService*>(
       GetInstance()->GetServiceForBrowserContext(profile, true));
 }
@@ -111,7 +103,6 @@ BraveVpnService* BraveVpnServiceFactory::GetForProfile(Profile* profile) {
 void BraveVpnServiceFactory::BindForContext(
     content::BrowserContext* context,
     mojo::PendingReceiver<brave_vpn::mojom::ServiceHandler> receiver) {
-  CHECK(GetInstance());
   auto* service = static_cast<BraveVpnService*>(
       GetInstance()->GetServiceForBrowserContext(context, true));
   if (service) {

--- a/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_observer_factory_win.cc
@@ -39,8 +39,10 @@ KeyedService* BraveVpnWireguardObserverFactory::BuildServiceInstanceFor(
 BraveVpnWireguardObserverService*
 BraveVpnWireguardObserverFactory::GetServiceForContext(
     content::BrowserContext* context) {
-  DCHECK(
-      brave_vpn::IsBraveVPNWireguardEnabled(g_browser_process->local_state()));
+  if (!brave_vpn::IsBraveVPNWireguardEnabled(
+          g_browser_process->local_state())) {
+    return nullptr;
+  }
   DCHECK(brave_vpn::IsAllowedForContext(context));
   return static_cast<BraveVpnWireguardObserverService*>(
       GetInstance()->GetServiceForBrowserContext(context, true));

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -53,7 +53,10 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
 }  // namespace
 
 bool IsBraveVPNWireguardEnabled(PrefService* local_state) {
-  DCHECK(IsBraveVPNFeatureEnabled());
+  if (!IsBraveVPNFeatureEnabled()) {
+    return false;
+  }
+
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   auto enabled = local_state->GetBoolean(prefs::kBraveVPNWireguardEnabled);
 #if BUILDFLAG(IS_MAC)

--- a/components/skus/renderer/BUILD.gn
+++ b/components/skus/renderer/BUILD.gn
@@ -31,6 +31,10 @@ source_set("renderer") {
     "//third_party/blink/public/strings",
     "//v8",
   ]
+
+  if (enable_brave_vpn) {
+    deps += [ "//brave/components/brave_vpn/common" ]
+  }
 }
 
 source_set("unit_tests") {

--- a/components/skus/renderer/skus_js_handler.cc
+++ b/components/skus/renderer/skus_js_handler.cc
@@ -316,7 +316,9 @@ void SkusJSHandler::OnCredentialSummary(
     return;
   }
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  vpn_service_->LoadPurchasedState(domain);
+  if (vpn_service_.is_bound()) {
+    vpn_service_->LoadPurchasedState(domain);
+  }
 #endif
   v8::Local<v8::Value> local_result =
       content::V8ValueConverter::Create()->ToV8Value(*result_dict, context);

--- a/components/skus/renderer/skus_js_handler.cc
+++ b/components/skus/renderer/skus_js_handler.cc
@@ -28,6 +28,10 @@
 #include "third_party/blink/public/web/web_local_frame.h"
 #include "third_party/blink/public/web/web_script_source.h"
 
+#if BUILDFLAG(ENABLE_BRAVE_VPN)
+#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
+#endif
+
 namespace skus {
 
 gin::WrapperInfo SkusJSHandler::kWrapperInfo = {gin::kEmbedderNativeGin};
@@ -44,7 +48,7 @@ bool SkusJSHandler::EnsureConnected() {
   }
   bool result = skus_service_.is_bound();
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  if (!vpn_service_.is_bound()) {
+  if (brave_vpn::IsBraveVPNFeatureEnabled() && !vpn_service_.is_bound()) {
     render_frame_->GetBrowserInterfaceBroker()->GetInterface(
         vpn_service_.BindNewPipeAndPassReceiver());
   }

--- a/components/skus/renderer/skus_js_handler.cc
+++ b/components/skus/renderer/skus_js_handler.cc
@@ -48,11 +48,13 @@ bool SkusJSHandler::EnsureConnected() {
   }
   bool result = skus_service_.is_bound();
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  if (brave_vpn::IsBraveVPNFeatureEnabled() && !vpn_service_.is_bound()) {
-    render_frame_->GetBrowserInterfaceBroker()->GetInterface(
-        vpn_service_.BindNewPipeAndPassReceiver());
+  if (brave_vpn::IsBraveVPNFeatureEnabled()) {
+    if (!vpn_service_.is_bound()) {
+      render_frame_->GetBrowserInterfaceBroker()->GetInterface(
+          vpn_service_.BindNewPipeAndPassReceiver());
+    }
+    result = result && vpn_service_.is_bound();
   }
-  result = result && vpn_service_.is_bound();
 #endif
 
   return result;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/35395

When VPN feature flag is disabled, SkusJSHandler should not try to bind to vpn service handler
as BraveVpnService is not instantiated.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave
2. Disable vpn feature from brave://flags and relaunch
3. Load account.brave.com
4. Should not see crash