### PR TITLE
Revert "Allow first tab to be selected at edge of screen in fullscreen"

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -9,8 +9,6 @@
 #include <limits>
 
 #include "brave/browser/ui/brave_browser.h"
-#include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
-#include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/views/frame/brave_contents_view_util.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
@@ -22,7 +20,6 @@
 #include "chrome/browser/ui/views/bookmarks/bookmark_bar_view.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/browser_view_layout_delegate.h"
-#include "chrome/browser/ui/views/frame/tab_strip_region_view.h"
 #include "chrome/browser/ui/views/infobars/infobar_container_view.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
 #include "ui/views/border.h"
@@ -144,28 +141,7 @@ int BraveBrowserViewLayout::LayoutTabStripRegion(int top) {
     return top;
   }
 
-  top = BrowserViewLayout::LayoutTabStripRegion(top);
-
-  if (tabs::features::HorizontalTabsUpdateEnabled()) {
-    // If we are not maximized or fullscreen, then insert a medium sized space
-    // between the tab strip and the left (or right, depending upon RTL) edge of
-    // the browser. In maximized or fullscreen mode, we don't want a margin
-    // because the user should be able to select the first tab by clicking the
-    // edge of the screen.
-    if (!browser_view_->IsFullscreen() && !browser_view_->IsMaximized()) {
-      constexpr int kTabStripMargin =
-          brave_tabs::kHorizontalTabStripLeftMargin -
-          brave_tabs::kHorizontalTabInset;
-      static_assert(kTabStripMargin >= 0,
-                    "The tabstrip margin cannot be less than 0.");
-      auto tab_strip_region_view_bounds = tab_strip_region_view_->bounds();
-      tab_strip_region_view_bounds.Inset(
-          gfx::Insets::TLBR(0, kTabStripMargin, 0, 0));
-      tab_strip_region_view_->SetBoundsRect(tab_strip_region_view_bounds);
-    }
-  }
-
-  return top;
+  return BrowserViewLayout::LayoutTabStripRegion(top);
 }
 
 int BraveBrowserViewLayout::LayoutBookmarkAndInfoBars(int top,

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/shared_pinned_tab_service.h"
@@ -165,6 +166,8 @@ void BraveTabStrip::MaybeStartDrag(
 
 void BraveTabStrip::AddedToWidget() {
   TabStrip::AddedToWidget();
+
+  UpdateTabStripMargins();
 
   if (BrowserView::GetBrowserViewForBrowser(GetBrowser())) {
     UpdateTabContainer();
@@ -376,6 +379,25 @@ void BraveTabStrip::UpdateTabContainer() {
     // In order to update shadow state, call ActiveStateChanged().
     tab_at(active_index.value())->ActiveStateChanged();
   }
+}
+
+void BraveTabStrip::UpdateTabStripMargins() {
+  if (!tabs::features::HorizontalTabsUpdateEnabled()) {
+    return;
+  }
+
+  gfx::Insets margins;
+
+  if (!ShouldShowVerticalTabs()) {
+    // There should be a medium size gap between the left edge of the tabstrip
+    // and the visual left edge of the first tab. Set a left margin that takes
+    // into account the visual tab inset.
+    margins.set_left(brave_tabs::kHorizontalTabStripLeftMargin -
+                     brave_tabs::kHorizontalTabInset);
+    DCHECK_GE(margins.left(), 0);
+  }
+
+  SetProperty(views::kMarginsKey, margins);
 }
 
 bool BraveTabStrip::ShouldShowVerticalTabs() const {

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -38,6 +38,7 @@ class BraveTabStrip : public TabStrip {
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ScrollBarVisibility);
 
   void UpdateTabContainer();
+  void UpdateTabStripMargins();
   bool ShouldShowVerticalTabs() const;
 
   TabContainer* GetTabContainerForTesting();

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -129,17 +129,6 @@ SkPath BraveVerticalTabStyle::GetPath(
         hit_test_outsets.set_top(0);
       }
 
-      // We also want the first tab (taking RTL into account) to be selectable
-      // in maximized or fullscreen mode by clicking at the very edge of the
-      // screen.
-      if (ShouldExtendHitTest() && tab()->controller()->IsTabFirst(tab())) {
-        if (tab()->GetMirrored()) {
-          hit_test_outsets.set_right(brave_tabs::kHorizontalTabInset * scale);
-        } else {
-          hit_test_outsets.set_left(brave_tabs::kHorizontalTabInset * scale);
-        }
-      }
-
       aligned_bounds.Outset(hit_test_outsets);
     }
   }


### PR DESCRIPTION
This reverts commit 2997f1b643d6240765d314c2e1362e36b636cb5a.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36025

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

