### PR TITLE
Use DoH from the OS DNS provider OR a fallback DoH provider

### DIFF
--- a/android/brave_java_resources.gni
+++ b/android/brave_java_resources.gni
@@ -1046,6 +1046,7 @@ brave_java_resources = [
   "java/res/xml/media_preferences.xml",
   "java/res/xml/qa_preferences.xml",
   "java/res/xml/quick_action_search_and_bookmark_widget_info.xml",
+  "java/res/xml/secure_dns_settings.xml",
   "java/res/xml/sns_preferences.xml",
   "java/res/xml/unstoppable_domains_preferences.xml",
 ]

--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -317,6 +317,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java",
   "../../brave/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettings.java",
   "../../brave/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettingsObserver.java",
+  "../../brave/android/java/org/chromium/chrome/browser/privacy/secure_dns/BraveSecureDnsProviderPreference.java",
   "../../brave/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java",
   "../../brave/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsIPFSUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/qrreader/BarcodeTracker.java",

--- a/android/java/org/chromium/base/BraveFeatureList.java
+++ b/android/java/org/chromium/base/BraveFeatureList.java
@@ -32,4 +32,5 @@ public abstract class BraveFeatureList {
     public static final String BRAVE_SHOW_STRICT_FINGERPRINTING_MODE =
             "BraveShowStrictFingerprintingMode";
     public static final String BRAVE_ZERO_DAY_FLAG_ANDROID = "BraveZeroDayFlagAndroid";
+    public static final String BRAVE_FALLBACK_DOH_PROVIDER = "BraveFallbackDoHProvider";
 }

--- a/android/java/org/chromium/chrome/browser/privacy/secure_dns/BraveSecureDnsProviderPreference.java
+++ b/android/java/org/chromium/chrome/browser/privacy/secure_dns/BraveSecureDnsProviderPreference.java
@@ -1,0 +1,67 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package org.chromium.chrome.browser.privacy.secure_dns;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.preference.PreferenceViewHolder;
+
+import org.chromium.base.BraveFeatureList;
+import org.chromium.chrome.R;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.components.browser_ui.widget.RadioButtonWithDescription;
+
+class BraveSecureDnsProviderPreference extends SecureDnsProviderPreference {
+    private String mPrimaryText;
+    private String mDescriptionText;
+
+    public BraveSecureDnsProviderPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_FALLBACK_DOH_PROVIDER)) {
+            String endpoint =
+                    ChromeFeatureList.getFieldTrialParamByFeature(
+                            BraveFeatureList.BRAVE_FALLBACK_DOH_PROVIDER,
+                            "BraveFallbackDoHProviderEndpoint");
+            String altDescriptionText =
+                    context.getString(R.string.settings_automatic_mode_description_fallback);
+            switch (endpoint) {
+                case "quad9":
+                    mPrimaryText =
+                            context.getString(R.string.settings_automatic_mode_with_quad9_label);
+                    mDescriptionText = altDescriptionText;
+                    break;
+                case "wikimedia":
+                    mPrimaryText =
+                            context.getString(
+                                    R.string.settings_automatic_mode_with_wikimedia_label);
+                    mDescriptionText = altDescriptionText;
+                    break;
+                case "cloudflare":
+                    mPrimaryText =
+                            context.getString(
+                                    R.string.settings_automatic_mode_with_cloudflare_label);
+                    mDescriptionText = altDescriptionText;
+                    break;
+                case "none":
+                default:
+                    mPrimaryText = context.getString(R.string.settings_automatic_mode_label);
+                    break;
+            }
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        if (ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_FALLBACK_DOH_PROVIDER)) {
+            RadioButtonWithDescription automaticModeButton =
+                    (RadioButtonWithDescription) holder.findViewById(R.id.automatic);
+            automaticModeButton.setPrimaryText(mPrimaryText);
+            automaticModeButton.setDescriptionText(mDescriptionText);
+        }
+    }
+}

--- a/android/java/res/xml/secure_dns_settings.xml
+++ b/android/java/res/xml/secure_dns_settings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+Copyright 2024 The Chromium Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file.
+-->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+        android:key="secure_dns_switch"
+        android:persistent="false"
+        android:title="@string/settings_secure_dns_title"
+        android:summary="@string/settings_secure_dns_description" />
+
+    <org.chromium.chrome.browser.privacy.secure_dns.BraveSecureDnsProviderPreference
+        android:key="secure_dns_provider"
+        app:allowDividerBelow="false" />
+
+</PreferenceScreen>

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1484,6 +1484,18 @@ Leo. This action cannot be undone.
     This option will automatically cache media files so you can play them without an Internet connection.
   </message>
 
