### PR TITLE
Wait for adblock components to be fully initialized before loading engines

### DIFF
--- a/components/brave_shields/content/test/test_filters_provider.cc
+++ b/components/brave_shields/content/test/test_filters_provider.cc
@@ -28,11 +28,13 @@ TestFiltersProvider::TestFiltersProvider(const std::string& rules,
 TestFiltersProvider::TestFiltersProvider(const std::string& rules,
                                          const std::string& resources,
                                          bool engine_is_default,
-                                         uint8_t permission_mask)
+                                         uint8_t permission_mask,
+                                         bool is_initialized)
     : AdBlockFiltersProvider(engine_is_default),
       rules_(rules),
       resources_(resources),
-      permission_mask_(permission_mask) {}
+      permission_mask_(permission_mask),
+      is_initialized_(is_initialized) {}
 
 TestFiltersProvider::~TestFiltersProvider() = default;
 
@@ -51,6 +53,16 @@ void TestFiltersProvider::LoadFilterSet(
 void TestFiltersProvider::LoadResources(
     base::OnceCallback<void(const std::string& resources_json)> cb) {
   std::move(cb).Run(resources_);
+}
+
+void TestFiltersProvider::Initialize() {
+  CHECK(!is_initialized_);
+  is_initialized_ = true;
+  NotifyObservers(engine_is_default_);
+}
+
+bool TestFiltersProvider::IsInitialized() const {
+  return is_initialized_;
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/content/test/test_filters_provider.h
+++ b/components/brave_shields/content/test/test_filters_provider.h
@@ -25,7 +25,8 @@ class TestFiltersProvider : public AdBlockFiltersProvider,
   TestFiltersProvider(const std::string& rules,
                       const std::string& resources,
                       bool engine_is_default,
-                      uint8_t permission_mask = 0);
+                      uint8_t permission_mask = 0,
+                      bool is_initialized = true);
   ~TestFiltersProvider() override;
 
   void LoadFilterSet(
@@ -35,12 +36,16 @@ class TestFiltersProvider : public AdBlockFiltersProvider,
   void LoadResources(
       base::OnceCallback<void(const std::string& resources_json)> cb) override;
 
+  void Initialize();
+  bool IsInitialized() const override;
+
   std::string GetNameForDebugging() override;
 
  private:
   std::string rules_;
   std::string resources_;
   uint8_t permission_mask_;
+  bool is_initialized_;
 };
 
 }  // namespace brave_shields

--- a/components/brave_shields/core/browser/BUILD.gn
+++ b/components/brave_shields/core/browser/BUILD.gn
@@ -31,4 +31,5 @@ static_library("browser") {
     "//components/prefs",
     "//crypto",
   ]
+  public_deps = [ "//base" ]
 }

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
@@ -95,7 +95,7 @@ void AdBlockComponentFiltersProvider::OnComponentReady(
   NotifyObservers(engine_is_default_);
 }
 
