### PR TITLE
Fix build on Arm64 Windows

### DIFF
--- a/chromium_src/components/update_client/persisted_data.cc
+++ b/chromium_src/components/update_client/persisted_data.cc
@@ -3,17 +3,25 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/widevine/static_buildflags.h"
+
+#if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
+#define RegisterPersistedDataPrefs RegisterPersistedDataPrefs_ChromiumImpl
+#endif
+
 #include "src/components/update_client/persisted_data.cc"
+
+#if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
+
+#undef RegisterPersistedDataPrefs
 
 namespace update_client {
 
-bool PersistedDataImpl::BraveGetBool(const std::string& id,
-                                     const std::string& key){
-    return !GetString(id, key).empty()}
-
-void PersistedDataImpl::BraveSetBool(const std::string& id,
-                                     const std::string& key) {
-  SetString(id, key, "true");
+void RegisterPersistedDataPrefs(PrefRegistrySimple* registry) {
+  RegisterPersistedDataPrefs_ChromiumImpl(registry);
+  registry->RegisterBooleanPref(kUpstreamHasArm64WidevineKey, false);
 }
 
 }  // namespace update_client
+
+#endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)

--- a/chromium_src/components/update_client/persisted_data.cc
+++ b/chromium_src/components/update_client/persisted_data.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/update_client/persisted_data.cc"
+
+namespace update_client {
+
+bool PersistedDataImpl::BraveGetBool(const std::string& id,
+                                     const std::string& key){
+    return !GetString(id, key).empty()}
+
+void PersistedDataImpl::BraveSetBool(const std::string& id,
+                                     const std::string& key) {
+  SetString(id, key, "true");
+}
+
+}  // namespace update_client

--- a/chromium_src/components/update_client/persisted_data.cc
+++ b/chromium_src/components/update_client/persisted_data.cc
@@ -6,8 +6,12 @@
 #include "brave/components/widevine/static_buildflags.h"
 
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
+
+#include "components/prefs/pref_service.h"
+
 #define RegisterPersistedDataPrefs RegisterPersistedDataPrefs_ChromiumImpl
-#endif
+
+#endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
 
 #include "src/components/update_client/persisted_data.cc"
 
@@ -15,11 +19,24 @@
 
 #undef RegisterPersistedDataPrefs
 
+namespace {
+constexpr char kUpstreamHasArm64WidevineKey[] =
+    "brave_upstream_has_arm64_widevine";
+}
+
 namespace update_client {
 
 void RegisterPersistedDataPrefs(PrefRegistrySimple* registry) {
   RegisterPersistedDataPrefs_ChromiumImpl(registry);
   registry->RegisterBooleanPref(kUpstreamHasArm64WidevineKey, false);
+}
+
+bool UpstreamHasArm64Widevine(PrefService* prefService) {
+  return prefService->GetBoolean(kUpstreamHasArm64WidevineKey);
+}
+
+void SetUpstreamHasArm64Widevine(PrefService* prefService) {
+  prefService->SetBoolean(kUpstreamHasArm64WidevineKey, true);
 }
 
 }  // namespace update_client

--- a/chromium_src/components/update_client/persisted_data.h
+++ b/chromium_src/components/update_client/persisted_data.h
@@ -8,6 +8,8 @@
 
 #include "brave/components/widevine/static_buildflags.h"
 
+#include "src/components/update_client/persisted_data.h"  // IWYU pragma: export
+
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
 
 class PrefService;
@@ -21,7 +23,5 @@ void SetUpstreamHasArm64Widevine(PrefService* prefService);
 }  // namespace update_client
 
 #endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-
-#include "src/components/update_client/persisted_data.h"  // IWYU pragma: export
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_PERSISTED_DATA_H_

