### PR TITLE
feat(wallet): Center Nav and Body Together

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
@@ -7,7 +7,10 @@ import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import {
   layoutSmallWidth,
-  layoutTopPosition
+  layoutTopPosition,
+  maxCardWidth,
+  navWidth,
+  navSpace
 } from '../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const Wrapper = styled.div<{
@@ -27,10 +30,20 @@ export const Wrapper = styled.div<{
   border-radius: 16px;
   position: absolute;
   top: ${layoutTopPosition}px;
-  left: 32px;
+  /*
+    (100vw / 2) - (${navWidth}px / 2) makes the nav perfectly centered
+    horizontally in the browser window.
+
+    - (${maxCardWidth}px / 2) - (${navSpace}px / 2) is to then adjust the
+    nav to the left to be centered with the layout card body.
+  */
+  left: calc(
+    (100vw / 2) - (${navWidth}px / 2) - (${maxCardWidth}px / 2) -
+      (${navSpace}px / 2)
+  );
   overflow: visible;
   z-index: 10;
-  width: 240px;
+  width: ${navWidth}px;
   padding: 12px 0px;
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.07);
   @media screen and (max-width: ${layoutSmallWidth}px) {

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -8,12 +8,14 @@ import * as leo from '@brave/leo/tokens/css'
 import { Row } from '../../shared/style'
 
 const minCardHeight = 497
-const maxCardWidth = 768
-const layoutScaleWithNav = 1374
+export const maxCardWidth = 768
 const layoutSmallCardBottom = 67
-export const layoutSmallWidth = 980
+export const layoutSmallWidth = 1100
 export const layoutPanelWidth = 660
 export const layoutTopPosition = 68
+// navSpace and navWidth need to be defined here to prevent circular imports.
+export const navSpace = 24
+export const navWidth = 240
 
 export const Wrapper = styled.div<{
   noPadding?: boolean
@@ -48,10 +50,22 @@ export const LayoutCardWrapper = styled.div<{
       ? 'var(--no-header-top-position)'
       : 'var(--header-top-position)'};
   --bottom-position: ${(p) => (p.hideNav ? 0 : layoutSmallCardBottom)}px;
+  /*
+    (100vw / 2) - (${maxCardWidth}px / 2) makes the card body perfectly centered
+    horizontally in the browser window.
+  */
+  --left-padding-without-nav: calc((100vw / 2) - (${maxCardWidth}px / 2));
+  /*
+    + (${navWidth}px / 2) + (${navSpace}px / 2) is to then adjust the card body
+    to the right to be centered with the nav.
+  */
+  --left-padding-with-nav: calc(
+    var(--left-padding-without-nav) + (${navWidth}px / 2) + (${navSpace}px / 2)
+  );
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   top: var(--top-position);
   bottom: 0px;
   position: absolute;
@@ -62,10 +76,10 @@ export const LayoutCardWrapper = styled.div<{
   &::-webkit-scrollbar {
     display: none;
   }
-  @media screen and (max-width: ${layoutScaleWithNav}px) {
-    padding: 0px 32px 32px 304px;
-    align-items: flex-start;
-  }
+  padding-left: ${(p) =>
+    p.hideNav
+      ? 'var(--left-padding-without-nav)'
+      : 'var(--left-padding-with-nav)'};
   @media screen and (max-width: ${layoutSmallWidth}px) {
     bottom: var(--bottom-position);
     padding: 0px 32px 32px 32px;
@@ -78,7 +92,6 @@ export const LayoutCardWrapper = styled.div<{
 
 export const ContainerCard = styled.div<{
   noPadding?: boolean
-  maxWidth?: number
   hideCardHeader?: boolean
   noMinCardHeight?: boolean
   noBorderRadius?: boolean
@@ -99,10 +112,10 @@ export const ContainerCard = styled.div<{
   padding: ${(p) => (p.noPadding ? 0 : 20)}px;
   width: 100%;
   min-height: ${(p) => (p.noMinCardHeight ? 'unset' : `${minCardHeight}px`)};
-  max-width: ${(p) => (p.maxWidth ? p.maxWidth : maxCardWidth)}px;
+  max-width: ${maxCardWidth}px;
   position: relative;
   @media screen and (max-width: ${layoutSmallWidth}px) {
-    max-width: ${(p) => (p.maxWidth ? `${p.maxWidth}px` : 'unset')};
+    max-width: unset;
     width: 100%;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
@@ -117,28 +130,20 @@ export const ContainerCard = styled.div<{
 `
 
 export const CardHeaderWrapper = styled.div<{
-  maxWidth?: number
   isPanel?: boolean
 }>`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
-  align-items: center;
+  align-items: flex-start;
   top: var(--layout-top-position);
   position: fixed;
   width: 100%;
-  max-width: ${(p) => (p.maxWidth ? `${p.maxWidth}px` : 'unset')};
-  @media screen and (max-width: ${layoutScaleWithNav}px) {
-    padding: ${(p) => (p.maxWidth ? '0px' : '0px 32px 0px 304px')};
-    left: ${(p) => (p.maxWidth ? 'unset' : '0px')};
-    right: ${(p) => (p.maxWidth ? 'unset' : '0px')};
-    align-items: flex-start;
-  }
   @media screen and (max-width: ${layoutSmallWidth}px) {
     left: unset;
     right: unset;
     align-items: center;
-    padding: ${(p) => (p.maxWidth ? '0px' : '0px 32px')};
+    padding: 0px 32px;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
     padding: 0px;

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -45,7 +45,6 @@ import { loadTimeData } from '../../../../common/loadTimeData'
 
 export interface Props {
   wrapContentInBox?: boolean
-  cardWidth?: number
   noPadding?: boolean
   noCardPadding?: boolean
   hideBackground?: boolean
@@ -63,7 +62,6 @@ export interface Props {
 export const WalletPageWrapper = (props: Props) => {
   const {
     children,
-    cardWidth,
     noPadding,
     noCardPadding,
     wrapContentInBox,
@@ -176,17 +174,13 @@ export const WalletPageWrapper = (props: Props) => {
             hideNav={hideNav}
           >
             {cardHeader && !isPanel && (
-              <CardHeaderWrapper
-                maxWidth={cardWidth}
-                isPanel={isPanel}
-              >
+              <CardHeaderWrapper isPanel={isPanel}>
                 <CardHeaderShadow headerHeight={headerHeight} />
               </CardHeaderWrapper>
             )}
 
             <ContainerCard
               noPadding={noCardPadding}
-              maxWidth={cardWidth}
               hideCardHeader={!cardHeader}
               noMinCardHeight={noMinCardHeight}
               noBorderRadius={noBorderRadius}
@@ -198,7 +192,6 @@ export const WalletPageWrapper = (props: Props) => {
             {cardHeader && (
               <CardHeaderWrapper
                 ref={headerRef}
-                maxWidth={cardWidth}
                 isPanel={isPanel}
               >
                 <CardHeader

--- a/components/brave_wallet_ui/page/container.tsx
+++ b/components/brave_wallet_ui/page/container.tsx
@@ -161,7 +161,6 @@ export const Container = () => {
       >
         <WalletPageWrapper
           wrapContentInBox={true}
-          cardWidth={680}
           hideNav={true}
           hideHeaderMenu={true}
           noBorderRadius={true}

--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -129,7 +129,6 @@ export const DepositFundsScreen = ({ isAndroid }: Props) => {
           hideNav={isAndroid}
           hideHeader={isAndroid}
           wrapContentInBox={true}
-          cardWidth={456}
           cardHeader={
             <PageTitleHeader
               title={getLocale('braveWalletDepositCryptoButton')}
@@ -147,7 +146,6 @@ export const DepositFundsScreen = ({ isAndroid }: Props) => {
           hideNav={isAndroid}
           hideHeader={isAndroid}
           wrapContentInBox={true}
-          cardWidth={456}
           cardHeader={
             <PageTitleHeader
               title={getLocale('braveWalletDepositCryptoButton')}


### PR DESCRIPTION
## Description 
The Wallet `Nav` and `Card` body are now centered together on the `Wallet Page` and all page bodies now have the same fixed width.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/34471>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the Wallet `Page` view and visit every tab.
2. The `Nav` and `Card` body should be perfectly centered on the page.
3. Test scaling the Browser window, the `Nav` and `Card` body should stay perfectly centered together.

https://github.com/brave/brave-core/assets/40611140/d7af87ff-f353-428b-915f-931696996441
