### PR TITLE
Prevent show spinner when drag Leo panel on Android

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -225,6 +225,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/custom_layout/popup_window_tooltip/ArrowColorDrawable.java",
   "../../brave/android/java/org/chromium/chrome/browser/custom_layout/popup_window_tooltip/PopupWindowTooltip.java",
   "../../brave/android/java/org/chromium/chrome/browser/custom_layout/popup_window_tooltip/PopupWindowTooltipUtils.java",
+  "../../brave/android/java/org/chromium/chrome/browser/customtabs/features/partialcustomtab/BravePartialCustomTabBottomSheetStrategy.java",
   "../../brave/android/java/org/chromium/chrome/browser/decentralized_dns/settings/ENSSettingsFragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/decentralized_dns/settings/RadioButtonGroupDDnsResolveMethodPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/decentralized_dns/settings/RadioButtonGroupEnsOffchainResolveMethodPreference.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -821,3 +821,12 @@
 -keep class org.chromium.chrome.browser.bookmarks.BraveBookmarkUiPrefs {
     <init>(...);
 }
+
+-keep class org.chromium.chrome.browser.customtabs.features.partialcustomtab.PartialCustomTabBottomSheetStrategy {
+    public <init>(...);
+    *** mStopShowingSpinner;
+}
+
+-keep class org.chromium.chrome.browser.customtabs.features.partialcustomtab.BravePartialCustomTabBottomSheetStrategy {
+    public <init>(...);
+}

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -825,6 +825,7 @@
 -keep class org.chromium.chrome.browser.customtabs.features.partialcustomtab.PartialCustomTabBottomSheetStrategy {
     public <init>(...);
     *** mStopShowingSpinner;
+    *** mTab;
 }
 
 -keep class org.chromium.chrome.browser.customtabs.features.partialcustomtab.BravePartialCustomTabBottomSheetStrategy {

--- a/android/java/org/chromium/chrome/browser/BraveSwipeRefreshHandler.java
+++ b/android/java/org/chromium/chrome/browser/BraveSwipeRefreshHandler.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser;
 
 import org.chromium.chrome.browser.tab.Tab;
+import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.ui.OverscrollAction;
 import org.chromium.ui.base.PageTransition;
 import org.chromium.url.GURL;
@@ -26,26 +27,11 @@ public class BraveSwipeRefreshHandler extends SwipeRefreshHandler {
         GURL url = mTab.getUrl();
         if (url.getScheme().equals("chrome-untrusted")
                 && url.getHost().equals("chat")
-                && getTransition(mTab) == PageTransition.FROM_API) {
+                && TabUtils.getTransition(mTab) == PageTransition.FROM_API) {
             mSwipeType = OverscrollAction.NONE;
             return false;
         }
 
         return super.start(type, startX, startY, navigateForward);
-    }
-
-    private static int getTransition(Tab tab) {
-        if (tab != null
-                && tab.getWebContents() != null
-                && tab.getWebContents().getNavigationController() != null
-                && tab.getWebContents().getNavigationController().getVisibleEntry() != null) {
-            int transition =
-                    tab.getWebContents()
-                            .getNavigationController()
-                            .getVisibleEntry()
-                            .getTransition();
-            return transition;
-        }
-        return 0;
     }
 }

--- a/android/java/org/chromium/chrome/browser/customtabs/features/partialcustomtab/BravePartialCustomTabBottomSheetStrategy.java
+++ b/android/java/org/chromium/chrome/browser/customtabs/features/partialcustomtab/BravePartialCustomTabBottomSheetStrategy.java
@@ -1,0 +1,60 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.customtabs.features.partialcustomtab;
+
+import android.app.Activity;
+
+import org.chromium.base.supplier.Supplier;
+import org.chromium.chrome.browser.browserservices.intents.BrowserServicesIntentDataProvider;
+import org.chromium.chrome.browser.fullscreen.FullscreenManager;
+import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
+import org.chromium.chrome.browser.tab.Tab;
+import org.chromium.components.browser_ui.widget.TouchEventProvider;
+
+public class BravePartialCustomTabBottomSheetStrategy extends PartialCustomTabBottomSheetStrategy {
+
+    public BravePartialCustomTabBottomSheetStrategy(
+            Activity activity,
+            BrowserServicesIntentDataProvider intentData,
+            Supplier<TouchEventProvider> touchEventProvider,
+            Supplier<Tab> tab,
+            OnResizedCallback onResizedCallback,
+            OnActivityLayoutCallback onActivityLayoutCallback,
+            ActivityLifecycleDispatcher lifecycleDispatcher,
+            FullscreenManager fullscreenManager,
+            boolean isTablet,
+            boolean startMaximized,
+            PartialCustomTabHandleStrategyFactory handleStrategyFactory) {
+        super(
+                activity,
+                intentData,
+                touchEventProvider,
+                tab,
+                onResizedCallback,
+                onActivityLayoutCallback,
+                lifecycleDispatcher,
+                fullscreenManager,
+                isTablet,
+                startMaximized,
+                handleStrategyFactory);
+    }
+
+    public boolean mStopShowingSpinner;
+
+    @Override
+    public void onDragStart(int y) {
+        super.onDragStart(y);
+        mStopShowingSpinner = true;
+    }
+
+    public static Class<OnResizedCallback> getOnResizedCallbackClass() {
+        return OnResizedCallback.class;
+    }
+
+    public static Class<OnActivityLayoutCallback> getOnActivityLayoutCallbackClass() {
+        return OnActivityLayoutCallback.class;
+    }
+}