--- a/chromium_src/components/update_client/persisted_data.h
+++ b/chromium_src/components/update_client/persisted_data.h
@@ -9,15 +9,17 @@
 #include "brave/components/widevine/static_buildflags.h"
 
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-#define pref_service_ \
-  pref_service_;      \
-  friend class SequentialUpdateChecker
+#define SetThrottleUpdatesUntil(...)                                       \
+  SetThrottleUpdatesUntil(__VA_ARGS__) = 0;                                \
+  virtual bool BraveGetBool(const std::string& id, const std::string& key) \
+      const = 0;                                                           \
+  virtual void BraveSetBool(const std::string& id, const std::string& key)
 #endif
 
 #include "src/components/update_client/persisted_data.h"  // IWYU pragma: export
 
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-#undef pref_service_
+#undef SetThrottleUpdatesUntil
 #endif
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_PERSISTED_DATA_H_

--- a/chromium_src/components/update_client/persisted_data.h
+++ b/chromium_src/components/update_client/persisted_data.h
@@ -9,17 +9,12 @@
 #include "brave/components/widevine/static_buildflags.h"
 
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-#define SetThrottleUpdatesUntil(...)                                       \
-  SetThrottleUpdatesUntil(__VA_ARGS__) = 0;                                \
-  virtual bool BraveGetBool(const std::string& id, const std::string& key) \
-      const = 0;                                                           \
-  virtual void BraveSetBool(const std::string& id, const std::string& key)
+namespace update_client {
+constexpr char kUpstreamHasArm64WidevineKey[] =
+    "brave_upstream_has_arm64_widevine";
+}
 #endif
 
 #include "src/components/update_client/persisted_data.h"  // IWYU pragma: export
-
-#if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-#undef SetThrottleUpdatesUntil
-#endif
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_PERSISTED_DATA_H_

--- a/chromium_src/components/update_client/persisted_data.h
+++ b/chromium_src/components/update_client/persisted_data.h
@@ -9,11 +9,18 @@
 #include "brave/components/widevine/static_buildflags.h"
 
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
+
+class PrefService;
+
 namespace update_client {
-constexpr char kUpstreamHasArm64WidevineKey[] =
-    "brave_upstream_has_arm64_widevine";
+
+bool UpstreamHasArm64Widevine(PrefService* prefService);
+
+void SetUpstreamHasArm64Widevine(PrefService* prefService);
+
 }
-#endif
+
+#endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
 
 #include "src/components/update_client/persisted_data.h"  // IWYU pragma: export
 

--- a/chromium_src/components/update_client/persisted_data.h
+++ b/chromium_src/components/update_client/persisted_data.h
@@ -18,7 +18,7 @@ bool UpstreamHasArm64Widevine(PrefService* prefService);
 
 void SetUpstreamHasArm64Widevine(PrefService* prefService);
 
-}
+}  // namespace update_client
 
 #endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
 

--- a/chromium_src/components/update_client/update_checker.cc
+++ b/chromium_src/components/update_client/update_checker.cc
@@ -9,14 +9,11 @@
 
 #if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
 #include "brave/components/widevine/constants.h"