+  <!-- Settings / Secure DNS -->
+  <message name="IDS_SETTINGS_AUTOMATIC_MODE_WITH_QUAD9_DESCRIPTION" desc="Text of the select option that puts secure DNS in auto-upgrade mode that falls back to Quad9">
+    OS default or Quad9
+  </message>
+  <message name="IDS_SETTINGS_AUTOMATIC_MODE_WITH_WIKIMEDIA_DESCRIPTION" desc="Text of the select option that puts secure DNS in auto-upgrade mode that falls back to Wikimedia">
+    OS default or Wikimedia
+  </message>
+  <message name="IDS_SETTINGS_AUTOMATIC_MODE_WITH_CLOUDFLARE_DESCRIPTION" desc="Text of the select option that puts secure DNS in auto-upgrade mode that falls back to Cloudflare">
+    OS default or Cloudflare
+  </message>
+
+
 <!-- Avatars. Generated via zsh and node:
         declare -i a=56
         for file in $(cat < avatarlist); do node -e "console.log(\`<message name=\"IDS_BRAVE_AVATAR_LABEL_$a\" desc=\"The label for the $file avatar.\">

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -925,6 +925,14 @@
           FEATURE_VALUE_TYPE(net::features::kBraveHttpsByDefault),             \
       },                                                                       \
       {                                                                        \
+          "fallback-dns-over-https",                                           \
+          "Use a fallback DoH provider",                                       \
+          "In Automatic DoH mode, use a fallback DoH provider if the current " \
+          "provider doesn't offer Secure DNS.",                                \
+          kOsAll,                                                              \
+          FEATURE_VALUE_TYPE(net::features::kBraveFallbackDoHProvider),        \
+      },                                                                       \
+      {                                                                        \
           "brave-show-strict-fingerprinting-mode",                             \
           "Show Strict Fingerprinting Mode",                                   \
           "Show Strict (aggressive) option for Fingerprinting Mode in "        \

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -4100,6 +4100,20 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_LEO_GO_PREMIUM_PREF" desc="Title for Leo Go premium settings.">
       Go Premium
     </message>
+    <!-- Secure DNS settings -->
+    <message name="IDS_SETTINGS_AUTOMATIC_MODE_WITH_QUAD9_LABEL" desc="Text of the radio button that puts secure DNS in auto-upgrade mode">
+      Use your current service provider or Quad9
+    </message>
+    <message name="IDS_SETTINGS_AUTOMATIC_MODE_WITH_WIKIMEDIA_LABEL" desc="Text of the radio button that puts secure DNS in auto-upgrade mode">
+      Use your current service provider or Wikimedia DNS
+    </message>
+    <message name="IDS_SETTINGS_AUTOMATIC_MODE_WITH_CLOUDFLARE_LABEL" desc="Text of the radio button that puts secure DNS in auto-upgrade mode">
+      Use your current service provider or Cloudflare
+    </message>
+    <message name="IDS_SETTINGS_AUTOMATIC_MODE_DESCRIPTION_FALLBACK" desc="Descriptive text that appears below IDS_SETTINGS_AUTOMATIC_MODE_LABEL.">
+      If your current service provider is insecure, Brave uses a secure alternative DNS provider
+    </message>
+    <!-- End of Secure DNS Settings -->
   </messages>
   </release>
 </grit>

--- a/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
+++ b/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
@@ -43,6 +43,7 @@
     &speedreader::kSpeedreaderFeature,                                  \
     &debounce::features::kBraveDebounce,                                \
     &net::features::kBraveHttpsByDefault,                               \
+    &net::features::kBraveFallbackDoHProvider,                          \
     &google_sign_in_permission::features::kBraveGoogleSignInPermission, \
     &net::features::kBraveForgetFirstPartyStorage,                      \
     &brave_shields::features::kBraveShowStrictFingerprintingMode,       \

--- a/chromium_src/chrome/browser/ui/webui/settings/shared_settings_localized_strings_provider.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/shared_settings_localized_strings_provider.cc
@@ -3,7 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "base/containers/fixed_flat_map.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
+#include "brave/net/dns/secure_dns_endpoints.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/net/secure_dns_config.h"
@@ -13,7 +15,7 @@
 #include "chrome/grit/generated_resources.h"
 #include "components/grit/brave_components_strings.h"
 #include "components/prefs/pref_service.h"
-#include "net/dns/public/secure_dns_mode.h"
+#include "net/base/features.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/common/features.h"
@@ -36,27 +38,43 @@ bool ShouldReplaceSecureDNSDisabledDescription() {
 
 }  // namespace
 
-#define AddSecureDnsStrings AddSecureDnsStrings_ChromiumImpl
-
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
+
+#define AddSecureDnsStrings AddSecureDnsStrings_ChromiumImpl
 
 #include "src/chrome/browser/ui/webui/settings/shared_settings_localized_strings_provider.cc"
 
-#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
 #undef AddSecureDnsStrings
 namespace settings {
 
 void AddSecureDnsStrings(content::WebUIDataSource* html_source) {
   AddSecureDnsStrings_ChromiumImpl(html_source);
-  if (!ShouldReplaceSecureDNSDisabledDescription())
-    return;
-  static constexpr webui::LocalizedString kLocalizedStrings[] = {
-      {"secureDnsDisabledForManagedEnvironment",
-       IDS_SETTINGS_SECURE_DNS_DISABLED_BY_BRAVE_VPN}};
-
-  html_source->AddLocalizedStrings(kLocalizedStrings);
+  if (base::FeatureList::IsEnabled(net::features::kBraveFallbackDoHProvider)) {
+    static const net::DohFallbackEndpointType endpoint =
+        net::features::kBraveFallbackDoHProviderEndpoint.Get();
+    if (endpoint != net::DohFallbackEndpointType::kNone) {
+      static constexpr auto kAlternateLocalizedStrings =
+          base::MakeFixedFlatMap<net::DohFallbackEndpointType, int>({
+              {net::DohFallbackEndpointType::kQuad9,
+               IDS_SETTINGS_AUTOMATIC_MODE_WITH_QUAD9_DESCRIPTION},
+              {net::DohFallbackEndpointType::kWikimedia,
+               IDS_SETTINGS_AUTOMATIC_MODE_WITH_WIKIMEDIA_DESCRIPTION},
+              {net::DohFallbackEndpointType::kCloudflare,
+               IDS_SETTINGS_AUTOMATIC_MODE_WITH_CLOUDFLARE_DESCRIPTION},
+          });
+      html_source->AddLocalizedString("secureDnsAutomaticModeDescription",
+                                      kAlternateLocalizedStrings.at(endpoint));
+    }
+  }
+#if BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
+  if (ShouldReplaceSecureDNSDisabledDescription()) {
+    static constexpr webui::LocalizedString kLocalizedStrings[] = {
+        {"secureDnsDisabledForManagedEnvironment",
+         IDS_SETTINGS_SECURE_DNS_DISABLED_BY_BRAVE_VPN}};
+    html_source->AddLocalizedStrings(kLocalizedStrings);
+  }
+#endif  // BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)
 }
 
 }  // namespace settings
 
-#endif  // BUILDFLAG(ENABLE_BRAVE_VPN) && BUILDFLAG(IS_WIN)

--- a/chromium_src/net/base/features.cc
+++ b/chromium_src/net/base/features.cc
@@ -6,6 +6,7 @@
 #include "src/net/base/features.cc"
 
 #include "base/feature_override.h"
+#include "brave/net/dns/secure_dns_endpoints.h"
 
 namespace net {
 namespace features {
@@ -63,6 +64,24 @@ BASE_FEATURE(kBraveTorWindowsHttpsOnly,
 BASE_FEATURE(kBraveHttpsByDefault,
              "HttpsByDefault",
              base::FEATURE_ENABLED_BY_DEFAULT);
+
+// When enabled, use a fallback DNS over HTTPS (DoH)
+// provider when the current DNS provider does not offer Secure DNS.
+BASE_FEATURE(kBraveFallbackDoHProvider,
+             "BraveFallbackDoHProvider",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+constexpr base::FeatureParam<DohFallbackEndpointType>::Option
+    kBraveFallbackDoHProviderEndpointOptions[] = {
+        {DohFallbackEndpointType::kNone, "none"},
+        {DohFallbackEndpointType::kQuad9, "quad9"},
+        {DohFallbackEndpointType::kWikimedia, "wikimedia"},
+        {DohFallbackEndpointType::kCloudflare, "cloudflare"}};
+constexpr base::FeatureParam<DohFallbackEndpointType>
+    kBraveFallbackDoHProviderEndpoint{
+        &kBraveFallbackDoHProvider, "BraveFallbackDoHProviderEndpoint",
+        DohFallbackEndpointType::kNone,
+        &kBraveFallbackDoHProviderEndpointOptions};
 
 // Add "Forget by default" cookie blocking mode which cleanups storage after a
 // website is closed.

--- a/chromium_src/net/base/features.h
+++ b/chromium_src/net/base/features.h
@@ -8,6 +8,7 @@
 
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "brave/net/dns/secure_dns_endpoints.h"
 #include "net/base/net_export.h"
 
 namespace net {
@@ -19,6 +20,9 @@ NET_EXPORT extern const base::FeatureParam<int>
     kBraveEphemeralStorageKeepAliveTimeInSeconds;
 NET_EXPORT BASE_DECLARE_FEATURE(kBraveFirstPartyEphemeralStorage);
 NET_EXPORT BASE_DECLARE_FEATURE(kBraveHttpsByDefault);
+NET_EXPORT BASE_DECLARE_FEATURE(kBraveFallbackDoHProvider);
+NET_EXPORT extern const base::FeatureParam<DohFallbackEndpointType>
+    kBraveFallbackDoHProviderEndpoint;
 NET_EXPORT BASE_DECLARE_FEATURE(kBravePartitionBlobStorage);
 NET_EXPORT BASE_DECLARE_FEATURE(kBravePartitionHSTS);
 NET_EXPORT BASE_DECLARE_FEATURE(kBraveTorWindowsHttpsOnly);

--- a/chromium_src/net/dns/dns_client.cc
+++ b/chromium_src/net/dns/dns_client.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/containers/fixed_flat_map.h"
+#include "base/feature_list.h"
+#include "brave/net/dns/secure_dns_endpoints.h"
+#include "net/base/features.h"
+#include "net/dns/dns_util.h"
+#include "net/dns/public/dns_over_https_server_config.h"
+
+#include <vector>
+
+namespace net {
+namespace {
+
+constexpr auto kDohFallbackEndpointAddresses{
+    base::MakeFixedFlatMap<DohFallbackEndpointType, const char*>({
+        {DohFallbackEndpointType::kQuad9, "https://dns.quad9.net/dns-query"},
+        {DohFallbackEndpointType::kWikimedia,
+         "https://wikimedia-dns.org/dns-query"},
+        {DohFallbackEndpointType::kCloudflare,
+         "https://cloudflare-dns.com/dns-query"},
+    })};
+
+std::vector<DnsOverHttpsServerConfig> MaybeAddFallbackDohServer(
+    const std::vector<DnsOverHttpsServerConfig> doh_servers) {
+  if (!base::FeatureList::IsEnabled(net::features::kBraveFallbackDoHProvider)) {
+    return doh_servers;
+  }
+  static const DohFallbackEndpointType endpoint =
+      net::features::kBraveFallbackDoHProviderEndpoint.Get();
+  if (endpoint == DohFallbackEndpointType::kNone) {
+    return doh_servers;
+  }
+  const char* endpointAddress = kDohFallbackEndpointAddresses.at(endpoint);
+  auto fallbackDohServer =
+      DnsOverHttpsServerConfig::FromString(endpointAddress);
+  std::vector<DnsOverHttpsServerConfig> extended_doh_servers = doh_servers;
+  if (fallbackDohServer.has_value()) {
+    extended_doh_servers.push_back(fallbackDohServer.value());
+  }
+  return extended_doh_servers;
+}
+
+}  // namespace
+}  // namespace net
+
+#define GetDohUpgradeServersFromNameservers(...) \
+  MaybeAddFallbackDohServer(GetDohUpgradeServersFromNameservers(__VA_ARGS__))
+
+#include "src/net/dns/dns_client.cc"
+
+#undef GetDohUpgradeServersFromNameservers

--- a/net/dns/secure_dns_endpoints.h
+++ b/net/dns/secure_dns_endpoints.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_NET_DNS_SECURE_DNS_ENDPOINTS_H_
+#define BRAVE_NET_DNS_SECURE_DNS_ENDPOINTS_H_
+
+namespace net {
+
+enum class DohFallbackEndpointType {
+  kNone,
+  kQuad9,
+  kWikimedia,
+  kCloudflare,
+};
+
+}  // namespace net
+
+#endif  // BRAVE_NET_DNS_SECURE_DNS_ENDPOINTS_H_

--- a/net/dns/sources.gni
+++ b/net/dns/sources.gni
@@ -6,4 +6,5 @@
 brave_net_dns_sources = [
   "//brave/net/dns/secure_dns_counter.cc",
   "//brave/net/dns/secure_dns_counter.h",
+  "//brave/net/dns/secure_dns_endpoints.h",
 ]


### PR DESCRIPTION
This behavior is behind a flag: BraveFallbackDoHProvider, and involves an integer parameter, kBraveFallbackDoHProviderEndpointIndex:
1 = Quad9
2 = Wikimedia
3 = Cloudflare

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35677

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

