### PR TITLE
SKUs SDK: regenerate the request id when moving from Active to Generated (uplift to 1.63.x)

### DIFF
--- a/components/skus/browser/rs/lib/src/sdk/credentials/fetch.rs
+++ b/components/skus/browser/rs/lib/src/sdk/credentials/fetch.rs
@@ -132,13 +132,6 @@ where
                     let blinded_creds: Vec<BlindedToken> =
                         match self.client.get_time_limited_v2_creds(&item.id).await? {
                             Some(item_creds) => {
-                                // overwrite our request id if creds are already present
-                                request_id = match item_creds.request_id {
-                                    Some(request_id) => request_id,
-                                    // use the item id as the request id if it was not persisted
-                                    None => item_id.to_string(),
-                                };
-
                                 // are we almost expired
                                 let almost_expired = self
                                     .last_matching_time_limited_v2_credential(&item.id)
@@ -155,6 +148,14 @@ where
                                 match item_creds.state {
                                     CredentialState::GeneratedCredentials
                                     | CredentialState::SubmittedCredentials => {
+                                        // overwrite our request id if creds are already present
+                                        // that we need to resubmit
+                                        request_id = match item_creds.request_id {
+                                            Some(request_id) => request_id,
+                                            // use the item id as the request id if it was not persisted
+                                            None => item_id.to_string(),
+                                        };
+
                                         // we have generated, or performed submission, reuse the
                                         // creds we created for signing.
                                         creds

--- a/components/skus/browser/rs/lib/src/storage/kv.rs
+++ b/components/skus/browser/rs/lib/src/storage/kv.rs
@@ -303,6 +303,7 @@ where
                 // blinded tokens to the item_credentials.creds for signing
                 // request
                 if let Credentials::TimeLimitedV2(item_credentials) = item_credentials {
+                    item_credentials.request_id = Some(request_id.to_string());
                     item_credentials.creds = creds;
                     // update state to generated credentials
                     item_credentials.state = CredentialState::GeneratedCredentials;


### PR DESCRIPTION
Uplift of #21847
Resolves https://github.com/brave/brave-browser/issues/35742

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.