### PR TITLE
Fix #36092: Fix Javascript URL navigation on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/AddEditBookmarkTableViewController.swift
@@ -280,7 +280,7 @@ class AddEditBookmarkTableViewController: UITableViewController {
     switch mode {
     case .addBookmark(_, _):
       guard let urlString = bookmarkDetailsView.urlTextField?.text,
-        let url = URL(string: urlString) ?? urlString.bookmarkletURL
+        let url = URL(string: urlString) ?? URL.bookmarkletURL(from: urlString)
       else {
         return earlyReturn()
       }
@@ -317,7 +317,7 @@ class AddEditBookmarkTableViewController: UITableViewController {
       }
     case .editBookmark(let bookmark):
       guard let urlString = bookmarkDetailsView.urlTextField?.text,
-        let url = URL(string: urlString) ?? urlString.bookmarkletURL
+        let url = URL(string: urlString) ?? URL.bookmarkletURL(from: urlString)
       else {
         return earlyReturn()
       }
@@ -358,7 +358,7 @@ class AddEditBookmarkTableViewController: UITableViewController {
 
     case .editFavorite(let favorite):
       guard let urlString = bookmarkDetailsView.urlTextField?.text,
-        let url = URL(string: urlString) ?? urlString.bookmarkletURL
+        let url = URL(string: urlString) ?? URL.bookmarkletURL(from: urlString)
       else {
         return earlyReturn()
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarkDetailsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/Bookmarks/BookmarkDetailsView.swift
@@ -73,8 +73,8 @@ class BookmarkDetailsView: AddEditHeaderView, BookmarkFormFieldsProtocol {
       .forEach(contentStackView.addArrangedSubview)
 
     var url = url
-    if url?.isBookmarklet == true {
-      url = url?.removingPercentEncoding
+    if let urlString = url, URL.bookmarkletURL(from: urlString) != nil {
+      url = urlString.removingPercentEncoding
     } else if let url = url, let favUrl = URL(string: url) {
       faviconImageView.loadFavicon(siteURL: favUrl, isPrivateBrowsing: isPrivateBrowsing)
     }
@@ -94,7 +94,7 @@ class BookmarkDetailsView: AddEditHeaderView, BookmarkFormFieldsProtocol {
   // MARK: - Delegate actions
 
   @objc func textFieldDidChange(_ textField: UITextField) {
-    if textField.text?.isBookmarklet == true {
+    if let text = textField.text, URL.bookmarkletURL(from: text) != nil {
       delegate?.correctValues(validationPassed: validateCodeFields())
     } else {
       delegate?.correctValues(validationPassed: validateFields())

--- a/ios/brave-ios/Sources/Shared/BookmarkValidation.swift
+++ b/ios/brave-ios/Sources/Shared/BookmarkValidation.swift
@@ -18,8 +18,8 @@ public struct BookmarkValidation {
 
   public static func validateBookmarklet(title: String?, url: String?) -> Bool {
     guard let url = url else { return validateTitle(title) }
-    if !url.isBookmarklet { return false }
-    guard let javascriptCode = url.bookmarkletCodeComponent else {
+    guard let bookmarklet = URL.bookmarkletURL(from: url) else { return false }
+    guard let javascriptCode = bookmarklet.bookmarkletCodeComponent else {
       return false
     }
 

--- a/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
@@ -412,38 +412,39 @@ extension URL {
 
 extension URL {
   public var isBookmarklet: Bool {
-    return self.absoluteString.isBookmarklet
-  }
-
-  public var bookmarkletCodeComponent: String? {
-    return self.absoluteString.bookmarkletCodeComponent
-  }
-}
-
-extension String {
-  public var isBookmarklet: Bool {
-    let url = self.lowercased()
-    return url.hasPrefix("javascript:") && !url.hasPrefix("javascript:/")
+    if let scheme = self.scheme {
+      return scheme == "javascript"
+    }
+    return self.absoluteString.hasPrefix("javascript:")
   }
 
   public var bookmarkletCodeComponent: String? {
     if self.isBookmarklet {
-      if let result = String(self.dropFirst("javascript:".count)).removingPercentEncoding {
-        return result.isEmpty ? nil : result
+      // Chrome, Safari, Desktop all treat anything after `javascript:` including `//` as the component!
+      // So `javascript:/` has a component of `/`
+      // `javascript://test` has a component of `//test`
+      if self.absoluteString.hasPrefix("javascript:") {
+        if let result = String(self.absoluteString.dropFirst("javascript:".count))
+          .removingPercentEncoding
+        {
+          return result.isEmpty ? nil : result
+        }
       }
     }
     return nil
   }
 
-  public var bookmarkletURL: URL? {
-    if self.isBookmarklet,
-      let escaped = self.addingPercentEncoding(withAllowedCharacters: .urlAllowed)
+  public static func bookmarkletURL(from string: String) -> URL? {
+    if string.hasPrefix("javascript:"),
+      let escaped = string.addingPercentEncoding(withAllowedCharacters: .urlAllowed)
     {
       return URL(string: escaped)
     }
     return nil
   }
+}
 
+extension String {
   public func removeSchemeFromURLString(_ scheme: String?) -> String {
     guard let scheme = scheme else {
       return self

--- a/ios/brave-ios/Tests/BraveSharedTests/NSURLExtensionsTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/NSURLExtensionsTests.swift
@@ -697,46 +697,52 @@ class NSURLExtensionsTests: XCTestCase {
   }
 
   func testIsBookmarkletURL() {
-    let goodURLs = [
+    let javascriptURLs = [
       "javascript:",
+      "javascript://",
       "javascript:void(window.close(self))",
       "javascript:window.open('https://brave.com')",
     ]
 
-    let badURLs = [
-      "javascript:/",
-      "javascript://",
-      "javascript://something",
+    let nonJavascriptURLs = [
+      "https://brave",
+      "https://brave.com",
+      "https://javascript://",
+      "javascript//",
     ]
 
-    goodURLs.forEach {
-      XCTAssertNotNil($0.bookmarkletURL)
+    javascriptURLs.forEach {
+      XCTAssertNotNil(URL.bookmarkletURL(from: $0))
     }
 
-    badURLs.forEach {
-      XCTAssertNil($0.bookmarkletURL)
+    nonJavascriptURLs.forEach {
+      XCTAssertNil(URL.bookmarkletURL(from: $0))
     }
   }
 
   func testIsBookmarkletURLComponent() {
-    let goodURLs = [
+    let javascriptURLs = [
+      "javascript:/",
+      "javascript://",
+      "javascript://something",
       "javascript:void(window.close(self))",
       "javascript:window.open('https://brave.com')",
+      "javascript://%0a%0dalert('UXSS')",
     ]
 
     let badURLs = [
       "javascript:",
-      "javascript:/",
-      "javascript://",
-      "javascript://something",
+      "https://test",
+      "javascript//test",
+      "javascript/test",
     ]
 
-    goodURLs.forEach {
-      XCTAssertNotNil($0.bookmarkletCodeComponent)
+    javascriptURLs.forEach {
+      XCTAssertNotNil(URL.bookmarkletURL(from: $0)?.bookmarkletCodeComponent)
     }
 
     badURLs.forEach {
-      XCTAssertNil($0.bookmarkletCodeComponent)
+      XCTAssertNil(URL.bookmarkletURL(from: $0)?.bookmarkletCodeComponent)
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix Javascript navigation. `javascript:` and `javascript://` are the both `javascript` schemes. So block them for navigation.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36092

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

