### PR TITLE
AI Chat onboarding links shouldn't open in webui on android (uplift to 1.63.x)

### DIFF
--- a/components/ai_chat/resources/page/components/privacy_message/index.tsx
+++ b/components/ai_chat/resources/page/components/privacy_message/index.tsx
@@ -21,7 +21,8 @@ const PRIVACY_URL = "https://brave.com/privacy/browser/#brave-leo"
 function PrivacyMessage () {
   const context = React.useContext(DataContext)
 
-  const handleLinkClick = (url: string) => {
+  const handleLinkClick = (e: React.MouseEvent, url: string) => {
+    e.preventDefault()
     const mojomUrl = new Url()
     mojomUrl.url = url
 
@@ -29,7 +30,7 @@ function PrivacyMessage () {
   }
 
   const createLinkWithClickHandler = (content: string, url: string) => (
-      <a onClick={() => handleLinkClick(url)} href={url} target='_blank'>
+      <a onClick={(e) => handleLinkClick(e, url)} href={url} target='_blank'>
         {content}
       </a>
   )


### PR DESCRIPTION
Uplift of #22020
Resolves https://github.com/brave/brave-browser/issues/35990

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.