### PR TITLE
fix: add loading spinner to pending transaction panels

### DIFF
--- a/components/brave_wallet_ui/components/extension/pending_signature_requests_panel/pending_signature_requests_panel.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/pending_signature_requests_panel/pending_signature_requests_panel.stories.tsx
@@ -1,0 +1,85 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// types
+import { BraveWallet } from '../../../constants/types'
+
+// mocks
+import {
+  mockSolDappSignAllTransactionsRequest,
+  mockSolDappSignAndSendTransactionRequest,
+  mockSolDappSignTransactionRequest
+} from '../../../common/constants/mocks'
+
+// utils
+import {
+  deserializeTransaction //
+} from '../../../utils/model-serialization-utils'
+
+// components
+import {
+  WalletPanelStory, //
+  WalletPanelStoryProps
+} from '../../../stories/wrappers/wallet-panel-story-wrapper'
+
+import PendingSignatureRequestsPanel from './pending_signature_requests_panel'
+
+const storyContextProps: WalletPanelStoryProps = {
+  panelStateOverride: {
+    selectedPanel: 'signTransaction',
+    signTransactionRequests: [
+      mockSolDappSignTransactionRequest,
+      mockSolDappSignTransactionRequest
+    ],
+    signAllTransactionsRequests: [
+      mockSolDappSignAllTransactionsRequest,
+      mockSolDappSignAllTransactionsRequest
+    ]
+  },
+  walletApiDataOverrides: {
+    transactionInfos: [
+      deserializeTransaction(mockSolDappSignAndSendTransactionRequest),
+      deserializeTransaction({
+        ...mockSolDappSignAndSendTransactionRequest,
+        txStatus: BraveWallet.TransactionStatus.Unapproved
+      })
+    ]
+  },
+  uiStateOverride: {
+    selectedPendingTransactionId: mockSolDappSignAndSendTransactionRequest.id
+  }
+}
+
+export const _PendingSolanaSignAllRequestsPanel = () => {
+  return (
+    <WalletPanelStory {...storyContextProps}>
+      <PendingSignatureRequestsPanel signMode='signAllTxs' />
+    </WalletPanelStory>
+  )
+}
+
+_PendingSolanaSignAllRequestsPanel.story = {
+  name: 'Pending Solana Sign-All Signature Requests Panel'
+}
+
+export const _PendingSolanaTxSignaturesPanel = () => {
+  return (
+    <WalletPanelStory {...storyContextProps}>
+      <PendingSignatureRequestsPanel signMode='signTx' />
+    </WalletPanelStory>
+  )
+}
+
+_PendingSolanaTxSignaturesPanel.story = {
+  name: 'Pending Solana Transaction Signatures Panel'
+}
+
+export default {
+  parameters: {
+    layout: 'centered'
+  }
+}

--- a/components/brave_wallet_ui/components/extension/pending_signature_requests_panel/pending_signature_requests_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/pending_signature_requests_panel/pending_signature_requests_panel.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// Hooks
+import {
+  useSignSolanaTransactionsQueue //
+} from '../../../common/hooks/use_sign_solana_tx_queue'
+
+// Components
+import SignTransactionPanel from '../sign-panel/sign-transaction-panel'
+import { LoadingPanel } from '../loading_panel/loading_panel'
+
+interface Props {
+  signMode: 'signTx' | 'signAllTxs'
+}
+
+export const PendingSignatureRequestsPanel: React.FC<Props> = ({
+  signMode
+}) => {
+  // custom hooks
+  const {
+    isDisabled,
+    network,
+    queueLength,
+    queueNextSignTransaction,
+    queueNumber,
+    selectedQueueData,
+    signingAccount
+  } = useSignSolanaTransactionsQueue(signMode)
+
+  // render
+
+  // Loading/Fetching network
+  if (!network) {
+    return <LoadingPanel />
+  }
+
+  // Default (not simulated)
+  return (
+    <SignTransactionPanel
+      signMode={signMode}
+      isSigningDisabled={isDisabled}
+      network={network}
+      queueLength={queueLength}
+      queueNextSignTransaction={queueNextSignTransaction}
+      queueNumber={queueNumber}
+      selectedQueueData={selectedQueueData}
+      signingAccount={signingAccount}
+    />
+  )
+}
+
+export default PendingSignatureRequestsPanel