+#include "components/prefs/pref_service.h"
+#include "components/update_client/persisted_data.h"
 #endif
 
 namespace update_client {
-
-#if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-constexpr char kUpstreamHasArm64WidevineKey[] =
-    "brave_upstream_has_arm64_widevine";
-#endif
 
 SequentialUpdateChecker::SequentialUpdateChecker(
     scoped_refptr<Configurator> config,
@@ -176,12 +173,12 @@ void SequentialUpdateChecker::UpdateResultAvailable(
 
 void SequentialUpdateChecker::SetPersistedFlag(const std::string& extension_id,
                                                const std::string& key) {
-  update_context_->persisted_data->BraveSetBool(extension_id, key);
+  update_context_->config->GetPrefService()->SetBoolean(extension_id + key, true);
 }
 
 bool SequentialUpdateChecker::GetPersistedFlag(const std::string& extension_id,
                                                const std::string& key) {
-  return update_context_->persisted_data->BraveGetBool(extension_id, key);
+  return update_context_->config->GetPrefService()->GetBoolean(extension_id + key);
 }
 
 #endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)

--- a/chromium_src/components/update_client/update_checker.cc
+++ b/chromium_src/components/update_client/update_checker.cc
@@ -121,7 +121,7 @@ void SequentialUpdateChecker::UpdateResultAvailable(
     CHECK(!results->list.empty());
     auto r = results->list.begin();
     if (r->extension_id == kWidevineComponentId && fake_architecture.empty()) {
-      if (update_client::UpstreamHasArm64Widevine(config_->GetPrefService())) {
+      if (UpstreamHasArm64Widevine(config_->GetPrefService())) {
         VLOG(1) << "Skipping WIDEVINE_ARM64_DLL_FIX because we already saw "
                    "once that upstream offers Arm64 binaries for Widevine. "
                    "Consider removing our WIDEVINE_ARM64_DLL_FIX.";
@@ -139,7 +139,7 @@ void SequentialUpdateChecker::UpdateResultAvailable(
           // us not fall back to x64 in the benign case where we are on the
           // latest version of Arm64 Widevine and are getting a "noupdate"
           // response.
-          update_client::SetUpstreamHasArm64Widevine(config_->GetPrefService());
+          SetUpstreamHasArm64Widevine(config_->GetPrefService());
         }
       }
     }

--- a/chromium_src/components/update_client/update_checker.cc
+++ b/chromium_src/components/update_client/update_checker.cc
@@ -176,12 +176,12 @@ void SequentialUpdateChecker::UpdateResultAvailable(
 
 void SequentialUpdateChecker::SetPersistedFlag(const std::string& extension_id,
                                                const std::string& key) {
-  update_context_->persisted_data->SetString(extension_id, key, "true");
+  update_context_->persisted_data->BraveSetBool(extension_id, key);
 }
 
 bool SequentialUpdateChecker::GetPersistedFlag(const std::string& extension_id,
                                                const std::string& key) {
-  return !update_context_->persisted_data->GetString(extension_id, key).empty();
+  return update_context_->persisted_data->BraveGetBool(extension_id, key);
 }
 
 #endif  // BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)

--- a/chromium_src/components/update_client/update_checker.h
+++ b/chromium_src/components/update_client/update_checker.h
@@ -26,7 +26,7 @@ namespace update_client {
 
 // SequentialUpdateChecker delegates to UpdateChecker to perform a separate
 // update request for each component, instead of one request for all components.
-// We do for the following reason:
+// We do this for the following reason:
 // Google's ToS do not allow distributing all components. In particular, the
 // Widevine plugin must be fetched from Google servers. Brave's update server
 // for components handles this as follows: When an update for a Google
@@ -68,13 +68,6 @@ class SequentialUpdateChecker : public UpdateChecker {
       ErrorCategory error_category,
       int error,
       int retry_after_sec);
-
-#if BUILDFLAG(WIDEVINE_ARM64_DLL_FIX)
-  void SetPersistedFlag(const std::string& extension_id,
-                        const std::string& key);
-  bool GetPersistedFlag(const std::string& extension_id,
-                        const std::string& key);
-#endif
 
   THREAD_CHECKER(thread_checker_);
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/35975.

One difference of this new implementation is that the persisted flag is now not stored in / as

```
"updateclientdata": {
    "<Widevine component ID>": {
        "brave_upstream_has_arm64_widevine": "true"
    }
}
```

but instead as

```
"brave_upstream_has_arm64_widevine": "true"
```

The previous value in `updateclientdata` does not need to be cleaned up because it was never set for any user. (Upstream has not yet made Arm64 Widevine available, so the condition never triggered.)

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please test that Widevine still works on Arm64 Windows. For more concrete instructions, please see for instance the Test Plan at the bottom of #18695.