--- a/android/java/org/chromium/chrome/browser/customtabs/features/partialcustomtab/BravePartialCustomTabBottomSheetStrategy.java
+++ b/android/java/org/chromium/chrome/browser/customtabs/features/partialcustomtab/BravePartialCustomTabBottomSheetStrategy.java
@@ -12,7 +12,10 @@ import org.chromium.chrome.browser.browserservices.intents.BrowserServicesIntent
 import org.chromium.chrome.browser.fullscreen.FullscreenManager;
 import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
 import org.chromium.chrome.browser.tab.Tab;
+import org.chromium.chrome.browser.util.TabUtils;
 import org.chromium.components.browser_ui.widget.TouchEventProvider;
+import org.chromium.ui.base.PageTransition;
+import org.chromium.url.GURL;
 
 public class BravePartialCustomTabBottomSheetStrategy extends PartialCustomTabBottomSheetStrategy {
 
@@ -43,11 +46,20 @@ public class BravePartialCustomTabBottomSheetStrategy extends PartialCustomTabBo
     }
 
     public boolean mStopShowingSpinner;
+    public Supplier<Tab> mTab;
 
     @Override
     public void onDragStart(int y) {
         super.onDragStart(y);
-        mStopShowingSpinner = true;
+        if (!mTab.hasValue()) {
+            return;
+        }
+        GURL url = mTab.get().getUrl();
+        if (url.getScheme().equals("chrome-untrusted")
+                && url.getHost().equals("chat")
+                && TabUtils.getTransition(mTab.get()) == PageTransition.FROM_API) {
+            mStopShowingSpinner = true;
+        }
     }
 
     public static Class<OnResizedCallback> getOnResizedCallbackClass() {

--- a/android/java/org/chromium/chrome/browser/util/TabUtils.java
+++ b/android/java/org/chromium/chrome/browser/util/TabUtils.java
@@ -306,4 +306,24 @@ public class TabUtils {
 
         context.startActivity(intent);
     }
+
+    /**
+     * Returns transition for the given tab
+     *
+     * @param tab
+     */
+    public static int getTransition(Tab tab) {
+        if (tab != null
+                && tab.getWebContents() != null
+                && tab.getWebContents().getNavigationController() != null
+                && tab.getWebContents().getNavigationController().getVisibleEntry() != null) {
+            int transition =
+                    tab.getWebContents()
+                            .getNavigationController()
+                            .getVisibleEntry()
+                            .getTransition();
+            return transition;
+        }
+        return 0;
+    }
 }

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -45,10 +45,13 @@ import org.chromium.chrome.browser.bookmarks.BookmarkUndoController;
 import org.chromium.chrome.browser.browser_controls.BrowserControlsSizer;
 import org.chromium.chrome.browser.browser_controls.BrowserControlsStateProvider;
 import org.chromium.chrome.browser.browser_controls.BrowserStateBrowserControlsVisibilityDelegate;
+import org.chromium.chrome.browser.browserservices.intents.BrowserServicesIntentDataProvider;
 import org.chromium.chrome.browser.compositor.CompositorViewHolder;
 import org.chromium.chrome.browser.compositor.layouts.content.TabContentManager;
 import org.chromium.chrome.browser.contextmenu.ContextMenuItemDelegate;
 import org.chromium.chrome.browser.contextmenu.ContextMenuNativeDelegate;
+import org.chromium.chrome.browser.customtabs.features.partialcustomtab.BravePartialCustomTabBottomSheetStrategy;
+import org.chromium.chrome.browser.customtabs.features.partialcustomtab.PartialCustomTabHandleStrategyFactory;
 import org.chromium.chrome.browser.feed.FeedActionDelegate;
 import org.chromium.chrome.browser.feed.FeedSurfaceCoordinator;
 import org.chromium.chrome.browser.feed.SnapScrollHelper;
@@ -1116,6 +1119,23 @@ public class BytecodeTest {
                         "org/chromium/chrome/browser/bookmarks/BookmarkUiPrefs",
                         "org/chromium/chrome/browser/bookmarks/BraveBookmarkUiPrefs",
                         SharedPreferencesManager.class));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/chrome/browser/customtabs/features/"
