### PR TITLE
chore: remove isV2 prop from NavButton component

### DIFF
--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/index.tsx
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/index.tsx
@@ -32,7 +32,6 @@ interface BaseProps {
   maxHeight?: string
   minHeight?: string
   minWidth?: string
-  isV2?: boolean
 }
 
 type ClickProps =
@@ -56,8 +55,7 @@ export const NavButton: React.FC<Props> = ({
   needsTopMargin,
   onSubmit,
   text,
-  url,
-  isV2
+  url
 }) => {
   // memos
   const buttonContent = React.useMemo(() => {
@@ -66,12 +64,7 @@ export const NavButton: React.FC<Props> = ({
         {buttonType === 'reject' && <RejectIcon />}
         {buttonType === 'sign' && <SignIcon />}
         {buttonType === 'confirm' && <ConfirmIcon />}
-        <ButtonText
-          buttonType={buttonType}
-          isV2={isV2}
-        >
-          {text}
-        </ButtonText>
+        <ButtonText buttonType={buttonType}>{text}</ButtonText>
       </>
     )
   }, [buttonType, text])
@@ -97,7 +90,6 @@ export const NavButton: React.FC<Props> = ({
       maxHeight={maxHeight}
       minWidth={minWidth}
       minHeight={minHeight}
-      isV2={isV2}
     >
       {buttonContent}
     </StyledButton>

--- a/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
+++ b/components/brave_wallet_ui/components/extension/buttons/nav-button/style.ts
@@ -26,7 +26,6 @@ interface StyledButtonProps {
   maxHeight?: string
   minHeight?: string
   minWidth?: string
-  isV2?: boolean
 }
 
 const StyledButtonCssMixin = (p: StyledButtonProps) => {
@@ -42,21 +41,17 @@ const StyledButtonCssMixin = (p: StyledButtonProps) => {
     justify-content: center;
     cursor: ${(p) => (p.disabled ? 'default' : 'pointer')};
     border-radius: 40px;
-    padding: ${p.isV2 ? '18px 24px' : '10px 22px'};
+    padding: 10px 22px;
     outline: none;
     margin-top: ${(p) => (p?.addTopMargin ? '8px' : '0px')};
 
     background-color: ${(p) =>
       p.disabled
-        ? p.isV2
-          ? leo.color.icon.disabled
-          : p.theme.color.disabled
+        ? leo.color.icon.disabled
         : p.buttonType === 'primary' ||
           p.buttonType === 'confirm' ||
           p.buttonType === 'sign'
-        ? p.isV2
-          ? leo.color.primitive.primary[60]
-          : p.theme.palette.blurple500
+        ? leo.color.primitive.primary[60]
         : p.buttonType === 'danger'
         ? p.theme.color.errorBorder
         : 'transparent'};

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
@@ -456,7 +456,6 @@ function AssetSelection({ isAndroid }: Props) {
               )
             }}
             disabled={!isNextStepEnabled}
-            isV2={true}
             minWidth='360px'
           />
         </NextButtonRow>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35728

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Continue button on asset selection step of the deposit screen should continue to appear but with the new color and padding