### PR TITLE
Fixed add button is not activated when reading list panel is opened

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -201,6 +201,8 @@ source_set("ui") {
       "webui/settings/default_brave_shields_handler.h",
       "webui/settings/settings_cookies_view_handler.cc",
       "webui/settings/settings_cookies_view_handler.h",
+      "webui/side_panel/reading_list/brave_reading_list_page_handler.cc",
+      "webui/side_panel/reading_list/brave_reading_list_page_handler.h",
       "webui/speedreader/speedreader_toolbar_data_handler_impl.cc",
       "webui/speedreader/speedreader_toolbar_data_handler_impl.h",
       "webui/speedreader/speedreader_toolbar_ui.cc",
@@ -215,6 +217,9 @@ source_set("ui") {
       "whats_new/whats_new_util.cc",
       "whats_new/whats_new_util.h",
     ]
+
+    deps +=
+        [ "//chrome/browser/ui/webui/side_panel/reading_list:mojo_bindings" ]
 
     if (enable_request_otr) {
       deps += [

--- a/browser/ui/webui/side_panel/reading_list/brave_reading_list_page_handler.cc
+++ b/browser/ui/webui/side_panel/reading_list/brave_reading_list_page_handler.cc
@@ -1,0 +1,39 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/webui/side_panel/reading_list/brave_reading_list_page_handler.h"
+
+#include <utility>
+
+#include "content/public/browser/web_ui.h"
+
+BraveReadingListPageHandler::BraveReadingListPageHandler(
+    mojo::PendingReceiver<reading_list::mojom::PageHandler> receiver,
+    mojo::PendingRemote<reading_list::mojom::Page> page,
+    ReadingListUI* reading_list_ui,
+    content::WebUI* web_ui)
+    : ReadingListPageHandler(std::move(receiver),
+                             std::move(page),
+                             reading_list_ui,
+                             web_ui),
+      WebContentsObserver(web_ui->GetWebContents()) {}
+
+BraveReadingListPageHandler::~BraveReadingListPageHandler() = default;
+
+void BraveReadingListPageHandler::OnVisibilityChanged(
+    content::Visibility visibility) {
+  if (visibility == content::Visibility::VISIBLE) {
+    // As we have our own panel open/closing logic,
+    // UpdateCurrentPageActionButton() could be called before web contents is
+    // not visible during the initialization. UpdateCurrentPageActionButton()
+    // does early return when web contents is not visible. Because of this,
+    // panel can't get proper initial button state. Need to make sure that it
+    // should be called once when web contents is visible after panel is opened.
+    // After that, upstream code will update properly for relavant events such
+    // as tab change and etc.
+    Observe(nullptr);
+    UpdateCurrentPageActionButton();
+  }
+}

--- a/browser/ui/webui/side_panel/reading_list/brave_reading_list_page_handler.h
+++ b/browser/ui/webui/side_panel/reading_list/brave_reading_list_page_handler.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_SIDE_PANEL_READING_LIST_BRAVE_READING_LIST_PAGE_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_SIDE_PANEL_READING_LIST_BRAVE_READING_LIST_PAGE_HANDLER_H_
+
+#include "chrome/browser/ui/webui/side_panel/reading_list/reading_list.mojom.h"
+#include "chrome/browser/ui/webui/side_panel/reading_list/reading_list_page_handler.h"
+#include "content/public/browser/visibility.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+class ReadingListUI;
+
+class BraveReadingListPageHandler : public ReadingListPageHandler,
+                                    public content::WebContentsObserver {
+ public:
+  BraveReadingListPageHandler(
+      mojo::PendingReceiver<reading_list::mojom::PageHandler> receiver,
+      mojo::PendingRemote<reading_list::mojom::Page> page,
+      ReadingListUI* reading_list_ui,
+      content::WebUI* web_ui);
+  ~BraveReadingListPageHandler() override;
+
+  // content::WebContentsObserver overrides:
+  void OnVisibilityChanged(content::Visibility visibility) override;
+};
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_SIDE_PANEL_READING_LIST_BRAVE_READING_LIST_PAGE_HANDLER_H_

--- a/chromium_src/chrome/browser/ui/webui/side_panel/reading_list/reading_list_page_handler.h
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/reading_list/reading_list_page_handler.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_READING_LIST_READING_LIST_PAGE_HANDLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_READING_LIST_READING_LIST_PAGE_HANDLER_H_
+
+#define UpdateCurrentPageActionButton       \
+  UpdateCurrentPageActionButton_UnUsed() {} \
+  friend class BraveReadingListPageHandler; \
+  void UpdateCurrentPageActionButton
+
+#include "src/chrome/browser/ui/webui/side_panel/reading_list/reading_list_page_handler.h"  // IWYU pragma: export
+
+#undef UpdateCurrentPageActionButton
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_SIDE_PANEL_READING_LIST_READING_LIST_PAGE_HANDLER_H_

--- a/chromium_src/chrome/browser/ui/webui/side_panel/reading_list/reading_list_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/side_panel/reading_list/reading_list_ui.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/webui/side_panel/reading_list/reading_list_ui.h"
+
+#include "brave/browser/ui/webui/side_panel/reading_list/brave_reading_list_page_handler.h"
+
+#define ReadingListPageHandler BraveReadingListPageHandler
+
+#include "src/chrome/browser/ui/webui/side_panel/reading_list/reading_list_ui.cc"
+
+#undef ReadingListPageHandler


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/35421

As we have our own panel open/closing logic, UpdateCurrentPageActionButton() could be called before web contents is not visible during the initialization. UpdateCurrentPageActionButton() does early return when web contents is not visible. Because of this, panel can't get proper initial button state. Need to make sure that it should be called once when web contents is visible after panel is opened. After that, upstream code will update properly for relavant events such as tab change and etc.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.