### PR TITLE
Use NetworkAnonymizationKey from ResolveProxy to setup tor proxy config

### DIFF
--- a/chromium_src/net/proxy_resolution/configured_proxy_resolution_service.cc
+++ b/chromium_src/net/proxy_resolution/configured_proxy_resolution_service.cc
@@ -6,22 +6,28 @@
 #include "net/proxy_resolution/configured_proxy_resolution_service.h"
 
 #include "brave/net/proxy_resolution/proxy_config_service_tor.h"
+#include "net/base/network_anonymization_key.h"
 
 namespace net {
 namespace {
 
 void SetTorCircuitIsolation(const ProxyConfigWithAnnotation& config,
                             const GURL& url,
+                            const NetworkAnonymizationKey& key,
                             ProxyInfo* result,
                             ProxyResolutionService* service) {
-  ProxyConfigServiceTor::SetProxyAuthorization(config, url, service, result);
+  ProxyConfigServiceTor::SetProxyAuthorization(config, url, key, service,
+                                               result);
 }
 
 }  // namespace
 }  // namespace net
 
-#define BRAVE_TRY_TO_COMPLETE_SYNCHRONOUSLY \
-  SetTorCircuitIsolation(config_.value(), url, result, this);
+#define BRAVE_CONFIGURED_PROXY_RESOLUTION_SERVICE_RESOLVE_PROXY      \
+  if (rv == OK) {                                                    \
+    SetTorCircuitIsolation(config_.value(), raw_url,                 \
+                           network_anonymization_key, result, this); \
+  }
 
 #include "src/net/proxy_resolution/configured_proxy_resolution_service.cc"
-#undef BRAVE_TRY_TO_COMPLETE_SYNCHRONOUSLY
+#undef BRAVE_CONFIGURED_PROXY_RESOLUTION_SERVICE_RESOLVE_PROXY

--- a/net/proxy_resolution/configured_proxy_resolution_service_unittest.cc
+++ b/net/proxy_resolution/configured_proxy_resolution_service_unittest.cc
@@ -5,16 +5,22 @@
 
 #include "net/proxy_resolution/configured_proxy_resolution_service.h"
 
+#include <memory>
 #include <string>
 
-#include "base/memory/ptr_util.h"
 #include "brave/net/proxy_resolution/proxy_config_service_tor.h"
+#include "net/base/host_port_pair.h"
+#include "net/base/network_anonymization_key.h"
+#include "net/base/proxy_server.h"
+#include "net/base/schemeful_site.h"
 #include "net/base/test_completion_callback.h"
+#include "net/log/net_log_source_type.h"
 #include "net/log/net_log_with_source.h"
 #include "net/proxy_resolution/mock_proxy_resolver.h"
 #include "net/proxy_resolution/proxy_resolution_request.h"
 #include "net/test/gtest_util.h"
 #include "net/test/test_with_task_environment.h"
