### PR TITLE
Remove mocking of "selfCustodyAvailable" data (uplift to 1.63.x)

### DIFF
--- a/components/brave_rewards/core/endpoints/brave/get_wallet.cc
+++ b/components/brave_rewards/core/endpoints/brave/get_wallet.cc
@@ -56,8 +56,6 @@ Result ParseBody(const std::string& body) {
     }
   }
 
-  result_value.self_custody_available.Set("solana", true);
-
   return result_value;
 }
 


### PR DESCRIPTION
Uplift of #21772
Resolves https://github.com/brave/brave-browser/issues/35622

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.