### PR TITLE
Fixed to have proper inkdrop size for browser actions

### DIFF
--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -39,11 +39,12 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
       return 24;
     }
     case LOCATION_BAR_HEIGHT:
+      // Consider adjust below element padding also when this height is changed.
       return 32;
     case LOCATION_BAR_TRAILING_ICON_SIZE:
       return 18;
     case LOCATION_BAR_ELEMENT_PADDING:
-      return 4;
+      return 2;
     default:
       break;
   }

--- a/browser/ui/views/brave_actions/brave_actions_container.cc
+++ b/browser/ui/views/brave_actions/brave_actions_container.cc
@@ -23,12 +23,6 @@
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/view.h"
 
-namespace {
-
-constexpr gfx::Size kToolbarActionSize(34, 30);
-
-}  // namespace
-
 BraveActionsContainer::BraveActionsContainer(Browser* browser, Profile* profile)
     : browser_(browser) {}
 
@@ -84,14 +78,14 @@ void BraveActionsContainer::AddActionViewForShields() {
       AddChildViewAt(std::make_unique<BraveShieldsActionView>(
                          *browser_->profile(), *browser_->tab_strip_model()),
                      1);
-  shields_action_btn_->SetPreferredSize(kToolbarActionSize);
+  shields_action_btn_->SetPreferredSize(GetActionSize());
   shields_action_btn_->Init();
 }
 
 void BraveActionsContainer::AddActionViewForRewards() {
   auto button = std::make_unique<BraveRewardsActionView>(browser_);
   rewards_action_btn_ = AddChildViewAt(std::move(button), 2);
-  rewards_action_btn_->SetPreferredSize(kToolbarActionSize);
+  rewards_action_btn_->SetPreferredSize(GetActionSize());
   rewards_action_btn_->SetVisible(ShouldShowBraveRewardsAction());
   rewards_action_btn_->Update();
 }
@@ -123,6 +117,11 @@ void BraveActionsContainer::UpdateVisibility() {
   // If no buttons are visible, then we want to hide this view so that the
   // separator is not displayed.
   SetVisible(!should_hide_ && can_show);
+}
+
+gfx::Size BraveActionsContainer::GetActionSize() const {
+  return {34, GetLayoutConstant(LOCATION_BAR_HEIGHT) -
+                  2 * GetLayoutConstant(LOCATION_BAR_ELEMENT_PADDING)};
 }
 
 void BraveActionsContainer::SetShouldHide(bool should_hide) {

--- a/browser/ui/views/brave_actions/brave_actions_container.h
+++ b/browser/ui/views/brave_actions/brave_actions_container.h
@@ -61,6 +61,7 @@ class BraveActionsContainer : public views::View {
   void AddActionViewForShields();
 
   void UpdateVisibility();
+  gfx::Size GetActionSize() const;
 
   // Brave Rewards preferences change observers callback.
   void OnBraveRewardsPreferencesChanged();

--- a/browser/ui/views/brave_actions/brave_rewards_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_rewards_action_view.cc
@@ -68,8 +68,8 @@ class ButtonHighlightPathGenerator : public views::HighlightPathGenerator {
     auto* layout_provider = ChromeLayoutProvider::Get();
     DCHECK(layout_provider);
 
-    int radius = layout_provider->GetCornerRadiusMetric(
-        views::Emphasis::kMaximum, rect.size());
+    int radius = layout_provider->GetCornerRadiusMetric(views::Emphasis::kHigh,
+                                                        rect.size());
 
     SkPath path;
     path.addRoundRect(gfx::RectToSkRect(rect), radius, radius);

--- a/browser/ui/views/brave_actions/brave_shields_action_view.cc
+++ b/browser/ui/views/brave_actions/brave_shields_action_view.cc
@@ -117,7 +117,7 @@ SkPath BraveShieldsActionView::GetHighlightPath() const {
   gfx::Rect rect(GetPreferredSize());
   rect.Inset(highlight_insets);
   const int radii = ChromeLayoutProvider::Get()->GetCornerRadiusMetric(
-      views::Emphasis::kMaximum, rect.size());
+      views::Emphasis::kHigh, rect.size());
   SkPath path;
   path.addRoundRect(gfx::RectToSkRect(rect), radii, radii);
   return path;

--- a/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_bar_view.cc
@@ -10,13 +10,13 @@
 #include "chrome/browser/ui/views/omnibox/omnibox_view_views.h"
 
 // |icon_left| - Padding between left border of location bar and first
-//               decoration. Use fixed 4px always.
+//               decoration. Use element padding.
 // |text_left| - Padding between omnibox view and last leading decoration.
 //               If last decoration has label, it has sufficient padding inside.
 //               If custom padding is provided(text_left is not null), respect
 //               it. Otherwise, set our design value - 5px.
 #define BRAVE_LAYOUT_LEADING_DECORATIONS                           \
-  icon_left = 4;                                                   \
+  icon_left = GetLayoutConstant(LOCATION_BAR_ELEMENT_PADDING);     \
   if (text_left == 0 && !location_icon_view_->ShouldShowLabel()) { \
     text_left = 5;                                                 \
   }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/35507

Actions button size should be adjusted based on location bar's height.
Also inkdrop highlight radius is aligned with other location bar's icon.
And item padding is reduced to give more space to buttons.

This PR's result with 32px location bar height and 2px item padding:
<img width="853" alt="image" src="https://github.com/brave/brave-core/assets/6786187/626fd631-997e-4412-841e-77ccf1dbfa16">

Belows are another result with different location bar height and item padding for just comparison and testing whether simply constant value change works well.
With 34px location bar height and 2px item padding:
<img width="856" alt="image" src="https://github.com/brave/brave-core/assets/6786187/0a24e97d-0a57-48d2-a0e2-1b67205934c3">

With 28px location bar height and 2px item padding:
<img width="852" alt="image" src="https://github.com/brave/brave-core/assets/6786187/5ff8bcff-47a8-402a-aec7-60897e5e9867">

With 36px location bar height and 4px item padding:
<img width="854" alt="image" src="https://github.com/brave/brave-core/assets/6786187/b2b81948-80b7-49af-a73a-faf0a24a7607">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

