### PR TITLE
(Wallet) Show all Solana accounts in connection panel during DApp integration

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/domain/DappsModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/DappsModel.java
@@ -77,11 +77,12 @@ public class DappsModel implements KeyringServiceObserver {
             return;
         }
 
-        mKeyringService.getAllAccounts(allAccounts -> {
-            List<AccountInfo> accounts =
-                    Utils.filterAccountsByCoin(allAccounts.accounts, coinType);
-            callback.call(new Pair<>(allAccounts.ethDappSelectedAccount, accounts));
-        });
+        mKeyringService.getAllAccounts(
+                allAccounts -> {
+                    List<AccountInfo> accounts =
+                            Utils.filterAccountsByCoin(allAccounts.accounts, coinType);
+                    callback.call(new Pair<>(allAccounts.ethDappSelectedAccount, accounts));
+                });
     }
 
     public LiveData<List<SignTransactionRequest>> fetchSignTxRequest() {

--- a/android/java/org/chromium/chrome/browser/app/domain/DappsModel.java
+++ b/android/java/org/chromium/chrome/browser/app/domain/DappsModel.java
@@ -78,18 +78,9 @@ public class DappsModel implements KeyringServiceObserver {
         }
 
         mKeyringService.getAllAccounts(allAccounts -> {
-            if (coinType == CoinType.SOL) {
-                // only the selected account is used for solana dapps
-                if (allAccounts.solDappSelectedAccount != null) {
-                    List<AccountInfo> accounts = new ArrayList();
-                    accounts.add(allAccounts.solDappSelectedAccount);
-                    callback.call(new Pair<>(allAccounts.solDappSelectedAccount, accounts));
-                }
-            } else {
-                List<AccountInfo> accounts =
-                        Utils.filterAccountsByCoin(allAccounts.accounts, coinType);
-                callback.call(new Pair<>(allAccounts.ethDappSelectedAccount, accounts));
-            }
+            List<AccountInfo> accounts =
+                    Utils.filterAccountsByCoin(allAccounts.accounts, coinType);
+            callback.call(new Pair<>(allAccounts.ethDappSelectedAccount, accounts));
         });
     }
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
@@ -5,6 +5,9 @@
 
 package org.chromium.chrome.browser.crypto_wallet.fragments.dapps;
 
+import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.Mode;
+import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.PermissionListener;
+
 import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.os.Bundle;
@@ -52,8 +55,7 @@ import java.util.Iterator;
 /**
  * Fragment used to connect Dapps to the crypto account.
  */
-public class ConnectAccountFragment extends BaseDAppsFragment
-        implements BravePermissionAccountsListAdapter.BravePermissionDelegate {
+public class ConnectAccountFragment extends BaseDAppsFragment implements PermissionListener {
     private static final String TAG = "ConnectAccount";
 
     private TextView mWebSite;
@@ -92,7 +94,7 @@ public class ConnectAccountFragment extends BaseDAppsFragment
                             mAccountsWithPermissions.size()));
             if (mAccountsListAdapter == null) {
                 mAccountsListAdapter =
-                        new BravePermissionAccountsListAdapter(mAccountInfos, false, this);
+                        new BravePermissionAccountsListAdapter(mAccountInfos, Mode.ACCOUNT_CONNECTION, this, null);
                 mRecyclerView.setAdapter(mAccountsListAdapter);
                 LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
                 mRecyclerView.setLayoutManager(layoutManager);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
@@ -14,6 +14,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -49,7 +50,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 
 /**
- * Fragment used to connect Dapps to the crypto account
+ * Fragment used to connect Dapps to the crypto account.
  */
 public class ConnectAccountFragment extends BaseDAppsFragment
         implements BravePermissionAccountsListAdapter.BravePermissionDelegate {
@@ -177,11 +178,13 @@ public class ConnectAccountFragment extends BaseDAppsFragment
     }
 
     @Override
+    @NonNull
     public HashSet<AccountInfo> getAccountsWithPermissions() {
         return mAccountsWithPermissions;
     }
 
     @Override
+    @Nullable
     public AccountInfo getSelectedAccount() {
         return mSelectedAccount;
     }
@@ -216,7 +219,7 @@ public class ConnectAccountFragment extends BaseDAppsFragment
     }
 
     @Override
