### PR TITLE
Fix crash when navigating to Rewards page in OFAC region (uplift to 1.63.x)

### DIFF
--- a/browser/ui/webui/brave_rewards_page_ui.cc
+++ b/browser/ui/webui/brave_rewards_page_ui.cc
@@ -511,7 +511,9 @@ void RewardsDOMHandler::Init() {
       brave_rewards::RewardsServiceFactory::GetForProfile(profile);
   ads_service_ = brave_ads::AdsServiceFactory::GetForProfile(profile);
 
-  rewards_service_->OnRewardsPageShown();
+  if (rewards_service_) {
+    rewards_service_->OnRewardsPageShown();
+  }
 
   // Configure a pref change registrar to update brave://rewards when settings
   // are changed via brave://settings


### PR DESCRIPTION
Uplift of #22171
Resolves https://github.com/brave/brave-browser/issues/36228

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.