### PR TITLE
fix(wallet): Card Header Button Border Radius

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
@@ -67,7 +67,7 @@ import {
   CopyIcon
 } from './account-details-header.style'
 import {
-  CircleButton,
+  MenuButton,
   ButtonIcon,
   MenuWrapper,
   HorizontalDivider
@@ -199,7 +199,7 @@ export const AccountDetailsHeader = (props: Props) => {
       justifyContent='space-between'
     >
       <Row width='unset'>
-        <CircleButton
+        <MenuButton
           size={28}
           marginRight={16}
           onClick={goBack}
@@ -208,7 +208,7 @@ export const AccountDetailsHeader = (props: Props) => {
             size={16}
             name='arrow-left'
           />
-        </CircleButton>
+        </MenuButton>
         <CreateAccountIcon
           account={account}
           size='big'
@@ -263,11 +263,11 @@ export const AccountDetailsHeader = (props: Props) => {
           </>
         )}
         <MenuWrapper ref={accountDetailsMenuRef}>
-          <CircleButton
+          <MenuButton
             onClick={() => setShowAccountDetailsMenu((prev) => !prev)}
           >
             <ButtonIcon name='more-vertical' />
-          </CircleButton>
+          </MenuButton>
           {showAccountDetailsMenu && (
             <AccountDetailsMenu
               options={menuOptions}

--- a/components/brave_wallet_ui/components/desktop/card-headers/accounts-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/accounts-header.tsx
@@ -23,7 +23,7 @@ import { AccountsMenu } from '../wallet-menus/accounts-menu'
 // Styled Components
 import {
   HeaderTitle,
-  CircleButton,
+  MenuButton,
   ButtonIcon,
   MenuWrapper
 } from './shared-card-headers.style'
@@ -56,11 +56,11 @@ export const AccountsHeader = () => {
     >
       <HeaderTitle>{getLocale('braveWalletTopNavAccounts')}</HeaderTitle>
       <MenuWrapper ref={portfolioOverviewMenuRef}>
-        <CircleButton
+        <MenuButton
           onClick={() => setShowPortfolioOverviewMenu((prev) => !prev)}
         >
           <ButtonIcon name='plus-add' />
-        </CircleButton>
+        </MenuButton>
         {showPortfolioOverviewMenu && <AccountsMenu />}
       </MenuWrapper>
     </Row>

--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
@@ -42,7 +42,7 @@ import { AssetDetailsMenu } from '../wallet-menus/asset-details-menu'
 
 // Styled Components
 import {
-  CircleButton,
+  MenuButton,
   ButtonIcon,
   MenuWrapper,
   HorizontalDivider
@@ -169,7 +169,7 @@ export const AssetDetailsHeader = (props: Props) => {
       justifyContent='space-between'
     >
       <Row width='unset'>
-        <CircleButton
+        <MenuButton
           size={28}
           marginRight={16}
           onClick={onBack}
@@ -178,7 +178,7 @@ export const AssetDetailsHeader = (props: Props) => {
             size={16}
             name='arrow-left'
           />
-        </CircleButton>
+        </MenuButton>
         <Row
           width='unset'
           gap='8px'
@@ -259,11 +259,11 @@ export const AssetDetailsHeader = (props: Props) => {
               <HorizontalDivider />
               <HorizontalSpace space='16px' />
               <MenuWrapper ref={assetDetailsMenuRef}>
-                <CircleButton
+                <MenuButton
                   onClick={() => setShowAssetDetailsMenu((prev) => !prev)}
                 >
                   <ButtonIcon name='more-vertical' />
-                </CircleButton>
+                </MenuButton>
                 {showAssetDetailsMenu && (
                   <AssetDetailsMenu
                     assetSymbol={selectedAsset?.symbol ?? ''}

--- a/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
@@ -19,7 +19,7 @@ import { getLocale } from '../../../../common/locale'
 
 // Styled Components
 import {
-  CircleButton,
+  MenuButton,
   HeaderTitle,
   ButtonIcon,
   SendButton
@@ -54,7 +54,7 @@ export const NftAssetHeader = ({
         justifyContent='flex-start'
         margin='0px 6px 0px 0px'
       >
-        <CircleButton
+        <MenuButton
           size={28}
           marginRight={16}
           onClick={onBack}
@@ -63,7 +63,7 @@ export const NftAssetHeader = ({
             size={16}
             name='arrow-left'
           />
-        </CircleButton>
+        </MenuButton>
         <HeaderTitle isPanel={isPanel}>
           {assetName}&nbsp;{tokenId ? `#${new Amount(tokenId).toNumber()}` : ''}
         </HeaderTitle>

--- a/components/brave_wallet_ui/components/desktop/card-headers/page-title-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/page-title-header.tsx
@@ -17,7 +17,7 @@ import { DefaultPanelHeader } from './default-panel-header'
 import { Row } from '../../shared/style'
 import {
   ButtonIcon,
-  CircleButton,
+  MenuButton,
   HeaderTitle
 } from './shared-card-headers.style'
 
@@ -39,7 +39,7 @@ export const PageTitleHeader = ({ title, showBackButton, onBack }: Props) => {
       justifyContent='flex-start'
     >
       {showBackButton && (
-        <CircleButton
+        <MenuButton
           size={28}
           marginRight={16}
           onClick={onBack}
@@ -48,7 +48,7 @@ export const PageTitleHeader = ({ title, showBackButton, onBack }: Props) => {
             size={16}
             name='arrow-left'
           />
-        </CircleButton>
+        </MenuButton>
       )}
       <HeaderTitle isPanel={isPanel}>{title}</HeaderTitle>
     </Row>

--- a/components/brave_wallet_ui/components/desktop/card-headers/portfolio-overview-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/portfolio-overview-header.tsx
@@ -23,7 +23,7 @@ import { PortfolioOverviewMenu } from '../wallet-menus/portfolio-overview-menu'
 // Styled Components
 import {
   HeaderTitle,
-  CircleButton,
+  MenuButton,
   ButtonIcon,
   MenuWrapper
 } from './shared-card-headers.style'
@@ -56,11 +56,11 @@ export const PortfolioOverviewHeader = () => {
     >
       <HeaderTitle>{getLocale('braveWalletTopNavPortfolio')}</HeaderTitle>
       <MenuWrapper ref={portfolioOverviewMenuRef}>
-        <CircleButton
+        <MenuButton
           onClick={() => setShowPortfolioOverviewMenu((prev) => !prev)}
         >
           <ButtonIcon name='tune' />
-        </CircleButton>
+        </MenuButton>
         {showPortfolioOverviewMenu && <PortfolioOverviewMenu />}
       </MenuWrapper>
     </Row>

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
@@ -24,7 +24,7 @@ export const MenuWrapper = styled.div`
   position: relative;
 `
 
-export const CircleButton = styled(WalletButton)<{
+export const MenuButton = styled(WalletButton)<{
   size?: number
   marginRight?: number
 }>`
@@ -36,7 +36,7 @@ export const CircleButton = styled(WalletButton)<{
   outline: none;
   background: none;
   background-color: ${leo.color.container.background};
-  border-radius: 100%;
+  border-radius: 8px;
   border: 1px solid var(--button-border-color);
   height: ${(p) => (p.size !== undefined ? p.size : 36)}px;
   width: ${(p) => (p.size !== undefined ? p.size : 36)}px;


### PR DESCRIPTION
## Description 
Updates the Wallet `Card Header` buttons `border-radius` to match the new designs in `figma`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/35780>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. All Wallet `Card Header` buttons should now have a `8px` - `border-radius`

![Screenshot](https://github.com/brave/brave-core/assets/40611140/b9733982-076b-4a48-9fe2-e8200663a864)
![Screenshot 1](https://github.com/brave/brave-core/assets/40611140/a18af20c-9938-4d1b-b0e1-45c05b73fa6d)
![Screenshot 2](https://github.com/brave/brave-core/assets/40611140/c9192b56-5229-4e7a-a818-039ea21943e5)
![Screenshot 3](https://github.com/brave/brave-core/assets/40611140/5bc0b051-ceff-449d-abe8-6173588fe612)
![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/5360420f-07f7-404e-8ad0-2fd3a3fffc79)

