### PR TITLE
Fixed some crashes with kChromeRefresh2023 features

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -48,6 +48,7 @@
 #include "content/public/test/browser_test.h"
 #include "testing/gmock/include/gmock/gmock-matchers.h"
 #include "testing/gmock/include/gmock/gmock.h"
+#include "ui/base/ui_base_features.h"
 #include "ui/events/base_event_utils.h"
 #include "ui/events/event.h"
 #include "ui/gfx/geometry/point.h"
@@ -753,6 +754,32 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {
       EXPECT_FALSE(IsDisabledItemForPrivate(item.built_in_item_type));
     }
   }
+}
+
+class SidebarBrowserTestWithChromeRefresh2023 : public SidebarBrowserTest {
+ public:
+  SidebarBrowserTestWithChromeRefresh2023() = default;
+  ~SidebarBrowserTestWithChromeRefresh2023() override = default;
+
+  void SetUp() override {
+    SidebarBrowserTest::SetUp();
+
+    feature_list_.InitAndEnableFeature(features::kChromeRefresh2023);
+  }
+
+  base::test::ScopedFeatureList feature_list_;
+};
+
+// To check enabling kChromeRefresh2023 doesn't make crash with sidebar opening.
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithChromeRefresh2023,
+                       SidebarOpeningTest) {
+  // Open side panel to check it doesn't make crash.
+  auto* panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser());
+  panel_ui->Toggle();
+
+  // Wait till panel UI opens.
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return GetSidePanel()->GetVisible(); }));
 }
 
 class SidebarBrowserTestWithPlaylist : public SidebarBrowserTest {

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -420,8 +420,19 @@ void BraveAppMenuModel::RemoveUpstreamMenus() {
 
   // Remove upstream's clear browsing data. It'll be added into history sub
   // menu at RecentTabsSubMenuModel::Build().
-  if (const auto index =
-          more_tools_model->GetIndexOfCommandId(IDC_CLEAR_BROWSING_DATA)) {
+  if (features::IsChromeRefresh2023()) {
+    auto index = GetIndexOfCommandId(IDC_CLEAR_BROWSING_DATA);
+    CHECK(index);
+    RemoveItemAt(*index);
+
+    // Remove upstream's profile menu. "Add new profile" will be added into more
+    // tools sub menu.
+    index = GetIndexOfCommandId(IDC_PROFILE_MENU_IN_APP_MENU);
+    CHECK(index);
+    RemoveItemAt(*index);
+  } else {
+    const auto index =
+        more_tools_model->GetIndexOfCommandId(IDC_CLEAR_BROWSING_DATA);
     more_tools_model->RemoveItemAt(*index);
   }
 

--- a/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
+++ b/browser/ui/views/frame/brave_non_client_hit_test_helper.cc
@@ -18,10 +18,21 @@ int NonClientHitTest(BrowserView* browser_view,
     return HTNOWHERE;
   }
 
-  // All toolbar elements are children of the container view in the toolbar.
-  DCHECK_EQ(1u, browser_view->toolbar()->children().size());
+  const auto children_count = browser_view->toolbar()->children().size();
+  int container_view_index = 0;
+  if (features::IsChromeRefresh2023()) {
+    // Upstream has two more children |background_view_left_| and
+    // |background_view_right_| behind the container view.
+    DCHECK_EQ(3u, children_count);
+    container_view_index = 2;
+  } else {
+    // All toolbar elements are children of the container view in the toolbar.
+    DCHECK_EQ(1u, children_count);
+  }
+
   int hit_test_result = views::GetHitTestComponent(
-      browser_view->toolbar()->children()[0], point_in_widget);
+      browser_view->toolbar()->children()[container_view_index],
+      point_in_widget);
   if (hit_test_result == HTNOWHERE || hit_test_result == HTCLIENT) {
     // The |point_in_widget| is out of toolbar or on toolbar's sub views.
     return hit_test_result;

--- a/browser/ui/views/side_panel/brave_side_panel.cc
+++ b/browser/ui/views/side_panel/brave_side_panel.cc
@@ -154,7 +154,10 @@ void BraveSidePanel::OnResize(int resize_amount, bool done_resizing) {
 }
 
 void BraveSidePanel::AddHeaderView(std::unique_ptr<views::View> view) {
-  // Do nothing.
+  // Need to keep here because SidePanelCoordinator referes this |view|'s
+  // child view(header_combobox_). We don't use this |header_view_|.
+  // So just keep it here.
+  header_view_ = std::move(view);
 }
 
 BEGIN_METADATA(BraveSidePanel, views::View)

--- a/browser/ui/views/side_panel/brave_side_panel.h
+++ b/browser/ui/views/side_panel/brave_side_panel.h
@@ -86,6 +86,7 @@ class BraveSidePanel : public views::View,
   IntegerPrefMember side_panel_width_;
   std::unique_ptr<SidePanelResizeWidget> resize_widget_;
   std::unique_ptr<ViewShadow> shadow_;
+  std::unique_ptr<views::View> header_view_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_H_

--- a/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
@@ -18,6 +18,7 @@
 #include "chrome/test/base/ui_test_utils.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/test_utils.h"
+#include "ui/base/ui_base_features.h"
 #include "ui/views/controls/button/toggle_button.h"
 #include "ui/views/controls/menu/menu_item_view.h"
 #include "ui/views/controls/menu/menu_runner.h"
@@ -88,3 +89,26 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, NotPurchasedVPN) {
   EXPECT_TRUE(!!menu_root->GetMenuItemByID(IDC_SHOW_BRAVE_VPN_PANEL));
 }
 #endif
+
+class BraveAppMenuBrowserTestWithChromeRefresh2023
+    : public BraveAppMenuBrowserTest {
+ public:
+  BraveAppMenuBrowserTestWithChromeRefresh2023() = default;
+  ~BraveAppMenuBrowserTestWithChromeRefresh2023() override = default;
+
+  void SetUp() override {
+    BraveAppMenuBrowserTest::SetUp();
+
+    feature_list_.InitAndEnableFeature(features::kChromeRefresh2023);
+  }
+
+  base::test::ScopedFeatureList feature_list_;
+};
+
+// To check enabling kChromeRefresh2023 doesn't make crash with app menu
+// opening.
+IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTestWithChromeRefresh2023,
+                       AppMenuOpeningTest) {
+  // Open app menu to check it doesn't make crash.
+  menu_button()->ShowMenu(views::MenuRunner::NO_FLAGS);
+}

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -128,7 +128,13 @@ void BraveToolbarView::Init() {
   // This will allow us to move this window by dragging toolbar.
   // See brave_non_client_hit_test_helper.h
   views::SetHitTestComponent(this, HTCAPTION);
-  DCHECK_EQ(1u, children().size());
+  if (features::IsChromeRefresh2023()) {
+    // Upstream has two more children |background_view_left_| and
+    // |background_view_right_| behind the container view.
+    DCHECK_EQ(3u, children().size());
+  } else {
+    DCHECK_EQ(1u, children().size());
+  }
   views::SetHitTestComponent(children()[0], HTCAPTION);
 
   // For non-normal mode, we don't have to more.


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/36214

There was some startup crash and runtime crash when opening sidebar/app menu with this feature.
All fixed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

No manual test available as kChromeRefresh2023 is disabled by default.
`BraveAppMenuBrowserTestWithChromeRefresh2023.*`
`SidebarBrowserTestWithChromeRefresh2023.*`