### PR TITLE
Remove dangling folder ID from playlist order preference

### DIFF
--- a/components/playlist/browser/playlist_service.cc
+++ b/components/playlist/browser/playlist_service.cc
@@ -79,7 +79,6 @@ PlaylistService::PlaylistService(content::BrowserContext* context,
   // This is for cleaning up malformed items during development. Once we
   // release Playlist feature officially, we should migrate items
   // instead of deleting them.
-  CleanUpMalformedPlaylistItems();
   MigratePlaylistValues();
 
   CleanUpOrphanedPlaylistItemDirs();
@@ -1240,22 +1239,8 @@ void PlaylistService::OnGetOrphanedPaths(
   }
 }
 
-void PlaylistService::CleanUpMalformedPlaylistItems() {
-  if (base::ranges::none_of(prefs_->GetDict(kPlaylistItemsPref),
-                            /* has_malformed_data = */ [](const auto& pair) {
-                              auto* dict = pair.second.GetIfDict();
-                              DCHECK(dict);
-                              return IsItemValueMalformed(*dict);
-                            })) {
-    return;
-  }
-
-  for (const auto* pref_key : {kPlaylistsPref, kPlaylistItemsPref}) {
-    prefs_->ClearPref(pref_key);
-  }
-}
-
 void PlaylistService::MigratePlaylistValues() {
+  // Migration code here should be gone after a few versions
   base::Value::List order = prefs_->GetList(kPlaylistOrderPref).Clone();
   MigratePlaylistOrder(prefs_->GetDict(kPlaylistsPref), order);
   prefs_->SetList(kPlaylistOrderPref, std::move(order));

--- a/components/playlist/browser/playlist_service.h
+++ b/components/playlist/browser/playlist_service.h
@@ -286,7 +286,6 @@ class PlaylistService : public KeyedService,
                          bool update_media_src_and_retry_on_fail,
                          DownloadMediaFileCallback callback);
 
-  void CleanUpMalformedPlaylistItems();
   void MigratePlaylistValues();
 
   // Delete orphaned playlist item directories that are not included in prefs.


### PR DESCRIPTION
Previously, a data pruning routine was implemented to handle new data schemas. However, this routine was flawed and left data in the order preference, leading to crashes. To resolve this, migration code has been added.

As this feature is nearing release on Android and Desktop platforms, data pruning will no longer be necessary. Therefore, the pruning code has been removed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35500
Resolves https://github.com/brave/brave-browser/issues/35496

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

