### PR TITLE
UX improvements for self-custody linking

### DIFF
--- a/browser/ui/webui/brave_rewards/tip_panel_ui.cc
+++ b/browser/ui/webui/brave_rewards/tip_panel_ui.cc
@@ -65,7 +65,8 @@ static constexpr webui::LocalizedString kStrings[] = {
     {"selfCustodyHeader", IDS_REWARDS_TIP_SELF_CUSTODY_HEADER},
     {"selfCustodyText", IDS_REWARDS_TIP_SELF_CUSTODY_TEXT},
     {"selfCustodySendButtonLabel",
-     IDS_REWARDS_TIP_SELF_CUSTODY_SEND_BUTTON_LABEL}};
+     IDS_REWARDS_TIP_SELF_CUSTODY_SEND_BUTTON_LABEL},
+    {"selfCustodyNoWeb3Label", IDS_REWARDS_TIP_SELF_CUSTODY_NO_WEB3_LABEL}};
 
 }  // namespace
 

--- a/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
@@ -8,7 +8,13 @@ import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 
 import { LocaleContext, formatMessage } from '../../lib/locale_context'
-import { ExternalWallet, getExternalWalletProviderName } from '../../lib/external_wallet'
+
+import {
+  ExternalWallet,
+  getExternalWalletProviderName,
+  isSelfCustodyProvider
+} from '../../lib/external_wallet'
+
 import { ProviderPayoutStatus } from '../../lib/provider_payout_status'
 import { UserType } from '../../lib/user_type'
 import { Optional } from '../../../shared/lib/optional'
@@ -62,6 +68,10 @@ export function WalletCard (props: Props) {
 
   const walletDisconnected =
     externalWallet && externalWallet.status === mojom.WalletStatus.kLoggedOut
+
+  // The contribution summary is not currently shown for self-custody users.
+  const showSummary = props.showSummary &&
+    (!externalWallet || !isSelfCustodyProvider(externalWallet.provider))
 
   function renderBalance () {
     if (externalWallet && walletDisconnected) {
@@ -118,7 +128,7 @@ export function WalletCard (props: Props) {
   }
 
   return (
-    <style.root className={props.showSummary ? 'show-summary' : ''}>
+    <style.root className={showSummary ? 'show-summary' : ''}>
       <style.statusPanel>
         <style.statusIndicator>
           <ExternalWalletView
@@ -176,7 +186,7 @@ export function WalletCard (props: Props) {
       </style.statusPanel>
       {renderBalance()}
       {
-        props.showSummary
+        showSummary
           ? <style.summaryBox>
               <RewardsSummary
                 data={props.summaryData}

--- a/components/brave_rewards/resources/tip_panel/components/tip_form.style.ts
+++ b/components/brave_rewards/resources/tip_panel/components/tip_form.style.ts
@@ -27,6 +27,8 @@ import * as mixins from '../lib/button_mixins'
 export const root = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  min-height: 400px;
   gap: 24px;
 
   --form-background-url: url(${formBackgroundURL});

--- a/components/brave_rewards/resources/tip_panel/components/tip_form.tsx
+++ b/components/brave_rewards/resources/tip_panel/components/tip_form.tsx
@@ -38,6 +38,10 @@ export function TipForm () {
 
   const insufficientBalance = state.rewardsUser.balance.valueOr(0) < sendAmount
 
+  const isSelfCustodyUser =
+    state.rewardsUser.walletProvider &&
+    isSelfCustodyProvider(state.rewardsUser.walletProvider)
+
   function sendButtonDisabled () {
     return sendAmount <= 0 || insufficientBalance || sendStatus === 'pending'
   }
@@ -118,6 +122,17 @@ export function TipForm () {
   let needsReconnect = false
 
   function renderInfo () {
+    if (isSelfCustodyUser && !state.creatorBanner.web3Url) {
+      showBalance = false
+      return (
+        <InfoBox title={getString('providerMismatchTitle')}>
+          <div>
+            {getString('selfCustodyNoWeb3Label')}
+          </div>
+        </InfoBox>
+      )
+    }
+
     // If the user does not have a wallet provider, then for simplicity assume
     // that this is a legacy "unconnected" user. A 2.5 or later user that is
     // unconnected should never be shown this UI, but if somehow they are it
@@ -226,10 +241,6 @@ export function TipForm () {
       </style.root>
     )
   }
-
-  const isSelfCustodyUser =
-    state.rewardsUser.walletProvider &&
-    isSelfCustodyProvider(state.rewardsUser.walletProvider)
 
   if (isSelfCustodyUser && state.creatorBanner.web3Url) {
     return (

--- a/components/brave_rewards/resources/tip_panel/lib/locale_strings.ts
+++ b/components/brave_rewards/resources/tip_panel/lib/locale_strings.ts
@@ -47,7 +47,8 @@ export const localeStrings = {
   selfCustodyTitle: 'Support your favorite creators',
   selfCustodyHeader: 'Show your love and send a token of your gratitude',
   selfCustodyText: 'Use your Web3 wallet to send a one time contribution to this creator and show them your appreciation',
-  selfCustodySendButtonLabel: 'Send with Web3 wallet'
+  selfCustodySendButtonLabel: 'Send with Web3 wallet',
+  selfCustodyNoWeb3Label: 'It looks like this creator isn\'t set up to receive contributions via Web3 wallets yet.'
 }
 
 export type StringKey = keyof typeof localeStrings

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -549,5 +549,8 @@
   <message name="IDS_REWARDS_TIP_SELF_CUSTODY_SEND_BUTTON_LABEL" desc="">
     Send with Web3 wallet
   </message>
+  <message name="IDS_REWARDS_TIP_SELF_CUSTODY_NO_WEB3_LABEL" desc="">
+    It looks like this creator isn't set up to receive contributions via Web3 wallets yet.
+  </message>
 
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35553
Resolves https://github.com/brave/brave-browser/issues/35498

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:


<img width="1171" alt="Screenshot 2024-01-24 at 3 57 58 PM" src="https://github.com/brave/brave-core/assets/5995084/c37c0fc7-5a14-4525-aed7-5fd79e1db3f1">

<img width="1476" alt="Screenshot 2024-01-24 at 3 58 30 PM" src="https://github.com/brave/brave-core/assets/5995084/1c8406bd-9734-45ca-a6dd-68b1c3415f63">

<img width="439" alt="Screenshot 2024-01-24 at 3 58 42 PM" src="https://github.com/brave/brave-core/assets/5995084/d4bb41e0-5370-4166-9e1f-60b4a3bda227">



