### PR TITLE
Add error message for UA without transparent part

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -753,6 +753,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_ADDRESS_REQUIRED_ERROR},
     {"braveWalletInvalidRecipientAddress",
      IDS_BRAVE_WALLET_INVALID_RECIPIENT_ADDRESS},
+    {"braveWalletInvalidZcashUnifiedRecipientAddress",
+     IDS_BRAVE_WALLET_INVALID_ZCASH_UNIFIED_RECIPIENT_ADDRESS},
     {"braveWalletChecksumModalTitle", IDS_BRAVE_WALLET_CHECKSUM_MODAL_TITLE},
     {"braveWalletChecksumModalDescription",
      IDS_BRAVE_WALLET_CHECKSUM_MODAL_DESCRIPTION},

--- a/components/brave_wallet/browser/zcash/zcash_wallet_service.h
+++ b/components/brave_wallet/browser/zcash/zcash_wallet_service.h
@@ -79,6 +79,10 @@ class ZCashWalletService : public KeyedService,
                                  bool change,
                                  DiscoverNextUnusedAddressCallback callback);
 
+  void ValidateZCashAddress(const std::string& addr,
+                            bool testnet,
+                            ValidateZCashAddressCallback callback) override;
+
   void GetUtxos(const std::string& chain_id,
                 mojom::AccountIdPtr account_id,
                 GetUtxosCallback);

--- a/components/brave_wallet/browser/zcash/zcash_wallet_service_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_wallet_service_unittest.cc
@@ -407,4 +407,91 @@ TEST_F(ZCashWalletServiceUnitTest, AddressDiscovery_FromPrefs) {
   }
 }
 
