### PR TITLE
Enforce profile checking for AIChat

### DIFF
--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -32,6 +32,7 @@ source_set("browser_tests") {
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
     sources = [
       "ai_chat_policy_browsertest.cc",
+      "ai_chat_profile_browsertest.cc",
       "page_content_fetcher_browsertest.cc",
     ]
     deps = [

--- a/browser/ai_chat/ai_chat_policy_browsertest.cc
+++ b/browser/ai_chat/ai_chat_policy_browsertest.cc
@@ -13,6 +13,7 @@
 #include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/sidebar/sidebar_item.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/renderer_context_menu/render_view_context_menu_test_util.h"
@@ -21,6 +22,7 @@
 #include "chrome/browser/ui/location_bar/location_bar.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_registry.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "chrome/test/base/ui_test_utils.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
@@ -32,6 +34,7 @@
 #include "components/policy/policy_constants.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/common/url_constants.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
 
@@ -157,6 +160,31 @@ IN_PROC_BROWSER_TEST_P(AIChatPolicyTest, ContextMenu) {
     EXPECT_TRUE(ai_chat_index.has_value());
   } else {
     EXPECT_FALSE(ai_chat_index.has_value());
+  }
+}
+
+IN_PROC_BROWSER_TEST_P(AIChatPolicyTest, SidePanelRegistry) {
+  auto* registry = SidePanelRegistry::Get(web_contents());
+  auto* entry = registry->GetEntryForKey(
+      SidePanelEntry::Key(SidePanelEntry::Id::kChatUI));
+  if (IsAIChatEnabledTest()) {
+    EXPECT_TRUE(entry);
+  } else {
+    EXPECT_FALSE(entry);
+  }
+}
+
+IN_PROC_BROWSER_TEST_P(AIChatPolicyTest, SpeedreaderToolbar) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), GURL(base::StrCat({content::kChromeUIScheme, "://",
+                                    kSpeedreaderPanelHost}))));
+  auto result =
+      content::EvalJs(web_contents(), "loadTimeData.data_.aiChatFeatureEnabled")
+          .ExtractBool();
+  if (IsAIChatEnabledTest()) {
+    EXPECT_EQ(result, true);
+  } else {
+    EXPECT_EQ(result, false);
   }
 }
 