+#include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 using net::test::IsOk;
@@ -48,17 +54,19 @@ class ConfiguredProxyResolutionServiceTest : public TestWithTaskEnvironment {
 
 TEST_F(ConfiguredProxyResolutionServiceTest, TorProxy) {
   ConfiguredProxyResolutionService* service = GetProxyResolutionService();
-  const GURL site_url("https://check.torproject.org/");
-  const std::string anonymization_key =
-      ProxyConfigServiceTor::CircuitAnonymizationKey(site_url);
+  const GURL url("https://check.torproject.org/");
+  const std::string circuit_anonymization_key =
+      ProxyConfigServiceTor::CircuitAnonymizationKey(url);
+  const SchemefulSite url_site(url);
+  const auto network_anonymization_key =
+      NetworkAnonymizationKey::CreateFromFrameSite(url_site, url_site);
 
   ProxyInfo info;
   TestCompletionCallback callback;
   std::unique_ptr<ProxyResolutionRequest> request;
-  int rv =
-      service->ResolveProxy(site_url, std::string(), NetworkAnonymizationKey(),
-                            &info, callback.callback(), &request,
-                            NetLogWithSource::Make(NetLogSourceType::NONE));
+  int rv = service->ResolveProxy(
+      url, std::string(), network_anonymization_key, &info, callback.callback(),
+      &request, NetLogWithSource::Make(NetLogSourceType::NONE));
   EXPECT_THAT(rv, IsOk());
 
   ProxyServer server = info.proxy_chain().proxy_server();
@@ -66,7 +74,7 @@ TEST_F(ConfiguredProxyResolutionServiceTest, TorProxy) {
   EXPECT_TRUE(server.scheme() == ProxyServer::SCHEME_SOCKS5);
   EXPECT_EQ(host_port.host(), "127.0.0.1");
   EXPECT_EQ(host_port.port(), 5566);
-  EXPECT_EQ(host_port.username(), anonymization_key);
+  EXPECT_EQ(host_port.username(), circuit_anonymization_key);
   EXPECT_FALSE(host_port.password().empty());
 }
 

--- a/net/proxy_resolution/proxy_config_service_tor.cc
+++ b/net/proxy_resolution/proxy_config_service_tor.cc
@@ -7,23 +7,32 @@
 
 #include <stdlib.h>
 
-#include <algorithm>
-#include <memory>
+#include <cstdint>
+#include <map>
 #include <optional>
+#include <queue>
+#include <string>
 #include <utility>
 #include <vector>
 
+#include "base/check.h"
+#include "base/location.h"
 #include "base/no_destructor.h"
 #include "base/strings/string_number_conversions.h"
-#include "base/strings/string_util.h"
 #include "base/time/time.h"
-#include "base/values.h"
+#include "base/timer/timer.h"
 #include "crypto/random.h"
+#include "net/base/host_port_pair.h"
 #include "net/base/network_anonymization_key.h"
+#include "net/base/proxy_chain.h"
+#include "net/base/proxy_server.h"
 #include "net/base/proxy_string_util.h"
 #include "net/base/schemeful_site.h"
+#include "net/proxy_resolution/proxy_config.h"
+#include "net/proxy_resolution/proxy_config_service.h"
 #include "net/proxy_resolution/proxy_config_with_annotation.h"
 #include "net/proxy_resolution/proxy_resolution_service.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
 
 namespace net {
 
@@ -71,12 +80,12 @@ constexpr NetworkTrafficAnnotationTag kTorProxyTrafficAnnotation =
         policy_exception_justification: "Not implemented."
       })");
 
-static base::NoDestructor<std::map<
-    ProxyResolutionService*, TorProxyMap>> tor_proxy_map_;
+static base::NoDestructor<std::map<ProxyResolutionService*, TorProxyMap>>
+    g_tor_proxy_map;
 
 TorProxyMap* GetTorProxyMap(
     ProxyResolutionService* service) {
-  return &(tor_proxy_map_.get()->operator[](service));
+  return &(g_tor_proxy_map.get()->operator[](service));
 }
 
 bool IsTorProxyConfig(const ProxyConfigWithAnnotation& config) {
@@ -85,10 +94,10 @@ bool IsTorProxyConfig(const ProxyConfigWithAnnotation& config) {
   // empty TorProxyMap (all entries have expired)
   // we do this here because the other methods are only called when
   // IsTorProxy is true so the last entry will never be deleted
-  for (auto it = tor_proxy_map_.get()->cbegin();
-       it != tor_proxy_map_.get()->cend(); ) {
+  for (auto it = g_tor_proxy_map.get()->cbegin();
+       it != g_tor_proxy_map.get()->cend();) {
     if (it->second.size() == 0) {
-      tor_proxy_map_->erase(it++);
+      g_tor_proxy_map->erase(it++);
     } else {
       ++it;
     }
@@ -96,6 +105,14 @@ bool IsTorProxyConfig(const ProxyConfigWithAnnotation& config) {
 
   return tag.unique_id_hash_code ==
          kTorProxyTrafficAnnotation.unique_id_hash_code;
+}
+
+std::string AnonymizationKeyToString(const NetworkAnonymizationKey& key) {
+  const std::optional<net::SchemefulSite>& schemeful_site =
+      key.GetTopFrameSite();
+  CHECK(schemeful_site.has_value());
+  std::string host = GURL(schemeful_site->Serialize()).host();
+  return host;
 }
 
 }  // namespace
@@ -146,11 +163,7 @@ std::string ProxyConfigServiceTor::CircuitAnonymizationKey(const GURL& url) {
   const auto network_anonymization_key =
       net::NetworkAnonymizationKey::CreateFromFrameSite(url_site, url_site);
 
-  const std::optional<net::SchemefulSite>& schemeful_site =
-      network_anonymization_key.GetTopFrameSite();
-  DCHECK(schemeful_site.has_value());
-  std::string host = GURL(schemeful_site->Serialize()).host();
-  return host;
+  return AnonymizationKeyToString(network_anonymization_key);
 }
 
 void ProxyConfigServiceTor::SetNewTorCircuit(const GURL& url) {
@@ -174,14 +187,16 @@ void ProxyConfigServiceTor::SetNewTorCircuit(const GURL& url) {
 void ProxyConfigServiceTor::SetProxyAuthorization(
     const ProxyConfigWithAnnotation& config,
     const GURL& url,
+    const NetworkAnonymizationKey& key,
     ProxyResolutionService* service,
     ProxyInfo* result) {
-  if (!IsTorProxyConfig(config))
+  if (!IsTorProxyConfig(config)) {
     return;
+  }
 
   // Adding username & password to global sock://127.0.0.1:[port] config
   // without actually modifying it when resolving proxy for each url.
-  const std::string username = CircuitAnonymizationKey(url);
+  const std::string username = AnonymizationKeyToString(key);
   const net::ProxyChain& chain =
       config.value().proxy_rules().single_proxies.First();
   CHECK(chain.is_single_proxy());

--- a/net/proxy_resolution/proxy_config_service_tor.h
+++ b/net/proxy_resolution/proxy_config_service_tor.h
@@ -6,18 +6,12 @@
 #ifndef BRAVE_NET_PROXY_RESOLUTION_PROXY_CONFIG_SERVICE_TOR_H_
 #define BRAVE_NET_PROXY_RESOLUTION_PROXY_CONFIG_SERVICE_TOR_H_
 
-#include <map>
-#include <queue>
 #include <string>
-#include <utility>
 
-#include "base/compiler_specific.h"
 #include "base/observer_list.h"
-#include "base/timer/timer.h"
 #include "net/base/net_export.h"
 #include "net/base/proxy_server.h"
 #include "net/proxy_resolution/proxy_config_service.h"
-#include "net/traffic_annotation/network_traffic_annotation.h"
 
 class GURL;
 
@@ -27,6 +21,7 @@ class Time;
 
 namespace net {
 
+class NetworkAnonymizationKey;
 class ProxyConfigWithAnnotation;
 class ProxyInfo;
 class ProxyResolutionService;
@@ -44,6 +39,7 @@ class NET_EXPORT ProxyConfigServiceTor : public net::ProxyConfigService {
   void SetNewTorCircuit(const GURL& url);
   static void SetProxyAuthorization(const ProxyConfigWithAnnotation& config,
                                     const GURL& url,
+                                    const NetworkAnonymizationKey& key,
                                     ProxyResolutionService* service,
                                     ProxyInfo* result);
 

--- a/net/proxy_resolution/proxy_config_service_tor_unittest.cc
+++ b/net/proxy_resolution/proxy_config_service_tor_unittest.cc
@@ -5,13 +5,19 @@
 
 #include "brave/net/proxy_resolution/proxy_config_service_tor.h"
 
-#include <string>
 #include <memory>
+#include <string>
+#include <utility>
 
+#include "base/location.h"
 #include "base/task/single_thread_task_runner.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
 #include "net/base/proxy_server.h"
+#include "net/base/schemeful_site.h"
 #include "net/proxy_resolution/configured_proxy_resolution_service.h"
 #include "net/proxy_resolution/mock_proxy_resolver.h"
+#include "net/proxy_resolution/proxy_config_service.h"
 #include "net/proxy_resolution/proxy_config_with_annotation.h"
 #include "net/test/test_with_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -21,13 +27,44 @@ namespace net {
 
 class ProxyConfigServiceTorTest : public TestWithTaskEnvironment {
  public:
-  ProxyConfigServiceTorTest() = default;
+  ProxyConfigServiceTorTest()
+      : TestWithTaskEnvironment(
+            base::test::TaskEnvironment::TimeSource::MOCK_TIME),
+        proxy_uri_("socks5://127.0.0.1:5566") {}
   ProxyConfigServiceTorTest(const ProxyConfigServiceTorTest&) = delete;
   ProxyConfigServiceTorTest& operator=(const ProxyConfigServiceTorTest&) =
       delete;
   ~ProxyConfigServiceTorTest() override = default;
 
+  void SetUp() override {
+    auto config_service =
+        net::ProxyConfigService::CreateSystemProxyConfigService(
+            base::SingleThreadTaskRunner::GetCurrentDefault());
+
+    service_ = std::make_unique<ConfiguredProxyResolutionService>(
+        std::move(config_service),
+        std::make_unique<MockAsyncProxyResolverFactory>(false), nullptr,
+        /*quick_check_enabled=*/true);
+  }
+
+  ConfiguredProxyResolutionService* service() { return service_.get(); }
+
+  void CheckProxyServer(const base::Location& location,
+                        const net::ProxyServer& proxy_server,
+                        const std::string& expected_username) {
+    SCOPED_TRACE(testing::Message() << location.ToString());
+    ASSERT_TRUE(proxy_server.scheme() == ProxyServer::SCHEME_SOCKS5);
+    ASSERT_EQ(proxy_server.host_port_pair().host(), "127.0.0.1");
+    ASSERT_EQ(proxy_server.host_port_pair().port(), 5566);
+    EXPECT_EQ(proxy_server.host_port_pair().username(), expected_username);
+    EXPECT_TRUE(!proxy_server.host_port_pair().password().empty());
+  }
+
+  std::string proxy_uri() const { return proxy_uri_; }
+
  private:
+  std::string proxy_uri_;
+  std::unique_ptr<net::ConfiguredProxyResolutionService> service_;
 };
 
 TEST_F(ProxyConfigServiceTorTest, CircuitAnonymizationKey) {
@@ -108,12 +145,11 @@ TEST_F(ProxyConfigServiceTorTest, CircuitAnonymizationKey) {
 }
 
 TEST_F(ProxyConfigServiceTorTest, SetNewTorCircuit) {
-  const std::string proxy_uri("socks5://127.0.0.1:5566");
   const GURL site_url("https://check.torproject.org/");
-  const std::string anonymization_key =
+  const std::string circuit_anonymization_key =
       ProxyConfigServiceTor::CircuitAnonymizationKey(site_url);
 
-  ProxyConfigServiceTor proxy_config_service(proxy_uri);
+  ProxyConfigServiceTor proxy_config_service(proxy_uri());
   ProxyConfigWithAnnotation config;
 
   proxy_config_service.SetNewTorCircuit(site_url);
@@ -121,102 +157,145 @@ TEST_F(ProxyConfigServiceTorTest, SetNewTorCircuit) {
   auto single_proxy =
       config.value().proxy_rules().single_proxies.First().GetProxyServer(
           /*chain_index=*/0);
-  EXPECT_TRUE(!single_proxy.host_port_pair().password().empty());
-  EXPECT_TRUE(single_proxy.scheme() == ProxyServer::SCHEME_SOCKS5);
-  EXPECT_EQ(single_proxy.host_port_pair().username(), anonymization_key);
-  EXPECT_EQ(single_proxy.host_port_pair().host(), "127.0.0.1");
-  EXPECT_EQ(single_proxy.host_port_pair().port(), 5566);
+  CheckProxyServer(FROM_HERE, single_proxy, circuit_anonymization_key);
 }
 
 TEST_F(ProxyConfigServiceTorTest, SetProxyAuthorization) {
-  const std::string proxy_uri("socks5://127.0.0.1:5566");
   const GURL site_url("https://check.torproject.org/");
   const GURL site_url2("https://brave.com/");
-  const std::string anonymization_key =
+  const std::string circuit_anonymization_key =
       ProxyConfigServiceTor::CircuitAnonymizationKey(site_url);
-  const std::string anonymization_key2 =
+  const std::string circuit_anonymization_key2 =
       ProxyConfigServiceTor::CircuitAnonymizationKey(site_url2);
+  const net::SchemefulSite site(site_url);
+  const net::SchemefulSite site2(site_url2);
+  const auto network_anonymization_key =
+      net::NetworkAnonymizationKey::CreateFromFrameSite(site, site);
+  const auto network_anonymization_key2 =
+      net::NetworkAnonymizationKey::CreateFromFrameSite(site2, site2);
 
-  auto config_service = net::ProxyConfigService::CreateSystemProxyConfigService(
-      base::SingleThreadTaskRunner::GetCurrentDefault());
-
-  auto* service = new ConfiguredProxyResolutionService(
-      std::move(config_service),
-      std::make_unique<MockAsyncProxyResolverFactory>(false), nullptr,
-      /*quick_check_enabled=*/true);
-
-  ProxyConfigServiceTor proxy_config_service(proxy_uri);
+  ProxyConfigServiceTor proxy_config_service(proxy_uri());
   ProxyConfigWithAnnotation config;
   proxy_config_service.GetLatestProxyConfig(&config);
 
   ProxyInfo info;
   ProxyConfigServiceTor::SetProxyAuthorization(
-      config, site_url, service, &info);
-  auto host_port_pair = info.proxy_chain().proxy_server().host_port_pair();
-
-  EXPECT_EQ(host_port_pair.username(), anonymization_key);
-  EXPECT_TRUE(info.proxy_chain().proxy_server().scheme() ==
-              ProxyServer::SCHEME_SOCKS5);
-  EXPECT_EQ(host_port_pair.host(), "127.0.0.1");
-  EXPECT_EQ(host_port_pair.port(), 5566);
+      config, site_url, network_anonymization_key, service(), &info);
+  auto proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
 
   // everything should still be the same on subsequent calls
-  std::string password = host_port_pair.password();
-  ProxyInfo info2;
+  std::string password = proxy_server.host_port_pair().password();
   ProxyConfigServiceTor::SetProxyAuthorization(
-      config, site_url, service, &info2);
-  host_port_pair = info2.proxy_chain().proxy_server().host_port_pair();
-
-  EXPECT_EQ(host_port_pair.username(), anonymization_key);
-  EXPECT_EQ(host_port_pair.password(), password);
-  EXPECT_TRUE(info2.proxy_chain().proxy_server().scheme() ==
-              ProxyServer::SCHEME_SOCKS5);
-  EXPECT_EQ(host_port_pair.host(), "127.0.0.1");
-  EXPECT_EQ(host_port_pair.port(), 5566);
-
-  // TODO(darkdh): Test persistent circuit anonymization until timeout.
+      config, site_url, network_anonymization_key, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
 
   // Test new tor circuit.
   proxy_config_service.SetNewTorCircuit(site_url);
   proxy_config_service.GetLatestProxyConfig(&config);
-  ProxyInfo info3;
   ProxyConfigServiceTor::SetProxyAuthorization(
-      config, site_url, service, &info3);
-  host_port_pair = info3.proxy_chain().proxy_server().host_port_pair();
+      config, site_url, network_anonymization_key, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
 
-  EXPECT_EQ(host_port_pair.username(), anonymization_key);
-  EXPECT_NE(host_port_pair.password(), password);
-  EXPECT_TRUE(info3.proxy_chain().proxy_server().scheme() ==
-              ProxyServer::SCHEME_SOCKS5);
-  EXPECT_EQ(host_port_pair.host(), "127.0.0.1");
-  EXPECT_EQ(host_port_pair.port(), 5566);
+  EXPECT_NE(proxy_server.host_port_pair().password(), password);
 
   // everything should still be the same on subsequent calls
-  password = host_port_pair.password();
-  ProxyInfo info4;
+  password = proxy_server.host_port_pair().password();
   ProxyConfigServiceTor::SetProxyAuthorization(
-      config, site_url, service, &info4);
-  host_port_pair = info4.proxy_chain().proxy_server().host_port_pair();
-
-  EXPECT_EQ(host_port_pair.username(), anonymization_key);
-  EXPECT_EQ(host_port_pair.password(), password);
-  EXPECT_TRUE(info4.proxy_chain().proxy_server().scheme() ==
-              ProxyServer::SCHEME_SOCKS5);
-  EXPECT_EQ(host_port_pair.host(), "127.0.0.1");
-  EXPECT_EQ(host_port_pair.port(), 5566);
+      config, site_url, network_anonymization_key, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
 
   // SetNewTorCircuit should not affect other urls
   proxy_config_service.GetLatestProxyConfig(&config);
-  ProxyInfo info5;
   ProxyConfigServiceTor::SetProxyAuthorization(
-      config, site_url2, service, &info5);
-  host_port_pair = info5.proxy_chain().proxy_server().host_port_pair();
-  EXPECT_EQ(host_port_pair.username(), anonymization_key2);
-  EXPECT_NE(host_port_pair.password(), password);
-  EXPECT_TRUE(info5.proxy_chain().proxy_server().scheme() ==
-              ProxyServer::SCHEME_SOCKS5);
-  EXPECT_EQ(host_port_pair.host(), "127.0.0.1");
-  EXPECT_EQ(host_port_pair.port(), 5566);
+      config, site_url2, network_anonymization_key2, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key2);
+  EXPECT_NE(proxy_server.host_port_pair().password(), password);
 }
 
+TEST_F(ProxyConfigServiceTorTest, SetProxyAuthorization_Subresources) {
+  const GURL site_url1("https://brave.com/");
+  const GURL site_url2("https://bravesoftware.com/");  // subresource
+  const GURL site_url3("https://brave.software.com/");
+  const net::SchemefulSite site1(site_url1);
+  const net::SchemefulSite site2(site_url2);
+  const net::SchemefulSite site3(site_url3);
+  const auto network_anonymization_key_1_2 =
+      net::NetworkAnonymizationKey::CreateFromFrameSite(site1, site2);
+  const std::string circuit_anonymization_key1 =
+      ProxyConfigServiceTor::CircuitAnonymizationKey(site_url1);
+  const auto network_anonymization_key_3_2 =
+      net::NetworkAnonymizationKey::CreateFromFrameSite(site3, site2);
+  const std::string circuit_anonymization_key3 =
+      ProxyConfigServiceTor::CircuitAnonymizationKey(site_url3);
+
+  ProxyConfigServiceTor proxy_config_service(proxy_uri());
+  ProxyConfigWithAnnotation config;
+  proxy_config_service.GetLatestProxyConfig(&config);
+
+  ProxyInfo info;
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      config, site_url2, network_anonymization_key_1_2, service(), &info);
+  auto proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key1);
+  const auto password1 = proxy_server.host_port_pair().password();
+
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      config, site_url2, network_anonymization_key_3_2, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key3);
+  const auto password3 = proxy_server.host_port_pair().password();
+
+  EXPECT_NE(password1, password3);
+}
+
+TEST_F(ProxyConfigServiceTorTest, CircuitTimeout) {
+  const GURL site_url("https://brave.com/");
+  const std::string circuit_anonymization_key =
+      ProxyConfigServiceTor::CircuitAnonymizationKey(site_url);
+  const net::SchemefulSite site(site_url);
+  const auto network_anonymization_key =
+      net::NetworkAnonymizationKey::CreateFromFrameSite(site, site);
+
+  ProxyConfigServiceTor proxy_config_service(proxy_uri());
+  ProxyConfigWithAnnotation config;
+  proxy_config_service.GetLatestProxyConfig(&config);
+
+  ProxyInfo info;
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      config, site_url, network_anonymization_key, service(), &info);
+  auto proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
+
+  auto password = proxy_server.host_port_pair().password();
+
+  // password is still the same
+  FastForwardBy(base::Minutes(9));
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      config, site_url, network_anonymization_key, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
+  EXPECT_EQ(proxy_server.host_port_pair().password(), password);
+
+  // Exceeds 10 mins, new password is generated
+  FastForwardBy(base::Minutes(2));
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      config, site_url, network_anonymization_key, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
+  EXPECT_NE(proxy_server.host_port_pair().password(), password);
+  password = proxy_server.host_port_pair().password();
+
+  // Another timeout
+  FastForwardBy(base::Minutes(11));
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      config, site_url, network_anonymization_key, service(), &info);
+  proxy_server = info.proxy_chain().proxy_server();
+  CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key);
+  EXPECT_NE(proxy_server.host_port_pair().password(), password);
+}
 }  // namespace net

--- a/patches/net-proxy_resolution-configured_proxy_resolution_service.cc.patch
+++ b/patches/net-proxy_resolution-configured_proxy_resolution_service.cc.patch
@@ -1,12 +1,12 @@
 diff --git a/net/proxy_resolution/configured_proxy_resolution_service.cc b/net/proxy_resolution/configured_proxy_resolution_service.cc
-index 7468d23f9e2e92e27f9eb05b934ca2c8a5470010..aa038cd2a973e642bb1651ab26d95d49f84518d7 100644
+index 7468d23f9e2e92e27f9eb05b934ca2c8a5470010..df31417199da2305d0d753bda0069ff8cd1eb471 100644
 --- a/net/proxy_resolution/configured_proxy_resolution_service.cc
 +++ b/net/proxy_resolution/configured_proxy_resolution_service.cc
-@@ -977,6 +977,7 @@ int ConfiguredProxyResolutionService::TryToCompleteSynchronously(
-   config_->value().proxy_rules().Apply(url, result);
-   result->set_traffic_annotation(
-       MutableNetworkTrafficAnnotationTag(config_->traffic_annotation()));
-+  BRAVE_TRY_TO_COMPLETE_SYNCHRONOUSLY
- 
-   return OK;
- }
+@@ -921,6 +921,7 @@ int ConfiguredProxyResolutionService::ResolveProxy(
+   // Check if the request can be completed right away. (This is the case when
+   // using a direct connection for example).
+   int rv = TryToCompleteSynchronously(url, result);
++  BRAVE_CONFIGURED_PROXY_RESOLUTION_SERVICE_RESOLVE_PROXY
+   if (rv != ERR_IO_PENDING) {
+     rv = DidFinishResolvingProxy(url, network_anonymization_key, method, result,
+                                  rv, net_log);


### PR DESCRIPTION
so that we always use `TopFrameSite` to calculate circuit key. Which means when dealing with subresource requests, it also uses origin from outmost frame.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35464

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### From issue description
1. Open Tor window
2. Open two tabs for https://arthuredelstein.net/tordemos/stream-isolation.html and https://arthuredelstein.github.io/tordemos/stream-isolation.html
3. ip should be different between two tabs
ex. <img width="731" alt="Screenshot 2024-01-31 at 16 52 04" src="https://github.com/brave/brave-core/assets/11330831/37de7534-8265-4689-8693-46e073a36f04">
### From comment
1. Open Tor window
2. Open two tabs for https://test-pages.privacytests.org/stream-isolation.html and https://test-pages.privacytests3.org/stream-isolation.html
3. ip set should be different between two tabs.
ex.
<img width="1169" alt="Screenshot 2024-01-31 at 16 51 02" src="https://github.com/brave/brave-core/assets/11330831/13c2bb8e-ab27-4fbe-9f7f-5c65218f1836">

