### PR TITLE
Reduce the space above the tabstrip in Windows (uplift to 1.63.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.cc
@@ -12,6 +12,13 @@
     return top;                                        \
   }
 
+// The top frame border thickness is smaller when using updated horizontal tabs.
+#define BRAVE_BROWSER_FRAME_VIEW_WIN_FRAME_TOP_BORDER_THICKNESS \
+  if (tabs::features::HorizontalTabsUpdateEnabled()) {          \
+    return 2;                                                   \
+  }
+
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_win.cc"  // IWYU pragma: export
 
+#undef BRAVE_BROWSER_FRAME_VIEW_WIN_FRAME_TOP_BORDER_THICKNESS
 #undef BRAVE_BROWSER_FRAME_VIEW_WIN_TOP_AREA_HEIGHT

--- a/patches/chrome-browser-ui-views-frame-browser_frame_view_win.cc.patch
+++ b/patches/chrome-browser-ui-views-frame-browser_frame_view_win.cc.patch
@@ -1,8 +1,16 @@
 diff --git a/chrome/browser/ui/views/frame/browser_frame_view_win.cc b/chrome/browser/ui/views/frame/browser_frame_view_win.cc
-index bd59ccd1b178450c7eba720ea8b235f24416a15e..3b2be5646116d60f79baf3e968aa164245dde937 100644
+index bd59ccd1b178450c7eba720ea8b235f24416a15e..40d21c79c71f8fb76dcaa8910ebd011db0443d19 100644
 --- a/chrome/browser/ui/views/frame/browser_frame_view_win.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame_view_win.cc
-@@ -547,6 +547,7 @@ int BrowserFrameViewWin::TopAreaHeight(bool restored) const {
+@@ -488,6 +488,7 @@ int BrowserFrameViewWin::FrameTopBorderThickness(bool restored) const {
+       // default. When maximized, the OS sizes the window such that the border
+       // extends beyond the screen edges. In that case, we must return the
+       // default value.
++      BRAVE_BROWSER_FRAME_VIEW_WIN_FRAME_TOP_BORDER_THICKNESS
+       const int kTopResizeFrameArea = features::IsChromeRefresh2023() ? 1 : 5;
+       return kTopResizeFrameArea;
+     }
+@@ -547,6 +548,7 @@ int BrowserFrameViewWin::TopAreaHeight(bool restored) const {
                       : caption_button_container_->GetPreferredSize().height();
      return top;
    }


### PR DESCRIPTION
Uplift of #22000
Resolves https://github.com/brave/brave-browser/issues/35972

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.