### PR TITLE
Use JSON rust sanitizer

### DIFF
--- a/browser/brave_wallet/asset_discovery_manager_unittest.cc
+++ b/browser/brave_wallet/asset_discovery_manager_unittest.cc
@@ -173,7 +173,7 @@ class AssetDiscoveryManagerUnitTest : public testing::Test {
       EXPECT_TRUE(wallet_service_observer_->OnDiscoverAssetsStartedFired());
       EXPECT_TRUE(wallet_service_observer_->OnDiscoverAssetsCompletedFired());
     } else {
-      base::RunLoop().RunUntilIdle();
+      task_environment_.RunUntilIdle();
       EXPECT_FALSE(wallet_service_observer_->OnDiscoverAssetsStartedFired());
       EXPECT_FALSE(wallet_service_observer_->OnDiscoverAssetsCompletedFired());
     }

--- a/browser/brave_wallet/brave_wallet_service_unittest.cc
+++ b/browser/brave_wallet/brave_wallet_service_unittest.cc
@@ -574,7 +574,7 @@ class BraveWalletServiceUnitTest : public testing::Test {
     auto old_default_wallet = observer_->GetDefaultEthereumWallet();
     EXPECT_FALSE(observer_->DefaultEthereumWalletChangedFired());
     service_->SetDefaultEthereumWallet(default_wallet);
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     if (old_default_wallet != default_wallet) {
       EXPECT_TRUE(observer_->DefaultEthereumWalletChangedFired());
     } else {
@@ -588,7 +588,7 @@ class BraveWalletServiceUnitTest : public testing::Test {
     auto old_default_wallet = observer_->GetDefaultSolanaWallet();
     EXPECT_FALSE(observer_->DefaultSolanaWalletChangedFired());
     service_->SetDefaultSolanaWallet(default_wallet);
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     if (old_default_wallet != default_wallet) {
       EXPECT_TRUE(observer_->DefaultSolanaWalletChangedFired());
     } else {
@@ -602,7 +602,7 @@ class BraveWalletServiceUnitTest : public testing::Test {
     auto old_currency = observer_->GetDefaultBaseCurrency();
     EXPECT_FALSE(observer_->DefaultBaseCurrencyChangedFired());
     service_->SetDefaultBaseCurrency(currency);
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     if (old_currency != currency) {
       EXPECT_TRUE(observer_->DefaultBaseCurrencyChangedFired());
     } else {
@@ -616,7 +616,7 @@ class BraveWalletServiceUnitTest : public testing::Test {
     auto old_cryptocurrency = observer_->GetDefaultBaseCryptocurrency();
     EXPECT_FALSE(observer_->DefaultBaseCryptocurrencyChangedFired());
     service_->SetDefaultBaseCryptocurrency(cryptocurrency);
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     if (old_cryptocurrency != cryptocurrency) {
       EXPECT_TRUE(observer_->DefaultBaseCryptocurrencyChangedFired());
     } else {
@@ -1508,7 +1508,7 @@ TEST_F(BraveWalletServiceUnitTest, NetworkListChangedEvent) {
   mojom::NetworkInfo chain = GetTestNetworkInfo1("0x5566");
 
   AddCustomNetwork(GetPrefs(), chain);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(observer_->OnNetworkListChangedFired());
 
   // Remove network.
@@ -1524,7 +1524,7 @@ TEST_F(BraveWalletServiceUnitTest, NetworkListChangedEvent) {
       return *chain_id_value == "0x5566";
     });
   }
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(observer_->OnNetworkListChangedFired());
 }
 
@@ -2408,7 +2408,7 @@ TEST_F(BraveWalletServiceUnitTest, SetNftDiscoveryEnabled) {
   // discovery
   EXPECT_CALL(*observer_, OnDiscoverAssetsCompleted(testing::_)).Times(1);
   service_->SetNftDiscoveryEnabled(true);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer_));
   EXPECT_TRUE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
 
@@ -2416,7 +2416,7 @@ TEST_F(BraveWalletServiceUnitTest, SetNftDiscoveryEnabled) {
   // asset discovery
   EXPECT_CALL(*observer_, OnDiscoverAssetsCompleted(testing::_)).Times(0);
   service_->SetNftDiscoveryEnabled(false);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer_));
   EXPECT_FALSE(GetPrefs()->GetBoolean(kBraveWalletNftDiscoveryEnabled));
 }
@@ -2672,13 +2672,13 @@ TEST_F(BraveWalletServiceUnitTest, GenerateReceiveAddress_Btc) {
   EXPECT_CALL(callback, Run(expected_address, std::optional<std::string>()));
   service_->GenerateReceiveAddress(btc_account->account_id.Clone(),
                                    callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(expected_address, std::optional<std::string>()));
   service_->GenerateReceiveAddress(btc_account->account_id.Clone(),
                                    callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   bitcoin_test_rpc_server_->address_stats_map()[*expected_address] =
@@ -2691,7 +2691,7 @@ TEST_F(BraveWalletServiceUnitTest, GenerateReceiveAddress_Btc) {
   EXPECT_CALL(callback, Run(expected_address, std::optional<std::string>()));
   service_->GenerateReceiveAddress(btc_account->account_id.Clone(),
                                    callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 

--- a/browser/brave_wallet/ethereum_provider_impl_unittest.cc
+++ b/browser/brave_wallet/ethereum_provider_impl_unittest.cc
@@ -654,7 +654,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
   int SignMessageRequest(const std::string& address,
                          const std::string& message) {
     provider()->SignMessage(address, message, base::DoNothing(), base::Value());
-    base::RunLoop().RunUntilIdle();
+    browser_task_environment_.RunUntilIdle();
     return brave_wallet_service_->sign_message_id_ - 1;
   }
 
@@ -835,7 +835,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
         base::Value());
     // Wait for KeyringService::GetSelectedAccount called by
     // BraveWalletProviderDelegateImpl::GetAllowedAccounts
-    base::RunLoop().RunUntilIdle();
+    browser_task_environment_.RunUntilIdle();
     auto requests = GetPendingGetEncryptionPublicKeyRequests();
     if (requests.size() > 0) {
       ASSERT_EQ(requests.size(), 1u);
@@ -876,7 +876,7 @@ class EthereumProviderImplUnitTest : public testing::Test {
         }),
         base::Value());
     // The request is not immediately added, needs sanitization first
-    base::RunLoop().RunUntilIdle();
+    browser_task_environment_.RunUntilIdle();
     auto requests = GetPendingDecryptRequests();
     if (requests.size() > 0) {
       ASSERT_EQ(requests.size(), 1u);
@@ -1107,7 +1107,7 @@ TEST_F(EthereumProviderImplUnitTest, AddAndApproveTransaction) {
             EXPECT_TRUE(error_message.empty());
             callback_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   const auto& chain_id =
       json_rpc_service()->GetChainIdSync(mojom::CoinType::ETH, GetOrigin());
   std::vector<mojom::TransactionInfoPtr> infos =
@@ -1131,7 +1131,7 @@ TEST_F(EthereumProviderImplUnitTest, AddAndApproveTransaction) {
 
   EXPECT_TRUE(
       ApproveTransaction(chain_id, infos[0]->id, &error, &error_message));
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
 
   EXPECT_EQ(error, mojom::ProviderError::kSuccess);
   EXPECT_TRUE(error_message.empty());
@@ -1286,7 +1286,7 @@ TEST_F(EthereumProviderImplUnitTest, AddAndApprove1559Transaction) {
 
   EXPECT_TRUE(
       ApproveTransaction(chain_id, infos[0]->id, &error, &error_message));
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
 
   EXPECT_EQ(error, mojom::ProviderError::kSuccess);
   EXPECT_TRUE(error_message.empty());
@@ -1635,7 +1635,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthereumPermissionsLocked) {
       base::Value(), "", GetOrigin());
   // Wait for KeyringService::GetSelectedAccount called by
   // BraveWalletProviderDelegateImpl::GetAllowedAccounts
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
 
   EXPECT_TRUE(keyring_service()->HasPendingUnlockRequest());
   // Allowed accounts are still empty when locked
@@ -2107,25 +2107,25 @@ TEST_F(EthereumProviderImplUnitTest, ChainChangedEvent) {
 
   EXPECT_CALL(*observer_, ChainChangedEvent(mojom::kGoerliChainId)).Times(1);
   SetNetwork(mojom::kGoerliChainId, std::nullopt);
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(observer_.get()));
 
   // Works a second time
   EXPECT_CALL(*observer_, ChainChangedEvent(mojom::kMainnetChainId)).Times(1);
   SetNetwork(mojom::kMainnetChainId, std::nullopt);
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(observer_.get()));
 
   EXPECT_CALL(*observer_, ChainChangedEvent(mojom::kSepoliaChainId)).Times(1);
   SetNetwork(mojom::kSepoliaChainId, GetOrigin());
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(observer_.get()));
 
   // SetNetwork for other origin will be ignored.
   EXPECT_CALL(*observer_, ChainChangedEvent(testing::_)).Times(0);
   SetNetwork(mojom::kLocalhostChainId,
              url::Origin::Create(GURL("https://a.com")));
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(observer_.get()));
 }
 
@@ -2443,11 +2443,11 @@ TEST_F(EthereumProviderImplUnitTest, AccountsChangedEventSelectedAccount) {
   AddEthereumPermission(account_0->account_id);
   // Wait for KeyringService::GetSelectedAccount called by
   // BraveWalletProviderDelegateImpl::GetAllowedAccounts
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   AddEthereumPermission(account_1->account_id);
   // Wait for KeyringService::GetSelectedAccount called by
   // BraveWalletProviderDelegateImpl::GetAllowedAccounts
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
   EXPECT_TRUE(observer_->AccountsChangedFired());
   EXPECT_THAT(observer_->GetLowercaseAccounts(),
               ElementsAre(address_0, address_1));
@@ -2923,7 +2923,7 @@ TEST_F(EthereumProviderImplUnitTest, RequestEthCoinbase) {
       base::Value(), "", GetOrigin());
   // Wait for KeyringService::GetSelectedAccount called by
   // BraveWalletProviderDelegateImpl::GetAllowedAccounts
-  base::RunLoop().RunUntilIdle();
+  browser_task_environment_.RunUntilIdle();
 
   EXPECT_TRUE(keyring_service()->HasPendingUnlockRequest());
   // eth_coinbase account is still empty when locked

--- a/browser/brave_wallet/keyring_service_unittest.cc
+++ b/browser/brave_wallet/keyring_service_unittest.cc
@@ -89,7 +89,9 @@ struct ImportData {
 
 class TestKeyringServiceObserver : public mojom::KeyringServiceObserver {
  public:
-  explicit TestKeyringServiceObserver(KeyringService& service) {
+  TestKeyringServiceObserver(KeyringService& service,
+                             base::test::TaskEnvironment& task_environment)
+      : task_environment_(&task_environment) {
     service.AddObserver(observer_receiver_.BindNewPipeAndPassRemote());
   }
   ~TestKeyringServiceObserver() override = default;
@@ -116,12 +118,13 @@ class TestKeyringServiceObserver : public mojom::KeyringServiceObserver {
               (override));
 
   void WaitAndVerify() {
-    base::RunLoop().RunUntilIdle();
+    task_environment_->RunUntilIdle();
     testing::Mock::VerifyAndClearExpectations(this);
   }
 
  private:
   mojo::Receiver<mojom::KeyringServiceObserver> observer_receiver_{this};
+  raw_ptr<base::test::TaskEnvironment> task_environment_;
 };
 
 class KeyringServiceUnitTest : public testing::Test {
@@ -765,7 +768,7 @@ TEST_F(KeyringServiceUnitTest, CreateDefaultKeyringInternal) {
       service.CreateEncryptorForKeyring("brave", mojom::kDefaultKeyringId));
   ASSERT_TRUE(service.CreateKeyringInternal(mojom::kDefaultKeyringId,
                                             kMnemonicDivideCruise, false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   auto* default_keyring = service.GetHDKeyringById(mojom::kDefaultKeyringId);
   default_keyring->AddAccounts(1);
   EXPECT_EQ(default_keyring->GetAddress(0),
@@ -952,7 +955,7 @@ TEST_F(KeyringServiceUnitTest, RestoreDefaultKeyring) {
             nonce);
   ASSERT_TRUE(AddAccount(&service, mojom::CoinType::ETH,
                          mojom::kDefaultKeyringId, "Account 1"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(service.GetAccountInfosForKeyring(mojom::kDefaultKeyringId).size(),
             1u);
   EXPECT_EQ(service.GetHDKeyringById(mojom::kDefaultKeyringId)->GetAddress(0),
@@ -1111,7 +1114,7 @@ TEST_F(KeyringServiceUnitTest, LockAndUnlock) {
   }
   {
     KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
-    NiceMock<TestKeyringServiceObserver> observer(service);
+    NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
     ASSERT_NE(service.CreateKeyring(mojom::kDefaultKeyringId,
                                     GenerateMnemonic(16), "brave"),
               nullptr);
@@ -1166,7 +1169,7 @@ TEST_F(KeyringServiceUnitTest, LockAndUnlock) {
 TEST_F(KeyringServiceUnitTest, Reset) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
   ASSERT_TRUE(CreateWallet(&service, "brave"));
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   ASSERT_TRUE(AddAccount(&service, mojom::CoinType::ETH,
                          mojom::kDefaultKeyringId, "Account 1"));
@@ -1409,7 +1412,7 @@ TEST_F(KeyringServiceUnitTest, MigrateDerivedAccountIndex) {
 TEST_F(KeyringServiceUnitTest, CreateAndRestoreWallet) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   EXPECT_CALL(observer, WalletRestored()).Times(0);
   EXPECT_CALL(observer, WalletCreated());
@@ -1565,9 +1568,9 @@ TEST_F(KeyringServiceUnitTest, ImportedAccounts) {
     EXPECT_TRUE(private_key);
     EXPECT_EQ(account.encoded_private_key, private_key);
   }
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   EXPECT_CALL(observer, AccountsChanged()).Times(0);
   EXPECT_FALSE(RemoveAccount(
@@ -1806,7 +1809,7 @@ TEST_F(KeyringServiceUnitTest, EncodePrivateKeyForExport) {
 TEST_F(KeyringServiceUnitTest, SetDefaultKeyringDerivedAccountMeta) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   const std::string updated_name = "Updated";
 
@@ -1868,7 +1871,7 @@ TEST_F(KeyringServiceUnitTest, SetDefaultKeyringDerivedAccountMeta) {
 TEST_F(KeyringServiceUnitTest, SetDefaultKeyringImportedAccountName) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   ASSERT_TRUE(CreateWallet(&service, kPasswordBrave));
 
@@ -2004,7 +2007,7 @@ TEST_F(KeyringServiceUnitTest, HardwareAccounts) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
   SetNetwork(mojom::kFilecoinMainnet, mojom::CoinType::FIL);
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   EXPECT_FALSE(service.IsLocked(mojom::kDefaultKeyringId));
   EXPECT_FALSE(service.IsLocked(mojom::kFilecoinKeyringId));
@@ -2492,7 +2495,7 @@ TEST_F(KeyringServiceUnitTest, SetSelectedAccount) {
   EXPECT_EQ(second_account, service.GetSelectedEthereumDappAccount());
   EXPECT_EQ(first_sol_account, service.GetSelectedSolanaDappAccount());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   // Can select SOL account. dApp selections don't change.
   EXPECT_CALL(observer,
@@ -2705,7 +2708,7 @@ TEST_F(KeyringServiceUnitTest, SetSelectedAccount) {
 TEST_F(KeyringServiceUnitTest, AddAccountsWithDefaultName) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
   ASSERT_TRUE(CreateWallet(&service, "brave"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_FALSE(service.IsLocked(mojom::kDefaultKeyringId));
 
   ASSERT_TRUE(AddAccount(&service, mojom::CoinType::ETH,
@@ -2765,7 +2768,7 @@ TEST_F(KeyringServiceUnitTest, SignMessageByDefaultKeyring) {
 
 TEST_F(KeyringServiceUnitTest, GetSetAutoLockMinutes) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   EXPECT_EQ(10, GetAutoLockMinutes(&service));
 
@@ -2911,7 +2914,7 @@ TEST_F(KeyringServiceUnitTest, SetDefaultKeyringHardwareAccountName) {
                     hardware_accounts[1].address),
       ""));
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   // Update second hardware account's name.
   EXPECT_CALL(observer, AccountsChanged());
@@ -3145,7 +3148,7 @@ TEST_F(KeyringServiceUnitTest, ImportFilecoinAccounts) {
        "9704d514d782f52614d7063445775426b53326c746f413d227d",
        "f1spw7nkvh5bb7th2g7n2w4p7fmh5ukje2kazf4wa",
        "LlZuTmMJFgKNkwGVWZVJypMQMx/RaMpcDWuBkS2ltoA="}};
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   ImportFilecoinAccounts(&service, &observer, imported_testnet_accounts,
                          mojom::kFilecoinTestnetKeyringId);
@@ -3288,7 +3291,7 @@ TEST_F(KeyringServiceUnitTest, PreCreateEncryptors) {
 
     service.Reset();
 
-    NiceMock<TestKeyringServiceObserver> observer(service);
+    NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
     EXPECT_CALL(observer, WalletRestored());
     EXPECT_CALL(observer, WalletCreated()).Times(0);
@@ -3304,7 +3307,7 @@ TEST_F(KeyringServiceUnitTest, PreCreateEncryptors) {
 TEST_F(KeyringServiceUnitTest, SolanaKeyring) {
   {
     KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
-    NiceMock<TestKeyringServiceObserver> observer(service);
+    NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
     ASSERT_TRUE(CreateWallet(&service, "brave"));
     ASSERT_TRUE(AddAccount(&service, mojom::CoinType::SOL,
@@ -3324,7 +3327,7 @@ TEST_F(KeyringServiceUnitTest, SolanaKeyring) {
   }
   {
     KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
-    NiceMock<TestKeyringServiceObserver> observer(service);
+    NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
     EXPECT_CALL(observer, WalletRestored());
     ASSERT_TRUE(RestoreWallet(&service, kMnemonicDivideCruise, "brave", false));
@@ -3413,7 +3416,7 @@ TEST_F(KeyringServiceUnitTest, SolanaKeyring) {
 TEST_F(KeyringServiceUnitTest, SignMessage) {
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
   ASSERT_TRUE(RestoreWallet(&service, kMnemonicDivideCruise, "brave", false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   auto first_sol_account = FirstSolAccount(&service);
   EXPECT_EQ(first_sol_account->address,
@@ -3465,7 +3468,7 @@ class KeyringServiceAccountDiscoveryUnitTest : public KeyringServiceUnitTest {
       }
       saved_addresses_.push_back(keyring->GetAddress(i));
     }
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
   void set_eth_transaction_count_callback(InterceptorCallback cb) {
@@ -3545,7 +3548,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, AccountDiscovery) {
       shared_url_loader_factory(), nullptr, &service, json_rpc_service(),
       nullptr, nullptr, nullptr, GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   std::vector<std::string> requested_addresses;
   set_eth_transaction_count_callback(base::BindLambdaForTesting(
@@ -3583,7 +3586,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, SolAccountDiscovery) {
       shared_url_loader_factory(), nullptr, &service, json_rpc_service(),
       nullptr, nullptr, nullptr, GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   std::vector<std::string> requested_addresses;
   set_sol_balance_callback(base::BindLambdaForTesting(
@@ -3602,7 +3605,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, SolAccountDiscovery) {
   EXPECT_CALL(observer, AccountsChanged()).Times(2);  // Accounts 3 and 10.
   EXPECT_TRUE(RestoreWallet(&service, saved_mnemonic(), "brave1", false));
   observer.WaitAndVerify();
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   std::vector<mojom::AccountInfoPtr> account_infos =
       service.GetAccountInfosForKeyring(mojom::kSolanaKeyringId);
   EXPECT_EQ(account_infos.size(), 11u);
@@ -3623,7 +3626,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, FilAccountDiscovery) {
       shared_url_loader_factory(), nullptr, &service, json_rpc_service(),
       nullptr, nullptr, nullptr, GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   std::vector<std::string> requested_addresses;
   set_fil_balance_callback(base::BindLambdaForTesting(
@@ -3696,7 +3699,7 @@ TEST_F(KeyringServiceUnitTest, BitcoinDiscovery) {
   bitcoin_test_rpc_server.AddTransactedAddress(
       *keyring_84_test.GetAddress(0, {0, 15}));
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   EXPECT_CALL(observer, AccountsAdded(_)).Times(5);
   EXPECT_TRUE(RestoreWallet(&service, kMnemonicAbandonAbandon,
@@ -3749,7 +3752,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, StopsOnError) {
       shared_url_loader_factory(), nullptr, &service, json_rpc_service(),
       nullptr, nullptr, nullptr, GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   std::vector<std::string> requested_addresses;
   set_eth_transaction_count_callback(base::BindLambdaForTesting(
@@ -3789,7 +3792,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, ManuallyAddAccount) {
       shared_url_loader_factory(), nullptr, &service, json_rpc_service(),
       nullptr, nullptr, nullptr, GetPrefs(), GetLocalState());
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   std::vector<std::string> requested_addresses;
   set_eth_transaction_count_callback(base::BindLambdaForTesting(
@@ -3823,7 +3826,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, ManuallyAddAccount) {
   EXPECT_CALL(observer, AccountsChanged())
       .Times(3);  // Two accounts added manually, one by discovery.
   EXPECT_TRUE(RestoreWallet(&service, saved_mnemonic(), "brave1", false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   std::vector<mojom::AccountInfoPtr> account_infos =
       service.GetAccountInfosForKeyring(mojom::kDefaultKeyringId);
   EXPECT_EQ(account_infos.size(), 7u);
@@ -3880,7 +3883,7 @@ TEST_F(KeyringServiceAccountDiscoveryUnitTest, RestoreWalletTwice) {
   first_restore = false;
   service.Reset();
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   EXPECT_CALL(observer, AccountsChanged()).Times(2);  // Accounts 3 and 10.
   EXPECT_TRUE(RestoreWallet(&service, saved_mnemonic(), "brave1", false));
@@ -4177,7 +4180,7 @@ TEST_F(KeyringServiceUnitTest, AccountsAdded) {
   // CreateWallet, RestoreWallet, AddHardwareAccounts, and
   // ImportAccountForKeyring
   KeyringService service(json_rpc_service(), GetPrefs(), GetLocalState());
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
 
   std::vector<mojom::AccountInfoPtr> default_eth_account;
   default_eth_account.push_back(mojom::AccountInfo::New(
@@ -4398,7 +4401,7 @@ TEST_F(KeyringServiceUnitTest, UpdateNextUnusedAddressForBitcoinAccount) {
             service.GetBitcoinAccountInfo(btc_acc->account_id)
                 ->next_change_address->key_id);
 
-  NiceMock<TestKeyringServiceObserver> observer(service);
+  NiceMock<TestKeyringServiceObserver> observer(service, task_environment_);
   EXPECT_CALL(observer, AccountsChanged());
   service.UpdateNextUnusedAddressForBitcoinAccount(btc_acc->account_id, 7,
                                                    std::nullopt);

--- a/browser/net/decentralized_dns_network_delegate_helper_unittest.cc
+++ b/browser/net/decentralized_dns_network_delegate_helper_unittest.cc
@@ -71,8 +71,9 @@ class DecentralizedDnsNetworkDelegateHelperTest : public testing::Test {
     return test_url_loader_factory_;
   }
 
- private:
   content::BrowserTaskEnvironment task_environment_;
+
+ private:
   std::unique_ptr<TestingProfile> profile_;
   std::unique_ptr<ScopedTestingLocalState> local_state_;
   network::TestURLLoaderFactory test_url_loader_factory_;
@@ -197,7 +198,7 @@ TEST_F(DecentralizedDnsNetworkDelegateHelperTest,
       brave_wallet::MakeJsonRpcStringArrayResponse(
           {"", "", "", "", "", "https://brave.com"}),
       net::HTTP_REQUEST_TIMEOUT);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(brave_request_info->new_url_spec.empty());
 
   // Polygon result.
@@ -214,7 +215,7 @@ TEST_F(DecentralizedDnsNetworkDelegateHelperTest,
       brave_wallet::MakeJsonRpcStringArrayResponse(
           {"hash", "", "", "", "", ""}),
       net::HTTP_OK);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(brave_request_info->new_url_spec, "https://brave.com/");
 
   // Eth result.
@@ -230,7 +231,7 @@ TEST_F(DecentralizedDnsNetworkDelegateHelperTest,
       brave_wallet::MakeJsonRpcStringArrayResponse(
           {"hash", "", "", "", "", ""}),
       net::HTTP_OK);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(brave_request_info->new_url_spec, "ipfs://hash");
 }
 

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -349,6 +349,7 @@ Config.prototype.buildArgs = function () {
     sardine_client_secret: this.sardineClientSecret,
     is_asan: this.isAsan(),
     enable_rust: true,
+    enable_rust_json: true,
     enable_full_stack_frames_for_profiling: this.isAsan(),
     v8_enable_verify_heap: this.isAsan(),
     disable_fieldtrial_testing_config: true,

--- a/chromium_src/base/json/json_reader.cc
+++ b/chromium_src/base/json/json_reader.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/base/json/json_reader.cc"
+
+namespace base {
+
+#if BUILDFLAG(BUILD_RUST_JSON_READER)
+JSONReader::Result DecodeJSONInRust(const std::string_view& json, int options) {
+  SCOPED_UMA_HISTOGRAM_TIMER_MICROS(kSecurityJsonParsingTime);
+  return DecodeJSONInRust(json, options, internal::kAbsoluteMaxDepth);
+}
+#endif  // BUILDFLAG(BUILD_RUST_JSON_READER)
+
+}  // namespace base

--- a/chromium_src/base/json/json_reader.cc
+++ b/chromium_src/base/json/json_reader.cc
@@ -8,7 +8,7 @@
 namespace base {
 
 #if BUILDFLAG(BUILD_RUST_JSON_READER)
-JSONReader::Result DecodeJSONInRust(const std::string_view& json, int options) {
+JSONReader::Result DecodeJSONInRust(std::string_view json, int options) {
   SCOPED_UMA_HISTOGRAM_TIMER_MICROS(kSecurityJsonParsingTime);
   return DecodeJSONInRust(json, options, internal::kAbsoluteMaxDepth);
 }

--- a/chromium_src/base/json/json_reader.h
+++ b/chromium_src/base/json/json_reader.h
@@ -1,0 +1,20 @@
+#ifndef BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_
+#define BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/rust_buildflags.h"       // IWYU pragma: private
+#include "src/base/json/json_reader.h"  // IWYU pragma: export
+
+namespace base {
+
+#if BUILDFLAG(BUILD_RUST_JSON_READER)
+BASE_EXPORT JSONReader::Result DecodeJSONInRust(const std::string_view& json,
+                                                int options);
+#endif  // BUILDFLAG(BUILD_RUST_JSON_READER)
+
+}  // namespace base
+
+#endif  // BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_

--- a/chromium_src/base/json/json_reader.h
+++ b/chromium_src/base/json/json_reader.h
@@ -1,9 +1,9 @@
-#ifndef BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_
-#define BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_
 /* Copyright (c) 2024 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
+#ifndef BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_
+#define BRAVE_CHROMIUM_SRC_BASE_JSON_JSON_READER_H_
 
 #include "base/rust_buildflags.h"       // IWYU pragma: private
 #include "src/base/json/json_reader.h"  // IWYU pragma: export
@@ -11,7 +11,7 @@
 namespace base {
 
 #if BUILDFLAG(BUILD_RUST_JSON_READER)
-BASE_EXPORT JSONReader::Result DecodeJSONInRust(const std::string_view& json,
+BASE_EXPORT JSONReader::Result DecodeJSONInRust(std::string_view json,
                                                 int options);
 #endif  // BUILDFLAG(BUILD_RUST_JSON_READER)
 

--- a/components/ai_chat/core/browser/engine/remote_completion_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/remote_completion_client_unittest.cc
@@ -37,9 +37,9 @@ class RemoteCompletionClientUnitTest : public testing::Test {
 
  protected:
   std::unique_ptr<RemoteCompletionClient> ai_chat_api_ = nullptr;
+  base::test::TaskEnvironment task_environment_;
 
  private:
-  base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;

--- a/components/ai_chat/core/browser/engine/remote_completion_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/remote_completion_client_unittest.cc
@@ -68,16 +68,12 @@ TEST_F(RemoteCompletionClientUnitTest, ParseJson) {
   run_loop2.Run();
 
   // This test verifies that the callback is not called when the response is
-  // "[DONE]". We use a run loop to wait for the callback to be called, and we
-  // expect it to never be called. Therefore, we use RunUntilIdle() instead of
-  // Run(), since Run() would time out waiting for the callback to be called.
-  base::RunLoop run_loop3;
+  // "[DONE]". We use RunUntilIdle() to wait for the callback to be called, and
+  // we expect it to never be called.
   SendMesage(
-      base::BindRepeating([](base::RunLoop* run_loop,
-                             const std::string& response) { run_loop->Quit(); },
-                          &run_loop3),
+      base::BindRepeating([](const std::string& response) { ADD_FAILURE(); }),
       "data: [DONE]");
-  run_loop3.RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 }  // namespace ai_chat

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -457,9 +457,6 @@ void APIRequestHelper::URLLoaderHandler::OnParseJsonResponse(
       // Rust parser returns the trailing comma error. Log the
       // urls and send a crash dump to find where trailing commas
       // could still be used.
-      LOG(ERROR) << "[APIRequestHelper] JSON respose with trailing "
-                    "commas detected "
-                 << result.final_url();
       DEBUG_ALIAS_FOR_GURL(url_alias, result.final_url());
       DEBUG_ALIAS_FOR_CSTR(result_str, result_value.error().c_str(), 1024);
       base::debug::DumpWithoutCrashing();

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -338,13 +338,14 @@ void APIRequestHelper::URLLoaderHandler::send_sse_data_for_testing(
 }
 
 void APIRequestHelper::URLLoaderHandler::ParseJsonImpl(
-    const std::string& json,
+    std::string json,
     data_decoder::DataDecoder::ValueParseCallback callback) {
 #if BUILDFLAG(BUILD_RUST_JSON_READER)
   if (base::FeatureList::IsEnabled(kUseBraveRustJSONSanitizer)) {
     task_runner_->PostTaskAndReplyWithResult(
         FROM_HERE,
-        base::BindOnce(&base::DecodeJSONInRust, json, base::JSON_PARSE_RFC),
+        base::BindOnce(&base::DecodeJSONInRust, std::move(json),
+                       base::JSON_PARSE_RFC),
         base::BindOnce(
             [](data_decoder::DataDecoder::ValueParseCallback callback,
                base::JSONReader::Result result) {
@@ -547,7 +548,7 @@ void APIRequestHelper::URLLoaderHandler::ParseSSE(
         };
 
     DVLOG(2) << "Going to call ParseJsonImpl";
-    ParseJsonImpl(std::move(std::string(json)),
+    ParseJsonImpl(std::string(json),
                   base::BindOnce(std::move(on_json_parsed),
                                  weak_ptr_factory_.GetWeakPtr()));
   }

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -12,11 +12,16 @@
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/containers/cxx20_erase_vector.h"
+#include "base/debug/alias.h"
+#include "base/debug/dump_without_crashing.h"
+#include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "base/memory/raw_ptr.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/ranges/algorithm.h"
+#include "base/rust_buildflags.h"
 #include "base/strings/string_split.h"
+#include "base/task/thread_pool.h"
 #include "base/time/time.h"
 #include "base/timer/elapsed_timer.h"
 #include "base/trace_event/trace_event.h"
@@ -30,6 +35,10 @@
 namespace api_request_helper {
 
 namespace {
+
+BASE_FEATURE(kUseBraveRustJSONSanitizer,
+             "UseBraveRustJSONSanitizer",
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 const unsigned int kRetriesCountOnNetworkChange = 1;
 
@@ -135,7 +144,10 @@ APIRequestHelper::APIRequestHelper(
     net::NetworkTrafficAnnotationTag annotation_tag,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : annotation_tag_(annotation_tag),
-      url_loader_factory_(url_loader_factory) {}
+      url_loader_factory_(url_loader_factory),
+      task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
+          {base::TaskPriority::USER_VISIBLE,
+           base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})) {}
 
 APIRequestHelper::~APIRequestHelper() = default;
 
@@ -248,7 +260,8 @@ APIRequestHelper::Ticket APIRequestHelper::CreateURLLoaderHandler(
           : network::SimpleURLLoader::RetryMode::RETRY_NEVER);
   url_loader->SetAllowHttpErrorResults(allow_http_error_result);
 
-  auto loader_wrapper_handler = std::make_unique<URLLoaderHandler>(this);
+  auto loader_wrapper_handler =
+      std::make_unique<URLLoaderHandler>(this, task_runner_);
   loader_wrapper_handler->RegisterURLLoader(std::move(url_loader));
 
   auto iter = url_loaders_.insert(url_loaders_.begin(),
@@ -281,8 +294,10 @@ APIRequestHelper::Ticket APIRequestHelper::CreateRequestURLLoaderHandler(
 }
 
 APIRequestHelper::URLLoaderHandler::URLLoaderHandler(
-    APIRequestHelper* api_request_helper)
-    : api_request_helper_(api_request_helper) {}
+    APIRequestHelper* api_request_helper,
+    scoped_refptr<base::SequencedTaskRunner> task_runner)
+    : api_request_helper_(api_request_helper),
+      task_runner_(std::move(task_runner)) {}
 APIRequestHelper::URLLoaderHandler::~URLLoaderHandler() = default;
 
 void APIRequestHelper::URLLoaderHandler::RegisterURLLoader(
@@ -317,18 +332,39 @@ void APIRequestHelper::URLLoaderHandler::send_sse_data_for_testing(
     std::string_view string_piece,
     bool is_sse,
     DataReceivedCallback callback) {
-  is_sse_ = true;
+  is_sse_ = is_sse;
   data_received_callback_ = std::move(callback);
   OnDataReceived(string_piece, base::BindOnce([]() {}));
 }
 
-data_decoder::DataDecoder*
-APIRequestHelper::URLLoaderHandler::GetDataDecoder() {
+void APIRequestHelper::URLLoaderHandler::ParseJsonImpl(
+    const std::string& json,
+    data_decoder::DataDecoder::ValueParseCallback callback) {
+#if BUILDFLAG(BUILD_RUST_JSON_READER)
+  if (base::FeatureList::IsEnabled(kUseBraveRustJSONSanitizer)) {
+    task_runner_->PostTaskAndReplyWithResult(
+        FROM_HERE,
+        base::BindOnce(&base::DecodeJSONInRust, json, base::JSON_PARSE_RFC),
+        base::BindOnce(
+            [](data_decoder::DataDecoder::ValueParseCallback callback,
+               base::JSONReader::Result result) {
+              if (!result.has_value()) {
+                std::move(callback).Run(
+                    base::unexpected(result.error().message));
+              } else {
+                std::move(callback).Run(std::move(*result));
+              }
+            },
+            std::move(callback)));
+    return;
+  }
+#endif  // BUILDFLAG(BUILD_RUST_JSON_READER)
   if (!data_decoder_) {
     VLOG(1) << "Creating DataDecoder for APIRequestHelper";
     data_decoder_ = std::make_unique<data_decoder::DataDecoder>();
   }
-  return data_decoder_.get();
+
+  data_decoder_->ParseJson(json, std::move(callback));
 }
 
 void APIRequestHelper::URLLoaderHandler::OnDataReceived(
@@ -400,7 +436,7 @@ void APIRequestHelper::URLLoaderHandler::OnResponse(
     raw_body = converted_body.value();
   }
 
-  GetDataDecoder()->ParseJson(
+  ParseJsonImpl(
       std::move(raw_body),
       base::BindOnce(&APIRequestHelper::URLLoaderHandler::OnParseJsonResponse,
                      GetWeakPtr(), std::move(result)));
@@ -416,6 +452,17 @@ void APIRequestHelper::URLLoaderHandler::OnParseJsonResponse(
   // response handler in ParseSSE.
   if (!result_value.has_value()) {
     VLOG(1) << "Response validation error:" << result_value.error();
+    if (result_value.error().starts_with("trailing comma")) {
+      // Rust parser returns the trailing comma error. Log the
+      // urls and send a crash dump to find where trailing commas
+      // could still be used.
+      LOG(ERROR) << "[APIRequestHelper] JSON respose with trailing "
+                    "commas detected "
+                 << result.final_url();
+      DEBUG_ALIAS_FOR_GURL(url_alias, result.final_url());
+      DEBUG_ALIAS_FOR_CSTR(result_str, result_value.error().c_str(), 1024);
+      base::debug::DumpWithoutCrashing();
+    }
     std::move(result_callback_).Run(std::move(result));
     return;
   }
@@ -499,10 +546,10 @@ void APIRequestHelper::URLLoaderHandler::ParseSSE(
           handler->MaybeSendResult();
         };
 
-    DVLOG(2) << "Going to call ParseJson";
-    GetDataDecoder()->ParseJson(std::move(std::string(json)),
-                                base::BindOnce(std::move(on_json_parsed),
-                                               weak_ptr_factory_.GetWeakPtr()));
+    DVLOG(2) << "Going to call ParseJsonImpl";
+    ParseJsonImpl(std::move(std::string(json)),
+                  base::BindOnce(std::move(on_json_parsed),
+                                 weak_ptr_factory_.GetWeakPtr()));
   }
 }
 

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -111,7 +111,8 @@ class APIRequestHelper {
 
   class URLLoaderHandler : public network::SimpleURLLoaderStreamConsumer {
    public:
-    explicit URLLoaderHandler(APIRequestHelper* api_request_helper);
+    URLLoaderHandler(APIRequestHelper* api_request_helper,
+                     scoped_refptr<base::SequencedTaskRunner> task_runner);
     ~URLLoaderHandler() override;
     URLLoaderHandler(const URLLoaderHandler&) = delete;
     URLLoaderHandler& operator=(const URLLoaderHandler&) = delete;
@@ -127,7 +128,8 @@ class APIRequestHelper {
    private:
     friend class APIRequestHelper;
 
-    data_decoder::DataDecoder* GetDataDecoder();
+    void ParseJsonImpl(const std::string& json,
+                       data_decoder::DataDecoder::ValueParseCallback callback);
 
     // Run completion callback if there are no operations in progress.
     // If Cancel is needed even if url or data operations are in progress,
@@ -171,6 +173,8 @@ class APIRequestHelper {
     // completes.
     int current_decoding_operation_count_ = 0;
     bool request_is_finished_ = false;
+
+    const scoped_refptr<base::SequencedTaskRunner> task_runner_;
 
     base::WeakPtrFactory<URLLoaderHandler> weak_ptr_factory_{this};
   };
@@ -248,6 +252,7 @@ class APIRequestHelper {
   net::NetworkTrafficAnnotationTag annotation_tag_;
   URLLoaderHandlerList url_loaders_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  const scoped_refptr<base::SequencedTaskRunner> task_runner_;
   base::WeakPtrFactory<APIRequestHelper> weak_ptr_factory_{this};
 };
 

--- a/components/api_request_helper/api_request_helper.h
+++ b/components/api_request_helper/api_request_helper.h
@@ -128,7 +128,7 @@ class APIRequestHelper {
    private:
     friend class APIRequestHelper;
 
-    void ParseJsonImpl(const std::string& json,
+    void ParseJsonImpl(std::string json,
                        data_decoder::DataDecoder::ValueParseCallback callback);
 
     // Run completion callback if there are no operations in progress.

--- a/components/api_request_helper/api_request_helper_unittest.cc
+++ b/components/api_request_helper/api_request_helper_unittest.cc
@@ -54,7 +54,8 @@ class ApiRequestHelperUnitTest : public testing::Test {
         shared_url_loader_factory_);
     loader_wrapper_handler_ =
         std::make_unique<APIRequestHelper::URLLoaderHandler>(
-            api_request_helper_.get());
+            api_request_helper_.get(),
+            base::SequencedTaskRunner::GetCurrentDefault());
   }
   ~ApiRequestHelperUnitTest() override = default;
 
@@ -100,7 +101,7 @@ class ApiRequestHelperUnitTest : public testing::Test {
         "POST", network_url, "", "application/json", callback.Get(), {},
         APIRequestOptions(false, enable_cache, -1u, std::nullopt),
         std::move(conversion_callback));
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
   void SendMessageSSEJSON(std::string_view string_piece,
@@ -117,9 +118,9 @@ class ApiRequestHelperUnitTest : public testing::Test {
 
  protected:
   std::unique_ptr<APIRequestHelper> api_request_helper_;
+  base::test::TaskEnvironment task_environment_;
 
  private:
-  base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
@@ -211,7 +212,7 @@ TEST_F(ApiRequestHelperUnitTest, URLLoaderHandlerParsing) {
                        run_loop->Quit();
                      },
                      &run_loop));
-  run_loop.RunUntilIdle();
+  run_loop.Run();
 }
 
 TEST_F(ApiRequestHelperUnitTest, SSEJsonParsing) {

--- a/components/brave_adaptive_captcha/get_adaptive_captcha_challenge_unittest.cc
+++ b/components/brave_adaptive_captcha/get_adaptive_captcha_challenge_unittest.cc
@@ -57,6 +57,7 @@ class GetAdaptiveCaptchaChallengeTest : public testing::Test {
 
  protected:
   network::TestURLLoaderFactory test_url_loader_factory_;
+  base::test::TaskEnvironment scoped_task_environment_;
   api_request_helper::APIRequestHelper api_request_helper_;
   std::unique_ptr<GetAdaptiveCaptchaChallenge> get_challenge_;
 
@@ -70,7 +71,6 @@ class GetAdaptiveCaptchaChallengeTest : public testing::Test {
   }
 
  private:
-  base::test::TaskEnvironment scoped_task_environment_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
   std::unique_ptr<base::RunLoop> run_loop_;
   bool url_loaded_ = false;

--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -726,9 +726,9 @@ TEST_F(BraveVPNServiceTest, ConnectionStateUpdateWithPurchasedStateTest) {
   std::string env = skus::GetDefaultEnvironment();
   SetPurchasedState(env, PurchasedState::PURCHASED);
   SetConnectionStateForTesting(ConnectionState::CONNECTING);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   SetConnectionStateForTesting(ConnectionState::CONNECTED);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
 }
 
@@ -740,9 +740,9 @@ TEST_F(BraveVPNServiceTest, IsConnectedWithPurchasedStateTest) {
 
   // Prepare connected state.
   SetConnectionStateForTesting(ConnectionState::CONNECTING);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   SetConnectionStateForTesting(ConnectionState::CONNECTED);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
   // Gets connected for purchased user.
   EXPECT_TRUE(service_->IsConnected());
@@ -760,10 +760,10 @@ TEST_F(BraveVPNServiceTest, DisconnectedIfDisabledByPolicy) {
   std::string env = skus::GetDefaultEnvironment();
   SetPurchasedState(env, PurchasedState::PURCHASED);
   SetConnectionStateForTesting(ConnectionState::CONNECTED);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(ConnectionState::CONNECTED, observer.GetConnectionState());
   BlockVPNByPolicy(true);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(ConnectionState::DISCONNECTED, observer.GetConnectionState());
 }
 
@@ -939,12 +939,12 @@ TEST_F(BraveVPNServiceTest, SetPurchasedState) {
   SetAndExpectPurchasedStateChange(&observer, env, PurchasedState::PURCHASED);
 
   SetPurchasedState(env, PurchasedState::PURCHASED);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   observer.ResetStates();
   // Do not notify if status is not changed.
   EXPECT_FALSE(observer.GetPurchasedState().has_value());
   SetPurchasedState(env, PurchasedState::PURCHASED);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_FALSE(observer.GetPurchasedState().has_value());
 }
 

--- a/components/brave_wallet/browser/account_discovery_manager_unittest.cc
+++ b/components/brave_wallet/browser/account_discovery_manager_unittest.cc
@@ -91,7 +91,7 @@ TEST_F(AccountDiscoveryManagerUnitTest, DiscoverBtcAccountCreatesNew) {
   AccountDiscoveryManager discovery_manager(nullptr, keyring_service_.get(),
                                             bitcoin_wallet_service_.get());
   discovery_manager.StartDiscovery();
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   EXPECT_EQ(2u, GetAccountUtils().AllBtcAccounts().size());
   auto account_0 = GetAccountUtils().AllBtcAccounts()[0]->account_id->Clone();
@@ -132,7 +132,7 @@ TEST_F(AccountDiscoveryManagerUnitTest, DiscoverBtcAccountUpdatesExisting) {
   AccountDiscoveryManager discovery_manager(nullptr, keyring_service_.get(),
                                             bitcoin_wallet_service_.get());
   discovery_manager.StartDiscovery();
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   EXPECT_EQ(*mojom::BitcoinKeyId::New(0, 10 + 1),
             *keyring_service_->GetBitcoinAccountInfo(account_id)

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -135,9 +135,9 @@ class AssetRatioServiceUnitTest : public testing::Test {
 
  protected:
   std::unique_ptr<AssetRatioService> asset_ratio_service_;
+  base::test::TaskEnvironment task_environment_;
 
  private:
-  base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
@@ -248,7 +248,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPrice) {
       base::BindOnce(&OnGetPrice, &callback_run, true,
                      std::move(expected_prices_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -278,7 +278,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceUppercase) {
       base::BindOnce(&OnGetPrice, &callback_run, true,
                      std::move(expected_prices_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -292,7 +292,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceError) {
       base::BindOnce(&OnGetPrice, &callback_run, false,
                      std::move(expected_prices_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -305,7 +305,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceUnexpectedResponse) {
       base::BindOnce(&OnGetPrice, &callback_run, false,
                      std::move(expected_prices_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -337,7 +337,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceHistory) {
       base::BindOnce(&OnGetPriceHistory, &callback_run, true,
                      std::move(expected_price_history_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -351,7 +351,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceHistoryError) {
       "bat", "usd", brave_wallet::mojom::AssetPriceTimeframe::OneDay,
       base::BindOnce(&OnGetPriceHistory, &callback_run, false,
                      std::move(expected_price_history_response)));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -366,7 +366,7 @@ TEST_F(AssetRatioServiceUnitTest, GetPriceHistoryUnexpectedResponse) {
       base::BindOnce(&OnGetPriceHistory, &callback_run, false,
                      std::move(expected_price_history_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -446,7 +446,7 @@ TEST_F(AssetRatioServiceUnitTest, GetCoinMarkets) {
       base::BindOnce(&OnGetCoinMarkets, &callback_run, true,
                      std::move(expected_coin_markets_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 
@@ -461,7 +461,7 @@ TEST_F(AssetRatioServiceUnitTest, GetCoinMarketsUnexpectedResponse) {
       base::BindOnce(&OnGetCoinMarkets, &callback_run, false,
                      std::move(expected_coin_markets_response)));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_run);
 }
 

--- a/components/brave_wallet/browser/bitcoin/bitcoin_rpc_unittest.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_rpc_unittest.cc
@@ -123,12 +123,12 @@ TEST_F(BitcoinRpcUnitTest, Throttling) {
     bitcoin_rpc_->GetChainHeight(chain_id, callback.Get());
     bitcoin_rpc_->GetChainHeight(chain_id, callback.Get());
     bitcoin_rpc_->GetChainHeight(chain_id, callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
 
     EXPECT_EQ(url_loader_factory_.pending_requests()->size(),
               test_case.expected_size);
     url_loader_factory_.AddResponse(req_url, "123");
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     testing::Mock::VerifyAndClearExpectations(&callback);
   }
 }
@@ -143,14 +143,14 @@ TEST_F(BitcoinRpcUnitTest, GetChainHeight) {
   EXPECT_CALL(callback, Run(GetChainHeightResult(base::ok(123))));
   url_loader_factory_.AddResponse(req_url, "123");
   bitcoin_rpc_->GetChainHeight(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // GetChainHeight works.
   EXPECT_CALL(callback, Run(GetChainHeightResult(base::ok(9999999))));
   url_loader_factory_.AddResponse(req_url, "9999999");
   bitcoin_rpc_->GetChainHeight(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid value returned.
@@ -158,7 +158,7 @@ TEST_F(BitcoinRpcUnitTest, GetChainHeight) {
               Run(GetChainHeightResult(base::unexpected(ParsingError()))));
   url_loader_factory_.AddResponse(req_url, "some string");
   bitcoin_rpc_->GetChainHeight(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP Error returned.
@@ -167,7 +167,7 @@ TEST_F(BitcoinRpcUnitTest, GetChainHeight) {
   url_loader_factory_.AddResponse(req_url, "123",
                                   net::HTTP_INTERNAL_SERVER_ERROR);
   bitcoin_rpc_->GetChainHeight(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Testnet works.
@@ -175,7 +175,7 @@ TEST_F(BitcoinRpcUnitTest, GetChainHeight) {
   url_loader_factory_.AddResponse(testnet_rpc_url_ + "blocks/tip/height",
                                   "123");
   bitcoin_rpc_->GetChainHeight(mojom::kBitcoinTestnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid chain fails.
@@ -183,7 +183,7 @@ TEST_F(BitcoinRpcUnitTest, GetChainHeight) {
               Run(GetChainHeightResult(base::unexpected(InternalError()))));
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetChainHeight("0x123", callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -209,7 +209,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
   EXPECT_CALL(callback, Run(GetFeeEstimatesResult(base::ok(estimates))));
   url_loader_factory_.AddResponse(req_url, estimates_json);
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid value returned.
@@ -217,7 +217,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
               Run(GetFeeEstimatesResult(base::unexpected(ParsingError()))));
   url_loader_factory_.AddResponse(req_url, "some string");
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Non-integer key fails.
@@ -225,7 +225,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
               Run(GetFeeEstimatesResult(base::unexpected(ParsingError()))));
   url_loader_factory_.AddResponse(req_url, R"({"a": 1})");
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Non-double key fails.
@@ -233,7 +233,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
               Run(GetFeeEstimatesResult(base::unexpected(ParsingError()))));
   url_loader_factory_.AddResponse(req_url, R"({"1": "a"})");
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Empty dict fails.
@@ -241,7 +241,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
               Run(GetFeeEstimatesResult(base::unexpected(ParsingError()))));
   url_loader_factory_.AddResponse(req_url, R"({})");
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // List fails.
@@ -249,7 +249,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
               Run(GetFeeEstimatesResult(base::unexpected(ParsingError()))));
   url_loader_factory_.AddResponse(req_url, R"([{"1": 1}])");
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP Error returned.
@@ -258,7 +258,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
   url_loader_factory_.AddResponse(req_url, "123",
                                   net::HTTP_INTERNAL_SERVER_ERROR);
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinMainnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Testnet works.
@@ -266,7 +266,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
   url_loader_factory_.AddResponse(testnet_rpc_url_ + "fee-estimates",
                                   estimates_json);
   bitcoin_rpc_->GetFeeEstimates(mojom::kBitcoinTestnet, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid chain fails.
@@ -274,7 +274,7 @@ TEST_F(BitcoinRpcUnitTest, GetFeeEstimates) {
               Run(GetFeeEstimatesResult(base::unexpected(InternalError()))));
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetFeeEstimates("0x123", callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -303,14 +303,14 @@ TEST_F(BitcoinRpcUnitTest, GetTransaction) {
               })));
   url_loader_factory_.AddResponse(req_url, tx_json);
   bitcoin_rpc_->GetTransaction(mojom::kBitcoinMainnet, txid, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid value returned.
   EXPECT_CALL(callback, Run(MatchError(ParsingError())));
   url_loader_factory_.AddResponse(req_url, "some string");
   bitcoin_rpc_->GetTransaction(mojom::kBitcoinMainnet, txid, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP Error returned.
@@ -318,7 +318,7 @@ TEST_F(BitcoinRpcUnitTest, GetTransaction) {
   url_loader_factory_.AddResponse(req_url, tx_json,
                                   net::HTTP_INTERNAL_SERVER_ERROR);
   bitcoin_rpc_->GetTransaction(mojom::kBitcoinMainnet, txid, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Testnet works.
@@ -331,14 +331,14 @@ TEST_F(BitcoinRpcUnitTest, GetTransaction) {
   url_loader_factory_.ClearResponses();
   url_loader_factory_.AddResponse(testnet_rpc_url_ + "tx/" + txid, tx_json);
   bitcoin_rpc_->GetTransaction(mojom::kBitcoinTestnet, txid, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid chain fails.
   EXPECT_CALL(callback, Run(MatchError(InternalError())));
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetTransaction("0x123", txid, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid txid arg format fails.
@@ -346,7 +346,7 @@ TEST_F(BitcoinRpcUnitTest, GetTransaction) {
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetTransaction(mojom::kBitcoinMainnet, txid + "/",
                                callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -390,7 +390,7 @@ TEST_F(BitcoinRpcUnitTest, GetAddressStats) {
   url_loader_factory_.AddResponse(req_url, address_json);
   bitcoin_rpc_->GetAddressStats(mojom::kBitcoinMainnet, address,
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid value returned.
@@ -398,7 +398,7 @@ TEST_F(BitcoinRpcUnitTest, GetAddressStats) {
   url_loader_factory_.AddResponse(req_url, "[123]");
   bitcoin_rpc_->GetAddressStats(mojom::kBitcoinMainnet, address,
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP Error returned.
@@ -407,7 +407,7 @@ TEST_F(BitcoinRpcUnitTest, GetAddressStats) {
                                   net::HTTP_INTERNAL_SERVER_ERROR);
   bitcoin_rpc_->GetAddressStats(mojom::kBitcoinMainnet, address,
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Testnet works.
@@ -419,14 +419,14 @@ TEST_F(BitcoinRpcUnitTest, GetAddressStats) {
                                   address_json);
   bitcoin_rpc_->GetAddressStats(mojom::kBitcoinTestnet, address,
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid chain fails.
   EXPECT_CALL(callback, Run(MatchError(InternalError())));
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetAddressStats("0x123", address, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid address arg format fails.
@@ -434,7 +434,7 @@ TEST_F(BitcoinRpcUnitTest, GetAddressStats) {
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetAddressStats(mojom::kBitcoinMainnet, address + "/",
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -492,14 +492,14 @@ TEST_F(BitcoinRpcUnitTest, GetUtxoList) {
               })));
   url_loader_factory_.AddResponse(req_url, utxo_json);
   bitcoin_rpc_->GetUtxoList(mojom::kBitcoinMainnet, address, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid value returned.
   EXPECT_CALL(callback, Run(MatchError(ParsingError())));
   url_loader_factory_.AddResponse(req_url, "[123]");
   bitcoin_rpc_->GetUtxoList(mojom::kBitcoinMainnet, address, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP Error returned.
@@ -507,7 +507,7 @@ TEST_F(BitcoinRpcUnitTest, GetUtxoList) {
   url_loader_factory_.AddResponse(req_url, utxo_json,
                                   net::HTTP_INTERNAL_SERVER_ERROR);
   bitcoin_rpc_->GetUtxoList(mojom::kBitcoinMainnet, address, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Testnet works.
@@ -520,14 +520,14 @@ TEST_F(BitcoinRpcUnitTest, GetUtxoList) {
   url_loader_factory_.AddResponse(
       testnet_rpc_url_ + "address/" + address + "/utxo", utxo_json);
   bitcoin_rpc_->GetUtxoList(mojom::kBitcoinTestnet, address, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid chain fails.
   EXPECT_CALL(callback, Run(MatchError(InternalError())));
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetUtxoList("0x123", address, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid address arg format fails.
@@ -535,7 +535,7 @@ TEST_F(BitcoinRpcUnitTest, GetUtxoList) {
   url_loader_factory_.ClearResponses();
   bitcoin_rpc_->GetUtxoList(mojom::kBitcoinMainnet, address + "/",
                             callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -550,7 +550,7 @@ TEST_F(BitcoinRpcUnitTest, PostTransaction) {
   EXPECT_CALL(callback, Run(Truly([&](auto& arg) { return arg == txid; })));
   bitcoin_rpc_->PostTransaction(mojom::kBitcoinMainnet, {1, 2, 3},
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   auto request = url_loader_factory_.GetPendingRequest(0)->request;
   EXPECT_EQ(request.url, req_url);
   EXPECT_EQ(request.request_body->elements()
@@ -559,7 +559,7 @@ TEST_F(BitcoinRpcUnitTest, PostTransaction) {
                 .AsStringPiece(),
             "010203");
   url_loader_factory_.AddResponse(req_url, txid);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid value returned.
@@ -567,11 +567,11 @@ TEST_F(BitcoinRpcUnitTest, PostTransaction) {
   EXPECT_CALL(callback, Run(MatchError(ParsingError())));
   bitcoin_rpc_->PostTransaction(mojom::kBitcoinMainnet, {1, 2, 3},
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   request = url_loader_factory_.GetPendingRequest(0)->request;
   EXPECT_EQ(request.url, req_url);
   url_loader_factory_.AddResponse(req_url, "not valid txid");
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP Error returned.
@@ -579,12 +579,12 @@ TEST_F(BitcoinRpcUnitTest, PostTransaction) {
   EXPECT_CALL(callback, Run(MatchError(InternalError())));
   bitcoin_rpc_->PostTransaction(mojom::kBitcoinMainnet, {1, 2, 3},
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   request = url_loader_factory_.GetPendingRequest(0)->request;
   EXPECT_EQ(request.url, req_url);
   url_loader_factory_.AddResponse(req_url, txid,
                                   net::HTTP_INTERNAL_SERVER_ERROR);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Testnet works.
@@ -592,7 +592,7 @@ TEST_F(BitcoinRpcUnitTest, PostTransaction) {
   EXPECT_CALL(callback, Run(Truly([&](auto& arg) { return arg == txid; })));
   bitcoin_rpc_->PostTransaction(mojom::kBitcoinTestnet, {1, 2, 3},
                                 callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   request = url_loader_factory_.GetPendingRequest(0)->request;
   EXPECT_EQ(request.url, testnet_rpc_url_ + "tx");
   EXPECT_EQ(request.request_body->elements()
@@ -601,14 +601,14 @@ TEST_F(BitcoinRpcUnitTest, PostTransaction) {
                 .AsStringPiece(),
             "010203");
   url_loader_factory_.AddResponse(testnet_rpc_url_ + "tx", txid);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Invalid chain fails.
   url_loader_factory_.ClearResponses();
   EXPECT_CALL(callback, Run(MatchError(InternalError())));
   bitcoin_rpc_->PostTransaction("0x123", {1, 2, 3}, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 

--- a/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service_unittest.cc
+++ b/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service_unittest.cc
@@ -124,7 +124,7 @@ TEST_F(BitcoinWalletServiceUnitTest, GetBalance) {
   EXPECT_CALL(callback,
               Run(EqualsMojo(expected_balance), std::optional<std::string>()));
   bitcoin_wallet_service_->GetBalance(account_id(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   bitcoin_test_rpc_server_->AddMempoolBalance(address_0, 1000, 10000000);
@@ -139,7 +139,7 @@ TEST_F(BitcoinWalletServiceUnitTest, GetBalance) {
   EXPECT_CALL(callback,
               Run(EqualsMojo(expected_balance), std::optional<std::string>()));
   bitcoin_wallet_service_->GetBalance(account_id(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -169,7 +169,7 @@ TEST_F(BitcoinWalletServiceUnitTest, GetBitcoinAccountInfo) {
 
   EXPECT_CALL(callback, Run(EqualsMojo(expected_bitcoin_account_info)));
   bitcoin_wallet_service_->GetBitcoinAccountInfo(account_id(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -213,7 +213,7 @@ TEST_F(BitcoinWalletServiceUnitTest, RunDiscovery) {
   EXPECT_CALL(callback, Run(Eq(std::ref(expected_receive_address)),
                             std::optional<std::string>()));
   bitcoin_wallet_service_->RunDiscovery(account_id(), false, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   bitcoin_account_info =
@@ -228,7 +228,7 @@ TEST_F(BitcoinWalletServiceUnitTest, RunDiscovery) {
   EXPECT_CALL(callback, Run(Eq(std::ref(expected_change_address)),
                             std::optional<std::string>()));
   bitcoin_wallet_service_->RunDiscovery(account_id(), true, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   bitcoin_account_info =
@@ -271,7 +271,7 @@ TEST_F(BitcoinWalletServiceUnitTest, GetUtxos) {
                 return true;
               })));
   bitcoin_wallet_service_->GetUtxos(account_id(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -294,7 +294,7 @@ TEST_F(BitcoinWalletServiceUnitTest, CreateTransaction_UpdatesChangeAddress) {
 
   bitcoin_wallet_service_->CreateTransaction(account_id(), kMockBtcAddress,
                                              48000, false, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   auto change_address_6 =
@@ -320,7 +320,7 @@ TEST_F(BitcoinWalletServiceUnitTest, CreateTransaction) {
               })));
   bitcoin_wallet_service_->CreateTransaction(account_id(), kMockBtcAddress,
                                              48000, false, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_EQ(actual_tx.locktime(), 12345u);
@@ -383,7 +383,7 @@ TEST_F(BitcoinWalletServiceUnitTest, SignAndPostTransaction) {
               })));
   bitcoin_wallet_service_->CreateTransaction(account_id(), kMockBtcAddress,
                                              48000, false, callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   BitcoinTransaction signed_tx;
@@ -392,7 +392,7 @@ TEST_F(BitcoinWalletServiceUnitTest, SignAndPostTransaction) {
           WithArg<1>([&](const BitcoinTransaction& tx) { signed_tx = tx; }));
   bitcoin_wallet_service_->SignAndPostTransaction(
       account_id(), std::move(initial_tx), sign_callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&sign_callback);
 
   EXPECT_EQ(BitcoinSerializer::CalcTransactionWeight(signed_tx, false), 832u);
@@ -440,7 +440,7 @@ TEST_F(BitcoinWalletServiceUnitTest, DiscoverAccount) {
               })));
   bitcoin_wallet_service_->DiscoverAccount(mojom::KeyringId::kBitcoin84, 0,
                                            callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(Truly([&](auto& arg) {
@@ -450,7 +450,7 @@ TEST_F(BitcoinWalletServiceUnitTest, DiscoverAccount) {
               })));
   bitcoin_wallet_service_->DiscoverAccount(mojom::KeyringId::kBitcoin84, 1,
                                            callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Receive addresses 5 and 30 for account 0 are transacted.
@@ -475,7 +475,7 @@ TEST_F(BitcoinWalletServiceUnitTest, DiscoverAccount) {
               })));
   bitcoin_wallet_service_->DiscoverAccount(mojom::KeyringId::kBitcoin84, 0,
                                            callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // For acc 1 nothing is still discovered.
@@ -486,7 +486,7 @@ TEST_F(BitcoinWalletServiceUnitTest, DiscoverAccount) {
               })));
   bitcoin_wallet_service_->DiscoverAccount(mojom::KeyringId::kBitcoin84, 1,
                                            callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Receive address 15 and change address 17 for account 0 are transacted.
@@ -519,7 +519,7 @@ TEST_F(BitcoinWalletServiceUnitTest, DiscoverAccount) {
               })));
   bitcoin_wallet_service_->DiscoverAccount(mojom::KeyringId::kBitcoin84, 0,
                                            callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Discovered 9 and 0.
@@ -531,7 +531,7 @@ TEST_F(BitcoinWalletServiceUnitTest, DiscoverAccount) {
               })));
   bitcoin_wallet_service_->DiscoverAccount(mojom::KeyringId::kBitcoin84, 1,
                                            callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 

--- a/components/brave_wallet/browser/eth_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/eth_tx_manager_unittest.cc
@@ -267,10 +267,10 @@ class EthTxManagerUnitTest : public testing::Test {
     WaitForTxStorageDelegateInitialized(tx_service_->GetDelegateForTesting());
 
     keyring_service_->CreateWallet("testing123", base::DoNothing());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     keyring_service_->AddAccountSync(mojom::CoinType::ETH,
                                      mojom::kDefaultKeyringId, "Account 1");
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
 
     ASSERT_TRUE(base::HexStringToBytes(
         "095ea7b3000000000000000000000000BFb30a082f650C2A15D0632f0e87bE4F8e6446"
@@ -339,7 +339,7 @@ class EthTxManagerUnitTest : public testing::Test {
         orig_meta_id, cancel,
         base::BindOnce(&AddUnapprovedTransactionSuccessCallback,
                        &callback_called, tx_meta_id));
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_called);
   }
 
@@ -374,7 +374,7 @@ class EthTxManagerUnitTest : public testing::Test {
         orig_meta_id, cancel,
         base::BindOnce(&AddUnapprovedTransactionSuccessCallback,
                        &callback_called, tx_meta_id));
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_called);
   }
 
@@ -386,7 +386,7 @@ class EthTxManagerUnitTest : public testing::Test {
         orig_meta_id, false,
         base::BindOnce(&AddUnapprovedTransactionFailureCallback,
                        &callback_called));
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_called);
   }
 
@@ -488,7 +488,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedTransactionWithGasPriceAndGasLimit) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -516,7 +516,7 @@ TEST_F(EthTxManagerUnitTest, WalletOrigin) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -539,7 +539,7 @@ TEST_F(EthTxManagerUnitTest, SomeSiteOrigin) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -562,7 +562,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedTransactionWithoutGasLimit) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -611,7 +611,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedTransactionWithoutGasLimit) {
         mojom::kLocalhostChainId, std::move(tx_data), from(),
         base::BindOnce(&AddUnapprovedTransactionSuccessCallback,
                        &callback_called, &tx_meta_id));
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_called);
     tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
     EXPECT_TRUE(tx_meta);
@@ -636,7 +636,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedTransactionWithoutGasPrice) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -655,7 +655,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapprovedTransactionWithoutGasPrice) {
       mojom::kLocalhostChainId, std::move(tx_data), from(),
       base::BindOnce(&AddUnapprovedTransactionFailureCallback,
                      &callback_called));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -673,7 +673,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -691,7 +691,7 @@ TEST_F(EthTxManagerUnitTest,
       mojom::kLocalhostChainId, std::move(tx_data), from(),
       base::BindOnce(&AddUnapprovedTransactionFailureCallback,
                      &callback_called));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -709,7 +709,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -735,7 +735,7 @@ TEST_F(EthTxManagerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -755,7 +755,7 @@ TEST_F(EthTxManagerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Fail if passing an empty gas price.
@@ -766,7 +766,7 @@ TEST_F(EthTxManagerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Fail if passing an empty gas limit.
@@ -776,7 +776,7 @@ TEST_F(EthTxManagerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   const std::string update_gas_price_hex_string = "0x20000000000";
@@ -800,7 +800,7 @@ TEST_F(EthTxManagerUnitTest, SetGasPriceAndLimitForUnapprovedTransaction) {
         EXPECT_TRUE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   EXPECT_TRUE(observer.TxUpdated());
 
@@ -823,7 +823,7 @@ TEST_F(EthTxManagerUnitTest, SetDataForUnapprovedTransaction) {
       mojom::kLocalhostChainId, std::move(tx_data), from(),
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
@@ -854,7 +854,7 @@ TEST_F(EthTxManagerUnitTest, SetDataForUnapprovedTransaction) {
       }));
   run_loop2.Run();
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(observer.TxUpdated());
 
   // Get the updated TX.
@@ -874,7 +874,7 @@ TEST_F(EthTxManagerUnitTest, SetNonceForUnapprovedTransaction) {
       mojom::kLocalhostChainId, std::move(tx_data), from(),
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
@@ -915,7 +915,7 @@ TEST_F(EthTxManagerUnitTest, SetNonceForUnapprovedTransaction) {
       }));
   run_loop3.Run();
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(observer.TxUpdated());
 
   // Get the updated TX.
@@ -933,7 +933,7 @@ TEST_F(EthTxManagerUnitTest, SetNonceForUnapprovedTransaction) {
       }));
   run_loop4.Run();
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(observer.TxUpdated());
 
   // Get the updated TX.
@@ -1032,7 +1032,7 @@ TEST_F(EthTxManagerUnitTest, ProcessHardwareSignature) {
   TestTxServiceObserver observer("0x6", "", "", "", "", std::vector<uint8_t>(),
                                  mojom::TransactionStatus::Approved);
   tx_service_->AddObserver(observer.GetReceiver());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Set an interceptor and just fake a common repsonse for
@@ -1074,7 +1074,7 @@ TEST_F(EthTxManagerUnitTest, ProcessHardwareSignatureFail) {
   TestTxServiceObserver observer("0x6", "", "", "", "", std::vector<uint8_t>(),
                                  mojom::TransactionStatus::Error);
   tx_service_->AddObserver(observer.GetReceiver());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   callback_called = false;
   eth_tx_manager()->ProcessHardwareSignature(
@@ -1092,7 +1092,7 @@ TEST_F(EthTxManagerUnitTest, ProcessHardwareSignatureFail) {
         EXPECT_EQ(tx_meta->status(), mojom::TransactionStatus::Error);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
   ASSERT_TRUE(observer.TxStatusChanged());
   observer.Reset();
@@ -1109,7 +1109,7 @@ TEST_F(EthTxManagerUnitTest, ProcessHardwareSignatureFail) {
             l10n_util::GetStringUTF8(IDS_BRAVE_WALLET_TRANSACTION_NOT_FOUND));
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
   ASSERT_FALSE(observer.TxStatusChanged());
 }
@@ -1127,7 +1127,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransaction) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   TestTxServiceObserver observer("", "", "", "", "", std::vector<uint8_t>(),
                                  mojom::TransactionStatus::Unapproved);
@@ -1144,7 +1144,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransaction) {
         EXPECT_EQ(Uint256ValueToHex(tx_meta->tx()->nonce().value()), nonce);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
 
   callback_called = false;
@@ -1161,7 +1161,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransaction) {
             "0000000000000000000000003fffffffffffffff8205398080");
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
   ASSERT_TRUE(observer.TxStatusChanged());
 }
@@ -1181,7 +1181,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransaction1559) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   TestTxServiceObserver observer("0x0", "", "", "", "", std::vector<uint8_t>(),
                                  mojom::TransactionStatus::Unapproved);
@@ -1198,7 +1198,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransaction1559) {
         EXPECT_EQ(Uint256ValueToHex(tx_meta->tx()->nonce().value()), nonce);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
 
   callback_called = false;
@@ -1212,7 +1212,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransaction1559) {
             "0x02dd04800101019401010101010101010101010101010101010101018080c0");
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
   ASSERT_TRUE(observer.TxStatusChanged());
 }
@@ -1227,7 +1227,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransactionFail) {
         EXPECT_FALSE(nonce);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
 
   callback_called = false;
@@ -1237,7 +1237,7 @@ TEST_F(EthTxManagerUnitTest, GetNonceForHardwareTransactionFail) {
         ASSERT_FALSE(message);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_called);
   ASSERT_FALSE(observer.TxStatusChanged());
 }
@@ -1259,7 +1259,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapproved1559TransactionWithGasFeeAndLimit) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1288,7 +1288,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapproved1559TransactionWithoutGasLimit) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1318,7 +1318,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapproved1559TransactionWithoutGasFee) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1350,7 +1350,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1411,7 +1411,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1485,7 +1485,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1540,7 +1540,7 @@ TEST_F(EthTxManagerUnitTest, AddUnapproved1559TransactionFeeHistoryFailed) {
       base::BindOnce(&AddUnapprovedTransactionFailureCallback,
                      &callback_called));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -1560,7 +1560,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1595,7 +1595,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1624,7 +1624,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1655,7 +1655,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1687,7 +1687,7 @@ TEST_F(EthTxManagerUnitTest, SetGasFeeAndLimitForUnapprovedTransaction) {
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1713,7 +1713,7 @@ TEST_F(EthTxManagerUnitTest, SetGasFeeAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Fail if passing an empty gas limit.
@@ -1724,7 +1724,7 @@ TEST_F(EthTxManagerUnitTest, SetGasFeeAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Fail if passing an empty max_priority_fee_per_gas.
@@ -1735,7 +1735,7 @@ TEST_F(EthTxManagerUnitTest, SetGasFeeAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Fail if passing an empty max_fee_per_gas.
@@ -1746,7 +1746,7 @@ TEST_F(EthTxManagerUnitTest, SetGasFeeAndLimitForUnapprovedTransaction) {
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   const std::string update_max_priority_fee_per_gas_hex_string = "0x3344";
@@ -1776,7 +1776,7 @@ TEST_F(EthTxManagerUnitTest, SetGasFeeAndLimitForUnapprovedTransaction) {
         EXPECT_TRUE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   EXPECT_TRUE(observer.TxUpdated());
 
@@ -1804,7 +1804,7 @@ TEST_F(EthTxManagerUnitTest,
       base::BindOnce(&AddUnapprovedTransactionSuccessCallback, &callback_called,
                      &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   EXPECT_TRUE(tx_meta);
@@ -1816,12 +1816,12 @@ TEST_F(EthTxManagerUnitTest,
         EXPECT_FALSE(success);
         callback_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
 TEST_F(EthTxManagerUnitTest, TestSubmittedToConfirmed) {
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EthTxMeta meta(EthAccount(0), std::make_unique<EthTransaction>());
   meta.set_id("001");
   meta.set_chain_id(mojom::kLocalhostChainId);
@@ -2132,7 +2132,7 @@ TEST_F(EthTxManagerUnitTest, RetryTransaction) {
       "001", base::BindOnce(&AddUnapprovedTransactionSuccessCallback,
                             &callback_called, &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   auto tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   ASSERT_TRUE(tx_meta);
@@ -2159,7 +2159,7 @@ TEST_F(EthTxManagerUnitTest, RetryTransaction) {
       "002", base::BindOnce(&AddUnapprovedTransactionSuccessCallback,
                             &callback_called, &tx_meta_id));
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
   tx_meta = eth_tx_manager()->GetTxForTesting(tx_meta_id);
   ASSERT_TRUE(tx_meta);
@@ -2171,7 +2171,7 @@ TEST_F(EthTxManagerUnitTest, RetryTransaction) {
   eth_tx_manager()->RetryTransaction(
       "123", base::BindOnce(&AddUnapprovedTransactionFailureCallback,
                             &callback_called));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Retry unapproved transaction should fail.
@@ -2179,7 +2179,7 @@ TEST_F(EthTxManagerUnitTest, RetryTransaction) {
   eth_tx_manager()->RetryTransaction(
       tx_meta_id, base::BindOnce(&AddUnapprovedTransactionFailureCallback,
                                  &callback_called));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 

--- a/components/brave_wallet/browser/fil_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/fil_tx_manager_unittest.cc
@@ -88,7 +88,7 @@ class FilTxManagerUnitTest : public testing::Test {
 
     keyring_service_->CreateWallet(kMnemonicDivideCruise, "brave",
                                    base::DoNothing());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     keyring_service_->AddAccountSync(
         mojom::CoinType::FIL, mojom::kFilecoinTestnetKeyringId, "Account 1");
   }
@@ -290,7 +290,7 @@ TEST_F(FilTxManagerUnitTest, SubmitTransactions) {
   ApproveTransaction(meta_id1, false, mojom::FilecoinProviderError::kSuccess,
                      std::string());
   // Wait for tx to be updated.
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   tx_meta1 = fil_tx_manager()->GetTxForTesting(meta_id1);
   ASSERT_TRUE(tx_meta1);
   EXPECT_FALSE(tx_meta1->tx_hash().empty());
@@ -300,7 +300,7 @@ TEST_F(FilTxManagerUnitTest, SubmitTransactions) {
   // Send another tx.
   ApproveTransaction(meta_id2, false, mojom::FilecoinProviderError::kSuccess,
                      std::string());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   tx_meta2 = fil_tx_manager()->GetTxForTesting(meta_id2);
   ASSERT_TRUE(tx_meta2);
@@ -351,7 +351,7 @@ TEST_F(FilTxManagerUnitTest, SubmitTransactionError) {
                      mojom::FilecoinProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
   // Wait for tx to be updated.
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   tx_meta1 = fil_tx_manager()->GetTxForTesting(meta_id1);
   ASSERT_TRUE(tx_meta1);
   EXPECT_TRUE(tx_meta1->tx_hash().empty());
@@ -410,7 +410,7 @@ TEST_F(FilTxManagerUnitTest, SubmitTransactionConfirmed) {
   ApproveTransaction(meta_id1, false, mojom::FilecoinProviderError::kSuccess,
                      std::string());
   // Wait for tx to be updated.
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   tx_meta1 = fil_tx_manager()->GetTxForTesting(meta_id1);
   ASSERT_TRUE(tx_meta1);
   EXPECT_FALSE(tx_meta1->tx_hash().empty());

--- a/components/brave_wallet/browser/json_rpc_service_unittest.cc
+++ b/components/brave_wallet/browser/json_rpc_service_unittest.cc
@@ -1720,9 +1720,9 @@ class JsonRpcServiceUnitTest : public testing::Test {
  protected:
   std::unique_ptr<JsonRpcService> json_rpc_service_;
   network::TestURLLoaderFactory url_loader_factory_;
+  base::test::TaskEnvironment task_environment_;
 
  private:
-  base::test::TaskEnvironment task_environment_;
   sync_preferences::TestingPrefServiceSyncable prefs_;
   sync_preferences::TestingPrefServiceSyncable local_state_prefs_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
@@ -1847,7 +1847,7 @@ TEST_F(JsonRpcServiceUnitTest, GetAllNetworks) {
             }
             callback_is_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_is_called);
 
   callback_is_called = false;
@@ -1859,7 +1859,7 @@ TEST_F(JsonRpcServiceUnitTest, GetAllNetworks) {
 
             callback_is_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_is_called);
 }
 
@@ -1983,7 +1983,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApproved) {
             ASSERT_TRUE(error_message.empty());
             callback_is_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   EXPECT_THAT(GetAllUserAssets(prefs()),
               Contains(Eq(std::ref(expected_token))));
@@ -2002,7 +2002,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainApproved) {
         ASSERT_FALSE(error_message.empty());
         failed_callback_is_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(failed_callback_is_called);
 
   json_rpc_service_->AddEthereumChainRequestCompleted("0x111", true);
@@ -2110,7 +2110,7 @@ TEST_F(JsonRpcServiceUnitTest, AddChain) {
     EXPECT_CALL(callback, Run("0x111", mojom::ProviderError::kSuccess, ""));
 
     json_rpc_service_->AddChain(chain.Clone(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_EQ(
         GURL("https://url1.com"),
         GetChain(prefs(), "0x111", mojom::CoinType::ETH)->rpc_endpoints[0]);
@@ -2195,7 +2195,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainError) {
             ASSERT_TRUE(error_message.empty());
             callback_is_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(callback_is_called);
 
   // Add a same chain.
@@ -2214,7 +2214,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainError) {
                                      IDS_SETTINGS_WALLET_NETWORKS_EXISTS));
         third_callback_is_called = true;
       }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(third_callback_is_called);
 
   // new chain, not valid rpc url
@@ -2241,7 +2241,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainError) {
                           base::ASCIIToUTF16(network_url.spec())));
             fourth_callback_is_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(fourth_callback_is_called);
 
   // new chain, broken validation response
@@ -2268,7 +2268,7 @@ TEST_F(JsonRpcServiceUnitTest, AddEthereumChainError) {
                           base::ASCIIToUTF16(GURL(network_url).spec())));
             fifth_callback_is_called = true;
           }));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   ASSERT_TRUE(fifth_callback_is_called);
 }
 
@@ -2368,7 +2368,7 @@ TEST_F(JsonRpcServiceUnitTest, Request) {
       mojom::CoinType::ETH,
       base::BindOnce(&OnRequestResponse, &callback_called, true /* success */,
                      result));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2386,7 +2386,7 @@ TEST_F(JsonRpcServiceUnitTest, Request) {
       mojom::CoinType::ETH,
       base::BindOnce(&OnRequestResponse, &callback_called, true /* success */,
                      result));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2396,7 +2396,7 @@ TEST_F(JsonRpcServiceUnitTest, Request) {
       mojom::CoinType::ETH,
       base::BindOnce(&OnRequestResponse, &callback_called, false /* success */,
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -2419,7 +2419,7 @@ TEST_F(JsonRpcServiceUnitTest, Request_BadHeaderValues) {
       mojom::kLocalhostChainId, request, true, base::Value(),
       mojom::CoinType::ETH,
       base::BindOnce(&OnRequestResponse, &callback_called, false, ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -2472,7 +2472,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
       mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "0xb539d5"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2483,7 +2483,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2494,7 +2494,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2504,7 +2504,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2515,7 +2515,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2526,7 +2526,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
       "addr", mojom::CoinType::FIL, mojom::kFilecoinMainnet,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "100000"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2536,7 +2536,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBalance) {
       "addr", mojom::CoinType::FIL, mojom::kFilecoinTestnet,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "100000"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -2677,7 +2677,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "",
                      "0x166e12cfce39a0000"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2688,7 +2688,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2699,7 +2699,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2710,7 +2710,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Invalid input should fail.
@@ -2721,7 +2721,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2732,7 +2732,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenBalance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -2751,7 +2751,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenAllowance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "",
                      "0x166e12cfce39a0000"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2763,7 +2763,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenAllowance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2775,7 +2775,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenAllowance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -2787,7 +2787,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenAllowance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Invalid input should fail.
@@ -2798,7 +2798,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC20TokenAllowance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -3079,7 +3079,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonNetworkError) {
   SetPolygonTimeoutResponse();
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.crypto", MakeToken(),
                                                      callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback,
@@ -3089,7 +3089,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonNetworkError) {
   SetPolygonTimeoutResponse();
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.crypto", MakeToken(),
                                                      callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback,
@@ -3099,7 +3099,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonNetworkError) {
   SetPolygonRawResponse("Not a json");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.crypto", MakeToken(),
                                                      callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback,
@@ -3108,7 +3108,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonNetworkError) {
   SetPolygonRawResponse(MakeJsonRpcErrorResponse(-32005, "Error!"));
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.crypto", MakeToken(),
                                                      callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -3119,7 +3119,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonResult) {
   SetPolygonResponse("javajobs.crypto", k0x3a2f3fAddr);
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "javajobs.crypto", MakeToken(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(k0x3a2f3fAddr, mojom::ProviderError::kSuccess, ""));
@@ -3127,7 +3127,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonResult) {
   SetPolygonResponse("javajobs.crypto", k0x3a2f3fAddr);
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "javajobs.crypto", MakeToken(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(k0x3a2f3fAddr, mojom::ProviderError::kSuccess, ""));
@@ -3135,7 +3135,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_PolygonResult) {
   SetPolygonResponse("javajobs.crypto", k0x3a2f3fAddr);
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "javajobs.crypto", MakeToken(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_FallbackToEthMainnet) {
@@ -3145,7 +3145,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_FallbackToEthMainnet) {
   SetPolygonResponse("brad.crypto", "");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.crypto", MakeToken(),
                                                      callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_FallbackToEthMainnetError) {
@@ -3157,7 +3157,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_FallbackToEthMainnetError) {
   SetPolygonResponse("brad.crypto", "");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.crypto", MakeToken(),
                                                      callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_InvalidDomain) {
@@ -3168,7 +3168,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_InvalidDomain) {
   json_rpc_service_->UnstoppableDomainsGetWalletAddr("brad.test", MakeToken(),
                                                      callback.Get());
   EXPECT_EQ(0, url_loader_factory_.NumPending());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_ManyCalls) {
@@ -3200,7 +3200,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_ManyCalls) {
       "javajobs.crypto", MakeToken(), callback1.Get());
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "javajobs.crypto", MakeToken(), callback2.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(1, eth_mainnet_getmany_call_handler_->calls_number());
   EXPECT_EQ(1, polygon_getmany_call_handler_->calls_number());
   testing::Mock::VerifyAndClearExpectations(&callback1);
@@ -3208,7 +3208,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_ManyCalls) {
 
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "another.crypto", MakeToken(), callback3.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(2, eth_mainnet_getmany_call_handler_->calls_number());
   EXPECT_EQ(2, polygon_getmany_call_handler_->calls_number());
   testing::Mock::VerifyAndClearExpectations(&callback3);
@@ -3228,7 +3228,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_MultipleKeys) {
                                              "crypto.ETH.address", "ethaddr1");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "test.crypto", token.Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // crypto.USDT.address is preferred over default.
@@ -3237,7 +3237,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_MultipleKeys) {
                                              "crypto.USDT.address", "ethaddr2");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "test.crypto", token.Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // crypto.USDT.version.BEP20.address is the most preferred.
@@ -3246,7 +3246,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_MultipleKeys) {
       "test.crypto", "crypto.USDT.version.BEP20.address", "ethaddr3");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "test.crypto", token.Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Address on Polygon network takes precedence over anything on ETH mainnet.
@@ -3255,7 +3255,7 @@ TEST_F(UnstoppableDomainsUnitTest, GetWalletAddr_MultipleKeys) {
                                          "polyaddr");
   json_rpc_service_->UnstoppableDomainsGetWalletAddr(
       "test.crypto", token.Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -3268,7 +3268,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonNetworkError) {
   SetPolygonTimeoutResponse();
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback,
@@ -3278,7 +3278,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonNetworkError) {
   SetPolygonTimeoutResponse();
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback,
@@ -3288,7 +3288,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonNetworkError) {
   SetPolygonRawResponse("Not a json");
   json_rpc_service_->UnstoppableDomainsResolveDns("brad.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(std::optional<GURL>(),
@@ -3297,7 +3297,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonNetworkError) {
   SetPolygonRawResponse(MakeJsonRpcErrorResponse(-32005, "Error!"));
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -3309,7 +3309,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonResult) {
   SetPolygonRawResponse(DnsBraveResponse());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(std::optional<GURL>("https://brave.com"),
@@ -3318,7 +3318,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonResult) {
   SetPolygonRawResponse(DnsBraveResponse());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(std::optional<GURL>("https://brave.com"),
@@ -3327,7 +3327,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_PolygonResult) {
   SetPolygonRawResponse(DnsBraveResponse());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(UnstoppableDomainsUnitTest, ResolveDns_FallbackToEthMainnet) {
@@ -3338,7 +3338,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_FallbackToEthMainnet) {
   SetPolygonRawResponse(DnsEmptyResponse());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback, Run(std::optional<GURL>("https://brave.com"),
@@ -3348,7 +3348,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_FallbackToEthMainnet) {
       MakeJsonRpcStringArrayResponse({"", "", "", "", "", "invalid url"}));
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -3361,7 +3361,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_FallbackToEthMainnetError) {
   SetPolygonRawResponse(DnsEmptyResponse());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   EXPECT_CALL(callback,
@@ -3371,7 +3371,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_FallbackToEthMainnetError) {
   SetPolygonRawResponse(DnsEmptyResponse());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -3382,7 +3382,7 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_InvalidDomain) {
                   l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)));
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.test", callback.Get());
   EXPECT_EQ(0, url_loader_factory_.NumPending());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(UnstoppableDomainsUnitTest, ResolveDns_ManyCalls) {
@@ -3419,14 +3419,14 @@ TEST_F(UnstoppableDomainsUnitTest, ResolveDns_ManyCalls) {
                                                   callback1.Get());
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.crypto",
                                                   callback2.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(1, eth_mainnet_getmany_call_handler_->calls_number());
   EXPECT_EQ(1, polygon_getmany_call_handler_->calls_number());
   testing::Mock::VerifyAndClearExpectations(&callback1);
   testing::Mock::VerifyAndClearExpectations(&callback2);
 
   json_rpc_service_->UnstoppableDomainsResolveDns("brave.x", callback3.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_EQ(2, eth_mainnet_getmany_call_handler_->calls_number());
   EXPECT_EQ(2, polygon_getmany_call_handler_->calls_number());
   testing::Mock::VerifyAndClearExpectations(&callback3);
@@ -3442,7 +3442,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBaseFeePerGas) {
       mojom::kLocalhostChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "0x181f22e7a9"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Successful path when the network is not EIP1559
@@ -3452,7 +3452,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBaseFeePerGas) {
       mojom::kLocalhostChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3462,7 +3462,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBaseFeePerGas) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3472,7 +3472,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBaseFeePerGas) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3482,7 +3482,7 @@ TEST_F(JsonRpcServiceUnitTest, GetBaseFeePerGas) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -3496,7 +3496,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559NotCalledForKnownChains) {
       .Times(1);
   EXPECT_TRUE(
       SetNetwork(mojom::kMainnetChainId, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
 }
 
@@ -3517,7 +3517,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559LocalhostChain) {
       .Times(1);
   EXPECT_TRUE(
       SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_TRUE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
 
@@ -3532,7 +3532,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559LocalhostChain) {
       .Times(1);
   EXPECT_TRUE(
       SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
 
@@ -3547,7 +3547,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559LocalhostChain) {
       .Times(1);
   EXPECT_TRUE(
       SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
 
@@ -3560,7 +3560,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559LocalhostChain) {
       .Times(1);
   EXPECT_TRUE(
       SetNetwork(mojom::kLocalhostChainId, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_FALSE(GetIsEip1559FromPrefs(mojom::kLocalhostChainId));
 }
@@ -3586,7 +3586,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559CustomChain) {
                                           testing::Eq(std::nullopt)))
       .Times(1);
   EXPECT_TRUE(SetNetwork(chain1.chain_id, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_TRUE(GetIsEip1559FromPrefs(chain1.chain_id));
 
@@ -3599,7 +3599,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559CustomChain) {
                                           testing::Eq(std::nullopt)))
       .Times(1);
   EXPECT_TRUE(SetNetwork(chain2.chain_id, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
@@ -3613,7 +3613,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559CustomChain) {
                                           testing::Eq(std::nullopt)))
       .Times(1);
   EXPECT_TRUE(SetNetwork(chain2.chain_id, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
@@ -3625,7 +3625,7 @@ TEST_F(JsonRpcServiceUnitTest, UpdateIsEip1559CustomChain) {
                                           testing::Eq(std::nullopt)))
       .Times(1);
   EXPECT_TRUE(SetNetwork(chain2.chain_id, mojom::CoinType::ETH, std::nullopt));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
   EXPECT_FALSE(GetIsEip1559FromPrefs(chain2.chain_id));
@@ -3643,7 +3643,7 @@ TEST_F(JsonRpcServiceUnitTest, GetWalletAddrInvalidDomain) {
                       l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)));
 
       json_rpc_service_->EnsGetEthAddr(domain, callback.Get());
-      base::RunLoop().RunUntilIdle();
+      task_environment_.RunUntilIdle();
     }
 
     {
@@ -3656,7 +3656,7 @@ TEST_F(JsonRpcServiceUnitTest, GetWalletAddrInvalidDomain) {
 
       json_rpc_service_->UnstoppableDomainsGetWalletAddr(
           domain, mojom::BlockchainToken::New(), callback.Get());
-      base::RunLoop().RunUntilIdle();
+      task_environment_.RunUntilIdle();
     }
   }
 }
@@ -3768,7 +3768,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3778,7 +3778,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3788,7 +3788,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetInterceptor(
@@ -3805,7 +3805,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
           &OnStringResponse, &callback_called, mojom::ProviderError::kSuccess,
           "",
           "0x983110309620D911731Ac0932219af06091b6744"));  // checksum address
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetHTTPRequestTimeoutInterceptor();
@@ -3815,7 +3815,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetInvalidJsonInterceptor();
@@ -3825,7 +3825,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetLimitExceededJsonErrorResponse();
@@ -3835,7 +3835,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721OwnerOf) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -3892,7 +3892,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3903,7 +3903,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3914,7 +3914,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -3925,7 +3925,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
                      mojom::ProviderError::kInvalidParams,
                      l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS),
                      ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetInterceptor(
@@ -3941,7 +3941,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
       "0x983110309620D911731Ac0932219af06091b6744", mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "0x1"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Non-checksum address can get the same balance.
@@ -3951,7 +3951,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
       "0x983110309620d911731ac0932219af06091b6744", mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "0x1"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Non-owner gets balance 0x0.
@@ -3961,7 +3961,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
       "0x983110309620d911731ac0932219af06091b7811", mojom::kMainnetChainId,
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", "0x0"));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetHTTPRequestTimeoutInterceptor();
@@ -3971,7 +3971,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetInvalidJsonInterceptor();
@@ -3981,7 +3981,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   SetLimitExceededJsonErrorResponse();
@@ -3991,7 +3991,7 @@ TEST_F(JsonRpcServiceUnitTest, GetERC721Balance) {
       base::BindOnce(&OnStringResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", ""));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -4061,7 +4061,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
       mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", true));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Successful, but does not support the interface
@@ -4076,7 +4076,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
       mojom::kMainnetChainId,
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kSuccess, "", false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   // Invalid result, should be in hex form
@@ -4091,7 +4091,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR),
                      false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4103,7 +4103,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR),
                      false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4115,7 +4115,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR),
                      false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4126,7 +4126,7 @@ TEST_F(JsonRpcServiceUnitTest, GetSupportsInterface) {
       base::BindOnce(&OnBoolResponse, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", false));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -4561,7 +4561,7 @@ TEST_F(JsonRpcServiceUnitTest, GetEthTransactionCount) {
       mojom::kLocalhostChainId, "0x4e02f254184E904300e0775E4b8eeCB1",
       base::BindOnce(&OnEthUint256Response, &callback_called,
                      mojom::ProviderError::kSuccess, "", 1));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4571,7 +4571,7 @@ TEST_F(JsonRpcServiceUnitTest, GetEthTransactionCount) {
       base::BindOnce(&OnEthUint256Response, &callback_called,
                      mojom::ProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), 0));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4581,7 +4581,7 @@ TEST_F(JsonRpcServiceUnitTest, GetEthTransactionCount) {
       base::BindOnce(&OnEthUint256Response, &callback_called,
                      mojom::ProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), 0));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4591,7 +4591,7 @@ TEST_F(JsonRpcServiceUnitTest, GetEthTransactionCount) {
       base::BindOnce(&OnEthUint256Response, &callback_called,
                      mojom::ProviderError::kLimitExceeded,
                      "Request exceeds defined limit", 0));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -4605,7 +4605,7 @@ TEST_F(JsonRpcServiceUnitTest, GetFilTransactionCount) {
       mojom::kLocalhostChainId, "t1h4n7rphclbmwyjcp6jrdiwlfcuwbroxy3jvg33q",
       base::BindOnce(&OnFilUint256Response, &callback_called,
                      mojom::FilecoinProviderError::kSuccess, "", UINT64_MAX));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4615,7 +4615,7 @@ TEST_F(JsonRpcServiceUnitTest, GetFilTransactionCount) {
       base::BindOnce(&OnFilUint256Response, &callback_called,
                      mojom::FilecoinProviderError::kInternalError,
                      l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR), 0));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4626,7 +4626,7 @@ TEST_F(JsonRpcServiceUnitTest, GetFilTransactionCount) {
       base::BindOnce(&OnFilUint256Response, &callback_called,
                      mojom::FilecoinProviderError::kParsingError,
                      l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR), 0));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 
   callback_called = false;
@@ -4636,7 +4636,7 @@ TEST_F(JsonRpcServiceUnitTest, GetFilTransactionCount) {
       base::BindOnce(&OnFilUint256Response, &callback_called,
                      mojom::FilecoinProviderError::kActorNotFound,
                      "resolution lookup failed", 0));
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   EXPECT_TRUE(callback_called);
 }
 
@@ -5528,7 +5528,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr) {
   EXPECT_CALL(callback, Run(offchain_eth_addr().ToHex(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Subdomain) {
@@ -5539,7 +5539,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Subdomain) {
   EXPECT_CALL(callback, Run(offchain_subdomain_eth_addr().ToHex(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetEthAddr(ens_subdomain_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Subdomain_NoEnsip10Support) {
@@ -5554,7 +5554,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Subdomain_NoEnsip10Support) {
               Run("", false, mojom::ProviderError::kInvalidParams,
                   l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)));
   json_rpc_service_->EnsGetEthAddr(ens_subdomain_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_NoResolver) {
@@ -5566,7 +5566,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_NoResolver) {
               Run("", false, mojom::ProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->EnsGetEthAddr("unknown-host.eth", callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_NoEnsip10Support) {
@@ -5580,7 +5580,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_NoEnsip10Support) {
   EXPECT_CALL(callback, Run(onchain_eth_addr().ToHex(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_NoEnsip10Support_GoOffchain) {
@@ -5596,7 +5596,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_NoEnsip10Support_GoOffchain) {
   EXPECT_CALL(callback, Run(offchain_eth_addr().ToHex(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Gateway500Error) {
@@ -5611,7 +5611,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Gateway500Error) {
               Run("", false, mojom::ProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_GatewayNoRecord) {
@@ -5626,7 +5626,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_GatewayNoRecord) {
               Run("", false, mojom::ProviderError::kInvalidParams,
                   l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)));
   json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Consent) {
@@ -5640,7 +5640,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Consent) {
     // Called with `require_offchain_consent` == true.
     EXPECT_CALL(callback, Run("", true, mojom::ProviderError::kSuccess, ""));
     json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_EQ(
         decentralized_dns::EnsOffchainResolveMethod::kAsk,
         decentralized_dns::GetEnsOffchainResolveMethod(local_state_prefs()));
@@ -5658,7 +5658,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Consent) {
     EXPECT_CALL(callback, Run(offchain_eth_addr().ToHex(), false,
                               mojom::ProviderError::kSuccess, ""));
     json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
   // Disable in prefs.
@@ -5673,7 +5673,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetWalletAddr_Consent) {
                 Run("", false, mojom::ProviderError::kInternalError,
                     l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
     json_rpc_service_->EnsGetEthAddr(ens_host(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 }
 
@@ -5686,7 +5686,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash) {
   EXPECT_CALL(callback, Run(offchain_contenthash(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Subdomain) {
@@ -5698,7 +5698,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Subdomain) {
   EXPECT_CALL(callback, Run(offchain_subdomain_contenthash(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetContentHash(ens_subdomain_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Subdomain_NoEnsip10Support) {
@@ -5715,7 +5715,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Subdomain_NoEnsip10Support) {
       Run(std::vector<uint8_t>(), false, mojom::ProviderError::kInvalidParams,
           l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)));
   json_rpc_service_->EnsGetContentHash(ens_subdomain_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_NoResolver) {
@@ -5729,7 +5729,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_NoResolver) {
       Run(std::vector<uint8_t>(), false, mojom::ProviderError::kInternalError,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->EnsGetContentHash("unknown-host.eth", callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_NoEnsip10Support) {
@@ -5745,7 +5745,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_NoEnsip10Support) {
   EXPECT_CALL(callback, Run(onchain_contenthash(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest,
@@ -5764,7 +5764,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest,
   EXPECT_CALL(callback, Run(offchain_contenthash(), false,
                             mojom::ProviderError::kSuccess, ""));
   json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Gateway500Error) {
@@ -5781,7 +5781,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Gateway500Error) {
       Run(std::vector<uint8_t>(), false, mojom::ProviderError::kInternalError,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_GatewayNoRecord) {
@@ -5798,7 +5798,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_GatewayNoRecord) {
       Run(std::vector<uint8_t>(), false, mojom::ProviderError::kInvalidParams,
           l10n_util::GetStringUTF8(IDS_WALLET_INVALID_PARAMETERS)));
   json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Consent) {
@@ -5812,7 +5812,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Consent) {
     EXPECT_CALL(callback, Run(std::vector<uint8_t>(), true,
                               mojom::ProviderError::kSuccess, ""));
     json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
   decentralized_dns::SetEnsOffchainResolveMethod(
@@ -5824,7 +5824,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Consent) {
     EXPECT_CALL(callback, Run(offchain_contenthash(), false,
                               mojom::ProviderError::kSuccess, ""));
     json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
   // Disable in prefs.
@@ -5840,7 +5840,7 @@ TEST_F(ENSL2JsonRpcServiceUnitTest, GetContentHash_Consent) {
         Run(std::vector<uint8_t>(), false, mojom::ProviderError::kInternalError,
             l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
     json_rpc_service_->EnsGetContentHash(ens_host(), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 }
 
@@ -5992,7 +5992,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_NftOwner) {
   EXPECT_CALL(callback, Run(NftOwnerAddress().ToBase58(),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP error while checking nft mint. Fail resolution.
@@ -6001,7 +6001,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_NftOwner) {
               Run("", mojom::SolanaProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   mint_address_handler_->FailWithTimeout(false);
 
@@ -6011,7 +6011,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_NftOwner) {
               Run("", mojom::SolanaProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   get_program_accounts_handler_->FailWithTimeout(false);
 
@@ -6020,7 +6020,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_NftOwner) {
   EXPECT_CALL(callback, Run(SolRecordAddress().ToBase58(),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -6033,7 +6033,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_DomainOwner) {
   EXPECT_CALL(callback, Run(DomainOwnerAddress().ToBase58(),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP error for domain key account. Fail resolution.
@@ -6042,7 +6042,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_DomainOwner) {
               Run("", mojom::SolanaProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   domain_address_handler_->FailWithTimeout(false);
 
@@ -6052,7 +6052,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_DomainOwner) {
               Run("", mojom::SolanaProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   domain_address_handler_->Disable(false);
@@ -6066,7 +6066,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_SolRecordOwner) {
   EXPECT_CALL(callback, Run(SolRecordAddress().ToBase58(),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Bad signature. Fallback to owner address.
@@ -6074,7 +6074,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_SolRecordOwner) {
   EXPECT_CALL(callback, Run(DomainOwnerAddress().ToBase58(),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   sol_record_address_handler_->data()[170] ^= 123;
 
@@ -6084,7 +6084,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_SolRecordOwner) {
               Run("", mojom::SolanaProviderError::kInternalError,
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   sol_record_address_handler_->FailWithTimeout(false);
 
@@ -6093,7 +6093,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, GetWalletAddr_SolRecordOwner) {
   EXPECT_CALL(callback, Run(DomainOwnerAddress().ToBase58(),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsGetSolAddr(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -6102,7 +6102,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, ResolveHost_UrlValue) {
   EXPECT_CALL(callback, Run(testing::Eq(url_value()),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsResolveHost(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP error for url record account. Fail resolution.
@@ -6112,7 +6112,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, ResolveHost_UrlValue) {
       Run(testing::Eq(GURL()), mojom::SolanaProviderError::kInternalError,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsResolveHost(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   url_record_address_handler_->FailWithTimeout(false);
 }
@@ -6125,7 +6125,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, ResolveHost_IpfsValue) {
   EXPECT_CALL(callback, Run(testing::Eq(ipfs_value()),
                             mojom::SolanaProviderError::kSuccess, ""));
   json_rpc_service_->SnsResolveHost(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // HTTP error for ipfs record account. Fail resolution.
@@ -6135,7 +6135,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, ResolveHost_IpfsValue) {
       Run(testing::Eq(GURL()), mojom::SolanaProviderError::kInternalError,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsResolveHost(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
   ipfs_record_address_handler_->FailWithTimeout(false);
 
@@ -6146,7 +6146,7 @@ TEST_F(SnsJsonRpcServiceUnitTest, ResolveHost_IpfsValue) {
       Run(testing::Eq(GURL()), mojom::SolanaProviderError::kInternalError,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   json_rpc_service_->SnsResolveHost(sns_host(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 

--- a/components/brave_wallet/browser/simulation_service_unittest.cc
+++ b/components/brave_wallet/browser/simulation_service_unittest.cc
@@ -194,9 +194,9 @@ class SimulationServiceUnitTest : public testing::Test {
   std::unique_ptr<SimulationService> simulation_service_;
   base::test::ScopedFeatureList feature_list_{
       features::kBraveWalletTransactionSimulationsFeature};
+  base::test::TaskEnvironment task_environment_;
 
  private:
-  base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
@@ -396,7 +396,7 @@ TEST_F(SimulationServiceUnitTest, ScanEVMTransactionUnsupportedNetwork) {
       GetCannedScanEVMTransactionParams(false, mojom::kOptimismMainnetChainId),
       "en-US", callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -411,7 +411,7 @@ TEST_F(SimulationServiceUnitTest, ScanEVMTransactionEmptyNetwork) {
   simulation_service_->ScanEVMTransaction(
       GetCannedScanEVMTransactionParams(false, ""), "en-US", callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -432,7 +432,7 @@ TEST_F(SimulationServiceUnitTest, ScanEVMTransactionValidErrorResponse) {
       GetCannedScanEVMTransactionParams(false, mojom::kPolygonMainnetChainId),
       "en-US", callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -450,7 +450,7 @@ TEST_F(SimulationServiceUnitTest, ScanEVMTransactionUnexpectedErrorResponse) {
       GetCannedScanEVMTransactionParams(false, mojom::kPolygonMainnetChainId),
       "en-US", callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -463,7 +463,7 @@ TEST_F(SimulationServiceUnitTest, ScanEVMTransactionNullParams) {
 
   simulation_service_->ScanEVMTransaction(nullptr, "en-US", callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -702,7 +702,7 @@ TEST_F(SimulationServiceUnitTest, ScanSolanaTransactionUnsupportedNetwork) {
   simulation_service_->ScanSolanaTransaction(std::move(request), "en-US",
                                              callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -721,7 +721,7 @@ TEST_F(SimulationServiceUnitTest, ScanSolanaTransactionEmptyNetwork) {
   simulation_service_->ScanSolanaTransaction(std::move(request), "en-US",
                                              callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -746,7 +746,7 @@ TEST_F(SimulationServiceUnitTest, ScanSolanaTransactionValidErrorResponse) {
   simulation_service_->ScanSolanaTransaction(std::move(request), "en-US",
                                              callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -769,7 +769,7 @@ TEST_F(SimulationServiceUnitTest,
   simulation_service_->ScanSolanaTransaction(std::move(request), "en-US",
                                              callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -782,7 +782,7 @@ TEST_F(SimulationServiceUnitTest, ScanSolanaTransactionNullParams) {
 
   simulation_service_->ScanSolanaTransaction(nullptr, "en-US", callback.Get());
 
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 

--- a/components/brave_wallet/browser/solana_tx_manager_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_manager_unittest.cc
@@ -514,7 +514,7 @@ TEST_F(SolanaTxManagerUnitTest, AddAndApproveTransaction) {
 
   ApproveTransaction(meta_id1);
   // Wait for tx to be updated.
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   tx->message()->set_recent_blockhash(latest_blockhash1_);
   tx->message()->set_last_valid_block_height(last_valid_block_height1_);
@@ -532,7 +532,7 @@ TEST_F(SolanaTxManagerUnitTest, AddAndApproveTransaction) {
   SetInterceptor(latest_blockhash1_, last_valid_block_height1_, tx_hash2_, "",
                  false, last_valid_block_height1_);
   ApproveTransaction(meta_id2);
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   tx_meta2 = solana_tx_manager()->GetTxForTesting(meta_id2);
   ASSERT_TRUE(tx_meta2);
@@ -1027,7 +1027,7 @@ TEST_F(SolanaTxManagerUnitTest, DropTxWithInvalidBlockhash) {
   ApproveTransaction(meta_id2);
 
   // Wait for tx to be updated.
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   // Check two submitted tx.
   auto pending_transactions =
@@ -1057,7 +1057,7 @@ TEST_F(SolanaTxManagerUnitTest, DropTxWithInvalidBlockhash) {
   task_environment_.FastForwardBy(
       base::Seconds(kBlockTrackerDefaultTimeInSeconds));
   // Wait for tx to be updated.
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 
   // Check blockhash1 should be dropped, blockhash2 stay as submitted.
   auto dropped_transactions =

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -187,7 +187,7 @@ class SwapServiceUnitTest : public testing::Test {
     swap_service_->GetQuote(
         GetCannedSwapQuoteParams(mojom::CoinType::SOL, mojom::kSolanaMainnet),
         callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
   void TestGetJupiterTransaction(
@@ -210,16 +210,16 @@ class SwapServiceUnitTest : public testing::Test {
 
     swap_service_->GetTransaction(
         GetCannedJupiterTransactionParams(output_mint), callback.Get());
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
   }
 
  protected:
   sync_preferences::TestingPrefServiceSyncable prefs_;
   std::unique_ptr<JsonRpcService> json_rpc_service_;
   std::unique_ptr<SwapService> swap_service_;
+  base::test::TaskEnvironment task_environment_;
 
  private:
-  base::test::TaskEnvironment task_environment_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;
   data_decoder::test::InProcessDataDecoder in_process_data_decoder_;
@@ -303,7 +303,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuote) {
       GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                mojom::kPolygonMainnetChainId),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Case 2: null zeroExFee
@@ -344,7 +344,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuote) {
       GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                mojom::kPolygonMainnetChainId),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -383,7 +383,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteError) {
       GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                mojom::kPolygonMainnetChainId),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(SwapServiceUnitTest, GetZeroExQuoteUnexpectedReturn) {
@@ -400,7 +400,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteUnexpectedReturn) {
       GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                mojom::kPolygonMainnetChainId),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(SwapServiceUnitTest, GetZeroExTransaction) {
@@ -490,7 +490,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransaction) {
           GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                    mojom::kPolygonMainnetChainId)),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Case 2: null zeroExFee
@@ -536,7 +536,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransaction) {
           GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                    mojom::kPolygonMainnetChainId)),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 
@@ -556,7 +556,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionError) {
           GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                    mojom::kPolygonMainnetChainId)),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(SwapServiceUnitTest, GetZeroExTransactionUnexpectedReturn) {
@@ -573,7 +573,7 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionUnexpectedReturn) {
           GetCannedSwapQuoteParams(mojom::CoinType::ETH,
                                    mojom::kPolygonMainnetChainId)),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
 }
 
 TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
@@ -821,7 +821,7 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuote) {
   swap_service_->GetQuote(
       GetCannedSwapQuoteParams(mojom::CoinType::SOL, mojom::kSolanaMainnet),
       callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // KO: empty JSON for conversion
@@ -872,7 +872,7 @@ TEST_F(SwapServiceUnitTest, GetBraveFee) {
   base::MockCallback<mojom::SwapService::GetBraveFeeCallback> callback;
   EXPECT_CALL(callback, Run(EqualsMojo(expected_response), ""));
   swap_service_->GetBraveFee(params->Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Case 2: Jupiter swap on Solana (no fees)
@@ -893,7 +893,7 @@ TEST_F(SwapServiceUnitTest, GetBraveFee) {
 
   EXPECT_CALL(callback, Run(EqualsMojo(expected_response), ""));
   swap_service_->GetBraveFee(params->Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Case 3: Jupiter swap on Solana (fees)
@@ -913,7 +913,7 @@ TEST_F(SwapServiceUnitTest, GetBraveFee) {
 
   EXPECT_CALL(callback, Run(EqualsMojo(expected_response), ""));
   swap_service_->GetBraveFee(params->Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // Case 4: Unsupported network
@@ -923,7 +923,7 @@ TEST_F(SwapServiceUnitTest, GetBraveFee) {
               Run(EqualsMojo(mojom::BraveSwapFeeResponsePtr()),
                   l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
   swap_service_->GetBraveFee(params->Clone(), callback.Get());
-  base::RunLoop().RunUntilIdle();
+  task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 }
 

--- a/components/brave_wallet/browser/wallet_data_files_installer_unittest.cc
+++ b/components/brave_wallet/browser/wallet_data_files_installer_unittest.cc
@@ -257,6 +257,7 @@ TEST_F(WalletDataFilesInstallerUnitTest, OnDemandInstallAndParsing_EmptyPath) {
       .Times(1)
       .WillOnce(testing::Return(true));
   SetOnDemandUpdateCallbackWithComponentReady(base::FilePath());
+  RunUntilIdle();
   CreateWallet();
 
   RunUntilIdle();

--- a/components/ipfs/keys/ipns_keys_manager_unittest.cc
+++ b/components/ipfs/keys/ipns_keys_manager_unittest.cc
@@ -49,9 +49,11 @@ class IpnsKeysManagerUnitTest : public testing::Test {
 
   IpnsKeysManager* ipns_keys_manager() { return ipns_keys_manager_.get(); }
 
+ protected:
+  content::BrowserTaskEnvironment browser_task_environment_;
+
  private:
   std::string response_text_;
-  content::BrowserTaskEnvironment browser_task_environment_;
   TestingProfile profile_;
   std::unique_ptr<IpfsBlobContextGetterFactory> blob_factory_;
   std::unique_ptr<IpnsKeysManager> ipns_keys_manager_;
@@ -73,7 +75,7 @@ TEST_F(IpnsKeysManagerUnitTest, SanitizedResponse) {
           EXPECT_EQ(value, "k51q");
           callback_is_called = true;
         }));
-    base::RunLoop().RunUntilIdle();
+    browser_task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_is_called);
   }
   {
@@ -88,7 +90,7 @@ TEST_F(IpnsKeysManagerUnitTest, SanitizedResponse) {
           EXPECT_TRUE(value.empty());
           callback_is_called = true;
         }));
-    base::RunLoop().RunUntilIdle();
+    browser_task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_is_called);
   }
 }

--- a/components/skus/browser/skus_service_unittest.cc
+++ b/components/skus/browser/skus_service_unittest.cc
@@ -264,8 +264,9 @@ class SkusServiceTestUnitTest : public testing::Test {
   }
   PrefService* prefs() { return &prefs_; }
 
- private:
   base::test::TaskEnvironment task_environment_;
+
+ private:
   std::unique_ptr<skus::SkusServiceImpl> skus_service_;
   TestingPrefServiceSimple prefs_;
   network::TestURLLoaderFactory url_loader_factory_;

--- a/components/skus/browser/skus_url_loader_impl_unittest.cc
+++ b/components/skus/browser/skus_url_loader_impl_unittest.cc
@@ -58,7 +58,7 @@ class SkusUrlLoaderImplUnitTest : public testing::Test {
               response = result.value_body().Clone();
             }),
         {}, {});
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     return response;
   }
   void FetchResponse(const std::string& method,
@@ -78,14 +78,15 @@ class SkusUrlLoaderImplUnitTest : public testing::Test {
     skus_url_loader()->BeginFetch(
         req, skus::SkusUrlLoaderImpl::FetchResponseCallback(),
         std::move(rt_ctx));
-    base::RunLoop().RunUntilIdle();
+    task_environment_.RunUntilIdle();
     EXPECT_TRUE(callback_called);
   }
+
+  base::test::TaskEnvironment task_environment_;
 
  private:
   std::string response_text_;
   net::HttpStatusCode status_ = net::HTTP_OK;
-  base::test::TaskEnvironment task_environment_;
   std::unique_ptr<skus::SkusUrlLoaderImpl> skus_url_loader_;
   network::TestURLLoaderFactory url_loader_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> shared_url_loader_factory_;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35886
**The PR approach is updated.** The key points: 
* `BUILD_RUST_JSON_READER` is enabled, chromium impl is used now but only for `APIRequestHelper`.
* the key changes is moved from `DataDecoder` to `APIRequestHelper`.

The problems we're going to solve:
1. APIRequestHelper spawns a lot of DataDecoder instances on desktops, which affects performance.
2. Android DataDecoder impl uses the UI thread. It means that large JSON processing hangs the UI thread.

DataDecoder has three sanitizer implementations:
1. (Desktop) out of process, spawn DataDecoder service process instances. Deserialization works on the UI thread, which creates freezes.
2. (Android) uses Java json impl to deserialize the string and serialize it back. Works on the UI thread.
3. (under disabled `BUILD_RUST_JSON_READER` & `UseRustJsonParser` feature). Chromium rust impl, uses the ThreadPool, parses strings in Rust, and constructs base::Value using the passed API. It looks very promising, but we don't want to use than parser by default before Chromium.

The plan:
* Enable `BUILD_RUST_JSON_READER`. It doesn't affect base::JsonReader because `UseRustJsonParser` is [disabled](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/base/json/json_reader.cc#206).
* Export chromium `DecodeJSONInRust()` from `json_reader.cc` to use in `APIRequestHelper`. This avoid changing upstream logic and tests. `DecodeJSONInRust()` uses `serde_json_lenient` that looks more reliable than plain `sedre_json`.
* `DecodeJSONInRust()` is used in the similar approach than `UseRustJsonParser`. The difference only in the task priority and sequence guaranties. That changes allow to preserve the old behavior (at least in test) to not change a lot of things in one PR.

Extra details:
1. **The new behavior discounts allowing trailing spaces**. We are adding a safe base::Feature for emergency reverting the old behavior. Also, we're sending a crash dump when trailing spaces are detected (to catch if we missed something).
2. When `BUILD_RUST_JSON_READER` + `UseRustJsonParser` are enabled the code expected to be simplified or removed.
3. Many tests have to be changed to `task_environment_.RunUntilIdle()`, because we have to wait for thread pool interaction. The chromium test in-process data decoder impl uses the UI thread, so it allows using `base::RunLoop().RunUntilIdle();`. With the thread pool, `RunLoop` is not enough (with both the new feature or chromium `BUILD_RUST_JSON_READER`)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

