### PR TITLE
[ads] Always run brave ads on iOS if ShouldAlwaysRunBraveAdsService true

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -348,7 +348,7 @@ public class BrowserViewController: UIViewController {
     }
 
     rewards.ads.captchaHandler = self
-    let shouldStartAds = rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value
+    let shouldStartAds = rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value || BraveAds.shouldAlwaysRunService()
     if shouldStartAds {
       // Only start rewards service automatically if ads is enabled
       if rewards.isEnabled {

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -100,7 +100,7 @@ public class BraveRewards: NSObject {
   private var braveNewsObservation: AnyCancellable?
 
   private var shouldShutdownAds: Bool {
-    ads.isServiceRunning() && !ads.isEnabled && !Preferences.BraveNews.isEnabled.value
+    ads.isServiceRunning() && !ads.isEnabled && !Preferences.BraveNews.isEnabled.value && !BraveAds.shouldAlwaysRunService()
   }
 
   /// Propose that the ads service should be shutdown based on whether or not that all features


### PR DESCRIPTION
Added ability to start Brave Ads service if ShouldAlwaysRunBraveAdsService feature is true when Brave Rewards is disabled. ShouldAlwaysRunBraveAdsService feature is disabled by default.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35520

The PR has been reviewed in brave-ios repo here: https://github.com/brave/brave-ios/pull/8699

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### `ShouldAlwaysRunBraveAdsService` feature DISABLED

### Test case 1:
- Fresh install
- Launch browser
    - EXPECTED RESULT: Ads service is not started

### Test case 2:
- Fresh install
- Launch browser
- Join Brave Rewards
    - EXPECTED RESULT: Ads service is started
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave Rewards
    - EXPECTED RESULT: Ads service is stopped
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is not started

### Test case 3:
- Fresh install
- Launch browser
- Join Brave News
    - EXPECTED RESULT: Ads service is started
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave News
    - EXPECTED RESULT: Ads service is stopped
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is not started

—

### `ShouldAlwaysRunBraveAdsService` feature ENABLED

### Test case 1:
- Fresh install
    - EXPECTED RESULT: Ads service is started
- Launch browser
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started

### Test case 2:
- Fresh install
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Join Brave Rewards
    - EXPECTED RESULT: Ads service should not be restarted
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave Rewards
    - EXPECTED RESULT: Ads service should not stop
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started

### Test case 3:
- Fresh install
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Join Brave News
    - EXPECTED RESULT: Ads service should not be restarted
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
- Disable Brave News
    - EXPECTED RESULT: Ads service should not stop
- Quit browser
- Launch browser
    - EXPECTED RESULT: Ads service is started
