### PR TITLE
Add "Bring All tabs to this window" to TabContextMenu

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -946,6 +946,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_TAB_CXMENU_CLOSETABSTORIGHT_VERTICAL_TABS" desc="The label of the 'Close Tabs below' Tab context menu item for vertical tabs.">
           Close tabs below
         </message>
+        <message name="IDS_TAB_CXMENU_BRING_ALL_TABS_TO_THIS_WINDOW" desc="The label of the 'Bring all tabs to this window' tab context menu item">
+          Bring all tabs to this window
+        </message>
       </if>
       <if expr="use_titlecase">
         <message name="IDS_TAB_CXMENU_BOOKMARK_ALL_TABS" desc="In Title Case: The label of the tab context menu item for creating a bookmark folder containing an entry for each open tab.">
@@ -965,6 +968,9 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         </message>
         <message name="IDS_TAB_CXMENU_CLOSETABSTORIGHT_VERTICAL_TABS" desc="The label of the 'Close Tabs below' Tab context menu item for vertical tabs.">
           Close Tabs Below
+        </message>
+        <message name="IDS_TAB_CXMENU_BRING_ALL_TABS_TO_THIS_WINDOW" desc="The label of the 'Bring all tabs to this window' tab context menu item">
+          Bring All Tabs to This Window
         </message>
       </if>
 

