### PR TITLE
fix(wallet): Buy Deposit Bridge Button Styles

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/market/market_asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/market/market_asset.tsx
@@ -81,16 +81,12 @@ import {
 } from '../../../../common/hooks/use-scoped-balance-updater'
 
 // Styled Components
-import { Row, Column } from '../../../shared/style'
+import { Row, Column, LeoSquaredButton } from '../../../shared/style'
 import { Skeleton } from '../../../shared/loading-skeleton/styles'
 import {
   WalletPageWrapper //
 } from '../../wallet-page-wrapper/wallet-page-wrapper'
-import {
-  BuySellBridgeButton,
-  ButtonRow,
-  StyledWrapper
-} from '../portfolio/style'
+import { ButtonRow, StyledWrapper } from '../portfolio/style'
 
 const emptyPriceList: TokenPriceHistory[] = []
 
@@ -420,20 +416,18 @@ export const MarketAsset = () => {
         <Row padding='0px 20px'>
           <ButtonRow>
             {isAssetBuySupported && (
-              <BuySellBridgeButton
-                onClick={onSelectBuy}
-                noBottomMargin={true}
-              >
-                {getLocale('braveWalletBuy')}
-              </BuySellBridgeButton>
+              <div>
+                <LeoSquaredButton onClick={onSelectBuy}>
+                  {getLocale('braveWalletBuy')}
+                </LeoSquaredButton>
+              </div>
             )}
             {isSelectedAssetDepositSupported && (
-              <BuySellBridgeButton
-                onClick={onSelectDeposit}
-                noBottomMargin={true}
-              >
-                {getLocale('braveWalletAccountsDeposit')}
-              </BuySellBridgeButton>
+              <div>
+                <LeoSquaredButton onClick={onSelectDeposit}>
+                  {getLocale('braveWalletAccountsDeposit')}
+                </LeoSquaredButton>
+              </div>
             )}
           </ButtonRow>
         </Row>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-fungible-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-fungible-asset.tsx
@@ -87,8 +87,8 @@ import {
 } from '../../../../common/slices/constants'
 
 // Styled Components
-import { BuySellBridgeButton, StyledWrapper, ButtonRow } from './style'
-import { Row, Column } from '../../../shared/style'
+import { StyledWrapper, ButtonRow } from './style'
+import { Row, Column, LeoSquaredButton } from '../../../shared/style'
 import {
   TokenDetailsModal //
 } from './components/token-details-modal/token-details-modal'
@@ -466,28 +466,25 @@ export const PortfolioFungibleAsset = () => {
         <Row padding='0px 20px'>
           <ButtonRow>
             {isAssetBuySupported && (
-              <BuySellBridgeButton
-                onClick={onSelectBuy}
-                noBottomMargin={true}
-              >
-                {getLocale('braveWalletBuy')}
-              </BuySellBridgeButton>
+              <div>
+                <LeoSquaredButton onClick={onSelectBuy}>
+                  {getLocale('braveWalletBuy')}
+                </LeoSquaredButton>
+              </div>
             )}
             {isSelectedAssetDepositSupported && (
-              <BuySellBridgeButton
-                onClick={onSelectDeposit}
-                noBottomMargin={true}
-              >
-                {getLocale('braveWalletAccountsDeposit')}
-              </BuySellBridgeButton>
+              <div>
+                <LeoSquaredButton onClick={onSelectDeposit}>
+                  {getLocale('braveWalletAccountsDeposit')}
+                </LeoSquaredButton>
+              </div>
             )}
             {isSelectedAssetBridgeSupported && (
-              <BuySellBridgeButton
-                onClick={onBridgeToAuroraButton}
-                noBottomMargin={true}
-              >
-                {getLocale('braveWalletBridgeToAuroraButton')}
-              </BuySellBridgeButton>
+              <div>
+                <LeoSquaredButton onClick={onBridgeToAuroraButton}>
+                  {getLocale('braveWalletBridgeToAuroraButton')}
+                </LeoSquaredButton>
+              </div>
             )}
           </ButtonRow>
         </Row>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -80,6 +80,7 @@ export const ButtonRow = styled.div<{
   margin: ${(p) => (p.noMargin ? '0px' : '20px 0px')};
   padding: 0px
     ${(p) => (p.horizontalPadding !== undefined ? p.horizontalPadding : 0)}px;
+  gap: 10px;
 `
 
 export const BalanceRow = styled.div<{ gap?: string }>`
@@ -159,30 +160,6 @@ export const FilterTokenRow = styled.div<{
   padding: 0px
     ${(p) => (p.horizontalPadding !== undefined ? p.horizontalPadding : 0)}px;
   margin-bottom: ${(p) => (p.isV2 ? '16px' : 0)};
-`
-
-export const BuySellBridgeButton = styled(WalletButton)<{
-  noBottomMargin?: boolean
-}>`
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  padding: 8px 14px;
-  height: 40px;
-  cursor: pointer;
-  outline: none;
-  border-radius: 40px;
-  font-family: 'Poppins';
-  font-style: normal;
-  font-weight: 600;
-  font-size: 14px;
-  line-height: 21px;
-  background-color: ${(p) => p.theme.palette.blurple500};
-  color: ${(p) => p.theme.palette.white};
-  border: none;
-  margin-bottom: ${(p) => (p.noBottomMargin ? 0 : 32)}px;
-  margin-right: 10px;
 `
 
 export const SelectTimelineWrapper = styled(Row)`


### PR DESCRIPTION
## Description 
Updates all of the `Buy, Deposit, Bridge` button styles to match the new designs in figma

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/36265>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Before:

![Screenshot 18](https://github.com/brave/brave-core/assets/40611140/eaeff390-80f0-46c1-b40e-ffcf67c8650f)

![Screenshot 19](https://github.com/brave/brave-core/assets/40611140/3aaf543c-6466-48e6-8131-42ba88ee40e5)

After:

![Screenshot 21](https://github.com/brave/brave-core/assets/40611140/9716e7bc-2ba5-4f2c-a10b-3f96f93cf5db)

![Screenshot 20](https://github.com/brave/brave-core/assets/40611140/d6816b27-c70c-49ad-8a7b-18d40b4c0d36)
