### PR TITLE
Remove early extension system initialization from Greaselion. (uplift to 1.62.x)

### DIFF
--- a/android/android_browser_tests.gni
+++ b/android/android_browser_tests.gni
@@ -38,6 +38,7 @@ android_test_exception_sources = [
   "//brave/browser/extensions/brave_extension_functional_test.h",
   "//brave/browser/extensions/brave_extension_provider_browsertest.cc",
   "//brave/browser/extensions/brave_theme_event_router_browsertest.cc",
+  "//brave/browser/extensions/extension_system_browsertest.cc",
   "//brave/browser/perf/brave_perf_features_processor_browsertest.cc",
   "//brave/browser/policy/brave_policy_browsertest.cc",
   "//brave/browser/renderer_context_menu/brave_mock_render_view_context_menu.cc",

--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_sync/features.h"
 #include "brave/components/constants/brave_constants.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/greaselion/browser/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "brave/components/translate/core/common/brave_translate_features.h"
@@ -61,6 +62,11 @@
 
 #if BUILDFLAG(ENABLE_TOR) || !BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/browser_process.h"
+#endif
+
+#if BUILDFLAG(ENABLE_GREASELION)
+#include "brave/browser/greaselion/greaselion_service_factory.h"
+#include "brave/components/greaselion/browser/greaselion_service.h"
 #endif
 
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED) && BUILDFLAG(ENABLE_EXTENSIONS)
@@ -182,6 +188,16 @@ void BraveBrowserMainParts::PostProfileInit(Profile* profile,
     content::RenderFrameHost::AllowInjectingJavaScript();
     auto* command_line = base::CommandLine::ForCurrentProcess();
     command_line->AppendSwitch(switches::kDisableBackgroundMediaSuspend);
+  }
+#endif
+
+#if BUILDFLAG(ENABLE_GREASELION)
+  if (auto* greaselion_service =
+          greaselion::GreaselionServiceFactory::GetForBrowserContext(profile)) {
+    extensions::ExtensionService* extension_service =
+        extensions::ExtensionSystem::Get(profile)->extension_service();
+    DCHECK(extension_service);
+    greaselion_service->SetExtensionService(extension_service);
   }
 #endif
 

--- a/browser/extensions/extension_system_browsertest.cc
+++ b/browser/extensions/extension_system_browsertest.cc
@@ -1,0 +1,89 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/path_service.h"
+#include "base/strings/stringprintf.h"
+#include "brave/components/constants/brave_paths.h"
+#include "chrome/browser/extensions/extension_browsertest.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "net/dns/mock_host_resolver.h"
+#include "services/network/public/cpp/network_switches.h"
+
+using extensions::ExtensionBrowserTest;
+
+class ExtensionSystemBrowserTest : public ExtensionBrowserTest {
+ public:
+  ExtensionSystemBrowserTest() {
+    brave::RegisterPathProvider();
+    dir_test_data_ = base::PathService::CheckedGet(brave::DIR_TEST_DATA);
+
+    https_server_ = std::make_unique<net::EmbeddedTestServer>(
+        net::test_server::EmbeddedTestServer::TYPE_HTTPS);
+    https_server_->ServeFilesFromDirectory(dir_test_data_);
+    EXPECT_TRUE(https_server_->Start());
+  }
+
+  void SetUpOnMainThread() override {
+    ExtensionBrowserTest::SetUpOnMainThread();
+    host_resolver()->AddRule("*", "127.0.0.1");
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    ExtensionBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitchASCII(
+        network::switches::kHostResolverRules,
+        base::StringPrintf("MAP *:443 127.0.0.1:%d", https_server_->port()));
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    ExtensionBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+    ExtensionBrowserTest::TearDownInProcessBrowserTestFixture();
+  }
+
+  void NavigateAndExpectErrorPage(const GURL& url, bool expect_error_page) {
+    SCOPED_TRACE(url);
+    auto* rfh = ui_test_utils::NavigateToURL(browser(), url);
+    ASSERT_TRUE(rfh);
+    EXPECT_EQ(rfh->IsErrorDocument(), expect_error_page);
+  }
+
+ protected:
+  base::FilePath dir_test_data_;
+  content::ContentMockCertVerifier mock_cert_verifier_;
+  std::unique_ptr<net::EmbeddedTestServer> https_server_;
+};
+
+IN_PROC_BROWSER_TEST_F(ExtensionSystemBrowserTest,
+                       PRE_DeclarativeNetRequestWorksAfterRestart) {
+  NavigateAndExpectErrorPage(GURL("https://a.com/simple.html"), false);
+  NavigateAndExpectErrorPage(GURL("https://b.com/simple.html"), false);
+
+  // Load extension that should block b.com main frame via declarative net
+  // requests feature.
+  ASSERT_TRUE(InstallExtensionWithPermissionsGranted(
+      dir_test_data_.AppendASCII("extensions")
+          .AppendASCII("declarative_net_request"),
+      1));
+
+  NavigateAndExpectErrorPage(GURL("https://a.com/simple.html"), false);
+  NavigateAndExpectErrorPage(GURL("https://b.com/simple.html"), true);
+}
+
+IN_PROC_BROWSER_TEST_F(ExtensionSystemBrowserTest,
+                       DeclarativeNetRequestWorksAfterRestart) {
+  // After a browser restart the extensions should work as expected.
+  NavigateAndExpectErrorPage(GURL("https://a.com/simple.html"), false);
+  NavigateAndExpectErrorPage(GURL("https://b.com/simple.html"), true);
+}

