### PR TITLE
Migrate hermetic toolchains

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -1243,7 +1243,7 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
       env.USE_BRAVE_HERMETIC_TOOLCHAIN = '1'
       env.DEPOT_TOOLS_WIN_TOOLCHAIN = '1'
       env.GYP_MSVS_HASH_27370823e7 = '01b3b59461'
-      env.DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL = 'https://brave-build-deps-public.s3.brave.com/windows-hermetic-toolchain/'
+      env.DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL = 'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/'
     }
 
     if (this.getCachePath()) {

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -141,6 +141,7 @@ const getBraveVersion = (ignorePatchVersionNumber) => {
 
 const Config = function () {
   this.isCI = process.env.BUILD_ID !== undefined || process.env.TEAMCITY_VERSION !== undefined
+  this.internalDepsUrl = 'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws'
   this.defaultBuildConfig = 'Component'
   this.buildConfig = this.defaultBuildConfig
   this.signTarget = 'sign_app'
@@ -1243,7 +1244,7 @@ Object.defineProperty(Config.prototype, 'defaultOptions', {
       env.USE_BRAVE_HERMETIC_TOOLCHAIN = '1'
       env.DEPOT_TOOLS_WIN_TOOLCHAIN = '1'
       env.GYP_MSVS_HASH_27370823e7 = '01b3b59461'
-      env.DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL = 'https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws/windows-hermetic-toolchain/'
+      env.DEPOT_TOOLS_WIN_TOOLCHAIN_BASE_URL = `${this.internalDepsUrl}/windows-hermetic-toolchain/`
     }
 
     if (this.getCachePath()) {

--- a/build/commands/lib/syncUtils.js
+++ b/build/commands/lib/syncUtils.js
@@ -189,9 +189,25 @@ function syncChromium(syncWithForce, sync_chromium, delete_unused_deps) {
   return true
 }
 
+async function checkInternalDepsEndpoint() {
+  if (!config.useBraveHermeticToolchain) {
+    return true
+  }
+
+  try {
+    const response = await fetch(
+      `${config.internalDepsUrl}/windows-hermetic-toolchain/test.txt`,
+      { method: 'HEAD', signal: AbortSignal.timeout(5000) }
+    )
+    return response.ok
+  } catch (error) {
+    return false
+  }
+}
 
 module.exports = {
   maybeInstallDepotTools,
   buildDefaultGClientConfig,
-  syncChromium
+  syncChromium,
+  checkInternalDepsEndpoint
 }

--- a/build/commands/scripts/sync.js
+++ b/build/commands/scripts/sync.js
@@ -99,6 +99,11 @@ async function RunCommand() {
   await util.applyPatches()
 
   if (!program.nohooks) {
+    if (!await syncUtil.checkInternalDepsEndpoint()) {
+      Log.warn(
+        'The internal dependencies endpoint is unreachable, which may block toolchain downloads. Please check your VPN connection.'
+      )
+    }
     // Run hooks for the root .gclient, this will include Chromium and Brave
     // hooks. Don't cache the result, just always rerun this step, because it's
     // pretty quick in a no-op scenario.

--- a/build/mac/download_hermetic_xcode.py
+++ b/build/mac/download_hermetic_xcode.py
@@ -14,7 +14,7 @@ from urllib.error import URLError  # pylint: disable=no-name-in-module,import-er
 import pkg_resources
 
 import deps
-from deps_config import DEPS_PACKAGES_URL, MAC_TOOLCHAIN_ROOT
+from deps_config import DEPS_PACKAGES_INTERNAL_URL, MAC_TOOLCHAIN_ROOT
 
 def LoadPList(path):
     """Loads Plist at |path| and returns it as a dictionary."""
@@ -24,7 +24,7 @@ def LoadPList(path):
 # This contains binaries from Xcode 14.3, along with the macOS 13.3 SDK
 XCODE_VERSION = '15.0'
 HERMETIC_XCODE_BINARY = (
-    DEPS_PACKAGES_URL +
+    DEPS_PACKAGES_INTERNAL_URL +
     '/xcode-hermetic-toolchain/xcode-hermetic-toolchain-xcode-' +
     XCODE_VERSION + '-sdk-14.0-13.3.tar.gz')
 

--- a/script/deps.py
+++ b/script/deps.py
@@ -53,7 +53,8 @@ def DownloadUrl(url, output_file):
         except URLError as e:
             sys.stdout.write('\n')
             print(e)
-            if num_retries == 0 or isinstance(e, HTTPError) and e.code in [403, 404]: # pylint: disable=no-member,line-too-long
+            if num_retries == 0 or isinstance(
+                    e, HTTPError) and e.code in [403, 404]:  # pylint: disable=no-member,line-too-long
                 raise e
             num_retries -= 1
             print("Retrying in {} s ...".format(retry_wait_s))

--- a/script/deps.py
+++ b/script/deps.py
@@ -53,7 +53,7 @@ def DownloadUrl(url, output_file):
         except URLError as e:
             sys.stdout.write('\n')
             print(e)
-            if num_retries == 0 or isinstance(e, HTTPError) and e.code == 404: # pylint: disable=no-member
+            if num_retries == 0 or isinstance(e, HTTPError) and e.code in [403, 404]: # pylint: disable=no-member,line-too-long
                 raise e
             num_retries -= 1
             print("Retrying in {} s ...".format(retry_wait_s))

--- a/script/deps_config.py
+++ b/script/deps_config.py
@@ -10,7 +10,7 @@ import os
 # Version number and URL for pre-configured rust dependency package
 # e.g. rust_deps_mac_0.1.0.gz
 DEPS_PACKAGES_URL = "https://brave-build-deps-public.s3.brave.com"
-DEPS_PACKAGES_INTERNAL_URL = "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws" # pylint: disable=line-too-long
+DEPS_PACKAGES_INTERNAL_URL = "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws"  # pylint: disable=line-too-long
 MAC_TOOLCHAIN_ROOT = os.path.join(os.path.dirname(os.path.dirname(
                                   os.path.dirname(__file__))),
                                   'build', 'mac_files')

--- a/script/deps_config.py
+++ b/script/deps_config.py
@@ -10,6 +10,7 @@ import os
 # Version number and URL for pre-configured rust dependency package
 # e.g. rust_deps_mac_0.1.0.gz
 DEPS_PACKAGES_URL = "https://brave-build-deps-public.s3.brave.com"
+DEPS_PACKAGES_INTERNAL_URL = "https://vhemnu34de4lf5cj6bx2wwshyy0egdxk.lambda-url.us-west-2.on.aws" # pylint: disable=line-too-long
 MAC_TOOLCHAIN_ROOT = os.path.join(os.path.dirname(os.path.dirname(
                                   os.path.dirname(__file__))),
                                   'build', 'mac_files')


### PR DESCRIPTION
Relates to https://github.com/brave/devops/issues/11132

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [X] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [X] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

