### PR TITLE
AIChat Bug Fix: Enable Context Menu Invocation on Long-Press/Long-Tap for Leo's Responses

### DIFF
--- a/components/ai_chat/resources/page/components/conversation_list/index.tsx
+++ b/components/ai_chat/resources/page/components/conversation_list/index.tsx
@@ -99,8 +99,8 @@ function ConversationList(props: ConversationListProps) {
 
   const longPressProps = useLongPress({
     onLongPress: (e: React.TouchEvent) => {
-      const target = e.target as HTMLElement
-      const id = target.getAttribute('data-id')
+      const currentTarget = e.currentTarget as HTMLElement
+      const id = currentTarget.getAttribute('data-id')
       if (id === null) return
       showAssistantMenu(parseInt(id))
     },

--- a/components/common/useLongPress.ts
+++ b/components/common/useLongPress.ts
@@ -29,12 +29,13 @@ export default function useLongPress(props: LongPressProps) {
 
   const handleTouchStart = React.useCallback(
     (e: React.TouchEvent) => {
-      // The TouchEvent `e` gets nullified and is not available to the caller
-      // We must persist it
-      // https://legacy.reactjs.org/docs/legacy-event-pooling.html
-      e.persist()
+    // The TouchEvent `e` gets nullified and is unavailable to the caller.
+    // Persisting it (e.persist) would lose the reference by the time it reaches the caller.
+    // Instead, we create a copy of it to pass along.
+    // TODO(nullhook): might not need this from React 17 onwards
+      const eventCopy = {...e}
       touchTimer.current = setTimeout(
-        () => props.onLongPress(e),
+        () => props.onLongPress(eventCopy),
         props.delay === undefined ? DEFAULT_THRESHOLD : props.delay
       )
     },


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36089

the custom context menu wasn't visible on tap because it reads from`e.target` as oppose to `e.currentTarget` (the currently executed target), where the event listener with the custom data attribute is attached. therefore, if a user taps on a child element, `e.target` lacks the data attribute. to make `e.currentTarget` available to the caller, creating a copy of the event is necessary in react's runtime.

ideally, react should offer an `e.clone()` so the returning object never changes. it seems that starting from react 17, this extra handling isn't needed.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