--- a/components/brave_wallet_ui/components/extension/pending_transaction_panel/pending_transaction_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/pending_transaction_panel/pending_transaction_panel.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// Types
+import {
+  BraveWallet,
+  SerializableTransactionInfo
+} from '../../../constants/types'
+
+// Components
+import { ConfirmSwapTransaction } from '../confirm-transaction-panel/swap'
+import {
+  ConfirmTransactionPanel //
+} from '../confirm-transaction-panel/confirm-transaction-panel'
+import { LoadingPanel } from '../loading_panel/loading_panel'
+
+interface Props {
+  selectedPendingTransaction: SerializableTransactionInfo
+}
+
+export const PendingTransactionPanel: React.FC<Props> = ({
+  selectedPendingTransaction
+}) => {
+  // render
+
+  // Loading/Fetching
+  if (!selectedPendingTransaction) {
+    return <LoadingPanel />
+  }
+
+  // Safer-Sign (Brave Swap)
+  if (
+    selectedPendingTransaction.txType === BraveWallet.TransactionType.ETHSwap
+  ) {
+    return <ConfirmSwapTransaction />
+  }
+
+  // Defaults
+  return <ConfirmTransactionPanel />
+}

--- a/components/brave_wallet_ui/components/extension/sign-panel/cow_swap_order.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/cow_swap_order.tsx
@@ -20,7 +20,7 @@ import {
   NetworkText,
   StyledWrapper,
   TopRow,
-  ButtonRow,
+  SignPanelButtonRow,
   HeaderTitle
 } from './style'
 import { WalletButton } from '../../shared/style'
@@ -188,7 +188,7 @@ export function SignCowSwapOrder(props: Props) {
         </TextButton>
       </NetworkFeeAndDetailsContainer>
 
-      <ButtonRow>
+      <SignPanelButtonRow>
         <NavButton
           buttonType='secondary'
           text={getLocale('braveWalletButtonCancel')}
@@ -201,7 +201,7 @@ export function SignCowSwapOrder(props: Props) {
           onSubmit={onSignIn}
           disabled={isDisabled}
         />
-      </ButtonRow>
+      </SignPanelButtonRow>
     </StyledWrapper>
   )
 }

--- a/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/index.tsx
@@ -39,7 +39,7 @@ import {
   PanelTitle,
   MessageBox,
   MessageText,
-  ButtonRow,
+  SignPanelButtonRow,
   WarningTitleRow
 } from './style'
 
@@ -306,7 +306,7 @@ export const SignPanel = (props: Props) => {
           )}
         </>
       )}
-      <ButtonRow>
+      <SignPanelButtonRow>
         <NavButton
           buttonType='secondary'
           text={getLocale('braveWalletButtonCancel')}
@@ -325,7 +325,7 @@ export const SignPanel = (props: Props) => {
           }
           disabled={isDisabled}
         />
-      </ButtonRow>
+      </SignPanelButtonRow>
     </StyledWrapper>
   )
 }

--- a/components/brave_wallet_ui/components/extension/sign-panel/sign-transaction-panel.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/sign-panel/sign-transaction-panel.stories.tsx
@@ -5,21 +5,34 @@
 
 import * as React from 'react'
 
+// types
+import { BraveWallet } from '../../../constants/types'
+
 // mocks
 import {
   mockSolDappSignAllTransactionsRequest,
   mockSolDappSignAndSendTransactionRequest,
   mockSolDappSignTransactionRequest
 } from '../../../common/constants/mocks'
+import {
+  mockSolanaMainnetNetwork //
+} from '../../../stories/mock-data/mock-networks'
+import {
+  mockSignMessageRequest //
+} from '../../../stories/mock-data/mock-eth-requests'
 
-// components
-import { WalletPanelStory } from '../../../stories/wrappers/wallet-panel-story-wrapper'
-import { SignTransactionPanel } from './sign-transaction-panel'
+// utils
 import { SignInWithEthereumError } from './sign_in_with_ethereum_error'
 import {
   deserializeTransaction //
 } from '../../../utils/model-serialization-utils'
-import { BraveWallet } from '../../../constants/types'
+
+// components
+import {
+  WalletPanelStory //
+} from '../../../stories/wrappers/wallet-panel-story-wrapper'
+import { SignTransactionPanel } from './sign-transaction-panel'
+import { SignInWithEthereum } from './sign_in_with_ethereum'
 
 export const _SignAllSolanaTxPanel = () => {
   return (
@@ -42,7 +55,17 @@ export const _SignAllSolanaTxPanel = () => {
         ]
       }}
     >
-      <SignTransactionPanel signMode={'signAllTxs'} />
+      <SignTransactionPanel
+        signMode={'signAllTxs'}
+        isSigningDisabled={false}
+        network={mockSolanaMainnetNetwork}
+        queueNextSignTransaction={function (): void {
+          throw new Error('Function not implemented.')
+        }}
+        selectedQueueData={mockSolDappSignAllTransactionsRequest}
+        queueLength={1}
+        queueNumber={0}
+      />
     </WalletPanelStory>
   )
 }
