### PR TITLE
Fix tabstrip background color when themes are used (uplift to 1.63.x)

### DIFF
--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -423,12 +423,12 @@ void BraveTabStrip::OnPaintBackground(gfx::Canvas* canvas) {
   // Unlike upstream, we are painting this view to an opaque layer in order to
   // support layer-based shadows under the active tab. Paint a background so
   // that all pixels are painted appropriately.
-  ui::ColorId color_id = ShouldShowVerticalTabs() ? kColorToolbar
-                         : GetWidget()->ShouldPaintAsActive()
-                             ? kColorTabBackgroundInactiveFrameActive
-                             : kColorTabBackgroundInactiveFrameInactive;
+  SkColor background_color =
+      ShouldShowVerticalTabs()
+          ? GetColorProvider()->GetColor(kColorToolbar)
+          : controller_->GetFrameColor(BrowserFrameActiveState::kUseCurrent);
 
-  canvas->DrawColor(GetColorProvider()->GetColor(color_id));
+  canvas->DrawColor(background_color);
 }
 
 BEGIN_METADATA(BraveTabStrip, TabStrip)


### PR DESCRIPTION
Uplift of #21969
Resolves https://github.com/brave/brave-browser/issues/35905

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.