### PR TITLE
Updated CSS file to fix overlapping of delete and search icons

### DIFF
--- a/ui/webui/resources/br_elements/br_toolbar/br_toolbar_selection_overplay_overrides.css
+++ b/ui/webui/resources/br_elements/br_toolbar/br_toolbar_selection_overplay_overrides.css
@@ -1,0 +1,3 @@
+#overlay-content {
+    padding: 0 var(--cr-toolbar-selection-overlay-padding, 70px);
+}


### PR DESCRIPTION
Hello maintainers @rebron @bsclifton @fallaciousreasoning 
I've made some changes that should fix the delete and search icons overlapping issue.
The issue is mentioned in https://github.com/brave/brave-browser/issues/32399

You can review the changes in the PR.

As a newcomer to open source, I appreciate your guidance and feedback on these changes. If there are additional considerations or modifications needed, please feel free to provide suggestions. Thank you for your time and assistance in reviewing this pull request.