@@ -65,7 +88,17 @@ export const _SignSolanaTxPanel = () => {
         ]
       }}
     >
-      <SignTransactionPanel signMode='signTx' />
+      <SignTransactionPanel
+        signMode='signTx'
+        isSigningDisabled={false}
+        network={mockSolanaMainnetNetwork}
+        queueNextSignTransaction={function (): void {
+          throw new Error('Function not implemented.')
+        }}
+        selectedQueueData={mockSolDappSignTransactionRequest}
+        queueLength={1}
+        queueNumber={0}
+      />
     </WalletPanelStory>
   )
 }
@@ -84,6 +117,22 @@ export const _SignInWithEthereumError = () => {
 
 _SignInWithEthereumError.story = {
   name: 'Sign in with Ethereum Error Panel'
+}
+
+export const _SignInWithEthereum = () => {
+  return (
+    <WalletPanelStory>
+      <SignInWithEthereum
+        data={mockSignMessageRequest}
+        onCancel={() => {}}
+        onSignIn={() => {}}
+      />
+    </WalletPanelStory>
+  )
+}
+
+_SignInWithEthereum.story = {
+  name: 'Sign in with Ethereum Panel'
 }
 
 export default {

--- a/components/brave_wallet_ui/components/extension/sign-panel/style.ts
+++ b/components/brave_wallet_ui/components/extension/sign-panel/style.ts
@@ -110,7 +110,7 @@ export const MessageText = styled.span`
   white-space: pre-wrap;
 `
 
-export const ButtonRow = styled.div`
+export const SignPanelButtonRow = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -16,9 +16,6 @@ import {
   AllowAddChangeNetworkPanel //
 } from '../components/extension/allow-add-change-network-panel/index'
 import {
-  ConfirmTransactionPanel //
-} from '../components/extension/confirm-transaction-panel/confirm-transaction-panel'
-import {
   ConnectHardwareWalletPanel //
 } from '../components/extension/connect-hardware-wallet-panel/index'
 import {
@@ -38,8 +35,6 @@ import { PanelWrapper, WelcomePanelWrapper } from './style'
 
 import { BraveWallet } from '../constants/types'
 
-import { SignTransactionPanel } from '../components/extension/sign-panel/sign-transaction-panel'
-import { ConfirmSwapTransaction } from '../components/extension/confirm-transaction-panel/swap'
 import { TransactionStatus } from '../components/extension/post-confirmation'
 import {
   useSafePanelSelector,
@@ -63,6 +58,12 @@ import PageContainer from '../page/container'
 import {
   SignInWithEthereumError //
 } from '../components/extension/sign-panel/sign_in_with_ethereum_error'
+import {
+  PendingTransactionPanel //
+} from '../components/extension/pending_transaction_panel/pending_transaction_panel'
+import {
+  PendingSignatureRequestsPanel //
+} from '../components/extension/pending_signature_requests_panel/pending_signature_requests_panel'
 
 // Allow BigInts to be stringified
 ;(BigInt.prototype as any).toJSON = function () {
@@ -283,26 +284,18 @@ function Container() {
     )
   }
 
-  if (
-    selectedPendingTransaction?.txType === BraveWallet.TransactionType.ETHSwap
-  ) {
-    return (
-      <PanelWrapper isLonger={true}>
-        <LongWrapper>
-          <ConfirmSwapTransaction />
-        </LongWrapper>
-      </PanelWrapper>
-    )
-  }
-
   if (selectedPendingTransaction) {
+    const isSwap =
+      selectedPendingTransaction?.txType === BraveWallet.TransactionType.ETHSwap
     return (
       <PanelWrapper
-        width={390}
-        height={650}
+        width={isSwap ? undefined : 390}
+        height={isSwap ? 540 : 650}
       >
         <LongWrapper>
-          <ConfirmTransactionPanel />
+          <PendingTransactionPanel
+            selectedPendingTransaction={selectedPendingTransaction}
+          />
         </LongWrapper>
       </PanelWrapper>
     )
@@ -317,7 +310,7 @@ function Container() {
     return (
       <PanelWrapper isLonger={true}>
         <LongWrapper>
-          <SignTransactionPanel
+          <PendingSignatureRequestsPanel
             signMode={
               signAllTransactionsRequests.length ||
               selectedPanel === 'signAllTransactions'


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35515

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Transaction panels should continue to work without regressions (other than a new loading spinner possibly showing).
Try with eth send, sol send, eth swap, sol swap.

The primary purspose of this PR is to setup plumbing for the transaction simulations feature.