--- a/browser/ui/tabs/brave_tab_menu_model.cc
+++ b/browser/ui/tabs/brave_tab_menu_model.cc
@@ -48,14 +48,17 @@ BraveTabMenuModel::~BraveTabMenuModel() = default;
 int BraveTabMenuModel::GetRestoreTabCommandStringId() const {
   int id = IDS_RESTORE_TAB;
 
-  if (!web_contents_)
+  if (!web_contents_) {
     return id;
+  }
 
-  if (!restore_service_)
+  if (!restore_service_) {
     return id;
+  }
 
-  if (!restore_service_->IsLoaded() || restore_service_->entries().empty())
+  if (!restore_service_->IsLoaded() || restore_service_->entries().empty()) {
     return id;
+  }
 
   if (restore_service_->entries().front()->type ==
       sessions::TabRestoreService::WINDOW) {
@@ -96,6 +99,8 @@ void BraveTabMenuModel::Build(int selected_tab_count) {
 
   AddItemWithStringId(CommandRestoreTab, GetRestoreTabCommandStringId());
   AddItemWithStringId(CommandBookmarkAllTabs, IDS_TAB_CXMENU_BOOKMARK_ALL_TABS);
+  AddItemWithStringId(CommandBringAllTabsToThisWindow,
+                      IDS_TAB_CXMENU_BRING_ALL_TABS_TO_THIS_WINDOW);
 
   AddSeparator(ui::NORMAL_SEPARATOR);
   AddCheckItemWithStringId(CommandShowVerticalTabs,

--- a/browser/ui/tabs/brave_tab_menu_model.h
+++ b/browser/ui/tabs/brave_tab_menu_model.h
@@ -26,6 +26,7 @@ class BraveTabMenuModel : public TabMenuModel {
     CommandBookmarkAllTabs,
     CommandShowVerticalTabs,
     CommandToggleTabMuted,
+    CommandBringAllTabsToThisWindow,
     CommandLast,
   };
 

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.cc
@@ -7,10 +7,14 @@
 
 #include <algorithm>
 #include <iterator>
+#include <stack>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/notreached.h"
+#include "base/ranges/algorithm.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -22,6 +26,7 @@
 #include "chrome/browser/sessions/tab_restore_service_factory.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/tabs/tab_enums.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/tabs/tab_utils.h"
@@ -29,6 +34,16 @@
 #include "components/sessions/core/tab_restore_service.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/views/controls/menu/menu_runner.h"
+
+namespace {
+
+bool CanTakeTabs(const Browser* from, const Browser* to) {
+  return from != to && !from->IsAttemptingToCloseBrowser() &&
+         !from->IsBrowserClosing() && !from->is_delete_scheduled() &&
+         to->profile() == from->profile();
+}
+
+}  // namespace
 
 BraveTabContextMenuContents::BraveTabContextMenuContents(
     Tab* tab,
@@ -38,8 +53,7 @@ BraveTabContextMenuContents::BraveTabContextMenuContents(
       tab_index_(index),
       browser_(const_cast<Browser*>(controller->browser())),
       controller_(controller) {
-  const bool is_vertical_tab =
-      tabs::utils::ShouldShowVerticalTabs(browser_);
+  const bool is_vertical_tab = tabs::utils::ShouldShowVerticalTabs(browser_);
 
   model_ = std::make_unique<BraveTabMenuModel>(
       this, controller->browser()->tab_menu_model_delegate(),
@@ -84,8 +98,9 @@ bool BraveTabContextMenuContents::IsCommandIdEnabled(int command_id) const {
     return false;
   }
 
-  if (IsBraveCommandId(command_id))
+  if (IsBraveCommandId(command_id)) {
     return IsBraveCommandIdEnabled(command_id);
+  }
 
   return controller_->IsCommandEnabledForTab(
       static_cast<TabStripModel::ContextMenuCommand>(command_id), tab_);
@@ -100,6 +115,12 @@ bool BraveTabContextMenuContents::IsCommandIdVisible(int command_id) const {
     return tabs::utils::SupportsVerticalTabs(browser_);
   }
 
+  if (command_id == BraveTabMenuModel::CommandBringAllTabsToThisWindow) {
+    return base::ranges::any_of(
+        *BrowserList::GetInstance(),
+        [&](const auto* from) { return CanTakeTabs(from, browser_); });
+  }
+
   return ui::SimpleMenuModel::Delegate::IsCommandIdVisible(command_id);
 }
 
@@ -110,8 +131,9 @@ bool BraveTabContextMenuContents::GetAcceleratorForCommandId(
     return false;
   }
 
-  if (IsBraveCommandId(command_id))
+  if (IsBraveCommandId(command_id)) {
     return false;
+  }
 
   int browser_cmd;
   views::Widget* widget =
@@ -127,8 +149,9 @@ void BraveTabContextMenuContents::ExecuteCommand(int command_id,
     return;
   }
 
-  if (IsBraveCommandId(command_id))
+  if (IsBraveCommandId(command_id)) {
     return ExecuteBraveCommand(command_id);
+  }
 
   // Executing the command destroys |this|, and can also end up destroying
   // |controller_|. So stop the highlights before executing the command.
@@ -153,13 +176,17 @@ bool BraveTabContextMenuContents::IsBraveCommandIdEnabled(
     case BraveTabMenuModel::CommandToggleTabMuted: {
       auto* model = static_cast<BraveTabStripModel*>(controller_->model());
       for (const auto& index : model->GetTabIndicesForCommandAt(tab_index_)) {
-        if (!model->GetWebContentsAt(index)->GetLastCommittedURL().is_empty())
+        if (!model->GetWebContentsAt(index)->GetLastCommittedURL().is_empty()) {
           return true;
+        }
       }
       return false;
     }
     case BraveTabMenuModel::CommandShowVerticalTabs:
       return true;
+    case BraveTabMenuModel::CommandBringAllTabsToThisWindow: {
+      return true;
+    }
     default:
       NOTREACHED();
       break;
@@ -199,9 +226,57 @@ void BraveTabContextMenuContents::ExecuteBraveCommand(int command_id) {
       }
       return;
     }
+    case BraveTabMenuModel::CommandBringAllTabsToThisWindow: {
+      BringAllTabsToThisWindow();
+      return;
+    }
     default:
       NOTREACHED();
       return;
+  }
+}
+
+void BraveTabContextMenuContents::BringAllTabsToThisWindow() {
+  // Find all browsers with the same profile
+  std::vector<Browser*> browsers;
+  base::ranges::copy_if(
+      *BrowserList::GetInstance(), std::back_inserter(browsers),
+      [&](const auto* from) { return CanTakeTabs(from, browser_); });
+
+  // Detach all tabs from other browsers
+  std::stack<std::unique_ptr<content::WebContents>> detached_pinned_tabs;
+  std::stack<std::unique_ptr<content::WebContents>> detached_unpinned_tabs;
+
+  base::ranges::for_each(browsers, [&detached_pinned_tabs,
+                                    &detached_unpinned_tabs](auto* other) {
+    auto* tab_strip_model = other->tab_strip_model();
+    const int pinned_tab_count = tab_strip_model->IndexOfFirstNonPinnedTab();
+    for (int i = tab_strip_model->count() - 1; i >= 0; --i) {
+      auto contents = tab_strip_model->DetachWebContentsAtForInsertion(i);
+      const bool is_pinned = i < pinned_tab_count;
+      if (is_pinned) {
+        detached_pinned_tabs.push(std::move(contents));
+      } else {
+        detached_unpinned_tabs.push(std::move(contents));
+      }
+    }
+  });
+
+  // Insert pinned tabs
+  auto* tab_strip_model = browser_->tab_strip_model();
+  while (!detached_pinned_tabs.empty()) {
+    tab_strip_model->InsertWebContentsAt(
+        tab_strip_model->IndexOfFirstNonPinnedTab(),
+        std::move(detached_pinned_tabs.top()), AddTabTypes::ADD_PINNED);
+    detached_pinned_tabs.pop();
+  }
+
+  // Insert unpinned tabs
+  while (!detached_unpinned_tabs.empty()) {
+    tab_strip_model->InsertWebContentsAt(
+        tab_strip_model->count(), std::move(detached_unpinned_tabs.top()),
+        AddTabTypes::ADD_NONE);
+    detached_unpinned_tabs.pop();
   }
 }
 

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents.h
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents.h
@@ -59,6 +59,8 @@ class BraveTabContextMenuContents : public ui::SimpleMenuModel::Delegate {
 
   bool IsBraveCommandIdEnabled(int command_id) const;
   void ExecuteBraveCommand(int command_id);
+  void BringAllTabsToThisWindow();
+
   bool IsBraveCommandId(int command_id) const;
   bool IsValidContextMenu() const;
   void OnMenuClosed();

--- a/browser/ui/views/tabs/brave_tab_context_menu_contents_browsertest.cc
+++ b/browser/ui/views/tabs/brave_tab_context_menu_contents_browsertest.cc
@@ -3,11 +3,15 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/views/tabs/brave_tab_context_menu_contents.h"
+
+#include <memory>
+
+#include "brave/browser/ui/tabs/brave_tab_menu_model.h"
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/tabs/browser_tab_strip_controller.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -16,38 +20,162 @@
 #include "content/public/test/browser_test.h"
 #include "url/gurl.h"
 
-using BraveTabContextMenuContentsTest = InProcessBrowserTest;
+class BraveTabContextMenuContentsTest : public InProcessBrowserTest {
+ public:
+  BraveTabContextMenuContentsTest() = default;
+  ~BraveTabContextMenuContentsTest() override = default;
+
+ protected:
+  std::unique_ptr<BraveTabContextMenuContents> CreateMenu() {
+    TabStrip* tabstrip =
+        BrowserView::GetBrowserViewForBrowser(browser())->tabstrip();
+    return std::make_unique<BraveTabContextMenuContents>(
+        tabstrip->tab_at(0),
+        static_cast<BraveBrowserTabStripController*>(
+            BrowserView::GetBrowserViewForBrowser(browser())
+                ->tabstrip()
+                ->controller()),
+        0);
+  }
+
+  Browser* CreateBrowser(bool incognito) {
+    if (incognito) {
+      return chrome::OpenEmptyWindow(
+          browser()->profile()->GetPrimaryOTRProfile(/*create_if_needed=*/true),
+          /*should_trigger_session_restore=*/false);
+    }
+    return chrome::OpenEmptyWindow(browser()->profile(),
+                                   /*should_trigger_session_restore=*/false);
+  }
+
+  void AddTabs(Browser* browser, int new_tab_count, int pinned_tab_count) {
+    std::vector expected = {browser->tab_strip_model()->GetWebContentsAt(0)};
+    for (int i = 0; i < new_tab_count; ++i) {
+      expected.push_back(chrome::AddAndReturnTabAt(browser, GURL(),
+                                                   /*index=*/-1,
+                                                   /*foreground=*/false));
+    }
+    for (int i = 0; i < pinned_tab_count; ++i) {
+      browser->tab_strip_model()->SetTabPinned(i, true);
+    }
+  }
+
+  std::vector<content::WebContents*> GetWebContentses(Browser* browser) {
+    std::vector<content::WebContents*> web_contentses;
+    const auto count = browser->tab_strip_model()->count();
+    for (int i = 0; i < count; i++) {
+      web_contentses.push_back(browser->tab_strip_model()->GetWebContentsAt(i));
+    }
+    return web_contentses;
+  }
+};
 
 IN_PROC_BROWSER_TEST_F(BraveTabContextMenuContentsTest, Basics) {
-  TabStrip* tabstrip =
-      BrowserView::GetBrowserViewForBrowser(browser())->tabstrip();
-  BraveTabContextMenuContents menu(
-      tabstrip->tab_at(0),
-      static_cast<BraveBrowserTabStripController*>(
-          BrowserView::GetBrowserViewForBrowser(
-              browser())->tabstrip()->controller()),
-      0);
+  auto menu = CreateMenu();
 
   // All items are disable state when there is only one tab.
-  EXPECT_FALSE(menu.IsCommandIdEnabled(
-      BraveTabMenuModel::CommandRestoreTab));
-  EXPECT_FALSE(menu.IsCommandIdEnabled(
-      BraveTabMenuModel::CommandBookmarkAllTabs));
+  EXPECT_FALSE(menu->IsCommandIdEnabled(BraveTabMenuModel::CommandRestoreTab));
+  EXPECT_FALSE(
+      menu->IsCommandIdEnabled(BraveTabMenuModel::CommandBookmarkAllTabs));
 
   chrome::NewTab(browser());
   // Still restore tab menu is disabled because there is no closed tab.
-  EXPECT_FALSE(menu.IsCommandIdEnabled(
-      BraveTabMenuModel::CommandRestoreTab));
+  EXPECT_FALSE(menu->IsCommandIdEnabled(BraveTabMenuModel::CommandRestoreTab));
   // Bookmark all tabs item is enabled if the number of tabs are 2 or more.
-  EXPECT_TRUE(menu.IsCommandIdEnabled(
-      BraveTabMenuModel::CommandBookmarkAllTabs));
+  EXPECT_TRUE(
+      menu->IsCommandIdEnabled(BraveTabMenuModel::CommandBookmarkAllTabs));
 
   // When a tab is closed, restore tab menu item is enabled.
   ASSERT_TRUE(
       ui_test_utils::NavigateToURL(browser(), GURL("brave://version/")));
   chrome::CloseTab(browser());
-  EXPECT_TRUE(menu.IsCommandIdEnabled(
-      BraveTabMenuModel::CommandRestoreTab));
-  EXPECT_FALSE(menu.IsCommandIdEnabled(
-      BraveTabMenuModel::CommandBookmarkAllTabs));
+  EXPECT_TRUE(menu->IsCommandIdEnabled(BraveTabMenuModel::CommandRestoreTab));
+  EXPECT_FALSE(
+      menu->IsCommandIdEnabled(BraveTabMenuModel::CommandBookmarkAllTabs));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveTabContextMenuContentsTest,
+                       BringAllTabsToThisWindow_VisibleWhenOtherBrowserExists) {
+  auto menu = CreateMenu();
+  auto is_command_visible = [&]() {
+    return menu->IsCommandIdVisible(
+        BraveTabMenuModel::CommandBringAllTabsToThisWindow);
+  };
+
+  // No other browser exists, so the command is not visible.
+  EXPECT_FALSE(is_command_visible());
+
+  // Open a new browser and the command becomes visible.
+  auto* new_browser = CreateBrowser(/*incognito=*/false);
+  ASSERT_FALSE(new_browser->tab_strip_model()->empty());
+  EXPECT_TRUE(is_command_visible());
+
+  // Close the new browser and the command becomes invisible again.
+  CloseBrowserSynchronously(new_browser);
+  EXPECT_FALSE(is_command_visible());
+
+  // New incognito window shouldn't affect the visibility of the command.
+  new_browser = CreateBrowser(/*incognito=*/true);
+  ASSERT_FALSE(new_browser->tab_strip_model()->empty());
+  EXPECT_FALSE(is_command_visible());
+}
+
+IN_PROC_BROWSER_TEST_F(BraveTabContextMenuContentsTest,
+                       BringAllTabsToThisWindow_TabsInOrder) {
+  // Prepare a new browser with multiple tabs.
+  auto* new_browser = CreateBrowser(/*incognito=*/false);
+  constexpr auto kNewTabCount = 4;
+  constexpr auto kPinnedTabCount = 2;
+  AddTabs(new_browser, kNewTabCount, kPinnedTabCount);
+  ASSERT_EQ(new_browser->tab_strip_model()->count(), kNewTabCount + 1);
+  ASSERT_EQ(new_browser->tab_strip_model()->IndexOfFirstNonPinnedTab(),
+            kPinnedTabCount);
+  auto expected = GetWebContentses(new_browser);
+
+  auto* tab_strip_model = browser()->tab_strip_model();
+  AddTabs(browser(), /*new_tab_count*/ 1, /*pinned_tab*/ 1);
+  ASSERT_EQ(tab_strip_model->count(), 2);
+  ASSERT_TRUE(tab_strip_model->IsTabPinned(0));
+  ASSERT_FALSE(tab_strip_model->IsTabPinned(1));
+
+  // All other unpinned tab should be appended after the existing tabs.
+  expected.insert(expected.begin() + kPinnedTabCount,
+                  tab_strip_model->GetWebContentsAt(1));
+  expected.insert(expected.begin(), tab_strip_model->GetWebContentsAt(0));
+
+  // Bring all tabs to this browser
+  auto menu = CreateMenu();
+  ASSERT_TRUE(menu->IsCommandIdVisible(
+      BraveTabMenuModel::CommandBringAllTabsToThisWindow));
+  menu->ExecuteCommand(BraveTabMenuModel::CommandBringAllTabsToThisWindow,
+                       /*event_flags=*/0);
+
+  // The tabs should be moved to the current browser in the order.
+  EXPECT_EQ(tab_strip_model->IndexOfFirstNonPinnedTab(), kPinnedTabCount + 1);
+  EXPECT_THAT(GetWebContentses(browser()), testing::ElementsAreArray(expected));
+}
+
+IN_PROC_BROWSER_TEST_F(BraveTabContextMenuContentsTest,
+                       BringAllTabsToThisWindow_MultipleWindows) {
+  auto* new_browser_1 = CreateBrowser(/*incognito=*/false);
+  AddTabs(new_browser_1, /*new_tab_count=*/2, /*pinned_tab_count=*/0);
+  auto tab_count = new_browser_1->tab_strip_model()->count();
+
+  auto* new_browser_2 = CreateBrowser(/*incognito=*/false);
+  AddTabs(new_browser_2, /*new_tab_count=*/3, /*pinned_tab_count=*/0);
+  tab_count += new_browser_2->tab_strip_model()->count();
+
+  auto* incognito_browser = CreateBrowser(/*incognito=*/true);
+  AddTabs(incognito_browser, /*new_tab_count=*/4, /*pinned_tab_count=*/0);
+  const auto incognito_tab_count =
+      incognito_browser->tab_strip_model()->count();
+
+  auto menu = CreateMenu();
+  ASSERT_TRUE(menu->IsCommandIdVisible(
+      BraveTabMenuModel::CommandBringAllTabsToThisWindow));
+  menu->ExecuteCommand(BraveTabMenuModel::CommandBringAllTabsToThisWindow,
+                       /*event_flags=*/0);
+
+  EXPECT_EQ(browser()->tab_strip_model()->count(), tab_count + 1);
+  EXPECT_EQ(incognito_browser->tab_strip_model()->count(), incognito_tab_count);
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/27022

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Open up multiple browsers
* Activate one of them, and right-click a tab
* In the context menu that shows up, click "Bring all tabs to this window"
* Check if all tabs are moved to the window
  * But tabs in other windows with different profile, such as "Private" or "Tor" shouldn't be moved.
  * If the target window is bound to "Private/Tor" profile, tabs moved from other windows also should be from "Private/Tor" profile.

