### PR TITLE
chore: add transaction warnings components

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -45,6 +45,7 @@ inline constexpr char kSimpleHashBraveProxyUrl[] =
     "https://simplehash.wallet.brave.com";
 
 inline constexpr webui::LocalizedString kLocalizedStrings[] = {
+    {"braveWalletFoundRisks", IDS_BRAVE_WALLET_FOUND_RISKS},
     {"braveWalletTestNetworkAccount", IDS_BRAVE_WALLET_TEST_NETWORK_ACCOUNT},
     {"braveWalletPopular", IDS_BRAVE_WALLET_POPULAR},
     {"braveWalletFeatured", IDS_BRAVE_WALLET_FEATURED},

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/tx_warnings.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/tx_warnings.stories.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { TransactionWarnings } from './tx_warnings'
+import { BraveWallet } from '../../../../constants/types'
+// import { Column } from '../../../shared/style'
+
+const warnings: Array<
+  Pick<BraveWallet.BlowfishWarning, 'message' | 'severity'>
+> = [
+  {
+    message: 'An example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Additional example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Yet another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Yet another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Yet another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Yet another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Yet another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  },
+  {
+    message: 'Yet another example warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kWarning
+  }
+]
+
+const criticalWarnings: Array<
+  Pick<BraveWallet.BlowfishWarning, 'message' | 'severity'>
+> = [
+  {
+    message: 'An example critical warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kCritical
+  },
+  {
+    message: 'Another example critical warning',
+    severity: BraveWallet.BlowfishWarningSeverity.kCritical
+  }
+]
+
+export const _TxWarning = () => {
+  // state
+  const [isCollapsed, setIsCollapsed] = React.useState(false)
+  return (
+    <TransactionWarnings
+      isWarningCollapsed={isCollapsed}
+      setIsWarningCollapsed={setIsCollapsed}
+      warnings={[warnings[0]]}
+      onDismiss={() => alert('dismiss')}
+    />
+  )
+}
+
+export const _TxWarnings = () => {
+  // state
+  const [isCollapsed, setIsCollapsed] = React.useState(true)
+  return (
+    <TransactionWarnings
+      isWarningCollapsed={isCollapsed}
+      setIsWarningCollapsed={setIsCollapsed}
+      warnings={warnings}
+      onDismiss={() => alert('dismiss')}
+    />
+  )
+}
+
+export const _CriticalTxWarning = () => {
+  // state
+  const [isCollapsed, setIsCollapsed] = React.useState(false)
+  return (
+    <TransactionWarnings
+      isWarningCollapsed={isCollapsed}
+      setIsWarningCollapsed={setIsCollapsed}
+      warnings={[criticalWarnings[0]]}
+      onDismiss={() => alert('dismiss')}
+    />
+  )
+}
+
+export const _CriticalTxWarnings = () => {
+  // state
+  const [isCollapsed, setIsCollapsed] = React.useState(false)
+  return (
+    <TransactionWarnings
+      isWarningCollapsed={isCollapsed}
+      setIsWarningCollapsed={setIsCollapsed}
+      warnings={criticalWarnings}
+      onDismiss={() => alert('dismiss')}
+    />
+  )
+}
+
+export default _TxWarnings

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/tx_warnings.styles.ts
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/tx_warnings.styles.ts
@@ -1,0 +1,106 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css'
+
+import Button from '@brave/leo/react/button'
+import Icon from '@brave/leo/react/icon'
+import Collapse from '@brave/leo/react/collapse'
+
+// shared styles
+import { styledScrollbarMixin } from '../../../shared/style'
+
+interface WarningProps {
+  isCritical?: boolean
+}
+
+export const WarningCloseIcon = styled(Icon).attrs<WarningProps>({
+  name: 'close'
+})`
+  --leo-icon-size: 20px;
+`
+export const WarningButton = styled(Button)<WarningProps>`
+  --leo-button-color: ${(p) =>
+    p.isCritical
+      ? leo.color.systemfeedback.errorIcon
+      : leo.color.systemfeedback.warningIcon};
+`
+
+export const WarningCollapse = styled(Collapse)<WarningProps>`
+  --leo-collapse-summary-padding: 12px 16px;
+  --leo-collapse-content-padding: ${leo.spacing.m} ${leo.spacing['2Xl']};
+
+  --leo-collapse-radius: ${leo.radius.m};
+  --leo-collapse-shadow: none;
+  --leo-collapse-border-color: none;
+
+  --leo-collapse-background-color: ${(p) =>
+    p.isCritical
+      ? leo.color.systemfeedback.errorBackground
+      : leo.color.systemfeedback.warningBackground};
+
+  --leo-collapse-icon-color: ${(p) =>
+    p.isCritical
+      ? leo.color.systemfeedback.errorIcon
+      : leo.color.systemfeedback.warningIcon};
+
+  --leo-collapse-icon-color-hover: ${(p) =>
+    p.isCritical
+      ? leo.color.systemfeedback.errorIcon
+      : leo.color.systemfeedback.warningIcon};
+
+  @supports (color: color-mix(in srgb, transparent, transparent)) {
+    --leo-collapse-icon-color-hover: color-mix(
+      in srgb,
+      var(--leo-collapse-icon-color),
+      var(--leo-collapse-background-color) 50%
+    );
+  }
+
+  font: ${leo.font.small.semibold};
+
+  color: ${(p) =>
+    p.isCritical
+      ? leo.color.systemfeedback.errorText
+      : leo.color.systemfeedback.warningText};
+
+  & > * > li {
+    font: ${leo.font.small.regular};
+    margin-bottom: 8px;
+  }
+`
+
+export const WarningTitle = styled.span<WarningProps & { isBold?: boolean }>`
+  vertical-align: middle;
+  color: ${(p) =>
+    p.isCritical
+      ? leo.color.systemfeedback.errorText
+      : leo.color.systemfeedback.warningText};
+  font: ${(p) => (p.isBold ? leo.font.small.semibold : leo.font.small.regular)};
+`
+
+export const WarningsList = styled.ul`
+  margin: 0;
+  max-height: 230px;
+  overflow-y: scroll;
+  padding: 8px 12px;
+
+  ${styledScrollbarMixin}
+
+  & > li {
+    line-height: 18px;
+    margin-left: 2%;
+    margin-bottom: 14px;
+  }
+`
+
+export const DismissButton = styled(Button)`
+  flex-grow: 0;
+`
+
+export const FullWidth = styled.div`
+  min-width: 100%;
+`

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/tx_warnings.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/tx_warnings.tsx
@@ -1,0 +1,166 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Alert from '@brave/leo/react/alert'
+
+// types
+import { BraveWallet } from '../../../../constants/types'
+
+// utils
+import { getLocale } from '../../../../../common/locale'
+
+// styles
+import { Row } from '../../../shared/style'
+import {
+  WarningCollapse,
+  WarningTitle,
+  WarningsList,
+  WarningCloseIcon,
+  WarningButton,
+  DismissButton,
+  FullWidth
+} from './tx_warnings.styles'
+
+export function TxWarningBanner({
+  retrySimulation,
+  onDismiss,
+  isCritical,
+  children
+}: React.PropsWithChildren<{
+  retrySimulation?: (() => void) | (() => Promise<void>)
+  onDismiss?: (() => void) | (() => Promise<void>)
+  isCritical?: boolean
+}>) {
+  // render
+  return (
+    <FullWidth>
+      <Alert
+        type={isCritical ? 'error' : 'warning'}
+        mode='simple'
+      >
+        <div slot='icon'>{/* No Icon */}</div>
+
+        {retrySimulation ? (
+          <WarningTitle isCritical={isCritical}>
+            {getLocale('braveWalletTransactionPreviewFailed')}{' '}
+            <Button
+              kind='plain'
+              onClick={retrySimulation}
+            >
+              {getLocale('braveWalletButtonRetry')}
+            </Button>
+          </WarningTitle>
+        ) : (
+          <WarningTitle
+            isBold
+            isCritical={isCritical}
+          >
+            {children}
+          </WarningTitle>
+        )}
+
+        {onDismiss && (
+          <div slot='actions'>
+            <WarningButton
+              kind='plain'
+              onClick={onDismiss}
+              isCritical={isCritical}
+            >
+              <WarningCloseIcon />
+            </WarningButton>
+          </div>
+        )}
+      </Alert>
+    </FullWidth>
+  )
+}
+
+export function TransactionWarnings({
+  isWarningCollapsed,
+  setIsWarningCollapsed,
+  warnings,
+  onDismiss
+}: {
+  warnings: Array<Pick<BraveWallet.BlowfishWarning, 'message' | 'severity'>>
+  isWarningCollapsed: boolean
+  setIsWarningCollapsed?: React.Dispatch<React.SetStateAction<boolean>>
+  onDismiss?: (() => void) | (() => Promise<void>)
+}): JSX.Element | null {
+  // memos
+  const hasCriticalWarnings = warnings.some(
+    (warning) =>
+      warning.severity === BraveWallet.BlowfishWarningSeverity.kCritical
+  )
+
+  // no warnings
+  if (warnings.length < 1) {
+    return null
+  }
+
+  // 1 warning
+  if (warnings.length === 1) {
+    return (
+      <FullWidth>
+        <TxWarningBanner
+          isCritical={hasCriticalWarnings}
+          onDismiss={onDismiss}
+        >
+          {warnings[0].message}
+        </TxWarningBanner>
+      </FullWidth>
+    )
+  }
+
+  // multiple warnings
+  return (
+    <FullWidth>
+      <WarningCollapse
+        isOpen={!isWarningCollapsed}
+        isCritical={hasCriticalWarnings}
+        onToggle={
+          setIsWarningCollapsed
+            ? () => setIsWarningCollapsed((prev) => !prev)
+            : undefined
+        }
+      >
+        <WarningTitle
+          slot='title'
+          isCritical={hasCriticalWarnings}
+          isBold
+        >
+          {getLocale('braveWalletFoundRisks').replace(
+            '$1',
+            warnings.length.toString()
+          )}
+        </WarningTitle>
+
+        <div>
+          <WarningsList>
+            {warnings.map((warning) => (
+              <li key={warning.message}>{warning.message}</li>
+            ))}
+          </WarningsList>
+
+          {onDismiss && (
+            <Row
+              alignItems='flex-start'
+              justifyContent='flex-start'
+              minWidth={'100%'}
+            >
+              <DismissButton
+                kind='plain'
+                onClick={onDismiss}
+              >
+                {getLocale('braveWalletDismissButton')}
+              </DismissButton>
+            </Row>
+          )}
+        </div>
+      </WarningCollapse>
+    </FullWidth>
+  )
+}

--- a/components/brave_wallet_ui/components/shared/style.tsx
+++ b/components/brave_wallet_ui/components/shared/style.tsx
@@ -93,6 +93,36 @@ export const walletButtonFocusMixin = css`
   }
 `
 
+/**
+ * Also forces the scroll indicator to be visible on MacOS when present,
+ * even when the element is not hovered
+ */
+export const styledScrollbarMixin = css`
+  ::-webkit-scrollbar {
+    appearance: none;
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-scrollbar:vertical {
+    width: 7px;
+  }
+
+  ::-webkit-scrollbar:horizontal {
+    height: 7px;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0 1px rgba(255, 255, 255, 0.5);
+  }
+
+  ::-webkit-scrollbar-track {
+    background-color: none;
+    border-radius: 8px;
+  }
+`
+
 export const backgroundColorMixin = css<{
   color?: ThemeColor
 }>`
@@ -106,10 +136,12 @@ export const backgroundColorMixin = css<{
 export const Row = styled.div<
   FlexProps & {
     maxWidth?: CSSProperties['maxWidth']
+    minWidth?: CSSProperties['minWidth']
     margin?: number | string
     padding?: number | string
     width?: '100%' | 'unset'
     marginBottom?: number | string
+    // https://styled-components.com/docs/api#transient-props
     $wrap?: boolean
   }
 >`
@@ -122,6 +154,7 @@ export const Row = styled.div<
   justify-content: ${(p) => p.justifyContent ?? 'center'};
   gap: ${(p) => p.gap ?? 'unset'};
   width: ${(p) => p.width ?? '100%'};
+  min-width: ${(p) => p.minWidth ?? 'unset'};
   max-width: ${(p) => p.maxWidth ?? 'unset'};
   margin: ${(p) => p.margin ?? 'unset'};
   ${(p) =>

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1096,6 +1096,7 @@ provideStrings({
   // Warnings
   braveWalletNonAsciiCharactersInMessageWarning:
     'Non-ASCII characters detected!',
+  braveWalletFoundRisks: 'We found $1 risks.',
 
   // ASCII toggles
   braveWalletViewEncodedMessage: 'View original message',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1024,4 +1024,5 @@
   <message name="IDS_BRAVE_WALLET_PENDING_BALANCE_DESCRIPTION" desc="Available balance tooltip description">A pending change in your wallet balance.</message>
   <message name="IDS_BRAVE_WALLET_TOTAL_BALANCE_DESCRIPTION" desc="Total balance tooltip description">Your available funds plus any not-yet-confirmed transactions.</message>
   <message name="IDS_BRAVE_WALLET_UNAVAILABLE_BALANCES" desc="Some balances may be unavailable info bar">Some balances may be unavailable</message>
+  <message name="IDS_BRAVE_WALLET_FOUND_RISKS" desc="Notice that a number of risks were found">We found <ph name="VALUE">$1<ex>2</ex></ph> risks.</message>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35538

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
N/A: prep-work for transaction simulations feature. Storybook should build without errors.

![Screenshot 2024-01-24 at 11 44 30 AM](https://github.com/brave/brave-core/assets/30185185/108e613e-bafb-431e-a8a7-b7d5d55067a7)
![Screenshot 2024-01-24 at 11 44 41 AM](https://github.com/brave/brave-core/assets/30185185/d0d306b7-d8b1-4236-8df9-9a353189c9e3)
![Screenshot 2024-01-24 at 11 44 49 AM](https://github.com/brave/brave-core/assets/30185185/039570d2-aba1-462f-a9dc-9fbfd48e3a4c)
![Screenshot 2024-01-24 at 11 44 56 AM](https://github.com/brave/brave-core/assets/30185185/c74f9dac-1a62-47ae-9360-e12a22def43c)

