### PR TITLE
[Wallet/iOS] Fix #35986: Persist balance in Portfolio Assets

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -15,7 +15,6 @@ struct AddCustomAssetView: View {
   @ObservedObject var userAssetStore: UserAssetsStore
   var tokenNeedsTokenId: BraveWallet.BlockchainToken?
   var supportedTokenTypes: [TokenType] = [.token, .nft]
-  var onNewAssetAdded: (() -> Void)?
   
   @Environment(\.presentationMode) @Binding private var presentationMode
 
@@ -377,7 +376,6 @@ struct AddCustomAssetView: View {
     }
     userAssetStore.addUserAsset(token) { [self] success in
       if success {
-        onNewAssetAdded?()
         presentationMode.dismiss()
       } else {
         showError = true

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/EditUserAssetsView.swift
@@ -75,7 +75,6 @@ struct EditUserAssetsView: View {
   var networkStore: NetworkStore
   var keyringStore: KeyringStore
   @ObservedObject var userAssetsStore: UserAssetsStore
-  var assetsUpdated: () -> Void
 
   @Environment(\.presentationMode) @Binding private var presentationMode
   @State private var query = ""
@@ -173,7 +172,6 @@ struct EditUserAssetsView: View {
         }
         ToolbarItemGroup(placement: .confirmationAction) {
           Button(action: {
-            assetsUpdated()
             presentationMode.dismiss()
           }) {
             Text(Strings.done)

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -59,9 +59,7 @@ struct PortfolioView: View {
           networkStore: networkStore,
           keyringStore: keyringStore,
           userAssetsStore: portfolioStore.userAssetsStore
-        ) {
-          cryptoStore.updateAssets()
-        }
+        )
       })
     .background(Color.clear
       .sheet(isPresented: $isPresentingAssetsFilters) {
@@ -93,9 +91,7 @@ struct PortfolioView: View {
           keyringStore: keyringStore,
           userAssetStore: cryptoStore.nftStore.userAssetsStore,
           supportedTokenTypes: [.nft]
-        ) {
-          cryptoStore.updateAssets()
-        }
+        )
       })
     .background(Color.clear
       .sheet(isPresented: $isPresentingNFTsFilters) {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -310,8 +310,8 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
         if network.id.lowercased() == defaultSelectedChainId.lowercased() {
           rpcService.setNetwork(BraveWallet.MainnetChainId, coin: .eth, origin: nil, completion: { _ in })
         }
-        // delete local stored user assets that in this custom network
-        assetManager.removeGroup(for: network.walletUserAssetGroupId, completion: nil)
+        // delete local stored user assets' balances that in this custom network
+        assetManager.removeUserAssetsAndBalance(for: network, completion: nil)
         Task {
           await updateChainList()
         }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -13,6 +13,8 @@ public class AssetStore: ObservableObject, Equatable, WalletObserverStore {
   @Published var token: BraveWallet.BlockchainToken
   @Published var isVisible: Bool {
     didSet {
+      // update user asset's visibility. `assetManager` will broadcast to all its user assets data
+      // observers to update views. `assetManager` will also fetch user asset's balance
       assetManager.updateUserAsset(for: token, visible: isVisible, isSpam: false, isDeletedByUser: false, completion: nil)
     }
   }

--- a/ios/brave-ios/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -277,7 +277,7 @@ public class WalletUserAssetManager: WalletUserAssetManagerType, WalletObserverS
   }
   
   public func getBalances(for asset: BraveWallet.BlockchainToken?, account: String?) -> [WalletUserAssetBalance]? {
-    WalletUserAssetBalance.getBalance(for: asset, account: account)
+    WalletUserAssetBalance.getBalances(for: asset, account: account)
   }
   
   public func updateBalance(for asset: BraveWallet.BlockchainToken, account: String, balance: String, completion: (() -> Void)?) {

--- a/ios/brave-ios/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -9,6 +9,13 @@ import BraveCore
 import Preferences
 import CoreData
 
+public protocol WalletUserAssetDataObserver: AnyObject {
+  /// This will be trigger when a balance refresh has been finished
+  func cachedBalanceRefreshed()
+  /// This will be trigger when user asset is updated
+  func userAssetUpdated()
+}
+
 public protocol WalletUserAssetManagerType: AnyObject {
   /// Return all visible or all invisible user assets in form of `NetworkAssets`
   func getAllUserAssetsInNetworkAssetsByVisibility(networks: [BraveWallet.NetworkInfo], visible: Bool) -> [NetworkAssets]
@@ -30,19 +37,84 @@ public protocol WalletUserAssetManagerType: AnyObject {
   func removeGroup(for groupId: String, completion: (() -> Void)?)
   /// Update a `WalletUserAsset`'s `visible`, `isSpam`, and `isDeletedByUser` status
   func updateUserAsset(for asset: BraveWallet.BlockchainToken, visible: Bool, isSpam: Bool, isDeletedByUser: Bool, completion: (() -> Void)?)
+  
+  /// Balance
+  /// Return balance in String of the given asset. Return nil if there no balance stored
+  func getBalances(for asset: BraveWallet.BlockchainToken?, account: String?) -> [WalletUserAssetBalance]?
+  /// Store asset balance if there is none exists. Update asset balance if asset exists in database
+  func updateBalance(for asset: BraveWallet.BlockchainToken, account: String, balance: String, completion: (() -> Void)?)
+  /// Remove a `WalletUserAssetBalance` representation of the given
+  /// `BraveWallet.BlockchainToken` from CoreData
+  func removeBalance(for asset: BraveWallet.BlockchainToken, completion: (() -> Void)?)
+  /// Remove a `WalletUserAssetBalance` representation of the given
+  /// `BraveWallet.NetworkInfo` from CoreData
+  func removeBalance(for network: BraveWallet.NetworkInfo, completion: (() -> Void)?)
+  /// Add a user asset data observer
+  func addUserAssetDataObserver(_ observer: WalletUserAssetDataObserver)
+  /// Remove user assets and their cached balance that belongs to given network
+  func removeUserAssetsAndBalance(for network: BraveWallet.NetworkInfo?, completion: (() -> Void)?)
 }
 
-public class WalletUserAssetManager: WalletUserAssetManagerType {
+public class WalletUserAssetManager: WalletUserAssetManagerType, WalletObserverStore {
   
+  private let keyringService: BraveWalletKeyringService
   private let rpcService: BraveWalletJsonRpcService
   private let walletService: BraveWalletBraveWalletService
+  private let txService: BraveWalletTxService
+  
+  private var keyringServiceObserver: KeyringServiceObserver?
+  private var txServiceObserver: TxServiceObserver?
+  
+  let dataObservers = NSHashTable<AnyObject>.weakObjects()
+  
+  var isObserving: Bool {
+    keyringServiceObserver != nil && txServiceObserver != nil
+  }
   
   public init(
+    keyringService: BraveWalletKeyringService,
     rpcService: BraveWalletJsonRpcService,
-    walletService: BraveWalletBraveWalletService
+    walletService: BraveWalletBraveWalletService,
+    txService: BraveWalletTxService
   ) {
+    self.keyringService = keyringService
     self.rpcService = rpcService
     self.walletService = walletService
+    self.txService = txService
+    
+    setupObservers()
+    
+    Preferences.Wallet.showTestNetworks.observe(from: self)
+  }
+  
+  public func tearDown() {
+    keyringServiceObserver = nil
+    txServiceObserver = nil
+  }
+  
+  public func setupObservers() {
+    guard !isObserving else { return }
+    
+    self.keyringServiceObserver = KeyringServiceObserver(
+      keyringService: keyringService,
+      _unlocked: { [weak self] in
+        self?.refreshBalances()
+      },
+      _accountsChanged: { [weak self] in
+        self?.refreshBalances()
+      },
+      _accountsAdded: { [weak self] newAccounts in
+        self?.refreshBalances()
+      }
+    )
+    self.txServiceObserver = TxServiceObserver(
+      txService: txService,
+      _onTransactionStatusChanged: { [weak self] txInfo in
+        if txInfo.txStatus == .confirmed || txInfo.txStatus == .error || txInfo.txStatus == .dropped {
+          self?.refreshBalances()
+        }
+      }
+    )
   }
   
   /// Return all user's assets stored in CoreData
@@ -113,18 +185,33 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
   public func addUserAsset(_ asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
     if let existedAsset = WalletUserAsset.getUserAsset(asset: asset) {
       if existedAsset.isDeletedByUser { // this asset was added before but user marked as deleted after
-        WalletUserAsset.updateUserAsset(for: asset, visible: true, isSpam: false, isDeletedByUser: false, completion: completion)
+        WalletUserAsset.updateUserAsset(for: asset, visible: true, isSpam: false, isDeletedByUser: false, completion: { [weak self] in
+          self?.refreshBalance(for: asset)
+          self?.retriveAllDataObserver().forEach { $0.userAssetUpdated() }
+          completion?()
+        })
       } else { // this asset already exists
         completion?()
         return
       }
     } else { // asset does not exist in database
-      WalletUserAsset.addUserAsset(asset: asset, completion: completion)
+      WalletUserAsset.addUserAsset(
+        asset: asset,
+        completion: { [weak self] in
+          self?.refreshBalance(for: asset)
+          self?.retriveAllDataObserver().forEach { $0.userAssetUpdated() }
+          completion?()
+        }
+      )
     }
   }
   
   public func removeUserAsset(_ asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
-    WalletUserAsset.removeUserAsset(asset: asset, completion: completion)
+    WalletUserAsset.removeUserAsset(asset: asset, completion: { [weak self] in
+      self?.removeBalance(for: asset, completion: nil)
+      self?.retriveAllDataObserver().forEach { $0.userAssetUpdated() }
+      completion?()
+    })
   }
   
   public func updateUserAsset(
@@ -139,29 +226,176 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
       visible: visible,
       isSpam: isSpam,
       isDeletedByUser: isDeletedByUser,
-      completion: completion
+      completion: { [weak self] in
+        if visible {
+          self?.refreshBalance(for: asset)
+        }
+        self?.retriveAllDataObserver().forEach { observer in
+          observer.userAssetUpdated()
+        }
+        completion?()
+      }
     )
   }
   
   public func removeGroup(for groupId: String, completion: (() -> Void)?) {
-    WalletUserAssetGroup.removeGroup(groupId, completion: completion)
+    WalletUserAssetGroup.removeGroup(
+      groupId,
+      completion: { [weak self] in
+        self?.retriveAllDataObserver().forEach { $0.userAssetUpdated() }
+        completion?()
+      })
   }
   
   public func migrateUserAssets(completion: (() -> Void)? = nil) {
     Task { @MainActor in
       if !Preferences.Wallet.migrateCoreToWalletUserAssetCompleted.value {
-        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes()), completion: completion)
+        migrateUserAssets(for: Array(WalletConstants.supportedCoinTypes()), completion: { [weak self] in
+          // new wallet created or new wallet restored. finished user asset migration
+          // so we want to fetch user assets balances and cache them
+          self?.refreshBalances()
+          completion?()
+        })
       } else {
         let allNetworks = await rpcService.allNetworksForSupportedCoins(respectTestnetPreference: false)
         DataController.performOnMainContext { context in
           let newCoins = self.allNewCoinsIntroduced(networks: allNetworks, context: context)
           if !newCoins.isEmpty {
-            self.migrateUserAssets(for: newCoins, completion: completion)
+            // new coin type introduced, so we want to fetch user assets balances and cache them after
+            // new coin type assets have been migrated to CD
+            self.migrateUserAssets(for: newCoins, completion: { [weak self] in
+              self?.refreshBalances()
+              completion?()
+            })
           } else {
+            // no migration happens. refreshing user assets balance will happen after unlock
             completion?()
           }
         }
       }
+    }
+  }
+  
+  public func getBalances(for asset: BraveWallet.BlockchainToken?, account: String?) -> [WalletUserAssetBalance]? {
+    WalletUserAssetBalance.getBalance(for: asset, account: account)
+  }
+  
+  public func updateBalance(for asset: BraveWallet.BlockchainToken, account: String, balance: String, completion: (() -> Void)?) {
+    WalletUserAssetBalance.updateBalance(
+      for: asset,
+      balance: balance,
+      account: account,
+      completion: completion
+    )
+  }
+  
+  public func removeBalance(for asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
+    WalletUserAssetBalance.removeBalance(
+      for: asset,
+      completion: { [weak self] in
+        self?.retriveAllDataObserver().forEach { $0.cachedBalanceRefreshed() }
+        completion?()
+      }
+    )
+  }
+  
+  public func removeBalance(for network: BraveWallet.NetworkInfo, completion: (() -> Void)?) {
+    WalletUserAssetBalance.removeBalance(
+      for: network,
+      completion: { [weak self] in
+        self?.retriveAllDataObserver().forEach { $0.cachedBalanceRefreshed() }
+        completion?()
+      })
+  }
+  
+  public func addUserAssetDataObserver(_ observer: WalletUserAssetDataObserver) {
+    dataObservers.add(observer)
+  }
+  
+  private var refreshBalanceTask: Task<Void, Never>?
+  public func refreshBalances(_ completion: (() -> Void)? = nil) {
+    refreshBalanceTask?.cancel()
+    refreshBalanceTask = Task { @MainActor in
+      let accounts = await keyringService.allAccounts().accounts
+      let allNetworks = await rpcService.allNetworksForSupportedCoins()
+      let allUserAssets: [NetworkAssets] = self.getAllUserAssetsInNetworkAssets(
+        networks: allNetworks,
+        includingUserDeleted: false
+      )
+      await withTaskGroup(
+        of: Void.self,
+        body: { @MainActor [rpcService] group in
+          for account in accounts {
+            group.addTask { @MainActor in
+              let allTokenBalanceForAccount = await rpcService.fetchBalancesForTokens(account: account, networkAssets: allUserAssets)
+              for tokenBalanceForAccount in allTokenBalanceForAccount {
+                let networkAssets = allUserAssets.first { oneNetworkAssets in
+                  oneNetworkAssets.tokens.contains { asset in
+                    asset.id == tokenBalanceForAccount.key
+                  }
+                }
+                if let token = networkAssets?.tokens.first(where: { $0.id == tokenBalanceForAccount.key }) {
+                  WalletUserAssetBalance.updateBalance(for: token, balance: String(tokenBalanceForAccount.value), account: account.address)
+                }
+              }
+            }
+          }
+        }
+      )
+      retriveAllDataObserver().forEach { $0.cachedBalanceRefreshed() }
+      completion?()
+    }
+  }
+  
+  public func removeUserAssetsAndBalance(for network: BraveWallet.NetworkInfo?, completion: (() -> Void)?) {
+    let group = DispatchGroup()
+    if let network {
+      group.enter()
+      WalletUserAssetGroup.removeGroup(network.walletUserAssetGroupId) {
+        group.leave()
+      }
+      group.enter()
+      WalletUserAssetBalance.removeBalance(for: network) {
+        group.leave()
+      }
+    } else {
+      group.enter()
+      WalletUserAssetGroup.removeAllGroup {
+        group.leave()
+      }
+      group.enter()
+      WalletUserAssetBalance.removeBalance {
+        group.leave()
+      }
+    }
+    group.notify(queue: .main) {
+      completion?()
+    }
+  }
+  
+  private func refreshBalance(for asset: BraveWallet.BlockchainToken, completion: (() -> Void)? = nil) {
+    Task { @MainActor in
+      let accounts = await keyringService.allAccounts().accounts.filter { $0.coin == asset.coin }
+      let network = await rpcService.allNetworksForSupportedCoins().first { $0.chainId.lowercased() == asset.chainId.lowercased() }
+      
+      guard let network = network else { return }
+      await withTaskGroup(
+        of: Void.self,
+        body: { @MainActor [rpcService] group in
+          for account in accounts { // for each account
+            group.addTask { @MainActor in
+              let assetBalance = await rpcService.balance(
+                for: asset,
+                in: account,
+                network: network
+              )
+              WalletUserAssetBalance.updateBalance(for: asset, balance: String(assetBalance ?? 0), account: account.address)
+            }
+          }
+        }
+      )
+      retriveAllDataObserver().forEach { $0.cachedBalanceRefreshed() }
+      completion?()
     }
   }
   
@@ -190,6 +424,20 @@ public class WalletUserAssetManager: WalletUserAssetManagerType {
       }
     }
   }
+  
+  private func retriveAllDataObserver() -> [WalletUserAssetDataObserver] {
+    return dataObservers.allObjects as? [WalletUserAssetDataObserver] ?? []
+  }
+}
+
+extension WalletUserAssetManager: PreferencesObserver {
+  public func preferencesDidChange(for key: String) {
+    if key == Preferences.Wallet.showTestNetworks.key {
+      refreshBalances { [weak self] in
+        self?.retriveAllDataObserver().forEach { $0.cachedBalanceRefreshed() }
+      }
+    }
+  }
 }
 
 #if DEBUG
@@ -198,6 +446,7 @@ public class TestableWalletUserAssetManager: WalletUserAssetManagerType {
   public var _getAllUserAssetsInNetworkAssets: ((_ networks: [BraveWallet.NetworkInfo], _ includingUserDeleted: Bool) -> [NetworkAssets])?
   public var _getAllUserNFTs: ((_ networks: [BraveWallet.NetworkInfo], _ spamStatus: Bool) -> [NetworkAssets])?
   public var _getAllUserDeletedNFTs: (() -> [WalletUserAsset])?
+  public var _getBalance: ((_ asset: BraveWallet.BlockchainToken?, _ account: String?) -> [WalletUserAssetBalance]?)?
   
   public init() {}
   
@@ -233,7 +482,7 @@ public class TestableWalletUserAssetManager: WalletUserAssetManagerType {
   
   public func removeUserAsset(_ asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
   }
-
+  
   public func removeGroup(for groupId: String, completion: (() -> Void)?) {
   }
   
@@ -244,6 +493,29 @@ public class TestableWalletUserAssetManager: WalletUserAssetManagerType {
     isDeletedByUser: Bool,
     completion: (() -> Void)?
   ) {
+  }
+  
+  public func getBalances(for asset: BraveWallet.BlockchainToken?, account: String?) -> [WalletUserAssetBalance]? {
+    _getBalance?(asset, account)
+  }
+  
+  public func updateBalance(for asset: BraveWallet.BlockchainToken, account: String, balance: String, completion: (() -> Void)?) {
+    completion?()
+  }
+  
+  public func removeBalance(for asset: BraveWallet.BlockchainToken, completion: (() -> Void)?) {
+    completion?()
+  }
+  
+  public func removeBalance(for network: BraveWallet.NetworkInfo, completion: (() -> Void)?) {
+    completion?()
+  }
+  
+  public func addUserAssetDataObserver(_ observer: WalletUserAssetDataObserver) {
+  }
+  
+  public func removeUserAssetsAndBalance(for network: BraveWallet.NetworkInfo?, completion: (() -> Void)?) {
+    completion?()
   }
 }
 #endif

--- a/ios/brave-ios/Sources/Data/models/Domain.swift
+++ b/ios/brave-ios/Sources/Data/models/Domain.swift
@@ -288,6 +288,8 @@ public final class Domain: NSManagedObject, CRUD {
             break
           case .btc:
             break
+          case .zec:
+            break
           @unknown default:
             break
           }

--- a/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
+++ b/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>Model27.xcdatamodel</string>
+	<string>Model28.xcdatamodel</string>
 </dict>
 </plist>

--- a/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/Model28.xcdatamodel/contents
+++ b/ios/brave-ios/Sources/Data/models/Model.xcdatamodeld/Model28.xcdatamodel/contents
@@ -1,0 +1,229 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22222" systemVersion="23D60" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="BlockedResource" representedClassName="Data.BlockedResource" syncable="YES">
+        <attribute name="domain" optional="YES" attributeType="String"/>
+        <attribute name="faviconUrl" optional="YES" attributeType="String"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <fetchIndex name="byHost">
+            <fetchIndexElement property="host" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byDomain">
+            <fetchIndexElement property="domain" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Bookmark" representedClassName="Data.Favorite" syncable="YES">
+        <attribute name="created" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="customTitle" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isFolder" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastVisited" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="syncDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="syncOrder" optional="YES" attributeType="String"/>
+        <attribute name="syncParentDisplayUUID" optional="YES" attributeType="String"/>
+        <attribute name="tags" optional="YES" attributeType="Transformable"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="domain" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Domain" inverseName="bookmarks" inverseEntity="Domain"/>
+        <fetchIndex name="byLastVisitedIndex">
+            <fetchIndexElement property="lastVisited" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="BraveVPNAlert" representedClassName="Data.BraveVPNAlert" syncable="YES">
+        <attribute name="action" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="category" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="host" optional="YES" attributeType="String"/>
+        <attribute name="message" optional="YES" attributeType="String"/>
+        <attribute name="timestamp" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <fetchIndex name="byUUID">
+            <fetchIndexElement property="uuid" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="uuid"/>
+            </uniquenessConstraint>
+            <uniquenessConstraint>
+                <constraint value="timestamp"/>
+                <constraint value="host"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="CustomFilterListSetting" representedClassName="Data.CustomFilterListSetting" syncable="YES">
+        <attribute name="externalURL" optional="YES" attributeType="URI"/>
+        <attribute name="isEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="DataSaved" representedClassName="Data.DataSaved" syncable="YES">
+        <attribute name="amount" optional="YES" attributeType="String"/>
+        <attribute name="savedUrl" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="savedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="Domain" representedClassName="Data.Domain" syncable="YES">
+        <attribute name="blockedFromTopSites" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="shield_adblockAndTp" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_allOff" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_fpProtection" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_httpse" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_noScript" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="shield_safeBrowsing" optional="YES" attributeType="Boolean" usesScalarValueType="NO"/>
+        <attribute name="topsite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="visits" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="wallet_permittedAccounts" optional="YES" attributeType="String"/>
+        <attribute name="wallet_solanaPermittedAcccounts" optional="YES" attributeType="String"/>
+        <attribute name="zoom_level" optional="YES" attributeType="Double" usesScalarValueType="NO"/>
+        <relationship name="bookmarks" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Bookmark" inverseName="domain" inverseEntity="Bookmark"/>
+        <fetchIndex name="byBlockedFromTopSitesIndex">
+            <fetchIndexElement property="blockedFromTopSites" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byUrlIndex">
+            <fetchIndexElement property="url" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="byVisitsIndex">
+            <fetchIndexElement property="visits" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="FeedSourceOverride" representedClassName="Data.FeedSourceOverride" syncable="YES">
+        <attribute name="enabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="publisherID" attributeType="String"/>
+        <fetchIndex name="byPublisherID">
+            <fetchIndexElement property="publisherID" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="publisherID"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="FilterListSetting" representedClassName="Data.FilterListSetting" syncable="YES">
+        <attribute name="componentId" optional="YES" attributeType="String"/>
+        <attribute name="folderPath" optional="YES" attributeType="String"/>
+        <attribute name="isAlwaysAggressive" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="uuid" attributeType="String"/>
+    </entity>
+    <entity name="PlaylistFolder" representedClassName="Data.PlaylistFolder" syncable="YES">
+        <attribute name="creatorLink" optional="YES" attributeType="String"/>
+        <attribute name="creatorName" optional="YES" attributeType="String"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sharedFolderETag" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderId" optional="YES" attributeType="String"/>
+        <attribute name="sharedFolderUrl" optional="YES" attributeType="String"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="uuid" attributeType="String"/>
+        <relationship name="playlistItems" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlaylistItem" inverseName="playlistFolder" inverseEntity="PlaylistItem"/>
+    </entity>
+    <entity name="PlaylistItem" representedClassName="Data.PlaylistItem" syncable="YES">
+        <attribute name="cachedData" optional="YES" attributeType="Binary"/>
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="lastPlayedOffset" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="mediaSrc" attributeType="String"/>
+        <attribute name="mimeType" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
+        <attribute name="order" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pageSrc" attributeType="String"/>
+        <attribute name="pageTitle" optional="YES" attributeType="String"/>
+        <attribute name="uuid" optional="YES" attributeType="String"/>
+        <relationship name="playlistFolder" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PlaylistFolder" inverseName="playlistItems" inverseEntity="PlaylistFolder"/>
+    </entity>
+    <entity name="RecentlyClosed" representedClassName="Data.RecentlyClosed" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="historyIndex" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="historyList" optional="YES" attributeType="Transformable"/>
+        <attribute name="interactionState" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="url" attributeType="String"/>
+    </entity>
+    <entity name="RecentSearch" representedClassName="Data.RecentSearch" syncable="YES">
+        <attribute name="dateAdded" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="searchType" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="websiteUrl" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="RSSFeedSource" representedClassName="Data.RSSFeedSource" syncable="YES">
+        <attribute name="feedUrl" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="feedUrl"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="SessionTab" representedClassName="Data.SessionTab" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="interactionState" attributeType="Binary"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="screenshotData" attributeType="Binary"/>
+        <attribute name="tabId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="title" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
+        <relationship name="sessionTabGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionTabGroup" inverseName="sessionTabs" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabs" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionTabGroup" representedClassName="Data.SessionTabGroup" syncable="YES">
+        <attribute name="groupId" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="SessionTab" inverseName="sessionTabGroup" inverseEntity="SessionTab"/>
+        <relationship name="sessionWindow" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SessionWindow" inverseName="sessionTabGroups" inverseEntity="SessionWindow"/>
+    </entity>
+    <entity name="SessionWindow" representedClassName="Data.SessionWindow" syncable="YES">
+        <attribute name="index" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isPrivate" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSelected" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="windowId" attributeType="UUID" usesScalarValueType="NO"/>
+        <relationship name="sessionTabGroups" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTabGroup" inverseName="sessionWindow" inverseEntity="SessionTabGroup"/>
+        <relationship name="sessionTabs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="SessionTab" inverseName="sessionWindow" inverseEntity="SessionTab"/>
+    </entity>
+    <entity name="WalletUserAsset" representedClassName="Data.WalletUserAsset" syncable="YES">
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="coin" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="coingeckoId" optional="YES" attributeType="String"/>
+        <attribute name="contractAddress" optional="YES" attributeType="String"/>
+        <attribute name="decimals" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isDeletedByUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isERC20" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC721" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isERC1155" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isNFT" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isSpam" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="logo" optional="YES" attributeType="String"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="symbol" optional="YES" attributeType="String"/>
+        <attribute name="tokenId" optional="YES" attributeType="String"/>
+        <attribute name="visible" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="walletUserAssetGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WalletUserAssetGroup" inverseName="walletUserAssets" inverseEntity="WalletUserAssetGroup"/>
+    </entity>
+    <entity name="WalletUserAssetBalance" representedClassName="Data.WalletUserAssetBalance" syncable="YES">
+        <attribute name="accountAddress" optional="YES" attributeType="String"/>
+        <attribute name="balance" optional="YES" attributeType="String"/>
+        <attribute name="chainId" optional="YES" attributeType="String"/>
+        <attribute name="contractAddress" optional="YES" attributeType="String"/>
+        <attribute name="symbol" optional="YES" attributeType="String"/>
+        <attribute name="tokenId" optional="YES" attributeType="String"/>
+    </entity>
+    <entity name="WalletUserAssetGroup" representedClassName="Data.WalletUserAssetGroup" syncable="YES">
+        <attribute name="groupId" optional="YES" attributeType="String"/>
+        <relationship name="walletUserAssets" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WalletUserAsset" inverseName="walletUserAssetGroup" inverseEntity="WalletUserAsset"/>
+    </entity>
+</model>

--- a/ios/brave-ios/Sources/Data/models/WalletUserAssetBalance.swift
+++ b/ios/brave-ios/Sources/Data/models/WalletUserAssetBalance.swift
@@ -123,7 +123,7 @@ public final class WalletUserAssetBalance: NSManagedObject, CRUD {
   ///     - asset: An optional value of `BraveWallet.BlockchainToken` to be removed from CD, nil value will remove the restriction of asset matching
   ///     - account: An optional value of `String`. It is the account's address value. nil value will remove the restriction of account address matching
   ///     - completion: An optional completion block
-  public static func removeBalance(
+  public static func removeBalances(
     for asset: BraveWallet.BlockchainToken? = nil,
     account: String? = nil,
     completion: (() -> Void)? = nil
@@ -157,7 +157,7 @@ public final class WalletUserAssetBalance: NSManagedObject, CRUD {
   ///     - network: `BraveWallet.NetworkInfo`, any user asset balance that matches this network's chainId
   ///     will be removed
   ///     - completion: An optional completion block
-  public static func removeBalance(
+  public static func removeBalances(
     for network: BraveWallet.NetworkInfo,
     completion: (() -> Void)? = nil
   ) {

--- a/ios/brave-ios/Sources/Data/models/WalletUserAssetBalance.swift
+++ b/ios/brave-ios/Sources/Data/models/WalletUserAssetBalance.swift
@@ -49,7 +49,7 @@ public final class WalletUserAssetBalance: NSManagedObject, CRUD {
   ///     - context: An optional value of `NSManagedObjectContext`
   ///
   /// - Returns: An optional of list of `WalletUserAssetBalance` that matches given parameters.
-  public static func getBalance(
+  public static func getBalances(
     for asset: BraveWallet.BlockchainToken? = nil,
     account: String? = nil,
     context: NSManagedObjectContext? = nil

--- a/ios/brave-ios/Sources/Data/models/WalletUserAssetBalance.swift
+++ b/ios/brave-ios/Sources/Data/models/WalletUserAssetBalance.swift
@@ -1,0 +1,190 @@
+// Copyright 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+import Shared
+import BraveCore
+import os.log
+
+public final class WalletUserAssetBalance: NSManagedObject, CRUD {
+  @NSManaged public var contractAddress: String
+  @NSManaged public var symbol: String
+  @NSManaged public var chainId: String
+  @NSManaged public var tokenId: String
+  @NSManaged public var balance: String
+  @NSManaged public var accountAddress: String
+  
+  @available(*, unavailable)
+  public init() {
+    fatalError("No Such Initializer: init()")
+  }
+  
+  @available(*, unavailable)
+  public init(context: NSManagedObjectContext) {
+    fatalError("No Such Initializer: init(context:)")
+  }
+  
+  @objc
+  private override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+    super.init(entity: entity, insertInto: context)
+  }
+  
+  public init(context: NSManagedObjectContext, asset: BraveWallet.BlockchainToken, balance: String, account: String) {
+    let entity = Self.entity(context)
+    super.init(entity: entity, insertInto: context)
+    self.contractAddress = asset.contractAddress
+    self.chainId = asset.chainId
+    self.symbol = asset.symbol
+    self.tokenId = asset.tokenId
+    self.balance = balance
+    self.accountAddress = account
+  }
+  
+  /// - Parameters:
+  ///     - asset: An optional value of `BraveWallet.BlockchainToken`, nil value will remove the restriction of asset matching
+  ///     - account: An optional value of `String`. It is the account's address value. nil value will remove the restriction of account address matching
+  ///     - context: An optional value of `NSManagedObjectContext`
+  ///
+  /// - Returns: An optional of list of `WalletUserAssetBalance` that matches given parameters.
+  public static func getBalance(
+    for asset: BraveWallet.BlockchainToken? = nil,
+    account: String? = nil,
+    context: NSManagedObjectContext? = nil
+  ) -> [WalletUserAssetBalance]? {
+    if asset == nil, account == nil { // all `WalletAssetBalnce` with no restriction on assets or accounts
+      return WalletUserAssetBalance.all()
+    } else if let asset, account == nil {
+      let predicate = NSPredicate(
+        format: "contractAddress == %@ && chainId == %@ && symbol == %@ && tokenId == %@",
+        asset.contractAddress,
+        asset.chainId,
+        asset.symbol,
+        asset.tokenId
+      )
+      return WalletUserAssetBalance.all(
+        where: predicate,
+        context: context ?? DataController.viewContext
+      )
+    } else if asset == nil, let account {
+      return WalletUserAssetBalance.all(
+        where: NSPredicate(format: "accountAddress == %@", account),
+        context: context ?? DataController.viewContext
+      )
+    } else if let asset, let account {
+      let predicate = NSPredicate(
+        format: "contractAddress == %@ && chainId == %@ && symbol == %@ && tokenId == %@ && accountAddress == %@",
+        asset.contractAddress,
+        asset.chainId,
+        asset.symbol,
+        asset.tokenId,
+        account
+      )
+      return WalletUserAssetBalance.all(
+        where: predicate,
+        context: context ?? DataController.viewContext
+      )
+    }
+    return nil
+  }
+  
+  public static func updateBalance(
+    for asset: BraveWallet.BlockchainToken,
+    balance: String,
+    account: String,
+    completion: (() -> Void)? = nil
+  ) {
+    DataController.perform(context: .new(inMemory: false), save: false) { context in
+      let predicate = NSPredicate(
+        format: "contractAddress == %@ && chainId == %@ && symbol == %@ && tokenId == %@ && accountAddress == %@",
+        asset.contractAddress,
+        asset.chainId,
+        asset.symbol,
+        asset.tokenId,
+        account
+      )
+      if let asset = WalletUserAssetBalance.first(where: predicate, context: context) {
+        asset.balance = balance
+      } else {
+        _ = WalletUserAssetBalance(context: context, asset: asset, balance: balance, account: account)
+      }
+      
+      WalletUserAssetBalance.saveContext(context)
+      
+      DispatchQueue.main.async {
+        completion?()
+      }
+    }
+  }
+  
+  /// - Parameters:
+  ///     - asset: An optional value of `BraveWallet.BlockchainToken` to be removed from CD, nil value will remove the restriction of asset matching
+  ///     - account: An optional value of `String`. It is the account's address value. nil value will remove the restriction of account address matching
+  ///     - completion: An optional completion block
+  public static func removeBalance(
+    for asset: BraveWallet.BlockchainToken? = nil,
+    account: String? = nil,
+    completion: (() -> Void)? = nil
+  ) {
+    var predicate: NSPredicate?
+    if let asset, let accountAddress = account {
+      predicate = NSPredicate(
+        format: "contractAddress == %@ && chainId == %@ && symbol == %@ && tokenId == %@ && accountAddress == %@",
+        asset.contractAddress,
+        asset.chainId,
+        asset.symbol,
+        asset.tokenId,
+        accountAddress
+      )
+    } else if let asset {
+      predicate = NSPredicate(
+        format: "contractAddress == %@ && chainId == %@ && symbol == %@ && tokenId == %@",
+        asset.contractAddress,
+        asset.chainId,
+        asset.symbol,
+        asset.tokenId
+      )
+    }
+    WalletUserAssetBalance.deleteAll(
+      predicate: predicate,
+      completion: completion
+    )
+  }
+  
+  /// - Parameters:
+  ///     - network: `BraveWallet.NetworkInfo`, any user asset balance that matches this network's chainId
+  ///     will be removed
+  ///     - completion: An optional completion block
+  public static func removeBalance(
+    for network: BraveWallet.NetworkInfo,
+    completion: (() -> Void)? = nil
+  ) {
+    let predict = NSPredicate(format: "chainId == %@", network.chainId)
+    WalletUserAssetBalance.deleteAll(
+      predicate: predict,
+      completion: completion
+    )
+  }
+}
+
+extension WalletUserAssetBalance {
+  private static func entity(_ context: NSManagedObjectContext) -> NSEntityDescription {
+    NSEntityDescription.entity(forEntityName: "WalletUserAssetBalance", in: context)!
+  }
+  
+  private static func saveContext(_ context: NSManagedObjectContext) {
+    if context.concurrencyType == .mainQueueConcurrencyType {
+      Logger.module.warning("Writing to view context, this should be avoided.")
+    }
+    
+    if context.hasChanges {
+      do {
+        try context.save()
+      } catch {
+        assertionFailure("Error saving DB: \(error.localizedDescription)")
+      }
+    }
+  }
+}

--- a/ios/brave-ios/Tests/DataTests/WalletUserAssetBalanceTests.swift
+++ b/ios/brave-ios/Tests/DataTests/WalletUserAssetBalanceTests.swift
@@ -28,9 +28,9 @@ class WalletUserAssetBalanceTests: CoreDataTestCase {
     createAndWait(asset: asset2, balance: "5.6789", account: account3)
     
     DataController.viewContext.refreshAllObjects()
-    let assetBalance = WalletUserAssetBalance.getBalance(for: asset, account: account1)
-    let asset2Balance = WalletUserAssetBalance.getBalance(for: asset2, account: account3)
-    let assetBalances = WalletUserAssetBalance.getBalance(for: asset)
+    let assetBalance = WalletUserAssetBalance.getBalances(for: asset, account: account1)
+    let asset2Balance = WalletUserAssetBalance.getBalances(for: asset2, account: account3)
+    let assetBalances = WalletUserAssetBalance.getBalances(for: asset)
     let allAssetBalance = assetBalances?.reduce(0.0, { partialResult, assetBalance in
       partialResult + (Double(assetBalance.balance) ?? 0.0)
     })
@@ -95,13 +95,13 @@ class WalletUserAssetBalanceTests: CoreDataTestCase {
     }
     
     DataController.viewContext.refreshAllObjects()
-    let assetBalance1 = WalletUserAssetBalance.getBalance(for: asset, account: account1)
+    let assetBalance1 = WalletUserAssetBalance.getBalances(for: asset, account: account1)
     XCTAssertEqual(assetBalance1?.count, 1)
     XCTAssertEqual(assetBalance1!.first!.balance, "9.8765")
-    let assetBalance2 = WalletUserAssetBalance.getBalance(for: asset, account: account2)
+    let assetBalance2 = WalletUserAssetBalance.getBalances(for: asset, account: account2)
     XCTAssertEqual(assetBalance2?.count, 1)
     XCTAssertEqual(assetBalance2!.first!.balance, "0.8766")
-    let assetBalance3 = WalletUserAssetBalance.getBalance(for: asset2, account: account3)
+    let assetBalance3 = WalletUserAssetBalance.getBalances(for: asset2, account: account3)
     XCTAssertEqual(assetBalance3?.count, 1)
     XCTAssertEqual(assetBalance3!.first!.balance, "5.6789")
   }

--- a/ios/brave-ios/Tests/DataTests/WalletUserAssetBalanceTests.swift
+++ b/ios/brave-ios/Tests/DataTests/WalletUserAssetBalanceTests.swift
@@ -52,7 +52,7 @@ class WalletUserAssetBalanceTests: CoreDataTestCase {
     XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAssetBalance.removeBalance(for: asset)
+      WalletUserAssetBalance.removeBalances(for: asset)
     }
     
     XCTAssertEqual(try! DataController.viewContext.count(for: self.fetchRequest), 0)
@@ -64,7 +64,7 @@ class WalletUserAssetBalanceTests: CoreDataTestCase {
     XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAssetBalance.removeBalance(for: asset, account: account1)
+      WalletUserAssetBalance.removeBalances(for: asset, account: account1)
     }
     
     XCTAssertEqual(try! DataController.viewContext.count(for: self.fetchRequest), 1)
@@ -77,7 +77,7 @@ class WalletUserAssetBalanceTests: CoreDataTestCase {
     XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 3)
     
     backgroundSaveAndWaitForExpectation {
-      WalletUserAssetBalance.removeBalance(for: mockSolNetwork)
+      WalletUserAssetBalance.removeBalances(for: mockSolNetwork)
     }
     
     XCTAssertEqual(try! DataController.viewContext.count(for: self.fetchRequest), 2)

--- a/ios/brave-ios/Tests/DataTests/WalletUserAssetBalanceTests.swift
+++ b/ios/brave-ios/Tests/DataTests/WalletUserAssetBalanceTests.swift
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import CoreData
+import XCTest
+@testable import Data
+import TestHelpers
+import BraveCore
+
+class WalletUserAssetBalanceTests: CoreDataTestCase {
+  
+  let asset = BraveWallet.BlockchainToken(contractAddress: "0x123", name: "mockAsset", logo: "", isErc20: true, isErc721: false, isErc1155: false, isNft: false, isSpam: false, symbol: "MA", decimals: 18, visible: true, tokenId: "asset", coingeckoId: "", chainId: "0x1", coin: .eth)
+  let asset2 = BraveWallet.BlockchainToken(contractAddress: "0x123", name: "mockAsset2", logo: "", isErc20: false, isErc721: false, isErc1155: false, isNft: false, isSpam: false, symbol: "MA2", decimals: 16, visible: false, tokenId: "asset2", coingeckoId: "", chainId: "0x67", coin: .sol)
+  let account1 = "0x35DCec532e809A3dAa04ED3Fd949495f7BAc9090"
+  let account2 = "0x84D4937cd23753FB71310438b7C2e4Ade45b3896"
+  let account3 = "Be6iLdEVKj4bqSMKseMs8qdzBWudLFkebsEVGRmgabcd"
+  let mockSolNetwork = BraveWallet.NetworkInfo(chainId: "0x67", chainName: "Solana Test Network", blockExplorerUrls: [], iconUrls: [], activeRpcEndpointIndex: 0, rpcEndpoints: [], symbol: "SOL", symbolName: "SOL", decimals: 9, coin: .sol, supportedKeyrings: [], isEip1559: false)
+  
+  let fetchRequest = NSFetchRequest<WalletUserAssetBalance>(entityName: String(describing: WalletUserAssetBalance.self))
+  
+  // MARK: - Get Balance
+  
+  func testGetBalance() {
+    createAndWait(asset: asset, balance: "0.1234", account: account1)
+    createAndWait(asset: asset, balance: "0.8766", account: account2)
+    createAndWait(asset: asset2, balance: "5.6789", account: account3)
+    
+    DataController.viewContext.refreshAllObjects()
+    let assetBalance = WalletUserAssetBalance.getBalance(for: asset, account: account1)
+    let asset2Balance = WalletUserAssetBalance.getBalance(for: asset2, account: account3)
+    let assetBalances = WalletUserAssetBalance.getBalance(for: asset)
+    let allAssetBalance = assetBalances?.reduce(0.0, { partialResult, assetBalance in
+      partialResult + (Double(assetBalance.balance) ?? 0.0)
+    })
+    XCTAssertEqual(assetBalance?.count, 1)
+    XCTAssertEqual(assetBalance!.first!.balance, "0.1234")
+    XCTAssertEqual(assetBalance!.first!.accountAddress, account1)
+    XCTAssertEqual(asset2Balance?.count, 1)
+    XCTAssertEqual(asset2Balance!.first!.balance, "5.6789")
+    XCTAssertEqual(asset2Balance!.first!.accountAddress, account3)
+    XCTAssertEqual(assetBalances?.count, 2)
+    XCTAssertEqual(allAssetBalance, 1) // 0.1234 + 0.8766 == 1
+  }
+  
+  // MARK: - Delete
+  
+  func testRemoveAllAssetBalance() {
+    createAndWait(asset: asset, balance: "0.1234", account: account1)
+    createAndWait(asset: asset, balance: "0.8766", account: account2)
+    XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
+    
+    backgroundSaveAndWaitForExpectation {
+      WalletUserAssetBalance.removeBalance(for: asset)
+    }
+    
+    XCTAssertEqual(try! DataController.viewContext.count(for: self.fetchRequest), 0)
+  }
+  
+  func testRemoveAssetBalanceByAccount() {
+    createAndWait(asset: asset, balance: "0.1234", account: account1)
+    createAndWait(asset: asset, balance: "0.8766", account: account2)
+    XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 2)
+    
+    backgroundSaveAndWaitForExpectation {
+      WalletUserAssetBalance.removeBalance(for: asset, account: account1)
+    }
+    
+    XCTAssertEqual(try! DataController.viewContext.count(for: self.fetchRequest), 1)
+  }
+  
+  func testRemoveAssetBalanceByNetwork() {
+    createAndWait(asset: asset, balance: "0.1234", account: account1)
+    createAndWait(asset: asset, balance: "0.8766", account: account2)
+    createAndWait(asset: asset2, balance: "5.6789", account: account3)
+    XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 3)
+    
+    backgroundSaveAndWaitForExpectation {
+      WalletUserAssetBalance.removeBalance(for: mockSolNetwork)
+    }
+    
+    XCTAssertEqual(try! DataController.viewContext.count(for: self.fetchRequest), 2)
+  }
+  
+  // MARK: - Update
+  func testUpdateAssetBalance() {
+    createAndWait(asset: asset, balance: "0.1234", account: account1)
+    createAndWait(asset: asset, balance: "0.8766", account: account2)
+    createAndWait(asset: asset2, balance: "5.6789", account: account3)
+    XCTAssertEqual(try! DataController.viewContext.count(for: fetchRequest), 3)
+    
+    backgroundSaveAndWaitForExpectation {
+      WalletUserAssetBalance.updateBalance(for: asset, balance: "9.8765", account: account1)
+    }
+    
+    DataController.viewContext.refreshAllObjects()
+    let assetBalance1 = WalletUserAssetBalance.getBalance(for: asset, account: account1)
+    XCTAssertEqual(assetBalance1?.count, 1)
+    XCTAssertEqual(assetBalance1!.first!.balance, "9.8765")
+    let assetBalance2 = WalletUserAssetBalance.getBalance(for: asset, account: account2)
+    XCTAssertEqual(assetBalance2?.count, 1)
+    XCTAssertEqual(assetBalance2!.first!.balance, "0.8766")
+    let assetBalance3 = WalletUserAssetBalance.getBalance(for: asset2, account: account3)
+    XCTAssertEqual(assetBalance3?.count, 1)
+    XCTAssertEqual(assetBalance3!.first!.balance, "5.6789")
+  }
+  
+  // MARK: - Utility
+  
+  @discardableResult
+  private func createAndWait(
+    asset: BraveWallet.BlockchainToken,
+    balance: String,
+    account: String
+  ) -> WalletUserAssetBalance {
+    backgroundSaveAndWaitForExpectation {
+      WalletUserAssetBalance.updateBalance(for: asset, balance: balance, account: account)
+    }
+    let request = try! DataController.viewContext.fetch(fetchRequest)
+    return request.first!
+  }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35986

We are now caching asset's balance. They can be easily fetch from CD via token info or account info or both.
Cached balance will be refreshed under certain scenarios. they will be listed in the test plan.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
<!-- Any useful notes explaining how best to test and verify. -->
- Upgrade (current target 1.63.x)
1. install a older version of Brave (1.62.x and earlier)
2. set up a wallet with some balance 
3. Dismiss wallet then open 
4. Notice every time wallet open triggers balance fetching
5. upgrade Brave to the 1.63.x
6. Open wallet you will notice there will be a loading time to fetch balance since we have never cached any
7. Dismiss wallet and open again
8. Notice the balance still being displayed with no loading. 

- New Wallet Set up
1. Fresh install wallet and create a new wallet from onboarding 
9. All default user assets will appear in Portfolio with 0 balance. 
10. Dismiss the wallet then open it (without locking)
11. There will be no loading in Portfolio. 

- Restore A Wallet 
Note: Currently, we have known issues https://github.com/brave/brave-browser/issues/35696 and https://github.com/brave/brave-browser/issues/35697 these two cause auto-discovery assets are not discovered right after restoring. We will use a workaround to verify auto-discovery assets can be discovered and their balances are being fetched correctly. But this issue helps us to verify another scenario I will explain later in other test steps.
1. Delete Brave and fresh install Brave 
2. Restore a wallet from onboarding (Wallet A)
3. You will see default user assets are being displayed and their balance are being fetched or in within couple seconds based on internet speed.
4. Dismiss the wallet then open it (without locking)
12. There will be no loading in Portfolio.
13. Notice there is no auto-discovered assets got discovered. This is the issue mentioned earlier. 
14. Let's take advantage of this issue by checking if wallet will add and fetch balance of a token that we already know this wallet has
15. Let's say we already know Wallet A has some balance of `WETH` on `Polygon Mainnet`
16. Tap Edit Visible Asset to bring up the token list, and search for `WETH`
17. Tap on `WETH` to mark it as visible asset
18. Back to Portfolio, check `WETH` now appears and its balance is fetched. 
19. A workaround to let core give the rest of auto-discovery assets is go to `NFTs` tab, enable NFT auto-discovery in the prompt
20. A spinner will show up indicating wallet starts discovering assets. 
21. The spinner under `Assets` also shows up if you navigate to `Assets`
22. After a while, once the spinner disappears, some new assets will show up in `Assets` that this Wallet A owns with some balance. Please check if their balances were fetched correctly. 
23. repeat step 4-5
24. Lock the wallet
25. restore a new wallet (Wallet A)
26. Check user assets and balance are fetched correctly, 
27. Repeat step 4-5
- Add a primary or secondary account to wallet 
1. Group visible assets by `Account` in Portfolio 
2. add a primary account 
3. check the native token has been added to Portfolio and its balance is fetched "0"
4. add a secondary account with some balance 
6. check all visible assets have the same coin type are displayed under this new account and their balances are fetched correctly 
- Add/Remove a new network 
1. Group visible assets by `Group`
2. add/remove a custom network from wallet settings or a dapp 
3. Check if the new network group is added in Portfolio and its native asset is displayed in the group with its balance fetched correctly. (Or removed if the network is removed)
- Add/Remove custom token
1. add/remove a custom token from wallet settings or a dapp 
2. Check if the new token is displayed in Portfolio with its balance fetched correctly. (Or removed if the token is removed)
- Check balance after a transaction is confirmed/error/dropped 
1. make a send transaction of token A from Portfolio 
2. after the transaction status becomes `Confirmed`
3. check if token A balance is updated
4. Not sure how to make a transaction error out or dropped. but Once a transaction status becomes error or dropped. Some gas fee was consumed so the native token balance is relatively decreased. 

In summary, balances in Portfolio (Assets) will be refreshed when
1. A wallet is created 
2. A wallet is restored
3. When wallet is unlocked 
4. A account is created or added 
6. A network is added
7. An asset is added 
8. An asset's visibility status is changed to be visible
9. A transaction is confirmed or error out or dropped

Note: Transactions that are submitted by Dapps via signing request through wallet, since there is no access from Wallet to know the transaction status that is not created by Brave Wallet, it is not possible to determine when to refresh the balance based this transaction's status until we can observe all on-chain activity for an address. In this case, to refresh balance, user has to lock and unlock the wallet. 

