### PR TITLE
Improve create_dist --build_omaha argument parsing

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -463,10 +463,12 @@ Config.prototype.buildArgs = function () {
     }
   }
 
-  if (process.platform === 'win32' && this.build_omaha) {
+  if (this.build_omaha) {
     args.build_omaha = this.build_omaha
     args.tag_ap = this.tag_ap
-    args.tag_installdataindex = this.tag_installdataindex
+    if (this.tag_installdataindex) {
+      args.tag_installdataindex = this.tag_installdataindex
+    }
   }
 
   if ((process.platform === 'win32' || process.platform === 'darwin') && this.build_delta_installer) {
@@ -1062,9 +1064,19 @@ Config.prototype.update = function (options) {
     this.channel = ''
   }
 
-  if (process.platform === 'win32' && options.build_omaha) {
+  if (options.build_omaha) {
+    assert(process.platform === 'win32')
     this.build_omaha = true
+    assert(options.tag_ap, "--tag_ap is required for --build_omaha")
+  }
+
+  if (options.tag_ap) {
+    assert(options.build_omaha, "--tag_ap requires --build_omaha")
     this.tag_ap = options.tag_ap
+  }
+
+  if (options.tag_installdataindex) {
+    assert(options.build_omaha, "--tag_installdataindex requires --build_omaha")
     this.tag_installdataindex = options.tag_installdataindex
   }
 

--- a/build/config.gni
+++ b/build/config.gni
@@ -30,9 +30,6 @@ declare_args() {
   brave_version_build = ""
   brave_version_patch = 0
   chrome_version_string = ""
-  build_omaha = false
-  tag_ap = ""
-  tag_installdataindex = ""
   target_android_base = ""
   target_android_output_format = ""
   brave_android_keystore_path = "."
@@ -50,6 +47,15 @@ declare_args() {
   # overrides with empty ones to make //base buildable for redirect_cc.
   is_redirect_cc_build = false
   android_aab_to_apk = false
+}
+
+if (target_os == "win") {
+  # Omaha 3 and its related arguments are available on Windows only.
+  declare_args() {
+    build_omaha = false
+    tag_ap = ""
+    tag_installdataindex = ""
+  }
 }
 
 declare_args() {


### PR DESCRIPTION
Previously, `npm run create_dist -- --build_omaha` without `--tag_ap` or `--tag_installdataindex` gave very cryptic errors.

```
c:\Users\micha\dev\brave-browser\src\brave>npm run create_dist -- Release --channel=nightly --build_omaha

> brave-core@1.64.22 create_dist
> node ./build/commands/scripts/commands.js create_dist Release --channel=nightly --build_omaha

touch overridden files...
touch original files overridden by chromium_src...
...touch original files overridden by chromium_src done
touch original vector icon files overridden by brave/vector_icons...
...touch original vector icon files overridden by brave/vector_icons done
...touch overridden files done
update branding...
Recursing through GRD to find GRDP files...
Done recursing through GRD to find GRDP files.
...update branding done
generate ninja files...
update midl files...
...update midl files done
Widevine cdm host verification is disabled
-----------------------------------------------------------------------------
C:\Users\micha\dev\brave-browser\src
> gn gen C:\Users\micha\dev\brave-browser\src\out\Release --args="[...]"

ERROR at the command-line "--args":1:3512: Expecting assignment or function call.
```

Now, omitting `--tag_ap` prints `--tag_ap is required for --build_omaha`, giving `--tag_ap` without `--build_omaha` prints `--tag_ap requires --build_omaha` and omitting `--tag_installdataindex` produces no error.

Resolves https://github.com/brave/brave-browser/issues/35580.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This is purely a build change; No separate testing is required.