### PR TITLE
Workaround to prevent infinite accessibilityParent access for the same view

### DIFF
--- a/chromium_src/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+++ b/chromium_src/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
@@ -1,0 +1,11 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Temporary fix for https://github.com/brave/brave-browser/issues/35938
+#define BRAVE_ACCESSIBILITY_PARENT  \
+  if (self == _accessibilityParent) \
+    return [super accessibilityParent];
+#include "src/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm"
+#undef BRAVE_ACCESSIBILITY_PARENT

--- a/patches/content-app_shim_remote_cocoa-render_widget_host_view_cocoa.mm.patch
+++ b/patches/content-app_shim_remote_cocoa-render_widget_host_view_cocoa.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+index 81f705328efd2de0957c1ef309e20c421e0959eb..589d342594bbff3a7e3ad83626b02f94adfad3f5 100644
+--- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
++++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+@@ -1935,6 +1935,7 @@ void ExtractUnderlines(NSAttributedString* string,
+ }
+ 
+ - (id)accessibilityParent {
++  BRAVE_ACCESSIBILITY_PARENT
+   if (_accessibilityParent)
+     return NSAccessibilityUnignoredAncestor(_accessibilityParent);
+   return [super accessibilityParent];


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35938
Resolves https://github.com/brave/brave-browser/issues/35396
Resolves https://github.com/brave/brave-browser/issues/35504

With local debugger and debug build, those accessibilityParent calls are all the same address when focus changed between tabs on certain machine.
This is supposed to be a temporary fix until we figure out the root cause.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan: 
(macOS only, arm64 or x86_64 are all reproducible)
1. Open two tabs, one with Leo panel opened and another is brave://settings/
2. Switch to setting page and click on some dropdown menu. ex. default wallet setting in brave://settings/web3
3. Switch back to the tab with Leo panel and change the size of the panel
4. Browser should not crash
