### PR TITLE
Workaround to prevent infinite accessibilityParent access for the same view (uplift to 1.63.x)

### DIFF
--- a/chromium_src/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+++ b/chromium_src/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
@@ -1,0 +1,11 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// Temporary fix for https://github.com/brave/brave-browser/issues/35938
+#define BRAVE_ACCESSIBILITY_PARENT  \
+  if (self == _accessibilityParent) \
+    return [super accessibilityParent];
+#include "src/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm"
+#undef BRAVE_ACCESSIBILITY_PARENT

--- a/patches/content-app_shim_remote_cocoa-render_widget_host_view_cocoa.mm.patch
+++ b/patches/content-app_shim_remote_cocoa-render_widget_host_view_cocoa.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+index 81f705328efd2de0957c1ef309e20c421e0959eb..589d342594bbff3a7e3ad83626b02f94adfad3f5 100644
+--- a/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
++++ b/content/app_shim_remote_cocoa/render_widget_host_view_cocoa.mm
+@@ -1935,6 +1935,7 @@ void ExtractUnderlines(NSAttributedString* string,
+ }
+ 
+ - (id)accessibilityParent {
++  BRAVE_ACCESSIBILITY_PARENT
+   if (_accessibilityParent)
+     return NSAccessibilityUnignoredAncestor(_accessibilityParent);
+   return [super accessibilityParent];


### PR DESCRIPTION
Uplift of #21992
Resolves https://github.com/brave/brave-browser/issues/35938
Resolves https://github.com/brave/brave-browser/issues/35396
Resolves https://github.com/brave/brave-browser/issues/35504

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.