### PR TITLE
Updated omnibox chip button's background color in light mode (uplift to 1.63.x)

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -242,6 +242,12 @@ void AddChromeLightThemeColorMixer(ui::ColorProvider* provider,
       ui::kColorFocusableBorderFocused};
   mixer[kColorTabFocusRingActive] = {ui::kColorFocusableBorderFocused};
   mixer[kColorTabFocusRingInactive] = {ui::kColorFocusableBorderFocused};
+
+  // Upstream uses tab's background color as omnibox chip background color.
+  // In our light mode, there is no difference between location bar's bg
+  // color and tab's bg color. So, it looks like chip's bg color is transparent.
+  // Use frame color as chip background to have different bg color.
+  mixer[kColorOmniboxChipBackground] = {kLightFrame};
 }
 
 void AddChromeDarkThemeColorMixer(ui::ColorProvider* provider,


### PR DESCRIPTION
Uplift of #21637
fix https://github.com/brave/brave-browser/issues/35358

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.