### PR TITLE
Fix incorrect 1pes token invalidation on 1pes/normal switch. (uplift to 1.64.x)

### DIFF
--- a/browser/ephemeral_storage/ephemeral_storage_1p_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_1p_browsertest.cc
@@ -578,6 +578,16 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorage1pBrowserTest,
   ExpectValuesFromFramesAreEmpty(FROM_HERE,
                                  GetValuesFromFrames(first_party_tab));
 
+  SetValuesInFrame(first_party_tab->GetPrimaryMainFrame(), "ephemeral-a.com",
+                   "from=ephemeral-a.com");
+  {
+    ValuesFromFrame first_party_values =
+        GetValuesFromFrame(first_party_tab->GetPrimaryMainFrame());
+    EXPECT_EQ("ephemeral-a.com", first_party_values.local_storage);
+    EXPECT_EQ("ephemeral-a.com", first_party_values.session_storage);
+    EXPECT_EQ("from=ephemeral-a.com", first_party_values.cookies);
+  }
+
   // Disable 1p Ephemeral Storage mode.
   SetCookieSetting(a_site_ephemeral_storage_url_, CONTENT_SETTING_DEFAULT);
 
@@ -592,6 +602,22 @@ IN_PROC_BROWSER_TEST_F(EphemeralStorage1pBrowserTest,
     EXPECT_EQ("a.com", first_party_values.local_storage);
     EXPECT_EQ("a.com", first_party_values.session_storage);
     EXPECT_EQ("from=a.com", first_party_values.cookies);
+  }
+
+  // Re-enable 1p Ephemeral Storage mode.
+  SetCookieSetting(a_site_ephemeral_storage_url_, CONTENT_SETTING_SESSION_ONLY);
+
+  // Reload the page.
+  first_party_tab->GetController().Reload(content::ReloadType::NORMAL, true);
+  WaitForLoadStop(first_party_tab);
+
+  // Data should be read from Ephemeral Storage.
+  {
+    ValuesFromFrame first_party_values =
+        GetValuesFromFrame(first_party_tab->GetPrimaryMainFrame());
+    EXPECT_EQ("ephemeral-a.com", first_party_values.local_storage);
+    EXPECT_EQ("ephemeral-a.com", first_party_values.session_storage);
+    EXPECT_EQ("from=ephemeral-a.com", first_party_values.cookies);
   }
 }
 

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -137,8 +137,6 @@ std::optional<base::UnguessableToken> EphemeralStorageService::Get1PESToken(
     }
     token = base::UnguessableToken::Create();
     fpes_tokens_[ephemeral_storage_domain] = *token;
-  } else {
-    fpes_tokens_.erase(ephemeral_storage_domain);
   }
   return token;
 }


### PR DESCRIPTION
Uplift of #22147
Resolves https://github.com/brave/brave-browser/issues/36055

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.