### PR TITLE
(Wallet) Connect back up wallet action from WebUI to native backup screen

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -803,10 +803,14 @@ public abstract class BraveActivity extends ChromeActivity
         setComesFromNewTab(false);
         setNewsItemsFeedCards(null);
         Intent intent = getIntent();
-        if (intent != null && intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY, false)) {
-            openBraveWallet(false,
-                    intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_SETUP, false),
-                    intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, false));
+        if (intent != null
+                && intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY, false)) {
+            openBraveWallet(
+                    false,
+                    intent.getBooleanExtra(
+                            BraveWalletActivity.RESTART_WALLET_ACTIVITY_SETUP, false),
+                    intent.getBooleanExtra(
+                            BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, false));
         }
     }
 
@@ -1405,7 +1409,8 @@ public abstract class BraveActivity extends ChromeActivity
         Intent braveWalletIntent = new Intent(this, BraveWalletActivity.class);
         braveWalletIntent.putExtra(BraveWalletActivity.IS_FROM_DAPPS, fromDapp);
         braveWalletIntent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_SETUP, setupAction);
-        braveWalletIntent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, restoreAction);
+        braveWalletIntent.putExtra(
+                BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, restoreAction);
         braveWalletIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         braveWalletIntent.setAction(Intent.ACTION_VIEW);
         startActivity(braveWalletIntent);

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -803,10 +803,10 @@ public abstract class BraveActivity extends ChromeActivity
         setComesFromNewTab(false);
         setNewsItemsFeedCards(null);
         Intent intent = getIntent();
-        if (intent != null && intent.getBooleanExtra(Utils.RESTART_WALLET_ACTIVITY, false)) {
+        if (intent != null && intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY, false)) {
             openBraveWallet(false,
-                    intent.getBooleanExtra(Utils.RESTART_WALLET_ACTIVITY_SETUP, false),
-                    intent.getBooleanExtra(Utils.RESTART_WALLET_ACTIVITY_RESTORE, false));
+                    intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_SETUP, false),
+                    intent.getBooleanExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, false));
         }
     }
 