-bool AdBlockComponentFiltersProvider::IsInitialized() {
+bool AdBlockComponentFiltersProvider::IsInitialized() const {
   return !component_path_.empty();
 }
 

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
@@ -95,6 +95,10 @@ void AdBlockComponentFiltersProvider::OnComponentReady(
   NotifyObservers(engine_is_default_);
 }
 
+bool AdBlockComponentFiltersProvider::IsInitialized() {
+  return !component_path_.empty();
+}
+
 void AdBlockComponentFiltersProvider::LoadFilterSet(
     base::OnceCallback<
         void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb) {

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.h
@@ -61,6 +61,8 @@ class AdBlockComponentFiltersProvider : public AdBlockFiltersProvider {
 
   std::string GetNameForDebugging() override;
 
+  bool IsInitialized() override;
+
  private:
   friend class ::AdBlockServiceTest;
   friend class ::DebounceBrowserTest;

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.h
@@ -61,7 +61,7 @@ class AdBlockComponentFiltersProvider : public AdBlockFiltersProvider {
 
   std::string GetNameForDebugging() override;
 
-  bool IsInitialized() override;
+  bool IsInitialized() const override;
 
  private:
   friend class ::AdBlockServiceTest;

--- a/components/brave_shields/core/browser/ad_block_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider.cc
@@ -45,7 +45,7 @@ void AdBlockFiltersProvider::NotifyObservers(bool is_for_default_engine) {
   }
 }
 
-bool AdBlockFiltersProvider::IsInitialized() {
+bool AdBlockFiltersProvider::IsInitialized() const {
   return true;
 }
 

--- a/components/brave_shields/core/browser/ad_block_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider.cc
@@ -45,6 +45,10 @@ void AdBlockFiltersProvider::NotifyObservers(bool is_for_default_engine) {
   }
 }
 
+bool AdBlockFiltersProvider::IsInitialized() {
+  return true;
+}
+
 base::WeakPtr<AdBlockFiltersProvider> AdBlockFiltersProvider::AsWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }

--- a/components/brave_shields/core/browser/ad_block_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_filters_provider.h
@@ -48,7 +48,7 @@ class AdBlockFiltersProvider {
 
   // Intended to be overridden if the provider implementation is not immediately
   // ready at creation time.
-  virtual bool IsInitialized();
+  virtual bool IsInitialized() const;
 
  protected:
   bool engine_is_default_;

--- a/components/brave_shields/core/browser/ad_block_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_filters_provider.h
@@ -46,6 +46,10 @@ class AdBlockFiltersProvider {
 
   virtual std::string GetNameForDebugging() = 0;
 
+  // Intended to be overridden if the provider implementation is not immediately
+  // ready at creation time.
+  virtual bool IsInitialized();
+
  protected:
   bool engine_is_default_;
 

--- a/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
@@ -55,6 +55,14 @@ std::string AdBlockFiltersProviderManager::GetNameForDebugging() {
 }
 
 void AdBlockFiltersProviderManager::OnChanged(bool is_for_default_engine) {
+  auto& filters_providers = is_for_default_engine
+                                ? default_engine_filters_providers_
+                                : additional_engine_filters_providers_;
+  for (auto*& provider : filters_providers) {
+    if (!provider->IsInitialized()) {
+      return;
+    }
+  }
   NotifyObservers(is_for_default_engine);
 }
 

--- a/components/brave_shields/core/test/BUILD.gn
+++ b/components/brave_shields/core/test/BUILD.gn
@@ -8,8 +8,12 @@ import("//testing/test.gni")
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "ad_block_component_service_unittest.cc" ]
+  sources = [
+    "ad_block_component_service_unittest.cc",
+    "ad_block_filters_provider_manager_unittest.cc",
+  ]
   deps = [
+    "//brave/components/brave_shields/content/test:test_support",
     "//brave/components/brave_shields/core/browser",
     "//testing/gtest",
   ]

--- a/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
+++ b/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#include "brave/components/brave_shields/content/test/test_filters_provider.h"
+
+class FiltersProviderManagerTestObserver
+    : public brave_shields::AdBlockFiltersProvider::Observer {
+ public:
+  FiltersProviderManagerTestObserver() = default;
+
+  // AdBlockFiltersProvider::Observer
+  void OnChanged(bool is_default_engine) override { changed_count += 1; }
+
+  int changed_count = 0;
+};
+
+TEST(AdBlockFiltersProviderManagerTest, WaitUntilInitialized) {
+  FiltersProviderManagerTestObserver test_observer;
+  brave_shields::AdBlockFiltersProviderManager::GetInstance()->AddObserver(
+      &test_observer);
+
+  brave_shields::TestFiltersProvider provider1("", "", true, 0, false);
+  brave_shields::TestFiltersProvider provider2("", "", true, 0, false);
+  brave_shields::TestFiltersProvider provider3("", "", true, 0, false);
+
+  provider1.Initialize();
+  EXPECT_EQ(test_observer.changed_count, 0);
+  provider2.Initialize();
+  EXPECT_EQ(test_observer.changed_count, 0);
+  provider3.Initialize();
+  EXPECT_EQ(test_observer.changed_count, 1);
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35922

While tracing https://github.com/brave/brave-core/pull/22049, I noticed that `ReadDATFileData` is called over 2000 times when all adblock lists are enabled. This change cuts that down to 53 (i.e. just once per component).

**NOTE**: this change increases the amount of time necessary for adblock to be available after first launch, limiting it by the time taken to download the **slowest** adblock component. I was able to see YouTube ads on a fresh profile by immediately pasting `youtube.com` into the URL bar after making this change. It's not obvious how likely that is to be an issue across various network conditions and launch patterns. That said, this change _does_ noticeably improve startup performance, and I'm running out of alternative options.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

