### PR TITLE
Set embedded_permission_element_initiated for wallet permission requests

### DIFF
--- a/browser/permissions/permission_manager_browsertest.cc
+++ b/browser/permissions/permission_manager_browsertest.cc
@@ -7,7 +7,6 @@
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
-#include "base/ranges/algorithm.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
@@ -160,10 +159,6 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
           &sub_request_origins[j]))
           << "case: " << i << ", address: " << j;
     }
-    // The activation of features::kPermissionQuietChip affects the order in
-    // which permission_request_manager->Requests() stores the request in to
-    // FILO.
-    base::ranges::reverse(sub_request_origins);
 
     url::Origin origin;
     ASSERT_TRUE(brave_wallet::GetConcatOriginFromWalletAddresses(
@@ -262,8 +257,6 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest, RequestPermissions) {
     EXPECT_TRUE(!observer->IsShowingBubble()) << "case: " << i;
     EXPECT_TRUE(IsPendingGroupedRequestsEmpty(cases[i].type)) << "case: " << i;
 
-    // Reversing back sub_request_origins to its original ordering.
-    base::ranges::reverse(sub_request_origins);
     for (size_t j = 0; j < addresses.size(); ++j) {
       EXPECT_EQ(host_content_settings_map()->GetContentSetting(
                     sub_request_origins[j].GetURL(),
@@ -308,10 +301,6 @@ IN_PROC_BROWSER_TEST_F(PermissionManagerBrowserTest,
           &sub_request_origins[j]))
           << "case: " << i << ", address: " << j;
     }
-    // The activation of features::kPermissionQuietChip affects the order in
-    // which permission_request_manager->Requests() stores the request in to
-    // FILO.
-    base::ranges::reverse(sub_request_origins);
 
     url::Origin origin;
     ASSERT_TRUE(brave_wallet::GetConcatOriginFromWalletAddresses(

--- a/chromium_src/components/permissions/permission_request_manager.cc
+++ b/chromium_src/components/permissions/permission_request_manager.cc
@@ -48,19 +48,13 @@ void PermissionRequestManager::AcceptDenyCancel(
   DCHECK((accepted_requests.size() + denied_requests.size() +
           cancelled_requests.size()) == requests_.size());
 
-  // We need to process requests in reverse order because
-  // PermissionRequestQueue impelementation of Push and Pop are paired with
-  // base::circular_dequeue's (push_back, pop_back) and (push_front, pop_front)
-  // Once pending_permission_requests_ is popped to the vector request_, the
-  // order is fixed because the reorder takes place in
-  // pending_permission_requests_.
-  for (auto it = requests_.crbegin(); it != requests_.crend(); ++it) {
-    if (base::Contains(accepted_requests, *it)) {
-      PermissionGrantedIncludingDuplicates(*it, /*is_one_time=*/false);
-    } else if (base::Contains(denied_requests, *it)) {
-      PermissionDeniedIncludingDuplicates(*it);
+  for (const auto& request : requests_) {
+    if (base::Contains(accepted_requests, request)) {
+      PermissionGrantedIncludingDuplicates(request, /*is_one_time=*/false);
+    } else if (base::Contains(denied_requests, request)) {
+      PermissionDeniedIncludingDuplicates(request);
     } else {
-      CancelledIncludingDuplicates(*it);
+      CancelledIncludingDuplicates(request);
     }
   }
 

--- a/components/permissions/contexts/brave_wallet_permission_context.cc
+++ b/components/permissions/contexts/brave_wallet_permission_context.cc
@@ -109,10 +109,14 @@ void BraveWalletPermissionContext::RequestPermission(
   if (addr_queue.empty()) {
     request_address_queues_.erase(addr_queue_it);
   }
-  PermissionContextBase::RequestPermission(
+  auto data =
       PermissionRequestData(this, request_data.id, request_data.user_gesture,
-                            sub_request_origin.GetURL()),
-      std::move(callback));
+                            sub_request_origin.GetURL());
+  // This will prevent PermissionRequestManager from reprioritize the request
+  // queue.
+  data.embedded_permission_element_initiated = true;
+  PermissionContextBase::RequestPermission(std::move(data),
+                                           std::move(callback));
 }
 
 // static


### PR DESCRIPTION
So that `requests_` in `PermissionRequestManager` won't get reordered then we can assume it is the same order as requested accounts requested from `permissions::BraveWalletPermissionContext::RequestPermissions`
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35971


The order difference between desktop and android was due to `PermissionUtil::DoesPlatformSupportChip()` in 
`PermissionRequestManager::ReprioritizeCurrentRequestIfNeeded()` so the best way to get consistent order between platforms is no reprioritization. 

Upstream doesn't run `"permission_manager_browsertest.cc` on Android and neither do we. So we relies on the same `PermissionManagerBrowserTest.RequestPermissions` from `//brave/browser/permissions/permission_manager_browsertest.cc` to guarantee the order is correct. 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Regression test
1. Test test plan in https://github.com/brave/brave-core/pull/18907 on desktop
2. There should be no regression

### Android test
1. Setup wallet with two Solana accounts
2. Navigate to https://anza-xyz.github.io/wallet-adapter/example/
3. Connect and choose desired account
4. After connect, the account in the button should be same as we just chose.