### PR TITLE
Show correct error when transaction failed due existance of posted one

### DIFF
--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -134,6 +134,8 @@ enum ZCashProviderError {
   kSuccess = ProviderError.kSuccess,  // No error
   kUnknown = ProviderError.kUnknown,
   kInternalError = JsonRpcError.kInternalError,
+  // Fired when there are several outgoings transactions
+  kMultipleTransactionsNotSupported
 };
 
 union ProviderErrorUnion {

--- a/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
+++ b/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
@@ -455,7 +455,7 @@ export const usePendingTransactions = () => {
     }
 
     try {
-      await dispatch(
+      const result = await dispatch(
         walletApi.endpoints.approveTransaction.initiate({
           chainId: transactionInfo.chainId,
           id: transactionInfo.id,
@@ -463,8 +463,17 @@ export const usePendingTransactions = () => {
           txType: transactionInfo.txType
         })
       ).unwrap()
-      dispatch(PanelActions.setSelectedTransactionId(transactionInfo.id))
-      dispatch(PanelActions.navigateTo('transactionStatus'))
+      if (!result.status) {
+        dispatch(
+          UIActions.setTransactionProviderError({
+            providerError: {
+              code: result.errorUnion,
+              message: result.errorMessage
+            },
+            transactionId: transactionInfo.id
+          })
+        )
+      }
     } catch (error) {
       dispatch(
         UIActions.setTransactionProviderError({
@@ -472,6 +481,9 @@ export const usePendingTransactions = () => {
           transactionId: transactionInfo.id
         })
       )
+    } finally {
+      dispatch(PanelActions.setSelectedTransactionId(transactionInfo.id))
+      dispatch(PanelActions.navigateTo('transactionStatus'))
     }
   }, [transactionInfo])
 

--- a/components/brave_wallet_ui/common/slices/endpoints/transaction.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/transaction.endpoints.ts
@@ -778,7 +778,11 @@ export const transactionEndpoints = ({
     }),
 
     approveTransaction: mutation<
-      { success: boolean },
+      {
+        status: boolean
+        errorUnion: BraveWallet.ProviderErrorUnion
+        errorMessage: string
+      },
       Pick<SerializableTransactionInfo, 'id' | 'chainId' | 'txType'> & {
         coinType: BraveWallet.CoinType
       }
@@ -797,21 +801,13 @@ export const transactionEndpoints = ({
             txInfo.id
           )
 
-          const error =
-            result.errorUnion.providerError ??
-            result.errorUnion.solanaProviderError
-
-          if (error && error !== BraveWallet.ProviderError.kSuccess) {
-            throw new Error(`${error}: ${result.errorMessage}`)
-          }
-
-          if (shouldReportTransactionP3A({ txInfo })) {
+          if (result.errorUnion.providerError ===
+                BraveWallet.ProviderError.kSuccess &&
+              shouldReportTransactionP3A({ txInfo })) {
             braveWalletP3A.reportTransactionSent(txInfo.coinType, true)
           }
 
-          return {
-            data: { success: true }
-          }
+          return { data: result }
         } catch (error) {
           return handleEndpointError(
             endpoint,

--- a/components/brave_wallet_ui/common/slices/endpoints/transaction.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/transaction.endpoints.ts
@@ -779,7 +779,7 @@ export const transactionEndpoints = ({
 
     approveTransaction: mutation<
       {
-        status: boolean
+        success: boolean
         errorUnion: BraveWallet.ProviderErrorUnion
         errorMessage: string
       },
@@ -807,7 +807,13 @@ export const transactionEndpoints = ({
             braveWalletP3A.reportTransactionSent(txInfo.coinType, true)
           }
 
-          return { data: result }
+          return {
+            data: {
+              success: result.status,
+              errorMessage: result.errorMessage,
+              errorUnion: result.errorUnion
+            }
+          }
         } catch (error) {
           return handleEndpointError(
             endpoint,

--- a/components/brave_wallet_ui/components/extension/post-confirmation/failed/failed.stories.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/failed/failed.stories.tsx
@@ -28,6 +28,7 @@ export const _TransactionFailed = () => {
               'braveWalletTransactionFailedModalSubtitle'
             )}
             errorDetailContent='[ethjs-query] while formatting outputs from RPC ‘{“value”: {“code”:-32603,”data”: {“code”-32603,”message”:”Internal error”}}}’'
+            customDescription={undefined}
             onClose={onClose}
             onClickPrimaryCTA={() => alert('Clicked primary CTA')}
           />

--- a/components/brave_wallet_ui/components/extension/post-confirmation/failed/failed.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/failed/failed.tsx
@@ -21,6 +21,7 @@ import { PopupModal } from '../../popup-modals'
 interface Props {
   headerTitle: string
   isPrimaryCTADisabled: boolean
+  customDescription: string | undefined
   errorDetailTitle: string
   errorDetailContent?: string | undefined
   onClose: () => void
@@ -33,12 +34,16 @@ export const TransactionFailed = (props: Props) => {
     errorDetailTitle,
     errorDetailContent,
     isPrimaryCTADisabled,
+    customDescription,
     onClose,
     onClickPrimaryCTA
   } = props
 
   const [showErrorCodeModal, setShowErrorCodeModal] =
     React.useState<boolean>(false)
+
+  const description = customDescription ||
+      getLocale('braveWalletTransactionFailedDescription')
 
   return (
     <Panel
@@ -49,7 +54,7 @@ export const TransactionFailed = (props: Props) => {
       <ErrorIcon />
       <Title>{getLocale('braveWalletTransactionFailedTitle')}</Title>
       <TransactionStatusDescription>
-        {getLocale('braveWalletTransactionFailedDescription')}
+        {description}
       </TransactionStatusDescription>
       <ButtonRow>
         {errorDetailContent && (

--- a/components/brave_wallet_ui/components/extension/post-confirmation/index.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/index.tsx
@@ -170,8 +170,21 @@ export function TransactionStatus(props: Props) {
 
   if (tx.txStatus === BraveWallet.TransactionStatus.Error) {
     const providerError = transactionProviderErrorRegistry[tx.id]
+    const errorCode =
+        providerError.code.providerError ??
+        providerError.code.zcashProviderError ??
+        providerError.code.bitcoinProviderError ??
+        providerError.code.solanaProviderError ??
+        providerError.code.filecoinProviderError
+
     const errorDetailContent =
-      providerError && `${providerError.code}: ${providerError.message}`
+      errorCode !== BraveWallet.ProviderError.kSuccess ?
+      `${errorCode}: ${providerError.message}` : undefined
+    const customDescription =
+      providerError?.code.zcashProviderError ===
+          BraveWallet.ZCashProviderError.kMultipleTransactionsNotSupported ?
+          providerError.message : undefined
+
     return (
       <TransactionFailed
         headerTitle={transactionIntent}
@@ -180,6 +193,7 @@ export function TransactionStatus(props: Props) {
           'braveWalletTransactionFailedModalSubtitle'
         )}
         errorDetailContent={errorDetailContent}
+        customDescription={customDescription}
         onClose={onClose}
         onClickPrimaryCTA={onClose}
       />

--- a/components/brave_wallet_ui/components/extension/post-confirmation/index.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/index.tsx
@@ -171,19 +171,19 @@ export function TransactionStatus(props: Props) {
   if (tx.txStatus === BraveWallet.TransactionStatus.Error) {
     const providerError = transactionProviderErrorRegistry[tx.id]
     const errorCode =
-        providerError.code.providerError ??
-        providerError.code.zcashProviderError ??
-        providerError.code.bitcoinProviderError ??
-        providerError.code.solanaProviderError ??
-        providerError.code.filecoinProviderError
+      providerError?.code.providerError ??
+      providerError?.code.zcashProviderError ??
+      providerError?.code.bitcoinProviderError ??
+      providerError?.code.solanaProviderError ??
+      providerError?.code.filecoinProviderError ??
+      BraveWallet.ProviderError.kUnknown
 
     const errorDetailContent =
-      errorCode !== BraveWallet.ProviderError.kSuccess ?
-      `${errorCode}: ${providerError.message}` : undefined
+      providerError && `${errorCode}: ${providerError.message}`
     const customDescription =
-      providerError?.code.zcashProviderError ===
-          BraveWallet.ZCashProviderError.kMultipleTransactionsNotSupported ?
-          providerError.message : undefined
+      errorCode ===
+        BraveWallet.ZCashProviderError.kMultipleTransactionsNotSupported ?
+        providerError.message : undefined
 
     return (
       <TransactionFailed

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -715,7 +715,7 @@ export interface NFTMetadataReturnType {
 }
 
 export interface TransactionProviderError {
-  code: BraveWallet.ProviderError | BraveWallet.SolanaProviderError
+  code: BraveWallet.ProviderErrorUnion
   message: string
 }
 

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -719,6 +719,14 @@ export interface TransactionProviderError {
   message: string
 }
 
+export const emptyProviderErrorCodeUnion: BraveWallet.ProviderErrorUnion = {
+  providerError: undefined,
+  zcashProviderError: undefined,
+  bitcoinProviderError: undefined,
+  filecoinProviderError: undefined,
+  solanaProviderError: undefined
+}
+
 export interface TransactionProviderErrorRegistry {
   [transactionId: string]: TransactionProviderError
 }

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -610,6 +610,7 @@
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_HEADER_TITLE" desc="Transaction failed header title"><ph name="VALUE">$1<ex>1 ETH</ex></ph> was returned to your wallet</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_TITLE" desc="Transaction failed title">Transaction failed</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_DESCRIPTION" desc="Transaction failed description">Transaction was failed due to a large price movement. Increase slippage tolerance to succeed at a larger price movement.</message>
+  <message name="IDS_BRAVE_WALLET_ZCASH_TRANSACTION_ALREADY_EXISTS_DESCRIPTION" desc="Zcash transaction failed since there is already one">There is already a Zcash transaction in progress, please try again later.</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_SWAP_NEXT_CTA" desc="Transaction failed CTA text for swap">New trade</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_NEXT_CTA" desc="Transaction failed CTA text">New transaction</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_VIEW_ERROR_CTA" desc="Transaction failed view error CTA text">View Error</message>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -610,7 +610,7 @@
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_HEADER_TITLE" desc="Transaction failed header title"><ph name="VALUE">$1<ex>1 ETH</ex></ph> was returned to your wallet</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_TITLE" desc="Transaction failed title">Transaction failed</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_DESCRIPTION" desc="Transaction failed description">Transaction was failed due to a large price movement. Increase slippage tolerance to succeed at a larger price movement.</message>
-  <message name="IDS_BRAVE_WALLET_ZCASH_TRANSACTION_ALREADY_EXISTS_DESCRIPTION" desc="Zcash transaction failed since there is already one">There is already a Zcash transaction in progress, please try again later.</message>
+  <message name="IDS_BRAVE_WALLET_ZCASH_TRANSACTION_ALREADY_EXISTS_DESCRIPTION" desc="Zcash transaction failed since there is already one in progress">There is already a Zcash transaction in progress. Please try again later.</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_SWAP_NEXT_CTA" desc="Transaction failed CTA text for swap">New trade</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_NEXT_CTA" desc="Transaction failed CTA text">New transaction</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_FAILED_VIEW_ERROR_CTA" desc="Transaction failed view error CTA text">View Error</message>


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/35734

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run lint`, `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1) With Zcash post 2 transaction from one account. Second one should fail with a message saying only one is allowed
![image](https://github.com/brave/brave-core/assets/106654560/08967975-af9a-4630-b0f8-b6716325782d)
2) Transactions posted at one time but from different accounts should be successful.
3) For other coins check that "view error" button is shown. Could be tested when network is disabled before approve for example. Description should not be changed too.
4) Check that success transactions show correct message and don't show error button.