### PR TITLE
fix(wallet): Portfolio Action Button Border Radius

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -59,7 +59,7 @@ import { AddOrEditNftModal } from '../../../popup-modals/add-edit-nft-modal/add-
 import { NftsEmptyState } from './nfts-empty-state/nfts-empty-state'
 import {
   ButtonIcon,
-  CircleButton,
+  PortfolioActionButton,
   SearchBarWrapper,
   ControlBarWrapper,
   ContentWrapper
@@ -499,35 +499,29 @@ export const Nfts = (props: Props) => {
                   autoFocus={true}
                 />
               </SearchBarWrapper>
-              <CircleButton onClick={onCloseSearchBar}>
+              <PortfolioActionButton onClick={onCloseSearchBar}>
                 <ButtonIcon name='close' />
-              </CircleButton>
+              </PortfolioActionButton>
             </Row>
           ) : (
-            <Row width='unset'>
-              <CircleButton
-                marginRight={12}
-                onClick={() => setShowSearchBar(true)}
-              >
+            <Row
+              width='unset'
+              gap='12px'
+            >
+              <PortfolioActionButton onClick={() => setShowSearchBar(true)}>
                 <ButtonIcon name='search' />
-              </CircleButton>
+              </PortfolioActionButton>
               {isNftPinningFeatureEnabled && nonFungibleTokens.length > 0 ? (
-                <CircleButton
-                  onClick={onClickIpfsButton}
-                  marginRight={12}
-                >
+                <PortfolioActionButton onClick={onClickIpfsButton}>
                   <ButtonIcon name='product-ipfs-outline' />
-                </CircleButton>
+                </PortfolioActionButton>
               ) : null}
-              <CircleButton
-                onClick={toggleShowAddNftModal}
-                marginRight={12}
-              >
+              <PortfolioActionButton onClick={toggleShowAddNftModal}>
                 <ButtonIcon name='plus-add' />
-              </CircleButton>
-              <CircleButton onClick={onShowPortfolioSettings}>
+              </PortfolioActionButton>
+              <PortfolioActionButton onClick={onShowPortfolioSettings}>
                 <ButtonIcon name='filter-settings' />
-              </CircleButton>
+              </PortfolioActionButton>
             </Row>
           )}
         </Row>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -90,7 +90,7 @@ import {
 } from '../../../../../shared/style'
 import {
   FilterTokenRow,
-  CircleButton,
+  PortfolioActionButton,
   ButtonIcon,
   SearchBarWrapper,
   ControlBarWrapper,
@@ -720,33 +720,32 @@ export const TokenLists = ({
             )}
             {showSearchBar && (
               <Row width='unset'>
-                <CircleButton onClick={onCloseSearchBar}>
+                <PortfolioActionButton onClick={onCloseSearchBar}>
                   <ButtonIcon name='close' />
-                </CircleButton>
+                </PortfolioActionButton>
               </Row>
             )}
             {!showSearchBar && (
-              <Row width='unset'>
+              <Row
+                width='unset'
+                gap='12px'
+              >
                 {!showEmptyState && (
                   <SearchButtonWrapper width='unset'>
-                    <CircleButton
-                      marginRight={12}
+                    <PortfolioActionButton
                       onClick={() => setShowSearchBar(true)}
                     >
                       <ButtonIcon name='search' />
-                    </CircleButton>
+                    </PortfolioActionButton>
                   </SearchButtonWrapper>
                 )}
-                <CircleButton
-                  marginRight={12}
-                  onClick={showAddAssetsModal}
-                >
+                <PortfolioActionButton onClick={showAddAssetsModal}>
                   <ButtonIcon name='list-settings' />
-                </CircleButton>
+                </PortfolioActionButton>
 
-                <CircleButton onClick={onShowPortfolioSettings}>
+                <PortfolioActionButton onClick={onShowPortfolioSettings}>
                   <ButtonIcon name='filter-settings' />
-                </CircleButton>
+                </PortfolioActionButton>
               </Row>
             )}
           </Row>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -229,9 +229,7 @@ export const BalanceAndChangeWrapper = styled(Column)`
   }
 `
 
-export const CircleButton = styled(WalletButton)<{
-  marginRight?: number
-}>`
+export const PortfolioActionButton = styled(WalletButton)`
   --button-border-color: ${leo.color.divider.interactive};
   display: flex;
   align-items: center;
@@ -240,16 +238,22 @@ export const CircleButton = styled(WalletButton)<{
   outline: none;
   background: none;
   background-color: ${leo.color.container.background};
-  border-radius: 100%;
+  border-radius: 8px;
   border: 1px solid var(--button-border-color);
   height: 36px;
   width: 36px;
-  margin-right: ${(p) => (p.marginRight !== undefined ? p.marginRight : 0)}px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    height: 28px;
+    width: 28px;
+  }
 `
 
 export const ButtonIcon = styled(Icon)`
   --leo-icon-size: 18px;
   color: ${leo.color.icon.interactive};
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    --leo-icon-size: 16px;
+  }
 `
 
 export const SearchBarWrapper = styled(Row)<{


### PR DESCRIPTION
## Description 
Updates the `Portfolio Action` buttons `border-radius` to the updated designs in `figma`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/35592>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Before:

![Screenshot 47](https://github.com/brave/brave-core/assets/40611140/d63395c8-fff5-4b71-9af8-f521269f14ea)

![Screenshot 48](https://github.com/brave/brave-core/assets/40611140/d0a4a64d-f990-46c7-8d97-d25b96f55803)

After:

![Screenshot 45](https://github.com/brave/brave-core/assets/40611140/15bb4a9e-4f13-4b99-b907-cedfe4d25ed0)

![Screenshot 46](https://github.com/brave/brave-core/assets/40611140/798d1ccb-3088-465c-b4ca-47ff791d1e71)
