### PR TITLE
fix(wallet): Android WebUI Top Gap

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -19,9 +19,9 @@ export const navWidth = 240
 
 export const Wrapper = styled.div<{
   noPadding?: boolean
-  isPanel?: boolean
+  noTopPosition?: boolean
 }>`
-  --layout-top-position: ${(p) => (p.isPanel ? 0 : layoutTopPosition)}px;
+  --layout-top-position: ${(p) => (p.noTopPosition ? 0 : layoutTopPosition)}px;
   position: fixed;
   top: 0px;
   bottom: 0px;
@@ -155,6 +155,7 @@ export const CardHeader = styled.div<{
   shadowOpacity?: number
   backgroundOpacity?: number
   isPanel?: boolean
+  isAndroid?: boolean
   useDarkBackground?: boolean
 }>`
   --shadow-opacity: ${(p) =>
@@ -177,7 +178,8 @@ export const CardHeader = styled.div<{
     p.useDarkBackground
       ? 'var(--dark-background-color)'
       : leo.color.container.background};
-  border-radius: ${(p) => (p.isPanel ? '0px' : '24px 24px 0px 0px')};
+  border-radius: ${(p) =>
+    p.isPanel || p.isAndroid ? '0px' : '24px 24px 0px 0px'};
   width: 100%;
   padding: ${(p) => (p.isPanel ? '0px' : '0px 32px')};
   position: relative;

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -160,7 +160,7 @@ export const WalletPageWrapper = (props: Props) => {
       )}
       <Wrapper
         noPadding={noPadding}
-        isPanel={isPanel}
+        noTopPosition={isPanel || isAndroid}
       >
         {isWalletCreated && !hideHeader && !isPanel && !isAndroid && (
           <TabHeader hideHeaderMenu={hideHeaderMenu} />
@@ -205,6 +205,7 @@ export const WalletPageWrapper = (props: Props) => {
                 <CardHeader
                   shadowOpacity={headerShadowOpacity}
                   isPanel={isPanel}
+                  isAndroid={isAndroid}
                   useDarkBackground={useDarkBackground}
                   backgroundOpacity={headerBackgroundOpacity}
                 >


### PR DESCRIPTION
## Description 
Removes the `Top Gap` for `Android` webUI

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/36065>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. There should no longer be a `Top Gap` for `Android` webUI pages

Before:

![Screenshot 3](https://github.com/brave/brave-core/assets/40611140/34b4e98e-bbf9-47c0-89c4-494682a8c146)

After:

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/788eb37e-6a74-4bf9-9c86-98e1bb3f50c7)
