### PR TITLE
fix(wallet): Auto Discovery Modal Android and Panel

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal.style.ts
@@ -5,17 +5,6 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 
-import { WalletButton } from '../../../shared/style'
-
-export const StyledWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 32px 40px;
-  border-radius: 16px;
-  z-index: 2;
-`
-
 export const Header = styled.h1`
   font-family: 'Poppins';
   font-style: normal;
@@ -56,42 +45,6 @@ export const ButtonRow = styled.div`
   align-items: center;
   width: 100%;
   margin-top: 24px;
-`
-
-export const ConfirmButton = styled(WalletButton)`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 12px 16px;
-  background-color: ${leo.color.button.background};
-  border-radius: 1000px;
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 20px;
-  letter-spacing: 0.03em;
-  color: ${leo.color.white};
-  border: none;
-  cursor: pointer;
-`
-
-export const CancelButton = styled(WalletButton)`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 12px 16px;
-  background-color: transparent;
-  border-radius: 1000px;
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 13px;
-  line-height: 20px;
-  letter-spacing: 0.03em;
-  color: ${leo.color.text.secondary};
-  border: none;
-  cursor: pointer;
+  gap: ${leo.spacing.l};
+  flex-wrap: wrap-reverse;
 `

--- a/components/brave_wallet_ui/components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/enable-nft-discovery-modal/enable-nft-discovery-modal.tsx
@@ -4,8 +4,15 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
 
+// selectors
+import {
+  useSafeUISelector //
+} from '../../../../common/hooks/use-safe-selector'
+import { UISelectors } from '../../../../common/selectors'
+
 // utils
 import { getLocale, splitStringForTag } from '../../../../../common/locale'
+import { loadTimeData } from '../../../../../common/loadTimeData'
 
 // components
 import { PopupModal } from '../../popup-modals/index'
@@ -13,14 +20,12 @@ import { PopupModal } from '../../popup-modals/index'
 // styles
 import {
   ButtonRow,
-  CancelButton,
-  ConfirmButton,
   Description,
   Header,
   Link,
-  StyledWrapper,
   Underline
 } from './enable-nft-discovery-modal.style'
+import { LeoSquaredButton, Column } from '../../../shared/style'
 
 interface Props {
   onConfirm: () => void
@@ -31,6 +36,10 @@ const LEARN_MORE_LINK =
   'https://github.com/brave/brave-browser/wiki/NFT-Discovery'
 
 export const EnableNftDiscoveryModal = ({ onConfirm, onCancel }: Props) => {
+  // Selectors
+  const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+
   const { beforeTag, duringTag, afterTag } = splitStringForTag(
     getLocale('braveWalletEnableNftAutoDiscoveryModalDescription'),
     1
@@ -44,10 +53,15 @@ export const EnableNftDiscoveryModal = ({ onConfirm, onCancel }: Props) => {
     <PopupModal
       title=''
       width='477px'
-      hideHeader
+      hideHeader={!isPanel && !isAndroid}
       onClose={onCancel}
     >
-      <StyledWrapper>
+      <Column
+        fullHeight={true}
+        fullWidth={true}
+        justifyContent='flex-start'
+        padding='32px 40px'
+      >
         <Header>
           {getLocale('braveWalletEnableNftAutoDiscoveryModalHeader')}
         </Header>
@@ -64,14 +78,17 @@ export const EnableNftDiscoveryModal = ({ onConfirm, onCancel }: Props) => {
           </Link>
         </Description>
         <ButtonRow>
-          <CancelButton onClick={onCancel}>
+          <LeoSquaredButton
+            onClick={onCancel}
+            kind='plain'
+          >
             {getLocale('braveWalletEnableNftAutoDiscoveryModalCancel')}
-          </CancelButton>
-          <ConfirmButton onClick={onConfirm}>
+          </LeoSquaredButton>
+          <LeoSquaredButton onClick={onConfirm}>
             {getLocale('braveWalletEnableNftAutoDiscoveryModalConfirm')}
-          </ConfirmButton>
+          </LeoSquaredButton>
         </ButtonRow>
-      </StyledWrapper>
+      </Column>
     </PopupModal>
   )
 }


### PR DESCRIPTION
## Description 
Fixes the `Auto Discovery Modal` styling for `Android` webUI and `Panel`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/36071>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Before:

![Screenshot 5](https://github.com/brave/brave-core/assets/40611140/85f15f70-5eb5-4fb8-a58b-c32011841ec0)

After:

![Screenshot 6](https://github.com/brave/brave-core/assets/40611140/9affcdfc-7b6a-4515-8135-8851e099a110)
