### PR TITLE
[Android] fix crash in brave news settings (uplift to 1.64.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveNewsPreferencesV2.java
@@ -267,7 +267,10 @@ public class BraveNewsPreferencesV2 extends BravePreferenceFragment
     private void updateFollowerCount() {
         List<Publisher> followingPublisherList = BraveNewsUtils.getFollowingPublisherList();
         List<Channel> followingChannelList = BraveNewsUtils.getFollowingChannelList();
-        int followingCount = followingChannelList.size() + followingPublisherList.size();
+        int followingPublisherCount =
+                followingPublisherList != null ? followingPublisherList.size() : 0;
+        int followingChannelCount = followingChannelList != null ? followingChannelList.size() : 0;
+        int followingCount = followingPublisherCount + followingChannelCount;
         if (mLayoutFollowing != null && mTvFollowingCount != null) {
             mTvFollowingCount.setText(String.valueOf(followingCount));
             mLayoutFollowing.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Uplift of #22198
Resolves https://github.com/brave/brave-browser/issues/36225

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.