### PR TITLE
fix(wallet): BTC Offramp

### DIFF
--- a/components/brave_wallet/browser/asset_ratio_service.cc
+++ b/components/brave_wallet/browser/asset_ratio_service.cc
@@ -242,12 +242,14 @@ void AssetRatioService::GetBuyUrlV1(mojom::OnRampProvider provider,
   std::string url;
   if (provider == mojom::OnRampProvider::kRamp) {
     GURL ramp_url = GURL(kRampBaseUrl);
+    ramp_url = net::AppendQueryParameter(ramp_url, "enabledFlows",
+                                         kOnRampEnabledFlows);
     ramp_url = net::AppendQueryParameter(ramp_url, "userAddress", address);
     ramp_url = net::AppendQueryParameter(ramp_url, "swapAsset", symbol);
     ramp_url = net::AppendQueryParameter(ramp_url, "fiatValue", amount);
     ramp_url =
         net::AppendQueryParameter(ramp_url, "fiatCurrency", currency_code);
-    ramp_url = net::AppendQueryParameter(ramp_url, "hostApiKey", kRampID);
+    ramp_url = net::AppendQueryParameter(ramp_url, "hostApiKey", kOnRampID);
     std::move(callback).Run(std::move(ramp_url.spec()), std::nullopt);
   } else if (provider == mojom::OnRampProvider::kSardine) {
     auto internal_callback =
@@ -348,7 +350,6 @@ void AssetRatioService::GetBuyUrlV1(mojom::OnRampProvider provider,
 
 void AssetRatioService::GetSellUrl(mojom::OffRampProvider provider,
                                    const std::string& chain_id,
-                                   const std::string& address,
                                    const std::string& symbol,
                                    const std::string& amount,
                                    const std::string& currency_code,
@@ -356,12 +357,8 @@ void AssetRatioService::GetSellUrl(mojom::OffRampProvider provider,
   std::string url;
   if (provider == mojom::OffRampProvider::kRamp) {
     GURL off_ramp_url = GURL(kRampBaseUrl);
-    off_ramp_url =
-        net::AppendQueryParameter(off_ramp_url, "userAddress", address);
     off_ramp_url = net::AppendQueryParameter(off_ramp_url, "enabledFlows",
                                              kOffRampEnabledFlows);
-    off_ramp_url = net::AppendQueryParameter(off_ramp_url, "defaultFlow",
-                                             kOffRampDefaultFlow);
     off_ramp_url = net::AppendQueryParameter(off_ramp_url, "swapAsset", symbol);
     off_ramp_url =
         net::AppendQueryParameter(off_ramp_url, "offrampAsset", symbol);
@@ -370,7 +367,7 @@ void AssetRatioService::GetSellUrl(mojom::OffRampProvider provider,
     off_ramp_url =
         net::AppendQueryParameter(off_ramp_url, "fiatCurrency", currency_code);
     off_ramp_url =
-        net::AppendQueryParameter(off_ramp_url, "hostApiKey", kRampID);
+        net::AppendQueryParameter(off_ramp_url, "hostApiKey", kOffRampID);
     std::move(callback).Run(off_ramp_url.spec(), std::nullopt);
   } else {
     std::move(callback).Run(url, "UNSUPPORTED_OFFRAMP_PROVIDER");

--- a/components/brave_wallet/browser/asset_ratio_service.h
+++ b/components/brave_wallet/browser/asset_ratio_service.h
@@ -51,7 +51,6 @@ class AssetRatioService : public KeyedService, public mojom::AssetRatioService {
   // Get sell URL for off-ramps
   void GetSellUrl(mojom::OffRampProvider provider,
                   const std::string& chain_id,
-                  const std::string& address,
                   const std::string& symbol,
                   const std::string& amount,
                   const std::string& currency_code,

--- a/components/brave_wallet/browser/asset_ratio_service_unittest.cc
+++ b/components/brave_wallet/browser/asset_ratio_service_unittest.cc
@@ -115,7 +115,6 @@ class AssetRatioServiceUnitTest : public testing::Test {
 
   void TestGetSellUrl(mojom::OffRampProvider off_ramp_provider,
                       const std::string& chain_id,
-                      const std::string& address,
                       const std::string& symbol,
                       const std::string& amount,
                       const std::string& currency_code,
@@ -123,7 +122,7 @@ class AssetRatioServiceUnitTest : public testing::Test {
                       std::optional<std::string> expected_error) {
     base::RunLoop run_loop;
     asset_ratio_service_->GetSellUrl(
-        off_ramp_provider, chain_id, address, symbol, amount, currency_code,
+        off_ramp_provider, chain_id, symbol, amount, currency_code,
         base::BindLambdaForTesting(
             [&](const std::string& url,
                 const std::optional<std::string>& error) {
@@ -148,7 +147,8 @@ TEST_F(AssetRatioServiceUnitTest, GetBuyUrlV1Ramp) {
   TestGetBuyUrlV1(mojom::OnRampProvider::kRamp, mojom::kMainnetChainId,
                   "0xdeadbeef", "USDC", "55000000", "USD",
                   "https://app.ramp.network/"
-                  "?userAddress=0xdeadbeef&swapAsset=USDC&fiatValue=55000000"
+                  "?enabledFlows=ONRAMP"
+                  "&userAddress=0xdeadbeef&swapAsset=USDC&fiatValue=55000000"
                   "&fiatCurrency=USD&hostApiKey="
                   "8yxja8782as5essk2myz3bmh4az6gpq4nte9n2gf",
                   std::nullopt);
@@ -182,13 +182,13 @@ TEST_F(AssetRatioServiceUnitTest, GetBuyUrlV1Sardine) {
 
 TEST_F(AssetRatioServiceUnitTest, GetSellUrl) {
   TestGetSellUrl(mojom::OffRampProvider::kRamp, mojom::kMainnetChainId,
-                 "0xdeadbeef", "ETH_BAT", "250", "USD",
+                 "ETH_BAT", "250", "USD",
                  "https://app.ramp.network/"
-                 "?userAddress=0xdeadbeef&enabledFlows=ONRAMP%2COFFRAMP"
-                 "&defaultFlow=OFFRAMP&swapAsset=ETH_BAT&offrampAsset=ETH_BAT"
+                 "?enabledFlows=OFFRAMP"
+                 "&swapAsset=ETH_BAT&offrampAsset=ETH_BAT"
                  "&swapAmount=250"
                  "&fiatCurrency=USD&hostApiKey="
-                 "8yxja8782as5essk2myz3bmh4az6gpq4nte9n2gf",
+                 "y57zqta99ohs7o2paf4ak6vpfb7wf8ubj9krwtwe",
                  std::nullopt);
 }
 

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -30,9 +30,10 @@ constexpr int32_t kAssetDiscoveryMinutesPerRequest = 1;
 inline constexpr char kWalletBaseDirectory[] = "BraveWallet";
 inline constexpr char kImageSourceHost[] = "erc-token-images";
 inline constexpr char kRampBaseUrl[] = "https://app.ramp.network";
-inline constexpr char kOffRampEnabledFlows[] = "ONRAMP,OFFRAMP";
-inline constexpr char kOffRampDefaultFlow[] = "OFFRAMP";
-inline constexpr char kRampID[] = "8yxja8782as5essk2myz3bmh4az6gpq4nte9n2gf";
+inline constexpr char kOffRampEnabledFlows[] = "OFFRAMP";
+inline constexpr char kOnRampEnabledFlows[] = "ONRAMP";
+inline constexpr char kOnRampID[] = "8yxja8782as5essk2myz3bmh4az6gpq4nte9n2gf";
+inline constexpr char kOffRampID[] = "y57zqta99ohs7o2paf4ak6vpfb7wf8ubj9krwtwe";
 inline constexpr char kSardineStorefrontBaseURL[] = "https://crypto.sardine.ai";
 inline constexpr char kSardineClientTokensURL[] =
     "https://api.sardine.ai/v1/auth/client-tokens";

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -975,7 +975,7 @@ interface AssetRatioService {
   GetBuyUrlV1(OnRampProvider provider, string chain_id, string address, string symbol, string amount, string currencyCode) => (string url, string? error);
 
   // Obtains the URL for selling assets specifying currency
-  GetSellUrl(OffRampProvider provider, string chain_id, string address, string symbol, string amount, string currencyCode) => (string url, string? error);
+  GetSellUrl(OffRampProvider provider, string chain_id, string symbol, string amount, string currencyCode) => (string url, string? error);
 
   // Obtains the prices from a list of assets to a list of assets
   // Each from asset is represented in the to asset and includes the timeframe

--- a/components/brave_wallet_ui/common/hooks/use-multi-chain-sell-assets.ts
+++ b/components/brave_wallet_ui/common/hooks/use-multi-chain-sell-assets.ts
@@ -64,10 +64,8 @@ export const useMultiChainSellAssets = () => {
 
   const openSellAssetLink = React.useCallback(
     async ({
-      sellAddress,
       sellAsset
     }: {
-      sellAddress: string
       sellAsset: BraveWallet.BlockchainToken | undefined
     }) => {
       if (!sellAsset || !defaultFiatCurrency) {
@@ -79,9 +77,8 @@ export const useMultiChainSellAssets = () => {
           assetSymbol: getRampAssetSymbol(sellAsset, true),
           offRampProvider: BraveWallet.OffRampProvider.kRamp,
           chainId: sellAsset.chainId,
-          address: sellAddress,
           amount: new Amount(sellAmount)
-            .multiplyByDecimals(sellAsset?.decimals ?? 18)
+            .multiplyByDecimals(sellAsset.decimals)
             .toNumber()
             .toString(),
           fiatCurrencyCode: defaultFiatCurrency

--- a/components/brave_wallet_ui/common/slices/endpoints/off-ramp.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/off-ramp.endpoints.ts
@@ -82,7 +82,6 @@ export const offRampEndpoints = ({ query }: WalletApiEndpointBuilderParams) => {
         assetSymbol: string
         offRampProvider: BraveWallet.OffRampProvider
         chainId: string
-        address: string
         amount: string
         fiatCurrencyCode: string
       }
@@ -93,7 +92,6 @@ export const offRampEndpoints = ({ query }: WalletApiEndpointBuilderParams) => {
           const { url, error } = await api.assetRatioService.getSellUrl(
             arg.offRampProvider,
             arg.chainId,
-            arg.address,
             arg.assetSymbol,
             arg.amount,
             arg.fiatCurrencyCode

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -202,10 +202,9 @@ export const AccountsAndTransactionsList = ({
 
   const onOpenSellAssetLink = React.useCallback(() => {
     openSellAssetLink({
-      sellAddress: selectedSellAccount?.address ?? '',
       sellAsset: selectedAsset
     })
-  }, [selectedAsset, selectedSellAccount?.address, openSellAssetLink])
+  }, [selectedAsset, openSellAssetLink])
 
   const onToggleHideBalances = React.useCallback(() => {
     window.localStorage.setItem(

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
@@ -122,13 +122,10 @@ export const AssetItemMenu = (props: Props) => {
   }, [setSelectedSellAsset, asset])
 
   const onOpenSellAssetLink = React.useCallback(() => {
-    if (account?.address) {
-      openSellAssetLink({
-        sellAddress: account.address,
-        sellAsset: selectedSellAsset
-      })
-    }
-  }, [account?.address, openSellAssetLink])
+    openSellAssetLink({
+      sellAsset: selectedSellAsset
+    })
+  }, [openSellAssetLink, selectedSellAsset])
 
   return (
     <StyledWrapper yPosition={42}>

--- a/components/brave_wallet_ui/utils/string-utils.ts
+++ b/components/brave_wallet_ui/utils/string-utils.ts
@@ -72,6 +72,8 @@ export const getRampNetworkPrefix = (chainId: string, isOfframp?: boolean) => {
       return 'FANTOM'
     case BraveWallet.FILECOIN_MAINNET:
       return 'FILECOIN'
+    case BraveWallet.BITCOIN_MAINNET:
+      return isOfframp ? 'BTC' : ''
     default:
       return ''
   }


### PR DESCRIPTION
## Description 
Fixes `Bitcoin` sell with `Ramp`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/35796>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

## Test Plan:
   1. Fund your `Wallet` with some `Bitcoin`
   2. Open token details screen
   3. Select more menu for account and select `Sell`
   4. Enter value and click on `Sell on Ramp`, it should load the `Ramp Offramp` page

Before:

https://github.com/brave/brave-core/assets/40611140/6084ef03-d1c5-4c51-82e3-bf5ab96b07ce

After:

https://github.com/brave/brave-core/assets/40611140/aa10e46f-e3eb-45b5-8905-1c82431e1170
