### PR TITLE
Added diagnostic tracing of leave sync case

### DIFF
--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -163,6 +163,9 @@ void BraveSyncWorker::ResetSync(JNIEnv* env) {
   if (!sync_service)
     return;
 
+  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
+                                                      __func__);
+
   auto* device_info_sync_service =
       DeviceInfoSyncServiceFactory::GetForProfile(profile_);
   brave_sync::ResetSync(sync_service, device_info_sync_service,
@@ -257,6 +260,9 @@ void BraveSyncWorker::PermanentlyDeleteAccount(
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   auto* sync_service = GetSyncService();
   CHECK_NE(sync_service, nullptr);
+
+  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
+                                                      __func__);
 
   base::android::ScopedJavaGlobalRef<jobject> java_callback;
   java_callback.Reset(env, callback);

--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -163,8 +163,7 @@ void BraveSyncWorker::ResetSync(JNIEnv* env) {
   if (!sync_service)
     return;
 
-  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
-                                                      __func__);
+  sync_service->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
 
   auto* device_info_sync_service =
       DeviceInfoSyncServiceFactory::GetForProfile(profile_);
@@ -261,8 +260,7 @@ void BraveSyncWorker::PermanentlyDeleteAccount(
   auto* sync_service = GetSyncService();
   CHECK_NE(sync_service, nullptr);
 
-  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
-                                                      __func__);
+  sync_service->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
 
   base::android::ScopedJavaGlobalRef<jobject> java_callback;
   java_callback.Reset(env, callback);

--- a/chromium_src/components/sync/service/sync_internals_util.cc
+++ b/chromium_src/components/sync/service/sync_internals_util.cc
@@ -49,6 +49,10 @@ base::Value::Dict ConstructAboutInformation(
       section_brave_sync.AddBoolStat("OS encryption available");
   is_os_encryption_available->Set(OSCrypt::IsEncryptionAvailable());
 
+  Stat<std::string>* leave_chain_details =
+      section_brave_sync.AddStringStat("Leave chain details");
+  leave_chain_details->Set(brave_sync_service->prefs().GetLeaveChainDetails());
+
   base::Value::List* details = about_info.FindList(kDetailsKey);
   DCHECK_NE(details, nullptr);
 

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -24,6 +24,8 @@ const char kSyncFailedDecryptSeedNoticeDismissed[] =
 const char kSyncAccountDeletedNoticePending[] =
     "brave_sync_v2.account_deleted_notice_pending";
 
+const char kSyncLeaveChainDetails[] = "brave_sync_v2.diag.leave_chain_details";
+
 // Deprecated
 // ============================================================================
 const char kSyncSeed[] = "brave_sync.seed";
@@ -69,6 +71,7 @@ void Prefs::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterStringPref(kSyncV2Seed, std::string());
   registry->RegisterBooleanPref(kSyncFailedDecryptSeedNoticeDismissed, false);
   registry->RegisterBooleanPref(kSyncAccountDeletedNoticePending, false);
+  registry->RegisterStringPref(kSyncLeaveChainDetails, std::string());
 }
 
 // static
@@ -161,6 +164,19 @@ bool Prefs::IsSyncAccountDeletedNoticePending() const {
 
 void Prefs::SetSyncAccountDeletedNoticePending(bool is_pending) {
   pref_service_->SetBoolean(kSyncAccountDeletedNoticePending, is_pending);
+}
+
+void Prefs::AddLeaveChainDetail(const char* file, int line, const char* func) {
+  std::string details = pref_service_->GetString(kSyncLeaveChainDetails);
+
+  logging::LogMessage lm(file, line, logging::LOGGING_INFO);
+  lm.stream() << " " << func << std::endl;
+
+  pref_service_->SetString(kSyncLeaveChainDetails, details + lm.str());
+}
+
+void Prefs::ClearLeaveChainDetails() {
+  pref_service_->ClearPref(kSyncLeaveChainDetails);
 }
 
 void Prefs::Clear() {

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -15,10 +15,6 @@
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
 
-#if BUILDFLAG(IS_WIN)
-#include "base/strings/utf_string_conversions.h"
-#endif
-
 namespace brave_sync {
 namespace {
 
@@ -173,15 +169,9 @@ void Prefs::SetSyncAccountDeletedNoticePending(bool is_pending) {
 void Prefs::AddLeaveChainDetail(const char* file, int line, const char* func) {
   std::string details = pref_service_->GetString(kSyncLeaveChainDetails);
 
-#if BUILDFLAG(IS_WIN)
-  base::FilePath::StringType file_path_string(base::ASCIIToWide(file));
-#else
-  base::FilePath::StringType file_path_string(file);
-#endif
-
   std::ostringstream stream;
   stream << base::Time::Now() << " "
-         << base::FilePath(file_path_string).BaseName() << "(" << line << ") "
+         << base::FilePath::FromASCII(file).BaseName() << "(" << line << ") "
          << func << std::endl;
   pref_service_->SetString(kSyncLeaveChainDetails, details + stream.str());
 }

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/base64.h"
+#include "base/files/file_path.h"
 #include "base/logging.h"
 #include "components/os_crypt/sync/os_crypt.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -23,7 +24,6 @@ const char kSyncFailedDecryptSeedNoticeDismissed[] =
     "brave_sync_v2.failed_decrypt_seed_notice_dismissed";
 const char kSyncAccountDeletedNoticePending[] =
     "brave_sync_v2.account_deleted_notice_pending";
-
 const char kSyncLeaveChainDetails[] = "brave_sync_v2.diag.leave_chain_details";
 
 // Deprecated
@@ -168,11 +168,14 @@ void Prefs::SetSyncAccountDeletedNoticePending(bool is_pending) {
 
 void Prefs::AddLeaveChainDetail(const char* file, int line, const char* func) {
   std::string details = pref_service_->GetString(kSyncLeaveChainDetails);
+  std::ostringstream stream;
+  stream << base::Time::Now() << " " << base::FilePath(file).BaseName() << "("
+         << line << ") " << func << std::endl;
+  pref_service_->SetString(kSyncLeaveChainDetails, details + stream.str());
+}
 
-  logging::LogMessage lm(file, line, logging::LOGGING_INFO);
-  lm.stream() << " " << func << std::endl;
-
-  pref_service_->SetString(kSyncLeaveChainDetails, details + lm.str());
+std::string Prefs::GetLeaveChainDetails() const {
+  return pref_service_->GetString(kSyncLeaveChainDetails);
 }
 
 void Prefs::ClearLeaveChainDetails() {

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -15,6 +15,10 @@
 #include "components/prefs/pref_service.h"
 #include "components/prefs/scoped_user_pref_update.h"
 
+#if BUILDFLAG(IS_WIN)
+#include "base/strings/utf_string_conversions.h"
+#endif
+
 namespace brave_sync {
 namespace {
 
@@ -168,9 +172,17 @@ void Prefs::SetSyncAccountDeletedNoticePending(bool is_pending) {
 
 void Prefs::AddLeaveChainDetail(const char* file, int line, const char* func) {
   std::string details = pref_service_->GetString(kSyncLeaveChainDetails);
+
+#if BUILDFLAG(IS_WIN)
+  base::FilePath::StringType file_path_string(base::ASCIIToWide(file));
+#else
+  base::FilePath::StringType file_path_string(file);
+#endif
+
   std::ostringstream stream;
-  stream << base::Time::Now() << " " << base::FilePath(file).BaseName() << "("
-         << line << ") " << func << std::endl;
+  stream << base::Time::Now() << " "
+         << base::FilePath(file_path_string).BaseName() << "(" << line << ") "
+         << func << std::endl;
   pref_service_->SetString(kSyncLeaveChainDetails, details + stream.str());
 }
 

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -45,6 +45,9 @@ class Prefs {
   bool IsFailedDecryptSeedNoticeDismissed() const;
   void DismissFailedDecryptSeedNotice();
 
+  void AddLeaveChainDetail(const char* file, int line, const char* func);
+  void ClearLeaveChainDetails();
+
   void Clear();
 
  private:

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -46,6 +46,7 @@ class Prefs {
   void DismissFailedDecryptSeedNotice();
 
   void AddLeaveChainDetail(const char* file, int line, const char* func);
+  std::string GetLeaveChainDetails() const;
   void ClearLeaveChainDetails();
 
   void Clear();

--- a/components/brave_sync/sync_service_impl_helper.cc
+++ b/components/brave_sync/sync_service_impl_helper.cc
@@ -18,6 +18,8 @@ namespace brave_sync {
 void ResetSync(syncer::BraveSyncServiceImpl* sync_service_impl,
                syncer::DeviceInfoSyncService* device_info_service,
                base::OnceClosure on_reset_done) {
+  sync_service_impl->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
+                                                           __func__);
   if (sync_service_impl->GetTransportState() !=
       syncer::SyncService::TransportState::ACTIVE) {
     sync_service_impl->OnSelfDeviceInfoDeleted(std::move(on_reset_done));

--- a/components/brave_sync/sync_service_impl_helper.cc
+++ b/components/brave_sync/sync_service_impl_helper.cc
@@ -18,8 +18,7 @@ namespace brave_sync {
 void ResetSync(syncer::BraveSyncServiceImpl* sync_service_impl,
                syncer::DeviceInfoSyncService* device_info_service,
                base::OnceClosure on_reset_done) {
-  sync_service_impl->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
-                                                           __func__);
+  sync_service_impl->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
   if (sync_service_impl->GetTransportState() !=
       syncer::SyncService::TransportState::ACTIVE) {
     sync_service_impl->OnSelfDeviceInfoDeleted(std::move(on_reset_done));

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -61,6 +61,7 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   void Initialize() override;
 
   const brave_sync::Prefs& prefs() { return brave_sync_prefs_; }
+  brave_sync::Prefs& modifying_prefs() { return brave_sync_prefs_; }
 
   void PermanentlyDeleteAccount(
       base::OnceCallback<void(const SyncProtocolError&)> callback);

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -60,8 +60,8 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
 
   void Initialize() override;
 
-  const brave_sync::Prefs& prefs() { return brave_sync_prefs_; }
-  brave_sync::Prefs& modifying_prefs() { return brave_sync_prefs_; }
+  const brave_sync::Prefs& prefs() const { return brave_sync_prefs_; }
+  brave_sync::Prefs& prefs() { return brave_sync_prefs_; }
 
   void PermanentlyDeleteAccount(
       base::OnceCallback<void(const SyncProtocolError&)> callback);

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -313,6 +313,9 @@ void BraveSyncWorker::ResetSync() {
     return;
   }
 
+  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
+                                                      __func__);
+
   auto* device_info_service =
       DeviceInfoSyncServiceFactory::GetForBrowserState(browser_state_);
   DCHECK(device_info_service);
@@ -357,6 +360,9 @@ void BraveSyncWorker::PermanentlyDeleteAccount(
   if (!sync_service) {
     return;
   }
+
+  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
+                                                      __func__);
 
   sync_service->PermanentlyDeleteAccount(std::move(callback));
 }

--- a/ios/browser/api/sync/brave_sync_worker.cc
+++ b/ios/browser/api/sync/brave_sync_worker.cc
@@ -313,8 +313,7 @@ void BraveSyncWorker::ResetSync() {
     return;
   }
 
-  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
-                                                      __func__);
+  sync_service->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
 
   auto* device_info_service =
       DeviceInfoSyncServiceFactory::GetForBrowserState(browser_state_);
@@ -361,8 +360,7 @@ void BraveSyncWorker::PermanentlyDeleteAccount(
     return;
   }
 
-  sync_service->modifying_prefs().AddLeaveChainDetail(__FILE__, __LINE__,
-                                                      __func__);
+  sync_service->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
 
   sync_service->PermanentlyDeleteAccount(std::move(callback));
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35609

This PR adds diagnostic info for the leave sync chain case. Info is saved into profile preferences. It must help to understand why some iOS devices randomly by themselves leave the sync chain.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open brave://sync-internals/, find `Leave chain details` section, ensure it is empty
2. Create sync chain
3. Leave sync chain
4. at brave://sync-internals/, find `Leave chain details`, ensure it contains info about time and functions used to leave the sync chain.

![image](https://github.com/brave/brave-core/assets/24739341/76d6283f-1d0f-4916-866e-30da0610e630)