--- a/browser/ai_chat/ai_chat_profile_browsertest.cc
+++ b/browser/ai_chat/ai_chat_profile_browsertest.cc
@@ -1,0 +1,173 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/brave_browser.h"
+#include "brave/browser/ui/browser_commands.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
+#include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "brave/components/constants/webui_url_constants.h"
+#include "brave/components/sidebar/sidebar_item.h"
+#include "chrome/browser/profiles/profile_window.h"
+#include "chrome/browser/renderer_context_menu/render_view_context_menu_test_util.h"
+#include "chrome/browser/ui/location_bar/location_bar.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_registry.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/omnibox/browser/autocomplete_controller.h"
+#include "components/omnibox/browser/omnibox_controller.h"
+#include "components/omnibox/browser/omnibox_view.h"
+#include "content/public/common/url_constants.h"
+#include "content/public/test/browser_test.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+using ui_test_utils::BrowserChangeObserver;
+
+enum class ProfileType { kRegular, kGuest, kPrivate, kTor };
+
+const char* GetProfileTypeString(ProfileType type) {
+  switch (type) {
+    case ProfileType::kRegular:
+      return "Regular";
+    case ProfileType::kGuest:
+      return "Guest";
+    case ProfileType::kPrivate:
+      return "Private";
+    case ProfileType::kTor:
+      return "Tor";
+    default:
+      NOTREACHED_NORETURN();
+  }
+}
+}  // namespace
+
+class AIChatProfileTest : public InProcessBrowserTest,
+                          public ::testing::WithParamInterface<ProfileType> {
+ public:
+  AIChatProfileTest() = default;
+  ~AIChatProfileTest() override = default;
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    browser_ = CreateBrowser();
+    ASSERT_TRUE(browser_);
+  }
+
+  Browser* CreateBrowser() {
+    switch (GetParam()) {
+      case ProfileType::kRegular:
+        return browser();
+      case ProfileType::kGuest:
+        profiles::SwitchToGuestProfile();
+        return ui_test_utils::WaitForBrowserToOpen();
+        ;
+      case ProfileType::kPrivate:
+        return CreateIncognitoBrowser();
+      case ProfileType::kTor: {
+        BrowserChangeObserver observer(
+            nullptr, BrowserChangeObserver::ChangeType::kAdded);
+        brave::NewOffTheRecordWindowTor(browser());
+        return observer.Wait();
+      }
+      default:
+        NOTREACHED_NORETURN();
+    }
+  }
+
+  bool IsAIChatEnabled() { return GetParam() == ProfileType::kRegular; }
+
+  content::WebContents* web_contents() const {
+    return browser_->tab_strip_model()->GetActiveWebContents();
+  }
+
+ protected:
+  raw_ptr<Browser> browser_ = nullptr;
+};
+
+IN_PROC_BROWSER_TEST_P(AIChatProfileTest, SidebarCheck) {
+  auto* sidebar_model =
+      static_cast<BraveBrowser*>(browser_)->sidebar_controller()->model();
+
+  bool is_in_sidebar = base::ranges::any_of(
+      sidebar_model->GetAllSidebarItems(), [](const auto& item) {
+        return item.built_in_item_type ==
+               sidebar::SidebarItem::BuiltInItemType::kChatUI;
+      });
+  if (IsAIChatEnabled()) {
+    EXPECT_TRUE(is_in_sidebar);
+  } else {
+    EXPECT_FALSE(is_in_sidebar);
+  }
+}
+
+IN_PROC_BROWSER_TEST_P(AIChatProfileTest, Autocomplete) {
+  auto* autocomplete_controller = browser_->window()
+                                      ->GetLocationBar()
+                                      ->GetOmniboxView()
+                                      ->controller()
+                                      ->autocomplete_controller();
+  const auto& providers = autocomplete_controller->providers();
+  bool is_in_providers =
+      base::ranges::any_of(providers, [](const auto& provider) {
+        return provider->type() == AutocompleteProvider::TYPE_BRAVE_LEO;
+      });
+  if (IsAIChatEnabled()) {
+    EXPECT_TRUE(is_in_providers);
+  } else {
+    EXPECT_FALSE(is_in_providers);
+  }
+}
+
+IN_PROC_BROWSER_TEST_P(AIChatProfileTest, ContextMenu) {
+  content::ContextMenuParams params;
+  params.is_editable = false;
+  params.page_url = GURL("http://test.page/");
+  params.selection_text = u"brave";
+  TestRenderViewContextMenu menu(*web_contents()->GetPrimaryMainFrame(),
+                                 params);
+  menu.Init();
+  std::optional<size_t> ai_chat_index =
+      menu.menu_model().GetIndexOfCommandId(IDC_AI_CHAT_CONTEXT_LEO_TOOLS);
+  if (IsAIChatEnabled()) {
+    EXPECT_TRUE(ai_chat_index.has_value());
+  } else {
+    EXPECT_FALSE(ai_chat_index.has_value());
+  }
+}
+
+IN_PROC_BROWSER_TEST_P(AIChatProfileTest, SidePanelRegistry) {
+  auto* registry = SidePanelRegistry::Get(web_contents());
+  auto* entry = registry->GetEntryForKey(
+      SidePanelEntry::Key(SidePanelEntry::Id::kChatUI));
+  if (IsAIChatEnabled()) {
+    EXPECT_TRUE(entry);
+  } else {
+    EXPECT_FALSE(entry);
+  }
+}
+
+IN_PROC_BROWSER_TEST_P(AIChatProfileTest, SpeedreaderToolbar) {
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser_, GURL(base::StrCat({content::kChromeUIScheme, "://",
+                                   kSpeedreaderPanelHost}))));
+  auto result =
+      content::EvalJs(web_contents(), "loadTimeData.data_.aiChatFeatureEnabled")
+          .ExtractBool();
+  if (IsAIChatEnabled()) {
+    EXPECT_EQ(result, true);
+  } else {
+    EXPECT_EQ(result, false);
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    All,
+    AIChatProfileTest,
+    testing::ValuesIn({ProfileType::kRegular, ProfileType::kGuest,
+                       ProfileType::kPrivate, ProfileType::kTor}),
+    [](const testing::TestParamInfo<AIChatProfileTest::ParamType>& info) {
+      return GetProfileTypeString(info.param);
+    });

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -813,7 +813,7 @@ void BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
   auto* prefs =
       user_prefs::UserPrefs::Get(render_frame_host->GetBrowserContext());
   if (ai_chat::IsAIChatEnabled(prefs) &&
-      !render_frame_host->GetBrowserContext()->IsTor()) {
+      brave::IsRegularProfile(render_frame_host->GetBrowserContext())) {
     content::RegisterWebUIControllerInterfaceBinder<ai_chat::mojom::PageHandler,
                                                     AIChatUI>(map);
   }
@@ -1253,9 +1253,11 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
 #endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
