### PR TITLE
fix: handle untranslated provider during rewards data lookup (uplift to 1.64.x)

### DIFF
--- a/components/brave_wallet_ui/utils/rewards_utils.ts
+++ b/components/brave_wallet_ui/utils/rewards_utils.ts
@@ -26,11 +26,15 @@ export const getRewardsProviderName = (provider?: string) => {
 
   const capitalized = provider.charAt(0).toUpperCase() + provider.slice(1)
   const localeString = `braveWallet${capitalized}`
-  const foundLocale = getLocale(localeString)
-  // If getLocale returns the string it was passed, that means
-  // no localization string was found. So we return the
-  // provider in that case.
-  return foundLocale === localeString ? provider : foundLocale
+  try {
+    const foundLocale = getLocale(localeString)
+    // If getLocale returns the string it was passed, that means
+    // no localization string was found. So we return the
+    // provider in that case.
+    return foundLocale === localeString ? provider : foundLocale
+  } catch (error) {
+    return provider
+  }
 }
 
 export const getRewardsAccountName = (provider?: string) => {


### PR DESCRIPTION
Uplift of #22174
Resolves https://github.com/brave/brave-browser/issues/36233

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.