### PR TITLE
Add default browser P3A metric name to whitelist (uplift to 1.63.x)

### DIFF
--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -49,6 +49,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     "Brave.DNS.AutoSecureRequests",
     "Brave.DNS.SecureSetting",
     "Brave.Extensions.AdBlock",
+    "Brave.IOS.IsLikelyDefault",
 
     // IPFS
     "Brave.IPFS.DaemonRunTime",


### PR DESCRIPTION
Uplift of #21888
Resolves https://github.com/brave/brave-ios/issues/8674

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.