### PR TITLE
[iOS] - Fix ReaderMode CSP

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ReaderMode.swift
@@ -150,7 +150,9 @@ extension BrowserViewController {
     let forwardList = webView.backForwardList.forwardList
 
     guard let currentURL = webView.backForwardList.currentItem?.url,
-      let readerModeURL = currentURL.encodeEmbeddedInternalURL(for: .readermode)
+      let headers = (tab.responses[currentURL] as? HTTPURLResponse)?.allHeaderFields
+        as? [String: String],
+      let readerModeURL = currentURL.encodeEmbeddedInternalURL(for: .readermode, headers: headers)
     else { return }
 
     recordTimeBasedNumberReaderModeUsedP3A(activated: true)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -600,6 +600,11 @@ extension BrowserViewController: WKNavigationDelegate {
     let responseURL = response.url
     let tab = tab(for: webView)
 
+    // Store the response in the tab
+    if let responseURL = responseURL {
+      tab?.responses[responseURL] = response
+    }
+
     // Check if we upgraded to https and if so we need to update the url of frame evaluations
     if let responseURL = responseURL,
       let domain = tab?.currentPageData?.domain(persistent: !isPrivateBrowsing),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
@@ -21,6 +21,13 @@ public protocol InternalSchemeResponse {
 
 public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
 
+  private weak var tab: Tab?
+
+  init(tab: Tab?) {
+    self.tab = tab
+    super.init()
+  }
+
   public static func response(forUrl url: URL) -> URLResponse {
     return URLResponse(
       url: url,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -97,6 +97,7 @@ class Tab: NSObject {
   private(set) var type: TabType = .regular
 
   var redirectURLs = [URL]()
+  var responses = [URL: URLResponse]()
 
   var isPrivate: Bool {
     return type.isPrivate
@@ -463,7 +464,7 @@ class Tab: NSObject {
 
       if configuration!.urlSchemeHandler(forURLScheme: InternalURL.scheme) == nil {
         configuration!.setURLSchemeHandler(
-          InternalSchemeHandler(),
+          InternalSchemeHandler(tab: self),
           forURLScheme: InternalURL.scheme
         )
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Reader/Reader.html
+++ b/ios/brave-ios/Sources/Brave/Frontend/Reader/Reader.html
@@ -8,6 +8,7 @@
   <meta content="text/html; charset=UTF-8" http-equiv="content-type">
   <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=.25, maximum-scale=1.6, initial-scale=1.0">
   <meta name="referrer" content="no-referrer">
+  %READER-ORIGINAL-PAGE-META-TAGS%
   <link rel="stylesheet" type="text/css" href="/reader-mode/styles/Reader.css">
   <title id="reader-page-title"></title>
 </head>

--- a/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Reader/ReaderModeUtils.swift
@@ -49,6 +49,10 @@ struct ReaderModeUtils {
           ?? readabilityResult.direction.htmlEntityEncodedString
       )
       .replacingOccurrences(of: "%READER-MESSAGE%", with: "")
+      .replacingOccurrences(
+        of: "%READER-ORIGINAL-PAGE-META-TAGS%",
+        with: readabilityResult.cspMetaTags.joined(separator: "  \n")
+      )
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsContentViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsContentViewController.swift
@@ -120,7 +120,7 @@ class SettingsContentViewController: UIViewController, WKNavigationDelegate {
   func makeWebView() -> BraveWebView {
     let frame = CGRect(width: 1, height: 1)
     let configuration = WKWebViewConfiguration().then {
-      $0.setURLSchemeHandler(InternalSchemeHandler(), forURLScheme: InternalURL.scheme)
+      $0.setURLSchemeHandler(InternalSchemeHandler(tab: nil), forURLScheme: InternalURL.scheme)
     }
     let webView = BraveWebView(frame: frame, configuration: configuration)
     webView.allowsLinkPreview = false

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Sandboxed/MainFrame/AtDocumentStart/ReaderModeScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Sandboxed/MainFrame/AtDocumentStart/ReaderModeScript.js
@@ -75,6 +75,15 @@ function checkReadability() {
         return;
       }
 
+      
+      // Preserve the CSP meta tag
+      delete document.querySelector;
+      delete document.querySelectorAll;
+      let cspMetaTags = document.querySelectorAll("meta[http-equiv=\"Content-Security-Policy\"]");
+      if (cspMetaTags) {
+        readabilityResult.cspMetaTags = [...cspMetaTags].map((e) => new XMLSerializer().serializeToString(e));
+      }
+      
       debug({Type: "ReaderModeStateChange", Value: readabilityResult !== null ? "Available" : "Unavailable"});
       webkit.messageHandlers.readerModeMessageHandler.postMessage({"securityToken": SECURITY_TOKEN, "data": {Type: "ReaderModeStateChange", Value: readabilityResult !== null ? "Available" : "Unavailable"}});
       webkit.messageHandlers.readerModeMessageHandler.postMessage({"securityToken": SECURITY_TOKEN, "data": {Type: "ReaderContentParsed", Value: readabilityResult}});

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ReaderModeScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ReaderModeScriptHandler.swift
@@ -172,6 +172,7 @@ struct ReadabilityResult {
   var title = ""
   var credits = ""
   var direction = "auto"
+  var cspMetaTags = [String]()
 
   init?(object: AnyObject?) {
     if let dict = object as? NSDictionary {
@@ -199,6 +200,9 @@ struct ReadabilityResult {
       if let direction = dict["dir"] as? String {
         self.direction = direction
       }
+      if let cspMetaTags = dict["cspMetaTags"] as? [String] {
+        self.cspMetaTags = cspMetaTags
+      }
     } else {
       return nil
     }
@@ -213,6 +217,7 @@ struct ReadabilityResult {
     let title = object["title"].string
     let credits = object["credits"].string
     let direction = object["dir"].string
+    let cspMetaTags = object["cspMetaTags"].arrayObject as? [String]
 
     if domain == nil || url == nil || content == nil || title == nil || credits == nil {
       return nil
@@ -224,13 +229,14 @@ struct ReadabilityResult {
     self.title = title!
     self.credits = credits!
     self.direction = direction ?? "auto"
+    self.cspMetaTags = cspMetaTags ?? []
   }
 
   /// Encode to a dictionary, which can then for example be json encoded
   func encode() -> [String: Any] {
     return [
       "domain": domain, "url": url, "content": content, "title": title, "credits": credits,
-      "dir": direction,
+      "dir": direction, "cspMetaTags": cspMetaTags,
     ]
   }
 

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -106,13 +106,28 @@ extension URL {
   }
 
   /// Embed a url into an internal URL for the given path. The url will be placed in a `url` querey param
-  public func encodeEmbeddedInternalURL(for path: InternalURL.Path) -> URL? {
+  public func encodeEmbeddedInternalURL(
+    for path: InternalURL.Path,
+    headers: [String: String]? = nil
+  ) -> URL? {
     let baseURL = "\(InternalURL.baseUrl)/\(path.rawValue)"
 
     guard
       let encodedURL = absoluteString.addingPercentEncoding(withAllowedCharacters: .alphanumerics)
     else {
       return nil
+    }
+
+    if let headers = headers, !headers.isEmpty,
+      let data = try? JSONSerialization.data(withJSONObject: headers),
+      let encodedHeaders = data.base64EncodedString.addingPercentEncoding(
+        withAllowedCharacters: .alphanumerics
+      )
+    {
+      return URL(
+        string:
+          "\(baseURL)?\(InternalURL.Param.url.rawValue)=\(encodedURL)&headers=\(encodedHeaders)"
+      )
     }
 
     return URL(string: "\(baseURL)?\(InternalURL.Param.url.rawValue)=\(encodedURL)")


### PR DESCRIPTION
- Add CSP Parser
- Store Response Headers for use in Reader-Mode or elsewhere.
- Use page's CSP meta tag in Reader-Mode page.
- Encode ReaderMode headers in the URL
- Prevent abuse of `document.querySelector` prototype pollution when selecting the CSP meta-tag.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36259

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

