### PR TITLE
bump adblock to 0.8.4 (uplift to 1.63.x)

### DIFF
--- a/third_party/rust/Cargo.lock
+++ b/third_party/rust/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "adblock"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "base64",
  "bitflags",

--- a/third_party/rust/adblock/v0_8/BUILD.gn
+++ b/third_party/rust/adblock/v0_8/BUILD.gn
@@ -45,7 +45,7 @@ cargo_crate("lib") {
   # Unit tests skipped. Generate with --with-tests to include them.
   build_native_rust_unit_tests = false
   edition = "2021"
-  cargo_pkg_version = "0.8.3"
+  cargo_pkg_version = "0.8.4"
   cargo_pkg_authors =
       "Andrius Aucinas <aaucinas@brave.com>, Anton Lazarev <alazarev@brave.com>"
   cargo_pkg_name = "adblock"

--- a/third_party/rust/adblock/v0_8/crate/Cargo.toml
+++ b/third_party/rust/adblock/v0_8/crate/Cargo.toml
@@ -12,7 +12,7 @@
 [package]
 edition = "2021"
 name = "adblock"
-version = "0.8.3"
+version = "0.8.4"
 authors = [
     "Andrius Aucinas <aaucinas@brave.com>",
     "Anton Lazarev <alazarev@brave.com>",

--- a/third_party/rust/adblock/v0_8/crate/src/blocker.rs
+++ b/third_party/rust/adblock/v0_8/crate/src/blocker.rs
@@ -800,6 +800,7 @@ impl NetworkFilterList {
             };
 
             optimized.append(&mut unoptimizable);
+            optimized.shrink_to_fit();
             optimized_map.insert(key, optimized);
         }
 

--- a/third_party/rust/third_party.toml
+++ b/third_party/rust/third_party.toml
@@ -239,7 +239,7 @@ if (is_mac) {
 '''
 
 [dependencies.adblock]
-version = "0.8.3"
+version = "0.8.4"
 default-features = false
 features = ["full-regex-handling", "regex-debug-info", "css-validation"]
 gn-variables-lib = '''


### PR DESCRIPTION
Uplift of #21705
Resolves https://github.com/brave/brave-browser/issues/35397

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.