### PR TITLE
Updated Wireguard enabled state timing

### DIFF
--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -15,7 +15,6 @@
 #include "brave/components/brave_news/browser/brave_news_p3a.h"
 #include "brave/components/brave_search_conversion/p3a.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
-#include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
 #include "brave/components/constants/pref_names.h"
@@ -43,10 +42,6 @@
 
 #if BUILDFLAG(ENABLE_WIDEVINE)
 #include "brave/browser/widevine/widevine_utils.h"
-#endif
-
-#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
-#include "brave/components/brave_vpn/common/brave_vpn_utils.h"
 #endif
 
 #if !BUILDFLAG(ENABLE_EXTENSIONS)
@@ -255,11 +250,6 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
 #endif
 
   decentralized_dns::MigrateObsoleteLocalStatePrefs(local_state);
-
-#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
-  // Migrating the feature flag here because dependencies relying on its value.
-  brave_vpn::MigrateWireguardFeatureFlag(local_state);
-#endif
 
 #if !BUILDFLAG(IS_ANDROID)
   // Added 10/2022

--- a/chromium_src/chrome/browser/prefs/sources.gni
+++ b/chromium_src/chrome/browser/prefs/sources.gni
@@ -3,7 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import("//brave/components/brave_vpn/common/buildflags/buildflags.gni")
 import("//components/gcm_driver/config.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
@@ -21,10 +20,6 @@ if (enable_widevine) {
   brave_chromium_src_chrome_browser_prefs_deps += [ "//brave/browser/widevine" ]
 }
 
-if (enable_brave_vpn) {
-  brave_chromium_src_chrome_browser_prefs_deps +=
-      [ "//brave/components/brave_vpn/common" ]
-}
 if (!use_gcm_from_platform) {
   brave_chromium_src_chrome_browser_prefs_deps +=
       [ "//brave/browser/gcm_driver" ]

--- a/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_os_connection_api.cc
@@ -309,6 +309,11 @@ void BraveVPNOSConnectionAPI::MaybeInstallSystemServices() {
 void BraveVPNOSConnectionAPI::OnInstallSystemServicesCompleted(bool success) {
   VLOG(1) << "OnInstallSystemServicesCompleted: success=" << success;
   if (success) {
+#if BUILDFLAG(IS_WIN)
+    // Update prefs first before signaling the event because the event could
+    // check the prefs.
+    UpdateWireguardEnabledPrefsIfNeeded(local_prefs_);
+#endif
     system_service_installed_event_.Signal();
   }
   install_in_progress_ = false;

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -69,7 +69,7 @@ bool IsBraveVPNWireguardEnabled(PrefService* local_state) {
 #endif
 }
 #if BUILDFLAG(IS_WIN)
-void MigrateWireguardFeatureFlag(PrefService* local_prefs) {
+void UpdateWireguardEnabledPrefsIfNeeded(PrefService* local_prefs) {
   auto* wireguard_enabled_pref =
       local_prefs->FindPreference(prefs::kBraveVPNWireguardEnabled);
   if (wireguard_enabled_pref && wireguard_enabled_pref->IsDefaultValue()) {

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -38,7 +38,7 @@ bool HasValidSkusCredential(PrefService* local_prefs);
 std::string GetSkusCredential(PrefService* local_prefs);
 bool IsBraveVPNWireguardEnabled(PrefService* local_state);
 #if BUILDFLAG(IS_WIN)
-void MigrateWireguardFeatureFlag(PrefService* local_prefs);
+void UpdateWireguardEnabledPrefsIfNeeded(PrefService* local_prefs);
 #endif  // BUILDFLAG(IS_WIN)
 }  // namespace brave_vpn
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/35590

As we install wg system service after user purchased vpn subscription,
we don't know before whether user could use wg or not.
Update wg enabled state after system service is installed.
It's set to `true` once if it's default value and installation gets success.
Once it's changed, it could be changed only by user.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.

1. Launch with clean profile
2. Check wireguard settings option is off at brave://settings/system
3. Set VPN purchased state
4. Check again at brave://settings/system and it's enabled