### PR TITLE
Fix error 0x80000003 on naive Windows install

### DIFF
--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
@@ -216,7 +216,8 @@ bool UninstallBraveWireguardService() {
           {}, {})) {
     LOG(WARNING) << "Failed to delete "
                  << brave_vpn::GetBraveVpnWireguardServiceName();
-    return false;
+    // No need to `return false` because we can also reach here when the service
+    // didn't exist.
   }
   return true;
 }

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
@@ -216,8 +216,7 @@ bool UninstallBraveWireguardService() {
           {}, {})) {
     LOG(WARNING) << "Failed to delete "
                  << brave_vpn::GetBraveVpnWireguardServiceName();
-    // No need to `return false` because we can also reach here when the service
-    // didn't exist.
+    return false;
   }
   return true;
 }

--- a/chromium_src/chrome/installer/setup/install_worker.cc
+++ b/chromium_src/chrome/installer/setup/install_worker.cc
@@ -44,8 +44,11 @@ namespace {
 
 // delete `BraveVpnWireguardService` from services and remove the tray icon.
 bool UninstallBraveVPNWireguardService(const CallbackWorkItem&) {
-  return brave_vpn::UninstallBraveWireguardService() &&
-         brave_vpn::UninstallStatusTrayIcon();
+  // Safe to ignore result as this is being called during installation.
+  // If false is returned, it will abort the installation.
+  brave_vpn::UninstallBraveWireguardService() &&
+      brave_vpn::UninstallStatusTrayIcon();
+  return true;
 }
 
 // Brave 1.50.114+ would register `BraveVpnService` for system level installs.


### PR DESCRIPTION
Both online and offline installers errored out with the above message when run on Windows systems that had never seen Brave before.

Resolves https://github.com/brave/brave-browser/issues/36147.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please test Brave's online and offline installers on a _clean_ Windows VM, that is, on a VM that has never seen Brave before.