### PR TITLE
Fix Brave Ads 426 upgrade required UI message.

### DIFF
--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -296,7 +296,6 @@ class RewardsDOMHandler
   raw_ptr<brave_ads::AdsService> ads_service_ = nullptr;  // NOT OWNED
   mojo::Receiver<bat_ads::mojom::BatAdsObserver> bat_ads_observer_receiver_{
       this};
-  bool browser_upgrade_required_to_serve_ads_ = false;
 
   PrefChangeRegistrar pref_change_registrar_;
 
@@ -1226,7 +1225,7 @@ void RewardsDOMHandler::GetAdsData(const base::Value::List& args) {
       prefs->GetBoolean(brave_ads::prefs::kShouldAllowSubdivisionTargeting));
   ads_data.Set("adsUIEnabled", true);
   ads_data.Set("needsBrowserUpgradeToServeAds",
-               browser_upgrade_required_to_serve_ads_);
+               ads_service_->IsBrowserUpgradeRequiredToServeAds());
 
   const std::string country_code = brave_l10n::GetCountryCode(GetLocalState());
   ads_data.Set("subdivisions",
@@ -1534,7 +1533,6 @@ void RewardsDOMHandler::OnAdRewardsDidChange() {
 }
 
 void RewardsDOMHandler::OnBrowserUpgradeRequiredToServeAds() {
-  browser_upgrade_required_to_serve_ads_ = true;
   GetAdsData(base::Value::List());
 }
 

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -567,15 +567,15 @@ void BraveNewTabMessageHandler::OnPreferencesChanged() {
 }
 
 base::Value::Dict BraveNewTabMessageHandler::GetAdsDataDictionary() const {
-  base::Value::Dict ads_data;
+  if (!ads_service_) {
+    return {};
+  }
 
-  ads_data.Set(kNeedsBrowserUpgradeToServeAds,
-               browser_upgrade_required_to_serve_ads_);
-
-  return ads_data;
+  return base::Value::Dict().Set(
+      kNeedsBrowserUpgradeToServeAds,
+      ads_service_->IsBrowserUpgradeRequiredToServeAds());
 }
 
 void BraveNewTabMessageHandler::OnBrowserUpgradeRequiredToServeAds() {
-  browser_upgrade_required_to_serve_ads_ = true;
   FireWebUIListener("new-tab-ads-data-updated", GetAdsDataDictionary());
 }

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.h
@@ -84,7 +84,6 @@ class BraveNewTabMessageHandler : public content::WebUIMessageHandler,
   raw_ptr<brave_ads::AdsService> ads_service_ = nullptr;
   mojo::Receiver<bat_ads::mojom::BatAdsObserver> bat_ads_observer_receiver_{
       this};
-  bool browser_upgrade_required_to_serve_ads_ = false;
 
   bool was_invisible_and_restored_ = false;
 

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -73,6 +73,9 @@ class AdsService : public KeyedService {
   virtual void GetStatementOfAccounts(
       GetStatementOfAccountsCallback callback) = 0;
 
+  // Returns true if a browser upgrade is required to serve ads.
+  virtual bool IsBrowserUpgradeRequiredToServeAds() const = 0;
+
   // Should be called to serve an inline content ad for the specified
   // `dimensions`. The callback takes two arguments - `std::string` containing
   // the dimensions and `base::Value::Dict` containing the info for the ad.

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1164,6 +1164,10 @@ void AdsServiceImpl::GetStatementOfAccounts(
   bat_ads_associated_remote_->GetStatementOfAccounts(std::move(callback));
 }
 
+bool AdsServiceImpl::IsBrowserUpgradeRequiredToServeAds() const {
+  return browser_upgrade_required_to_serve_ads_;
+}
+
 void AdsServiceImpl::MaybeServeInlineContentAd(
     const std::string& dimensions,
     MaybeServeInlineContentAdAsDictCallback callback) {
@@ -1792,6 +1796,10 @@ void AdsServiceImpl::Log(const std::string& file,
     ::logging::LogMessage(file.c_str(), line, -verbose_level).stream()
         << message;
   }
+}
+
+void AdsServiceImpl::OnBrowserUpgradeRequiredToServeAds() {
+  browser_upgrade_required_to_serve_ads_ = true;
 }
 
 void AdsServiceImpl::OnRemindUser(const brave_ads::mojom::ReminderType type) {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -217,6 +217,8 @@ class AdsServiceImpl : public AdsService,
 
   void GetStatementOfAccounts(GetStatementOfAccountsCallback callback) override;
 
+  bool IsBrowserUpgradeRequiredToServeAds() const override;
+
   void MaybeServeInlineContentAd(
       const std::string& dimensions,
       MaybeServeInlineContentAdAsDictCallback callback) override;
@@ -373,7 +375,7 @@ class AdsServiceImpl : public AdsService,
 
   // bat_ads::mojom::BatAdsObserver:
   void OnAdRewardsDidChange() override {}
-  void OnBrowserUpgradeRequiredToServeAds() override {}
+  void OnBrowserUpgradeRequiredToServeAds() override;
   void OnIneligibleRewardsWalletToServeAds() override {}
   void OnRemindUser(mojom::ReminderType type) override;
 
@@ -392,6 +394,8 @@ class AdsServiceImpl : public AdsService,
   void OnCompleteReset(bool success) override;
 
   bool is_bat_ads_initialized_ = false;
+
+  bool browser_upgrade_required_to_serve_ads_ = false;
 
   // Brave Ads Service starts count is needed to avoid possible double Brave
   // Ads initialization.

--- a/components/brave_ads/browser/ads_service_mock.h
+++ b/components/brave_ads/browser/ads_service_mock.h
@@ -47,6 +47,8 @@ class AdsServiceMock : public AdsService {
 
   MOCK_METHOD(void, GetStatementOfAccounts, (GetStatementOfAccountsCallback));
 
+  MOCK_METHOD(bool, IsBrowserUpgradeRequiredToServeAds, (), (const));
+
   MOCK_METHOD(void,
               MaybeServeInlineContentAd,
               (const std::string&, MaybeServeInlineContentAdAsDictCallback));


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34960

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Override https://mywallet.ads.brave.com/v2/confirmation/token/* response code to 426
- Enable rewards and ads
- Connect to a custodian
- Check that upgrade required UI modal is shown on brave rewards settings page
- Check that upgrade required UI modal is shown on new tab page