### PR TITLE
fix: auto-discover assets after wallet onboarding completion

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -1282,10 +1282,6 @@ void BraveWalletService::Base58Encode(
   std::move(callback).Run(std::move(encoded_addresses));
 }
 
-void BraveWalletService::DiscoverAssetsOnAllSupportedChains() {
-  DiscoverAssetsOnAllSupportedChains(false);
-}
-
 void BraveWalletService::DiscoverAssetsOnAllSupportedChains(
     bool bypass_rate_limit) {
   std::map<mojom::CoinType, std::vector<std::string>> addresses;

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -212,7 +212,7 @@ class BraveWalletService : public KeyedService,
   void Base58Encode(const std::vector<std::vector<std::uint8_t>>& addresses,
                     Base58EncodeCallback callback) override;
 
-  void DiscoverAssetsOnAllSupportedChains() override;
+  void DiscoverAssetsOnAllSupportedChains(bool bypass_rate_limit) override;
 
   void GetNftDiscoveryEnabled(GetNftDiscoveryEnabledCallback callback) override;
 
@@ -354,7 +354,6 @@ class BraveWalletService : public KeyedService,
   void CancelAllSignAllTransactionsCallbacks();
   void CancelAllGetEncryptionPublicKeyCallbacks();
   void CancelAllDecryptCallbacks();
-  void DiscoverAssetsOnAllSupportedChains(bool bypass_rate_limit);
 
   base::OnceClosure sign_tx_request_added_cb_for_testing_;
   base::OnceClosure sign_all_txs_request_added_cb_for_testing_;

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -2033,7 +2033,7 @@ interface BraveWalletService {
 
   Base58Encode(array<array<uint8>> addresses) => (array<string> addresses);
 
-  DiscoverAssetsOnAllSupportedChains();
+  DiscoverAssetsOnAllSupportedChains(bool bypass_rate_limit);
 
   GetNftDiscoveryEnabled() => (bool enabled);
 

--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -145,7 +145,7 @@ handler.on(
         .unwrap()
       await store.dispatch(refreshVisibleTokenInfo())
       await store.dispatch(refreshPortfolioFilterOptions())
-      await braveWalletService.discoverAssetsOnAllSupportedChains()
+      await braveWalletService.discoverAssetsOnAllSupportedChains(false)
     }
   }
 )

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -172,6 +172,7 @@ export const {
   useCompleteWalletBackupMutation,
   useConnectToSiteMutation,
   useCreateWalletMutation,
+  useDiscoverAssetsMutation,
   useEnableEnsOffchainLookupMutation,
   useGenerateBraveSwapFeeMutation,
   useGenerateReceiveAddressMutation,
@@ -195,7 +196,6 @@ export const {
   useGetERC20AllowanceQuery,
   useGetERC721MetadataQuery,
   useGetEthAddressChecksumQuery,
-  useValidateUnifiedAddressQuery,
   useGetEVMTransactionSimulationQuery,
   useGetFVMAddressQuery,
   useGetGasEstimation1559Query,
@@ -316,7 +316,8 @@ export const {
   useUpdateUnapprovedTransactionNonceMutation,
   useUpdateUnapprovedTransactionSpendAllowanceMutation,
   useUpdateUserAssetVisibleMutation,
-  useUpdateUserTokenMutation
+  useUpdateUserTokenMutation,
+  useValidateUnifiedAddressQuery
 } = walletApi
 
 // Derived Data Queries

--- a/components/brave_wallet_ui/common/slices/endpoints/token.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/token.endpoints.ts
@@ -366,6 +366,28 @@ export const tokenEndpoints = ({
           )
         }
       }
+    }),
+    discoverAssets: mutation<true, void>({
+      queryFn: async (
+        _arg,
+        { endpoint, dispatch },
+        extraOptions,
+        baseQuery
+      ) => {
+        try {
+          const { data: api } = baseQuery(undefined)
+          api.braveWalletService.discoverAssetsOnAllSupportedChains(true)
+          return {
+            data: true
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Failed to start asset auto-discovery',
+            error
+          )
+        }
+      }
     })
   }
 }

--- a/components/brave_wallet_ui/page/screens/onboarding/onboarding-success/onboarding-success.tsx
+++ b/components/brave_wallet_ui/page/screens/onboarding/onboarding-success/onboarding-success.tsx
@@ -11,6 +11,7 @@ import { useDispatch } from 'react-redux'
 import { getLocale } from '../../../../../common/locale'
 import { WalletPageActions } from '../../../actions'
 import {
+  useDiscoverAssetsMutation,
   useReportOnboardingActionMutation //
 } from '../../../../common/slices/api.slice'
 
@@ -50,6 +51,7 @@ export const OnboardingSuccess = () => {
 
   // mutations
   const [report] = useReportOnboardingActionMutation()
+  const [discoverAssets] = useDiscoverAssetsMutation()
 
   // methods
   const onComplete = React.useCallback(() => {
@@ -69,8 +71,11 @@ export const OnboardingSuccess = () => {
 
   // effects
   React.useEffect(() => {
+    // now that the token registry is populated, discover assets
+    discoverAssets()
+
     report(BraveWallet.OnboardingAction.Complete)
-  }, [report])
+  }, [report, discoverAssets])
 
   // render
   return (

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -631,7 +631,7 @@ public class CryptoStore: ObservableObject, WalletObserverStore {
   func prepare(isInitialOpen: Bool = false) {
     Task { @MainActor in
       if isInitialOpen {
-        walletService.discoverAssetsOnAllSupportedChains()
+        walletService.discoverAssets(onAllSupportedChains: true)
       }
 
       let pendingTransactions = await fetchPendingTransactions()

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/CryptoStore.swift
@@ -631,7 +631,7 @@ public class CryptoStore: ObservableObject, WalletObserverStore {
   func prepare(isInitialOpen: Bool = false) {
     Task { @MainActor in
       if isInitialOpen {
-        walletService.discoverAssets(onAllSupportedChains: true)
+        walletService.discoverAssetsOnAllSupportedChains(bypassRateLimit: true)
       }
 
       let pendingTransactions = await fetchPendingTransactions()

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -292,7 +292,7 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   func setDefaultSolanaWallet(defaultWallet: BraveWallet.DefaultWallet) {
   }
 
-  func discoverAssetsOnAllSupportedChains() {
+  func discoverAssets(onAllSupportedChains bypassRateLimit: Bool) {
   }
 
   func nftDiscoveryEnabled(completion: @escaping (Bool) -> Void) {

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -292,9 +292,6 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   func setDefaultSolanaWallet(defaultWallet: BraveWallet.DefaultWallet) {
   }
 
-  func discoverAssets(onAllSupportedChains bypassRateLimit: Bool) {
-  }
-
   func nftDiscoveryEnabled(completion: @escaping (Bool) -> Void) {
     completion(false)
   }
@@ -392,6 +389,9 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
     completion: @escaping (String?, String?) -> Void
   ) {
     completion(nil, "Error Message")
+  }
+
+  func discoverAssetsOnAllSupportedChains(bypassRateLimit: Bool) {
   }
 }
 #endif


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves [Race condition between fetching token registry and asset discovery on wallet restore](https://github.com/brave/brave-browser/issues/35696#top)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Restore wallet using QA wallet
2. tokens should be auto discovered when first viewing the portfolio overview page