+TEST_F(ZCashWalletServiceUnitTest, ValidateZCashAddress) {
+  // https://github.com/Electric-Coin-Company/zcash-android-wallet-sdk/blob/v2.0.6/sdk-incubator-lib/src/main/java/cash/z/ecc/android/sdk/fixture/WalletFixture.kt
+
+  // Normal transparent address - mainnet
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback, Run(mojom::ZCashAddressValidationResult::Success));
+    zcash_wallet_service_->ValidateZCashAddress(
+        "t1JP7PHu72xHztsZiwH6cye4yvC9Prb3EvQ", false, callback.Get());
+  }
+
+  // Normal transparent address - testnet
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback, Run(mojom::ZCashAddressValidationResult::Success));
+    zcash_wallet_service_->ValidateZCashAddress(
+        "tmP3uLtGx5GPddkq8a6ddmXhqJJ3vy6tpTE", true, callback.Get());
+  }
+
+  // Testnet mismatch
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback,
+                Run(mojom::ZCashAddressValidationResult::NetworkMismatch));
+    zcash_wallet_service_->ValidateZCashAddress(
+        "tmP3uLtGx5GPddkq8a6ddmXhqJJ3vy6tpTE", false, callback.Get());
+  }
+
+  // Wrong transparent address
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback,
+                Run(mojom::ZCashAddressValidationResult::InvalidTransparent));
+    zcash_wallet_service_->ValidateZCashAddress("t1xxx", false, callback.Get());
+  }
+
+  // Unified address - mainnet
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback, Run(mojom::ZCashAddressValidationResult::Success));
+    zcash_wallet_service_->ValidateZCashAddress(
+        "u1lmy8anuylj33arxh3sx7ysq54tuw7zehsv6pdeeaqlrhkjhm3uvl9egqxqfd7hcsp3ms"
+        "zp6jxxx0gsw0ldp5wyu95r4mfzlueh8h5xhrjqgz7xtxp3hvw45dn4gfrz5j54ryg6reyf"
+        "0",
+        false, callback.Get());
+  }
+
+  // Unified address - testnet
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback, Run(mojom::ZCashAddressValidationResult::Success));
+    zcash_wallet_service_->ValidateZCashAddress(
+        "utest1vergg5jkp4xy8sqfasw6s5zkdpnxvfxlxh35uuc3me7dp596y2r05t6dv9htwe3p"
+        "f8ksrfr8ksca2lskzjanqtl8uqp5vln3zyy246ejtx86vqftp73j7jg9099jxafyjhfm6u"
+        "956j3",
+        true, callback.Get());
+  }
+
+  // Unified address network mismatch
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback,
+                Run(mojom::ZCashAddressValidationResult::NetworkMismatch));
+    zcash_wallet_service_->ValidateZCashAddress(
+        "utest1vergg5jkp4xy8sqfasw6s5zkdpnxvfxlxh35uuc3me7dp596y2r05t6dv9htwe3p"
+        "f8ksrfr8ksca2lskzjanqtl8uqp5vln3zyy246ejtx86vqftp73j7jg9099jxafyjhfm6u"
+        "956j3",
+        false, callback.Get());
+  }
+
+  // Wrong unified address
+  {
+    base::MockCallback<ZCashWalletService::ValidateZCashAddressCallback>
+        callback;
+    EXPECT_CALL(callback,
+                Run(mojom::ZCashAddressValidationResult::InvalidUnified));
+    zcash_wallet_service_->ValidateZCashAddress("u1xx", false, callback.Get());
+  }
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1456,10 +1456,14 @@ enum ZCashAddressValidationResult {
 };
 
 interface ZCashWalletService {
-  GetBalance(string network_id, AccountId account_id) => (ZCashBalance? balance, string? error_message);
-  GetReceiverAddress(AccountId account_id) => (ZCashAddress? address, string? error_message);
-  GetZCashAccountInfo(AccountId account_id) => (ZCashAccountInfo? account_info);
-  ValidateZCashAddress(string addr, bool testnet) => (ZCashAddressValidationResult result);
+  GetBalance(string network_id, AccountId account_id) =>
+      (ZCashBalance? balance, string? error_message);
+  GetReceiverAddress(AccountId account_id) =>
+      (ZCashAddress? address, string? error_message);
+  GetZCashAccountInfo(AccountId account_id) =>
+      (ZCashAccountInfo? account_info);
+  ValidateZCashAddress(string addr, bool testnet) =>
+      (ZCashAddressValidationResult result);
 };
 
 enum TransactionStatus {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1447,10 +1447,19 @@ struct ZCashAccountInfo {
   ZCashAddress next_transparent_change_address;
 };
 
+enum ZCashAddressValidationResult {
+  Unknown = 0,
+  Success = 1,
+  InvalidTransparent = 2,
+  InvalidUnified = 3,
+  NetworkMismatch = 4
+};
+
 interface ZCashWalletService {
   GetBalance(string network_id, AccountId account_id) => (ZCashBalance? balance, string? error_message);
   GetReceiverAddress(AccountId account_id) => (ZCashAddress? address, string? error_message);
   GetZCashAccountInfo(AccountId account_id) => (ZCashAccountInfo? account_info);
+  ValidateZCashAddress(string addr, bool testnet) => (ZCashAddressValidationResult result);
 };
 
 enum TransactionStatus {

--- a/components/brave_wallet/common/zcash_utils.cc
+++ b/components/brave_wallet/common/zcash_utils.cc
@@ -111,6 +111,10 @@ bool IsUnifiedAddress(const std::string& address) {
   return address.starts_with("u1") || address.starts_with("utest1");
 }
 
+bool IsUnifiedTestnetAddress(const std::string& address) {
+  return address.starts_with("utest1");
+}
+
 std::string PubkeyToTransparentAddress(base::span<const uint8_t> pubkey,
                                        bool testnet) {
   std::vector<uint8_t> result = GetNetworkPrefix(testnet);

--- a/components/brave_wallet/common/zcash_utils.h
+++ b/components/brave_wallet/common/zcash_utils.h
@@ -27,6 +27,7 @@ struct DecodedZCashAddress {
 };
 
 bool IsUnifiedAddress(const std::string& address);
+bool IsUnifiedTestnetAddress(const std::string& address);
 
 std::string PubkeyToTransparentAddress(base::span<const uint8_t> pubkey,
                                        bool testnet);

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -194,6 +194,7 @@ export const {
   useGetERC20AllowanceQuery,
   useGetERC721MetadataQuery,
   useGetEthAddressChecksumQuery,
+  useValidateUnifiedAddressQuery,
   useGetEVMTransactionSimulationQuery,
   useGetFVMAddressQuery,
   useGetGasEstimation1559Query,

--- a/components/brave_wallet_ui/common/slices/endpoints/address.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/address.endpoints.ts
@@ -91,6 +91,32 @@ export const addressEndpoints = ({
       }
     }),
 
+    validateUnifiedAddress: query<
+      BraveWallet.ZCashAddressValidationResult,
+      {
+        address: string,
+        testnet: boolean
+      }
+    >({
+      queryFn: async (arg, { endpoint }, _extra, baseQuery) => {
+        try {
+          const { data: api } = baseQuery(undefined)
+          const { result } =
+            await api.zcashWalletService.validateZCashAddress(
+                arg.address, arg.testnet)
+          return {
+            data: result
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            `Failed to validate Zcash address: ${arg.address}`,
+            error
+          )
+        }
+      }
+    }),
+
     getAddressFromNameServiceUrl: query<
       { address: string; requireOffchainConsent: boolean },
       {

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -50,8 +50,7 @@ import {
 import {
   isValidBtcAddress,
   isValidEVMAddress,
-  isValidFilAddress,
-  isValidZecAddress
+  isValidFilAddress
 } from '../../../../utils/address-utils'
 import { makeSendRoute } from '../../../../utils/routes-utils'
 import {
@@ -72,6 +71,7 @@ import {
   useEnableEnsOffchainLookupMutation,
   useGetFVMAddressQuery,
   useGetEthAddressChecksumQuery,
+  useValidateUnifiedAddressQuery,
   useGetIsBase58EncodedSolPubkeyQuery,
   useSendSPLTransferMutation,
   useSendERC20TransferMutation,
@@ -299,6 +299,19 @@ export const SendScreen = React.memo((props: Props) => {
     isValidEvmAddress ? trimmedToAddressOrUrl : skipToken
   )
 
+  const {
+    data: zecAddressValidationResult
+      = BraveWallet.ZCashAddressValidationResult.Unknown
+  } = useValidateUnifiedAddressQuery(
+    accountFromParams?.accountId.coin === BraveWallet.CoinType.ZEC &&
+    trimmedToAddressOrUrl
+    ? {
+      address: trimmedToAddressOrUrl,
+      testnet: networkFromParams?.chainId === BraveWallet.Z_CASH_TESTNET
+    }
+    : skipToken
+  )
+
   // memos & computed
   const sendAmountValidationError: AmountValidationErrorType | undefined =
     React.useMemo(() => {
@@ -392,7 +405,8 @@ export const SendScreen = React.memo((props: Props) => {
           isBase58,
           coinType:
             accountFromParams.accountId.coin ?? BraveWallet.CoinType.ETH,
-          token: tokenFromParams
+          token: tokenFromParams,
+          zecAddressValidationResult: zecAddressValidationResult,
         })
       : undefined
     : undefined
@@ -1037,8 +1051,16 @@ const processEthereumAddress = (
     : 'braveWalletInvalidRecipientAddress'
 }
 
-const processZCashAddress = (addressOrUrl: string) => {
-  if (!isValidZecAddress(addressOrUrl)) {
+const processZCashAddress = (
+    addressOrUrl: string,
+    zecAddressValidationResult: BraveWallet.ZCashAddressValidationResult) => {
+  if (zecAddressValidationResult === BraveWallet.ZCashAddressValidationResult.Unknown) {
+    return undefined
+  }
+  if (zecAddressValidationResult === BraveWallet.ZCashAddressValidationResult.InvalidUnified) {
+    return 'braveWalletInvalidZcashUnifiedRecipientAddress'
+  }
+  if (zecAddressValidationResult !== BraveWallet.ZCashAddressValidationResult.Success) {
     return 'braveWalletInvalidRecipientAddress'
   }
   return undefined
@@ -1085,6 +1107,7 @@ function processAddressOrUrl({
   ethAddressChecksum,
   isBase58,
   coinType,
+  zecAddressValidationResult,
   token
 }: {
   addressOrUrl: string
@@ -1092,6 +1115,7 @@ function processAddressOrUrl({
   token: BraveWallet.BlockchainToken | undefined
   ethAddressChecksum: string
   isBase58: boolean
+  zecAddressValidationResult: BraveWallet.ZCashAddressValidationResult
 }) {
   // Do nothing if value is an empty string
   if (addressOrUrl === '') {
@@ -1117,7 +1141,7 @@ function processAddressOrUrl({
       )
     }
     case BraveWallet.CoinType.ZEC: {
-      return processZCashAddress(addressOrUrl)
+      return processZCashAddress(addressOrUrl, zecAddressValidationResult)
     }
     default: {
       console.log(`Unknown coin ${coinType}`)

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -1054,13 +1054,16 @@ const processEthereumAddress = (
 const processZCashAddress = (
     addressOrUrl: string,
     zecAddressValidationResult: BraveWallet.ZCashAddressValidationResult) => {
-  if (zecAddressValidationResult === BraveWallet.ZCashAddressValidationResult.Unknown) {
+  if (zecAddressValidationResult ===
+        BraveWallet.ZCashAddressValidationResult.Unknown) {
     return undefined
   }
-  if (zecAddressValidationResult === BraveWallet.ZCashAddressValidationResult.InvalidUnified) {
+  if (zecAddressValidationResult ===
+        BraveWallet.ZCashAddressValidationResult.InvalidUnified) {
     return 'braveWalletInvalidZcashUnifiedRecipientAddress'
   }
-  if (zecAddressValidationResult !== BraveWallet.ZCashAddressValidationResult.Success) {
+  if (zecAddressValidationResult !==
+        BraveWallet.ZCashAddressValidationResult.Success) {
     return 'braveWalletInvalidRecipientAddress'
   }
   return undefined

--- a/components/brave_wallet_ui/utils/address-utils.ts
+++ b/components/brave_wallet_ui/utils/address-utils.ts
@@ -44,12 +44,6 @@ export function isValidSolanaAddress(value: string): boolean {
   return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(value)
 }
 
-export function isValidZecAddress(value: string): boolean {
-  return /^t1[a-km-zA-HJ-NP-Z1-9]{33}$/.test(value) ||
-         /^u1[a-z0-9]+$/.test(value) ||
-         /^utest1[a-z0-9]+$/.test(value)
-}
-
 export function isValidBtcAddress(value: string, testnet: boolean): boolean {
   if (testnet) {
     return /^(tb1|[2nm])[a-zA-HJ-NP-Z0-9]{25,59}$/.test(value)

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -455,6 +455,7 @@
   <message name="IDS_BRAVE_WALLET_ZERO_BALANCE_ERROR" desc="Send amount must be greater than 0 error">Amount must be greater than 0</message>
   <message name="IDS_BRAVE_WALLET_ADDRESS_REQUIRED_ERROR" desc="Address field is required error">To address is required</message>
   <message name="IDS_BRAVE_WALLET_INVALID_RECIPIENT_ADDRESS" desc="Invalid recipient address error">Invalid recipient address</message>
+  <message name="IDS_BRAVE_WALLET_INVALID_ZCASH_UNIFIED_RECIPIENT_ADDRESS" desc="Invalid recipient zcash unified address error">Transparent part missing</message>
   <message name="IDS_BRAVE_WALLET_CHECKSUM_MODAL_TITLE" desc="Invalid checksum modal title">How can I find the right address?</message>
   <message name="IDS_BRAVE_WALLET_CHECKSUM_MODAL_DESCRIPTION" desc="Invalid checksum modal description">Brave validates and prevents users from sending funds to the wrong address due to incorrect capitalization. This is a "checksum" process to verify that it is a valid Ethereum address.</message>
   <message name="IDS_BRAVE_WALLET_CHECKSUM_MODAL_STEP_ONE_TITLE" desc="Invalid checksum modal step one title">1. Visit</message>


### PR DESCRIPTION
Additional address verification added and used in the UI instead of simple regex check.
This allows to check not only address format but also checksum and check whether UA contains transparent part.

Resolves https://github.com/brave/brave-browser/issues/35923

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1)
Wrong unified addresses or UA without a transparent part should show "Transparent part missing" error.
Correct address with transparent part:
u1ap7zakdnuefrgdglr334cw62hnqjkhr65t7tketyym0amkhdvyedpucuyxwu9z2te5vp0jf75jgsm36d7r09h6z3qe5rkgd8y28er6fz8z5rckspevxnx4y9wfk49njpcujh5gle7mfan90m9tt9a2gltyh8hx27cwt7h6u8ndmzhtk8qrq8hjytnakjqm0n658llh4z0277cyl2rcu
Correct address without transparent part:
u19a4vmx7ysmtavmnaz4d2dgl9pyshexw35rl5ezg5dkkxktg08p42lng7kf9hqtn2fhr63qzyhe8gtnvgtfl9yvne46x6zfzwgedx7c0chnrxty0k5r5qqph8k02zs8e3keul9vj8myju7rvqgjaysa9kt0fucxpzuky6kf0pjgy0a6hx
Incorrect address:
u1
![image](https://github.com/brave/brave-core/assets/106654560/78bb3ad1-1604-421e-9098-e7deae043a5b)
2) When user types wrong transparent(t1*) address there should also be an error "Invalid recipient address".
3) Check correct UA and Transparent addresses don't show an error.