-    public void connectAccount(AccountInfo account) {
+    public void connectAccount(@NonNull final AccountInfo account) {
         Tab tab = BraveRewardsHelper.currentActiveChromeTabbedActivityTab();
         if (tab != null) {
             if (tab.getWebContents() != null) {
@@ -238,7 +241,7 @@ public class ConnectAccountFragment extends BaseDAppsFragment
     }
 
     @Override
-    public void disconnectAccount(AccountInfo account) {
+    public void disconnectAccount(@NonNull final AccountInfo account) {
         getBraveWalletService().resetPermission(account.accountId, success -> {
             if (!success) {
                 return;
@@ -262,7 +265,7 @@ public class ConnectAccountFragment extends BaseDAppsFragment
     }
 
     @Override
-    public void switchAccount(AccountInfo account) {
+    public void switchAccount(@NonNull final AccountInfo account) {
         getKeyringService().setSelectedAccount(account.accountId, setSuccess -> {
             if (setSuccess) {
                 updateAccounts();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/dapps/ConnectAccountFragment.java
@@ -5,9 +5,6 @@
 
 package org.chromium.chrome.browser.crypto_wallet.fragments.dapps;
 
-import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.Mode;
-import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.PermissionListener;
-
 import android.annotation.SuppressLint;
 import android.graphics.Bitmap;
 import android.os.Bundle;
@@ -39,6 +36,8 @@ import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.app.domain.WalletModel;
 import org.chromium.chrome.browser.crypto_wallet.fragments.CreateAccountBottomSheetFragment;
 import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter;
+import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.Mode;
+import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.PermissionListener;
 import org.chromium.chrome.browser.crypto_wallet.util.AccountsPermissionsHelper;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
@@ -52,9 +51,7 @@ import org.chromium.url.GURL;
 import java.util.HashSet;
 import java.util.Iterator;
 
-/**
- * Fragment used to connect Dapps to the crypto account.
- */
+/** Fragment used to connect Dapps to the crypto account. */
 public class ConnectAccountFragment extends BaseDAppsFragment implements PermissionListener {
     private static final String TAG = "ConnectAccount";
 
@@ -87,24 +84,28 @@ public class ConnectAccountFragment extends BaseDAppsFragment implements Permiss
         if (mSelectedAccount == null || mAccountInfos == null) return;
         AccountsPermissionsHelper accountsPermissionsHelper =
                 new AccountsPermissionsHelper(getBraveWalletService(), mAccountInfos);
-        accountsPermissionsHelper.checkAccounts(() -> {
-            mAccountsWithPermissions = accountsPermissionsHelper.getAccountsWithPermissions();
-            mAccountsConnected.setText(
-                    String.format(getResources().getString(R.string.wallet_accounts_connected),
-                            mAccountsWithPermissions.size()));
-            if (mAccountsListAdapter == null) {
-                mAccountsListAdapter =
-                        new BravePermissionAccountsListAdapter(mAccountInfos, Mode.ACCOUNT_CONNECTION, this, null);
-                mRecyclerView.setAdapter(mAccountsListAdapter);
-                LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
-                mRecyclerView.setLayoutManager(layoutManager);
-            } else {
-                mAccountsListAdapter.setAccounts(mAccountInfos);
-                mAccountsListAdapter.setAccountsWithPermissions(mAccountsWithPermissions);
-                mAccountsListAdapter.setSelectedAccount(mSelectedAccount);
-                mAccountsListAdapter.notifyDataSetChanged();
-            }
-        });
+        accountsPermissionsHelper.checkAccounts(
+                () -> {
+                    mAccountsWithPermissions =
+                            accountsPermissionsHelper.getAccountsWithPermissions();
+                    mAccountsConnected.setText(
+                            String.format(
+                                    getResources().getString(R.string.wallet_accounts_connected),
+                                    mAccountsWithPermissions.size()));
+                    if (mAccountsListAdapter == null) {
+                        mAccountsListAdapter =
+                                new BravePermissionAccountsListAdapter(
+                                        mAccountInfos, Mode.ACCOUNT_CONNECTION, this, null);
+                        mRecyclerView.setAdapter(mAccountsListAdapter);
+                        LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity());
+                        mRecyclerView.setLayoutManager(layoutManager);
+                    } else {
+                        mAccountsListAdapter.setAccounts(mAccountInfos);
+                        mAccountsListAdapter.setAccountsWithPermissions(mAccountsWithPermissions);
+                        mAccountsListAdapter.setSelectedAccount(mSelectedAccount);
+                        mAccountsListAdapter.notifyDataSetChanged();
+                    }
+                });
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -54,14 +54,14 @@ import java.lang.ref.WeakReference;
 import java.util.List;
 
 /**
- * Dialog to grant website permissions to use Dapps
+ * Dialog to grant website permissions to use DApps.
  */
 public class BraveDappPermissionPromptDialog
         implements ModalDialogProperties.Controller, ConnectionErrorHandler {
     private static final String TAG = "BraveDappPermission";
 
     private final ModalDialogManager mModalDialogManager;
-    private int mCoinType;
+    private final int mCoinType;
     private final Context mContext;
     private long mNativeDialogController;
     private PropertyModel mPropertyModel;
@@ -99,7 +99,7 @@ public class BraveDappPermissionPromptDialog
             BraveActivity activity = BraveActivity.getBraveActivity();
             mWalletModel = activity.getWalletModel();
         } catch (BraveActivity.BraveActivityNotFoundException e) {
-            Log.e(TAG, "BraveDappPermissionPromptDialog constructor " + e);
+            Log.e(TAG, "BraveDappPermissionPromptDialog", e);
         }
     }
 
@@ -162,7 +162,7 @@ public class BraveDappPermissionPromptDialog
     }
 
     @NonNull
-    private ViewGroup getPermissionModalViewContainer(View customView) {
+    private ViewGroup getPermissionModalViewContainer(@NonNull View customView) {
         ViewParent viewParent = customView.getParent();
         while (viewParent.getParent() != null) {
             viewParent = viewParent.getParent();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -64,7 +64,6 @@ public class BraveDappPermissionPromptDialog
     private final Context mContext;
     private long mNativeDialogController;
     private PropertyModel mPropertyModel;
-    private WebContents mWebContents;
     private String mFavIconURL;
     private MaterialCardView mCvFavContainer;
     private ImageView mFavIconImage;
@@ -78,16 +77,15 @@ public class BraveDappPermissionPromptDialog
 
     @CalledByNative
     private static BraveDappPermissionPromptDialog create(long nativeDialogController,
-            @NonNull WindowAndroid windowAndroid, WebContents webContents, String favIconURL,
+            @NonNull WindowAndroid windowAndroid, String favIconURL,
             @CoinType.EnumType int coinType) {
         return new BraveDappPermissionPromptDialog(
-                nativeDialogController, windowAndroid, webContents, favIconURL, coinType);
+                nativeDialogController, windowAndroid, favIconURL, coinType);
     }
 
     public BraveDappPermissionPromptDialog(long nativeDialogController, WindowAndroid windowAndroid,
-            WebContents webContents, String favIconURL, @CoinType.EnumType int coinType) {
+                                           String favIconURL, @CoinType.EnumType int coinType) {
         mNativeDialogController = nativeDialogController;
-        mWebContents = webContents;
         mFavIconURL = favIconURL;
         mContext = windowAndroid.getActivity().get();
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -5,8 +5,6 @@
 
 package org.chromium.chrome.browser.crypto_wallet.permission;
 
-import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.Mode;
-
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.View;
@@ -37,6 +35,7 @@ import org.chromium.chrome.browser.app.helpers.ImageLoader;
 import org.chromium.chrome.browser.crypto_wallet.BraveWalletServiceFactory;
 import org.chromium.chrome.browser.crypto_wallet.KeyringServiceFactory;
 import org.chromium.chrome.browser.crypto_wallet.fragments.dapps.ConnectAccountFragment;
+import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.Mode;
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 import org.chromium.components.browser_ui.modaldialog.ModalDialogView;
@@ -55,9 +54,7 @@ import org.chromium.ui.modelutil.PropertyModel;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
-/**
- * Dialog to grant website permissions to use DApps.
- */
+/** Dialog to grant website permissions to use DApps. */
 public class BraveDappPermissionPromptDialog
         implements ModalDialogProperties.Controller, ConnectionErrorHandler {
     private static final String TAG = "BraveDappPermission";
@@ -188,14 +185,21 @@ public class BraveDappPermissionPromptDialog
         assert mWalletModel != null;
         // Solana accounts support only single account selection,
         // while Ethereum account offer multiple selection mode.
-        final Mode mode = mCoinType == CoinType.SOL ? Mode.SINGLE_ACCOUNT_SELECTION : Mode.MULTIPLE_ACCOUNT_SELECTION;
-        mAccountsListAdapter = new BravePermissionAccountsListAdapter(new AccountInfo[0], mode, null,
-                (account, checked) -> {
-                    if (mPermissionDialogPositiveButton != null) {
-                        mPermissionDialogPositiveButton.setEnabled(
-                                getSelectedAccounts().length > 0);
-                    }
-                });
+        final Mode mode =
+                mCoinType == CoinType.SOL
+                        ? Mode.SINGLE_ACCOUNT_SELECTION
+                        : Mode.MULTIPLE_ACCOUNT_SELECTION;
+        mAccountsListAdapter =
+                new BravePermissionAccountsListAdapter(
+                        new AccountInfo[0],
+                        mode,
+                        null,
+                        (account, checked) -> {
+                            if (mPermissionDialogPositiveButton != null) {
+                                mPermissionDialogPositiveButton.setEnabled(
+                                        getSelectedAccounts().length > 0);
+                            }
+                        });
         mRecyclerView.setAdapter(mAccountsListAdapter);
         LinearLayoutManager layoutManager = new LinearLayoutManager(mContext);
         mRecyclerView.setLayoutManager(layoutManager);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -5,6 +5,8 @@
 
 package org.chromium.chrome.browser.crypto_wallet.permission;
 
+import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccountsListAdapter.Mode;
+
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.view.View;
@@ -184,14 +186,14 @@ public class BraveDappPermissionPromptDialog
     private void initAccounts() {
         assert mKeyringService != null;
         assert mWalletModel != null;
-        mAccountsListAdapter = new BravePermissionAccountsListAdapter(new AccountInfo[0], true,
-                new BravePermissionAccountsListAdapter.BravePermissionDelegate() {
-                    @Override
-                    public void onAccountCheckChanged(AccountInfo account, boolean isChecked) {
-                        if (mPermissionDialogPositiveButton != null) {
-                            mPermissionDialogPositiveButton.setEnabled(
-                                    getSelectedAccounts().length > 0);
-                        }
+        // Solana accounts support only single account selection,
+        // while Ethereum account offer multiple selection mode.
+        final Mode mode = mCoinType == CoinType.SOL ? Mode.SINGLE_ACCOUNT_SELECTION : Mode.MULTIPLE_ACCOUNT_SELECTION;
+        mAccountsListAdapter = new BravePermissionAccountsListAdapter(new AccountInfo[0], mode, null,
+                (account, checked) -> {
+                    if (mPermissionDialogPositiveButton != null) {
+                        mPermissionDialogPositiveButton.setEnabled(
+                                getSelectedAccounts().length > 0);
                     }
                 });
         mRecyclerView.setAdapter(mAccountsListAdapter);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -39,7 +39,6 @@ import org.chromium.chrome.browser.crypto_wallet.permission.BravePermissionAccou
 import org.chromium.chrome.browser.crypto_wallet.util.Utils;
 import org.chromium.chrome.browser.crypto_wallet.util.WalletConstants;
 import org.chromium.components.browser_ui.modaldialog.ModalDialogView;
-import org.chromium.content_public.browser.WebContents;
 import org.chromium.mojo.bindings.ConnectionErrorHandler;
 import org.chromium.mojo.system.MojoException;
 import org.chromium.ui.LayoutInflaterUtils;
@@ -76,15 +75,20 @@ public class BraveDappPermissionPromptDialog
     private WalletModel mWalletModel;
 
     @CalledByNative
-    private static BraveDappPermissionPromptDialog create(long nativeDialogController,
-            @NonNull WindowAndroid windowAndroid, String favIconURL,
+    private static BraveDappPermissionPromptDialog create(
+            long nativeDialogController,
+            @NonNull WindowAndroid windowAndroid,
+            String favIconURL,
             @CoinType.EnumType int coinType) {
         return new BraveDappPermissionPromptDialog(
                 nativeDialogController, windowAndroid, favIconURL, coinType);
     }
 
-    public BraveDappPermissionPromptDialog(long nativeDialogController, WindowAndroid windowAndroid,
-                                           String favIconURL, @CoinType.EnumType int coinType) {
+    public BraveDappPermissionPromptDialog(
+            long nativeDialogController,
+            WindowAndroid windowAndroid,
+            String favIconURL,
+            @CoinType.EnumType int coinType) {
         mNativeDialogController = nativeDialogController;
         mFavIconURL = favIconURL;
         mContext = windowAndroid.getActivity().get();

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BravePermissionAccountsListAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BravePermissionAccountsListAdapter.java
@@ -11,7 +11,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CheckBox;
-import android.widget.CompoundButton;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -38,49 +37,55 @@ public class BravePermissionAccountsListAdapter
         extends RecyclerView.Adapter<BravePermissionAccountsListAdapter.ViewHolder> {
 
     /**
-     * Mode determines different styles in the UI,
-     * and offers different interactions with the available accounts.
+     * Mode determines different styles in the UI, and offers different interactions with the
+     * available accounts.
      */
     public enum Mode {
         /**
-         * Multiple accounts can be selected to be connected to a DApp.
-         * ETH accounts support multiple account selection.
+         * Multiple accounts can be selected to be connected to a DApp. ETH accounts support
+         * multiple account selection.
+         *
          * @see BraveDappPermissionPromptDialog
          */
         MULTIPLE_ACCOUNT_SELECTION,
         /**
-         * Only a single account can be selected to be connected to a DApp.
-         * SOL accounts support single account selection.
+         * Only a single account can be selected to be connected to a DApp. SOL accounts support
+         * single account selection.
+         *
          * @see BraveDappPermissionPromptDialog
          */
         SINGLE_ACCOUNT_SELECTION,
         /**
-         * Account connection mode shows for every account supported by a given DApp
-         * its relative permission, giving also the ability to grant, or revoke it for that DApp.
+         * Account connection mode shows for every account supported by a given DApp its relative
+         * permission, giving also the ability to grant, or revoke it for that DApp.
+         *
          * @see org.chromium.chrome.browser.crypto_wallet.fragments.dapps.ConnectAccountFragment
          */
         ACCOUNT_CONNECTION
     }
+
     private final ExecutorService mExecutor;
     private final Handler mHandler;
     private final List<Integer> mCheckedPositions = new ArrayList<>();
     private int mSelectedPosition = -1;
-    @Nullable
-    private final PermissionListener mDelegate;
-    @Nullable
-    private final AccountChangeListener mAccountChangeListener;
-    @NonNull
-    private final Mode mMode;
-    @NonNull
-    private AccountInfo[] mAccountInfoArray;
+    @Nullable private final PermissionListener mDelegate;
+    @Nullable private final AccountChangeListener mAccountChangeListener;
+    @NonNull private final Mode mMode;
+    @NonNull private AccountInfo[] mAccountInfoArray;
     private HashSet<AccountInfo> mAccountsWithPermissions;
     private AccountInfo mSelectedAccount;
 
     public interface PermissionListener {
-        @NonNull HashSet<AccountInfo> getAccountsWithPermissions();
-        @Nullable AccountInfo getSelectedAccount();
+        @NonNull
+        HashSet<AccountInfo> getAccountsWithPermissions();
+
+        @Nullable
+        AccountInfo getSelectedAccount();
+
         void connectAccount(@NonNull final AccountInfo account);
+
         void disconnectAccount(@NonNull final AccountInfo account);
+
         void switchAccount(@NonNull final AccountInfo account);
     }
 
@@ -89,7 +94,10 @@ public class BravePermissionAccountsListAdapter
     }
 
     public BravePermissionAccountsListAdapter(
-            @NonNull final AccountInfo[] accountInfo, @NonNull final Mode mode, @Nullable final PermissionListener delegate, @Nullable final AccountChangeListener accountChangeListener) {
+            @NonNull final AccountInfo[] accountInfo,
+            @NonNull final Mode mode,
+            @Nullable final PermissionListener delegate,
+            @Nullable final AccountChangeListener accountChangeListener) {
         mAccountInfoArray = accountInfo;
         mMode = mode;
         mDelegate = delegate;
@@ -133,21 +141,26 @@ public class BravePermissionAccountsListAdapter
 
         ViewHolder viewHolder = new ViewHolder(view);
         if (mMode != Mode.ACCOUNT_CONNECTION) {
-            viewHolder.itemView.setOnClickListener(v -> {
-                if (viewHolder.accountRadioButton.getVisibility() == View.VISIBLE) {
-                    viewHolder.accountRadioButton.setChecked(true);
-                } else if (viewHolder.accountCheck.getVisibility() == View.VISIBLE) {
-                    viewHolder.accountCheck.setChecked(!viewHolder.accountCheck.isChecked());
-                }
-            });
+            viewHolder.itemView.setOnClickListener(
+                    v -> {
+                        if (viewHolder.accountRadioButton.getVisibility() == View.VISIBLE) {
+                            viewHolder.accountRadioButton.setChecked(true);
+                        } else if (viewHolder.accountCheck.getVisibility() == View.VISIBLE) {
+                            viewHolder.accountCheck.setChecked(
+                                    !viewHolder.accountCheck.isChecked());
+                        }
+                    });
         }
         return viewHolder;
     }
 
     @Override
-    public void onBindViewHolder(@NonNull ViewHolder holder, int position, @NonNull List<Object> payloads) {
+    public void onBindViewHolder(
+            @NonNull ViewHolder holder, int position, @NonNull List<Object> payloads) {
         // Skip binding function when payload matches the previous selected position.
-        if (payloads.isEmpty() || !(payloads.get(0) instanceof Integer) || ((int) payloads.get(0)) != position) {
+        if (payloads.isEmpty()
+                || !(payloads.get(0) instanceof Integer)
+                || ((int) payloads.get(0)) != position) {
             super.onBindViewHolder(holder, position, payloads);
         }
     }
@@ -160,10 +173,11 @@ public class BravePermissionAccountsListAdapter
         Utils.setBlockiesBitmapResourceFromAccount(
                 mExecutor, mHandler, holder.iconImg, accountInfo, true, false);
 
-        switch(mMode) {
+        switch (mMode) {
             case SINGLE_ACCOUNT_SELECTION -> {
                 holder.accountRadioButton.setVisibility(View.VISIBLE);
-                if (mSelectedAccount != null && mSelectedAccount.address.equals(accountInfo.address)) {
+                if (mSelectedAccount != null
+                        && mSelectedAccount.address.equals(accountInfo.address)) {
                     holder.accountRadioButton.setChecked(true);
                 } else {
                     holder.accountRadioButton.setChecked(position == mSelectedPosition);
@@ -175,11 +189,13 @@ public class BravePermissionAccountsListAdapter
 
             case MULTIPLE_ACCOUNT_SELECTION -> {
                 holder.accountCheck.setVisibility(View.VISIBLE);
-                if (mSelectedAccount != null && mSelectedAccount.address.equals(accountInfo.address)) {
+                if (mSelectedAccount != null
+                        && mSelectedAccount.address.equals(accountInfo.address)) {
                     holder.accountCheck.setChecked(true);
                 }
                 holder.accountCheck.setOnCheckedChangeListener(
-                        (buttonView, checked) -> setUpListener(holder, accountInfo, checked, false));
+                        (buttonView, checked) ->
+                                setUpListener(holder, accountInfo, checked, false));
             }
 
             case ACCOUNT_CONNECTION -> {
@@ -187,8 +203,10 @@ public class BravePermissionAccountsListAdapter
                 boolean hasPermission = hasPermission(accountInfo.address);
                 boolean isConnected = accountInfo.address.equals(mSelectedAccount.address);
                 if (CoinType.SOL == mSelectedAccount.accountId.coin) {
-                    connectionButtonText = hasPermission ? R.string.brave_wallet_site_permissions_revoke
-                            : R.string.brave_wallet_site_permissions_trust;
+                    connectionButtonText =
+                            hasPermission
+                                    ? R.string.brave_wallet_site_permissions_revoke
+                                    : R.string.brave_wallet_site_permissions_trust;
                 } else {
                     if (hasPermission) {
                         if (isConnected) {
@@ -200,37 +218,45 @@ public class BravePermissionAccountsListAdapter
                         connectionButtonText = R.string.fragment_connect_account_connect;
                     }
                 }
-                holder.accountAction.setText(holder.accountAction.getContext().getResources().getString(
-                        connectionButtonText));
+                holder.accountAction.setText(
+                        holder.accountAction
+                                .getContext()
+                                .getResources()
+                                .getString(connectionButtonText));
 
                 holder.accountAction.setVisibility(View.VISIBLE);
-                holder.accountAction.setOnClickListener(v -> {
-                    if (mDelegate == null) {
-                        return;
-                    }
-                    if (CoinType.SOL == accountInfo.accountId.coin) {
-                        if (hasPermission) {
-                            mDelegate.disconnectAccount(accountInfo);
-                        } else {
-                            mDelegate.connectAccount(accountInfo);
-                        }
-                    } else {
-                        if (hasPermission) {
-                            if (isConnected) {
-                                mDelegate.disconnectAccount(accountInfo);
-                            } else {
-                                mDelegate.switchAccount(accountInfo);
+                holder.accountAction.setOnClickListener(
+                        v -> {
+                            if (mDelegate == null) {
+                                return;
                             }
-                        } else {
-                            mDelegate.connectAccount(accountInfo);
-                        }
-                    }
-                });
+                            if (CoinType.SOL == accountInfo.accountId.coin) {
+                                if (hasPermission) {
+                                    mDelegate.disconnectAccount(accountInfo);
+                                } else {
+                                    mDelegate.connectAccount(accountInfo);
+                                }
+                            } else {
+                                if (hasPermission) {
+                                    if (isConnected) {
+                                        mDelegate.disconnectAccount(accountInfo);
+                                    } else {
+                                        mDelegate.switchAccount(accountInfo);
+                                    }
+                                } else {
+                                    mDelegate.connectAccount(accountInfo);
+                                }
+                            }
+                        });
             }
         }
     }
 
-    private void setUpListener(@NonNull final ViewHolder holder, @NonNull final AccountInfo accountInfo, final boolean checked, final boolean singleSelection) {
+    private void setUpListener(
+            @NonNull final ViewHolder holder,
+            @NonNull final AccountInfo accountInfo,
+            final boolean checked,
+            final boolean singleSelection) {
         if (checked) {
             mCheckedPositions.add(holder.getBindingAdapterPosition());
             if (singleSelection) {
@@ -240,12 +266,13 @@ public class BravePermissionAccountsListAdapter
                 if (getItemCount() > 1) {
                     // Notify data set changed inside `Handler#post()` because of
                     // https://issuetracker.google.com/issues/37136189
-                    mHandler.post(() -> {
-                        // Pass the selected position in the payload so it will be
-                        // excluded from `onBindViewHolder(ViewHolder, int)`. Excluding
-                        // it from another binding will fully preserve animation selection.
-                        notifyItemRangeChanged(0, getItemCount(), mSelectedPosition);
-                    });
+                    mHandler.post(
+                            () -> {
+                                // Pass the selected position in the payload so it will be
+                                // excluded from `onBindViewHolder(ViewHolder, int)`. Excluding
+                                // it from another binding will fully preserve animation selection.
+                                notifyItemRangeChanged(0, getItemCount(), mSelectedPosition);
+                            });
                 }
             }
         } else {

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BravePermissionAccountsListAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BravePermissionAccountsListAdapter.java
@@ -5,7 +5,6 @@
 
 package org.chromium.chrome.browser.crypto_wallet.permission;
 
-import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.view.LayoutInflater;
@@ -17,7 +16,10 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.radiobutton.MaterialRadioButton;
 
 import org.chromium.brave_wallet.mojom.AccountInfo;
 import org.chromium.brave_wallet.mojom.CoinType;
@@ -28,61 +30,77 @@ import org.chromium.chrome.browser.crypto_wallet.util.WalletUtils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 public class BravePermissionAccountsListAdapter
         extends RecyclerView.Adapter<BravePermissionAccountsListAdapter.ViewHolder> {
-    private Context mContext;
-    private AccountInfo[] mAccountInfos;
-    private ExecutorService mExecutor;
-    private Handler mHandler;
-    private List<Integer> mCheckedPositions = new ArrayList<>();
-    private boolean mCheckBoxStyle;
-    private BravePermissionDelegate mDelegate;
+
+    /**
+     * Mode determines different styles in the UI,
+     * and offers different interactions with the available accounts.
+     */
+    public enum Mode {
+        /**
+         * Multiple accounts can be selected to be connected to a DApp.
+         * ETH accounts support multiple account selection.
+         * @see BraveDappPermissionPromptDialog
+         */
+        MULTIPLE_ACCOUNT_SELECTION,
+        /**
+         * Only a single account can be selected to be connected to a DApp.
+         * SOL accounts support single account selection.
+         * @see BraveDappPermissionPromptDialog
+         */
+        SINGLE_ACCOUNT_SELECTION,
+        /**
+         * Account connection mode shows for every account supported by a given DApp
+         * its relative permission, giving also the ability to grant, or revoke it for that DApp.
+         * @see org.chromium.chrome.browser.crypto_wallet.fragments.dapps.ConnectAccountFragment
+         */
+        ACCOUNT_CONNECTION
+    }
+    private final ExecutorService mExecutor;
+    private final Handler mHandler;
+    private final List<Integer> mCheckedPositions = new ArrayList<>();
+    private int mSelectedPosition = -1;
+    @Nullable
+    private final PermissionListener mDelegate;
+    @Nullable
+    private final AccountChangeListener mAccountChangeListener;
+    @NonNull
+    private final Mode mMode;
+    @NonNull
+    private AccountInfo[] mAccountInfoArray;
     private HashSet<AccountInfo> mAccountsWithPermissions;
     private AccountInfo mSelectedAccount;
 
-    public interface BravePermissionDelegate {
-        default HashSet<AccountInfo> getAccountsWithPermissions() {
-            return null;
-        }
-        default AccountInfo getSelectedAccount() {
-            return null;
-        }
-        default void connectAccount(AccountInfo account){};
-        default void disconnectAccount(AccountInfo account){};
-        default void switchAccount(AccountInfo account){};
-        default void onAccountCheckChanged(AccountInfo account, boolean isChecked){};
+    public interface PermissionListener {
+        @NonNull HashSet<AccountInfo> getAccountsWithPermissions();
+        @Nullable AccountInfo getSelectedAccount();
+        void connectAccount(@NonNull final AccountInfo account);
+        void disconnectAccount(@NonNull final AccountInfo account);
+        void switchAccount(@NonNull final AccountInfo account);
+    }
+
+    public interface AccountChangeListener {
+        void onAccountCheckChanged(@NonNull final AccountInfo account, final boolean checked);
     }
 
     public BravePermissionAccountsListAdapter(
-            AccountInfo[] accountInfo, boolean checkBoxStyle, BravePermissionDelegate delegate) {
-        assert accountInfo != null;
-        mAccountInfos = accountInfo;
-        mCheckBoxStyle = checkBoxStyle;
+            @NonNull final AccountInfo[] accountInfo, @NonNull final Mode mode, @Nullable final PermissionListener delegate, @Nullable final AccountChangeListener accountChangeListener) {
+        mAccountInfoArray = accountInfo;
+        mMode = mode;
         mDelegate = delegate;
+        mAccountChangeListener = accountChangeListener;
         mExecutor = Executors.newSingleThreadExecutor();
         mHandler = new Handler(Looper.getMainLooper());
     }
 
-    @Override
-    public @NonNull ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
-        mContext = parent.getContext();
-        LayoutInflater inflater = LayoutInflater.from(mContext);
-        View view = inflater.inflate(R.layout.brave_wallet_accounts_list_item, parent, false);
-        if (!mCheckBoxStyle && mDelegate != null) {
-            mAccountsWithPermissions = mDelegate.getAccountsWithPermissions();
-            mSelectedAccount = mDelegate.getSelectedAccount();
-        }
-
-        return new ViewHolder(view);
-    }
-
-    public void setAccounts(AccountInfo[] accountInfo) {
-        mAccountInfos = accountInfo;
+    public void setAccounts(@NonNull final AccountInfo[] accountInfo) {
+        mAccountInfoArray = accountInfo;
+        mCheckedPositions.clear();
     }
 
     public void setAccountsWithPermissions(HashSet<AccountInfo> accountsWithPermissions) {
@@ -91,98 +109,167 @@ public class BravePermissionAccountsListAdapter
 
     public void setSelectedAccount(AccountInfo selectedAccount) {
         mSelectedAccount = selectedAccount;
-        if (mAccountInfos == null || !mCheckBoxStyle) return;
-        for (int i = 0; i < mAccountInfos.length; i++) {
-            if (WalletUtils.accountIdsEqual(mSelectedAccount, mAccountInfos[i])) {
-                mCheckedPositions.add(i);
+        if (mMode == Mode.ACCOUNT_CONNECTION) return;
+        for (int i = 0; i < mAccountInfoArray.length; i++) {
+            if (WalletUtils.accountIdsEqual(mSelectedAccount, mAccountInfoArray[i])) {
+                // Do not add duplicates.
+                if (!mCheckedPositions.contains(i)) {
+                    mCheckedPositions.add(i);
+                }
                 break;
             }
         }
     }
 
     @Override
-    public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        final int arrayPosition = position;
-        AccountInfo accountInfo = mAccountInfos[position];
+    @NonNull
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        LayoutInflater inflater = LayoutInflater.from(parent.getContext());
+        View view = inflater.inflate(R.layout.brave_wallet_accounts_list_item, parent, false);
+        if (mMode == Mode.ACCOUNT_CONNECTION && mDelegate != null) {
+            mAccountsWithPermissions = mDelegate.getAccountsWithPermissions();
+            mSelectedAccount = mDelegate.getSelectedAccount();
+        }
+
+        ViewHolder viewHolder = new ViewHolder(view);
+        if (mMode != Mode.ACCOUNT_CONNECTION) {
+            viewHolder.itemView.setOnClickListener(v -> {
+                if (viewHolder.accountRadioButton.getVisibility() == View.VISIBLE) {
+                    viewHolder.accountRadioButton.setChecked(true);
+                } else if (viewHolder.accountCheck.getVisibility() == View.VISIBLE) {
+                    viewHolder.accountCheck.setChecked(!viewHolder.accountCheck.isChecked());
+                }
+            });
+        }
+        return viewHolder;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, int position, @NonNull List<Object> payloads) {
+        // Skip binding function when payload matches the previous selected position.
+        if (payloads.isEmpty() || !(payloads.get(0) instanceof Integer) || ((int) payloads.get(0)) != position) {
+            super.onBindViewHolder(holder, position, payloads);
+        }
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ViewHolder holder, final int position) {
+        final AccountInfo accountInfo = mAccountInfoArray[position];
         holder.titleText.setText(accountInfo.name);
         holder.subTitleText.setText(AddressUtils.getTruncatedAddress(accountInfo.address));
         Utils.setBlockiesBitmapResourceFromAccount(
                 mExecutor, mHandler, holder.iconImg, accountInfo, true, false);
 
-        if (mCheckBoxStyle) {
-            holder.accountCheck.setVisibility(View.VISIBLE);
-            if (mSelectedAccount != null && mSelectedAccount.address.equals(accountInfo.address)) {
-                holder.accountCheck.setChecked(true);
-            }
-            holder.accountCheck.setOnCheckedChangeListener(
-                    new CompoundButton.OnCheckedChangeListener() {
-                        @Override
-                        public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                            if (isChecked) {
-                                mCheckedPositions.add(arrayPosition);
-                            } else {
-                                mCheckedPositions.remove((Integer) arrayPosition);
-                            }
-                            if (mDelegate != null) {
-                                mDelegate.onAccountCheckChanged(accountInfo, isChecked);
-                            }
-                        }
-                    });
-        } else {
-            int connectionButtonText = R.string.fragment_connect_account_disconnect;
-            boolean hasPermission = hasPermission(accountInfo.address);
-            boolean isConnected = accountInfo.address.equals(mSelectedAccount.address);
-            if (CoinType.SOL == mSelectedAccount.accountId.coin) {
-                connectionButtonText = hasPermission ? R.string.brave_wallet_site_permissions_revoke
-                                                     : R.string.brave_wallet_site_permissions_trust;
-            } else {
-                if (hasPermission) {
-                    if (isConnected) {
-                        connectionButtonText = R.string.fragment_connect_account_disconnect;
-                    } else {
-                        connectionButtonText = R.string.fragment_connect_account_switch;
-                    }
+        switch(mMode) {
+            case SINGLE_ACCOUNT_SELECTION -> {
+                holder.accountRadioButton.setVisibility(View.VISIBLE);
+                if (mSelectedAccount != null && mSelectedAccount.address.equals(accountInfo.address)) {
+                    holder.accountRadioButton.setChecked(true);
                 } else {
-                    connectionButtonText = R.string.fragment_connect_account_connect;
+                    holder.accountRadioButton.setChecked(position == mSelectedPosition);
                 }
-            }
-            holder.accountAction.setText(holder.accountAction.getContext().getResources().getString(
-                    connectionButtonText));
 
-            holder.accountAction.setVisibility(View.VISIBLE);
-            holder.accountAction.setOnClickListener(v -> {
-                assert mDelegate != null;
-                if (CoinType.SOL == accountInfo.accountId.coin) {
-                    if (hasPermission) {
-                        mDelegate.disconnectAccount(accountInfo);
-                    } else {
-                        mDelegate.connectAccount(accountInfo);
-                    }
+                holder.accountRadioButton.setOnCheckedChangeListener(
+                        (buttonView, checked) -> setUpListener(holder, accountInfo, checked, true));
+            }
+
+            case MULTIPLE_ACCOUNT_SELECTION -> {
+                holder.accountCheck.setVisibility(View.VISIBLE);
+                if (mSelectedAccount != null && mSelectedAccount.address.equals(accountInfo.address)) {
+                    holder.accountCheck.setChecked(true);
+                }
+                holder.accountCheck.setOnCheckedChangeListener(
+                        (buttonView, checked) -> setUpListener(holder, accountInfo, checked, false));
+            }
+
+            case ACCOUNT_CONNECTION -> {
+                int connectionButtonText;
+                boolean hasPermission = hasPermission(accountInfo.address);
+                boolean isConnected = accountInfo.address.equals(mSelectedAccount.address);
+                if (CoinType.SOL == mSelectedAccount.accountId.coin) {
+                    connectionButtonText = hasPermission ? R.string.brave_wallet_site_permissions_revoke
+                            : R.string.brave_wallet_site_permissions_trust;
                 } else {
                     if (hasPermission) {
                         if (isConnected) {
-                            mDelegate.disconnectAccount(accountInfo);
+                            connectionButtonText = R.string.fragment_connect_account_disconnect;
                         } else {
-                            mDelegate.switchAccount(accountInfo);
+                            connectionButtonText = R.string.fragment_connect_account_switch;
                         }
                     } else {
-                        mDelegate.connectAccount(accountInfo);
+                        connectionButtonText = R.string.fragment_connect_account_connect;
                     }
                 }
-            });
+                holder.accountAction.setText(holder.accountAction.getContext().getResources().getString(
+                        connectionButtonText));
+
+                holder.accountAction.setVisibility(View.VISIBLE);
+                holder.accountAction.setOnClickListener(v -> {
+                    if (mDelegate == null) {
+                        return;
+                    }
+                    if (CoinType.SOL == accountInfo.accountId.coin) {
+                        if (hasPermission) {
+                            mDelegate.disconnectAccount(accountInfo);
+                        } else {
+                            mDelegate.connectAccount(accountInfo);
+                        }
+                    } else {
+                        if (hasPermission) {
+                            if (isConnected) {
+                                mDelegate.disconnectAccount(accountInfo);
+                            } else {
+                                mDelegate.switchAccount(accountInfo);
+                            }
+                        } else {
+                            mDelegate.connectAccount(accountInfo);
+                        }
+                    }
+                });
+            }
+        }
+    }
+
+    private void setUpListener(@NonNull final ViewHolder holder, @NonNull final AccountInfo accountInfo, final boolean checked, final boolean singleSelection) {
+        if (checked) {
+            mCheckedPositions.add(holder.getBindingAdapterPosition());
+            if (singleSelection) {
+                mSelectedPosition = holder.getBindingAdapterPosition();
+                // Notify data set changed ONLY for more
+                // than one item, otherwise there is not point
+                if (getItemCount() > 1) {
+                    // Notify data set changed inside `Handler#post()` because of
+                    // https://issuetracker.google.com/issues/37136189
+                    mHandler.post(() -> {
+                        // Pass the selected position in the payload so it will be
+                        // excluded from `onBindViewHolder(ViewHolder, int)`. Excluding
+                        // it from another binding will fully preserve animation selection.
+                        notifyItemRangeChanged(0, getItemCount(), mSelectedPosition);
+                    });
+                }
+            }
+        } else {
+            mCheckedPositions.remove((Integer) holder.getBindingAdapterPosition());
+        }
+        if (mAccountChangeListener != null) {
+            mAccountChangeListener.onAccountCheckChanged(accountInfo, checked);
         }
     }
 
     @Override
     public int getItemCount() {
-        return mAccountInfos.length;
+        return mAccountInfoArray.length;
+    }
+
+    @Override
+    public long getItemId(int position) {
+        return position;
     }
 
     private boolean hasPermission(String address) {
         assert mAccountsWithPermissions != null;
-        Iterator<AccountInfo> it = mAccountsWithPermissions.iterator();
-        while (it.hasNext()) {
-            if (it.next().address.equals(address)) {
+        for (AccountInfo mAccountsWithPermission : mAccountsWithPermissions) {
+            if (mAccountsWithPermission.address.equals(address)) {
                 return true;
             }
         }
@@ -193,7 +280,7 @@ public class BravePermissionAccountsListAdapter
     public AccountInfo[] getCheckedAccounts() {
         AccountInfo[] checkedAccounts = new AccountInfo[mCheckedPositions.size()];
         for (int i = 0; i < mCheckedPositions.size(); i++) {
-            checkedAccounts[i] = mAccountInfos[mCheckedPositions.get(i)];
+            checkedAccounts[i] = mAccountInfoArray[mCheckedPositions.get(i)];
         }
 
         return checkedAccounts;
@@ -204,6 +291,7 @@ public class BravePermissionAccountsListAdapter
         public TextView titleText;
         public TextView subTitleText;
         public CheckBox accountCheck;
+        public MaterialRadioButton accountRadioButton;
         public TextView accountAction;
 
         public ViewHolder(View itemView) {
@@ -212,6 +300,7 @@ public class BravePermissionAccountsListAdapter
             this.titleText = itemView.findViewById(R.id.title);
             this.subTitleText = itemView.findViewById(R.id.sub_title);
             this.accountCheck = itemView.findViewById(R.id.account_check);
+            this.accountRadioButton = itemView.findViewById(R.id.account_radio_button);
             this.accountAction = itemView.findViewById(R.id.account_action);
         }
     }

--- a/android/java/res/layout/brave_wallet_accounts_list_item.xml
+++ b/android/java/res/layout/brave_wallet_accounts_list_item.xml
@@ -5,7 +5,6 @@
      You can obtain one at https://mozilla.org/MPL/2.0/. */ -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="?android:attr/selectableItemBackground"
@@ -57,6 +56,13 @@
        android:layout_height="wrap_content"
        android:visibility="gone"
        android:layout_gravity="end" />
+
+    <com.google.android.material.radiobutton.MaterialRadioButton
+        android:id="@+id/account_radio_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_gravity="end" />
 
     <TextView
         android:id="@+id/account_action"

--- a/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.cc
+++ b/browser/permissions/brave_dapp_permission_prompt_dialog_controller_android.cc
@@ -92,7 +92,6 @@ BraveDappPermissionPromptDialogController::GetOrCreateJavaObject() {
   return java_object_ = Java_BraveDappPermissionPromptDialog_create(
              env, reinterpret_cast<intptr_t>(this),
              view_android->GetWindowAndroid()->GetJavaObject(),
-             web_contents_->GetJavaWebContents(),
              base::android::ConvertUTF8ToJavaString(
                  env, fav_icon_url.is_valid() ? fav_icon_url.spec() : ""),
              static_cast<int32_t>(coin_type_));


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/35951

Implements the ability to show all available Solana accounts during (Solana) DApp integration.


https://github.com/brave/brave-core/assets/3308503/687c6626-1da3-487b-9b45-f49ae0f874d7

### Solana Accounts

<img width="588" alt="Android_SDK_built_for_x86" src="https://github.com/brave/brave-core/assets/3308503/69e4b88a-5c44-4b9a-94bd-0dc837189257">

### Ethereum Accounts

<img width="585" alt="Android_SDK_built_for_x86" src="https://github.com/brave/brave-core/assets/3308503/20314db0-4b25-4295-b534-e59d2c1d9edb">



Because Solana supports connecting to **one** and **only one** account, the DApp integration dialog UI will show radio buttons instead of check buttons, following the same implementation adopted by Desktop.

Splits `BravePermissionDelegate` into two separate interfaces `PewrmissionListener` and `AccountChangeListener`.

Implements new `Mode` enum to tame the complexity of the adapter:

```java
    /**
     * Mode determines different styles in the UI, and offers different interactions with the
     * available accounts.
     */
    public enum Mode {
        /**
         * Multiple accounts can be selected to be connected to a DApp. ETH accounts support
         * multiple account selection.
         *
         * @see BraveDappPermissionPromptDialog
         */
        MULTIPLE_ACCOUNT_SELECTION,
        /**
         * Only a single account can be selected to be connected to a DApp. SOL accounts support
         * single account selection.
         *
         * @see BraveDappPermissionPromptDialog
         */
        SINGLE_ACCOUNT_SELECTION,
        /**
         * Account connection mode shows for every account supported by a given DApp its relative
         * permission, giving also the ability to grant, or revoke it for that DApp.
         *
         * @see org.chromium.chrome.browser.crypto_wallet.fragments.dapps.ConnectAccountFragment
         */
        ACCOUNT_CONNECTION
    }
```

Improves logic and performs heavy refactoring to entire `BravePermissionAccountsListAdapter` class.

Removes unused web content parameter passed from Core.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
**Preconditions:**
- Set up a Wallet with multiple Solana accounts

**Steps:**
- Navigate to https://anza-xyz.github.io/wallet-adapter/example/
- Tap on Select Wallet
- Tap on Brave Wallet
- If required, unlock the Wallet
- Observe the DApp integration dialog showing all the Solana account
- Observe one and only one account can be selected
- Tap Continue
- Observe the correct account is displayed in the page 