@@ -1403,9 +1403,17 @@ public abstract class BraveActivity extends ChromeActivity
 
     public void openBraveWallet(boolean fromDapp, boolean setupAction, boolean restoreAction) {
         Intent braveWalletIntent = new Intent(this, BraveWalletActivity.class);
-        braveWalletIntent.putExtra(Utils.IS_FROM_DAPPS, fromDapp);
-        braveWalletIntent.putExtra(Utils.RESTART_WALLET_ACTIVITY_SETUP, setupAction);
-        braveWalletIntent.putExtra(Utils.RESTART_WALLET_ACTIVITY_RESTORE, restoreAction);
+        braveWalletIntent.putExtra(BraveWalletActivity.IS_FROM_DAPPS, fromDapp);
+        braveWalletIntent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_SETUP, setupAction);
+        braveWalletIntent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, restoreAction);
+        braveWalletIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        braveWalletIntent.setAction(Intent.ACTION_VIEW);
+        startActivity(braveWalletIntent);
+    }
+
+    public void openBraveWalletBackup() {
+        Intent braveWalletIntent = new Intent(this, BraveWalletActivity.class);
+        braveWalletIntent.putExtra(BraveWalletActivity.SHOW_WALLET_ACTIVITY_BACKUP, true);
         braveWalletIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         braveWalletIntent.setAction(Intent.ACTION_VIEW);
         startActivity(braveWalletIntent);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/BraveWalletProviderDelegateImplHelper.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/BraveWalletProviderDelegateImplHelper.java
@@ -32,6 +32,16 @@ public class BraveWalletProviderDelegateImplHelper {
     }
 
     @CalledByNative
+    public static void showWalletBackup() {
+        try {
+            BraveActivity activity = BraveActivity.getBraveActivity();
+            activity.openBraveWalletBackup();
+        } catch (BraveActivity.BraveActivityNotFoundException e) {
+            Log.e(TAG, "showWalletBackup", e);
+        }
+    }
+
+    @CalledByNative
     public static void showWalletOnboarding() {
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
@@ -5,6 +5,7 @@
 
 package org.chromium.chrome.browser.crypto_wallet.activities;
 
+import android.content.Intent;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -54,6 +55,13 @@ import java.util.List;
  * Main Brave Wallet activity
  */
 public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNextPage {
+
+    public static final String IS_FROM_DAPPS = "isFromDapps";
+    public static final String RESTART_WALLET_ACTIVITY = "restartWalletActivity";
+    public static final String RESTART_WALLET_ACTIVITY_SETUP = "restartWalletActivitySetup";
+    public static final String RESTART_WALLET_ACTIVITY_RESTORE = "restartWalletActivityRestore";
+    public static final String SHOW_WALLET_ACTIVITY_BACKUP = "showWalletActivityBackup";
+
     private static final String TAG = "BWalletBaseActivity";
 
     /**
@@ -87,6 +95,7 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
     private WalletModel mWalletModel;
     private boolean mRestartSetupAction;
     private boolean mRestartRestoreAction;
+    private boolean mBackupWallet;
 
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
@@ -118,12 +127,14 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
     protected void triggerLayoutInflation() {
         setContentView(R.layout.activity_brave_wallet);
         mIsFromDapps = false;
-        if (getIntent() != null) {
-            mIsFromDapps = getIntent().getBooleanExtra(Utils.IS_FROM_DAPPS, false);
+        final Intent intent = getIntent();
+        if (intent != null) {
+            mIsFromDapps = intent.getBooleanExtra(IS_FROM_DAPPS, false);
             mRestartSetupAction =
-                    getIntent().getBooleanExtra(Utils.RESTART_WALLET_ACTIVITY_SETUP, false);
+                    intent.getBooleanExtra(RESTART_WALLET_ACTIVITY_SETUP, false);
             mRestartRestoreAction =
-                    getIntent().getBooleanExtra(Utils.RESTART_WALLET_ACTIVITY_RESTORE, false);
+                    intent.getBooleanExtra(RESTART_WALLET_ACTIVITY_RESTORE, false);
+            mBackupWallet = intent.getBooleanExtra(SHOW_WALLET_ACTIVITY_BACKUP, false);
         }
         mShowBiometricPrompt = true;
 
@@ -173,6 +184,8 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
                     isLocked -> {
                         if (isLocked) {
                             setNavigationFragments(WalletAction.UNLOCK);
+                        } else if (mBackupWallet) {
+                            showOnboardingLayout();
                         } else {
                             showMainLayout();
                         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/activities/BraveWalletActivity.java
@@ -130,10 +130,8 @@ public class BraveWalletActivity extends BraveWalletBaseActivity implements OnNe
         final Intent intent = getIntent();
         if (intent != null) {
             mIsFromDapps = intent.getBooleanExtra(IS_FROM_DAPPS, false);
-            mRestartSetupAction =
-                    intent.getBooleanExtra(RESTART_WALLET_ACTIVITY_SETUP, false);
-            mRestartRestoreAction =
-                    intent.getBooleanExtra(RESTART_WALLET_ACTIVITY_RESTORE, false);
+            mRestartSetupAction = intent.getBooleanExtra(RESTART_WALLET_ACTIVITY_SETUP, false);
+            mRestartRestoreAction = intent.getBooleanExtra(RESTART_WALLET_ACTIVITY_RESTORE, false);
             mBackupWallet = intent.getBooleanExtra(SHOW_WALLET_ACTIVITY_BACKUP, false);
         }
         mShowBiometricPrompt = true;

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingInitWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingInitWalletFragment.java
@@ -26,7 +26,7 @@ import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ChromeTabbedActivity;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.helpers.Api33AndPlusBackPressHelper;
-import org.chromium.chrome.browser.crypto_wallet.util.Utils;
+import org.chromium.chrome.browser.crypto_wallet.activities.BraveWalletActivity;
 
 /**
  * Initial onboarding fragment to setup Brave Wallet.
@@ -136,9 +136,9 @@ public class OnboardingInitWalletFragment extends BaseOnboardingWalletFragment {
         } catch (BraveActivity.BraveActivityNotFoundException e) {
             Log.e(TAG, "checkOnBraveActivity " + e);
             Intent intent = new Intent(getActivity(), ChromeTabbedActivity.class);
-            intent.putExtra(Utils.RESTART_WALLET_ACTIVITY, true);
-            intent.putExtra(Utils.RESTART_WALLET_ACTIVITY_SETUP, setupAction);
-            intent.putExtra(Utils.RESTART_WALLET_ACTIVITY_RESTORE, restoreAction);
+            intent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY, true);
+            intent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_SETUP, setupAction);
+            intent.putExtra(BraveWalletActivity.RESTART_WALLET_ACTIVITY_RESTORE, restoreAction);
             intent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
             intent.setAction(Intent.ACTION_VIEW);
             startActivity(intent);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/util/Utils.java
@@ -113,10 +113,7 @@ public class Utils {
     public static final String ASSET_NAME = "assetName";
     public static final String ASSET_ID = "assetId";
     public static final String CHAIN_ID = "chainId";
-    public static final String IS_FROM_DAPPS = "isFromDapps";
-    public static final String RESTART_WALLET_ACTIVITY = "restartWalletActivity";
-    public static final String RESTART_WALLET_ACTIVITY_SETUP = "restartWalletActivitySetup";
-    public static final String RESTART_WALLET_ACTIVITY_RESTORE = "restartWalletActivityRestore";
+
     public static final String ETHEREUM_CONTRACT_FOR_SWAP =
             "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
     public static final BigInteger MAX_UINT256 =

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.cc
@@ -85,6 +85,10 @@ void BraveWalletProviderDelegateImpl::ShowPanel() {
   ::brave_wallet::ShowPanel(web_contents_);
 }
 
+void BraveWalletProviderDelegateImpl::ShowWalletBackup() {
+  ::brave_wallet::ShowWalletBackup();
+}
+
 void BraveWalletProviderDelegateImpl::WalletInteractionDetected() {
   ::brave_wallet::WalletInteractionDetected(web_contents_);
 }

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl.h
@@ -39,6 +39,7 @@ class BraveWalletProviderDelegateImpl : public BraveWalletProviderDelegate,
 
   bool IsTabVisible() override;
   void ShowPanel() override;
+  void ShowWalletBackup() override;
   void WalletInteractionDetected() override;
   void ShowWalletOnboarding() override;
   void ShowAccountCreation(mojom::CoinType type) override;

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
@@ -33,7 +33,7 @@ void ShowPanel(content::WebContents* web_contents) {
   }
 }
 
-void ShowWalletBackup() { }
+void ShowWalletBackup() {}
 
 void ShowWalletOnboarding(content::WebContents* web_contents) {
   Browser* browser =

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
@@ -33,6 +33,8 @@ void ShowPanel(content::WebContents* web_contents) {
   }
 }
 
+void ShowWalletBackup() { }
+
 void ShowWalletOnboarding(content::WebContents* web_contents) {
   Browser* browser =
       web_contents ? chrome::FindBrowserWithTab(web_contents) : nullptr;

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.cc
@@ -33,7 +33,9 @@ void ShowPanel(content::WebContents* web_contents) {
   }
 }
 
-void ShowWalletBackup() {}
+void ShowWalletBackup() {
+  NOTREACHED();
+}
 
 void ShowWalletOnboarding(content::WebContents* web_contents) {
   Browser* browser =

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
@@ -21,7 +21,7 @@ namespace brave_wallet {
 // ...etc.
 void ShowPanel(content::WebContents* web_contents);
 
-// Show native Brave Wallet backup UI.
+// Show native Brave Wallet backup UI - Used only by Android.
 void ShowWalletBackup();
 
 // Show wallet onboarding page.

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper.h
@@ -21,6 +21,9 @@ namespace brave_wallet {
 // ...etc.
 void ShowPanel(content::WebContents* web_contents);
 
+// Show native Brave Wallet backup UI.
+void ShowWalletBackup();
+
 // Show wallet onboarding page.
 void ShowWalletOnboarding(content::WebContents* web_contents);
 

--- a/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_android.cc
+++ b/browser/brave_wallet/brave_wallet_provider_delegate_impl_helper_android.cc
@@ -23,6 +23,11 @@ void ShowPanel(content::WebContents*) {
   Java_BraveWalletProviderDelegateImplHelper_showPanel(env);
 }
 
+void ShowWalletBackup() {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  Java_BraveWalletProviderDelegateImplHelper_showWalletBackup(env);
+}
+
 void ShowWalletOnboarding(content::WebContents*) {
   JNIEnv* env = base::android::AttachCurrentThread();
   Java_BraveWalletProviderDelegateImplHelper_showWalletOnboarding(env);

--- a/browser/ui/webui/brave_wallet/android/android_wallet_page_handler.cc
+++ b/browser/ui/webui/brave_wallet/android/android_wallet_page_handler.cc
@@ -26,3 +26,7 @@ void AndroidWalletPageHandler::ShowApprovePanelUI() {
 
   ::brave_wallet::ShowPanel(webui_controller_->web_ui()->GetWebContents());
 }
+
+void AndroidWalletPageHandler::ShowWalletBackupUI() {
+  ::brave_wallet::ShowWalletBackup();
+}

--- a/browser/ui/webui/brave_wallet/android/android_wallet_page_handler.h
+++ b/browser/ui/webui/brave_wallet/android/android_wallet_page_handler.h
@@ -24,6 +24,7 @@ class AndroidWalletPageHandler : WalletPageHandler {
   ~AndroidWalletPageHandler() override;
 
   void ShowApprovePanelUI() override;
+  void ShowWalletBackupUI() override;
 
  private:
   raw_ptr<ui::MojoWebUIController> const webui_controller_;

--- a/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
+++ b/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
@@ -28,4 +28,4 @@ void WalletPageHandler::ShowApprovePanelUI() {
 #endif
 }
 
-void WalletPageHandler::ShowWalletBackupUI() { }
+void WalletPageHandler::ShowWalletBackupUI() {}

--- a/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
+++ b/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
@@ -28,4 +28,6 @@ void WalletPageHandler::ShowApprovePanelUI() {
 #endif
 }
 
-void WalletPageHandler::ShowWalletBackupUI() {}
+void WalletPageHandler::ShowWalletBackupUI() {
+  NOTREACHED();
+}

--- a/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
+++ b/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.cc
@@ -27,3 +27,5 @@ void WalletPageHandler::ShowApprovePanelUI() {
   }
 #endif
 }
+
+void WalletPageHandler::ShowWalletBackupUI() { }

--- a/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.h
+++ b/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.h
@@ -28,6 +28,7 @@ class WalletPageHandler : public brave_wallet::mojom::PageHandler {
   ~WalletPageHandler() override;
 
   void ShowApprovePanelUI() override;
+  void ShowWalletBackupUI() override;
 
  private:
   raw_ptr<Profile> profile_ = nullptr;  // NOT OWNED

--- a/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.h
+++ b/browser/ui/webui/brave_wallet/page_handler/wallet_page_handler.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_BRAVE_WALLET_PAGE_HANDLER_WALLET_PAGE_HANDLER_H_
 #define BRAVE_BROWSER_UI_WEBUI_BRAVE_WALLET_PAGE_HANDLER_WALLET_PAGE_HANDLER_H_
 
-#include <string>
-
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"

--- a/components/brave_wallet/browser/brave_wallet_provider_delegate.h
+++ b/components/brave_wallet/browser/brave_wallet_provider_delegate.h
@@ -30,6 +30,7 @@ class BraveWalletProviderDelegate {
 
   virtual bool IsTabVisible() = 0;
   virtual void ShowPanel() = 0;
+  virtual void ShowWalletBackup() = 0;
   virtual void WalletInteractionDetected() = 0;
   virtual void ShowWalletOnboarding() = 0;
   virtual void ShowAccountCreation(mojom::CoinType type) = 0;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -425,6 +425,9 @@ interface PanelHandler {
 interface PageHandler {
   // Used by the brave://wallet page to open up the approval panel
   ShowApprovePanelUI();
+
+  // Used by the brave://wallet page to open up the backup UI.
+  ShowWalletBackupUI();
 };
 
 enum AssetPriceTimeframe {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -426,7 +426,7 @@ interface PageHandler {
   // Used by the brave://wallet page to open up the approval panel
   ShowApprovePanelUI();
 
-  // Used by the brave://wallet page to open up the backup UI.
+  // Android only - Used by the brave://wallet page to open up the backup UI.
   ShowWalletBackupUI();
 };
 

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -206,7 +206,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
               }}
               onClick={() => {
                 if (isAndroid) {
-                  pageHandler.showApprovePanelUI()
+                  pageHandler.showWalletBackupUI()
                 } else {
                   onShowBackup()
                 }

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -14,6 +14,7 @@ import {
 import { useSelector } from 'react-redux'
 
 // utils
+import { loadTimeData } from '../../../../../common/loadTimeData'
 import { getLocale } from '../../../../../common/locale'
 import {
   useSafeWalletSelector,
@@ -39,6 +40,7 @@ import { StyledWrapper } from './style'
 import { Column } from '../../../shared/style'
 
 // components
+import getWalletPageApiProxy from '../../../../page/wallet_page_api_proxy'
 import { WalletBanner } from '../../wallet-banner/index'
 import {
   EditVisibleAssetsModal //
@@ -69,6 +71,8 @@ export interface Props {
 }
 
 export const CryptoView = ({ sessionRoute }: Props) => {
+  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+
   // redux
   const isNftPinningFeatureEnabled = useSafeWalletSelector(
     WalletSelectors.isNftPinningFeatureEnabled
@@ -150,6 +154,8 @@ export const CryptoView = ({ sessionRoute }: Props) => {
     }
   }, [location.key])
 
+  const { pageHandler } = getWalletPageApiProxy()
+
   // computed
   const isCheckingWallets =
     isCheckingInstalledExtensions ||
@@ -198,7 +204,13 @@ export const CryptoView = ({ sessionRoute }: Props) => {
               onDismiss={() => {
                 setDismissBackupWarning(true)
               }}
-              onClick={onShowBackup}
+              onClick={() => {
+                if (isAndroid) {
+                  pageHandler.showApprovePanelUI()
+                } else {
+                  onShowBackup()
+                }
+              }}
               bannerType='danger'
               buttonText={getLocale('braveWalletBackupButton')}
               description={getLocale('braveWalletBackupWarningText')}

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -73,6 +73,8 @@ export interface Props {
 export const CryptoView = ({ sessionRoute }: Props) => {
   const isAndroid = loadTimeData.getBoolean('isAndroid') || false
 
+  const { pageHandler } = getWalletPageApiProxy()
+
   // redux
   const isNftPinningFeatureEnabled = useSafeWalletSelector(
     WalletSelectors.isNftPinningFeatureEnabled
@@ -132,7 +134,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
       return
     }
     history.push(WalletRoutes.Backup)
-  }, [isPanel])
+  }, [isPanel, isAndroid])
 
   const onShowVisibleAssetsModal = React.useCallback((showModal: boolean) => {
     if (showModal) {
@@ -158,8 +160,6 @@ export const CryptoView = ({ sessionRoute }: Props) => {
       history.push(WalletRoutes.PortfolioNFTs)
     }
   }, [location.key])
-
-  const { pageHandler } = getWalletPageApiProxy()
 
   // computed
   const isCheckingWallets =

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -111,6 +111,11 @@ export const CryptoView = ({ sessionRoute }: Props) => {
 
   // methods
   const onShowBackup = React.useCallback(() => {
+    if (isAndroid) {
+      pageHandler.showWalletBackupUI()
+      return
+    }
+
     if (isPanel) {
       chrome.tabs.create(
         {
@@ -204,13 +209,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
               onDismiss={() => {
                 setDismissBackupWarning(true)
               }}
-              onClick={() => {
-                if (isAndroid) {
-                  pageHandler.showWalletBackupUI()
-                } else {
-                  onShowBackup()
-                }
-              }}
+              onClick={onShowBackup}
               bannerType='danger'
               buttonText={getLocale('braveWalletBackupButton')}
               description={getLocale('braveWalletBackupWarningText')}

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -73,8 +73,6 @@ export interface Props {
 export const CryptoView = ({ sessionRoute }: Props) => {
   const isAndroid = loadTimeData.getBoolean('isAndroid') || false
 
-  const { pageHandler } = getWalletPageApiProxy()
-
   // redux
   const isNftPinningFeatureEnabled = useSafeWalletSelector(
     WalletSelectors.isNftPinningFeatureEnabled
@@ -114,7 +112,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
   // methods
   const onShowBackup = React.useCallback(() => {
     if (isAndroid) {
-      pageHandler.showWalletBackupUI()
+      getWalletPageApiProxy().pageHandler.showWalletBackupUI()
       return
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Wallet.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Wallet.swift
@@ -317,6 +317,10 @@ extension Tab: BraveWalletProviderDelegate {
   func walletInteractionDetected() {
     // No usage for iOS
   }
+
+  func showWalletBackup(){
+    // No usage for iOS
+  }
   
   func showWalletOnboarding() {
     showPanel()

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios+private.h
@@ -31,6 +31,7 @@ class BraveWalletProviderDelegateBridge
   void WalletInteractionDetected() override;
   url::Origin GetOrigin() const override;
   void ShowWalletOnboarding() override;
+  void ShowWalletBackup() override;
   void ShowAccountCreation(mojom::CoinType type) override;
   void RequestPermissions(mojom::CoinType type,
                           const std::vector<std::string>& accounts,

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.h
@@ -24,6 +24,7 @@ OBJC_EXPORT
 - (URLOriginIOS*)getOrigin;
 - (void)walletInteractionDetected;
 - (void)showWalletOnboarding;
+- (void)showWalletBackup;
 - (void)showAccountCreation:(BraveWalletCoinType)type;
 - (void)requestPermissions:(BraveWalletCoinType)type
                   accounts:(NSArray<NSString*>*)accounts

--- a/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
+++ b/ios/browser/api/brave_wallet/brave_wallet_provider_delegate_ios.mm
@@ -36,6 +36,10 @@ void BraveWalletProviderDelegateBridge::ShowWalletOnboarding() {
   [bridge_ showWalletOnboarding];
 }
 
+void BraveWalletProviderDelegateBridge::ShowWalletBackup() {
+  [bridge_ showWalletBackup];
+}
+
 void BraveWalletProviderDelegateBridge::ShowAccountCreation(
     mojom::CoinType type) {
   [bridge_ showAccountCreation:static_cast<BraveWalletCoinType>(type)];


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/35928


https://github.com/brave/brave-core/assets/3308503/ac372f8c-0455-4ea6-95e8-38669f8ca7ea

Launch native UI to back up Brave Wallet when tapping on "Back up now" button.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Navigate to Brave Wallet 
- Tap on "Back up now"
- Observe the native UI will open asking to type the Wallet password
- Complete the back up process
- Observe the bannear disappearing
