### PR TITLE
Extract transparent part using pubkey hash instead of pubkey in UA

### DIFF
--- a/components/brave_wallet/common/zcash_utils.h
+++ b/components/brave_wallet/common/zcash_utils.h
@@ -31,6 +31,10 @@ bool IsUnifiedAddress(const std::string& address);
 std::string PubkeyToTransparentAddress(base::span<const uint8_t> pubkey,
                                        bool testnet);
 
+std::optional<std::string> PubkeyHashToTransparentAddress(
+    base::span<const uint8_t> pubkey_hash,
+    bool testnet);
+
 std::optional<DecodedZCashAddress> DecodeZCashAddress(
     const std::string& address);
 

--- a/components/brave_wallet/common/zcash_utils_unittest.cc
+++ b/components/brave_wallet/common/zcash_utils_unittest.cc
@@ -48,6 +48,17 @@ TEST(ZCashUtilsUnitTest, PubkeyToTransparentAddress) {
                 false));
 }
 
+TEST(ZCashUtilsUnitTest, PubkeyHashToTransparentAddress) {
+  EXPECT_FALSE(
+      PubkeyHashToTransparentAddress(std::vector<uint8_t>(19, 0), false));
+  EXPECT_FALSE(
+      PubkeyHashToTransparentAddress(std::vector<uint8_t>(21, 0), false));
+  // https://github.com/zcash/librustzcash/blob/zcash_address-0.3.1/components/zcash_address/src/encoding.rs#L243
+  EXPECT_EQ("t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs",
+            PubkeyHashToTransparentAddress(std::vector<uint8_t>(20, 0), false)
+                .value());
+}
+
 TEST(ZCashUtilsUnitTest, ExtractTransparentPart) {
   // https://github.com/zcash/librustzcash/blob/zcash_primitives-0.13.0/components/zcash_address/src/kind/unified/address/test_vectors.rs#L17
   {
@@ -57,10 +68,27 @@ TEST(ZCashUtilsUnitTest, ExtractTransparentPart) {
         "f",
         false);
     EXPECT_EQ(
-        PubkeyToTransparentAddress(
+        PubkeyHashToTransparentAddress(
             std::vector<uint8_t>({0x7b, 0xb8, 0x35, 0x70, 0xb8, 0xfa, 0xe1,
                                   0x46, 0xe0, 0x3c, 0x53, 0x31, 0xa0, 0x20,
                                   0xb1, 0xe0, 0x89, 0x2f, 0x63, 0x1d}),
+            false),
+        transparent_part);
+  }
+
+  // https://github.com/zcash/librustzcash/blob/zcash_address-0.3.1/components/zcash_address/src/kind/unified/address/test_vectors.rs#L981
+  {
+    auto transparent_part = ExtractTransparentPart(
+        "u1ap7zakdnuefrgdglr334cw62hnqjkhr65t7tketyym0amkhdvyedpucuyxwu9z2te5vp"
+        "0jf75jgsm36d7r09h6z3qe5rkgd8y28er6fz8z5rckspevxnx4y9wfk49njpcujh5gle7m"
+        "fan90m9tt9a2gltyh8hx27cwt7h6u8ndmzhtk8qrq8hjytnakjqm0n658llh4z0277cyl2"
+        "rcu",
+        false);
+    EXPECT_EQ(
+        PubkeyHashToTransparentAddress(
+            std::vector<uint8_t>({0xf1, 0xbc, 0x3d, 0x72, 0x61, 0xbf, 0x77,
+                                  0xfe, 0x80, 0x8e, 0x2b, 0x71, 0x78, 0x98,
+                                  0x1c, 0x7c, 0xfe, 0x55, 0x70, 0xfd}),
             false),
         transparent_part);
   }
@@ -72,7 +100,7 @@ TEST(ZCashUtilsUnitTest, ExtractTransparentPart) {
         "7fzy8fwet0r0pt4wkdfs794ycqrvhe2hc97tkevpjr8rh3uenj3kz3rdqy78hmsmsx69dw"
         "raxwgy42xuhjh249uckn2elfwwhg36t7f9ms",
         false);
-    EXPECT_EQ(PubkeyToTransparentAddress(
+    EXPECT_EQ(PubkeyHashToTransparentAddress(
                   std::vector<uint8_t>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
                   false),
@@ -98,7 +126,7 @@ TEST(ZCashUtilsUnitTest, ExtractTransparentPart) {
         "na7kx9nfn0637np9k6tagzss48l6u9kcjf6gadlcnfusm42klsmmxnwj80q40cfwe8dnj7"
         "373w0",
         true);
-    EXPECT_EQ(PubkeyToTransparentAddress(
+    EXPECT_EQ(PubkeyHashToTransparentAddress(
                   std::vector<uint8_t>({0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0}),
                   true),

--- a/components/brave_wallet/common/zcash_utils_unittest.cc
+++ b/components/brave_wallet/common/zcash_utils_unittest.cc
@@ -60,6 +60,32 @@ TEST(ZCashUtilsUnitTest, PubkeyHashToTransparentAddress) {
 }
 
 TEST(ZCashUtilsUnitTest, ExtractTransparentPart) {
+  // https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/blob/v2.0.6/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
+  {
+    auto transparent_part = ExtractTransparentPart(
+        "u1lmy8anuylj33arxh3sx7ysq54tuw7zehsv6pdeeaqlrhkjhm3uvl9egqxqfd7hcsp3ms"
+        "zp6jxxx0gsw0ldp5wyu95r4mfzlueh8h5xhrjqgz7xtxp3hvw45dn4gfrz5j54ryg6reyf"
+        "0",
+        false);
+    EXPECT_EQ("t1JP7PHu72xHztsZiwH6cye4yvC9Prb3EvQ", transparent_part);
+  }
+  {
+    auto transparent_part = ExtractTransparentPart(
+        "u1czzc8jcl50svfezmfc9xsxnh63p374nptqplt0yw2uekr7v9wprp84y6esys6derp6uv"
+        "dcq6x6ykjrkpdyhjzneq5ud78h6j68n63hewg7xp9fpneuh64wgzt3d7mh6zh3qpqapzlc"
+        "4",
+        false);
+    EXPECT_EQ("t1duiEGg7b39nfQee3XaTY4f5McqfyJKhBi", transparent_part);
+  }
+  {
+    auto transparent_part = ExtractTransparentPart(
+        "utest16zd8zfx6n6few7mjsjpn6qtn8tlg6law7qnq33257855mdqekk7vru8lettx3vud"
+        "4mh99elglddltmfjkduar69h7vy08h3xdq6zuls9pqq7quyuehjqwtthc3hfd8gshhw42d"
+        "fr96e",
+        true);
+    EXPECT_EQ("tmCxJG72RWN66xwPtNgu4iKHpyysGrc7rEg", transparent_part);
+  }
+
   // https://github.com/zcash/librustzcash/blob/zcash_primitives-0.13.0/components/zcash_address/src/kind/unified/address/test_vectors.rs#L17
   {
     auto transparent_part = ExtractTransparentPart(


### PR DESCRIPTION
Problem is that wrong transparent address was extracted from the provided unified address
When sending from Brave Wallet to YWallet for ex.

Unified address contains pubkey hash part instead of pubkey.

Resolves https://github.com/brave/brave-browser/issues/35883

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

