### PR TITLE
UX improvements for self-custody linking (uplift to 1.63.x)

### DIFF
--- a/browser/ui/webui/brave_rewards/tip_panel_ui.cc
+++ b/browser/ui/webui/brave_rewards/tip_panel_ui.cc
@@ -65,7 +65,8 @@ static constexpr webui::LocalizedString kStrings[] = {
     {"selfCustodyHeader", IDS_REWARDS_TIP_SELF_CUSTODY_HEADER},
     {"selfCustodyText", IDS_REWARDS_TIP_SELF_CUSTODY_TEXT},
     {"selfCustodySendButtonLabel",
-     IDS_REWARDS_TIP_SELF_CUSTODY_SEND_BUTTON_LABEL}};
+     IDS_REWARDS_TIP_SELF_CUSTODY_SEND_BUTTON_LABEL},
+    {"selfCustodyNoWeb3Label", IDS_REWARDS_TIP_SELF_CUSTODY_NO_WEB3_LABEL}};
 
 }  // namespace
 

--- a/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
+++ b/components/brave_rewards/resources/shared/components/wallet_card/wallet_card.tsx
@@ -8,7 +8,13 @@ import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 
 import { LocaleContext, formatMessage } from '../../lib/locale_context'
-import { ExternalWallet, getExternalWalletProviderName } from '../../lib/external_wallet'
+
+import {
+  ExternalWallet,
+  getExternalWalletProviderName,
+  isSelfCustodyProvider
+} from '../../lib/external_wallet'
+
 import { ProviderPayoutStatus } from '../../lib/provider_payout_status'
 import { UserType } from '../../lib/user_type'
 import { Optional } from '../../../shared/lib/optional'
@@ -62,6 +68,10 @@ export function WalletCard (props: Props) {
 
   const walletDisconnected =
     externalWallet && externalWallet.status === mojom.WalletStatus.kLoggedOut
+
+  // The contribution summary is not currently shown for self-custody users.
+  const showSummary = props.showSummary &&
+    (!externalWallet || !isSelfCustodyProvider(externalWallet.provider))
 
   function renderBalance () {
     if (externalWallet && walletDisconnected) {
@@ -118,7 +128,7 @@ export function WalletCard (props: Props) {
   }
 
   return (
-    <style.root className={props.showSummary ? 'show-summary' : ''}>
+    <style.root className={showSummary ? 'show-summary' : ''}>
       <style.statusPanel>
         <style.statusIndicator>
           <ExternalWalletView
@@ -176,7 +186,7 @@ export function WalletCard (props: Props) {
       </style.statusPanel>
       {renderBalance()}
       {
-        props.showSummary
+        showSummary
           ? <style.summaryBox>
               <RewardsSummary
                 data={props.summaryData}

--- a/components/brave_rewards/resources/tip_panel/components/tip_form.style.ts
+++ b/components/brave_rewards/resources/tip_panel/components/tip_form.style.ts
@@ -27,6 +27,8 @@ import * as mixins from '../lib/button_mixins'
 export const root = styled.div`
   display: flex;
   flex-direction: column;
+  justify-content: center;
+  min-height: 400px;
   gap: 24px;
 
   --form-background-url: url(${formBackgroundURL});

--- a/components/brave_rewards/resources/tip_panel/components/tip_form.tsx
+++ b/components/brave_rewards/resources/tip_panel/components/tip_form.tsx
@@ -38,6 +38,10 @@ export function TipForm () {
 
   const insufficientBalance = state.rewardsUser.balance.valueOr(0) < sendAmount
 
+  const isSelfCustodyUser =
+    state.rewardsUser.walletProvider &&
+    isSelfCustodyProvider(state.rewardsUser.walletProvider)
+
   function sendButtonDisabled () {
     return sendAmount <= 0 || insufficientBalance || sendStatus === 'pending'
   }
@@ -118,6 +122,17 @@ export function TipForm () {
   let needsReconnect = false
 
   function renderInfo () {
+    if (isSelfCustodyUser && !state.creatorBanner.web3Url) {
+      showBalance = false
+      return (
+        <InfoBox title={getString('providerMismatchTitle')}>
+          <div>
+            {getString('selfCustodyNoWeb3Label')}
+          </div>
+        </InfoBox>
+      )
+    }
+
     // If the user does not have a wallet provider, then for simplicity assume
     // that this is a legacy "unconnected" user. A 2.5 or later user that is
     // unconnected should never be shown this UI, but if somehow they are it
@@ -226,10 +241,6 @@ export function TipForm () {
       </style.root>
     )
   }
-
-  const isSelfCustodyUser =
-    state.rewardsUser.walletProvider &&
-    isSelfCustodyProvider(state.rewardsUser.walletProvider)
 
   if (isSelfCustodyUser && state.creatorBanner.web3Url) {
     return (

--- a/components/brave_rewards/resources/tip_panel/lib/locale_strings.ts
+++ b/components/brave_rewards/resources/tip_panel/lib/locale_strings.ts
@@ -47,7 +47,8 @@ export const localeStrings = {
   selfCustodyTitle: 'Support your favorite creators',
   selfCustodyHeader: 'Show your love and send a token of your gratitude',
   selfCustodyText: 'Use your Web3 wallet to send a one time contribution to this creator and show them your appreciation',
-  selfCustodySendButtonLabel: 'Send with Web3 wallet'
+  selfCustodySendButtonLabel: 'Send with Web3 wallet',
+  selfCustodyNoWeb3Label: 'It looks like this creator isn\'t set up to receive contributions via Web3 wallets yet.'
 }
 
 export type StringKey = keyof typeof localeStrings

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -549,5 +549,8 @@
   <message name="IDS_REWARDS_TIP_SELF_CUSTODY_SEND_BUTTON_LABEL" desc="">
     Send with Web3 wallet
   </message>
+  <message name="IDS_REWARDS_TIP_SELF_CUSTODY_NO_WEB3_LABEL" desc="">
+    It looks like this creator isn't set up to receive contributions via Web3 wallets yet.
+  </message>
 
 </grit-part>


### PR DESCRIPTION
Uplift of #21738
Resolves https://github.com/brave/brave-browser/issues/35553
Resolves https://github.com/brave/brave-browser/issues/35498

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.