--- a/browser/greaselion/greaselion_service_factory.cc
+++ b/browser/greaselion/greaselion_service_factory.cc
@@ -58,7 +58,6 @@ KeyedService* GreaselionServiceFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
   extensions::ExtensionSystem* extension_system =
       extensions::ExtensionSystem::Get(context);
-  extension_system->InitForRegularProfile(true /* extensions_enabled */);
   extensions::ExtensionRegistry* extension_registry =
       extensions::ExtensionRegistry::Get(context);
   scoped_refptr<base::SequencedTaskRunner> task_runner =

--- a/components/greaselion/browser/greaselion_service.h
+++ b/components/greaselion/browser/greaselion_service.h
@@ -22,6 +22,10 @@ namespace base {
 class Version;
 }
 
+namespace extensions {
+class ExtensionService;
+}
+
 namespace greaselion {
 
 enum GreaselionFeature {
@@ -45,6 +49,8 @@ class GreaselionService : public KeyedService,
   // KeyedService
   void Shutdown() override {}
 
+  virtual void SetExtensionService(
+      extensions::ExtensionService* extension_service) = 0;
   virtual void SetFeatureEnabled(GreaselionFeature feature, bool enabled) = 0;
   virtual void UpdateInstalledExtensions() = 0;
   virtual bool IsGreaselionExtension(const std::string& id) = 0;

--- a/components/greaselion/browser/greaselion_service_impl.cc
+++ b/components/greaselion/browser/greaselion_service_impl.cc
@@ -226,7 +226,6 @@ GreaselionServiceImpl::GreaselionServiceImpl(
     : download_service_(download_service),
       install_directory_(install_directory),
       extension_system_(extension_system),
-      extension_service_(extension_system->extension_service()),
       extension_registry_(extension_registry),
       all_rules_installed_successfully_(true),
       update_in_progress_(false),
@@ -251,6 +250,13 @@ void GreaselionServiceImpl::Shutdown() {
   extension_registry_->RemoveObserver(this);
   task_runner_->PostTask(FROM_HERE,
                          base::BindOnce(&DeleteExtensionDirs, extension_dirs_));
+}
+
+void GreaselionServiceImpl::SetExtensionService(
+    extensions::ExtensionService* extension_service) {
+  DCHECK(extension_service);
+  DCHECK(!extension_service_);
+  extension_service_ = extension_service;
 }
 
 bool GreaselionServiceImpl::IsGreaselionExtension(const std::string& id) {

--- a/components/greaselion/browser/greaselion_service_impl.h
+++ b/components/greaselion/browser/greaselion_service_impl.h
@@ -50,6 +50,8 @@ class GreaselionServiceImpl : public GreaselionService,
   void Shutdown() override;
 
   // GreaselionService overrides
+  void SetExtensionService(
+      extensions::ExtensionService* extension_service) override;
   void SetFeatureEnabled(GreaselionFeature feature, bool enabled) override;
   void UpdateInstalledExtensions() override;
   bool IsGreaselionExtension(const std::string& id) override;
@@ -85,8 +87,6 @@ class GreaselionServiceImpl : public GreaselionService,
   const base::FilePath install_directory_;
   raw_ptr<extensions::ExtensionSystem> extension_system_ =
       nullptr;  // NOT OWNED
-  raw_ptr<extensions::ExtensionService> extension_service_ =
-      nullptr;  // NOT OWNED
   raw_ptr<extensions::ExtensionRegistry> extension_registry_ =
       nullptr;  // NOT OWNED
   bool all_rules_installed_successfully_;
@@ -98,6 +98,8 @@ class GreaselionServiceImpl : public GreaselionService,
   std::vector<extensions::ExtensionId> greaselion_extensions_;
   std::vector<base::FilePath> extension_dirs_;
   base::Version browser_version_;
+  raw_ptr<extensions::ExtensionService> extension_service_ =
+      nullptr;  // NOT OWNED
   base::WeakPtrFactory<GreaselionServiceImpl> weak_factory_;
 };
 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -759,6 +759,7 @@ test("brave_browser_tests") {
     "//brave/browser/extensions/brave_extension_functional_test.h",
     "//brave/browser/extensions/brave_extension_provider_browsertest.cc",
     "//brave/browser/extensions/brave_theme_event_router_browsertest.cc",
+    "//brave/browser/extensions/extension_system_browsertest.cc",
     "//brave/browser/perf/brave_perf_features_processor_browsertest.cc",
     "//brave/browser/policy/brave_policy_browsertest.cc",
     "//brave/browser/profiles/brave_profile_manager_browsertest.cc",

--- a/test/data/extensions/declarative_net_request/manifest.json
+++ b/test/data/extensions/declarative_net_request/manifest.json
@@ -1,0 +1,18 @@
+{
+    "name": "Declarative net request",
+    "version": "0.1",
+    "manifest_version": 3,
+    "background": {},
+    "permissions": ["declarativeNetRequest"],
+    "declarative_net_request": {
+        "rule_resources": [
+            {
+                "id": "rules",
+                "enabled": true,
+                "path": "rules.json"
+            }
+        ]
+    },
+    "host_permissions": ["*://*/*"],
+    "action": {}
+}

--- a/test/data/extensions/declarative_net_request/rules.json
+++ b/test/data/extensions/declarative_net_request/rules.json
@@ -1,0 +1,13 @@
+[
+    {
+        "id": 1,
+        "priority": 1,
+        "action": {
+            "type": "block"
+        },
+        "condition": {
+            "urlFilter": "https://b.com/*",
+            "resourceTypes": ["main_frame"]
+        }
+    }
+]


### PR DESCRIPTION
Uplift of #21459
Resolves https://github.com/brave/brave-browser/issues/30854

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.