### PR TITLE
[ads] Unify iOS kBraveNTPBrandedWallpaper

### DIFF
--- a/components/ntp_background_images/browser/features.h
+++ b/components/ntp_background_images/browser/features.h
@@ -8,6 +8,7 @@
 
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/time/time.h"
 
 namespace ntp_background_images {
 namespace features {
@@ -20,11 +21,11 @@ BASE_DECLARE_FEATURE(kBraveNTPBrandedWallpaper);
 
 // Show initial branded wallpaper after nth new tab page for fresh opens.
 inline constexpr base::FeatureParam<int> kInitialCountToBrandedWallpaper{
-    &kBraveNTPBrandedWallpaper, "initial_count_to_branded_wallpaper", 1};
+    &kBraveNTPBrandedWallpaper, "initial_count_to_branded_wallpaper", 2};
 
 // Show branded wallpaper every nth new tab page.
 inline constexpr base::FeatureParam<int> kCountToBrandedWallpaper{
-    &kBraveNTPBrandedWallpaper, "count_to_branded_wallpaper", 2};
+    &kBraveNTPBrandedWallpaper, "count_to_branded_wallpaper", 3};
 
 // Reset counter when a specific amount of time has elapsed in SI mode.
 inline constexpr base::FeatureParam<base::TimeDelta> kResetCounterAfter{

--- a/components/ntp_background_images/browser/view_counter_model.cc
+++ b/components/ntp_background_images/browser/view_counter_model.cc
@@ -19,7 +19,8 @@ ViewCounterModel::ViewCounterModel(PrefService* prefs) : prefs_(prefs) {
 
   // When browser is restarted we reset to "initial" count. This will also get
   // set again in the Reset() function, called e.g. when component is updated.
-  count_to_branded_wallpaper_ = features::kInitialCountToBrandedWallpaper.Get();
+  count_to_branded_wallpaper_ =
+      features::kInitialCountToBrandedWallpaper.Get() - 1;
 
   // We also reset when a specific amount of time is elapsed when in SI mode
   timer_counts_reset_.Start(FROM_HERE, features::kResetCounterAfter.Get(), this,
@@ -97,7 +98,7 @@ void ViewCounterModel::RegisterPageViewForBrandedImages() {
   count_to_branded_wallpaper_--;
   if (count_to_branded_wallpaper_ < 0) {
     // Reset count and randomize image index for next time.
-    count_to_branded_wallpaper_ = features::kCountToBrandedWallpaper.Get();
+    count_to_branded_wallpaper_ = features::kCountToBrandedWallpaper.Get() - 1;
 
     // Randomize SI campaign branded image index for next time.
     campaigns_current_branded_image_index_[current_campaign_index_] =
@@ -152,7 +153,7 @@ void ViewCounterModel::MaybeResetBrandedWallpaperCount() {
   if (!always_show_branded_wallpaper_ && show_branded_wallpaper_) {
     count_to_branded_wallpaper_ =
         std::min(count_to_branded_wallpaper_,
-                 features::kInitialCountToBrandedWallpaper.Get());
+                 features::kInitialCountToBrandedWallpaper.Get() - 1);
   }
 }
 

--- a/components/ntp_background_images/browser/view_counter_model_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_model_unittest.cc
@@ -31,8 +31,8 @@ class ViewCounterModelTest : public testing::Test {
 
     base::FieldTrialParams parameters;
     std::vector<base::test::FeatureRefAndParams> enabled_features;
-    parameters[features::kInitialCountToBrandedWallpaper.name] = "1";
-    parameters[features::kCountToBrandedWallpaper.name] = "3";
+    parameters[features::kInitialCountToBrandedWallpaper.name] = "2";
+    parameters[features::kCountToBrandedWallpaper.name] = "4";
     enabled_features.emplace_back(features::kBraveNTPBrandedWallpaper,
                                   parameters);
     feature_list_.InitWithFeaturesAndParameters(enabled_features, {});
@@ -62,7 +62,8 @@ TEST_F(ViewCounterModelTest, NTPSponsoredImagesTest) {
   EXPECT_FALSE(model.always_show_branded_wallpaper_);
 
   // Loading initial count times.
-  for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get(); ++i) {
+  for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
+       ++i) {
     EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
     model.RegisterPageView();
   }
@@ -83,7 +84,7 @@ TEST_F(ViewCounterModelTest, NTPSponsoredImagesTest) {
     model.RegisterPageView();
 
     // Loading regular-count times.
-    for (int j = 0; j < features::kCountToBrandedWallpaper.Get(); ++j) {
+    for (int j = 0; j < features::kCountToBrandedWallpaper.Get() - 1; ++j) {
       EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
       model.RegisterPageView();
     }
@@ -116,7 +117,7 @@ TEST_F(ViewCounterModelTest, NTPSponsoredImagesCountToBrandedWallpaperTest) {
 
   // Loading regular-count times from kCountToBrandedWallpaper to 0 and do not
   // show branded wallpaper.
-  for (int i = 0; i < features::kCountToBrandedWallpaper.Get(); ++i) {
+  for (int i = 0; i < features::kCountToBrandedWallpaper.Get() - 1; ++i) {
     EXPECT_FALSE(model.ShouldShowBrandedWallpaper());
     model.RegisterPageView();
   }
@@ -183,7 +184,8 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
   model.set_total_image_count(kTestImageCount);
 
   // Loading initial count times.
-  for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get(); ++i) {
+  for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
+       ++i) {
     EXPECT_EQ(i, model.current_wallpaper_image_index());
     model.RegisterPageView();
   }
@@ -193,9 +195,9 @@ TEST_F(ViewCounterModelTest, NTPBackgroundImagesTest) {
 
   // Loading regular-count times.
   int expected_wallpaper_index;
-  for (int i = 0; i < features::kCountToBrandedWallpaper.Get(); ++i) {
+  for (int i = 0; i < features::kCountToBrandedWallpaper.Get() - 1; ++i) {
     expected_wallpaper_index =
-        (i + features::kInitialCountToBrandedWallpaper.Get()) %
+        (i + (features::kInitialCountToBrandedWallpaper.Get() - 1)) %
         model.total_image_count_;
     EXPECT_EQ(expected_wallpaper_index, model.current_wallpaper_image_index());
     model.RegisterPageView();
@@ -294,7 +296,8 @@ TEST_F(ViewCounterModelTest, NTPFailedToLoadSponsoredImagesTest) {
   model.set_total_image_count(kTestImageCount);
 
   // Loading initial count model.
-  for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get(); ++i) {
+  for (int i = 0; i < features::kInitialCountToBrandedWallpaper.Get() - 1;
+       ++i) {
     EXPECT_EQ(i, model.current_wallpaper_image_index());
     model.RegisterPageView();
   }

--- a/components/ntp_background_images/browser/view_counter_service_unittest.cc
+++ b/components/ntp_background_images/browser/view_counter_service_unittest.cc
@@ -232,7 +232,7 @@ class NTPBackgroundImagesViewCounterTest : public testing::Test {
   }
 
   int GetInitialCountToBrandedWallpaper() const {
-    return features::kInitialCountToBrandedWallpaper.Get();
+    return features::kInitialCountToBrandedWallpaper.Get() - 1;
   }
 
   std::optional<base::Value::Dict> TryGetFirstSponsoredImageWallpaper() {
@@ -360,7 +360,7 @@ TEST_F(NTPBackgroundImagesViewCounterTest, IsActiveOptedIn) {
 TEST_F(NTPBackgroundImagesViewCounterTest, PrefsWithModelTest) {
   auto& model = view_counter_->model_;
 
-  EXPECT_EQ(features::kInitialCountToBrandedWallpaper.Get(),
+  EXPECT_EQ(features::kInitialCountToBrandedWallpaper.Get() - 1,
             model.show_branded_wallpaper_);
   EXPECT_TRUE(model.show_wallpaper_);
   EXPECT_TRUE(model.show_branded_wallpaper_);

--- a/ios/browser/api/ntp_background_images/ntp_background_images_service_ios.h
+++ b/ios/browser/api/ntp_background_images/ntp_background_images_service_ios.h
@@ -23,6 +23,11 @@ OBJC_EXPORT
 @property(readonly, nullable) NTPSponsoredImageData* sponsoredImageData;
 @property(readonly, nullable) NTPSponsoredImageData* superReferralImageData;
 
+// TODO(https://github.com/brave/brave-core/pull/21559): Remove these properties
+// once we have a better way to handle Griffin feature params from iOS.
+@property(nonatomic, readonly) NSInteger initialCountToBrandedWallpaper;
+@property(nonatomic, readonly) NSInteger countToBrandedWallpaper;
+
 - (void)updateSponsoredImageComponentIfNeeded;
 
 @property(readonly) NSString* superReferralCode;

--- a/ios/browser/api/ntp_background_images/ntp_background_images_service_ios.mm
+++ b/ios/browser/api/ntp_background_images/ntp_background_images_service_ios.mm
@@ -9,6 +9,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/strings/sys_string_conversions.h"
+#include "brave/components/ntp_background_images/browser/features.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_images_data.h"
@@ -101,6 +102,14 @@ class NTPBackgroundImagesServiceObserverBridge
     return nil;
   }
   return [[NTPSponsoredImageData alloc] initWithData:*data];
+}
+
+- (NSInteger)initialCountToBrandedWallpaper {
+  return ntp_background_images::features::kInitialCountToBrandedWallpaper.Get();
+}
+
+- (NSInteger)countToBrandedWallpaper {
+  return ntp_background_images::features::kCountToBrandedWallpaper.Get();
 }
 
 - (void)updateSponsoredImageComponentIfNeeded {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35522

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Fresh install
- Launch browser
- Restart browser to fetch Griffin seed
- Open new tabs until an New Tab Takeover ad is shown
    - EXPECTED RESULT: New Tab Takeover ad should be shown on the nth `BraveNTPBrandedWallpaper`/`initial_count_to_branded_wallpaper` Griffin feature param
- Open new tabs until an New Tab Takeover ad is shown
    - EXPECTED RESULT: New Tab Takeover ad should be shown on the nth `BraveNTPBrandedWallpaper`/`count_to_branded_wallpaper` Griffin feature param

We should also test the default values if the Griffin feature does not exist. Default value is 2 for `BraveNTPBrandedWallpaper`/`initial_count_to_branded_wallpaper` and 3 for `BraveNTPBrandedWallpaper`/`count_to_branded_wallpaper`.