+                                + "partialcustomtab/PartialCustomTabBottomSheetStrategy",
+                        "org/chromium/chrome/browser/customtabs/features/"
+                                + "partialcustomtab/BravePartialCustomTabBottomSheetStrategy",
+                        Activity.class,
+                        BrowserServicesIntentDataProvider.class,
+                        Supplier.class,
+                        Supplier.class,
+                        BravePartialCustomTabBottomSheetStrategy.getOnResizedCallbackClass(),
+                        BravePartialCustomTabBottomSheetStrategy.getOnActivityLayoutCallbackClass(),
+                        ActivityLifecycleDispatcher.class,
+                        FullscreenManager.class,
+                        boolean.class,
+                        boolean.class,
+                        PartialCustomTabHandleStrategyFactory.class));
     }
 
     @Test
@@ -1353,6 +1373,12 @@ public class BytecodeTest {
         Assert.assertTrue(
                 fieldExists("org/chromium/chrome/browser/SwipeRefreshHandler", "mSwipeType"));
         Assert.assertTrue(fieldExists("org/chromium/chrome/browser/SwipeRefreshHandler", "mTab"));
+
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/customtabs/features/"
+                                + "partialcustomtab/PartialCustomTabBottomSheetStrategy",
+                        "mStopShowingSpinner"));
     }
 
     @Test

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -1379,6 +1379,11 @@ public class BytecodeTest {
                         "org/chromium/chrome/browser/customtabs/features/"
                                 + "partialcustomtab/PartialCustomTabBottomSheetStrategy",
                         "mStopShowingSpinner"));
+        Assert.assertTrue(
+                fieldExists(
+                        "org/chromium/chrome/browser/customtabs/features/"
+                                + "partialcustomtab/PartialCustomTabBottomSheetStrategy",
+                        "mTab"));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -67,6 +67,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveNotificationBuilderClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveNotificationManagerProxyImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveNotificationPermissionRationaleDialogControllerClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BravePartialCustomTabBottomSheetStrategyClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePasswordAccessReauthenticationHelperClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePasswordSettingsBaseClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePermissionDialogDelegateClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -67,6 +67,7 @@ public class BraveClassAdapter {
         chain = new BraveNotificationBuilderClassAdapter(chain);
         chain = new BraveNotificationManagerProxyImplClassAdapter(chain);
         chain = new BraveNotificationPermissionRationaleDialogControllerClassAdapter(chain);
+        chain = new BravePartialCustomTabBottomSheetStrategyClassAdapter(chain);
         chain = new BravePasswordAccessReauthenticationHelperClassAdapter(chain);
         chain = new BravePasswordSettingsBaseClassAdapter(chain);
         chain = new BravePermissionDialogDelegateClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BravePartialCustomTabBottomSheetStrategyClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BravePartialCustomTabBottomSheetStrategyClassAdapter.java
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BravePartialCustomTabBottomSheetStrategyClassAdapter extends BraveClassVisitor {
+    static String sNamespace = "org/chromium/chrome/browser/customtabs/features/partialcustomtab/";
+    static String sStrategy = sNamespace + "PartialCustomTabBottomSheetStrategy";
+    static String sBraveStrategy = sNamespace + "BravePartialCustomTabBottomSheetStrategy";
+
+    BravePartialCustomTabBottomSheetStrategyClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(sStrategy, sBraveStrategy);
+
+        deleteField(sBraveStrategy, "mStopShowingSpinner");
+        makeProtectedField(sStrategy, "mStopShowingSpinner");
+    }
+}

--- a/build/android/bytecode/java/org/brave/bytecode/BravePartialCustomTabBottomSheetStrategyClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BravePartialCustomTabBottomSheetStrategyClassAdapter.java
@@ -19,5 +19,8 @@ public class BravePartialCustomTabBottomSheetStrategyClassAdapter extends BraveC
 
         deleteField(sBraveStrategy, "mStopShowingSpinner");
         makeProtectedField(sStrategy, "mStopShowingSpinner");
+
+        deleteField(sBraveStrategy, "mTab");
+        makeProtectedField(sStrategy, "mTab");
     }
 }

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1261,6 +1261,7 @@ if (is_android) {
       "//brave/components/brave_wallet/common:mojom_java",
       "//cc:cc_java",
       "//chrome/android:chrome_apk_pak_assets",
+      "//chrome/browser/android/browserservices/intents:java",
       "//chrome/browser/android/lifecycle:java",
       "//chrome/browser/back_press/android:java",
       "//chrome/browser/browser_controls/android:java",


### PR DESCRIPTION
Fixes brave/brave-browser#35838

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35838

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

#### I. Normal flow with Leo panel
See the issue.

####  II. Ensure default behavior is the same for non-Leo cases
1. Make Brave Browser default
2. Launch and exit Brave Browser - just in case - otherwise on my device it kept opening Chrome in custom tab somehow. 
3. Install https://github.com/GoogleChrome/android-browser-helper/tree/main/demos/custom-tabs-example-app . You can build it by yourslef or take the one I've built 
[custom-tabs-example-app-debug.zip](https://github.com/brave/brave-core/files/14192710/custom-tabs-example-app-debug.zip)
4. Launch `Custom Tabs Demos`
5. Press `Partial Custom Tab` section
6. Press `OPEN CUSTOM TAB` button
7. Drag tab panel to the top, ensure you see spinner 
