### PR TITLE
AI Chat: on android, don't show "refresh auth" UI for iAP subscriptions (uplift to 1.63.x)

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -408,6 +408,15 @@ void AIChatUIPageHandler::OnGetPremiumStatus(
     ai_chat::mojom::PremiumStatus status,
     ai_chat::mojom::PremiumInfoPtr info) {
   if (page_.is_bound()) {
+#if BUILDFLAG(IS_ANDROID)
+    // There is no UI for android to "refresh" with an iAP - we are likely still
+    // authenticating after first iAP, so we should show as active.
+    if (status == mojom::PremiumStatus::ActiveDisconnected &&
+        profile_->GetPrefs()->GetBoolean(
+            prefs::kBraveChatSubscriptionActiveAndroid)) {
+      status = mojom::PremiumStatus::Active;
+    }
+#endif
     std::move(callback).Run(status, std::move(info));
   }
 }


### PR DESCRIPTION
Uplift of #22149
Resolves https://github.com/brave/brave-browser/issues/36211

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.