### PR TITLE
Override all danger levels with download flag

### DIFF
--- a/chromium_src/chrome/browser/download/download_target_determiner.cc
+++ b/chromium_src/chrome/browser/download/download_target_determiner.cc
@@ -11,12 +11,10 @@
   true) {}                                                \
   if (
 
-#define BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL2       \
-  if (danger_level == DownloadFileType::ALLOW_ON_USER_GESTURE) { \
-    if (base::FeatureList::IsEnabled(                            \
-            features::kBraveOverrideDownloadDangerLevel)) {      \
-      return DownloadFileType::NOT_DANGEROUS;                    \
-    }                                                            \
+#define BRAVE_DOWNLOAD_TARGET_DETERMINER_GET_DANGER_LEVEL2 \
+  if (base::FeatureList::IsEnabled(                        \
+          features::kBraveOverrideDownloadDangerLevel)) {  \
+    return DownloadFileType::NOT_DANGEROUS;                \
   }
 
 #include "src/chrome/browser/download/download_target_determiner.cc"


### PR DESCRIPTION
Fixes brave/brave-browser#35561

This is a follow-up to https://github.com/brave/brave-browser/issues/28917 which was an incomplete fix for the underlying issue.

Sec review: https://github.com/brave/reviews/issues/1306

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Needs to be tested on all three platforms (Windows, Mac, Linux), but no need to test on different flavours of each OS.

1. Open <https://fmarier.org/files/safebrowsing-test.html> in a new browser profile.
2. Set _Safe Browsing_ to **No protection** in `brave://settings/security`.
3. [Windows] Click on `test.exe` and then _Save_. The download should be blocked and you should see a warning in the download manager:
![Screenshot from 2024-01-25 16-44-37](https://github.com/brave/brave-core/assets/167821/d4cfa922-0023-4cc2-bf5b-f77280319551)
![Screenshot from 2024-01-25 16-44-43](https://github.com/brave/brave-core/assets/167821/9c7a0f91-078b-4505-ae91-e8ef1e536a1e)
![Screenshot from 2024-01-25 16-44-58](https://github.com/brave/brave-core/assets/167821/1923942b-fd50-4963-b68c-c0fba1c4301b)

4. [Windows] Click on `test.ini` and then _Save_. The download should be blocked and you should see the same warning in the download manager.
5. [Mac]  Click on `test.dmg` and then _Save_. The download should be blocked and you should see the same warning in the download manager.
6. [Linux]  Click on `test.deb` and then _Save_. The download should be blocked and you should see the same warning in the download manager.
7. [Windows/Mac/Linux] Click on `test.txt` and then _Save_. The download should succeed without any warnings.
8. Set `chrome://flags/#brave-override-download-danger-level` to **Enabled** and relaunch the browser.
9. Repeat steps 4-7. All of the downloads should succeed without warnings.