### PR TITLE
Fixed installed vpn services are not updated for browser update

### DIFF
--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
@@ -11,8 +11,6 @@
 #include <winsvc.h>
 #include <winuser.h>
 
-#include <memory>
-
 #include <ios>
 
 #include "base/base_paths.h"
@@ -139,12 +137,12 @@ bool ConfigureServiceAutoRestart(const std::wstring& service_name,
   return true;
 }
 
-}  // namespace
-
 base::FilePath GetBraveVpnHelperServicePath() {
   base::FilePath asset_dir = base::PathService::CheckedGet(base::DIR_ASSETS);
   return asset_dir.Append(brave_vpn::kBraveVPNHelperExecutable);
 }
+
+}  // namespace
 
 bool ConfigureBraveWireguardService(const std::wstring& service_name) {
   ScopedScHandle scm(::OpenSCManager(nullptr, nullptr, SC_MANAGER_ALL_ACCESS));
@@ -176,9 +174,16 @@ bool ConfigureBraveWireguardService(const std::wstring& service_name) {
 // config.
 bool InstallBraveWireguardService() {
   base::CommandLine service_cmd(GetBraveVPNWireguardServiceExecutablePath());
-  std::unique_ptr<WorkItem> work_item(
-      CreateWorkItemForWireguardServiceInstall(service_cmd));
-  if (work_item->Do()) {
+  installer::InstallServiceWorkItem install_service_work_item(
+      brave_vpn::GetBraveVpnWireguardServiceName(),
+      brave_vpn::GetBraveVpnWireguardServiceDisplayName(), SERVICE_DEMAND_START,
+      service_cmd, base::CommandLine(base::CommandLine::NO_PROGRAM),
+      brave_vpn::wireguard::GetBraveVpnWireguardServiceRegistryStoragePath(),
+      {brave_vpn::GetBraveVpnWireguardServiceClsid()},
+      {brave_vpn::GetBraveVpnWireguardServiceIid()});
+  install_service_work_item.set_best_effort(true);
+  install_service_work_item.set_rollback_enabled(false);
+  if (install_service_work_item.Do()) {
     auto success = brave_vpn::ConfigureBraveWireguardService(
         brave_vpn::GetBraveVpnWireguardServiceName());
     if (success) {
@@ -229,41 +234,20 @@ bool UninstallStatusTrayIcon() {
 
 bool InstallBraveVPNHelperService() {
   base::CommandLine service_cmd(GetBraveVpnHelperServicePath());
-  std::unique_ptr<WorkItem> work_item(
-      CreateWorkItemForVpnHelperServiceInstall(service_cmd));
-  if (work_item->Do()) {
+  installer::InstallServiceWorkItem install_service_work_item(
+      brave_vpn::GetBraveVpnHelperServiceName(),
+      brave_vpn::GetBraveVpnHelperServiceDisplayName(), SERVICE_DEMAND_START,
+      service_cmd, base::CommandLine(base::CommandLine::NO_PROGRAM),
+      GetBraveVpnHelperRegistryStoragePath(), {}, {});
+  install_service_work_item.set_best_effort(true);
+  install_service_work_item.set_rollback_enabled(false);
+  if (install_service_work_item.Do()) {
     auto success =
         ConfigureServiceAutoRestart(brave_vpn::GetBraveVpnHelperServiceName(),
                                     brave_vpn::GetBraveVPNConnectionName());
     return success;
   }
   return false;
-}
-
-WorkItem* CreateWorkItemForWireguardServiceInstall(
-    const base::CommandLine& service_cmd) {
-  WorkItem* work_item = new installer::InstallServiceWorkItem(
-      brave_vpn::GetBraveVpnWireguardServiceName(),
-      brave_vpn::GetBraveVpnWireguardServiceDisplayName(), SERVICE_DEMAND_START,
-      service_cmd, base::CommandLine(base::CommandLine::NO_PROGRAM),
-      brave_vpn::wireguard::GetBraveVpnWireguardServiceRegistryStoragePath(),
-      {brave_vpn::GetBraveVpnWireguardServiceClsid()},
-      {brave_vpn::GetBraveVpnWireguardServiceIid()});
-  work_item->set_best_effort(true);
-  work_item->set_rollback_enabled(false);
-  return work_item;
-}
-
-WorkItem* CreateWorkItemForVpnHelperServiceInstall(
-    const base::CommandLine& service_cmd) {
-  WorkItem* work_item = new installer::InstallServiceWorkItem(
-      brave_vpn::GetBraveVpnHelperServiceName(),
-      brave_vpn::GetBraveVpnHelperServiceDisplayName(), SERVICE_DEMAND_START,
-      service_cmd, base::CommandLine(base::CommandLine::NO_PROGRAM),
-      GetBraveVpnHelperRegistryStoragePath(), {}, {});
-  work_item->set_best_effort(true);
-  work_item->set_rollback_enabled(false);
-  return work_item;
 }
 
 }  // namespace brave_vpn

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.cc
@@ -137,9 +137,8 @@ bool ConfigureServiceAutoRestart(const std::wstring& service_name,
   return true;
 }
 
-base::FilePath GetBraveVpnHelperServicePath() {
-  base::FilePath asset_dir = base::PathService::CheckedGet(base::DIR_ASSETS);
-  return asset_dir.Append(brave_vpn::kBraveVPNHelperExecutable);
+base::FilePath GetBraveVpnHelperServicePath(const base::FilePath& root_dir) {
+  return root_dir.Append(brave_vpn::kBraveVPNHelperExecutable);
 }
 
 }  // namespace
@@ -172,8 +171,9 @@ bool ConfigureBraveWireguardService(const std::wstring& service_name) {
 
 // Installs Brave VPN Wireguard Windows service and configures the service
 // config.
-bool InstallBraveWireguardService() {
-  base::CommandLine service_cmd(GetBraveVPNWireguardServiceExecutablePath());
+bool InstallBraveWireguardService(const base::FilePath& root_dir) {
+  base::CommandLine service_cmd(
+      GetBraveVPNWireguardServiceExecutablePath(root_dir));
   installer::InstallServiceWorkItem install_service_work_item(
       brave_vpn::GetBraveVpnWireguardServiceName(),
       brave_vpn::GetBraveVpnWireguardServiceDisplayName(), SERVICE_DEMAND_START,
@@ -232,8 +232,8 @@ bool UninstallStatusTrayIcon() {
                      IDC_BRAVE_VPN_TRAY_EXIT, 0) == TRUE;
 }
 
-bool InstallBraveVPNHelperService() {
-  base::CommandLine service_cmd(GetBraveVpnHelperServicePath());
+bool InstallBraveVPNHelperService(const base::FilePath& root_dir) {
+  base::CommandLine service_cmd(GetBraveVpnHelperServicePath(root_dir));
   installer::InstallServiceWorkItem install_service_work_item(
       brave_vpn::GetBraveVpnHelperServiceName(),
       brave_vpn::GetBraveVpnHelperServiceDisplayName(), SERVICE_DEMAND_START,

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h
@@ -8,8 +8,22 @@
 
 #include <string>
 
+namespace base {
+class CommandLine;
+class FilePath;
+}  // namespace base
+
+class WorkItem;
+
 namespace brave_vpn {
 
+// Caller should take care of deleting the returned work item.
+WorkItem* CreateWorkItemForWireguardServiceInstall(
+    const base::CommandLine& service_cmd);
+WorkItem* CreateWorkItemForVpnHelperServiceInstall(
+    const base::CommandLine& service_cmd);
+
+base::FilePath GetBraveVpnHelperServicePath();
 bool ConfigureBraveWireguardService(const std::wstring& service_name);
 bool InstallBraveWireguardService();
 bool UninstallBraveWireguardService();

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h
@@ -8,22 +8,8 @@
 
 #include <string>
 
-namespace base {
-class CommandLine;
-class FilePath;
-}  // namespace base
-
-class WorkItem;
-
 namespace brave_vpn {
 
-// Caller should take care of deleting the returned work item.
-WorkItem* CreateWorkItemForWireguardServiceInstall(
-    const base::CommandLine& service_cmd);
-WorkItem* CreateWorkItemForVpnHelperServiceInstall(
-    const base::CommandLine& service_cmd);
-
-base::FilePath GetBraveVpnHelperServicePath();
 bool ConfigureBraveWireguardService(const std::wstring& service_name);
 bool InstallBraveWireguardService();
 bool UninstallBraveWireguardService();

--- a/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h
+++ b/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h
@@ -8,13 +8,19 @@
 
 #include <string>
 
+#include "base/files/file_path.h"
+
+namespace base {
+class FilePath;
+}  // namespace base
+
 namespace brave_vpn {
 
 bool ConfigureBraveWireguardService(const std::wstring& service_name);
-bool InstallBraveWireguardService();
+bool InstallBraveWireguardService(const base::FilePath& root_dir);
 bool UninstallBraveWireguardService();
 bool UninstallStatusTrayIcon();
-bool InstallBraveVPNHelperService();
+bool InstallBraveVPNHelperService(const base::FilePath& root_dir);
 
 }  // namespace brave_vpn
 

--- a/browser/brave_vpn/win/service_details.cc
+++ b/browser/brave_vpn/win/service_details.cc
@@ -144,17 +144,9 @@ std::wstring GetBraveVpnWireguardTunnelServiceName() {
   NOTREACHED_NORETURN();
 }
 
-base::FilePath GetBraveVPNWireguardServiceInstallationPath(
-    const base::FilePath& target_path,
-    const base::Version& version) {
-  return target_path.AppendASCII(version.GetString())
-      .Append(brave_vpn::kBraveVpnWireguardServiceSubFolder)
-      .Append(brave_vpn::kBraveVpnWireguardServiceExecutable);
-}
-
-base::FilePath GetBraveVPNWireguardServiceExecutablePath() {
-  base::FilePath asset_dir = base::PathService::CheckedGet(base::DIR_ASSETS);
-  return asset_dir.Append(brave_vpn::kBraveVpnWireguardServiceSubFolder)
+base::FilePath GetBraveVPNWireguardServiceExecutablePath(
+    const base::FilePath& root_dir) {
+  return root_dir.Append(brave_vpn::kBraveVpnWireguardServiceSubFolder)
       .Append(brave_vpn::kBraveVpnWireguardServiceExecutable);
 }
 

--- a/browser/brave_vpn/win/service_details.h
+++ b/browser/brave_vpn/win/service_details.h
@@ -18,10 +18,8 @@ const IID& GetBraveVpnWireguardServiceIid();
 std::wstring GetBraveVpnWireguardTunnelServiceName();
 std::wstring GetBraveVpnWireguardServiceName();
 std::wstring GetBraveVpnWireguardServiceDisplayName();
-base::FilePath GetBraveVPNWireguardServiceInstallationPath(
-    const base::FilePath& target_path,
-    const base::Version& version);
-base::FilePath GetBraveVPNWireguardServiceExecutablePath();
+base::FilePath GetBraveVPNWireguardServiceExecutablePath(
+    const base::FilePath& root_dir);
 }  // namespace brave_vpn
 
 #endif  // BRAVE_BROWSER_BRAVE_VPN_WIN_SERVICE_DETAILS_H_

--- a/browser/brave_vpn/win/wireguard_utils_win.cc
+++ b/browser/brave_vpn/win/wireguard_utils_win.cc
@@ -16,16 +16,17 @@
 #include "base/command_line.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
+#include "base/path_service.h"
 #include "base/process/launch.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/win/com_init_util.h"
 #include "base/win/scoped_bstr.h"
-#include "brave/components/brave_vpn/common/win/utils.h"
-#include "brave/components/brave_vpn/common/wireguard/win/brave_wireguard_manager_idl.h"
 #include "brave/browser/brave_vpn/win/service_constants.h"
 #include "brave/browser/brave_vpn/win/service_details.h"
+#include "brave/components/brave_vpn/common/win/utils.h"
+#include "brave/components/brave_vpn/common/wireguard/win/brave_wireguard_manager_idl.h"
 
 namespace brave_vpn {
 
@@ -193,7 +194,8 @@ void WireguardGenerateKeypair(
 }
 
 void ShowBraveVpnStatusTrayIcon() {
-  auto executable_path = brave_vpn::GetBraveVPNWireguardServiceExecutablePath();
+  auto executable_path = brave_vpn::GetBraveVPNWireguardServiceExecutablePath(
+      base::PathService::CheckedGet(base::DIR_ASSETS));
   base::CommandLine interactive_cmd(executable_path);
   interactive_cmd.AppendSwitch(
       brave_vpn::kBraveVpnWireguardServiceInteractiveSwitchName);

--- a/chromium_src/chrome/elevation_service/elevator.cc
+++ b/chromium_src/chrome/elevation_service/elevator.cc
@@ -10,6 +10,7 @@
 
 #include <intsafe.h>
 
+#include "base/path_service.h"
 #include "base/win/windows_types.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 
@@ -29,7 +30,8 @@ namespace elevation_service {
 HRESULT Elevator::InstallVPNServices() {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   if (!brave_vpn::IsBraveVPNHelperServiceInstalled()) {
-    auto success = brave_vpn::InstallBraveVPNHelperService();
+    auto success = brave_vpn::InstallBraveVPNHelperService(
+        base::PathService::CheckedGet(base::DIR_ASSETS));
     if (!success) {
       return E_FAIL;
     }
@@ -37,7 +39,8 @@ HRESULT Elevator::InstallVPNServices() {
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)
   if (!brave_vpn::wireguard::IsWireguardServiceInstalled()) {
-    auto success = brave_vpn::InstallBraveWireguardService();
+    auto success = brave_vpn::InstallBraveWireguardService(
+        base::PathService::CheckedGet(base::DIR_ASSETS));
     if (!success) {
       return E_FAIL;
     }

--- a/chromium_src/chrome/installer/DEPS
+++ b/chromium_src/chrome/installer/DEPS
@@ -2,7 +2,6 @@ include_rules = [
   "+brave/browser/brave_vpn/win/brave_vpn_helper",
   "+brave/browser/brave_vpn/win/brave_vpn_wireguard_service",
   "+brave/browser/brave_vpn/win/service_details.h",
-  "+brave/browser/brave_vpn/win/wireguard_utils_win.h",
   "+brave/components/brave_vpn/browser/connection/ikev2/win",
   "+brave/components/brave_vpn/common/buildflags",
   "+brave/installer",

--- a/chromium_src/chrome/installer/DEPS
+++ b/chromium_src/chrome/installer/DEPS
@@ -2,6 +2,7 @@ include_rules = [
   "+brave/browser/brave_vpn/win/brave_vpn_helper",
   "+brave/browser/brave_vpn/win/brave_vpn_wireguard_service",
   "+brave/browser/brave_vpn/win/service_details.h",
+  "+brave/browser/brave_vpn/win/wireguard_utils_win.h",
   "+brave/components/brave_vpn/browser/connection/ikev2/win",
   "+brave/components/brave_vpn/common/buildflags",
   "+brave/installer",

--- a/chromium_src/chrome/installer/setup/install_worker.cc
+++ b/chromium_src/chrome/installer/setup/install_worker.cc
@@ -39,8 +39,6 @@
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_constants.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_helper/brave_vpn_helper_utils.h"
 #include "brave/browser/brave_vpn/win/brave_vpn_wireguard_service/install_utils.h"
-#include "brave/browser/brave_vpn/win/wireguard_utils_win.h"
-#endif
 
 namespace {
 
@@ -146,45 +144,10 @@ bool OneTimeVpnServiceCleanup(const base::FilePath& target_path,
   return true;
 }
 
-// Adds work items to register brave vpn helper service for Windows. Only for
-// system level installs.
-void AddBraveVPNHelperServiceWorkItems(WorkItemList* list) {
-  DCHECK(::IsUserAnAdmin());
-  list->AddWorkItem(CreateWorkItemForVpnHelperServiceInstall(service_cmd));
-}
-
-// Adds work items to register brave vpn wireguard service for Windows. Only for
-// system level installs.
-void AddBraveVPNWireguardServiceWorkItems(WorkItemList* list) {
-  DCHECK(::IsUserAnAdmin());
-  list->AddWorkItem(
-      brave_vpn::CreateWorkItemForWireguardServiceInstall(service_cmd));
-}
-
-void UpdateBraveVpn(const base::FilePath& target_path,
-                    const base::Version& new_version,
-                    WorkItemList* install_list) {
-  // When one time cleanup happens, we don't want to install the services.
-  // Service will be installed at the time of purchase.
-  if (OneTimeVpnServiceCleanup(target_path, new_version, install_list, false)) {
-    return;
-  }
-
-  // If the VPN service is installed, we should update installed services to
-  // make it have latest executable path.
-  if (brave_vpn::IsBraveVPNHelperServiceInstalled()) {
-    AddBraveVPNHelperServiceWorkItems(install_list);
-  }
-
-  if (brave_vpn::wireguard::IsWireguardServiceInstalled()) {
-    AddBraveVPNWireguardServiceWorkItems(install_list);
-  }
-}
-
 }  // namespace installer
 
-#define AddUpdateDowngradeVersionItem                     \
-  UpdateBraveVpn(target_path, new_version, install_list); \
+#define AddUpdateDowngradeVersionItem                               \
+  OneTimeVpnServiceCleanup(target_path, new_version, install_list); \
   AddUpdateDowngradeVersionItem
 
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/36210

If there is installed services, it should be updated during the browser update
to make these service has latest properties such as their executable path.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue

Another test plan:
1. Uninstall brave
2. Install brave and check vpn services(`BraveNightlyVpnWireguardService` and `BraveNightlyVpnService`) are not registered
   Can check installed service from `Task Manager` -> `Services`.