-  if (auto ai_chat_throttle =
-          ai_chat::AiChatThrottle::MaybeCreateThrottleFor(handle)) {
-    throttles.push_back(std::move(ai_chat_throttle));
+  if (brave::IsRegularProfile(context)) {
+    if (auto ai_chat_throttle =
+            ai_chat::AiChatThrottle::MaybeCreateThrottleFor(handle)) {
+      throttles.push_back(std::move(ai_chat_throttle));
+    }
   }
 #endif  // ENABLE_AI_CHAT
 

--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -20,6 +20,7 @@
 #include "brave/browser/misc_metrics/page_metrics_tab_helper.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
 #include "brave/browser/ntp_background/ntp_tab_helper.h"
+#include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/skus/skus_service_factory.h"
 #include "brave/browser/ui/bookmark/brave_bookmark_tab_helper.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
@@ -133,7 +134,8 @@ void AttachTabHelpers(content::WebContents* web_contents) {
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
     content::BrowserContext* context = web_contents->GetBrowserContext();
-    if (ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(context))) {
+    if (ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(context)) &&
+        IsRegularProfile(context)) {
       auto skus_service_getter = base::BindRepeating(
           [](content::BrowserContext* context) {
             return skus::SkusServiceFactory::GetForContext(context);

--- a/browser/ui/views/side_panel/brave_side_panel_utils.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_utils.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/profiles/profile_util.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
@@ -58,7 +59,8 @@ void RegisterContextualSidePanel(content::WebContents* web_contents) {
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   content::BrowserContext* context = web_contents->GetBrowserContext();
-  if (ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(context))) {
+  if (ai_chat::IsAIChatEnabled(user_prefs::UserPrefs::Get(context)) &&
+      IsRegularProfile(context)) {
     // If |registry| already has it, it's no-op.
     registry->Register(std::make_unique<SidePanelEntry>(
         SidePanelEntry::Id::kChatUI,

--- a/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_data_handler_impl.cc
@@ -10,6 +10,7 @@
 
 #include "base/strings/string_number_conversions.h"
 #include "brave/browser/brave_browser_features.h"
+#include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/speedreader/speedreader_service_factory.h"
 #include "brave/browser/speedreader/speedreader_tab_helper.h"
 #include "brave/browser/ui/brave_browser.h"
@@ -147,7 +148,8 @@ void SpeedreaderToolbarDataHandlerImpl::ViewOriginal() {
 
 void SpeedreaderToolbarDataHandlerImpl::AiChat() {
 #if BUILDFLAG(ENABLE_AI_CHAT)
-  if (!browser_ || !ai_chat::IsAIChatEnabled(browser_->profile()->GetPrefs())) {
+  if (!browser_ || !ai_chat::IsAIChatEnabled(browser_->profile()->GetPrefs()) ||
+      !brave::IsRegularProfile(browser_->profile())) {
     return;
   }
   auto* side_panel = SidePanelUI::GetSidePanelUIForBrowser(browser_.get());

--- a/browser/ui/webui/speedreader/speedreader_toolbar_ui.cc
+++ b/browser/ui/webui/speedreader/speedreader_toolbar_ui.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/ui/webui/brave_webui_source.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/constants/webui_url_constants.h"
@@ -50,7 +51,8 @@ SpeedreaderToolbarUI::SpeedreaderToolbarUI(content::WebUI* web_ui,
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
   source->AddBoolean("aiChatFeatureEnabled",
-                     ai_chat::IsAIChatEnabled(profile_->GetPrefs()));
+                     ai_chat::IsAIChatEnabled(profile_->GetPrefs()) &&
+                         brave::IsRegularProfile(profile_));
 #else
   source->AddBoolean("aiChatFeatureEnabled", false);
 #endif

--- a/chromium_src/components/omnibox/browser/autocomplete_controller.cc
+++ b/chromium_src/components/omnibox/browser/autocomplete_controller.cc
@@ -87,11 +87,12 @@ void MaybeAddCommanderProvider(AutocompleteController::Providers& providers,
 void MaybeAddLeoProvider(AutocompleteController::Providers& providers,
                          AutocompleteController* controller) {
 #if BUILDFLAG(ENABLE_AI_CHAT)
+  auto* provider_client = controller->autocomplete_provider_client();
   // TestOmniboxClient has null prefs getter
-  auto* prefs = controller->autocomplete_provider_client()->GetPrefs();
-  if (prefs && ai_chat::IsAIChatEnabled(prefs)) {
-    providers.push_back(base::MakeRefCounted<LeoProvider>(
-        controller->autocomplete_provider_client()));
+  auto* prefs = provider_client->GetPrefs();
+  if (prefs && ai_chat::IsAIChatEnabled(prefs) &&
+      !provider_client->IsOffTheRecord()) {
+    providers.push_back(base::MakeRefCounted<LeoProvider>(provider_client));
   }
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
 }


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35835

Only allows the feature in regular profile, other profiles like private, tor and guest are all disabled.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open https://brave.com/ads-manager/ in [ private | tor| guest ] window
2. Toggle reader mode
3. There should be no Leo icon on speed reader toolbar
