### PR TITLE
Remove corner rounding for tab hit test paths (uplift to 1.63.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -142,6 +142,12 @@ SkPath BraveVerticalTabStyle::GetPath(
   float tab_bottom = aligned_bounds.bottom();
   int radius = tabs::GetTabCornerRadius(*tab());
 
+  // For hit testing, the tab shape should not be rounded, as that would leave
+  // small hit test gaps between adjacent tabs at their corners.
+  if (path_type == TabStyle::PathType::kHitTest) {
+    radius = 0;
+  }
+
   if (is_pinned) {
     // Only pinned tabs have border
     if (path_type == TabStyle::PathType::kBorder ||


### PR DESCRIPTION
Uplift of #21967
Resolves https://github.com/brave/brave-browser/issues/35901

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.