### PR TITLE
feat(wallet): add support for cross-chain swaps

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -166,7 +166,6 @@ const Config = function () {
   this.googleDefaultClientId = getNPMConfig(['google_default_client_id']) || ''
   this.googleDefaultClientSecret = getNPMConfig(['google_default_client_secret']) || ''
   this.infuraProjectId = getNPMConfig(['brave_infura_project_id']) || ''
-  this.braveZeroExApiKey = getNPMConfig(['brave_zero_ex_api_key']) || ''
   this.sardineClientId = getNPMConfig(['sardine_client_id']) || ''
   this.sardineClientSecret = getNPMConfig(['sardine_client_secret']) || ''
   this.bitFlyerProductionClientId = getNPMConfig(['bitflyer_production_client_id']) || ''
@@ -371,7 +370,6 @@ Config.prototype.buildArgs = function () {
     google_default_client_id: this.googleDefaultClientId,
     google_default_client_secret: this.googleDefaultClientSecret,
     brave_infura_project_id: this.infuraProjectId,
-    brave_zero_ex_api_key: this.braveZeroExApiKey,
     bitflyer_production_client_id: this.bitFlyerProductionClientId,
     bitflyer_production_client_secret: this.bitFlyerProductionClientSecret,
     bitflyer_production_fee_address: this.bitFlyerProductionFeeAddress,
@@ -903,10 +901,6 @@ Config.prototype.update = function (options) {
 
   if (options.brave_infura_project_id) {
     this.infuraProjectId = options.brave_infura_project_id
-  }
-
-  if (options.brave_zero_ex_api_key) {
-    this.braveZeroExApiKey = options.brave_zero_ex_api_key
   }
 
   if (options.bitflyer_production_client_id) {

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1244,7 +1244,6 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_SWAP_MINIMUM_RECEIVED_AFTER_SLIPPAGE},
     {"braveSwapNetworkFee", IDS_BRAVE_SWAP_NETWORK_FEE},
     {"braveSwapBraveFee", IDS_BRAVE_SWAP_BRAVE_FEE},
-    {"braveSwapProtocolFee", IDS_BRAVE_SWAP_PROTOCOL_FEE},
     {"braveSwapFree", IDS_BRAVE_SWAP_FREE},
     {"braveSwapLiquidityProvider", IDS_BRAVE_SWAP_LIQUIDITY_PROVIDER},
     {"braveSwapSwapAndSend", IDS_BRAVE_SWAP_SWAP_AND_SEND},
@@ -1394,42 +1393,57 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletPlatforms", IDS_BRAVE_WALLET_PLATFORMS}};
 
 // 0x swap constants
-inline constexpr char kGoerliSwapBaseAPIURL[] = "https://goerli.api.0x.org/";
-inline constexpr char kPolygonSwapBaseAPIURL[] = "https://polygon.api.0x.org/";
-inline constexpr char kBinanceSmartChainSwapBaseAPIURL[] =
-    "https://bsc.api.0x.org/";
-inline constexpr char kAvalancheSwapBaseAPIURL[] =
-    "https://avalanche.api.0x.org/";
-inline constexpr char kFantomSwapBaseAPIURL[] = "https://fantom.api.0x.org/";
-inline constexpr char kCeloSwapBaseAPIURL[] = "https://celo.api.0x.org/";
-inline constexpr char kOptimismSwapBaseAPIURL[] =
-    "https://optimism.api.0x.org/";
-inline constexpr char kArbitrumSwapBaseAPIURL[] =
-    "https://arbitrum.api.0x.org/";
-inline constexpr char kBaseSwapBaseAPIURL[] = "https://base.api.0x.org/";
-inline constexpr char kSwapBaseAPIURL[] = "https://api.0x.org/";
-constexpr double k0xBuyTokenFeePercentage = 0.875;
-constexpr double k0xProtocolFeePercentage = 0.15;
+inline constexpr char kZeroExGoerliBaseAPIURL[] =
+    "https://goerli.api.0x.wallet.brave.com";
+inline constexpr char kZeroExPolygonBaseAPIURL[] =
+    "https://polygon.api.0x.wallet.brave.com";
+inline constexpr char kZeroExBinanceSmartChainBaseAPIURL[] =
+    "https://bsc.api.0x.wallet.brave.com";
+inline constexpr char kZeroExAvalancheBaseAPIURL[] =
+    "https://avalanche.api.0x.wallet.brave.com";
+inline constexpr char kZeroExFantomBaseAPIURL[] =
+    "https://fantom.api.0x.wallet.brave.com";
+inline constexpr char kZeroExCeloBaseAPIURL[] =
+    "https://celo.api.0x.wallet.brave.com";
+inline constexpr char kZeroExOptimismBaseAPIURL[] =
+    "https://optimism.api.0x.wallet.brave.com";
+inline constexpr char kZeroExArbitrumBaseAPIURL[] =
+    "https://arbitrum.api.0x.wallet.brave.com";
+inline constexpr char kZeroExBaseBaseAPIURL[] =
+    "https://base.api.0x.wallet.brave.com";
+inline constexpr char kZeroExEthereumBaseAPIURL[] =
+    "https://api.0x.wallet.brave.com";
+inline constexpr double kZeroExBuyTokenFeePercentage = 0.875;
 inline constexpr char kEVMFeeRecipient[] =
     "0xbd9420A98a7Bd6B89765e5715e169481602D9c3d";
 inline constexpr char kAffiliateAddress[] =
     "0xbd9420A98a7Bd6B89765e5715e169481602D9c3d";
-inline constexpr char k0xAPIKeyHeader[] = "0x-api-key";
+inline constexpr char kZeroExNativeAssetContractAddress[] =
+    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
 // Jupiter swap constants
-inline constexpr char kSolanaSwapBaseAPIURL[] = "https://quote-api.jup.ag/";
-constexpr double kSolanaBuyTokenFeePercentage = 0.85;
+inline constexpr char kJupiterBaseAPIURL[] = "https://quote-api.jup.ag";
+inline constexpr double kSolanaBuyTokenFeePercentage = 0.85;
 inline constexpr char kJupiterReferralKey[] =
     "7yke2kxg6ewNsun61qBkdsLdxuXcUiB8CMB47Zv39Aoy";
 inline constexpr char kJupiterReferralProgram[] =
     "REFER4ZgmyYx9c6He5XfaTMiGfdLwRnkV4RPp9t9iF3";
 inline constexpr char kJupiterReferralProgramHeader[] = "referral_ata";
+inline constexpr char kWrappedSolanaMintAddress[] =
+    "So11111111111111111111111111111111111111112";
 
 // Blowfish simulations constants
 inline constexpr char kBlowfishBaseAPIURL[] =
     "https://blowfish.wallet.brave.com";
 inline constexpr char kBlowfishAPIVersionHeader[] = "X-Api-Version";
 inline constexpr char kBlowfishAPIVersion[] = "2023-06-05";
+
+// LiFi constants
+inline constexpr char kLiFiBaseAPIURL[] = "https://li.quest";
+inline constexpr char kLiFiIntegratorID[] = "brave";
+inline constexpr char kLiFiNativeAssetContractAddress[] =
+    "0x0000000000000000000000000000000000000000";
+inline constexpr double kLiFiFeePercentage = 0.875;
 
 constexpr int64_t kBlockTrackerDefaultTimeInSeconds = 20;
 constexpr int64_t kLogTrackerDefaultTimeInSeconds = 20;

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -152,8 +152,7 @@ std::optional<std::string> EncodeChainId(const std::string& value) {
     return std::nullopt;
   }
 
-  if (val > std::numeric_limits<uint64_t>::max() ||
-      val < std::numeric_limits<uint64_t>::min()) {
+  if (val > std::numeric_limits<uint64_t>::max()) {
     return std::nullopt;
   }
 

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_wallet/browser/swap_request_helper.h"
 
+#include <limits>
 #include <optional>
 #include <utility>
 #include <vector>
@@ -17,10 +18,12 @@
 #include "brave/components/brave_wallet/browser/solana_keyring.h"
 #include "brave/components/brave_wallet/common/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/common/encoding_utils.h"
+#include "brave/components/brave_wallet/common/hex_utils.h"
 #include "brave/components/json/rs/src/lib.rs.h"
 
 namespace brave_wallet {
 
+namespace jupiter {
 namespace {
 
 // Docs: https://station.jup.ag/docs/apis/adding-fees
@@ -49,9 +52,8 @@ std::optional<std::string> GetFeeAccount(const std::string& output_mint) {
 
 }  // namespace
 
-std::optional<std::string> EncodeJupiterTransactionParams(
-    const mojom::JupiterTransactionParams& params,
-    bool has_fee) {
+std::optional<std::string> EncodeTransactionParams(
+    const mojom::JupiterTransactionParams& params) {
   base::Value::Dict tx_params;
 
   // The code below does the following two things:
@@ -66,7 +68,7 @@ std::optional<std::string> EncodeJupiterTransactionParams(
   // If the if-condition below is false, fee_account is unused,
   // but the originating call to GetFeeAccount() is still done to ensure
   // output_mint is always valid.
-  if (has_fee) {
+  if (params.quote->platform_fee) {
     tx_params.Set("feeAccount", *fee_account);
   }
 
@@ -87,6 +89,8 @@ std::optional<std::string> EncodeJupiterTransactionParams(
     platform_fee.Set("amount", params.quote->platform_fee->amount);
     platform_fee.Set("feeBps", params.quote->platform_fee->fee_bps);
     quote.Set("platformFee", std::move(platform_fee));
+  } else {
+    quote.Set("platformFee", base::Value());
   }
 
   base::Value::List route_plan_value;
@@ -131,5 +135,288 @@ std::optional<std::string> EncodeJupiterTransactionParams(
 
   return result;
 }
+
+}  // namespace jupiter
+
+namespace lifi {
+
+namespace {
+
+std::optional<std::string> EncodeChainId(const std::string& value) {
+  if (value == mojom::kSolanaMainnet) {
+    return "SOL";
+  }
+
+  uint256_t val;
+  if (!HexValueToUint256(value, &val)) {
+    return std::nullopt;
+  }
+
+  if (val > std::numeric_limits<uint64_t>::max() ||
+      val < std::numeric_limits<uint64_t>::min()) {
+    return std::nullopt;
+  }
+
+  return base::NumberToString(static_cast<uint64_t>(val));
+}
+
+base::Value::Dict EncodeToolDetails(
+    const mojom::LiFiToolDetailsPtr tool_details) {
+  base::Value::Dict result;
+  result.Set("key", tool_details->key);
+  result.Set("name", tool_details->name);
+  return result;
+}
+
+std::optional<base::Value::Dict> EncodeToken(
+    const mojom::BlockchainTokenPtr token) {
+  base::Value::Dict result;
+  result.Set("address", token->contract_address == ""
+                            ? kLiFiNativeAssetContractAddress
+                            : token->contract_address);
+  result.Set("decimals", token->decimals);
+  result.Set("symbol", token->symbol);
+
+  if (auto chain_id = EncodeChainId(token->chain_id)) {
+    result.Set("chainId", *chain_id);
+  } else {
+    return std::nullopt;
+  }
+
+  result.Set("name", token->name);
+  return result;
+}
+
+std::optional<std::string> EncodeStepType(const mojom::LiFiStepType type) {
+  if (type == mojom::LiFiStepType::kSwap) {
+    return "swap";
+  }
+
+  if (type == mojom::LiFiStepType::kCross) {
+    return "cross";
+  }
+
+  if (type == mojom::LiFiStepType::kNative) {
+    return "lifi";
+  }
+
+  return std::nullopt;
+}
+
+std::optional<base::Value::Dict> EncodeStepAction(mojom::LiFiActionPtr action) {
+  base::Value::Dict result;
+
+  if (auto chain_id = EncodeChainId(action->from_token->chain_id)) {
+    result.Set("fromChainId", *chain_id);
+  } else {
+    return std::nullopt;
+  }
+
+  result.Set("fromAmount", action->from_amount);
+
+  if (auto token = EncodeToken(std::move(action->from_token))) {
+    result.Set("fromToken", std::move(*token));
+  } else {
+    return std::nullopt;
+  }
+
+  if (action->from_address) {
+    result.Set("fromAddress", *action->from_address);
+  }
+
+  if (auto chain_id = EncodeChainId(action->to_token->chain_id)) {
+    result.Set("toChainId", *chain_id);
+  } else {
+    return std::nullopt;
+  }
+
+  if (auto token = EncodeToken(std::move(action->to_token))) {
+    result.Set("toToken", std::move(*token));
+  } else {
+    return std::nullopt;
+  }
+
+  if (action->to_address) {
+    result.Set("toAddress", *action->to_address);
+  }
+
+  double slippage = 0.0;
+  if (base::StringToDouble(action->slippage, &slippage)) {
+    result.Set("slippage", slippage);
+  } else {
+    return std::nullopt;
+  }
+
+  if (action->destination_call_data) {
+    result.Set("destinationCallData", *action->destination_call_data);
+  }
+
+  return result;
+}
+
+std::optional<base::Value::Dict> EncodeStepEstimate(
+    mojom::LiFiStepEstimatePtr estimate) {
+  base::Value::Dict result;
+
+  result.Set("tool", estimate->tool);
+  result.Set("fromAmount", estimate->from_amount);
+  result.Set("toAmount", estimate->to_amount);
+  result.Set("toAmountMin", estimate->to_amount_min);
+  result.Set("approvalAddress", estimate->approval_address);
+
+  double execution_duration = 0.0;
+  if (base::StringToDouble(estimate->execution_duration, &execution_duration)) {
+    result.Set("executionDuration", execution_duration);
+  } else {
+    return std::nullopt;
+  }
+
+  base::Value::List fee_costs_value;
+  for (const auto& fee_cost : estimate->fee_costs) {
+    base::Value::Dict fee_cost_value;
+    fee_cost_value.Set("name", fee_cost->name);
+    fee_cost_value.Set("description", fee_cost->description);
+    fee_cost_value.Set("amount", fee_cost->amount);
+    fee_cost_value.Set("percentage", fee_cost->percentage);
+    fee_cost_value.Set("included", fee_cost->included);
+
+    if (auto token = EncodeToken(std::move(fee_cost->token))) {
+      fee_cost_value.Set("token", std::move(*token));
+    } else {
+      return std::nullopt;
+    }
+
+    fee_costs_value.Append(std::move(fee_cost_value));
+  }
+  result.Set("feeCosts", std::move(fee_costs_value));
+
+  base::Value::List gas_costs_value;
+  for (const auto& gas_cost : estimate->gas_costs) {
+    base::Value::Dict gas_cost_value;
+    gas_cost_value.Set("type", gas_cost->type);
+    gas_cost_value.Set("estimate", gas_cost->estimate);
+    gas_cost_value.Set("limit", gas_cost->limit);
+    gas_cost_value.Set("amount", gas_cost->amount);
+
+    if (auto token = EncodeToken(std::move(gas_cost->token))) {
+      gas_cost_value.Set("token", std::move(*token));
+    } else {
+      return std::nullopt;
+    }
+
+    gas_costs_value.Append(std::move(gas_cost_value));
+  }
+  result.Set("gasCosts", std::move(gas_costs_value));
+
+  return result;
+}
+
+std::optional<base::Value::Dict> EncodeStep(mojom::LiFiStepPtr step) {
+  base::Value::Dict result;
+  result.Set("id", step->id);
+
+  if (auto type = EncodeStepType(step->type)) {
+    result.Set("type", *type);
+  } else {
+    return std::nullopt;
+  }
+
+  result.Set("tool", step->tool);
+
+  if (auto action = EncodeStepAction(std::move(step->action))) {
+    result.Set("action", std::move(*action));
+  } else {
+    return std::nullopt;
+  }
+
+  if (auto estimate = EncodeStepEstimate(step->estimate->Clone())) {
+    result.Set("estimate", std::move(*estimate));
+  } else {
+    return std::nullopt;
+  }
+
+  if (step->integrator) {
+    result.Set("integrator", *step->integrator);
+  }
+
+  result.Set("toolDetails", EncodeToolDetails(std::move(step->tool_details)));
+
+  if (!step->included_steps) {
+    return result;
+  }
+
+  base::Value::List included_steps_value;
+  for (auto& included_step : *step->included_steps) {
+    if (auto included_step_value = EncodeStep(std::move(included_step))) {
+      included_steps_value.Append(std::move(*included_step_value));
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  result.Set("includedSteps", std::move(included_steps_value));
+  return result;
+}
+
+}  // namespace
+
+std::optional<std::string> EncodeQuoteParams(mojom::SwapQuoteParamsPtr params) {
+  base::Value::Dict result;
+
+  if (auto chain_id = EncodeChainId(params->from_chain_id)) {
+    result.Set("fromChainId", *chain_id);
+  } else {
+    return std::nullopt;
+  }
+
+  result.Set("fromAmount", params->from_amount);
+  result.Set("fromTokenAddress", params->from_token == ""
+                                     ? kLiFiNativeAssetContractAddress
+                                     : params->from_token);
+  result.Set("fromAddress", params->from_account_id->address);
+
+  if (auto chain_id = EncodeChainId(params->to_chain_id)) {
+    result.Set("toChainId", *chain_id);
+  } else {
+    return std::nullopt;
+  }
+
+  result.Set("toTokenAddress", params->to_token == ""
+                                   ? kLiFiNativeAssetContractAddress
+                                   : params->to_token);
+  result.Set("toAddress", params->to_account_id->address);
+  result.Set("allowDestinationCall", true);
+
+  base::Value::Dict options;
+  options.Set("insurance", true);
+  options.Set("integrator", kLiFiIntegratorID);
+  options.Set("allowSwitchChain", false);
+  options.Set("fee", 0.2);  // FIXME
+
+  double slippage_percentage = 0.0;
+  if (base::StringToDouble(params->slippage_percentage, &slippage_percentage)) {
+    options.Set("slippage", slippage_percentage / 100);
+  }
+
+  result.Set("options", std::move(options));
+
+  return GetJSON(base::Value(std::move(result)));
+}
+
+std::optional<std::string> EncodeTransactionParams(mojom::LiFiStepPtr step) {
+  auto result = EncodeStep(std::move(step));
+  if (!result) {
+    return std::nullopt;
+  }
+
+  std::string result_str = GetJSON(base::Value(std::move(*result)));
+  if (result_str.empty()) {
+    return std::nullopt;
+  }
+
+  return result_str;
+}
+
+}  // namespace lifi
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -359,7 +359,9 @@ std::optional<base::Value::Dict> EncodeStep(mojom::LiFiStepPtr step) {
 
 }  // namespace
 
-std::optional<std::string> EncodeQuoteParams(mojom::SwapQuoteParamsPtr params) {
+std::optional<std::string> EncodeQuoteParams(
+    mojom::SwapQuoteParamsPtr params,
+    const std::optional<std::string>& fee_param) {
   base::Value::Dict result;
 
   if (auto chain_id = EncodeChainId(params->from_chain_id)) {
@@ -390,7 +392,13 @@ std::optional<std::string> EncodeQuoteParams(mojom::SwapQuoteParamsPtr params) {
   options.Set("insurance", true);
   options.Set("integrator", kLiFiIntegratorID);
   options.Set("allowSwitchChain", false);
-  options.Set("fee", 0.2);  // FIXME
+
+  if (fee_param.has_value() && !fee_param->empty()) {
+    double fee = 0.0;
+    if (base::StringToDouble(fee_param.value(), &fee)) {
+      options.Set("fee", fee);
+    }
+  }
 
   double slippage_percentage = 0.0;
   if (base::StringToDouble(params->slippage_percentage, &slippage_percentage)) {

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -170,7 +170,7 @@ base::Value::Dict EncodeToolDetails(
 std::optional<base::Value::Dict> EncodeToken(
     const mojom::BlockchainTokenPtr& token) {
   base::Value::Dict result;
-  result.Set("address", token->contract_address == ""
+  result.Set("address", token->contract_address.empty()
                             ? kLiFiNativeAssetContractAddress
                             : token->contract_address);
   result.Set("decimals", token->decimals);
@@ -365,7 +365,7 @@ std::optional<std::string> EncodeQuoteParams(
   }
 
   result.Set("fromAmount", params->from_amount);
-  result.Set("fromTokenAddress", params->from_token == ""
+  result.Set("fromTokenAddress", params->from_token.empty()
                                      ? kLiFiNativeAssetContractAddress
                                      : params->from_token);
   result.Set("fromAddress", params->from_account_id->address);
@@ -376,7 +376,7 @@ std::optional<std::string> EncodeQuoteParams(
     return std::nullopt;
   }
 
-  result.Set("toTokenAddress", params->to_token == ""
+  result.Set("toTokenAddress", params->to_token.empty()
                                    ? kLiFiNativeAssetContractAddress
                                    : params->to_token);
   result.Set("toAddress", params->to_account_id->address);

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -161,7 +161,7 @@ std::optional<std::string> EncodeChainId(const std::string& value) {
 }
 
 base::Value::Dict EncodeToolDetails(
-    const mojom::LiFiToolDetailsPtr tool_details) {
+    const mojom::LiFiToolDetailsPtr& tool_details) {
   base::Value::Dict result;
   result.Set("key", tool_details->key);
   result.Set("name", tool_details->name);
@@ -169,7 +169,7 @@ base::Value::Dict EncodeToolDetails(
 }
 
 std::optional<base::Value::Dict> EncodeToken(
-    const mojom::BlockchainTokenPtr token) {
+    const mojom::BlockchainTokenPtr& token) {
   base::Value::Dict result;
   result.Set("address", token->contract_address == ""
                             ? kLiFiNativeAssetContractAddress

--- a/components/brave_wallet/browser/swap_request_helper.cc
+++ b/components/brave_wallet/browser/swap_request_helper.cc
@@ -186,7 +186,7 @@ std::optional<base::Value::Dict> EncodeToken(
   return result;
 }
 
-std::optional<std::string> EncodeStepType(const mojom::LiFiStepType type) {
+std::string EncodeStepType(const mojom::LiFiStepType type) {
   if (type == mojom::LiFiStepType::kSwap) {
     return "swap";
   }
@@ -199,7 +199,7 @@ std::optional<std::string> EncodeStepType(const mojom::LiFiStepType type) {
     return "lifi";
   }
 
-  return std::nullopt;
+  NOTREACHED_NORETURN();
 }
 
 std::optional<base::Value::Dict> EncodeStepAction(mojom::LiFiActionPtr action) {
@@ -313,13 +313,7 @@ std::optional<base::Value::Dict> EncodeStepEstimate(
 std::optional<base::Value::Dict> EncodeStep(mojom::LiFiStepPtr step) {
   base::Value::Dict result;
   result.Set("id", step->id);
-
-  if (auto type = EncodeStepType(step->type)) {
-    result.Set("type", *type);
-  } else {
-    return std::nullopt;
-  }
-
+  result.Set("type", EncodeStepType(step->type));
   result.Set("tool", step->tool);
 
   if (auto action = EncodeStepAction(std::move(step->action))) {

--- a/components/brave_wallet/browser/swap_request_helper.h
+++ b/components/brave_wallet/browser/swap_request_helper.h
@@ -13,9 +13,16 @@
 
 namespace brave_wallet {
 
-std::optional<std::string> EncodeJupiterTransactionParams(
-    const mojom::JupiterTransactionParams& params,
-    bool has_fee);
+namespace jupiter {
+std::optional<std::string> EncodeTransactionParams(
+    const mojom::JupiterTransactionParams& params);
+}  // namespace jupiter
+
+namespace lifi {
+std::optional<std::string> EncodeQuoteParams(mojom::SwapQuoteParamsPtr params);
+
+std::optional<std::string> EncodeTransactionParams(mojom::LiFiStepPtr step);
+}  // namespace lifi
 
 }  // namespace brave_wallet
 

--- a/components/brave_wallet/browser/swap_request_helper.h
+++ b/components/brave_wallet/browser/swap_request_helper.h
@@ -19,7 +19,9 @@ std::optional<std::string> EncodeTransactionParams(
 }  // namespace jupiter
 
 namespace lifi {
-std::optional<std::string> EncodeQuoteParams(mojom::SwapQuoteParamsPtr params);
+std::optional<std::string> EncodeQuoteParams(
+    mojom::SwapQuoteParamsPtr params,
+    const std::optional<std::string>& fee_param);
 
 std::optional<std::string> EncodeTransactionParams(mojom::LiFiStepPtr step);
 }  // namespace lifi

--- a/components/brave_wallet/browser/swap_request_helper_unittest.cc
+++ b/components/brave_wallet/browser/swap_request_helper_unittest.cc
@@ -14,6 +14,7 @@
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 #include "brave/components/brave_wallet/browser/swap_response_parser.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "brave/components/brave_wallet/common/common_utils.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 using base::test::ParseJson;
@@ -68,6 +69,537 @@ const char* GetJupiterQuoteTemplate() {
     })";
 }
 
+const char* GetLiFiQuoteTemplate() {
+  return R"(
+    {
+      "routes": [
+        {
+          "id": "0x343bc553146a3dd8438518d80bd1b6957f3fec05d137ff65a940bfb5390d3f1f",
+          "fromChainId": "1",
+          "fromAmountUSD": "1.00",
+          "fromAmount": "1000000",
+          "fromToken": {
+            "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "chainId": "1",
+            "symbol": "USDC",
+            "decimals": "6",
+            "name": "USD Coin",
+            "coinKey": "USDC",
+            "logoURI": "usdc.png",
+            "priceUSD": "1"
+          },
+          "fromAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+          "toChainId": "10",
+          "toAmountUSD": "1.01",
+          "toAmount": "1013654",
+          "toAmountMin": "1008586",
+          "toToken": {
+            "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+            "chainId": "10",
+            "symbol": "USDT",
+            "decimals": "6",
+            "name": "USDT",
+            "coinKey": "USDT",
+            "logoURI": "usdt.png",
+            "priceUSD": "0.999685"
+          },
+          "toAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+          "gasCostUSD": "14.65",
+          "containsSwitchChain": false,
+          "steps": [
+            {
+              "type": "lifi",
+              "id": "5a6876f1-988e-4710-85b7-be2bd7681421",
+              "tool": "optimism",
+              "toolDetails": {
+                "key": "optimism",
+                "name": "Optimism Gateway",
+                "logoURI": "optimism.png"
+              },
+              "action": {
+                "fromToken": {
+                  "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                  "chainId": "1",
+                  "symbol": "USDC",
+                  "decimals": "6",
+                  "name": "USD Coin",
+                  "coinKey": "USDC",
+                  "logoURI": "usdc.png",
+                  "priceUSD": "1"
+                },
+                "fromAmount": "1000000",
+                "toToken": {
+                  "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                  "chainId": "10",
+                  "symbol": "USDT",
+                  "decimals": "6",
+                  "name": "USDT",
+                  "coinKey": "USDT",
+                  "logoURI": "usdt.png",
+                  "priceUSD": "0.999685"
+                },
+                "fromChainId": "1",
+                "toChainId": "10",
+                "slippage": "0.005",
+                "fromAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+                "toAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4"
+              },
+              "estimate": {
+                "tool": "optimism",
+                "approvalAddress": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "toAmountMin": "1008586",
+                "toAmount": "1013654",
+                "fromAmount": "1000000",
+                "feeCosts": [
+                  {
+                    "name": "LP Fee",
+                    "description": "Fee paid to the Liquidity Provider",
+                    "token": {
+                      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                      "chainId": "1",
+                      "symbol": "USDC",
+                      "decimals": "6",
+                      "name": "USD Coin",
+                      "coinKey": "USDC",
+                      "logoURI": "usdc.png",
+                      "priceUSD": "1"
+                    },
+                    "amount": "3000",
+                    "amountUSD": "0.01",
+                    "percentage": "0.003",
+                    "included": true
+                  }
+                ],
+                "gasCosts": [
+                  {
+                    "type": "SEND",
+                    "price": "17621901985",
+                    "estimate": "375000",
+                    "limit": "618000",
+                    "amount": "6608213244375000",
+                    "amountUSD": "14.65",
+                    "token": {
+                      "address": "0x0000000000000000000000000000000000000000",
+                      "chainId": "1",
+                      "symbol": "ETH",
+                      "decimals": "18",
+                      "name": "ETH",
+                      "coinKey": "ETH",
+                      "logoURI": "eth.png",
+                      "priceUSD": "2216.770000000000000000"
+                    }
+                  }
+                ],
+                "executionDuration": "106.944",
+                "fromAmountUSD": "1.00",
+                "toAmountUSD": "1.01"
+              },
+              "includedSteps": [
+                {
+                  "id": "9ac4d9f1-9b72-463d-baf1-fcd8b09f8a8d",
+                  "type": "swap",
+                  "action": {
+                    "fromChainId": "1",
+                    "fromAmount": "1000000",
+                    "fromToken": {
+                      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                      "chainId": "1",
+                      "symbol": "USDC",
+                      "decimals": "6",
+                      "name": "USD Coin",
+                      "coinKey": "USDC",
+                      "logoURI": "usdc.png",
+                      "priceUSD": "1"
+                    },
+                    "toChainId": "1",
+                    "toToken": {
+                      "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                      "chainId": "1",
+                      "symbol": "USDT",
+                      "decimals": "6",
+                      "name": "USDT",
+                      "coinKey": "USDT",
+                      "logoURI": "usdt.png",
+                      "priceUSD": "0.999685"
+                    },
+                    "slippage": "0.005"
+                  },
+                  "estimate": {
+                    "tool": "verse-dex",
+                    "fromAmount": "1000000",
+                    "toAmount": "1013654",
+                    "toAmountMin": "1008586",
+                    "approvalAddress": "0xB4B0ea46Fe0E9e8EAB4aFb765b527739F2718671",
+                    "executionDuration": "30",
+                    "feeCosts": [
+                      {
+                        "name": "LP Fee",
+                        "description": "Fee paid to the Liquidity Provider",
+                        "token": {
+                          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                          "chainId": "1",
+                          "symbol": "USDC",
+                          "decimals": "6",
+                          "name": "USD Coin",
+                          "coinKey": "USDC",
+                          "logoURI": "usdc.png",
+                          "priceUSD": "1"
+                        },
+                        "amount": "3000",
+                        "amountUSD": "0.01",
+                        "percentage": "0.003",
+                        "included": true
+                      }
+                    ],
+                    "gasCosts": [
+                      {
+                        "type": "SEND",
+                        "price": "17621901985",
+                        "estimate": "200000",
+                        "limit": "260000",
+                        "amount": "3524380397000000",
+                        "amountUSD": "7.81",
+                        "token": {
+                          "address": "0x0000000000000000000000000000000000000000",
+                          "chainId": "1",
+                          "symbol": "ETH",
+                          "decimals": "18",
+                          "name": "ETH",
+                          "coinKey": "ETH",
+                          "logoURI": "eth.png",
+                          "priceUSD": "2216.770000000000000000"
+                        }
+                      }
+                    ]
+                  },
+                  "tool": "verse-dex",
+                  "toolDetails": {
+                    "key": "verse-dex",
+                    "name": "Verse Dex",
+                    "logoURI": "https://analytics.verse.bitcoin.com/logo.png"
+                  }
+                },
+                {
+                  "id": "b952ed38-1d5c-43bc-990a-468fd32d29b9",
+                  "type": "cross",
+                  "action": {
+                    "fromChainId": "1",
+                    "fromAmount": "1008586",
+                    "fromToken": {
+                      "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                      "chainId": "1",
+                      "symbol": "USDT",
+                      "decimals": "6",
+                      "name": "USDT",
+                      "coinKey": "USDT",
+                      "logoURI": "usdt.png",
+                      "priceUSD": "0.999685"
+                    },
+                    "toChainId": "10",
+                    "toToken": {
+                      "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                      "chainId": "10",
+                      "symbol": "USDT",
+                      "decimals": "6",
+                      "name": "USDT",
+                      "coinKey": "USDT",
+                      "logoURI": "usdt.png",
+                      "priceUSD": "0.999685"
+                    },
+                    "slippage": "0.005",
+                    "destinationGasConsumption": "0",
+                    "destinationCallData": "0x0"
+                  },
+                  "estimate": {
+                    "tool": "optimism",
+                    "fromAmount": "1013654",
+                    "toAmount": "1013654",
+                    "toAmountMin": "1008586",
+                    "approvalAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+                    "executionDuration": "76.944",
+                    "feeCosts": [],
+                    "gasCosts": [
+                      {
+                        "type": "SEND",
+                        "price": "17621901985",
+                        "estimate": "175000",
+                        "limit": "227500",
+                        "amount": "3083832847375000",
+                        "amountUSD": "6.84",
+                        "token": {
+                          "address": "0x0000000000000000000000000000000000000000",
+                          "chainId": "1",
+                          "symbol": "ETH",
+                          "decimals": "18",
+                          "name": "ETH",
+                          "coinKey": "ETH",
+                          "logoURI": "eth.png",
+                          "priceUSD": "2216.770000000000000000"
+                        }
+                      }
+                    ]
+                  },
+                  "tool": "optimism",
+                  "toolDetails": {
+                    "key": "optimism",
+                    "name": "Optimism Gateway",
+                    "logoURI": "optimism.png"
+                  }
+                }
+              ],
+              "integrator": "jumper.exchange"
+            }
+          ],
+          "insurance": {
+            "state": "NOT_INSURABLE",
+            "feeAmountUsd": "0"
+          },
+          "tags": [
+            "RECOMMENDED",
+            "CHEAPEST",
+            "FASTEST"
+          ]
+        }
+      ]
+    }
+  )";
+}
+
+const char* GetLiFiEvmToSolQuoteTemplate() {
+  return R"(
+    {
+      "routes": [
+        {
+          "id": "0x9a448018e09b62da15c1bd64571c21b33cb177cee5d2f07c325d6485364362a5",
+          "fromChainId": "137",
+          "fromAmountUSD": "2.00",
+          "fromAmount": "2000000",
+          "fromToken": {
+            "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+            "chainId": "137",
+            "symbol": "USDCe",
+            "decimals": "6",
+            "name": "USDC.e",
+            "coinKey": "USDCe",
+            "logoURI": "eth.png",
+            "priceUSD": "1"
+          },
+          "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+          "toChainId": "1151111081099710",
+          "toAmountUSD": "1.14",
+          "toAmount": "1138627",
+          "toAmountMin": "1136350",
+          "toToken": {
+            "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "chainId": "1151111081099710",
+            "symbol": "USDC",
+            "decimals": "6",
+            "name": "USD Coin",
+            "coinKey": "USDC",
+            "logoURI": "usdc.png",
+            "priceUSD": "0.999501"
+          },
+          "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+          "gasCostUSD": "0.02",
+          "containsSwitchChain": false,
+          "steps": [
+            {
+              "type": "lifi",
+              "id": "57d247fc-d80a-4f4a-9596-72db3061aa72",
+              "tool": "allbridge",
+              "toolDetails": {
+                "key": "allbridge",
+                "name": "Allbridge",
+                "logoURI": "allbridge.png"
+              },
+              "action": {
+                "fromChainId": "137",
+                "fromAmount": "2000000",
+                "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+                "slippage": "0.03",
+                "toChainId": "1151111081099710",
+                "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+                "fromToken": {
+                  "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                  "chainId": "137",
+                  "symbol": "USDCe",
+                  "decimals": "6",
+                  "name": "USDC.e",
+                  "coinKey": "USDCe",
+                  "logoURI": "usdce.png",
+                  "priceUSD": "1"
+                },
+                "toToken": {
+                  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                  "chainId": "1151111081099710",
+                  "symbol": "USDC",
+                  "decimals": "6",
+                  "name": "USD Coin",
+                  "coinKey": "USDC",
+                  "logoURI": "usdc.png",
+                  "priceUSD": "0.999501"
+                }
+              },
+              "estimate": {
+                "tool": "allbridge",
+                "fromAmount": "2000000",
+                "fromAmountUSD": "2.00",
+                "toAmount": "1138627",
+                "toAmountMin": "1136350",
+                "approvalAddress": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "executionDuration": "500.298",
+                "feeCosts": [
+                  {
+                    "name": "Allbridge's fee",
+                    "description": "AllBridge fee and messenger fee charged by Allbridge",
+                    "token": {
+                      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                      "chainId": "137",
+                      "symbol": "USDCe",
+                      "decimals": "6",
+                      "name": "USDC.e",
+                      "coinKey": "USDCe",
+                      "logoURI": "usdce.png",
+                      "priceUSD": "1"
+                    },
+                    "amount": "853380",
+                    "amountUSD": "0.85",
+                    "percentage": "0.4267",
+                    "included": true
+                  }
+                ],
+                "gasCosts": [
+                  {
+                    "type": "SEND",
+                    "price": "112000000000",
+                    "estimate": "185000",
+                    "limit": "277500",
+                    "amount": "20720000000000000",
+                    "amountUSD": "0.02",
+                    "token": {
+                      "address": "0x0000000000000000000000000000000000000000",
+                      "chainId": "137",
+                      "symbol": "MATIC",
+                      "decimals": "18",
+                      "name": "MATIC",
+                      "coinKey": "MATIC",
+                      "logoURI": "matic.png",
+                      "priceUSD": "0.809079000000000000"
+                    }
+                  }
+                ],
+                "toAmountUSD": "1.14"
+              },
+              "includedSteps": [
+                {
+                  "id": "1b914bef-e1be-4895-a9b1-c57da16d9de5",
+                  "type": "cross",
+                  "action": {
+                    "fromChainId": "137",
+                    "fromAmount": "2000000",
+                    "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+                    "slippage": "0.03",
+                    "toChainId": "1151111081099710",
+                    "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+                    "fromToken": {
+                      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                      "chainId": "137",
+                      "symbol": "USDCe",
+                      "decimals": "6",
+                      "name": "USDC.e",
+                      "coinKey": "USDCe",
+                      "logoURI": "usdce.png",
+                      "priceUSD": "1"
+                    },
+                    "toToken": {
+                      "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                      "chainId": "1151111081099710",
+                      "symbol": "USDC",
+                      "decimals": "6",
+                      "name": "USD Coin",
+                      "coinKey": "USDC",
+                      "logoURI": "usdc.png",
+                      "priceUSD": "0.999501"
+                    }
+                  },
+                  "estimate": {
+                    "tool": "allbridge",
+                    "fromAmount": "2000000",
+                    "fromAmountUSD": "2.00",
+                    "toAmount": "1138627",
+                    "toAmountMin": "1136350",
+                    "approvalAddress": "0x7775d63836987f444E2F14AA0fA2602204D7D3E0",
+                    "executionDuration": "500.298",
+                    "feeCosts": [
+                      {
+                        "name": "Allbridge's fee",
+                        "description": "AllBridge fee and messenger fee charged by Allbridge",
+                        "token": {
+                          "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                          "chainId": "137",
+                          "symbol": "USDCe",
+                          "decimals": "6",
+                          "name": "USDC.e",
+                          "coinKey": "USDCe",
+                          "logoURI": "usdce.png",
+                          "priceUSD": "1"
+                        },
+                        "amount": "853380",
+                        "amountUSD": "0.85",
+                        "percentage": "0.4267",
+                        "included": true
+                      }
+                    ],
+                    "gasCosts": [
+                      {
+                        "type": "SEND",
+                        "price": "112000000000",
+                        "estimate": "185000",
+                        "limit": "277500",
+                        "amount": "20720000000000000",
+                        "amountUSD": "0.02",
+                        "token": {
+                          "address": "0x0000000000000000000000000000000000000000",
+                          "chainId": "137",
+                          "symbol": "MATIC",
+                          "decimals": "18",
+                          "name": "MATIC",
+                          "coinKey": "MATIC",
+                          "logoURI": "matic.png",
+                          "priceUSD": "0.809079000000000000"
+                        }
+                      }
+                    ]
+                  },
+                  "tool": "allbridge",
+                  "toolDetails": {
+                    "key": "allbridge",
+                    "name": "Allbridge",
+                    "logoURI": "allbridge.png"
+                  }
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "RECOMMENDED",
+            "CHEAPEST",
+            "FASTEST"
+          ],
+          "insurance": {
+            "state": "NOT_INSURABLE",
+            "feeAmountUsd": "0"
+          }
+        }
+      ],
+      "unavailableRoutes": {
+        "filteredOut": [],
+        "failed": []
+      }
+    }
+  )";
+}
+
 }  // namespace
 
 TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
@@ -75,13 +607,13 @@ TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
   std::string json = base::StringPrintf(
       json_template, "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");  // USDC
   mojom::JupiterQuotePtr swap_quote =
-      ParseJupiterQuoteResponse(ParseJson(json));
+      jupiter::ParseQuoteResponse(ParseJson(json));
   ASSERT_TRUE(swap_quote);
 
   mojom::JupiterTransactionParams params;
   params.quote = swap_quote.Clone();
   params.user_public_key = "mockPubKey";
-  auto encoded_params = EncodeJupiterTransactionParams(params, true);
+  auto encoded_params = jupiter::EncodeTransactionParams(params);
 
   std::string expected_params(R"(
     {
@@ -137,23 +669,19 @@ TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
   ASSERT_EQ(*encoded_params, GetJSON(expected_params_value));
 
   // OK: Jupiter transaction params WITHOUT feeAccount
-  params.quote->output_mint =
-      "SHDWyBxihqiCj6YekG2GUr7wqKLeLAMK1gHZck9pL6y";  // SHDW
-  encoded_params = EncodeJupiterTransactionParams(params, false);
+  params.quote->platform_fee = nullptr;
+  encoded_params = jupiter::EncodeTransactionParams(params);
   expected_params = R"(
     {
       "quoteResponse": {
         "inputMint": "So11111111111111111111111111111111111111112",
         "inAmount": "100000000",
-        "outputMint": "SHDWyBxihqiCj6YekG2GUr7wqKLeLAMK1gHZck9pL6y",
+        "outputMint": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
         "outAmount": "10886298",
         "otherAmountThreshold": "10885210",
         "swapMode": "ExactIn",
         "slippageBps": 1,
-        "platformFee": {
-          "amount": "93326",
-          "feeBps": 85
-        },
+        "platformFee": null,
         "priceImpactPct": "0",
         "routePlan": [
           {
@@ -192,9 +720,420 @@ TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
 
   // KO: invalid output mint
   params.quote->output_mint = "invalid output mint";
-  encoded_params = EncodeJupiterTransactionParams(params, true);
+  encoded_params = jupiter::EncodeTransactionParams(params);
   ASSERT_EQ(encoded_params, std::nullopt);
-  encoded_params = EncodeJupiterTransactionParams(params, false);
+  encoded_params = jupiter::EncodeTransactionParams(params);
   ASSERT_EQ(encoded_params, std::nullopt);
 }
+
+TEST(SwapRequestHelperUnitTest, EncodeLiFiQuoteParams) {
+  auto params = mojom::SwapQuoteParams::New();
+  params->from_account_id =
+      MakeAccountId(mojom::CoinType::ETH, mojom::KeyringId::kDefault,
+                    mojom::AccountKind::kDerived,
+                    "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4");
+  params->from_chain_id = mojom::kPolygonMainnetChainId;
+  params->from_token = "";
+  params->from_amount = "1000000000000000000000";
+  params->to_account_id =
+      MakeAccountId(mojom::CoinType::SOL, mojom::KeyringId::kDefault,
+                    mojom::AccountKind::kDerived,
+                    "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4");
+  params->to_chain_id = mojom::kSolanaMainnet;
+  params->to_token = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  params->slippage_percentage = "3";
+  params->route_priority = mojom::RoutePriority::kSafest;
+
+  auto encoded_params = lifi::EncodeQuoteParams(std::move(params));
+  ASSERT_NE(encoded_params, std::nullopt);
+  std::string expected_params(R"(
+    {
+      "allowDestinationCall": true,
+      "fromAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+      "fromAmount": "1000000000000000000000",
+      "fromChainId": "137",
+      "fromTokenAddress": "0x0000000000000000000000000000000000000000",
+      "options": {
+        "allowSwitchChain": false,
+        "fee": 0.2,
+        "insurance": true,
+        "integrator": "brave",
+        "slippage": 0.03
+      },
+      "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+      "toChainId": "SOL",
+      "toTokenAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+    }
+  )");
+  EXPECT_EQ(*encoded_params, GetJSON(ParseJson(expected_params)));
+}
+
+TEST(SwapRequestHelperUnitTest, EncodeLiFiTransactionParams) {
+  // OK: EVM -> EVM bridge quotes are correctly handled
+  mojom::LiFiQuotePtr quote =
+      lifi::ParseQuoteResponse(ParseJson(GetLiFiQuoteTemplate()));
+  ASSERT_TRUE(quote);
+  ASSERT_EQ(quote->routes.size(), 1UL);
+  ASSERT_EQ(quote->routes[0]->steps.size(), 1UL);
+
+  auto& step = quote->routes[0]->steps[0];
+  auto params = lifi::EncodeTransactionParams(std::move(step));
+  ASSERT_NE(params, std::nullopt);
+
+  std::string expected_params(R"(
+    {
+      "type": "lifi",
+      "id": "5a6876f1-988e-4710-85b7-be2bd7681421",
+      "tool": "optimism",
+      "toolDetails": {
+        "key": "optimism",
+        "name": "Optimism Gateway"
+      },
+      "action": {
+        "fromToken": {
+          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+          "chainId": "1",
+          "symbol": "USDC",
+          "decimals": 6,
+          "name": "USD Coin"
+        },
+        "fromAmount": "1000000",
+        "toToken": {
+          "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+          "chainId": "10",
+          "symbol": "USDT",
+          "decimals": 6,
+          "name": "USDT"
+        },
+        "fromChainId": "1",
+        "toChainId": "10",
+        "slippage": 0.005,
+        "fromAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+        "toAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4"
+      },
+      "estimate": {
+        "tool": "optimism",
+        "approvalAddress": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+        "toAmountMin": "1008586",
+        "toAmount": "1013654",
+        "fromAmount": "1000000",
+        "feeCosts": [
+          {
+            "name": "LP Fee",
+            "description": "Fee paid to the Liquidity Provider",
+            "token": {
+              "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+              "chainId": "1",
+              "symbol": "USDC",
+              "decimals": 6,
+              "name": "USD Coin"
+            },
+            "amount": "3000",
+            "percentage": "0.003",
+            "included": true
+          }
+        ],
+        "gasCosts": [
+          {
+            "type": "SEND",
+            "estimate": "375000",
+            "limit": "618000",
+            "amount": "6608213244375000",
+            "token": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "chainId": "1",
+              "symbol": "ETH",
+              "decimals": 18,
+              "name": "ETH"
+            }
+          }
+        ],
+        "executionDuration": 106.944
+      },
+      "includedSteps": [
+        {
+          "id": "9ac4d9f1-9b72-463d-baf1-fcd8b09f8a8d",
+          "type": "swap",
+          "action": {
+            "fromChainId": "1",
+            "fromAmount": "1000000",
+            "fromToken": {
+              "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+              "chainId": "1",
+              "symbol": "USDC",
+              "decimals": 6,
+              "name": "USD Coin"
+            },
+            "toChainId": "1",
+            "toToken": {
+              "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+              "chainId": "1",
+              "symbol": "USDT",
+              "decimals": 6,
+              "name": "USDT"
+            },
+            "slippage": 0.005
+          },
+          "estimate": {
+            "tool": "verse-dex",
+            "fromAmount": "1000000",
+            "toAmount": "1013654",
+            "toAmountMin": "1008586",
+            "approvalAddress": "0xB4B0ea46Fe0E9e8EAB4aFb765b527739F2718671",
+            "executionDuration": 30.0,
+            "feeCosts": [
+              {
+                "name": "LP Fee",
+                "description": "Fee paid to the Liquidity Provider",
+                "token": {
+                  "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                  "chainId": "1",
+                  "symbol": "USDC",
+                  "decimals": 6,
+                  "name": "USD Coin"
+                },
+                "amount": "3000",
+                "percentage": "0.003",
+                "included": true
+              }
+            ],
+            "gasCosts": [
+              {
+                "type": "SEND",
+                "estimate": "200000",
+                "limit": "260000",
+                "amount": "3524380397000000",
+                "token": {
+                  "address": "0x0000000000000000000000000000000000000000",
+                  "chainId": "1",
+                  "symbol": "ETH",
+                  "decimals": 18,
+                  "name": "ETH"
+                }
+              }
+            ]
+          },
+          "tool": "verse-dex",
+          "toolDetails": {
+            "key": "verse-dex",
+            "name": "Verse Dex"
+          }
+        },
+        {
+          "id": "b952ed38-1d5c-43bc-990a-468fd32d29b9",
+          "type": "cross",
+          "action": {
+            "fromChainId": "1",
+            "fromAmount": "1008586",
+            "fromToken": {
+              "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+              "chainId": "1",
+              "symbol": "USDT",
+              "decimals": 6,
+              "name": "USDT"
+            },
+            "toChainId": "10",
+            "toToken": {
+              "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+              "chainId": "10",
+              "symbol": "USDT",
+              "decimals": 6,
+              "name": "USDT"
+            },
+            "slippage": 0.005,
+            "destinationCallData": "0x0"
+          },
+          "estimate": {
+            "tool": "optimism",
+            "fromAmount": "1013654",
+            "toAmount": "1013654",
+            "toAmountMin": "1008586",
+            "approvalAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+            "executionDuration": 76.944,
+            "feeCosts": [],
+            "gasCosts": [
+              {
+                "type": "SEND",
+                "estimate": "175000",
+                "limit": "227500",
+                "amount": "3083832847375000",
+                "token": {
+                  "address": "0x0000000000000000000000000000000000000000",
+                  "chainId": "1",
+                  "symbol": "ETH",
+                  "decimals": 18,
+                  "name": "ETH"
+                }
+              }
+            ]
+          },
+          "tool": "optimism",
+          "toolDetails": {
+            "key": "optimism",
+            "name": "Optimism Gateway"
+          }
+        }
+      ],
+      "integrator": "jumper.exchange"
+    }
+  )");
+  EXPECT_EQ(*params, GetJSON(ParseJson(expected_params)));
+
+  // OK: EVM -> SOL bridge quotes are correctly handled
+  quote = lifi::ParseQuoteResponse(ParseJson(GetLiFiEvmToSolQuoteTemplate()));
+  ASSERT_TRUE(quote);
+  ASSERT_EQ(quote->routes.size(), 1UL);
+  ASSERT_EQ(quote->routes[0]->steps.size(), 1UL);
+
+  auto& step_1 = quote->routes[0]->steps[0];
+  params = lifi::EncodeTransactionParams(std::move(step_1));
+  ASSERT_NE(params, std::nullopt);
+
+  expected_params = R"(
+    {
+      "type": "lifi",
+      "id": "57d247fc-d80a-4f4a-9596-72db3061aa72",
+      "tool": "allbridge",
+      "toolDetails": {
+        "key": "allbridge",
+        "name": "Allbridge"
+      },
+      "action": {
+        "fromChainId": "137",
+        "fromAmount": "2000000",
+        "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "slippage": 0.03,
+        "toChainId": "SOL",
+        "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+        "fromToken": {
+          "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+          "chainId": "137",
+          "symbol": "USDCe",
+          "decimals": 6,
+          "name": "USDC.e"
+        },
+        "toToken": {
+          "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+          "chainId": "SOL",
+          "symbol": "USDC",
+          "decimals": 6,
+          "name": "USD Coin"
+        }
+      },
+      "estimate": {
+        "tool": "allbridge",
+        "fromAmount": "2000000",
+        "toAmount": "1138627",
+        "toAmountMin": "1136350",
+        "approvalAddress": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+        "executionDuration": 500.298,
+        "feeCosts": [
+          {
+            "name": "Allbridge's fee",
+            "description": "AllBridge fee and messenger fee charged by Allbridge",
+            "token": {
+              "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+              "chainId": "137",
+              "symbol": "USDCe",
+              "decimals": 6,
+              "name": "USDC.e"
+            },
+            "amount": "853380",
+            "percentage": "0.4267",
+            "included": true
+          }
+        ],
+        "gasCosts": [
+          {
+            "type": "SEND",
+            "estimate": "185000",
+            "limit": "277500",
+            "amount": "20720000000000000",
+            "token": {
+              "address": "0x0000000000000000000000000000000000000000",
+              "chainId": "137",
+              "symbol": "MATIC",
+              "decimals": 18,
+              "name": "MATIC"
+            }
+          }
+        ]
+      },
+      "includedSteps": [
+        {
+          "id": "1b914bef-e1be-4895-a9b1-c57da16d9de5",
+          "type": "cross",
+          "action": {
+            "fromChainId": "137",
+            "fromAmount": "2000000",
+            "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+            "slippage": 0.03,
+            "toChainId": "SOL",
+            "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+            "fromToken": {
+              "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+              "chainId": "137",
+              "symbol": "USDCe",
+              "decimals": 6,
+              "name": "USDC.e"
+            },
+            "toToken": {
+              "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+              "chainId": "SOL",
+              "symbol": "USDC",
+              "decimals": 6,
+              "name": "USD Coin"
+            }
+          },
+          "estimate": {
+            "tool": "allbridge",
+            "fromAmount": "2000000",
+            "toAmount": "1138627",
+            "toAmountMin": "1136350",
+            "approvalAddress": "0x7775d63836987f444E2F14AA0fA2602204D7D3E0",
+            "executionDuration": 500.298,
+            "feeCosts": [
+              {
+                "name": "Allbridge's fee",
+                "description": "AllBridge fee and messenger fee charged by Allbridge",
+                "token": {
+                  "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                  "chainId": "137",
+                  "symbol": "USDCe",
+                  "decimals": 6,
+                  "name": "USDC.e"
+                },
+                "amount": "853380",
+                "percentage": "0.4267",
+                "included": true
+              }
+            ],
+            "gasCosts": [
+              {
+                "type": "SEND",
+                "estimate": "185000",
+                "limit": "277500",
+                "amount": "20720000000000000",
+                "token": {
+                  "address": "0x0000000000000000000000000000000000000000",
+                  "chainId": "137",
+                  "symbol": "MATIC",
+                  "decimals": 18,
+                  "name": "MATIC"
+                }
+              }
+            ]
+          },
+          "tool": "allbridge",
+          "toolDetails": {
+            "key": "allbridge",
+            "name": "Allbridge"
+          }
+        }
+      ]
+    }
+  )";
+  EXPECT_EQ(*params, GetJSON(ParseJson(expected_params)));
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/swap_request_helper_unittest.cc
+++ b/components/brave_wallet/browser/swap_request_helper_unittest.cc
@@ -744,7 +744,7 @@ TEST(SwapRequestHelperUnitTest, EncodeLiFiQuoteParams) {
   params->slippage_percentage = "3";
   params->route_priority = mojom::RoutePriority::kSafest;
 
-  auto encoded_params = lifi::EncodeQuoteParams(std::move(params));
+  auto encoded_params = lifi::EncodeQuoteParams(std::move(params), "0.2");
   ASSERT_NE(encoded_params, std::nullopt);
   std::string expected_params(R"(
     {

--- a/components/brave_wallet/browser/swap_response_parser.cc
+++ b/components/brave_wallet/browser/swap_response_parser.cc
@@ -16,6 +16,8 @@
 #include "brave/components/brave_wallet/browser/json_rpc_requests_helper.h"
 #include "brave/components/brave_wallet/browser/json_rpc_response_parser.h"
 #include "brave/components/brave_wallet/browser/swap_responses.h"
+#include "brave/components/brave_wallet/common/hex_utils.h"
+#include "brave/components/brave_wallet/common/string_utils.h"
 #include "brave/components/json/rs/src/lib.rs.h"
 
 namespace {
@@ -29,6 +31,7 @@ constexpr char kJupiterNoRoutesMessage[] =
 
 namespace brave_wallet {
 
+namespace zeroex {
 namespace {
 mojom::ZeroExFeePtr ParseZeroExFee(const base::Value& value) {
   if (value.is_none()) {
@@ -56,8 +59,8 @@ mojom::ZeroExFeePtr ParseZeroExFee(const base::Value& value) {
 
 }  // namespace
 
-mojom::ZeroExQuotePtr ParseZeroExQuoteResponse(const base::Value& json_value,
-                                               bool expect_transaction_data) {
+mojom::ZeroExQuotePtr ParseQuoteResponse(const base::Value& json_value,
+                                         bool expect_transaction_data) {
   // {
   //   "price":"1916.27547998814058355",
   //   "guaranteedPrice":"1935.438234788021989386",
@@ -162,7 +165,7 @@ mojom::ZeroExQuotePtr ParseZeroExQuoteResponse(const base::Value& json_value,
   return swap_response;
 }
 
-mojom::ZeroExErrorPtr ParseZeroExErrorResponse(const base::Value& json_value) {
+mojom::ZeroExErrorPtr ParseErrorResponse(const base::Value& json_value) {
   // https://github.com/0xProject/0x-monorepo/blob/development/packages/json-schemas/schemas/relayer_api_error_response_schema.json
   //
   // {
@@ -214,8 +217,10 @@ mojom::ZeroExErrorPtr ParseZeroExErrorResponse(const base::Value& json_value) {
   return result;
 }
 
-mojom::JupiterQuotePtr ParseJupiterQuoteResponse(
-    const base::Value& json_value) {
+}  // namespace zeroex
+
+namespace jupiter {
+mojom::JupiterQuotePtr ParseQuoteResponse(const base::Value& json_value) {
   // {
   //   "inputMint": "So11111111111111111111111111111111111111112",
   //   "inAmount": "1000000",
@@ -318,7 +323,7 @@ mojom::JupiterQuotePtr ParseJupiterQuoteResponse(
   return swap_quote;
 }
 
-std::optional<std::string> ParseJupiterTransactionResponse(
+std::optional<std::string> ParseTransactionResponse(
     const base::Value& json_value) {
   auto value = swap_responses::JupiterSwapTransactions::FromValue(json_value);
   if (!value) {
@@ -328,8 +333,7 @@ std::optional<std::string> ParseJupiterTransactionResponse(
   return value->swap_transaction;
 }
 
-mojom::JupiterErrorPtr ParseJupiterErrorResponse(
-    const base::Value& json_value) {
+mojom::JupiterErrorPtr ParseErrorResponse(const base::Value& json_value) {
   auto jupiter_error_response_value =
       swap_responses::JupiterErrorResponse::FromValue(json_value);
   if (!jupiter_error_response_value) {
@@ -346,10 +350,11 @@ mojom::JupiterErrorPtr ParseJupiterErrorResponse(
 
   return result;
 }
+}  // namespace jupiter
 
 // Function to convert all numbers in JSON string to strings.
 //
-// For sample JSON response, refer to ParseJupiterQuote.
+// For sample JSON response, refer to jupiter::ParseQuoteResponse.
 std::optional<std::string> ConvertAllNumbersToString(const std::string& json) {
   auto converted_json =
       std::string(json::convert_all_numbers_to_string(json, ""));
@@ -359,5 +364,285 @@ std::optional<std::string> ConvertAllNumbersToString(const std::string& json) {
 
   return converted_json;
 }
+
+namespace lifi {
+
+namespace {
+
+std::optional<std::string> ChainIdToHex(const std::string& value) {
+  // LiFi uses the following two chain ID strings interchangeably for Solana
+  // Ref: https://docs.li.fi/li.fi-api/solana/request-examples
+  if (value == "SOL" || value == "1151111081099710") {
+    return mojom::kSolanaMainnet;
+  }
+
+  uint256_t out;
+  if (!Base10ValueToUint256(value, &out)) {
+    return std::nullopt;
+  }
+
+  return Uint256ValueToHex(out);
+}
+
+mojom::BlockchainTokenPtr ParseToken(const swap_responses::LiFiToken& value) {
+  auto result = mojom::BlockchainToken::New();
+  result->name = value.name;
+  result->symbol = value.symbol;
+  result->logo = value.logo_uri;
+  result->contract_address =
+      value.address == kLiFiNativeAssetContractAddress ? "" : value.address;
+
+  if (!base::StringToInt(value.decimals, &result->decimals)) {
+    return nullptr;
+  }
+
+  auto chain_id = ChainIdToHex(value.chain_id);
+  if (!chain_id) {
+    return nullptr;
+  }
+  result->chain_id = chain_id.value();
+
+  // LiFi does not return the coin type, so we infer it from the chain ID.
+  if (result->chain_id == mojom::kSolanaMainnet) {
+    result->coin = mojom::CoinType::SOL;
+  } else {
+    result->coin = mojom::CoinType::ETH;
+  }
+
+  return result;
+}
+
+std::optional<mojom::LiFiStepType> ParseStepType(const std::string& value) {
+  if (value == "swap") {
+    return mojom::LiFiStepType::kSwap;
+  }
+
+  if (value == "cross") {
+    return mojom::LiFiStepType::kCross;
+  }
+
+  if (value == "lifi") {
+    return mojom::LiFiStepType::kNative;
+  }
+
+  return std::nullopt;
+}
+
+mojom::LiFiActionPtr ParseAction(const swap_responses::LiFiAction& value) {
+  auto result = mojom::LiFiAction::New();
+  result->from_amount = value.from_amount;
+  result->from_token = ParseToken(value.from_token);
+  result->from_address = value.from_address;
+
+  result->to_token = ParseToken(value.to_token);
+  result->to_address = value.to_address;
+
+  result->slippage = value.slippage;
+  result->destination_call_data = value.destination_call_data;
+  return result;
+}
+
+mojom::LiFiStepEstimatePtr ParseEstimate(
+    const swap_responses::LiFiEstimate& value) {
+  auto result = mojom::LiFiStepEstimate::New();
+  result->tool = value.tool;
+  result->from_amount = value.from_amount;
+  result->to_amount = value.to_amount;
+  result->to_amount_min = value.to_amount_min;
+  result->approval_address = value.approval_address;
+
+  for (const auto& fee_cost_value : value.fee_costs) {
+    auto fee_cost = mojom::LiFiFeeCost::New();
+    fee_cost->name = fee_cost_value.name;
+    fee_cost->description = fee_cost_value.description;
+    fee_cost->percentage = fee_cost_value.percentage;
+    fee_cost->token = ParseToken(fee_cost_value.token);
+    fee_cost->amount = fee_cost_value.amount;
+    fee_cost->included = fee_cost_value.included;
+    result->fee_costs.push_back(std::move(fee_cost));
+  }
+
+  for (const auto& gas_cost_value : value.gas_costs) {
+    auto gas_cost = mojom::LiFiGasCost::New();
+    gas_cost->type = gas_cost_value.type;
+    gas_cost->estimate = gas_cost_value.estimate;
+    gas_cost->limit = gas_cost_value.limit;
+    gas_cost->amount = gas_cost_value.amount;
+    gas_cost->token = ParseToken(gas_cost_value.token);
+    result->gas_costs.push_back(std::move(gas_cost));
+  }
+
+  result->execution_duration = value.execution_duration;
+
+  return result;
+}
+
+mojom::LiFiStepPtr ParseStep(const swap_responses::LiFiStep& value) {
+  auto result = mojom::LiFiStep::New();
+  result->id = value.id;
+
+  auto step_type = ParseStepType(value.type);
+  if (!step_type) {
+    return nullptr;
+  }
+  result->type = std::move(*step_type);
+
+  result->tool = value.tool;
+
+  auto tool_details = mojom::LiFiToolDetails::New();
+  tool_details->key = value.tool_details.key;
+  tool_details->name = value.tool_details.name;
+  tool_details->logo = value.tool_details.logo_uri;
+  result->tool_details = std::move(tool_details);
+
+  result->action = ParseAction(value.action);
+  result->estimate = ParseEstimate(value.estimate);
+
+  result->integrator = value.integrator;
+
+  if (!value.included_steps) {
+    return result;
+  }
+
+  std::vector<mojom::LiFiStepPtr> included_steps = {};
+  for (const auto& included_step_value : *value.included_steps) {
+    auto included_step = ParseStep(included_step_value);
+    if (!included_step) {
+      return nullptr;
+    }
+
+    included_steps.push_back(std::move(included_step));
+  }
+  result->included_steps = std::move(included_steps);
+
+  return result;
+}
+
+}  // namespace
+
+mojom::LiFiQuotePtr ParseQuoteResponse(const base::Value& json_value) {
+  auto value = swap_responses::LiFiQuoteResponse::FromValue(json_value);
+  if (!value) {
+    return nullptr;
+  }
+
+  auto result = mojom::LiFiQuote::New();
+
+  for (const auto& route_value : value->routes) {
+    auto route = mojom::LiFiRoute::New();
+    route->id = route_value.id;
+
+    auto from_token = ParseToken(route_value.from_token);
+    if (!from_token) {
+      return nullptr;
+    }
+    route->from_token = std::move(from_token);
+    route->from_amount = route_value.from_amount;
+    route->from_address = route_value.from_address;
+
+    auto to_token = ParseToken(route_value.to_token);
+    if (!to_token) {
+      return nullptr;
+    }
+    route->to_token = std::move(to_token);
+
+    route->to_amount = route_value.to_amount;
+    route->to_amount_min = route_value.to_amount_min;
+    route->to_address = route_value.to_address;
+
+    auto insurance = mojom::LiFiInsurance::New();
+    insurance->state = route_value.insurance.state;
+    insurance->fee_amount_usd = route_value.insurance.fee_amount_usd;
+    route->insurance = std::move(insurance);
+
+    for (const auto& step_value : route_value.steps) {
+      auto step = ParseStep(step_value);
+      if (!step) {
+        return nullptr;
+      }
+
+      route->steps.push_back(std::move(step));
+    }
+
+    route->tags = route_value.tags;
+    result->routes.push_back(std::move(route));
+  }
+
+  return result;
+}
+
+mojom::LiFiTransactionUnionPtr ParseTransactionResponse(
+    const base::Value& json_value) {
+  auto value = swap_responses::LiFiTransactionResponse::FromValue(json_value);
+  if (!value) {
+    return nullptr;
+  }
+
+  // SOL -> any transfers
+  if (!value->transaction_request.data.empty() &&
+      !value->transaction_request.from && !value->transaction_request.to &&
+      !value->transaction_request.value &&
+      !value->transaction_request.gas_price &&
+      !value->transaction_request.gas_limit &&
+      !value->transaction_request.chain_id) {
+    return mojom::LiFiTransactionUnion::NewSolanaTransaction(
+        value->transaction_request.data);
+  }
+
+  // EVM -> any transfers
+  if (value->transaction_request.data.empty() ||
+
+      !value->transaction_request.from ||
+      value->transaction_request.from->empty() ||
+
+      !value->transaction_request.to ||
+      value->transaction_request.to->empty() ||
+
+      !value->transaction_request.value ||
+      value->transaction_request.value->empty() ||
+
+      !value->transaction_request.gas_price ||
+      value->transaction_request.gas_price->empty() ||
+
+      !value->transaction_request.gas_limit ||
+      value->transaction_request.gas_limit->empty() ||
+
+      !value->transaction_request.chain_id ||
+      value->transaction_request.chain_id->empty()) {
+    return nullptr;
+  }
+
+  auto evm_transaction = mojom::LiFiEVMTransaction::New();
+  evm_transaction->data = value->transaction_request.data;
+  evm_transaction->from = value->transaction_request.from.value();
+  evm_transaction->to = value->transaction_request.to.value();
+  evm_transaction->value = value->transaction_request.value.value();
+  evm_transaction->gas_price = value->transaction_request.gas_price.value();
+  evm_transaction->gas_limit = value->transaction_request.gas_limit.value();
+
+  if (value->transaction_request.chain_id) {
+    auto chain_id = ChainIdToHex(value->transaction_request.chain_id.value());
+    if (!chain_id) {
+      return nullptr;
+    }
+    evm_transaction->chain_id = chain_id.value();
+  }
+
+  return mojom::LiFiTransactionUnion::NewEvmTransaction(
+      std::move(evm_transaction));
+}
+
+mojom::LiFiErrorPtr ParseErrorResponse(const base::Value& json_value) {
+  auto value = swap_responses::LiFiErrorResponse::FromValue(json_value);
+  if (!value) {
+    return nullptr;
+  }
+
+  auto result = mojom::LiFiError::New();
+  result->message = value->message;
+  return result;
+}
+
+}  // namespace lifi
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/swap_response_parser.h
+++ b/components/brave_wallet/browser/swap_response_parser.h
@@ -13,15 +13,34 @@
 
 namespace brave_wallet {
 
-mojom::ZeroExQuotePtr ParseZeroExQuoteResponse(const base::Value& json_value,
-                                               bool expect_transaction_data);
-mojom::ZeroExErrorPtr ParseZeroExErrorResponse(const base::Value& json_value);
+namespace zeroex {
 
-mojom::JupiterQuotePtr ParseJupiterQuoteResponse(const base::Value& json_value);
-std::optional<std::string> ParseJupiterTransactionResponse(
+mojom::ZeroExQuotePtr ParseQuoteResponse(const base::Value& json_value,
+                                         bool expect_transaction_data);
+mojom::ZeroExErrorPtr ParseErrorResponse(const base::Value& json_value);
+
+}  // namespace zeroex
+
+namespace jupiter {
+
+mojom::JupiterQuotePtr ParseQuoteResponse(const base::Value& json_value);
+std::optional<std::string> ParseTransactionResponse(
     const base::Value& json_value);
-mojom::JupiterErrorPtr ParseJupiterErrorResponse(const base::Value& json_value);
+mojom::JupiterErrorPtr ParseErrorResponse(const base::Value& json_value);
+
+}  // namespace jupiter
+
+namespace lifi {
+
+mojom::LiFiTransactionUnionPtr ParseTransactionResponse(
+    const base::Value& json_value);
+mojom::LiFiQuotePtr ParseQuoteResponse(const base::Value& json_value);
+mojom::LiFiErrorPtr ParseErrorResponse(const base::Value& json_value);
+
+}  // namespace lifi
+
 std::optional<std::string> ConvertAllNumbersToString(const std::string& json);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_SWAP_RESPONSE_PARSER_H_

--- a/components/brave_wallet/browser/swap_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/swap_response_parser_unittest.cc
@@ -124,7 +124,7 @@ TEST(SwapResponseParserUnitTest, ParseZeroExQuoteResponse) {
     }
   )");
   mojom::ZeroExQuotePtr quote =
-      ParseZeroExQuoteResponse(ParseJson(json), false);
+      zeroex::ParseQuoteResponse(ParseJson(json), false);
   ASSERT_TRUE(quote);
 
   EXPECT_EQ(quote->price, "1916.27547998814058355");
@@ -187,7 +187,7 @@ TEST(SwapResponseParserUnitTest, ParseZeroExQuoteResponse) {
       }
     }
   )";
-  quote = ParseZeroExQuoteResponse(ParseJson(json), false);
+  quote = zeroex::ParseQuoteResponse(ParseJson(json), false);
   ASSERT_TRUE(quote);
   EXPECT_FALSE(quote->fees->zero_ex_fee);
 
@@ -217,18 +217,18 @@ TEST(SwapResponseParserUnitTest, ParseZeroExQuoteResponse) {
       "fees": null
     }
   )";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), false));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), false));
 
   // Case 4: other invalid cases
   json = R"({"price": "3"})";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), false));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), false));
   json = R"({"price": 3})";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), false));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), false));
   json = "3";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), false));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), false));
   json = "[3]";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), false));
-  EXPECT_FALSE(ParseZeroExQuoteResponse(base::Value(), false));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), false));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(base::Value(), false));
 }
 
 TEST(SwapResponseParserUnitTest, ParseZeroExTransactionResponse) {
@@ -270,7 +270,8 @@ TEST(SwapResponseParserUnitTest, ParseZeroExTransactionResponse) {
       }
     }
   )");
-  mojom::ZeroExQuotePtr quote = ParseZeroExQuoteResponse(ParseJson(json), true);
+  mojom::ZeroExQuotePtr quote =
+      zeroex::ParseQuoteResponse(ParseJson(json), true);
   ASSERT_TRUE(quote);
 
   EXPECT_EQ(quote->price, "1916.27547998814058355");
@@ -333,7 +334,7 @@ TEST(SwapResponseParserUnitTest, ParseZeroExTransactionResponse) {
       }
     }
   )";
-  quote = ParseZeroExQuoteResponse(ParseJson(json), true);
+  quote = zeroex::ParseQuoteResponse(ParseJson(json), true);
   ASSERT_TRUE(quote);
   EXPECT_FALSE(quote->fees->zero_ex_fee);
 
@@ -363,24 +364,24 @@ TEST(SwapResponseParserUnitTest, ParseZeroExTransactionResponse) {
       "fees": null
     }
   )";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), true));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), true));
 
   // Case 4: other invalid cases
   json = R"({"price": "3"})";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), true));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), true));
   json = R"({"price": 3})";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), true));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), true));
   json = "3";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), true));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), true));
   json = "[3]";
-  EXPECT_FALSE(ParseZeroExQuoteResponse(ParseJson(json), true));
-  EXPECT_FALSE(ParseZeroExQuoteResponse(base::Value(), true));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(ParseJson(json), true));
+  EXPECT_FALSE(zeroex::ParseQuoteResponse(base::Value(), true));
 }
 
 TEST(SwapResponseParserUnitTest, ParseJupiterQuoteResponse) {
   auto* json = GetJupiterQuoteResponse();
   mojom::JupiterQuotePtr swap_quote =
-      ParseJupiterQuoteResponse(ParseJson(json));
+      jupiter::ParseQuoteResponse(ParseJson(json));
 
   ASSERT_TRUE(swap_quote);
   EXPECT_EQ(swap_quote->input_mint,
@@ -440,7 +441,7 @@ TEST(SwapResponseParserUnitTest, ParseJupiterQuoteResponse) {
             "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263");
 
   // OK: null platformFee value
-  EXPECT_TRUE(ParseJupiterQuoteResponse(ParseJson(R"({
+  EXPECT_TRUE(jupiter::ParseQuoteResponse(ParseJson(R"({
     "inputMint": "So11111111111111111111111111111111111111112",
       "inAmount": "1000000",
       "outputMint": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
@@ -454,13 +455,13 @@ TEST(SwapResponseParserUnitTest, ParseJupiterQuoteResponse) {
   })")));
 
   // KO: Malformed quote
-  EXPECT_FALSE(ParseJupiterQuoteResponse(base::Value()));
+  EXPECT_FALSE(jupiter::ParseQuoteResponse(base::Value()));
 
   // KO: Invalid quote
-  EXPECT_FALSE(ParseJupiterQuoteResponse(ParseJson(R"({"price": "3"})")));
+  EXPECT_FALSE(jupiter::ParseQuoteResponse(ParseJson(R"({"price": "3"})")));
 
   // KO: Invalid platformFee value
-  EXPECT_FALSE(ParseJupiterQuoteResponse(ParseJson(R"({
+  EXPECT_FALSE(jupiter::ParseQuoteResponse(ParseJson(R"({
     "inputMint": "So11111111111111111111111111111111111111112",
       "inAmount": "1000000",
       "outputMint": "DezXAZ8z7PnrnRJjz3wXBoRgixCa6xjnB7YaB1pPB263",
@@ -480,12 +481,13 @@ TEST(SwapResponseParserUnitTest, ParseJupiterTransactionResponse) {
       "swapTransaction": "swap"
     })");
 
-  auto transaction = ParseJupiterTransactionResponse(ParseJson(json));
+  auto transaction = jupiter::ParseTransactionResponse(ParseJson(json));
   ASSERT_TRUE(transaction);
   ASSERT_EQ(transaction, "swap");
 
-  ASSERT_FALSE(ParseJupiterTransactionResponse(base::Value()));
-  ASSERT_FALSE(ParseJupiterTransactionResponse(ParseJson(R"({"foo": "bar"})")));
+  ASSERT_FALSE(jupiter::ParseTransactionResponse(base::Value()));
+  ASSERT_FALSE(
+      jupiter::ParseTransactionResponse(ParseJson(R"({"foo": "bar"})")));
 }
 
 TEST(SwapResponseParserUnitTest, ParseZeroExErrorResponse) {
@@ -503,7 +505,7 @@ TEST(SwapResponseParserUnitTest, ParseZeroExErrorResponse) {
       ]
     })");
 
-    auto swap_error = ParseZeroExErrorResponse(ParseJson(json));
+    auto swap_error = zeroex::ParseErrorResponse(ParseJson(json));
     EXPECT_EQ(swap_error->code, 100);
     EXPECT_EQ(swap_error->reason, "Validation Failed");
     EXPECT_EQ(swap_error->validation_errors.size(), 1u);
@@ -528,7 +530,7 @@ TEST(SwapResponseParserUnitTest, ParseZeroExErrorResponse) {
       ]
     })");
 
-    auto swap_error = ParseZeroExErrorResponse(ParseJson(json));
+    auto swap_error = zeroex::ParseErrorResponse(ParseJson(json));
     EXPECT_EQ(swap_error->code, 100);
     EXPECT_EQ(swap_error->reason, "Validation Failed");
     EXPECT_EQ(swap_error->validation_errors.size(), 1u);
@@ -549,7 +551,7 @@ TEST(SwapResponseParserUnitTest, ParseJupiterErrorResponse) {
       "message": "No routes found for the input and output mints"
     })");
 
-    auto jupiter_error = ParseJupiterErrorResponse(ParseJson(json));
+    auto jupiter_error = jupiter::ParseErrorResponse(ParseJson(json));
     EXPECT_EQ(jupiter_error->status_code, "some code");
     EXPECT_EQ(jupiter_error->error, "error");
     EXPECT_EQ(jupiter_error->message,
@@ -565,13 +567,726 @@ TEST(SwapResponseParserUnitTest, ParseJupiterErrorResponse) {
       "message": "some message"
     })");
 
-    auto jupiter_error = ParseJupiterErrorResponse(ParseJson(json));
+    auto jupiter_error = jupiter::ParseErrorResponse(ParseJson(json));
     EXPECT_EQ(jupiter_error->status_code, "some code");
     EXPECT_EQ(jupiter_error->error, "error");
     EXPECT_EQ(jupiter_error->message, "some message");
 
     EXPECT_FALSE(jupiter_error->is_insufficient_liquidity);
   }
+}
+
+TEST(SwapResponseParserUnitTest, ParseLiFiQuoteResponse) {
+  {
+    // OK: valid quote
+    std::string json(R"(
+    {
+      "routes": [
+        {
+          "id": "0x343bc553146a3dd8438518d80bd1b6957f3fec05d137ff65a940bfb5390d3f1f",
+          "fromChainId": "1",
+          "fromAmountUSD": "1.00",
+          "fromAmount": "1000000",
+          "fromToken": {
+            "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+            "chainId": "1",
+            "symbol": "USDC",
+            "decimals": "6",
+            "name": "USD Coin",
+            "coinKey": "USDC",
+            "logoURI": "usdc.png",
+            "priceUSD": "1"
+          },
+          "fromAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+          "toChainId": "10",
+          "toAmountUSD": "1.01",
+          "toAmount": "1013654",
+          "toAmountMin": "1008586",
+          "toToken": {
+            "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+            "chainId": "10",
+            "symbol": "USDT",
+            "decimals": "6",
+            "name": "USDT",
+            "coinKey": "USDT",
+            "logoURI": "usdt.png",
+            "priceUSD": "0.999685"
+          },
+          "toAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+          "gasCostUSD": "14.65",
+          "containsSwitchChain": false,
+          "steps": [
+            {
+              "type": "lifi",
+              "id": "5a6876f1-988e-4710-85b7-be2bd7681421",
+              "tool": "optimism",
+              "toolDetails": {
+                "key": "optimism",
+                "name": "Optimism Gateway",
+                "logoURI": "optimism.png"
+              },
+              "action": {
+                "fromToken": {
+                  "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                  "chainId": "1",
+                  "symbol": "USDC",
+                  "decimals": "6",
+                  "name": "USD Coin",
+                  "coinKey": "USDC",
+                  "logoURI": "usdc.png",
+                  "priceUSD": "1"
+                },
+                "fromAmount": "1000000",
+                "toToken": {
+                  "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                  "chainId": "10",
+                  "symbol": "USDT",
+                  "decimals": "6",
+                  "name": "USDT",
+                  "coinKey": "USDT",
+                  "logoURI": "usdt.png",
+                  "priceUSD": "0.999685"
+                },
+                "fromChainId": "1",
+                "toChainId": "10",
+                "slippage": "0.005",
+                "fromAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4",
+                "toAddress": "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4"
+              },
+              "estimate": {
+                "tool": "optimism",
+                "approvalAddress": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "toAmountMin": "1008586",
+                "toAmount": "1013654",
+                "fromAmount": "1000000",
+                "feeCosts": [
+                  {
+                    "name": "LP Fee",
+                    "description": "Fee paid to the Liquidity Provider",
+                    "token": {
+                      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                      "chainId": "1",
+                      "symbol": "USDC",
+                      "decimals": "6",
+                      "name": "USD Coin",
+                      "coinKey": "USDC",
+                      "logoURI": "usdc.png",
+                      "priceUSD": "1"
+                    },
+                    "amount": "3000",
+                    "amountUSD": "0.01",
+                    "percentage": "0.003",
+                    "included": true
+                  }
+                ],
+                "gasCosts": [
+                  {
+                    "type": "SEND",
+                    "price": "17621901985",
+                    "estimate": "375000",
+                    "limit": "618000",
+                    "amount": "6608213244375000",
+                    "amountUSD": "14.65",
+                    "token": {
+                      "address": "0x0000000000000000000000000000000000000000",
+                      "chainId": "1",
+                      "symbol": "ETH",
+                      "decimals": "18",
+                      "name": "ETH",
+                      "coinKey": "ETH",
+                      "logoURI": "eth.png",
+                      "priceUSD": "2216.770000000000000000"
+                    }
+                  }
+                ],
+                "executionDuration": "106.944",
+                "fromAmountUSD": "1.00",
+                "toAmountUSD": "1.01"
+              },
+              "includedSteps": [
+                {
+                  "id": "9ac4d9f1-9b72-463d-baf1-fcd8b09f8a8d",
+                  "type": "swap",
+                  "action": {
+                    "fromChainId": "1",
+                    "fromAmount": "1000000",
+                    "fromToken": {
+                      "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                      "chainId": "1",
+                      "symbol": "USDC",
+                      "decimals": "6",
+                      "name": "USD Coin",
+                      "coinKey": "USDC",
+                      "logoURI": "usdc.png",
+                      "priceUSD": "1"
+                    },
+                    "toChainId": "1",
+                    "toToken": {
+                      "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                      "chainId": "1",
+                      "symbol": "USDT",
+                      "decimals": "6",
+                      "name": "USDT",
+                      "coinKey": "USDT",
+                      "logoURI": "usdt.png",
+                      "priceUSD": "0.999685"
+                    },
+                    "slippage": "0.005"
+                  },
+                  "estimate": {
+                    "tool": "verse-dex",
+                    "fromAmount": "1000000",
+                    "toAmount": "1013654",
+                    "toAmountMin": "1008586",
+                    "approvalAddress": "0xB4B0ea46Fe0E9e8EAB4aFb765b527739F2718671",
+                    "executionDuration": "30",
+                    "feeCosts": [
+                      {
+                        "name": "LP Fee",
+                        "description": "Fee paid to the Liquidity Provider",
+                        "token": {
+                          "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+                          "chainId": "1",
+                          "symbol": "USDC",
+                          "decimals": "6",
+                          "name": "USD Coin",
+                          "coinKey": "USDC",
+                          "logoURI": "usdc.png",
+                          "priceUSD": "1"
+                        },
+                        "amount": "3000",
+                        "amountUSD": "0.01",
+                        "percentage": "0.003",
+                        "included": true
+                      }
+                    ],
+                    "gasCosts": [
+                      {
+                        "type": "SEND",
+                        "price": "17621901985",
+                        "estimate": "200000",
+                        "limit": "260000",
+                        "amount": "3524380397000000",
+                        "amountUSD": "7.81",
+                        "token": {
+                          "address": "0x0000000000000000000000000000000000000000",
+                          "chainId": "1",
+                          "symbol": "ETH",
+                          "decimals": "18",
+                          "name": "ETH",
+                          "coinKey": "ETH",
+                          "logoURI": "eth.png",
+                          "priceUSD": "2216.770000000000000000"
+                        }
+                      }
+                    ]
+                  },
+                  "tool": "verse-dex",
+                  "toolDetails": {
+                    "key": "verse-dex",
+                    "name": "Verse Dex",
+                    "logoURI": "https://analytics.verse.bitcoin.com/logo.png"
+                  }
+                },
+                {
+                  "id": "b952ed38-1d5c-43bc-990a-468fd32d29b9",
+                  "type": "cross",
+                  "action": {
+                    "fromChainId": "1",
+                    "fromAmount": "1008586",
+                    "fromToken": {
+                      "address": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+                      "chainId": "1",
+                      "symbol": "USDT",
+                      "decimals": "6",
+                      "name": "USDT",
+                      "coinKey": "USDT",
+                      "logoURI": "usdt.png",
+                      "priceUSD": "0.999685"
+                    },
+                    "toChainId": "10",
+                    "toToken": {
+                      "address": "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58",
+                      "chainId": "10",
+                      "symbol": "USDT",
+                      "decimals": "6",
+                      "name": "USDT",
+                      "coinKey": "USDT",
+                      "logoURI": "usdt.png",
+                      "priceUSD": "0.999685"
+                    },
+                    "slippage": "0.005",
+                    "destinationGasConsumption": "0",
+                    "destinationCallData": "0x0"
+                  },
+                  "estimate": {
+                    "tool": "optimism",
+                    "fromAmount": "1013654",
+                    "toAmount": "1013654",
+                    "toAmountMin": "1008586",
+                    "approvalAddress": "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1",
+                    "executionDuration": "76.944",
+                    "feeCosts": [],
+                    "gasCosts": [
+                      {
+                        "type": "SEND",
+                        "price": "17621901985",
+                        "estimate": "175000",
+                        "limit": "227500",
+                        "amount": "3083832847375000",
+                        "amountUSD": "6.84",
+                        "token": {
+                          "address": "0x0000000000000000000000000000000000000000",
+                          "chainId": "1",
+                          "symbol": "ETH",
+                          "decimals": "18",
+                          "name": "ETH",
+                          "coinKey": "ETH",
+                          "logoURI": "eth.png",
+                          "priceUSD": "2216.770000000000000000"
+                        }
+                      }
+                    ]
+                  },
+                  "tool": "optimism",
+                  "toolDetails": {
+                    "key": "optimism",
+                    "name": "Optimism Gateway",
+                    "logoURI": "optimism.png"
+                  }
+                }
+              ],
+              "integrator": "jumper.exchange"
+            }
+          ],
+          "insurance": {
+            "state": "NOT_INSURABLE",
+            "feeAmountUsd": "0"
+          },
+          "tags": [
+            "RECOMMENDED",
+            "CHEAPEST",
+            "FASTEST"
+          ]
+        }
+      ]
+    })");
+
+    auto quote = lifi::ParseQuoteResponse(ParseJson(json));
+    ASSERT_TRUE(quote);
+    ASSERT_EQ(quote->routes.size(), 1u);
+    const auto& route = quote->routes.at(0);
+    EXPECT_EQ(
+        route->id,
+        "0x343bc553146a3dd8438518d80bd1b6957f3fec05d137ff65a940bfb5390d3f1f");
+    EXPECT_EQ(route->from_amount, "1000000");
+    EXPECT_EQ(route->from_token->contract_address,
+              "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    EXPECT_EQ(route->from_token->chain_id, "0x1");
+    EXPECT_EQ(route->from_token->symbol, "USDC");
+    EXPECT_EQ(route->from_token->decimals, 6);
+    EXPECT_EQ(route->from_token->name, "USD Coin");
+    EXPECT_EQ(route->from_token->logo, "usdc.png");
+    EXPECT_EQ(route->from_address,
+              "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4");
+    EXPECT_EQ(route->to_amount, "1013654");
+    EXPECT_EQ(route->to_amount_min, "1008586");
+    EXPECT_EQ(route->to_token->contract_address,
+              "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58");
+    EXPECT_EQ(route->to_token->chain_id, "0xa");
+    EXPECT_EQ(route->to_token->symbol, "USDT");
+    EXPECT_EQ(route->to_token->decimals, 6);
+    EXPECT_EQ(route->to_token->name, "USDT");
+    EXPECT_EQ(route->to_token->logo, "usdt.png");
+    EXPECT_EQ(route->to_address, "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4");
+
+    ASSERT_EQ(route->steps.size(), 1u);
+    const auto& step = route->steps.at(0);
+    EXPECT_EQ(step->type, mojom::LiFiStepType::kNative);
+    EXPECT_EQ(step->id, "5a6876f1-988e-4710-85b7-be2bd7681421");
+    EXPECT_EQ(step->tool, "optimism");
+    EXPECT_EQ(step->tool_details->key, "optimism");
+    EXPECT_EQ(step->tool_details->name, "Optimism Gateway");
+    EXPECT_EQ(step->tool_details->logo, "optimism.png");
+    EXPECT_EQ(step->action->from_token->contract_address,
+              "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    EXPECT_EQ(step->action->from_token->chain_id, "0x1");
+    EXPECT_EQ(step->action->from_token->symbol, "USDC");
+    EXPECT_EQ(step->action->from_token->decimals, 6);
+    EXPECT_EQ(step->action->from_token->name, "USD Coin");
+    EXPECT_EQ(step->action->from_token->logo, "usdc.png");
+    EXPECT_EQ(step->action->from_amount, "1000000");
+    EXPECT_EQ(step->action->to_token->contract_address,
+              "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58");
+    EXPECT_EQ(step->action->to_token->chain_id, "0xa");
+    EXPECT_EQ(step->action->to_token->symbol, "USDT");
+    EXPECT_EQ(step->action->to_token->decimals, 6);
+    EXPECT_EQ(step->action->to_token->name, "USDT");
+    EXPECT_EQ(step->action->to_token->logo, "usdt.png");
+    EXPECT_EQ(step->action->slippage, "0.005");
+    EXPECT_EQ(step->action->from_address,
+              "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4");
+    EXPECT_EQ(step->action->to_address,
+              "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4");
+    EXPECT_EQ(step->estimate->tool, "optimism");
+    EXPECT_EQ(step->estimate->approval_address,
+              "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE");
+    EXPECT_EQ(step->estimate->to_amount_min, "1008586");
+    EXPECT_EQ(step->estimate->to_amount, "1013654");
+    EXPECT_EQ(step->estimate->from_amount, "1000000");
+    ASSERT_EQ(step->estimate->fee_costs.size(), 1u);
+    const auto& fee_cost = step->estimate->fee_costs.at(0);
+    EXPECT_EQ(fee_cost->name, "LP Fee");
+    EXPECT_EQ(fee_cost->description, "Fee paid to the Liquidity Provider");
+    EXPECT_EQ(fee_cost->token->contract_address,
+              "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    EXPECT_EQ(fee_cost->token->chain_id, "0x1");
+    EXPECT_EQ(fee_cost->token->symbol, "USDC");
+    EXPECT_EQ(fee_cost->token->decimals, 6);
+    EXPECT_EQ(fee_cost->token->name, "USD Coin");
+    EXPECT_EQ(fee_cost->token->logo, "usdc.png");
+    EXPECT_EQ(fee_cost->amount, "3000");
+    EXPECT_EQ(fee_cost->percentage, "0.003");
+    EXPECT_TRUE(fee_cost->included);
+    ASSERT_EQ(step->estimate->gas_costs.size(), 1u);
+    const auto& gas_cost = step->estimate->gas_costs.at(0);
+    EXPECT_EQ(gas_cost->type, "SEND");
+    EXPECT_EQ(gas_cost->estimate, "375000");
+    EXPECT_EQ(gas_cost->limit, "618000");
+    EXPECT_EQ(gas_cost->amount, "6608213244375000");
+    EXPECT_EQ(gas_cost->token->contract_address, "");
+    EXPECT_EQ(gas_cost->token->chain_id, "0x1");
+    EXPECT_EQ(gas_cost->token->symbol, "ETH");
+    EXPECT_EQ(gas_cost->token->decimals, 18);
+    EXPECT_EQ(gas_cost->token->name, "ETH");
+    EXPECT_EQ(gas_cost->token->logo, "eth.png");
+    EXPECT_EQ(step->estimate->execution_duration, "106.944");
+
+    ASSERT_TRUE(step->included_steps);
+    ASSERT_EQ(step->included_steps->size(), 2u);
+    const auto& included_step_1 = step->included_steps->at(0);
+    EXPECT_EQ(included_step_1->id, "9ac4d9f1-9b72-463d-baf1-fcd8b09f8a8d");
+    EXPECT_EQ(included_step_1->type, mojom::LiFiStepType::kSwap);
+    EXPECT_EQ(included_step_1->tool, "verse-dex");
+    EXPECT_EQ(included_step_1->tool_details->key, "verse-dex");
+    EXPECT_EQ(included_step_1->tool_details->name, "Verse Dex");
+    EXPECT_EQ(included_step_1->tool_details->logo,
+              "https://analytics.verse.bitcoin.com/logo.png");
+    EXPECT_EQ(included_step_1->action->from_amount, "1000000");
+    EXPECT_EQ(included_step_1->action->from_token->contract_address,
+              "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    EXPECT_EQ(included_step_1->action->from_token->chain_id, "0x1");
+    EXPECT_EQ(included_step_1->action->from_token->symbol, "USDC");
+    EXPECT_EQ(included_step_1->action->from_token->decimals, 6);
+    EXPECT_EQ(included_step_1->action->from_token->name, "USD Coin");
+    EXPECT_EQ(included_step_1->action->from_token->logo, "usdc.png");
+    EXPECT_EQ(included_step_1->action->to_token->contract_address,
+              "0xdAC17F958D2ee523a2206206994597C13D831ec7");
+    EXPECT_EQ(included_step_1->action->to_token->chain_id, "0x1");
+    EXPECT_EQ(included_step_1->action->to_token->symbol, "USDT");
+    EXPECT_EQ(included_step_1->action->to_token->decimals, 6);
+    EXPECT_EQ(included_step_1->action->to_token->name, "USDT");
+    EXPECT_EQ(included_step_1->action->to_token->logo, "usdt.png");
+    EXPECT_EQ(included_step_1->action->slippage, "0.005");
+    EXPECT_EQ(included_step_1->estimate->tool, "verse-dex");
+    EXPECT_EQ(included_step_1->estimate->from_amount, "1000000");
+    EXPECT_EQ(included_step_1->estimate->to_amount, "1013654");
+    EXPECT_EQ(included_step_1->estimate->to_amount_min, "1008586");
+    EXPECT_EQ(included_step_1->estimate->approval_address,
+              "0xB4B0ea46Fe0E9e8EAB4aFb765b527739F2718671");
+    EXPECT_EQ(included_step_1->estimate->execution_duration, "30");
+    ASSERT_EQ(included_step_1->estimate->fee_costs.size(), 1u);
+    const auto& included_step_1_fee_cost =
+        included_step_1->estimate->fee_costs.at(0);
+    EXPECT_EQ(included_step_1_fee_cost->name, "LP Fee");
+    EXPECT_EQ(included_step_1_fee_cost->description,
+              "Fee paid to the Liquidity Provider");
+    EXPECT_EQ(included_step_1_fee_cost->token->contract_address,
+              "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+    EXPECT_EQ(included_step_1_fee_cost->token->chain_id, "0x1");
+    EXPECT_EQ(included_step_1_fee_cost->token->symbol, "USDC");
+    EXPECT_EQ(included_step_1_fee_cost->token->decimals, 6);
+    EXPECT_EQ(included_step_1_fee_cost->token->name, "USD Coin");
+    EXPECT_EQ(included_step_1_fee_cost->token->logo, "usdc.png");
+    EXPECT_EQ(included_step_1_fee_cost->amount, "3000");
+    EXPECT_EQ(included_step_1_fee_cost->percentage, "0.003");
+    EXPECT_TRUE(included_step_1_fee_cost->included);
+    ASSERT_EQ(included_step_1->estimate->gas_costs.size(), 1u);
+    const auto& included_step_1_gas_cost =
+        included_step_1->estimate->gas_costs.at(0);
+    EXPECT_EQ(included_step_1_gas_cost->type, "SEND");
+    EXPECT_EQ(included_step_1_gas_cost->estimate, "200000");
+    EXPECT_EQ(included_step_1_gas_cost->limit, "260000");
+    EXPECT_EQ(included_step_1_gas_cost->amount, "3524380397000000");
+    EXPECT_EQ(included_step_1_gas_cost->token->contract_address, "");
+    EXPECT_EQ(included_step_1_gas_cost->token->chain_id, "0x1");
+    EXPECT_EQ(included_step_1_gas_cost->token->symbol, "ETH");
+    EXPECT_EQ(included_step_1_gas_cost->token->decimals, 18);
+    EXPECT_EQ(included_step_1_gas_cost->token->name, "ETH");
+    EXPECT_EQ(included_step_1_gas_cost->token->logo, "eth.png");
+    EXPECT_FALSE(included_step_1->included_steps);
+
+    const auto& included_step_2 = step->included_steps->at(1);
+    EXPECT_EQ(included_step_2->id, "b952ed38-1d5c-43bc-990a-468fd32d29b9");
+    EXPECT_EQ(included_step_2->type, mojom::LiFiStepType::kCross);
+    EXPECT_EQ(included_step_2->tool, "optimism");
+    EXPECT_EQ(included_step_2->tool_details->key, "optimism");
+    EXPECT_EQ(included_step_2->tool_details->name, "Optimism Gateway");
+    EXPECT_EQ(included_step_2->tool_details->logo, "optimism.png");
+    EXPECT_EQ(included_step_2->action->from_amount, "1008586");
+    EXPECT_EQ(included_step_2->action->from_token->contract_address,
+              "0xdAC17F958D2ee523a2206206994597C13D831ec7");
+    EXPECT_EQ(included_step_2->action->from_token->chain_id, "0x1");
+    EXPECT_EQ(included_step_2->action->from_token->symbol, "USDT");
+    EXPECT_EQ(included_step_2->action->from_token->decimals, 6);
+    EXPECT_EQ(included_step_2->action->from_token->name, "USDT");
+    EXPECT_EQ(included_step_2->action->from_token->logo, "usdt.png");
+    EXPECT_EQ(included_step_2->action->to_token->contract_address,
+              "0x94b008aA00579c1307B0EF2c499aD98a8ce58e58");
+    EXPECT_EQ(included_step_2->action->to_token->chain_id, "0xa");
+    EXPECT_EQ(included_step_2->action->to_token->symbol, "USDT");
+    EXPECT_EQ(included_step_2->action->to_token->decimals, 6);
+    EXPECT_EQ(included_step_2->action->to_token->name, "USDT");
+    EXPECT_EQ(included_step_2->action->to_token->logo, "usdt.png");
+    EXPECT_EQ(included_step_2->action->slippage, "0.005");
+    EXPECT_EQ(included_step_2->action->destination_call_data, "0x0");
+    EXPECT_EQ(included_step_2->estimate->tool, "optimism");
+    EXPECT_EQ(included_step_2->estimate->from_amount, "1013654");
+    EXPECT_EQ(included_step_2->estimate->to_amount, "1013654");
+    EXPECT_EQ(included_step_2->estimate->to_amount_min, "1008586");
+    EXPECT_EQ(included_step_2->estimate->approval_address,
+              "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1");
+    EXPECT_EQ(included_step_2->estimate->execution_duration, "76.944");
+    EXPECT_TRUE(included_step_2->estimate->fee_costs.empty());
+    ASSERT_EQ(included_step_2->estimate->gas_costs.size(), 1u);
+    const auto& included_step_2_gas_cost =
+        included_step_2->estimate->gas_costs.at(0);
+    EXPECT_EQ(included_step_2_gas_cost->type, "SEND");
+    EXPECT_EQ(included_step_2_gas_cost->estimate, "175000");
+    EXPECT_EQ(included_step_2_gas_cost->limit, "227500");
+    EXPECT_EQ(included_step_2_gas_cost->amount, "3083832847375000");
+    EXPECT_EQ(included_step_2_gas_cost->token->contract_address, "");
+    EXPECT_EQ(included_step_2_gas_cost->token->chain_id, "0x1");
+    EXPECT_EQ(included_step_2_gas_cost->token->symbol, "ETH");
+    EXPECT_EQ(included_step_2_gas_cost->token->decimals, 18);
+    EXPECT_EQ(included_step_2_gas_cost->token->name, "ETH");
+    EXPECT_EQ(included_step_2_gas_cost->token->logo, "eth.png");
+    EXPECT_FALSE(included_step_2->included_steps);
+
+    EXPECT_EQ(route->insurance->state, "NOT_INSURABLE");
+    EXPECT_EQ(route->insurance->fee_amount_usd, "0");
+    ASSERT_EQ(route->tags.size(), 3u);
+    EXPECT_EQ(route->tags.at(0), "RECOMMENDED");
+    EXPECT_EQ(route->tags.at(1), "CHEAPEST");
+    EXPECT_EQ(route->tags.at(2), "FASTEST");
+  }
+}
+
+TEST(SwapResponseParserUnitTest, ParseLiFiTransactionResponse) {
+  {
+    // OK: valid Solana transaction
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "data": "b255Yg=="
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    ASSERT_TRUE(transaction);
+    ASSERT_TRUE(transaction->is_solana_transaction());
+    EXPECT_EQ(transaction->get_solana_transaction(), "b255Yg==");
+  }
+
+  {
+    // KO: empty data field
+    std::string json(R"(
+    {
+      "transactionRequest": {}
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing transactionRequest field
+    std::string json(R"(
+    {
+      "foobar": 123
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // OK: valid EVM transaction
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    ASSERT_TRUE(transaction);
+    ASSERT_TRUE(transaction->is_evm_transaction());
+    const auto& evm_transaction = transaction->get_evm_transaction();
+    EXPECT_EQ(evm_transaction->from,
+              "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0");
+    EXPECT_EQ(evm_transaction->to,
+              "0x1111111254fb6c44bac0bed2854e76f90643097d");
+    EXPECT_EQ(evm_transaction->chain_id, "0x64");
+    EXPECT_EQ(evm_transaction->data, "0x...");
+    EXPECT_EQ(evm_transaction->value, "0x0de0b6b3a7640000");
+    EXPECT_EQ(evm_transaction->gas_price, "0xb2d05e00");
+    EXPECT_EQ(evm_transaction->gas_limit, "0x0e9cb2");
+  }
+
+  {
+    // KO: missing from field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing to field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "chainId": "100",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing chainId field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing data field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing value field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "data": "0x...",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing gasPrice field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasLimit": "0x0e9cb2"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+
+  {
+    // KO: missing gasLimit field
+    std::string json(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00"
+      }
+    })");
+
+    auto transaction = lifi::ParseTransactionResponse(ParseJson(json));
+    EXPECT_FALSE(transaction);
+  }
+}
+
+TEST(SwapResponseParserUnitTest, ParseLiFiErrorResponse) {
+  std::string json(R"(
+    {
+      "message": "Invalid request"
+    }
+  )");
+
+  auto error = lifi::ParseErrorResponse(ParseJson(json));
+  ASSERT_TRUE(error);
+  EXPECT_EQ(error->message, "Invalid request");
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/swap_responses.idl
+++ b/components/brave_wallet/browser/swap_responses.idl
@@ -100,4 +100,124 @@ namespace swap_responses {
     DOMString error;
     DOMString message;
   };
+
+  // LiFi response types
+
+  dictionary LiFiTransactionRequest {
+    // In case of SOL -> EVM transfers, only the data field is required which
+    // is a base64 encoded Solana transaction.
+    DOMString data;
+
+    // The following fields are mandatory for EVM -> any transfers.
+    DOMString? from;
+    DOMString? to;
+    DOMString? chainId;
+    DOMString? value;
+    DOMString? gasPrice;
+    DOMString? gasLimit;
+  };
+
+  dictionary LiFiToken {
+    DOMString address;
+    DOMString decimals;
+    DOMString symbol;
+    DOMString chainId;
+    DOMString coinKey;
+    DOMString name;
+    DOMString logoURI;
+  };
+
+  dictionary LiFiFeeCost {
+    DOMString name;
+    DOMString description;
+    DOMString percentage;
+    LiFiToken token;
+    DOMString amount;
+    boolean included;
+  };
+
+  dictionary LiFiGasCost {
+    DOMString type;
+    DOMString estimate;
+    DOMString limit;
+    DOMString amount;
+    LiFiToken token;
+  };
+
+  dictionary LiFiAction {
+    DOMString fromChainId;
+    DOMString fromAmount;
+    LiFiToken fromToken;
+    DOMString toChainId;
+    LiFiToken toToken;
+    DOMString slippage;
+
+    DOMString? fromAddress;
+    DOMString? toAddress;
+    DOMString? destinationCallData;
+  };
+
+  dictionary LiFiEstimate {
+    DOMString tool;
+    DOMString fromAmount;
+    DOMString toAmount;
+    DOMString toAmountMin;
+    DOMString approvalAddress;
+    LiFiFeeCost[] feeCosts;
+    LiFiGasCost[] gasCosts;
+    DOMString executionDuration;
+  };
+
+  dictionary LiFiToolDetails {
+    DOMString key;
+    DOMString name;
+    DOMString logoURI;
+  };
+
+  dictionary LiFiInsurance {
+    DOMString state;
+    DOMString feeAmountUsd;
+  };
+
+  dictionary LiFiStep {
+    DOMString id;
+    DOMString type;
+    DOMString tool;
+    LiFiToolDetails toolDetails;
+    LiFiAction action;
+    LiFiEstimate estimate;
+
+    DOMString? integrator;
+    LiFiStep[]? includedSteps;
+  };
+
+  dictionary LiFiRoute {
+    DOMString id;
+    DOMString fromChainId;
+    DOMString fromAmount;
+    LiFiToken fromToken;
+    DOMString fromAddress;
+    DOMString toChainId;
+    DOMString toAmount;
+    DOMString toAmountMin;
+    LiFiToken toToken;
+    DOMString toAddress;
+    LiFiStep[] steps;
+    LiFiInsurance insurance;
+    DOMString[] tags;
+  };
+
+  // Docs: https://apidocs.li.fi/reference/post_advanced-routes
+  dictionary LiFiQuoteResponse {
+    LiFiRoute[] routes;
+  };
+
+  // Docs: https://apidocs.li.fi/reference/post_advanced-steptransaction
+  dictionary LiFiTransactionResponse {
+    LiFiTransactionRequest transactionRequest;
+  };
+
+  dictionary LiFiErrorResponse {
+    DOMString message;
+  };
 };

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -315,10 +315,8 @@ GURL SwapService::GetZeroExQuoteURL(
   // this, noting the inability of /price to discover optimal RFQ quotes. This
   // should be considered a temporary workaround until 0x comes up with a
   // solution.
-  std::string spec =
-      base::StringPrintf(use_rfqt ? "%s/swap/v1/quote" : "%s/swap/v1/price",
-                         GetBaseSwapURL(params.from_chain_id).c_str());
-  GURL url(spec);
+  auto url = GURL(GetBaseSwapURL(params.from_chain_id))
+                 .Resolve(use_rfqt ? "/swap/v1/quote" : "/swap/v1/price");
   url = AppendZeroExSwapParams(url, params, fee_param);
   // That flag prevents an allowance validation by the 0x router. Disable it
   // here and perform the validation on the client side.
@@ -335,9 +333,8 @@ GURL SwapService::GetZeroExQuoteURL(
 GURL SwapService::GetZeroExTransactionURL(
     const mojom::SwapQuoteParams& params,
     const std::optional<std::string> fee_param) {
-  std::string spec = base::StringPrintf(
-      "%s/swap/v1/quote", GetBaseSwapURL(params.from_chain_id).c_str());
-  GURL url(spec);
+  auto url =
+      GURL(GetBaseSwapURL(params.from_chain_id)).Resolve("/swap/v1/quote");
   url = AppendZeroExSwapParams(url, params, fee_param);
 
   if (HasRFQTLiquidity(params.from_chain_id)) {
@@ -351,9 +348,7 @@ GURL SwapService::GetZeroExTransactionURL(
 GURL SwapService::GetJupiterQuoteURL(
     const mojom::SwapQuoteParams& params,
     const std::optional<std::string> fee_param) {
-  std::string spec = base::StringPrintf(
-      "%s/v6/quote", GetBaseSwapURL(params.from_chain_id).c_str());
-  GURL url(spec);
+  auto url = GURL(GetBaseSwapURL(params.from_chain_id)).Resolve("/v6/quote");
   url = AppendJupiterQuoteParams(url, params, fee_param);
 
   return url;
@@ -361,26 +356,17 @@ GURL SwapService::GetJupiterQuoteURL(
 
 // static
 GURL SwapService::GetJupiterTransactionURL(const std::string& chain_id) {
-  std::string spec =
-      base::StringPrintf("%s/v6/swap", GetBaseSwapURL(chain_id).c_str());
-  GURL url(spec);
-  return url;
+  return GURL(GetBaseSwapURL(chain_id)).Resolve("/v6/swap");
 }
 
 // static
 GURL SwapService::GetLiFiQuoteURL() {
-  std::string spec =
-      base::StringPrintf("%s/v1/advanced/routes", kLiFiBaseAPIURL);
-  GURL url(spec);
-  return url;
+  return GURL(kLiFiBaseAPIURL).Resolve("/v1/advanced/routes");
 }
 
 // static
 GURL SwapService::GetLiFiTransactionURL() {
-  std::string spec =
-      base::StringPrintf("%s/v1/advanced/stepTransaction", kLiFiBaseAPIURL);
-  GURL url(spec);
-  return url;
+  return GURL(kLiFiBaseAPIURL).Resolve("/v1/advanced/stepTransaction");
 }
 
 void SwapService::IsSwapSupported(const std::string& chain_id,

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -101,7 +101,7 @@ std::string GetAffiliateAddress(const std::string& chain_id) {
 mojom::SwapFeesPtr GetJupiterSwapFee(const mojom::SwapQuoteParams& params) {
   mojom::SwapFeesPtr response = mojom::SwapFees::New();
   bool has_fees = HasJupiterFeesForTokenMint(
-      params.to_token == "" ? kWrappedSolanaMintAddress : params.to_token);
+      params.to_token.empty() ? kWrappedSolanaMintAddress : params.to_token);
 
   auto fee_pct = kSolanaBuyTokenFeePercentage;
   response->fee_pct = base::NumberToString(fee_pct);

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -164,7 +164,7 @@ mojom::SwapFeesPtr GetZeroExSwapFee() {
 
 GURL AppendZeroExSwapParams(const GURL& swap_url,
                             const mojom::SwapQuoteParams& params,
-                            const std::optional<std::string> fee_param) {
+                            const std::optional<std::string>& fee_param) {
   GURL url = swap_url;
   if (!params.from_account_id->address.empty()) {
     url = net::AppendQueryParameter(url, "takerAddress",
@@ -213,7 +213,7 @@ GURL AppendZeroExSwapParams(const GURL& swap_url,
 
 GURL AppendJupiterQuoteParams(const GURL& swap_url,
                               const mojom::SwapQuoteParams& params,
-                              const std::optional<std::string> fee_param) {
+                              const std::optional<std::string>& fee_param) {
   GURL url = swap_url;
   url = net::AppendQueryParameter(url, "inputMint",
                                   params.from_token.empty()
@@ -246,7 +246,7 @@ GURL AppendJupiterQuoteParams(const GURL& swap_url,
   return url;
 }
 
-const base::flat_map<std::string, std::string> GetHeaders() {
+base::flat_map<std::string, std::string> GetHeaders() {
   return {{kBraveServicesKeyHeader, BUILDFLAG(BRAVE_SERVICES_KEY)}};
 }
 
@@ -305,7 +305,7 @@ void SwapService::Bind(mojo::PendingReceiver<mojom::SwapService> receiver) {
 // static
 GURL SwapService::GetZeroExQuoteURL(
     const mojom::SwapQuoteParams& params,
-    const std::optional<std::string> fee_param) {
+    const std::optional<std::string>& fee_param) {
   const bool use_rfqt = HasRFQTLiquidity(params.from_chain_id);
 
   // If chain has RFQ-T liquidity available, use the /quote endpoint for
@@ -332,7 +332,7 @@ GURL SwapService::GetZeroExQuoteURL(
 // static
 GURL SwapService::GetZeroExTransactionURL(
     const mojom::SwapQuoteParams& params,
-    const std::optional<std::string> fee_param) {
+    const std::optional<std::string>& fee_param) {
   auto url =
       GURL(GetBaseSwapURL(params.from_chain_id)).Resolve("/swap/v1/quote");
   url = AppendZeroExSwapParams(url, params, fee_param);
@@ -347,7 +347,7 @@ GURL SwapService::GetZeroExTransactionURL(
 // static
 GURL SwapService::GetJupiterQuoteURL(
     const mojom::SwapQuoteParams& params,
-    const std::optional<std::string> fee_param) {
+    const std::optional<std::string>& fee_param) {
   auto url = GURL(GetBaseSwapURL(params.from_chain_id)).Resolve("/v6/quote");
   url = AppendJupiterQuoteParams(url, params, fee_param);
 

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_wallet/browser/swap_request_helper.h"
 #include "brave/components/brave_wallet/browser/swap_response_parser.h"
 #include "brave/components/brave_wallet/common/buildflags.h"
+#include "brave/components/constants/brave_services_key.h"
 #include "net/base/load_flags.h"
 #include "net/base/url_util.h"
 #include "net/http/http_request_headers.h"
@@ -46,127 +47,124 @@ net::NetworkTrafficAnnotationTag GetNetworkTrafficAnnotationTag() {
     )");
 }
 
-bool IsEVMNetworkSupported(const std::string& chain_id) {
-  return (chain_id == brave_wallet::mojom::kGoerliChainId ||
-          chain_id == brave_wallet::mojom::kMainnetChainId ||
-          chain_id == brave_wallet::mojom::kPolygonMainnetChainId ||
-          chain_id == brave_wallet::mojom::kBinanceSmartChainMainnetChainId ||
-          chain_id == brave_wallet::mojom::kAvalancheMainnetChainId ||
-          chain_id == brave_wallet::mojom::kFantomMainnetChainId ||
-          chain_id == brave_wallet::mojom::kCeloMainnetChainId ||
-          chain_id == brave_wallet::mojom::kOptimismMainnetChainId ||
-          chain_id == brave_wallet::mojom::kArbitrumMainnetChainId ||
-          chain_id == brave_wallet::mojom::kBaseMainnetChainId);
+}  // namespace
+
+namespace brave_wallet {
+
+namespace {
+bool IsNetworkSupportedByZeroEx(const std::string& chain_id) {
+  return (chain_id == mojom::kGoerliChainId ||
+          chain_id == mojom::kMainnetChainId ||
+          chain_id == mojom::kPolygonMainnetChainId ||
+          chain_id == mojom::kBinanceSmartChainMainnetChainId ||
+          chain_id == mojom::kAvalancheMainnetChainId ||
+          chain_id == mojom::kFantomMainnetChainId ||
+          chain_id == mojom::kCeloMainnetChainId ||
+          chain_id == mojom::kOptimismMainnetChainId ||
+          chain_id == mojom::kArbitrumMainnetChainId ||
+          chain_id == mojom::kBaseMainnetChainId);
 }
 
-bool IsSolanaNetworkSupported(const std::string& chain_id) {
-  return chain_id == brave_wallet::mojom::kSolanaMainnet;
+bool IsNetworkSupportedByJupiter(const std::string& chain_id) {
+  return chain_id == mojom::kSolanaMainnet;
+}
+
+bool IsNetworkSupportedByLiFi(const std::string& chain_id) {
+  return (chain_id == mojom::kMainnetChainId ||
+          chain_id == mojom::kOptimismMainnetChainId ||
+          chain_id == mojom::kBinanceSmartChainMainnetChainId ||
+          chain_id == mojom::kPolygonZKEVMChainId ||
+          chain_id == mojom::kAvalancheMainnetChainId ||
+          chain_id == mojom::kGnosisChainId ||
+          chain_id == mojom::kArbitrumMainnetChainId ||
+          chain_id == mojom::kPolygonMainnetChainId ||
+          chain_id == mojom::kZkSyncEraChainId ||
+          chain_id == mojom::kBaseMainnetChainId ||
+          chain_id == mojom::kFantomMainnetChainId ||
+          chain_id == mojom::kAuroraMainnetChainId ||
+          chain_id == mojom::kSolanaMainnet);
 }
 
 bool HasRFQTLiquidity(const std::string& chain_id) {
-  return (chain_id == brave_wallet::mojom::kMainnetChainId ||
-          chain_id == brave_wallet::mojom::kPolygonMainnetChainId);
-}
-
-std::optional<double> GetFeePercentage(const std::string& chain_id) {
-  if (IsEVMNetworkSupported(chain_id)) {
-    return brave_wallet::k0xBuyTokenFeePercentage;
-  }
-
-  if (IsSolanaNetworkSupported(chain_id)) {
-    return brave_wallet::kSolanaBuyTokenFeePercentage;
-  }
-
-  return std::nullopt;
+  return (chain_id == mojom::kMainnetChainId ||
+          chain_id == mojom::kPolygonMainnetChainId);
 }
 
 std::string GetAffiliateAddress(const std::string& chain_id) {
-  if (IsEVMNetworkSupported(chain_id)) {
-    return brave_wallet::kAffiliateAddress;
+  if (IsNetworkSupportedByZeroEx(chain_id)) {
+    return kAffiliateAddress;
   }
 
   return "";
 }
 
-brave_wallet::mojom::BraveSwapFeeResponsePtr GetBraveFeeInternal(
-    const brave_wallet::mojom::BraveSwapFeeParamsPtr& params) {
-  const auto& percentage_fee = GetFeePercentage(params->chain_id);
-  if (!percentage_fee) {
-    return nullptr;
-  }
+mojom::SwapFeesPtr GetJupiterSwapFee(const mojom::SwapQuoteParams& params) {
+  mojom::SwapFeesPtr response = mojom::SwapFees::New();
+  bool has_fees = HasJupiterFeesForTokenMint(
+      params.to_token == "" ? kWrappedSolanaMintAddress : params.to_token);
 
-  if (IsSolanaNetworkSupported(params->chain_id)) {
-    brave_wallet::mojom::BraveSwapFeeResponsePtr response =
-        brave_wallet::mojom::BraveSwapFeeResponse::New();
+  auto fee_pct = kSolanaBuyTokenFeePercentage;
+  response->fee_pct = base::NumberToString(fee_pct);
 
-    bool has_fees =
-        brave_wallet::HasJupiterFeesForTokenMint(params->output_token);
+  auto discount = has_fees ? 0.0 : 100.0;
+  response->discount_pct = base::NumberToString(discount);
 
-    // Jupiter API v6 will take 20% of the platform fee charged by integrators.
-    // TODO(onyb): update the multipliers below during migration to Jupiter API
-    // v6.
-    auto protocol_fee_pct = percentage_fee.value() * 0.0;
-    auto brave_fee_pct = percentage_fee.value() * 1.0;
-    auto discount_on_brave_fee_pct = has_fees ? 0.0 : 100.0;
-    auto discount_on_prototcol_fee_pct = has_fees ? 0.0 : 100.0;
+  auto effective_fee_pct = (100.0 - discount) / 100.0 * fee_pct;
+  response->effective_fee_pct = base::NumberToString(effective_fee_pct);
 
-    response->brave_fee_pct = base::NumberToString(brave_fee_pct);
+  // Jupiter swap fee is specified in basis points
+  response->fee_param =
+      effective_fee_pct != 0.0
+          ? base::NumberToString(static_cast<int>(effective_fee_pct * 100.0))
+          : "";
 
-    response->discount_on_brave_fee_pct =
-        base::NumberToString(discount_on_brave_fee_pct);
+  response->discount_code =
+      has_fees ? mojom::SwapDiscountCode::kNone
+               : mojom::SwapDiscountCode::kUnknownJupiterOutputMint;
 
-    response->protocol_fee_pct = base::NumberToString(
-        (100.0 - discount_on_prototcol_fee_pct) / 100.0 * protocol_fee_pct);
-
-    response->effective_fee_pct = base::NumberToString(
-        (100.0 - discount_on_brave_fee_pct) / 100.0 * brave_fee_pct);
-
-    // Jupiter swap fee is specified in basis points
-    response->fee_param =
-        base::NumberToString(static_cast<int>(percentage_fee.value() * 100.0));
-
-    response->discount_code =
-        has_fees ? brave_wallet::mojom::DiscountCode::kNone
-                 : brave_wallet::mojom::DiscountCode::kUnknownJupiterOutputMint;
-
-    response->has_brave_fee = has_fees;
-
-    return response;
-  }
-
-  if (IsEVMNetworkSupported(params->chain_id)) {
-    brave_wallet::mojom::BraveSwapFeeResponsePtr response =
-        brave_wallet::mojom::BraveSwapFeeResponse::New();
-
-    // We currently do not offer discounts on 0x Brave fees.
-    auto discount_on_brave_fee_pct = 0.0;
-
-    // This indicates the 0x Swap fee of 15 bps on select tokens. It should
-    // only be surfaced to the users if quote has a non-null zeroExFee field.
-    response->protocol_fee_pct =
-        base::NumberToString(brave_wallet::k0xProtocolFeePercentage);
-    response->brave_fee_pct = base::NumberToString(percentage_fee.value());
-    response->discount_on_brave_fee_pct =
-        base::NumberToString(discount_on_brave_fee_pct);
-
-    auto effective_fee_pct =
-        (100.0 - discount_on_brave_fee_pct) / 100.0 * percentage_fee.value();
-    response->effective_fee_pct = base::NumberToString(effective_fee_pct);
-
-    // 0x swap fee is specified as a multiplier
-    response->fee_param = base::NumberToString(effective_fee_pct / 100.0);
-
-    response->discount_code = brave_wallet::mojom::DiscountCode::kNone;
-    response->has_brave_fee = effective_fee_pct > 0.0;
-
-    return response;
-  }
-
-  return nullptr;
+  return response;
 }
 
-GURL Append0xSwapParams(const GURL& swap_url,
-                        const brave_wallet::mojom::SwapQuoteParams& params) {
+mojom::SwapFeesPtr GetLiFiSwapFee() {
+  mojom::SwapFeesPtr response = mojom::SwapFees::New();
+
+  response->fee_pct = base::NumberToString(kLiFiFeePercentage);
+
+  // We currently do not offer discounts on LiFi Brave fees.
+  response->discount_pct = "0";
+  response->discount_code = mojom::SwapDiscountCode::kNone;
+  response->effective_fee_pct = response->fee_pct;
+
+  // LiFi swap fee is specified as a multiplier
+  response->fee_param = response->effective_fee_pct != "0"
+                            ? base::NumberToString(kLiFiFeePercentage / 100.0)
+                            : "";
+
+  return response;
+}
+
+mojom::SwapFeesPtr GetZeroExSwapFee() {
+  mojom::SwapFeesPtr response = mojom::SwapFees::New();
+
+  response->fee_pct = base::NumberToString(kZeroExBuyTokenFeePercentage);
+
+  // We currently do not offer discounts on 0x Brave fees.
+  response->discount_pct = "0";
+  response->discount_code = mojom::SwapDiscountCode::kNone;
+  response->effective_fee_pct = response->fee_pct;
+
+  // 0x swap fee is specified as a multiplier
+  response->fee_param =
+      response->effective_fee_pct != "0"
+          ? base::NumberToString(kZeroExBuyTokenFeePercentage / 100.0)
+          : "";
+
+  return response;
+}
+
+GURL AppendZeroExSwapParams(const GURL& swap_url,
+                            const mojom::SwapQuoteParams& params,
+                            const std::optional<std::string> fee_param) {
   GURL url = swap_url;
   if (!params.from_account_id->address.empty()) {
     url = net::AppendQueryParameter(url, "takerAddress",
@@ -178,22 +176,19 @@ GURL Append0xSwapParams(const GURL& swap_url,
   if (!params.to_amount.empty()) {
     url = net::AppendQueryParameter(url, "buyAmount", params.to_amount);
   }
-  if (!params.to_token.empty()) {
-    url = net::AppendQueryParameter(url, "buyToken", params.to_token);
-  }
-  if (!params.from_token.empty()) {
-    url = net::AppendQueryParameter(url, "sellToken", params.from_token);
-  }
 
-  auto brave_swap_fee_params = brave_wallet::mojom::BraveSwapFeeParams::New();
-  brave_swap_fee_params->chain_id = params.from_chain_id;
-  brave_swap_fee_params->taker = params.from_account_id->address;
-  brave_swap_fee_params->input_token = params.from_token;
-  brave_swap_fee_params->output_token = params.to_token;
-  const auto& brave_fee = GetBraveFeeInternal(brave_swap_fee_params);
-  if (brave_fee && brave_fee->has_brave_fee) {
-    url = net::AppendQueryParameter(url, "buyTokenPercentageFee",
-                                    brave_fee->fee_param);
+  url = net::AppendQueryParameter(url, "buyToken",
+                                  params.to_token.empty()
+                                      ? kZeroExNativeAssetContractAddress
+                                      : params.to_token);
+  url = net::AppendQueryParameter(url, "sellToken",
+                                  params.from_token.empty()
+                                      ? kZeroExNativeAssetContractAddress
+                                      : params.from_token);
+
+  if (!fee_param->empty()) {
+    url = net::AppendQueryParameter(url, "buyTokenPercentageFee", *fee_param);
+    url = net::AppendQueryParameter(url, "feeRecipient", kEVMFeeRecipient);
   }
 
   double slippage_percentage = 0.0;
@@ -202,9 +197,6 @@ GURL Append0xSwapParams(const GURL& swap_url,
         url, "slippagePercentage",
         base::StringPrintf("%.6f", slippage_percentage / 100));
   }
-
-  url = net::AppendQueryParameter(url, "feeRecipient",
-                                  brave_wallet::kEVMFeeRecipient);
 
   std::string affiliate_address = GetAffiliateAddress(params.from_chain_id);
   if (!affiliate_address.empty()) {
@@ -215,20 +207,21 @@ GURL Append0xSwapParams(const GURL& swap_url,
   // if (!params.gas_price.empty()) {
   // url = net::AppendQueryParameter(url, "gasPrice", params.gas_price);
   // }
+
   return url;
 }
 
-GURL AppendJupiterQuoteParams(
-    const GURL& swap_url,
-    const brave_wallet::mojom::SwapQuoteParams& params) {
+GURL AppendJupiterQuoteParams(const GURL& swap_url,
+                              const mojom::SwapQuoteParams& params,
+                              const std::optional<std::string> fee_param) {
   GURL url = swap_url;
-  if (!params.from_token.empty()) {
-    url = net::AppendQueryParameter(url, "inputMint", params.from_token);
-  }
-
-  if (!params.to_token.empty()) {
-    url = net::AppendQueryParameter(url, "outputMint", params.to_token);
-  }
+  url = net::AppendQueryParameter(url, "inputMint",
+                                  params.from_token.empty()
+                                      ? kWrappedSolanaMintAddress
+                                      : params.from_token);
+  url = net::AppendQueryParameter(
+      url, "outputMint",
+      params.to_token.empty() ? kWrappedSolanaMintAddress : params.to_token);
 
   if (!params.from_amount.empty()) {
     url = net::AppendQueryParameter(url, "amount", params.from_amount);
@@ -243,15 +236,8 @@ GURL AppendJupiterQuoteParams(
         base::StringPrintf("%d", static_cast<int>(slippage_percentage * 100)));
   }
 
-  auto brave_swap_fee_params = brave_wallet::mojom::BraveSwapFeeParams::New();
-  brave_swap_fee_params->chain_id = params.from_chain_id;
-  brave_swap_fee_params->taker = params.from_account_id->address;
-  brave_swap_fee_params->input_token = params.from_token;
-  brave_swap_fee_params->output_token = params.to_token;
-  const auto& brave_fee = GetBraveFeeInternal(brave_swap_fee_params);
-  if (brave_fee && brave_fee->has_brave_fee) {
-    url =
-        net::AppendQueryParameter(url, "platformFeeBps", brave_fee->fee_param);
+  if (!fee_param->empty()) {
+    url = net::AppendQueryParameter(url, "platformFeeBps", *fee_param);
   }
 
   // TODO(onyb): append userPublicKey to get information on fees and ATA
@@ -260,19 +246,40 @@ GURL AppendJupiterQuoteParams(
   return url;
 }
 
-base::flat_map<std::string, std::string> Get0xAPIHeaders() {
-  std::string brave_zero_ex_api_key(BUILDFLAG(BRAVE_ZERO_EX_API_KEY));
-  if (brave_zero_ex_api_key.empty()) {
-    return {};
+const base::flat_map<std::string, std::string> GetHeaders() {
+  return {{kBraveServicesKeyHeader, BUILDFLAG(BRAVE_SERVICES_KEY)}};
+}
+
+std::string GetBaseSwapURL(const std::string& chain_id) {
+  if (chain_id == brave_wallet::mojom::kGoerliChainId) {
+    return brave_wallet::kZeroExGoerliBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kMainnetChainId) {
+    return brave_wallet::kZeroExEthereumBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kPolygonMainnetChainId) {
+    return brave_wallet::kZeroExPolygonBaseAPIURL;
+  } else if (chain_id ==
+             brave_wallet::mojom::kBinanceSmartChainMainnetChainId) {
+    return brave_wallet::kZeroExBinanceSmartChainBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kAvalancheMainnetChainId) {
+    return brave_wallet::kZeroExAvalancheBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kFantomMainnetChainId) {
+    return brave_wallet::kZeroExFantomBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kCeloMainnetChainId) {
+    return brave_wallet::kZeroExCeloBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kOptimismMainnetChainId) {
+    return brave_wallet::kZeroExOptimismBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kArbitrumMainnetChainId) {
+    return brave_wallet::kZeroExArbitrumBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kSolanaMainnet) {
+    return brave_wallet::kJupiterBaseAPIURL;
+  } else if (chain_id == brave_wallet::mojom::kBaseMainnetChainId) {
+    return brave_wallet::kZeroExBaseBaseAPIURL;
   }
-  return {{brave_wallet::k0xAPIKeyHeader, std::move(brave_zero_ex_api_key)}};
+
+  return "";
 }
 
 }  // namespace
-
-namespace brave_wallet {
-
-GURL SwapService::base_url_for_test_;
 
 SwapService::SwapService(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
@@ -295,46 +302,10 @@ void SwapService::Bind(mojo::PendingReceiver<mojom::SwapService> receiver) {
   receivers_.Add(this, std::move(receiver));
 }
 
-void SwapService::SetBaseURLForTest(const GURL& base_url_for_test) {
-  base_url_for_test_ = base_url_for_test;
-}
-
 // static
-std::string SwapService::GetBaseSwapURL(const std::string& chain_id) {
-  if (!base_url_for_test_.is_empty()) {
-    return base_url_for_test_.spec();
-  }
-
-  if (chain_id == brave_wallet::mojom::kGoerliChainId) {
-    return brave_wallet::kGoerliSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kMainnetChainId) {
-    return brave_wallet::kSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kPolygonMainnetChainId) {
-    return brave_wallet::kPolygonSwapBaseAPIURL;
-  } else if (chain_id ==
-             brave_wallet::mojom::kBinanceSmartChainMainnetChainId) {
-    return brave_wallet::kBinanceSmartChainSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kAvalancheMainnetChainId) {
-    return brave_wallet::kAvalancheSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kFantomMainnetChainId) {
-    return brave_wallet::kFantomSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kCeloMainnetChainId) {
-    return brave_wallet::kCeloSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kOptimismMainnetChainId) {
-    return brave_wallet::kOptimismSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kArbitrumMainnetChainId) {
-    return brave_wallet::kArbitrumSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kSolanaMainnet) {
-    return brave_wallet::kSolanaSwapBaseAPIURL;
-  } else if (chain_id == brave_wallet::mojom::kBaseMainnetChainId) {
-    return brave_wallet::kBaseSwapBaseAPIURL;
-  }
-
-  return "";
-}
-
-// static
-GURL SwapService::GetZeroExQuoteURL(const mojom::SwapQuoteParams& params) {
+GURL SwapService::GetZeroExQuoteURL(
+    const mojom::SwapQuoteParams& params,
+    const std::optional<std::string> fee_param) {
   const bool use_rfqt = HasRFQTLiquidity(params.from_chain_id);
 
   // If chain has RFQ-T liquidity available, use the /quote endpoint for
@@ -345,10 +316,10 @@ GURL SwapService::GetZeroExQuoteURL(const mojom::SwapQuoteParams& params) {
   // should be considered a temporary workaround until 0x comes up with a
   // solution.
   std::string spec =
-      base::StringPrintf(use_rfqt ? "%sswap/v1/quote" : "%sswap/v1/price",
+      base::StringPrintf(use_rfqt ? "%s/swap/v1/quote" : "%s/swap/v1/price",
                          GetBaseSwapURL(params.from_chain_id).c_str());
   GURL url(spec);
-  url = Append0xSwapParams(url, params);
+  url = AppendZeroExSwapParams(url, params, fee_param);
   // That flag prevents an allowance validation by the 0x router. Disable it
   // here and perform the validation on the client side.
   url = net::AppendQueryParameter(url, "skipValidation", "true");
@@ -362,11 +333,12 @@ GURL SwapService::GetZeroExQuoteURL(const mojom::SwapQuoteParams& params) {
 
 // static
 GURL SwapService::GetZeroExTransactionURL(
-    const mojom::SwapQuoteParams& params) {
+    const mojom::SwapQuoteParams& params,
+    const std::optional<std::string> fee_param) {
   std::string spec = base::StringPrintf(
-      "%sswap/v1/quote", GetBaseSwapURL(params.from_chain_id).c_str());
+      "%s/swap/v1/quote", GetBaseSwapURL(params.from_chain_id).c_str());
   GURL url(spec);
-  url = Append0xSwapParams(url, params);
+  url = AppendZeroExSwapParams(url, params, fee_param);
 
   if (HasRFQTLiquidity(params.from_chain_id)) {
     url = net::AppendQueryParameter(url, "intentOnFilling", "true");
@@ -376,11 +348,13 @@ GURL SwapService::GetZeroExTransactionURL(
 }
 
 // static
-GURL SwapService::GetJupiterQuoteURL(const mojom::SwapQuoteParams& params) {
+GURL SwapService::GetJupiterQuoteURL(
+    const mojom::SwapQuoteParams& params,
+    const std::optional<std::string> fee_param) {
   std::string spec = base::StringPrintf(
-      "%sv6/quote", GetBaseSwapURL(params.from_chain_id).c_str());
+      "%s/v6/quote", GetBaseSwapURL(params.from_chain_id).c_str());
   GURL url(spec);
-  url = AppendJupiterQuoteParams(url, params);
+  url = AppendJupiterQuoteParams(url, params, fee_param);
 
   return url;
 }
@@ -388,111 +362,182 @@ GURL SwapService::GetJupiterQuoteURL(const mojom::SwapQuoteParams& params) {
 // static
 GURL SwapService::GetJupiterTransactionURL(const std::string& chain_id) {
   std::string spec =
-      base::StringPrintf("%sv6/swap", GetBaseSwapURL(chain_id).c_str());
+      base::StringPrintf("%s/v6/swap", GetBaseSwapURL(chain_id).c_str());
+  GURL url(spec);
+  return url;
+}
+
+// static
+GURL SwapService::GetLiFiQuoteURL() {
+  std::string spec =
+      base::StringPrintf("%s/v1/advanced/routes", kLiFiBaseAPIURL);
+  GURL url(spec);
+  return url;
+}
+
+// static
+GURL SwapService::GetLiFiTransactionURL() {
+  std::string spec =
+      base::StringPrintf("%s/v1/advanced/stepTransaction", kLiFiBaseAPIURL);
   GURL url(spec);
   return url;
 }
 
 void SwapService::IsSwapSupported(const std::string& chain_id,
                                   IsSwapSupportedCallback callback) {
-  std::move(callback).Run(IsEVMNetworkSupported(chain_id) ||
-                          IsSolanaNetworkSupported(chain_id));
+  // TODO(onyb): Enable LiFi support when it's ready.
+  std::move(callback).Run(IsNetworkSupportedByZeroEx(chain_id) ||
+                          IsNetworkSupportedByJupiter(chain_id));
 }
 
 void SwapService::GetQuote(mojom::SwapQuoteParamsPtr params,
                            GetQuoteCallback callback) {
-  // Cross-chain swaps are not supported.
-  if (params->from_chain_id != params->to_chain_id) {
-    std::move(callback).Run(
-        nullptr, nullptr,
-        l10n_util::GetStringUTF8(IDS_BRAVE_WALLET_UNSUPPORTED_NETWORK));
-    return;
-  }
+  if (params->from_chain_id == params->to_chain_id &&
+      IsNetworkSupportedByZeroEx(params->from_chain_id)) {
+    auto swap_fee = GetZeroExSwapFee();
+    auto fee_param = swap_fee->fee_param;
 
-  if (IsEVMNetworkSupported(params->from_chain_id)) {
-    auto internal_callback =
-        base::BindOnce(&SwapService::OnGetZeroExQuote,
-                       weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+    auto internal_callback = base::BindOnce(
+        &SwapService::OnGetZeroExQuote, weak_ptr_factory_.GetWeakPtr(),
+        std::move(swap_fee), std::move(callback));
 
     api_request_helper_.Request(net::HttpRequestHeaders::kGetMethod,
-                                GetZeroExQuoteURL(*params), "", "",
-                                std::move(internal_callback), Get0xAPIHeaders(),
-                                {.auto_retry_on_network_change = true});
+                                GetZeroExQuoteURL(*params, fee_param), "", "",
+                                std::move(internal_callback), GetHeaders(), {});
 
     return;
   }
 
-  if (IsSolanaNetworkSupported(params->from_chain_id)) {
-    auto internal_callback =
-        base::BindOnce(&SwapService::OnGetJupiterQuote,
-                       weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+  if (params->from_chain_id == params->to_chain_id &&
+      IsNetworkSupportedByJupiter(params->from_chain_id)) {
+    auto swap_fee = GetJupiterSwapFee(*params);
+    auto fee_param = swap_fee->fee_param;
+
+    auto internal_callback = base::BindOnce(
+        &SwapService::OnGetJupiterQuote, weak_ptr_factory_.GetWeakPtr(),
+        std::move(swap_fee), std::move(callback));
 
     auto conversion_callback = base::BindOnce(&ConvertAllNumbersToString);
 
-    base::flat_map<std::string, std::string> request_headers;
-    api_request_helper_.Request(
-        net::HttpRequestHeaders::kGetMethod, GetJupiterQuoteURL(*params), "",
-        "", std::move(internal_callback), request_headers,
-        {.auto_retry_on_network_change = true}, std::move(conversion_callback));
+    api_request_helper_.Request(net::HttpRequestHeaders::kGetMethod,
+                                GetJupiterQuoteURL(*params, fee_param), "", "",
+                                std::move(internal_callback), {}, {},
+                                std::move(conversion_callback));
 
+    return;
+  }
+
+  if (IsNetworkSupportedByLiFi(params->from_chain_id) &&
+      IsNetworkSupportedByLiFi(params->to_chain_id)) {
+    auto encoded_params = lifi::EncodeQuoteParams(std::move(params));
+    if (!encoded_params) {
+      std::move(callback).Run(
+          nullptr, nullptr, nullptr,
+          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+      return;
+    }
+
+    auto swap_fee = GetLiFiSwapFee();
+
+    auto internal_callback = base::BindOnce(
+        &SwapService::OnGetLiFiQuote, weak_ptr_factory_.GetWeakPtr(),
+        std::move(swap_fee), std::move(callback));
+
+    auto conversion_callback = base::BindOnce(&ConvertAllNumbersToString);
+
+    api_request_helper_.Request(
+        net::HttpRequestHeaders::kPostMethod, GetLiFiQuoteURL(),
+        *encoded_params, "application/json", std::move(internal_callback), {},
+        {}, std::move(conversion_callback));
     return;
   }
 
   std::move(callback).Run(
-      nullptr, nullptr,
+      nullptr, nullptr, nullptr,
       l10n_util::GetStringUTF8(IDS_BRAVE_WALLET_UNSUPPORTED_NETWORK));
 }
 
-void SwapService::OnGetZeroExQuote(GetQuoteCallback callback,
+void SwapService::OnGetZeroExQuote(mojom::SwapFeesPtr swap_fee,
+                                   GetQuoteCallback callback,
                                    APIRequestResult api_request_result) {
   if (!api_request_result.Is2XXResponseCode()) {
     if (auto swap_error_response =
-            ParseZeroExErrorResponse(api_request_result.value_body())) {
+            zeroex::ParseErrorResponse(api_request_result.value_body())) {
       std::move(callback).Run(
-          nullptr,
+          nullptr, nullptr,
           mojom::SwapErrorUnion::NewZeroExError(std::move(swap_error_response)),
           "");
     } else {
       std::move(callback).Run(
-          nullptr, nullptr, l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+          nullptr, nullptr, nullptr,
+          l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
     }
     return;
   }
 
   if (auto swap_response =
-          ParseZeroExQuoteResponse(api_request_result.value_body(), false)) {
+          zeroex::ParseQuoteResponse(api_request_result.value_body(), false)) {
     std::move(callback).Run(
         mojom::SwapQuoteUnion::NewZeroExQuote(std::move(swap_response)),
-        nullptr, "");
+        std::move(swap_fee), nullptr, "");
   } else {
-    std::move(callback).Run(nullptr, nullptr,
+    std::move(callback).Run(nullptr, nullptr, nullptr,
                             l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
   }
 }
 
-void SwapService::OnGetJupiterQuote(GetQuoteCallback callback,
+void SwapService::OnGetJupiterQuote(mojom::SwapFeesPtr swap_fee,
+                                    GetQuoteCallback callback,
                                     APIRequestResult api_request_result) {
   if (!api_request_result.Is2XXResponseCode()) {
     if (auto error_response =
-            ParseJupiterErrorResponse(api_request_result.value_body())) {
+            jupiter::ParseErrorResponse(api_request_result.value_body())) {
       std::move(callback).Run(
-          nullptr,
+          nullptr, nullptr,
           mojom::SwapErrorUnion::NewJupiterError(std::move(error_response)),
           "");
     } else {
       std::move(callback).Run(
-          nullptr, nullptr, l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+          nullptr, nullptr, nullptr,
+          l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
     }
     return;
   }
 
   if (auto swap_quote =
-          ParseJupiterQuoteResponse(api_request_result.value_body())) {
+          jupiter::ParseQuoteResponse(api_request_result.value_body())) {
     std::move(callback).Run(
-        mojom::SwapQuoteUnion::NewJupiterQuote(std::move(swap_quote)), nullptr,
-        "");
+        mojom::SwapQuoteUnion::NewJupiterQuote(std::move(swap_quote)),
+        std::move(swap_fee), nullptr, "");
   } else {
-    std::move(callback).Run(nullptr, nullptr,
+    std::move(callback).Run(nullptr, nullptr, nullptr,
+                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+  }
+}
+
+void SwapService::OnGetLiFiQuote(mojom::SwapFeesPtr swap_fee,
+                                 GetQuoteCallback callback,
+                                 APIRequestResult api_request_result) {
+  if (!api_request_result.Is2XXResponseCode()) {
+    if (auto error_response =
+            lifi::ParseErrorResponse(api_request_result.value_body())) {
+      std::move(callback).Run(
+          nullptr, nullptr,
+          mojom::SwapErrorUnion::NewLifiError(std::move(error_response)), "");
+    } else {
+      std::move(callback).Run(
+          nullptr, nullptr, nullptr,
+          l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+    }
+    return;
+  }
+
+  if (auto quote = lifi::ParseQuoteResponse(api_request_result.value_body())) {
+    std::move(callback).Run(
+        mojom::SwapQuoteUnion::NewLifiQuote(std::move(quote)),
+        std::move(swap_fee), nullptr, "");
+  } else {
+    std::move(callback).Run(nullptr, nullptr, nullptr,
                             l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
   }
 }
@@ -500,35 +545,25 @@ void SwapService::OnGetJupiterQuote(GetQuoteCallback callback,
 void SwapService::GetTransaction(mojom::SwapTransactionParamsUnionPtr params,
                                  GetTransactionCallback callback) {
   if (params->is_zero_ex_transaction_params()) {
+    auto swap_fee = GetZeroExSwapFee();
+
     auto internal_callback =
         base::BindOnce(&SwapService::OnGetZeroExTransaction,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback));
 
     api_request_helper_.Request(
         net::HttpRequestHeaders::kGetMethod,
-        GetZeroExTransactionURL(*params->get_zero_ex_transaction_params()), "",
-        "", std::move(internal_callback), Get0xAPIHeaders(),
-        {.auto_retry_on_network_change = true});
+        GetZeroExTransactionURL(*params->get_zero_ex_transaction_params(),
+                                swap_fee->fee_param),
+        "", "", std::move(internal_callback), GetHeaders(), {});
 
     return;
   }
 
   if (params->is_jupiter_transaction_params()) {
     auto& jupiter_transaction_params = params->get_jupiter_transaction_params();
-
-    auto brave_swap_fee_params = brave_wallet::mojom::BraveSwapFeeParams::New();
-    brave_swap_fee_params->chain_id = jupiter_transaction_params->chain_id;
-    brave_swap_fee_params->taker = jupiter_transaction_params->user_public_key;
-    brave_swap_fee_params->input_token =
-        jupiter_transaction_params->quote->input_mint;
-    brave_swap_fee_params->output_token =
-        jupiter_transaction_params->quote->output_mint;
-    const auto& brave_fee =
-        GetBraveFeeInternal(std::move(brave_swap_fee_params));
-    bool has_fee = brave_fee && brave_fee->has_brave_fee;
-
     auto encoded_params =
-        EncodeJupiterTransactionParams(*jupiter_transaction_params, has_fee);
+        jupiter::EncodeTransactionParams(*jupiter_transaction_params);
     if (!encoded_params) {
       std::move(callback).Run(
           nullptr, nullptr,
@@ -544,7 +579,31 @@ void SwapService::GetTransaction(mojom::SwapTransactionParamsUnionPtr params,
         net::HttpRequestHeaders::kPostMethod,
         GetJupiterTransactionURL(jupiter_transaction_params->chain_id),
         *encoded_params, "application/json", std::move(internal_callback), {},
-        {.auto_retry_on_network_change = true});
+        {});
+
+    return;
+  }
+
+  if (params->is_lifi_transaction_params()) {
+    auto& lifi_transaction_params = params->get_lifi_transaction_params();
+
+    auto encoded_params =
+        lifi::EncodeTransactionParams(std::move(lifi_transaction_params));
+    if (!encoded_params) {
+      std::move(callback).Run(
+          nullptr, nullptr,
+          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+      return;
+    }
+
+    auto internal_callback =
+        base::BindOnce(&SwapService::OnGetLiFiTransaction,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback));
+
+    api_request_helper_.Request(net::HttpRequestHeaders::kPostMethod,
+                                GetLiFiTransactionURL(), *encoded_params,
+                                "application/json",
+                                std::move(internal_callback), {}, {});
 
     return;
   }
@@ -558,7 +617,7 @@ void SwapService::OnGetZeroExTransaction(GetTransactionCallback callback,
                                          APIRequestResult api_request_result) {
   if (!api_request_result.Is2XXResponseCode()) {
     if (auto swap_error_response =
-            ParseZeroExErrorResponse(api_request_result.value_body())) {
+            zeroex::ParseErrorResponse(api_request_result.value_body())) {
       std::move(callback).Run(
           nullptr,
           mojom::SwapErrorUnion::NewZeroExError(std::move(swap_error_response)),
@@ -572,7 +631,7 @@ void SwapService::OnGetZeroExTransaction(GetTransactionCallback callback,
   }
 
   if (auto swap_response =
-          ParseZeroExQuoteResponse(api_request_result.value_body(), true)) {
+          zeroex::ParseQuoteResponse(api_request_result.value_body(), true)) {
     std::move(callback).Run(mojom::SwapTransactionUnion::NewZeroExTransaction(
                                 std::move(swap_response)),
                             nullptr, "");
@@ -586,7 +645,7 @@ void SwapService::OnGetJupiterTransaction(GetTransactionCallback callback,
                                           APIRequestResult api_request_result) {
   if (!api_request_result.Is2XXResponseCode()) {
     if (auto error_response =
-            ParseJupiterErrorResponse(api_request_result.value_body())) {
+            jupiter::ParseErrorResponse(api_request_result.value_body())) {
       std::move(callback).Run(
           nullptr,
           mojom::SwapErrorUnion::NewJupiterError(std::move(error_response)),
@@ -600,7 +659,7 @@ void SwapService::OnGetJupiterTransaction(GetTransactionCallback callback,
   }
 
   if (auto swap_transaction =
-          ParseJupiterTransactionResponse(api_request_result.value_body())) {
+          jupiter::ParseTransactionResponse(api_request_result.value_body())) {
     std::move(callback).Run(
         mojom::SwapTransactionUnion::NewJupiterTransaction(*swap_transaction),
         nullptr, "");
@@ -610,15 +669,31 @@ void SwapService::OnGetJupiterTransaction(GetTransactionCallback callback,
   }
 }
 
-void SwapService::GetBraveFee(mojom::BraveSwapFeeParamsPtr params,
-                              GetBraveFeeCallback callback) {
-  if (auto response = GetBraveFeeInternal(std::move(params))) {
-    std::move(callback).Run(std::move(response), "");
+void SwapService::OnGetLiFiTransaction(GetTransactionCallback callback,
+                                       APIRequestResult api_request_result) {
+  if (!api_request_result.Is2XXResponseCode()) {
+    if (auto error_response =
+            lifi::ParseErrorResponse(api_request_result.value_body())) {
+      std::move(callback).Run(
+          nullptr,
+          mojom::SwapErrorUnion::NewLifiError(std::move(error_response)), "");
+    } else {
+      std::move(callback).Run(
+          nullptr, nullptr, l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+    }
+
     return;
   }
 
-  std::move(callback).Run(nullptr,
-                          l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
+  if (auto transaction =
+          lifi::ParseTransactionResponse(api_request_result.value_body())) {
+    std::move(callback).Run(
+        mojom::SwapTransactionUnion::NewLifiTransaction(std::move(transaction)),
+        nullptr, "");
+  } else {
+    std::move(callback).Run(nullptr, nullptr,
+                            l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR));
+  }
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -416,15 +416,16 @@ void SwapService::GetQuote(mojom::SwapQuoteParamsPtr params,
 
   if (IsNetworkSupportedByLiFi(params->from_chain_id) &&
       IsNetworkSupportedByLiFi(params->to_chain_id)) {
-    auto encoded_params = lifi::EncodeQuoteParams(std::move(params));
+    auto swap_fee = GetLiFiSwapFee();
+    auto fee_param = swap_fee->fee_param;
+
+    auto encoded_params = lifi::EncodeQuoteParams(std::move(params), fee_param);
     if (!encoded_params) {
       std::move(callback).Run(
           nullptr, nullptr, nullptr,
           l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));
       return;
     }
-
-    auto swap_fee = GetLiFiSwapFee();
 
     auto internal_callback = base::BindOnce(
         &SwapService::OnGetLiFiQuote, weak_ptr_factory_.GetWeakPtr(),

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -186,8 +186,9 @@ GURL AppendZeroExSwapParams(const GURL& swap_url,
                                       ? kZeroExNativeAssetContractAddress
                                       : params.from_token);
 
-  if (!fee_param->empty()) {
-    url = net::AppendQueryParameter(url, "buyTokenPercentageFee", *fee_param);
+  if (fee_param.has_value() && !fee_param->empty()) {
+    url = net::AppendQueryParameter(url, "buyTokenPercentageFee",
+                                    fee_param.value());
     url = net::AppendQueryParameter(url, "feeRecipient", kEVMFeeRecipient);
   }
 
@@ -236,8 +237,8 @@ GURL AppendJupiterQuoteParams(const GURL& swap_url,
         base::StringPrintf("%d", static_cast<int>(slippage_percentage * 100)));
   }
 
-  if (!fee_param->empty()) {
-    url = net::AppendQueryParameter(url, "platformFeeBps", *fee_param);
+  if (fee_param.has_value() && !fee_param->empty()) {
+    url = net::AppendQueryParameter(url, "platformFeeBps", fee_param.value());
   }
 
   // TODO(onyb): append userPublicKey to get information on fees and ATA

--- a/components/brave_wallet/browser/swap_service.h
+++ b/components/brave_wallet/browser/swap_service.h
@@ -56,12 +56,12 @@ class SwapService : public KeyedService, public mojom::SwapService {
                        IsSwapSupportedCallback callback) override;
 
   static GURL GetZeroExQuoteURL(const mojom::SwapQuoteParams& params,
-                                const std::optional<std::string> fee_param);
+                                const std::optional<std::string>& fee_param);
   static GURL GetZeroExTransactionURL(
       const mojom::SwapQuoteParams& params,
-      const std::optional<std::string> fee_param);
+      const std::optional<std::string>& fee_param);
   static GURL GetJupiterQuoteURL(const mojom::SwapQuoteParams& params,
-                                 const std::optional<std::string> fee_param);
+                                 const std::optional<std::string>& fee_param);
   static GURL GetJupiterTransactionURL(const std::string& chain_id);
   static GURL GetLiFiQuoteURL();
   static GURL GetLiFiTransactionURL();

--- a/components/brave_wallet/browser/swap_service.h
+++ b/components/brave_wallet/browser/swap_service.h
@@ -55,28 +55,34 @@ class SwapService : public KeyedService, public mojom::SwapService {
   void IsSwapSupported(const std::string& chain_id,
                        IsSwapSupportedCallback callback) override;
 
-  static std::string GetBaseSwapURL(const std::string& chain_id);
-  static GURL GetZeroExQuoteURL(const mojom::SwapQuoteParams& params);
-  static GURL GetZeroExTransactionURL(const mojom::SwapQuoteParams& params);
-  static GURL GetJupiterQuoteURL(const mojom::SwapQuoteParams& params);
+  static GURL GetZeroExQuoteURL(const mojom::SwapQuoteParams& params,
+                                const std::optional<std::string> fee_param);
+  static GURL GetZeroExTransactionURL(
+      const mojom::SwapQuoteParams& params,
+      const std::optional<std::string> fee_param);
+  static GURL GetJupiterQuoteURL(const mojom::SwapQuoteParams& params,
+                                 const std::optional<std::string> fee_param);
   static GURL GetJupiterTransactionURL(const std::string& chain_id);
-
-  void GetBraveFee(mojom::BraveSwapFeeParamsPtr params,
-                   GetBraveFeeCallback callback) override;
-
-  static void SetBaseURLForTest(const GURL& base_url_for_test);
+  static GURL GetLiFiQuoteURL();
+  static GURL GetLiFiTransactionURL();
 
  private:
-  void OnGetZeroExQuote(GetQuoteCallback callback,
+  void OnGetZeroExQuote(mojom::SwapFeesPtr swap_fee,
+                        GetQuoteCallback callback,
                         APIRequestResult api_request_result);
-  void OnGetJupiterQuote(GetQuoteCallback callback,
+  void OnGetJupiterQuote(mojom::SwapFeesPtr swap_fee,
+                         GetQuoteCallback callback,
                          APIRequestResult api_request_result);
+  void OnGetLiFiQuote(mojom::SwapFeesPtr swap_fee,
+                      GetQuoteCallback callback,
+                      APIRequestResult api_request_result);
   void OnGetZeroExTransaction(GetTransactionCallback callback,
                               APIRequestResult api_request_result);
   void OnGetJupiterTransaction(GetTransactionCallback callback,
                                APIRequestResult api_request_result);
+  void OnGetLiFiTransaction(GetTransactionCallback callback,
+                            APIRequestResult api_request_result);
 
-  static GURL base_url_for_test_;
   api_request_helper::APIRequestHelper api_request_helper_;
 
   raw_ptr<JsonRpcService> json_rpc_service_ = nullptr;  // NOT OWNED

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -45,22 +45,30 @@ namespace brave_wallet {
 namespace {
 
 mojom::SwapQuoteParamsPtr GetCannedSwapQuoteParams(
-    mojom::CoinType coin,
-    const std::string& chain_id) {
+    mojom::CoinType from_coin,
+    const std::string& from_chain_id,
+    const std::string& from_token,
+    mojom::CoinType to_coin,
+    const std::string& to_chain_id,
+    const std::string& to_token) {
   auto params = mojom::SwapQuoteParams::New();
 
   params->from_account_id = MakeAccountId(
-      coin, mojom::KeyringId::kDefault, mojom::AccountKind::kDerived,
-      coin == mojom::CoinType::ETH
+      from_coin, mojom::KeyringId::kDefault, mojom::AccountKind::kDerived,
+      from_coin == mojom::CoinType::ETH
           ? "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4"
-          : "foo");
-  params->from_chain_id = chain_id;
-  params->from_token = "DAI";
+          : "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4");
+  params->from_chain_id = from_chain_id;
+  params->from_token = from_token;
   params->to_amount = "1000000000000000000000";
 
-  params->to_account_id = params->from_account_id.Clone();
-  params->to_chain_id = chain_id;
-  params->to_token = "ETH";
+  params->to_account_id = MakeAccountId(
+      to_coin, mojom::KeyringId::kDefault, mojom::AccountKind::kDerived,
+      to_coin == mojom::CoinType::ETH
+          ? "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4"
+          : "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4");
+  params->to_chain_id = to_chain_id;
+  params->to_token = to_token;
 
   params->slippage_percentage = "3";
   params->route_priority = mojom::RoutePriority::kRecommended;
@@ -116,11 +124,164 @@ mojom::SwapTransactionParamsUnionPtr GetCannedJupiterTransactionParams(
   quote->route_plan.push_back(step_2.Clone());
 
   params->quote = quote.Clone();
-  params->user_public_key = "foo";
+  params->user_public_key = "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4";
   params->chain_id = mojom::kSolanaMainnet;
 
   return mojom::SwapTransactionParamsUnion::NewJupiterTransactionParams(
       std::move(params));
+}
+
+mojom::LiFiQuotePtr GetCannedLiFiQuote() {
+  auto quote = mojom::LiFiQuote::New();
+  quote->routes.push_back(mojom::LiFiRoute::New());
+  quote->routes[0]->id =
+      "0x9a448018e09b62da15c1bd64571c21b33cb177cee5d2f07c325d6485364362a5";
+
+  auto from_token = mojom::BlockchainToken::New();
+  from_token->contract_address = "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174";
+  from_token->name = "USDC.e";
+  from_token->logo = "usdce.png";
+  from_token->symbol = "USDCe";
+  from_token->decimals = 6;
+  from_token->chain_id = mojom::kPolygonMainnetChainId;
+  from_token->coin = mojom::CoinType::ETH;
+  quote->routes[0]->from_token = from_token.Clone();
+
+  quote->routes[0]->from_amount = "2000000";
+  quote->routes[0]->from_address = "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0";
+
+  auto to_token = mojom::BlockchainToken::New();
+  to_token->contract_address = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  to_token->name = "USD Coin";
+  to_token->logo = "usdc.png";
+  to_token->symbol = "USDC";
+  to_token->decimals = 6;
+  to_token->chain_id = mojom::kSolanaMainnet;
+  to_token->coin = mojom::CoinType::SOL;
+  quote->routes[0]->to_token = to_token.Clone();
+
+  quote->routes[0]->to_amount = "1138627";
+  quote->routes[0]->to_amount_min = "1136350";
+  quote->routes[0]->to_address = "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4";
+
+  quote->routes[0]->steps.push_back(mojom::LiFiStep::New());
+  quote->routes[0]->steps[0]->id = "57d247fc-d80a-4f4a-9596-72db3061aa72";
+  quote->routes[0]->steps[0]->type = mojom::LiFiStepType::kNative;
+  quote->routes[0]->steps[0]->tool = "allbridge";
+  auto tool_details = mojom::LiFiToolDetails::New();
+  tool_details->key = "allbridge";
+  tool_details->name = "Allbridge";
+  tool_details->logo = "allbridge.png";
+  quote->routes[0]->steps[0]->tool_details = tool_details.Clone();
+
+  quote->routes[0]->steps[0]->action = mojom::LiFiAction::New();
+  quote->routes[0]->steps[0]->action->from_token = from_token.Clone();
+  quote->routes[0]->steps[0]->action->from_amount = "2000000";
+  quote->routes[0]->steps[0]->action->to_token = to_token.Clone();
+  quote->routes[0]->steps[0]->action->slippage = "0.03";
+  quote->routes[0]->steps[0]->action->from_address =
+      "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0";
+  quote->routes[0]->steps[0]->action->to_address =
+      "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4";
+
+  quote->routes[0]->steps[0]->estimate = mojom::LiFiStepEstimate::New();
+  quote->routes[0]->steps[0]->estimate->tool = "allbridge";
+  quote->routes[0]->steps[0]->estimate->from_amount = "2000000";
+  quote->routes[0]->steps[0]->estimate->to_amount = "1138627";
+  quote->routes[0]->steps[0]->estimate->to_amount_min = "1136350";
+  quote->routes[0]->steps[0]->estimate->approval_address =
+      "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE";
+  quote->routes[0]->steps[0]->estimate->execution_duration = "500.298";
+
+  auto fee_cost = mojom::LiFiFeeCost::New();
+  fee_cost->name = "Allbridge's fee";
+  fee_cost->description =
+      "AllBridge fee and messenger fee charged by Allbridge";
+  fee_cost->percentage = "0.4267";
+  fee_cost->amount = "853380";
+  fee_cost->included = true;
+  fee_cost->token = from_token.Clone();
+  quote->routes[0]->steps[0]->estimate->fee_costs.push_back(fee_cost.Clone());
+
+  auto gas_cost = mojom::LiFiGasCost::New();
+  gas_cost->type = "SEND";
+  gas_cost->estimate = "185000";
+  gas_cost->limit = "277500";
+  gas_cost->amount = "20720000000000000";
+
+  auto matic = mojom::BlockchainToken::New();
+  matic->contract_address = "";
+  matic->name = "MATIC";
+  matic->logo = "matic.png";
+  matic->symbol = "MATIC";
+  matic->decimals = 18;
+  matic->chain_id = mojom::kPolygonMainnetChainId;
+  matic->coin = mojom::CoinType::ETH;
+  gas_cost->token = matic.Clone();
+  quote->routes[0]->steps[0]->estimate->gas_costs.push_back(gas_cost.Clone());
+
+  quote->routes[0]->steps[0]->included_steps =
+      std::vector<mojom::LiFiStepPtr>();
+  quote->routes[0]->steps[0]->included_steps->push_back(mojom::LiFiStep::New());
+  quote->routes[0]->steps[0]->included_steps->at(0)->id =
+      "1b914bef-e1be-4895-a9b1-c57da16d9de5";
+  quote->routes[0]->steps[0]->included_steps->at(0)->type =
+      mojom::LiFiStepType::kCross;
+  quote->routes[0]->steps[0]->included_steps->at(0)->tool = "allbridge";
+  quote->routes[0]->steps[0]->included_steps->at(0)->tool_details =
+      tool_details.Clone();
+
+  quote->routes[0]->steps[0]->included_steps->at(0)->action =
+      mojom::LiFiAction::New();
+  quote->routes[0]->steps[0]->included_steps->at(0)->action->from_token =
+      from_token.Clone();
+  quote->routes[0]->steps[0]->included_steps->at(0)->action->from_amount =
+      "2000000";
+  quote->routes[0]->steps[0]->included_steps->at(0)->action->to_token =
+      to_token.Clone();
+
+  quote->routes[0]->steps[0]->included_steps->at(0)->action->slippage = "0.03";
+  quote->routes[0]->steps[0]->included_steps->at(0)->action->from_address =
+      "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0";
+  quote->routes[0]->steps[0]->included_steps->at(0)->action->to_address =
+      "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4";
+
+  quote->routes[0]->steps[0]->included_steps->at(0)->estimate =
+      mojom::LiFiStepEstimate::New();
+  quote->routes[0]->steps[0]->included_steps->at(0)->estimate->tool =
+      "allbridge";
+  quote->routes[0]->steps[0]->included_steps->at(0)->estimate->from_amount =
+      "2000000";
+  quote->routes[0]->steps[0]->included_steps->at(0)->estimate->to_amount =
+      "1138627";
+  quote->routes[0]->steps[0]->included_steps->at(0)->estimate->to_amount_min =
+      "1136350";
+  quote->routes[0]
+      ->steps[0]
+      ->included_steps->at(0)
+      ->estimate->approval_address =
+      "0x7775d63836987f444E2F14AA0fA2602204D7D3E0";
+  quote->routes[0]
+      ->steps[0]
+      ->included_steps->at(0)
+      ->estimate->execution_duration = "500.298";
+
+  quote->routes[0]
+      ->steps[0]
+      ->included_steps->at(0)
+      ->estimate->fee_costs.push_back(fee_cost.Clone());
+
+  quote->routes[0]
+      ->steps[0]
+      ->included_steps->at(0)
+      ->estimate->gas_costs.push_back(gas_cost.Clone());
+
+  quote->routes[0]->insurance = mojom::LiFiInsurance::New();
+  quote->routes[0]->insurance->state = "NOT_INSURABLE";
+  quote->routes[0]->insurance->fee_amount_usd = "0";
+  quote->routes[0]->tags = {"RECOMMENDED", "CHEAPEST", "FASTEST"};
+
+  return quote;
 }
 
 }  // namespace
@@ -161,31 +322,32 @@ class SwapServiceUnitTest : public testing::Test {
         }));
   }
 
-  bool IsSwapSupported(const std::string& chain_id) {
-    bool result;
-    base::RunLoop run_loop;
-    swap_service_->IsSwapSupported(chain_id,
-                                   base::BindLambdaForTesting([&](bool v) {
-                                     result = v;
-                                     run_loop.Quit();
-                                   }));
-    run_loop.Run();
-    return result;
+  void IsSwapSupported(const std::string& chain_id, bool expected_response) {
+    base::MockCallback<mojom::SwapService::IsSwapSupportedCallback> callback;
+    EXPECT_CALL(callback, Run(IsTruthy(expected_response)));
+    swap_service_->IsSwapSupported(chain_id, callback.Get());
+    task_environment_.RunUntilIdle();
   }
 
-  void TestGetJupiterQuoteCase(const std::string& json,
-                               const bool expected_success) {
+  void TestGetQuoteCase(const std::string& json,
+                        mojom::CoinType from_coin,
+                        const std::string& from_chain_id,
+                        mojom::CoinType to_coin,
+                        const std::string& to_chain_id,
+                        const bool expected_success) {
     SetInterceptor(json);
     auto expected_error_string =
         expected_success ? ""
                          : l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR);
     base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
-    EXPECT_CALL(callback, Run(IsTruthy(expected_success),
-                              EqualsMojo(mojom::SwapErrorUnionPtr()),
-                              expected_error_string));
+    EXPECT_CALL(
+        callback,
+        Run(IsTruthy(expected_success), IsTruthy(expected_success),
+            EqualsMojo(mojom::SwapErrorUnionPtr()), expected_error_string));
 
     swap_service_->GetQuote(
-        GetCannedSwapQuoteParams(mojom::CoinType::SOL, mojom::kSolanaMainnet),
+        GetCannedSwapQuoteParams(from_coin, from_chain_id, "DAI", to_coin,
+                                 to_chain_id, "ETH"),
         callback.Get());
     task_environment_.RunUntilIdle();
   }
@@ -294,14 +456,23 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuote) {
   fees->zero_ex_fee = std::move(zero_ex_fee);
   expected_zero_ex_quote->fees = std::move(fees);
 
+  auto expected_swap_fees = mojom::SwapFees::New();
+  expected_swap_fees->fee_pct = "0.875";
+  expected_swap_fees->discount_pct = "0";
+  expected_swap_fees->discount_code = mojom::SwapDiscountCode::kNone;
+  expected_swap_fees->effective_fee_pct = "0.875";
+  expected_swap_fees->fee_param = "0.00875";
+
   base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
   EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapQuoteUnion::NewZeroExQuote(
                                 expected_zero_ex_quote.Clone())),
+                            EqualsMojo(expected_swap_fees.Clone()),
                             EqualsMojo(mojom::SwapErrorUnionPtr()), ""));
 
   swap_service_->GetQuote(
-      GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                               mojom::kPolygonMainnetChainId),
+      GetCannedSwapQuoteParams(
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH"),
       callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
@@ -338,11 +509,13 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuote) {
   expected_zero_ex_quote->fees->zero_ex_fee = nullptr;
   EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapQuoteUnion::NewZeroExQuote(
                                 std::move(expected_zero_ex_quote))),
+                            EqualsMojo(expected_swap_fees.Clone()),
                             EqualsMojo(mojom::SwapErrorUnionPtr()), ""));
 
   swap_service_->GetQuote(
-      GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                               mojom::kPolygonMainnetChainId),
+      GetCannedSwapQuoteParams(
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH"),
       callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
@@ -375,13 +548,15 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteError) {
 
   base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
   EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapQuoteUnionPtr()),
+                            EqualsMojo(mojom::SwapFeesPtr()),
                             EqualsMojo(mojom::SwapErrorUnion::NewZeroExError(
-                                ParseZeroExErrorResponse(ParseJson(error)))),
+                                zeroex::ParseErrorResponse(ParseJson(error)))),
                             ""));
 
   swap_service_->GetQuote(
-      GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                               mojom::kPolygonMainnetChainId),
+      GetCannedSwapQuoteParams(
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH"),
       callback.Get());
   task_environment_.RunUntilIdle();
 }
@@ -393,12 +568,14 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteUnexpectedReturn) {
   base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
   EXPECT_CALL(callback,
               Run(EqualsMojo(mojom::SwapQuoteUnionPtr()),
+                  EqualsMojo(mojom::SwapFeesPtr()),
                   EqualsMojo(mojom::SwapErrorUnionPtr()),
                   l10n_util::GetStringUTF8(IDS_WALLET_PARSING_ERROR)));
 
   swap_service_->GetQuote(
-      GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                               mojom::kPolygonMainnetChainId),
+      GetCannedSwapQuoteParams(
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+          mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH"),
       callback.Get());
   task_environment_.RunUntilIdle();
 }
@@ -487,8 +664,9 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransaction) {
 
   swap_service_->GetTransaction(
       mojom::SwapTransactionParamsUnion::NewZeroExTransactionParams(
-          GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                                   mojom::kPolygonMainnetChainId)),
+          GetCannedSwapQuoteParams(
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH")),
       callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
@@ -533,8 +711,9 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransaction) {
 
   swap_service_->GetTransaction(
       mojom::SwapTransactionParamsUnion::NewZeroExTransactionParams(
-          GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                                   mojom::kPolygonMainnetChainId)),
+          GetCannedSwapQuoteParams(
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH")),
       callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
@@ -548,13 +727,14 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionError) {
   base::MockCallback<mojom::SwapService::GetTransactionCallback> callback;
   EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapTransactionUnionPtr()),
                             EqualsMojo(mojom::SwapErrorUnion::NewZeroExError(
-                                ParseZeroExErrorResponse(ParseJson(error)))),
+                                zeroex::ParseErrorResponse(ParseJson(error)))),
                             ""));
 
   swap_service_->GetTransaction(
       mojom::SwapTransactionParamsUnion::NewZeroExTransactionParams(
-          GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                                   mojom::kPolygonMainnetChainId)),
+          GetCannedSwapQuoteParams(
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH")),
       callback.Get());
   task_environment_.RunUntilIdle();
 }
@@ -570,32 +750,36 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionUnexpectedReturn) {
 
   swap_service_->GetTransaction(
       mojom::SwapTransactionParamsUnion::NewZeroExTransactionParams(
-          GetCannedSwapQuoteParams(mojom::CoinType::ETH,
-                                   mojom::kPolygonMainnetChainId)),
+          GetCannedSwapQuoteParams(
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+              mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "ETH")),
       callback.Get());
   task_environment_.RunUntilIdle();
 }
 
 TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
   const std::map<std::string, std::string> non_rfqt_chain_ids = {
-      {mojom::kGoerliChainId, "goerli.api.0x.org"},
-      {mojom::kBinanceSmartChainMainnetChainId, "bsc.api.0x.org"},
-      {mojom::kAvalancheMainnetChainId, "avalanche.api.0x.org"},
-      {mojom::kFantomMainnetChainId, "fantom.api.0x.org"},
-      {mojom::kCeloMainnetChainId, "celo.api.0x.org"},
-      {mojom::kOptimismMainnetChainId, "optimism.api.0x.org"},
-      {mojom::kArbitrumMainnetChainId, "arbitrum.api.0x.org"},
-      {mojom::kBaseMainnetChainId, "base.api.0x.org"}};
+      {mojom::kGoerliChainId, "goerli.api.0x.wallet.brave.com"},
+      {mojom::kBinanceSmartChainMainnetChainId, "bsc.api.0x.wallet.brave.com"},
+      {mojom::kAvalancheMainnetChainId, "avalanche.api.0x.wallet.brave.com"},
+      {mojom::kFantomMainnetChainId, "fantom.api.0x.wallet.brave.com"},
+      {mojom::kCeloMainnetChainId, "celo.api.0x.wallet.brave.com"},
+      {mojom::kOptimismMainnetChainId, "optimism.api.0x.wallet.brave.com"},
+      {mojom::kArbitrumMainnetChainId, "arbitrum.api.0x.wallet.brave.com"},
+      {mojom::kBaseMainnetChainId, "base.api.0x.wallet.brave.com"}};
 
   const std::map<std::string, std::string> rfqt_chain_ids = {
-      {mojom::kMainnetChainId, "api.0x.org"},
-      {mojom::kPolygonMainnetChainId, "polygon.api.0x.org"}};
+      {mojom::kMainnetChainId, "api.0x.wallet.brave.com"},
+      {mojom::kPolygonMainnetChainId, "polygon.api.0x.wallet.brave.com"}};
 
   for (const auto& [chain_id, domain] : non_rfqt_chain_ids) {
     SCOPED_TRACE(testing::Message() << "chain_id: " << chain_id);
-    auto url = swap_service_->GetZeroExQuoteURL(
-        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id));
 
+    // OK: with fees
+    auto url = swap_service_->GetZeroExQuoteURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "0.00875");
     EXPECT_EQ(url,
               base::StringPrintf(
                   "https://%s/swap/v1/price?"
@@ -604,8 +788,25 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
                   "buyToken=ETH&"
                   "sellToken=DAI&"
                   "buyTokenPercentageFee=0.00875&"
-                  "slippagePercentage=0.030000&"
                   "feeRecipient=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "slippagePercentage=0.030000&"
+                  "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "skipValidation=true",
+                  domain.c_str()));
+
+    // Ok: no fees
+    url = swap_service_->GetZeroExQuoteURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "");
+    EXPECT_EQ(url,
+              base::StringPrintf(
+                  "https://%s/swap/v1/price?"
+                  "takerAddress=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
+                  "buyAmount=1000000000000000000000&"
+                  "buyToken=ETH&"
+                  "sellToken=DAI&"
+                  "slippagePercentage=0.030000&"
                   "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
                   "skipValidation=true",
                   domain.c_str()));
@@ -615,9 +816,12 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
   // while fetching firm quotes.
   for (const auto& [chain_id, domain] : rfqt_chain_ids) {
     SCOPED_TRACE(testing::Message() << "chain_id: " << chain_id);
-    auto url = swap_service_->GetZeroExQuoteURL(
-        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id));
 
+    // OK: with fees
+    auto url = swap_service_->GetZeroExQuoteURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "0.00875");
     EXPECT_EQ(url,
               base::StringPrintf(
                   "https://%s/swap/v1/quote?"
@@ -626,8 +830,26 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
                   "buyToken=ETH&"
                   "sellToken=DAI&"
                   "buyTokenPercentageFee=0.00875&"
-                  "slippagePercentage=0.030000&"
                   "feeRecipient=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "slippagePercentage=0.030000&"
+                  "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "skipValidation=true&"
+                  "intentOnFilling=false",
+                  domain.c_str()));
+
+    // Ok: no fees
+    url = swap_service_->GetZeroExQuoteURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "");
+    EXPECT_EQ(url,
+              base::StringPrintf(
+                  "https://%s/swap/v1/quote?"
+                  "takerAddress=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
+                  "buyAmount=1000000000000000000000&"
+                  "buyToken=ETH&"
+                  "sellToken=DAI&"
+                  "slippagePercentage=0.030000&"
                   "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
                   "skipValidation=true&"
                   "intentOnFilling=false",
@@ -636,30 +858,35 @@ TEST_F(SwapServiceUnitTest, GetZeroExQuoteURL) {
 
   // KO: unsupported network
   EXPECT_EQ(swap_service_->GetZeroExQuoteURL(
-                *GetCannedSwapQuoteParams(mojom::CoinType::ETH, "0x3")),
+                *GetCannedSwapQuoteParams(mojom::CoinType::ETH, "0x3", "DAI",
+                                          mojom::CoinType::ETH, "0x3", "ETH"),
+                "0.00875"),
             "");
 }
 
 TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
   const std::map<std::string, std::string> non_rfqt_chain_ids = {
-      {mojom::kGoerliChainId, "goerli.api.0x.org"},
-      {mojom::kBinanceSmartChainMainnetChainId, "bsc.api.0x.org"},
-      {mojom::kAvalancheMainnetChainId, "avalanche.api.0x.org"},
-      {mojom::kFantomMainnetChainId, "fantom.api.0x.org"},
-      {mojom::kCeloMainnetChainId, "celo.api.0x.org"},
-      {mojom::kOptimismMainnetChainId, "optimism.api.0x.org"},
-      {mojom::kArbitrumMainnetChainId, "arbitrum.api.0x.org"},
-      {mojom::kBaseMainnetChainId, "base.api.0x.org"}};
+      {mojom::kGoerliChainId, "goerli.api.0x.wallet.brave.com"},
+      {mojom::kBinanceSmartChainMainnetChainId, "bsc.api.0x.wallet.brave.com"},
+      {mojom::kAvalancheMainnetChainId, "avalanche.api.0x.wallet.brave.com"},
+      {mojom::kFantomMainnetChainId, "fantom.api.0x.wallet.brave.com"},
+      {mojom::kCeloMainnetChainId, "celo.api.0x.wallet.brave.com"},
+      {mojom::kOptimismMainnetChainId, "optimism.api.0x.wallet.brave.com"},
+      {mojom::kArbitrumMainnetChainId, "arbitrum.api.0x.wallet.brave.com"},
+      {mojom::kBaseMainnetChainId, "base.api.0x.wallet.brave.com"}};
 
   const std::map<std::string, std::string> rfqt_chain_ids = {
-      {mojom::kMainnetChainId, "api.0x.org"},
-      {mojom::kPolygonMainnetChainId, "polygon.api.0x.org"}};
+      {mojom::kMainnetChainId, "api.0x.wallet.brave.com"},
+      {mojom::kPolygonMainnetChainId, "polygon.api.0x.wallet.brave.com"}};
 
   for (const auto& [chain_id, domain] : non_rfqt_chain_ids) {
     SCOPED_TRACE(testing::Message() << "chain_id: " << chain_id);
-    auto url = swap_service_->GetZeroExTransactionURL(
-        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id));
 
+    // OK: with fees
+    auto url = swap_service_->GetZeroExTransactionURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "0.00875");
     EXPECT_EQ(url,
               base::StringPrintf(
                   "https://%s/swap/v1/quote?"
@@ -668,8 +895,24 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
                   "buyToken=ETH&"
                   "sellToken=DAI&"
                   "buyTokenPercentageFee=0.00875&"
-                  "slippagePercentage=0.030000&"
                   "feeRecipient=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "slippagePercentage=0.030000&"
+                  "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d",
+                  domain.c_str()));
+
+    // OK: no fees
+    url = swap_service_->GetZeroExTransactionURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "");
+    EXPECT_EQ(url,
+              base::StringPrintf(
+                  "https://%s/swap/v1/quote?"
+                  "takerAddress=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
+                  "buyAmount=1000000000000000000000&"
+                  "buyToken=ETH&"
+                  "sellToken=DAI&"
+                  "slippagePercentage=0.030000&"
                   "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d",
                   domain.c_str()));
   }
@@ -678,9 +921,12 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
   // while fetching firm quotes.
   for (const auto& [chain_id, domain] : rfqt_chain_ids) {
     SCOPED_TRACE(testing::Message() << "chain_id: " << chain_id);
-    auto url = swap_service_->GetZeroExTransactionURL(
-        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id));
 
+    // OK: with fees
+    auto url = swap_service_->GetZeroExTransactionURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "0.00875");
     EXPECT_EQ(url,
               base::StringPrintf(
                   "https://%s/swap/v1/quote?"
@@ -689,8 +935,25 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
                   "buyToken=ETH&"
                   "sellToken=DAI&"
                   "buyTokenPercentageFee=0.00875&"
-                  "slippagePercentage=0.030000&"
                   "feeRecipient=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "slippagePercentage=0.030000&"
+                  "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
+                  "intentOnFilling=true",
+                  domain.c_str()));
+
+    // OK: no fees
+    url = swap_service_->GetZeroExTransactionURL(
+        *GetCannedSwapQuoteParams(mojom::CoinType::ETH, chain_id, "DAI",
+                                  mojom::CoinType::ETH, chain_id, "ETH"),
+        "");
+    EXPECT_EQ(url,
+              base::StringPrintf(
+                  "https://%s/swap/v1/quote?"
+                  "takerAddress=0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4&"
+                  "buyAmount=1000000000000000000000&"
+                  "buyToken=ETH&"
+                  "sellToken=DAI&"
+                  "slippagePercentage=0.030000&"
                   "affiliateAddress=0xbd9420A98a7Bd6B89765e5715e169481602D9c3d&"
                   "intentOnFilling=true",
                   domain.c_str()));
@@ -698,45 +961,52 @@ TEST_F(SwapServiceUnitTest, GetZeroExTransactionURL) {
 
   // KO: unsupported network
   EXPECT_EQ(swap_service_->GetZeroExTransactionURL(
-                *GetCannedSwapQuoteParams(mojom::CoinType::ETH, "0x3")),
+                *GetCannedSwapQuoteParams(mojom::CoinType::ETH, "0x3", "DAI",
+                                          mojom::CoinType::ETH, "0x3", "ETH"),
+                "0.00875"),
             "");
 }
 
 TEST_F(SwapServiceUnitTest, IsSwapSupported) {
   const std::vector<std::string> supported_chain_ids({
-      mojom::kMainnetChainId,
-      mojom::kGoerliChainId,
-      mojom::kPolygonMainnetChainId,
-      mojom::kPolygonMainnetChainId,
-      mojom::kBinanceSmartChainMainnetChainId,
-      mojom::kAvalancheMainnetChainId,
-      mojom::kFantomMainnetChainId,
-      mojom::kCeloMainnetChainId,
-      mojom::kOptimismMainnetChainId,
-      mojom::kArbitrumMainnetChainId,
-      mojom::kBaseMainnetChainId,
+      // ZeroEx
+      mojom::kMainnetChainId, mojom::kGoerliChainId,
+      mojom::kPolygonMainnetChainId, mojom::kBinanceSmartChainMainnetChainId,
+      mojom::kAvalancheMainnetChainId, mojom::kFantomMainnetChainId,
+      mojom::kCeloMainnetChainId, mojom::kOptimismMainnetChainId,
+      mojom::kArbitrumMainnetChainId, mojom::kBaseMainnetChainId,
+
+      // Jupiter
+      mojom::kSolanaMainnet,
+
+      // LiFi (in addition to ZeroEx)
+      //
+      // TODO(onyb): Uncomment once LiFi is supported.
+      // mojom::kPolygonZKEVMChainId, mojom::kGnosisChainId,
+      // mojom::kZkSyncEraChainId, mojom::kAuroraMainnetChainId
   });
 
   for (auto& chain_id : supported_chain_ids) {
-    EXPECT_TRUE(IsSwapSupported(chain_id));
+    SCOPED_TRACE(testing::Message() << "chain_id: " << chain_id);
+    IsSwapSupported(chain_id, true);
   }
 
-  EXPECT_FALSE(IsSwapSupported("0x4"));
-  EXPECT_FALSE(IsSwapSupported("0x3"));
-  EXPECT_FALSE(IsSwapSupported(""));
-  EXPECT_FALSE(IsSwapSupported("invalid chain_id"));
+  IsSwapSupported("0x4", false);
+  IsSwapSupported("0x3", false);
+  IsSwapSupported("", false);
+  IsSwapSupported("invalid chain_id", false);
 }
 
 TEST_F(SwapServiceUnitTest, GetJupiterQuoteURL) {
-  auto params =
-      GetCannedSwapQuoteParams(mojom::CoinType::SOL, mojom::kSolanaMainnet);
+  auto params = GetCannedSwapQuoteParams(
+      mojom::CoinType::SOL, mojom::kSolanaMainnet, "", mojom::CoinType::SOL,
+      mojom::kSolanaMainnet, "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
   params->from_token = "So11111111111111111111111111111111111111112";
   params->to_token = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
   params->from_amount = "10000";
 
-  auto url = swap_service_->GetJupiterQuoteURL(*params);
-
-  // OK: output mint has Jupiter fees
+  // OK: with fees
+  auto url = swap_service_->GetJupiterQuoteURL(*params, "85");
   EXPECT_EQ(url,
             "https://quote-api.jup.ag/v6/quote?"
             "inputMint=So11111111111111111111111111111111111111112&"
@@ -746,14 +1016,12 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuoteURL) {
             "slippageBps=300&"
             "platformFeeBps=85");
 
-  params->to_token = "SHDWyBxihqiCj6YekG2GUr7wqKLeLAMK1gHZck9pL6y";
-  url = swap_service_->GetJupiterQuoteURL(*params);
-
-  // OK: output mint does not have Jupiter fees
+  // OK: no fees
+  url = swap_service_->GetJupiterQuoteURL(*params, "");
   EXPECT_EQ(url,
             "https://quote-api.jup.ag/v6/quote?"
             "inputMint=So11111111111111111111111111111111111111112&"
-            "outputMint=SHDWyBxihqiCj6YekG2GUr7wqKLeLAMK1gHZck9pL6y&"
+            "outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&"
             "amount=10000&"
             "swapMode=ExactIn&"
             "slippageBps=300");
@@ -808,27 +1076,38 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuote) {
         }
       ]
     })");
-  base::RunLoop run_loop;
 
   const auto& params = GetCannedJupiterTransactionParams(
       "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
   auto& expected_quote = params->get_jupiter_transaction_params()->quote;
 
+  auto expected_swap_fees = mojom::SwapFees::New();
+  expected_swap_fees->fee_pct = "0.85";
+  expected_swap_fees->discount_pct = "0";
+  expected_swap_fees->effective_fee_pct = "0.85";
+  expected_swap_fees->discount_code = mojom::SwapDiscountCode::kNone;
+  expected_swap_fees->fee_param = "85";
+
   base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
   EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapQuoteUnion::NewJupiterQuote(
                                 std::move(expected_quote))),
+                            EqualsMojo(expected_swap_fees.Clone()),
                             EqualsMojo(mojom::SwapErrorUnionPtr()), ""));
   swap_service_->GetQuote(
-      GetCannedSwapQuoteParams(mojom::CoinType::SOL, mojom::kSolanaMainnet),
+      GetCannedSwapQuoteParams(mojom::CoinType::SOL, mojom::kSolanaMainnet, "",
+                               mojom::CoinType::SOL, mojom::kSolanaMainnet,
+                               "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
       callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
   // KO: empty JSON for conversion
-  TestGetJupiterQuoteCase(R"({})", false);
+  TestGetQuoteCase(R"({})", mojom::CoinType::SOL, mojom::kSolanaMainnet,
+                   mojom::CoinType::SOL, mojom::kSolanaMainnet, false);
 
   // KO: invalid JSON
-  TestGetJupiterQuoteCase(R"(foo)", false);
+  TestGetQuoteCase(R"(foo)", mojom::CoinType::SOL, mojom::kSolanaMainnet,
+                   mojom::CoinType::SOL, mojom::kSolanaMainnet, false);
 }
 
 TEST_F(SwapServiceUnitTest, GetJupiterTransaction) {
@@ -848,83 +1127,363 @@ TEST_F(SwapServiceUnitTest, GetJupiterTransaction) {
   TestGetJupiterTransaction(false, "", true);
 }
 
-TEST_F(SwapServiceUnitTest, GetBraveFee) {
-  auto params = mojom::BraveSwapFeeParams::New();
-  auto expected_response = mojom::BraveSwapFeeResponse::New();
+TEST_F(SwapServiceUnitTest, GetLiFiQuoteURL) {
+  auto url = swap_service_->GetLiFiQuoteURL();
+  EXPECT_EQ(url, "https://li.quest/v1/advanced/routes");
+}
 
-  base::RunLoop run_loop;
+TEST_F(SwapServiceUnitTest, GetLiFiTransactionURL) {
+  auto url = swap_service_->GetLiFiTransactionURL();
+  EXPECT_EQ(url, "https://li.quest/v1/advanced/stepTransaction");
+}
 
-  // Case 1: 0x swap on Ethereum
-  //         1000 DAI -> ETH
-  params->chain_id = mojom::kMainnetChainId;
-  params->input_token = "0x6b175474e89094c44da98b954eedeac495271d0f";
-  params->output_token = "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
-  params->taker = "0xa92D461a9a988A7f11ec285d39783A637Fdd6ba4";
+TEST_F(SwapServiceUnitTest, GetLiFiQuote) {
+  SetInterceptor(R"(
+    {
+      "routes": [
+        {
+          "id": "0x9a448018e09b62da15c1bd64571c21b33cb177cee5d2f07c325d6485364362a5",
+          "fromChainId": "137",
+          "fromAmountUSD": "2.00",
+          "fromAmount": "2000000",
+          "fromToken": {
+            "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+            "chainId": "137",
+            "symbol": "USDCe",
+            "decimals": "6",
+            "name": "USDC.e",
+            "coinKey": "USDCe",
+            "logoURI": "usdce.png",
+            "priceUSD": "1"
+          },
+          "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+          "toChainId": "1151111081099710",
+          "toAmountUSD": "1.14",
+          "toAmount": "1138627",
+          "toAmountMin": "1136350",
+          "toToken": {
+            "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "chainId": "1151111081099710",
+            "symbol": "USDC",
+            "decimals": "6",
+            "name": "USD Coin",
+            "coinKey": "USDC",
+            "logoURI": "usdc.png",
+            "priceUSD": "0.999501"
+          },
+          "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+          "gasCostUSD": "0.02",
+          "containsSwitchChain": false,
+          "steps": [
+            {
+              "type": "lifi",
+              "id": "57d247fc-d80a-4f4a-9596-72db3061aa72",
+              "tool": "allbridge",
+              "toolDetails": {
+                "key": "allbridge",
+                "name": "Allbridge",
+                "logoURI": "allbridge.png"
+              },
+              "action": {
+                "fromChainId": "137",
+                "fromAmount": "2000000",
+                "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+                "slippage": "0.03",
+                "toChainId": "1151111081099710",
+                "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+                "fromToken": {
+                  "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                  "chainId": "137",
+                  "symbol": "USDCe",
+                  "decimals": "6",
+                  "name": "USDC.e",
+                  "coinKey": "USDCe",
+                  "logoURI": "usdce.png",
+                  "priceUSD": "1"
+                },
+                "toToken": {
+                  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                  "chainId": "1151111081099710",
+                  "symbol": "USDC",
+                  "decimals": "6",
+                  "name": "USD Coin",
+                  "coinKey": "USDC",
+                  "logoURI": "usdc.png",
+                  "priceUSD": "0.999501"
+                }
+              },
+              "estimate": {
+                "tool": "allbridge",
+                "fromAmount": "2000000",
+                "fromAmountUSD": "2.00",
+                "toAmount": "1138627",
+                "toAmountMin": "1136350",
+                "approvalAddress": "0x1231DEB6f5749EF6cE6943a275A1D3E7486F4EaE",
+                "executionDuration": "500.298",
+                "feeCosts": [
+                  {
+                    "name": "Allbridge's fee",
+                    "description": "AllBridge fee and messenger fee charged by Allbridge",
+                    "token": {
+                      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                      "chainId": "137",
+                      "symbol": "USDCe",
+                      "decimals": "6",
+                      "name": "USDC.e",
+                      "coinKey": "USDCe",
+                      "logoURI": "usdce.png",
+                      "priceUSD": "1"
+                    },
+                    "amount": "853380",
+                    "amountUSD": "0.85",
+                    "percentage": "0.4267",
+                    "included": true
+                  }
+                ],
+                "gasCosts": [
+                  {
+                    "type": "SEND",
+                    "price": "112000000000",
+                    "estimate": "185000",
+                    "limit": "277500",
+                    "amount": "20720000000000000",
+                    "amountUSD": "0.02",
+                    "token": {
+                      "address": "0x0000000000000000000000000000000000000000",
+                      "chainId": "137",
+                      "symbol": "MATIC",
+                      "decimals": "18",
+                      "name": "MATIC",
+                      "coinKey": "MATIC",
+                      "logoURI": "matic.png",
+                      "priceUSD": "0.809079000000000000"
+                    }
+                  }
+                ],
+                "toAmountUSD": "1.14"
+              },
+              "includedSteps": [
+                {
+                  "id": "1b914bef-e1be-4895-a9b1-c57da16d9de5",
+                  "type": "cross",
+                  "action": {
+                    "fromChainId": "137",
+                    "fromAmount": "2000000",
+                    "fromAddress": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+                    "slippage": "0.03",
+                    "toChainId": "1151111081099710",
+                    "toAddress": "S5ARSDD3ddZqqqqqb2EUE2h2F1XQHBk7bErRW1WPGe4",
+                    "fromToken": {
+                      "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                      "chainId": "137",
+                      "symbol": "USDCe",
+                      "decimals": "6",
+                      "name": "USDC.e",
+                      "coinKey": "USDCe",
+                      "logoURI": "usdce.png",
+                      "priceUSD": "1"
+                    },
+                    "toToken": {
+                      "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+                      "chainId": "1151111081099710",
+                      "symbol": "USDC",
+                      "decimals": "6",
+                      "name": "USD Coin",
+                      "coinKey": "USDC",
+                      "logoURI": "usdc.png",
+                      "priceUSD": "0.999501"
+                    }
+                  },
+                  "estimate": {
+                    "tool": "allbridge",
+                    "fromAmount": "2000000",
+                    "fromAmountUSD": "2.00",
+                    "toAmount": "1138627",
+                    "toAmountMin": "1136350",
+                    "approvalAddress": "0x7775d63836987f444E2F14AA0fA2602204D7D3E0",
+                    "executionDuration": "500.298",
+                    "feeCosts": [
+                      {
+                        "name": "Allbridge's fee",
+                        "description": "AllBridge fee and messenger fee charged by Allbridge",
+                        "token": {
+                          "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+                          "chainId": "137",
+                          "symbol": "USDCe",
+                          "decimals": "6",
+                          "name": "USDC.e",
+                          "coinKey": "USDCe",
+                          "logoURI": "usdce.png",
+                          "priceUSD": "1"
+                        },
+                        "amount": "853380",
+                        "amountUSD": "0.85",
+                        "percentage": "0.4267",
+                        "included": true
+                      }
+                    ],
+                    "gasCosts": [
+                      {
+                        "type": "SEND",
+                        "price": "112000000000",
+                        "estimate": "185000",
+                        "limit": "277500",
+                        "amount": "20720000000000000",
+                        "amountUSD": "0.02",
+                        "token": {
+                          "address": "0x0000000000000000000000000000000000000000",
+                          "chainId": "137",
+                          "symbol": "MATIC",
+                          "decimals": "18",
+                          "name": "MATIC",
+                          "coinKey": "MATIC",
+                          "logoURI": "matic.png",
+                          "priceUSD": "0.809079000000000000"
+                        }
+                      }
+                    ]
+                  },
+                  "tool": "allbridge",
+                  "toolDetails": {
+                    "key": "allbridge",
+                    "name": "Allbridge",
+                    "logoURI": "allbridge.png"
+                  }
+                }
+              ]
+            }
+          ],
+          "tags": [
+            "RECOMMENDED",
+            "CHEAPEST",
+            "FASTEST"
+          ],
+          "insurance": {
+            "state": "NOT_INSURABLE",
+            "feeAmountUsd": "0"
+          }
+        }
+      ],
+      "unavailableRoutes": {
+        "filteredOut": [],
+        "failed": []
+      }
+    }
+  )");
 
-  expected_response->fee_param = "0.00875";
-  expected_response->protocol_fee_pct = "0.15";
-  expected_response->brave_fee_pct = "0.875";
-  expected_response->discount_on_brave_fee_pct = "0";
-  expected_response->effective_fee_pct = "0.875";
-  expected_response->discount_code = mojom::DiscountCode::kNone;
-  expected_response->has_brave_fee = true;
+  auto expected_swap_fees = mojom::SwapFees::New();
+  expected_swap_fees->fee_pct = "0.875";
+  expected_swap_fees->discount_pct = "0";
+  expected_swap_fees->effective_fee_pct = "0.875";
+  expected_swap_fees->discount_code = mojom::SwapDiscountCode::kNone;
+  expected_swap_fees->fee_param = "0.00875";
 
-  base::MockCallback<mojom::SwapService::GetBraveFeeCallback> callback;
-  EXPECT_CALL(callback, Run(EqualsMojo(expected_response), ""));
-  swap_service_->GetBraveFee(params->Clone(), callback.Get());
+  base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
+  EXPECT_CALL(
+      callback,
+      Run(EqualsMojo(mojom::SwapQuoteUnion::NewLifiQuote(GetCannedLiFiQuote())),
+          EqualsMojo(expected_swap_fees.Clone()),
+          EqualsMojo(mojom::SwapErrorUnionPtr()), ""));
+  auto quote_params = GetCannedSwapQuoteParams(
+      mojom::CoinType::ETH, mojom::kPolygonMainnetChainId, "DAI",
+      mojom::CoinType::SOL, mojom::kSolanaMainnet,
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+  swap_service_->GetQuote(std::move(quote_params), callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
 
-  // Case 2: Jupiter swap on Solana (no fees)
-  //         1000 SOL -> RAY
-  params->chain_id = mojom::kSolanaMainnet;
-  params->input_token = "So11111111111111111111111111111111111111112";
-  params->output_token = "4k3Dyjzvzp8eMZWUXbBCjEvwSkkk59S5iCNLY3QrkX6Rxxx";
-  params->taker = "LUKAzPV8dDbVykTVT14pCGKzFfNcgZgRbAXB8AGdKx3";
+  // KO: empty JSON for conversion
+  TestGetQuoteCase(R"({})", mojom::CoinType::ETH, mojom::kPolygonMainnetChainId,
+                   mojom::CoinType::SOL, mojom::kSolanaMainnet, false);
 
-  expected_response->fee_param = "85";
-  expected_response->protocol_fee_pct = "0";
-  expected_response->brave_fee_pct = "0.85";
-  expected_response->discount_on_brave_fee_pct = "100";
-  expected_response->effective_fee_pct = "0";
-  expected_response->discount_code =
-      mojom::DiscountCode::kUnknownJupiterOutputMint;
-  expected_response->has_brave_fee = false;
+  // KO: invalid JSON
+  TestGetQuoteCase(R"(foo)", mojom::CoinType::ETH,
+                   mojom::kPolygonMainnetChainId, mojom::CoinType::SOL,
+                   mojom::kSolanaMainnet, false);
+}
 
-  EXPECT_CALL(callback, Run(EqualsMojo(expected_response), ""));
-  swap_service_->GetBraveFee(params->Clone(), callback.Get());
-  task_environment_.RunUntilIdle();
-  testing::Mock::VerifyAndClearExpectations(&callback);
+TEST_F(SwapServiceUnitTest, GetLiFiTransaction) {
+  SetInterceptor(R"(
+    {
+      "transactionRequest": {
+        "from": "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0",
+        "to": "0x1111111254fb6c44bac0bed2854e76f90643097d",
+        "chainId": "100",
+        "data": "0x...",
+        "value": "0x0de0b6b3a7640000",
+        "gasPrice": "0xb2d05e00",
+        "gasLimit": "0x0e9cb2"
+      }
+    }
+  )");
 
-  // Case 3: Jupiter swap on Solana (fees)
-  //         1000 SOL -> USDC
-  params->chain_id = mojom::kSolanaMainnet;
-  params->input_token = "So11111111111111111111111111111111111111112";
-  params->output_token = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
-  params->taker = "LUKAzPV8dDbVykTVT14pCGKzFfNcgZgRbAXB8AGdKx3";
+  auto quote = GetCannedLiFiQuote();
+  auto expected_transaction = mojom::LiFiEVMTransaction::New();
+  expected_transaction->from = "0x552008c0f6870c2f77e5cC1d2eb9bdff03e30Ea0";
+  expected_transaction->to = "0x1111111254fb6c44bac0bed2854e76f90643097d";
+  expected_transaction->chain_id = "0x64";
+  expected_transaction->data = "0x...";
+  expected_transaction->value = "0x0de0b6b3a7640000";
+  expected_transaction->gas_price = "0xb2d05e00";
+  expected_transaction->gas_limit = "0x0e9cb2";
 
-  expected_response->fee_param = "85";
-  expected_response->protocol_fee_pct = "0";
-  expected_response->brave_fee_pct = "0.85";
-  expected_response->discount_on_brave_fee_pct = "0";
-  expected_response->effective_fee_pct = "0.85";
-  expected_response->discount_code = mojom::DiscountCode::kNone;
-  expected_response->has_brave_fee = true;
-
-  EXPECT_CALL(callback, Run(EqualsMojo(expected_response), ""));
-  swap_service_->GetBraveFee(params->Clone(), callback.Get());
-  task_environment_.RunUntilIdle();
-  testing::Mock::VerifyAndClearExpectations(&callback);
-
-  // Case 4: Unsupported network
-  //         1000 DAI -> ETH
-  params->chain_id = mojom::kAuroraMainnetChainId;
+  base::MockCallback<mojom::SwapService::GetTransactionCallback> callback;
   EXPECT_CALL(callback,
-              Run(EqualsMojo(mojom::BraveSwapFeeResponsePtr()),
-                  l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR)));
-  swap_service_->GetBraveFee(params->Clone(), callback.Get());
+              Run(EqualsMojo(mojom::SwapTransactionUnion::NewLifiTransaction(
+                      mojom::LiFiTransactionUnion::NewEvmTransaction(
+                          std::move(expected_transaction)))),
+                  EqualsMojo(mojom::SwapErrorUnionPtr()), ""));
+
+  swap_service_->GetTransaction(
+      mojom::SwapTransactionParamsUnion::NewLifiTransactionParams(
+          std::move(quote->routes[0]->steps[0])),
+      callback.Get());
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&callback);
+}
+
+TEST_F(SwapServiceUnitTest, GetLiFiQuoteError) {
+  std::string error = R"(
+    {
+      "message": "Invalid request"
+    })";
+  SetErrorInterceptor(error);
+
+  base::MockCallback<mojom::SwapService::GetQuoteCallback> callback;
+  EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapQuoteUnionPtr()),
+                            EqualsMojo(mojom::SwapFeesPtr()),
+                            EqualsMojo(mojom::SwapErrorUnion::NewLifiError(
+                                mojom::LiFiError::New("Invalid request"))),
+                            ""));
+
+  swap_service_->GetQuote(
+      GetCannedSwapQuoteParams(mojom::CoinType::ETH,
+                               mojom::kPolygonMainnetChainId, "DAI",
+                               mojom::CoinType::SOL, mojom::kSolanaMainnet,
+                               "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+      callback.Get());
+  task_environment_.RunUntilIdle();
+}
+
+TEST_F(SwapServiceUnitTest, GetLiFiTransactionError) {
+  std::string error = R"(
+    {
+      "message": "Invalid request"
+    })";
+  SetErrorInterceptor(error);
+
+  base::MockCallback<mojom::SwapService::GetTransactionCallback> callback;
+  EXPECT_CALL(callback, Run(EqualsMojo(mojom::SwapTransactionUnionPtr()),
+                            EqualsMojo(mojom::SwapErrorUnion::NewLifiError(
+                                mojom::LiFiError::New("Invalid request"))),
+                            ""));
+
+  auto quote = GetCannedLiFiQuote();
+  swap_service_->GetTransaction(
+      mojom::SwapTransactionParamsUnion::NewLifiTransactionParams(
+          std::move(quote->routes[0]->steps[0])),
+      callback.Get());
+  task_environment_.RunUntilIdle();
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/BUILD.gn
+++ b/components/brave_wallet/common/BUILD.gn
@@ -14,15 +14,10 @@ import("//tools/json_schema_compiler/json_schema_api.gni")
 preprocess_folder = "preprocessed"
 preprocess_mojo_manifest = "preprocessed_mojo_manifest.json"
 
-if (is_official_build) {
-  assert(brave_zero_ex_api_key != "")
-}
-
 buildflag_header("buildflags") {
   header = "buildflags.h"
   flags = [
     "BRAVE_INFURA_PROJECT_ID=\"$brave_infura_project_id\"",
-    "BRAVE_ZERO_EX_API_KEY=\"$brave_zero_ex_api_key\"",
     "ENABLE_BITCOIN_BY_DEFAULT=$enable_bitcoin_by_default",
     "ENABLE_ZCASH_BY_DEFAULT=$enable_zcash_by_default",
   ]

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -511,16 +511,19 @@ struct SwapQuoteParams {
 union SwapTransactionParamsUnion {
   JupiterTransactionParams jupiter_transaction_params;
   SwapQuoteParams zero_ex_transaction_params;
+  LiFiStep lifi_transaction_params;
 };
 
 union SwapQuoteUnion {
   JupiterQuote jupiter_quote;
   ZeroExQuote zero_ex_quote;
+  LiFiQuote lifi_quote;
 };
 
 union SwapTransactionUnion {
   string jupiter_transaction;
   ZeroExQuote zero_ex_transaction;
+  LiFiTransactionUnion lifi_transaction;
 };
 
 struct ZeroExSource {
@@ -578,6 +581,7 @@ struct ZeroExError {
 union SwapErrorUnion {
   JupiterError jupiter_error;
   ZeroExError zero_ex_error;
+  LiFiError lifi_error;
 };
 
 // Structs to model Jupiter (swap) HTTP API interactions
@@ -632,7 +636,113 @@ struct JupiterError {
   bool is_insufficient_liquidity;
 };
 
-enum DiscountCode {
+enum LiFiStepType {
+  kSwap,
+  kCross,
+  kNative
+};
+
+struct LiFiToolDetails {
+  string key;
+  string name;
+  string logo;
+};
+
+struct LiFiInsurance {
+  string state;
+  string fee_amount_usd;
+};
+
+struct LiFiAction {
+  BlockchainToken from_token;
+  string from_amount;
+  BlockchainToken to_token;
+  string slippage;
+
+  string? from_address;
+  string? to_address;
+  string? destination_call_data;
+};
+
+struct LiFiFeeCost {
+  string name;
+  string description;
+  string percentage;
+  BlockchainToken token;
+  string amount;
+  bool included;
+};
+
+struct LiFiGasCost {
+  string type;
+  string estimate;
+  string limit;
+  string amount;
+  BlockchainToken token;
+};
+
+struct LiFiStepEstimate {
+  string tool;
+  string from_amount;
+  string to_amount;
+  string to_amount_min;
+  string approval_address;
+  string execution_duration;
+  array<LiFiFeeCost> fee_costs;
+  array<LiFiGasCost> gas_costs;
+};
+
+struct LiFiStep {
+  string id;
+  LiFiStepType type;
+  string tool;
+  LiFiToolDetails tool_details;
+  LiFiAction action;
+  LiFiStepEstimate estimate;
+
+  // Not defined in included steps
+  string? integrator;
+  array<LiFiStep>? included_steps;
+};
+
+struct LiFiRoute {
+  string id;
+  BlockchainToken from_token;
+  string from_amount;
+  string from_address;
+  BlockchainToken to_token;
+  string to_amount;
+  string to_amount_min;
+  string to_address;
+  array<LiFiStep> steps;
+  LiFiInsurance insurance;
+  array<string> tags;
+};
+
+struct LiFiQuote {
+  array<LiFiRoute> routes;
+};
+
+union LiFiTransactionUnion {
+  string solana_transaction;
+  LiFiEVMTransaction evm_transaction;
+};
+
+struct LiFiEVMTransaction {
+  string data;
+  string from;
+  string to;
+  string chain_id;
+  string value;
+  string gas_price;
+  string gas_limit;
+};
+
+struct LiFiError {
+  string message;
+};
+
+enum SwapDiscountCode {
   // No discount
   kNone = 0,
 
@@ -643,21 +753,17 @@ enum DiscountCode {
   kUnknownJupiterOutputMint = 1,
 };
 
-struct BraveSwapFeeParams {
-  string chain_id;
-  string input_token;
-  string output_token;
-  string taker;
-};
-
-struct BraveSwapFeeResponse {
+struct SwapFees {
+  // The fee value to use for fetching quotes. The representation of this value
+  // is contextual to the underlying API being used.
+  //
+  // An empty value indicates that no fee value should be supplied to the
+  // API.
   string fee_param;
-  string protocol_fee_pct;
-  string brave_fee_pct;
-  string discount_on_brave_fee_pct;
+  string fee_pct;
+  string discount_pct;
   string effective_fee_pct;
-  DiscountCode discount_code;
-  bool has_brave_fee;
+  SwapDiscountCode discount_code;
 };
 
 const string kLedgerHardwareVendor = "Ledger";
@@ -996,19 +1102,21 @@ interface AssetRatioService {
   GetCoinMarkets(string vs_asset, uint8 limit) => (bool success, array<CoinMarket> values);
 };
 
-// Implements swapping related functionality through the 0x API.
+// Implements cross-chain swap functionality using 0x, Jupiter, and LiFi APIs
 interface SwapService {
   GetQuote(SwapQuoteParams params) =>
-      (SwapQuoteUnion? response, SwapErrorUnion? error, string error_string);
+    (SwapQuoteUnion? response,
+     SwapFees? fees,
+     SwapErrorUnion? error,
+     string error_string);
 
   GetTransaction(SwapTransactionParamsUnion params) =>
-      (SwapTransactionUnion? response, SwapErrorUnion? error, string error_string);
+    (SwapTransactionUnion? response,
+     SwapErrorUnion? error,
+     string error_string);
 
   // Obtains whether the given chain id supports swap
   IsSwapSupported(string chain_id) => (bool result);
-
-  GetBraveFee(BraveSwapFeeParams params) =>
-      (BraveSwapFeeResponse? response, string error_string);
 };
 
 interface IpfsService {

--- a/components/brave_wallet/common/config.gni
+++ b/components/brave_wallet/common/config.gni
@@ -8,7 +8,6 @@ import("//build/config/features.gni")
 
 declare_args() {
   brave_infura_project_id = ""
-  brave_zero_ex_api_key = ""
   enable_bitcoin_by_default = !is_ios && !is_android
   enable_zcash_by_default =
       !is_ios && !is_android &&

--- a/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
+++ b/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
@@ -433,7 +433,8 @@ export class MockedWalletApiProxy {
               sellAmount: fromAmount || '',
               price: '1'
             },
-            jupiterTransaction: undefined
+            jupiterTransaction: undefined,
+            lifiTransaction: undefined
           },
           errorString: ''
         }
@@ -443,12 +444,21 @@ export class MockedWalletApiProxy {
         params: BraveWallet.SwapQuoteParams
       ): Promise<{
         response: BraveWallet.SwapQuoteUnion | null
+        fees: BraveWallet.SwapFees | null
         error: BraveWallet.SwapErrorUnion | null
         errorString: string
       }> => ({
         response: {
           zeroExQuote: this.mockZeroExQuote,
-          jupiterQuote: undefined
+          jupiterQuote: undefined,
+          lifiQuote: undefined
+        },
+        fees: {
+          feeParam: '0.00875',
+          feePct: '0.875',
+          discountPct: '0',
+          effectiveFeePct: '0.875',
+          discountCode: BraveWallet.SwapDiscountCode.kNone
         },
         error: null,
         errorString: ''

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -174,7 +174,6 @@ export const {
   useCreateWalletMutation,
   useDiscoverAssetsMutation,
   useEnableEnsOffchainLookupMutation,
-  useGenerateBraveSwapFeeMutation,
   useGenerateReceiveAddressMutation,
   useGenerateSwapQuoteMutation,
   useGenerateSwapTransactionMutation,

--- a/components/brave_wallet_ui/common/slices/endpoints/swap.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/swap.endpoints.ts
@@ -15,33 +15,10 @@ export const swapEndpoints = ({
   query
 }: WalletApiEndpointBuilderParams) => {
   return {
-    generateBraveSwapFee: mutation<
-      {
-        response: BraveWallet.BraveSwapFeeResponse | null
-        errorString: string
-      },
-      BraveWallet.BraveSwapFeeParams
-    >({
-      queryFn: async (params, { endpoint }, extraOptions, baseQuery) => {
-        const { swapService } = baseQuery(undefined).data
-        try {
-          const result = await swapService.getBraveFee(params)
-          return {
-            data: result
-          }
-        } catch (error) {
-          return handleEndpointError(
-            endpoint,
-            'Unable to fetch Brave Swap fee',
-            error
-          )
-        }
-      }
-    }),
-
     generateSwapQuote: mutation<
       {
         response: BraveWallet.SwapQuoteUnion | null
+        fees: BraveWallet.SwapFees | null
         error: BraveWallet.SwapErrorUnion | null
         errorString: string
       },

--- a/components/brave_wallet_ui/page/screens/swap/components/swap/quote-info/quote-info.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/components/swap/quote-info/quote-info.tsx
@@ -49,10 +49,12 @@ interface Props {
   toToken: BraveWallet.BlockchainToken | undefined
   toAmount: string
   spotPrices?: SpotPriceRegistry
+  swapFees?: BraveWallet.SwapFees
 }
 
 export const QuoteInfo = (props: Props) => {
-  const { selectedQuoteOption, fromToken, toToken, spotPrices } = props
+  const { selectedQuoteOption, fromToken, toToken, spotPrices, swapFees } =
+    props
 
   // State
   const [showProviders, setShowProviders] = React.useState<boolean>(false)
@@ -158,23 +160,18 @@ export const QuoteInfo = (props: Props) => {
     )
   }, [selectedQuoteOption])
 
-  const braveFee = React.useMemo(() => {
-    if (!selectedQuoteOption?.braveFee) {
+  const braveFee: BraveWallet.SwapFees | undefined = React.useMemo(() => {
+    if (!swapFees) {
       return undefined
     }
 
-    const { braveFee: braveFeeOriginal } = selectedQuoteOption
-
     return {
-      ...braveFeeOriginal,
-      effectiveFeePct: new Amount(braveFeeOriginal.effectiveFeePct).format(6),
-      protocolFeePct: new Amount(braveFeeOriginal.protocolFeePct),
-      discountOnBraveFeePct: new Amount(
-        braveFeeOriginal.discountOnBraveFeePct
-      ).format(6),
-      braveFeePct: new Amount(braveFeeOriginal.braveFeePct).format(6)
+      ...swapFees,
+      effectiveFeePct: new Amount(swapFees.effectiveFeePct).format(6),
+      discountPct: new Amount(swapFees.discountPct).format(6),
+      feePct: new Amount(swapFees.feePct).format(6)
     }
-  }, [selectedQuoteOption])
+  }, [swapFees])
 
   return (
     <Column
@@ -314,7 +311,7 @@ export const QuoteInfo = (props: Props) => {
               name='search-fuel-tank'
               size={16}
             />
-            <Text textSize='14px'>{selectedQuoteOption.networkFee}</Text>
+            <Text textSize='14px'>{selectedQuoteOption.networkFeeFiat}</Text>
           </Bubble>
         </Row>
       )}
@@ -327,13 +324,13 @@ export const QuoteInfo = (props: Props) => {
           <Text textSize='14px'>{getLocale('braveSwapBraveFee')}</Text>
           <Text textSize='14px'>
             <BraveFeeContainer>
-              {braveFee.discountCode === BraveWallet.DiscountCode.kNone && (
+              {braveFee.discountCode === BraveWallet.SwapDiscountCode.kNone && (
                 <Text textSize='14px'>{braveFee.effectiveFeePct}%</Text>
               )}
 
-              {braveFee.discountCode !== BraveWallet.DiscountCode.kNone && (
+              {braveFee.discountCode !== BraveWallet.SwapDiscountCode.kNone && (
                 <>
-                  {!braveFee.hasBraveFee ? (
+                  {new Amount(braveFee.effectiveFeePct).isZero() ? (
                     <Text
                       textSize='14px'
                       textColor='success'
@@ -349,31 +346,14 @@ export const QuoteInfo = (props: Props) => {
                     textSize='14px'
                     textColor='text03'
                   >
-                    {braveFee.braveFeePct}%
+                    {braveFee.feePct}%
                   </BraveFeeDiscounted>
 
-                  {braveFee.hasBraveFee && (
-                    <Text textSize='14px'>
-                      (-{braveFee.discountOnBraveFeePct}%)
-                    </Text>
+                  {new Amount(braveFee.effectiveFeePct).gt(0) && (
+                    <Text textSize='14px'>(-{braveFee.discountPct}%)</Text>
                   )}
                 </>
               )}
-            </BraveFeeContainer>
-          </Text>
-        </Row>
-      )}
-
-      {braveFee && !braveFee.protocolFeePct.isZero() && (
-        <Row
-          rowWidth='full'
-          marginBottom={16}
-          horizontalPadding={16}
-        >
-          <Text textSize='14px'>{getLocale('braveSwapProtocolFee')}</Text>
-          <Text textSize='14px'>
-            <BraveFeeContainer>
-              <Text textSize='14px'>{braveFee.protocolFeePct.format(6)}%</Text>
             </BraveFeeContainer>
           </Text>
         </Row>

--- a/components/brave_wallet_ui/page/screens/swap/constants/types.ts
+++ b/components/brave_wallet_ui/page/screens/swap/constants/types.ts
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { BraveWallet, SpotPriceRegistry } from '../../../../constants/types'
+import { BraveWallet } from '../../../../constants/types'
 
 import Amount from '../../../../utils/amount'
 
@@ -13,7 +13,6 @@ type LiquiditySource = {
 }
 
 export type QuoteOption = {
-  label: string
   fromAmount: Amount
   toAmount: Amount
   minimumToAmount: Amount | undefined
@@ -33,9 +32,9 @@ export type QuoteOption = {
    */
   routing: 'split' | 'flow'
 
-  networkFee: string
+  networkFee: Amount
 
-  braveFee: BraveWallet.BraveSwapFeeResponse | undefined
+  networkFeeFiat: string
 }
 
 export type SwapAndSend = {
@@ -68,17 +67,25 @@ export type SwapValidationErrorType =
   | 'unknownError'
 
 export type SwapParams = {
-  selectedNetwork: BraveWallet.NetworkInfo | undefined
-  selectedAccount: BraveWallet.AccountInfo | undefined
+  fromAccount?: BraveWallet.AccountInfo
   fromToken?: BraveWallet.BlockchainToken
-  toToken?: BraveWallet.BlockchainToken
+  fromNetwork?: BraveWallet.NetworkInfo
   fromAmount: string
+
+  toAccountId?: BraveWallet.AccountId
+  toToken?: BraveWallet.BlockchainToken
   toAmount: string
+
   /**
    * This is the value as seen on the UI - should be converted to appropriate
    * format for Jupiter and 0x swap providers.
    */
   slippageTolerance: string
-  fromAccount?: BraveWallet.AccountInfo
-  spotPrices?: SpotPriceRegistry
+}
+
+export type SwapParamsOverrides = {
+  fromAmount?: string
+  toAmount?: string
+  fromToken?: BraveWallet.BlockchainToken
+  toToken?: BraveWallet.BlockchainToken
 }

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useJupiter.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useJupiter.ts
@@ -3,232 +3,59 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback } from 'react'
 
 // Types
-import { QuoteOption, SwapParams } from '../constants/types'
+import { SwapParams } from '../constants/types'
 import { BraveWallet } from '../../../../constants/types'
 
-// Constants
-import { WRAPPED_SOL_CONTRACT_ADDRESS } from '../constants/magics'
-
 // Utils
-import Amount from '../../../../utils/amount'
-import { makeNetworkAsset } from '../../../../options/asset-options'
-import { getTokenPriceAmountFromRegistry } from '../../../../utils/pricing-utils'
 import { toMojoUnion } from '../../../../utils/mojo-utils'
 
 // Query hooks
 import {
-  useGenerateBraveSwapFeeMutation,
-  useGenerateSwapQuoteMutation,
   useGenerateSwapTransactionMutation,
-  useGetDefaultFiatCurrencyQuery,
   useSendSolanaSerializedTransactionMutation
 } from '../../../../common/slices/api.slice'
 
-const networkFee = new Amount('0.000005')
-
 export function useJupiter(params: SwapParams) {
-  const { selectedNetwork, selectedAccount } = params
-
-  // Queries
-  // FIXME(onyb): what happens when defaultFiatCurrency is empty
-  const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
-  const nativeAsset = useMemo(
-    () => makeNetworkAsset(selectedNetwork),
-    [selectedNetwork]
-  )
+  const { fromAccount, fromNetwork } = params
 
   // Mutations
-  const [generateSwapQuote] = useGenerateSwapQuoteMutation()
-  const [generateBraveSwapFee] = useGenerateBraveSwapFeeMutation()
   const [generateSwapTransaction] = useGenerateSwapTransactionMutation()
   const [sendSolanaSerializedTransaction] =
     useSendSolanaSerializedTransactionMutation()
 
-  // State
-  const [quote, setQuote] = useState<BraveWallet.JupiterQuote | undefined>(
-    undefined
-  )
-  const [error, setError] = useState<BraveWallet.JupiterError | undefined>(
-    undefined
-  )
-  const [loading, setLoading] = useState<boolean>(false)
-  const [braveFee, setBraveFee] = useState<
-    BraveWallet.BraveSwapFeeResponse | undefined
-  >(undefined)
-  const [abortController, setAbortController] = useState<
-    AbortController | undefined
-  >(undefined)
-
-  const reset = useCallback(
-    async (callback?: () => Promise<void>) => {
-      setQuote(undefined)
-      setError(undefined)
-      setLoading(false)
-      setBraveFee(undefined)
-
-      if (abortController) {
-        abortController.abort()
-      }
-
-      if (callback) {
-        await callback()
-      }
-    },
-    [abortController]
-  )
-
-  const refresh = useCallback(
-    async function (
-      overrides: Partial<SwapParams> = {}
-    ): Promise<BraveWallet.JupiterQuote | undefined> {
-      const overriddenParams: SwapParams = {
-        ...params,
-        ...overrides
-      }
-
-      // Perform data validation and early-exit
+  const exchange = useCallback(
+    async function (quote: BraveWallet.JupiterQuote) {
       if (
-        !selectedNetwork ||
-        selectedNetwork.coin !== BraveWallet.CoinType.SOL
+        !fromAccount ||
+        !fromNetwork
       ) {
         return
       }
-      if (!overriddenParams.fromToken || !overriddenParams.toToken) {
-        return
-      }
-      if (!overriddenParams.fromAmount && !overriddenParams.toAmount) {
-        await reset()
-        return
-      }
 
-      const fromAmountWrapped = new Amount(overriddenParams.fromAmount)
-      const toAmountWrapped = new Amount(overriddenParams.toAmount)
-      const isFromAmountEmpty =
-        fromAmountWrapped.isZero() ||
-        fromAmountWrapped.isNaN() ||
-        fromAmountWrapped.isUndefined()
-      const isToAmountEmpty =
-        toAmountWrapped.isZero() ||
-        toAmountWrapped.isNaN() ||
-        toAmountWrapped.isUndefined()
-
-      if (isFromAmountEmpty && isToAmountEmpty) {
-        await reset()
-        return
-      }
-
-      if (!overriddenParams.fromAccount) {
-        return
-      }
-
-      const controller = new AbortController()
-      setAbortController(controller)
-
-      setLoading(true)
-
-      try {
-        const { response: braveFeeResponse } = await generateBraveSwapFee({
-          chainId: selectedNetwork.chainId,
-          inputToken:
-            overriddenParams.fromToken.contractAddress ||
-            WRAPPED_SOL_CONTRACT_ADDRESS,
-          outputToken:
-            overriddenParams.toToken.contractAddress ||
-            WRAPPED_SOL_CONTRACT_ADDRESS,
-          taker: overriddenParams.fromAccount.address
-        }).unwrap()
-        setBraveFee(braveFeeResponse || undefined)
-      } catch (e) {
-        console.log(
-          `Error getting Brave fee (Jupiter): ${
-            //
-            overriddenParams.toToken.symbol
-          }`
-        )
-      }
-
-      let jupiterQuoteResponse
-      try {
-        jupiterQuoteResponse = await generateSwapQuote({
-          fromAccountId: overriddenParams.fromAccount.accountId,
-          fromChainId: selectedNetwork.chainId,
-          fromToken:
-            overriddenParams.fromToken.contractAddress ||
-            WRAPPED_SOL_CONTRACT_ADDRESS,
-          fromAmount: isFromAmountEmpty
-            ? new Amount(overriddenParams.toAmount)
-                .multiplyByDecimals(overriddenParams.toToken.decimals)
-                .format()
-            : new Amount(overriddenParams.fromAmount)
-                .multiplyByDecimals(overriddenParams.fromToken.decimals)
-                .format(),
-          toAccountId: overriddenParams.fromAccount.accountId,
-          toChainId: selectedNetwork.chainId,
-          toToken:
-            overriddenParams.toToken.contractAddress ||
-            WRAPPED_SOL_CONTRACT_ADDRESS,
-          toAmount: '',
-          slippagePercentage: overriddenParams.slippageTolerance,
-          routePriority: BraveWallet.RoutePriority.kRecommended
-        }).unwrap()
-      } catch (e) {
-        console.log(`Error getting Jupiter quote: ${e}`)
-      }
-
-      if (controller.signal.aborted) {
-        setLoading(false)
-        setAbortController(undefined)
-        return
-      }
-
-      if (jupiterQuoteResponse?.response?.jupiterQuote) {
-        setQuote(jupiterQuoteResponse.response.jupiterQuote)
-      }
-
-      if (jupiterQuoteResponse?.error?.jupiterError) {
-        setError(jupiterQuoteResponse.error.jupiterError)
-      }
-
-      setLoading(false)
-      setAbortController(undefined)
-
-      // Return undefined if response is null.
-      return jupiterQuoteResponse?.response?.jupiterQuote || undefined
-    },
-    [selectedNetwork, params, reset, generateBraveSwapFee, generateSwapQuote]
-  )
-
-  const exchange = useCallback(
-    async function (callback?: () => Promise<void>) {
       // Perform data validation and early-exit
-      if (!quote || quote?.routePlan.length === 0) {
-        return
-      }
-      if (selectedNetwork?.coin !== BraveWallet.CoinType.SOL) {
-        return
-      }
-      if (!params.toToken || !params.fromToken) {
-        return
-      }
-      if (!selectedAccount) {
+      if (quote.routePlan.length === 0) {
         return
       }
 
-      setLoading(true)
+      if (fromNetwork.coin !== BraveWallet.CoinType.SOL) {
+        return
+      }
+
       let jupiterTransactionResponse
       try {
         jupiterTransactionResponse = await generateSwapTransaction(
           toMojoUnion(
             {
               jupiterTransactionParams: {
-                chainId: selectedNetwork.chainId,
-                userPublicKey: selectedAccount.address,
+                chainId: fromNetwork.chainId,
+                userPublicKey: fromAccount.address,
                 quote
               },
-              zeroExTransactionParams: undefined
+              zeroExTransactionParams: undefined,
+              lifiTransactionParams: undefined
             },
             'jupiterTransactionParams'
           )
@@ -238,11 +65,10 @@ export function useJupiter(params: SwapParams) {
       }
 
       if (jupiterTransactionResponse?.error?.jupiterError) {
-        setError(jupiterTransactionResponse.error.jupiterError)
+        return jupiterTransactionResponse.error
       }
 
       if (!jupiterTransactionResponse?.response?.jupiterTransaction) {
-        setLoading(false)
         return
       }
 
@@ -252,8 +78,8 @@ export function useJupiter(params: SwapParams) {
       try {
         await sendSolanaSerializedTransaction({
           encodedTransaction: swapTransaction,
-          chainId: selectedNetwork.chainId,
-          accountId: selectedAccount.accountId,
+          chainId: fromNetwork.chainId,
+          accountId: fromAccount.accountId,
           txType: BraveWallet.TransactionType.SolanaSwap,
           sendOptions: {
             skipPreflight: {
@@ -265,95 +91,22 @@ export function useJupiter(params: SwapParams) {
             preflightCommitment: 'processed'
           }
         }).unwrap()
-        await reset(callback)
       } catch (e) {
         // Bubble up error
         console.error(`Error creating Solana transaction: ${e}`)
-        setLoading(false)
       }
+
+      return undefined
     },
     [
-      quote,
-      selectedNetwork,
-      params.toToken,
-      selectedAccount,
+      fromAccount,
+      fromNetwork,
       generateSwapTransaction,
-      sendSolanaSerializedTransaction,
-      sendSolanaSerializedTransaction,
-      reset
+      sendSolanaSerializedTransaction
     ]
   )
 
-  const quoteOptions: QuoteOption[] = useMemo(() => {
-    if (!params.fromToken || !params.toToken || !params.spotPrices) {
-      return []
-    }
-
-    if (quote === undefined) {
-      return []
-    }
-
-    return [
-      {
-        label: '',
-        fromAmount: new Amount(quote.inAmount).divideByDecimals(
-          params.fromToken.decimals
-        ),
-        toAmount: new Amount(quote.outAmount).divideByDecimals(
-          params.toToken.decimals
-        ),
-        // TODO: minimumToAmount is applicable only for ExactIn swapMode.
-        // Create a maximumFromAmount field for ExactOut swapMode if needed.
-        minimumToAmount: new Amount(
-          quote.otherAmountThreshold
-        ).divideByDecimals(params.toToken.decimals),
-        fromToken: params.fromToken,
-        toToken: params.toToken,
-        rate: new Amount(quote.outAmount)
-          .divideByDecimals(params.toToken.decimals)
-          .div(
-            new Amount(quote.inAmount).divideByDecimals(
-              params.fromToken.decimals
-            )
-          ),
-        impact: new Amount(quote.priceImpactPct),
-        sources: [
-          ...new Set(quote.routePlan.map((step) => step.swapInfo.label))
-        ].map((name) => ({
-          name,
-          proportion: new Amount(1)
-        })),
-        // TODO(onyb): this is a placeholder value until we have a better
-        // routing UI
-        routing: 'flow',
-        networkFee: networkFee
-          .times(
-            nativeAsset && params.spotPrices
-              ? getTokenPriceAmountFromRegistry(params.spotPrices, nativeAsset)
-              : Amount.zero()
-          )
-          .formatAsFiat(defaultFiatCurrency),
-        braveFee
-      } as QuoteOption
-    ]
-  }, [
-    quote,
-    params.fromToken,
-    params.toToken,
-    defaultFiatCurrency,
-    nativeAsset,
-    params.spotPrices,
-    braveFee
-  ])
-
   return {
-    quote,
-    error,
-    loading,
-    exchange,
-    refresh,
-    reset,
-    quoteOptions,
-    networkFee
+    exchange
   }
 }

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
@@ -20,10 +20,9 @@ import {
 
 // Types and constants
 import {
-  QuoteOption,
   GasEstimate,
-  SwapParams,
-  SwapValidationErrorType
+  SwapValidationErrorType,
+  SwapParamsOverrides
 } from '../constants/types'
 import { BraveWallet, GasFeeOption } from '../../../../constants/types'
 
@@ -36,19 +35,24 @@ import { makeNetworkAsset } from '../../../../options/asset-options'
 import { getTokenPriceAmountFromRegistry } from '../../../../utils/pricing-utils'
 import { getBalance } from '../../../../utils/balance-utils'
 import { networkSupportsAccount } from '../../../../utils/network-utils'
+import {
+  getZeroExQuoteOptions,
+  getJupiterQuoteOptions,
+  getZeroExFromAmount,
+  getZeroExToAmount,
+  getJupiterFromAmount,
+  getJupiterToAmount
+} from '../swap.utils'
 
 // Queries
 import {
-  useGetAccountInfosRegistryQuery,
   useGetDefaultFiatCurrencyQuery,
   useGetSwapSupportedNetworksQuery,
-  useGetTokenSpotPricesQuery
+  useGetTokenSpotPricesQuery,
+  useGenerateSwapQuoteMutation
 } from '../../../../common/slices/api.slice'
 import { querySubscriptionOptions60s } from '../../../../common/slices/constants'
-import {
-  AccountInfoEntity,
-  selectAllAccountInfosFromQuery
-} from '../../../../common/slices/entities/account-info.entity'
+import { AccountInfoEntity } from '../../../../common/slices/entities/account-info.entity'
 
 const hasDecimalsOverflow = (
   amount: string,
@@ -70,57 +74,15 @@ const hasDecimalsOverflow = (
 }
 
 export const useSwap = () => {
-  // Queries
-  // FIXME(onyb): what happens when defaultFiatCurrency is empty
-  const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
-  const { data: supportedNetworks } = useGetSwapSupportedNetworksQuery()
-  const { data: accountsList } = useGetAccountInfosRegistryQuery(undefined, {
-    selectFromResult: (res) => ({
-      isLoading: res.isLoading,
-      data: selectAllAccountInfosFromQuery(res)
-    })
-  })
-
   // State
-  const [selectedAccountState, setSelectedAccountState] = useState<
+  const [fromAccount, setFromAccount] = useState<
     BraveWallet.AccountInfo | undefined
   >(undefined)
-  const [selectedNetworkState, setSelectedNetworkState] = useState<
-    BraveWallet.NetworkInfo | undefined
-  >(undefined)
-
-  const selectedNetwork = useMemo(() => {
-    if (!selectedNetworkState && supportedNetworks?.length) {
-      return (
-        supportedNetworks?.find(
-          (network) => network.chainId === BraveWallet.MAINNET_CHAIN_ID
-        ) ||
-        supportedNetworks?.find(
-          (network) => network.chainId === BraveWallet.SOLANA_MAINNET
-        )
-      )
-    }
-
-    return selectedNetworkState
-  }, [selectedNetworkState, supportedNetworks])
-
-  const selectedAccount = useMemo(() => {
-    if (!selectedAccountState && accountsList.length) {
-      return accountsList.find(
-        (account) => account.accountId.coin === selectedNetwork?.coin
-      )
-    }
-
-    return selectedAccountState
-  }, [selectedAccountState, accountsList, selectedNetwork])
-
-  const nativeAsset = useMemo(
-    () => makeNetworkAsset(selectedNetwork),
-    [selectedNetwork]
-  )
-
   const [fromToken, setFromToken] = useState<
     BraveWallet.BlockchainToken | undefined
+  >(undefined)
+  const [toAccountId, setToAccountId] = useState<
+    BraveWallet.AccountId | undefined
   >(undefined)
   const [toToken, setToToken] = useState<
     BraveWallet.BlockchainToken | undefined
@@ -130,29 +92,82 @@ export const useSwap = () => {
   const [selectingFromOrTo, setSelectingFromOrTo] = useState<
     'from' | 'to' | undefined
   >(undefined)
+  const [editingFromOrToAmount, setEditingFromOrToAmount] = useState<
+    'from' | 'to'
+  >('from')
   const [selectedSwapAndSendOption, setSelectedSwapAndSendOption] =
     useState<string>(SwapAndSendOptions[0].name)
   const [swapAndSendSelected, setSwapAndSendSelected] = useState<boolean>(false)
   const [toAnotherAddress, setToAnotherAddress] = useState<string>('')
   const [userConfirmedAddress, setUserConfirmedAddress] =
     useState<boolean>(false)
-  const [selectedSwapSendAccount, setSelectedSwapSendAccount] = useState<
-    AccountInfoEntity | undefined
-  >(selectedAccount)
   const [useDirectRoute, setUseDirectRoute] = useState<boolean>(false)
   const [slippageTolerance, setSlippageTolerance] = useState<string>('0.5')
   const [selectedGasFeeOption, setSelectedGasFeeOption] =
     useState<GasFeeOption>(gasFeeOptions[1])
+  const [quoteUnion, setQuoteUnion] = useState<
+    BraveWallet.SwapQuoteUnion | undefined
+  >(undefined)
+  const [quoteErrorUnion, setQuoteErrorUnion] = useState<
+    BraveWallet.SwapErrorUnion | undefined
+  >(undefined)
+  const [abortController, setAbortController] = useState<
+    AbortController | undefined
+  >(undefined)
+  const [isFetchingQuote, setIsFetchingQuote] = useState<boolean>(false)
+  const [swapFees, setSwapFees] = useState<BraveWallet.SwapFees | undefined>(
+    undefined
+  )
+
+  // Mutations
+  const [generateSwapQuote] = useGenerateSwapQuoteMutation()
+
+  // Queries
+  const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
+  const { data: supportedNetworks } = useGetSwapSupportedNetworksQuery()
+
+  // Memos
+  const fromNetwork = useMemo(() => {
+    if (fromToken && supportedNetworks?.length) {
+      return supportedNetworks.find(
+        (network) =>
+          network.chainId === fromToken.chainId &&
+          network.coin === fromToken.coin
+      )
+    }
+
+    return undefined
+  }, [fromToken, supportedNetworks])
+
+  const toNetwork = useMemo(() => {
+    if (toToken && supportedNetworks?.length) {
+      return supportedNetworks.find(
+        (network) =>
+          network.chainId === toToken.chainId && network.coin === toToken.coin
+      )
+    }
+
+    return fromNetwork
+  }, [toToken, supportedNetworks, fromNetwork])
+
+  const [selectedSwapSendAccount, setSelectedSwapSendAccount] = useState<
+    AccountInfoEntity | undefined
+  >(undefined)
 
   const { data: tokenBalancesRegistry, isLoading: isLoadingBalances } =
     useBalancesFetcher(
-      selectedNetwork && selectedAccount
+      fromNetwork && fromAccount
         ? {
-            networks: [selectedNetwork],
-            accounts: [selectedAccount]
+            networks: [fromNetwork],
+            accounts: [fromAccount]
           }
         : skipToken
     )
+
+  const nativeAsset = useMemo(
+    () => makeNetworkAsset(fromNetwork),
+    [fromNetwork]
+  )
 
   const tokenPriceIds = useMemo(
     () =>
@@ -172,35 +187,79 @@ export const useSwap = () => {
   )
 
   const jupiter = useJupiter({
-    selectedNetwork,
-    selectedAccount,
+    fromNetwork,
+    fromAccount,
     fromToken,
+    fromAmount: editingFromOrToAmount === 'from' ? fromAmount : '',
+    toAccountId,
     toToken,
-    fromAmount,
-    toAmount: '',
-    slippageTolerance,
-    fromAccount: selectedAccount,
-    spotPrices: spotPriceRegistry
+    toAmount: editingFromOrToAmount === 'to' ? toAmount : '',
+    slippageTolerance
   })
   const zeroEx = useZeroEx({
-    selectedNetwork,
-    selectedAccount,
-    fromAmount,
-    toAmount: '',
+    fromNetwork,
+    fromAccount,
     fromToken,
+    fromAmount: editingFromOrToAmount === 'from' ? fromAmount : '',
+    toAccountId,
     toToken,
-    slippageTolerance,
-    fromAccount: selectedAccount,
-    spotPrices: spotPriceRegistry
+    toAmount: editingFromOrToAmount === 'to' ? toAmount : '',
+    slippageTolerance
   })
 
-  const quoteOptions: QuoteOption[] = useMemo(() => {
-    if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-      return jupiter.quoteOptions
+  const quoteOptions = useMemo(() => {
+    if (
+      !fromNetwork ||
+      !fromToken ||
+      !toToken ||
+      !quoteUnion ||
+      !spotPriceRegistry ||
+      !defaultFiatCurrency
+    ) {
+      return []
     }
 
-    return zeroEx.quoteOptions
-  }, [selectedNetwork?.coin, jupiter.quoteOptions, zeroEx.quoteOptions])
+    if (quoteUnion.jupiterQuote) {
+      return getJupiterQuoteOptions({
+        quote: quoteUnion.jupiterQuote,
+        fromNetwork,
+        fromToken,
+        toToken,
+        spotPrices: spotPriceRegistry,
+        defaultFiatCurrency
+      })
+    }
+
+    if (quoteUnion.zeroExQuote) {
+      return getZeroExQuoteOptions({
+        quote: quoteUnion.zeroExQuote,
+        fromNetwork,
+        fromToken,
+        toToken,
+        spotPrices: spotPriceRegistry,
+        defaultFiatCurrency
+      })
+    }
+
+    return []
+  }, [
+    fromNetwork,
+    fromToken,
+    toToken,
+    quoteUnion,
+    spotPriceRegistry,
+    defaultFiatCurrency
+  ])
+
+  const reset = useCallback(() => {
+    setQuoteUnion(undefined)
+    setQuoteErrorUnion(undefined)
+    setIsFetchingQuote(false)
+    setSwapFees(undefined)
+    if (abortController) {
+      abortController.abort()
+    }
+  }, [abortController])
 
   const onSelectQuoteOption = useCallback(
     (index: number) => {
@@ -218,80 +277,156 @@ export const useSwap = () => {
     [quoteOptions, toToken]
   )
 
-  // Methods
-  const handleJupiterQuoteRefreshInternal = useCallback(
-    async (overrides: Partial<SwapParams>) => {
-      const quote = await jupiter.refresh(overrides)
-      if (!quote) {
+  const handleQuoteRefreshInternal = useCallback(
+    async (overrides: SwapParamsOverrides) => {
+      if (!fromAccount || !toAccountId) {
         return
       }
 
-      if (overrides.fromAmount === '') {
-        const token = overrides.fromToken || fromToken
-        if (token) {
-          setFromAmount(
-            new Amount(quote.inAmount)
-              .divideByDecimals(token.decimals)
-              .format(6)
-          )
-        }
+      const params = {
+        fromAmount:
+          overrides.fromAmount === undefined
+            ? fromAmount
+            : overrides.fromAmount,
+        toAmount:
+          overrides.toAmount === undefined ? toAmount : overrides.toAmount,
+        fromToken: overrides.fromToken || fromToken,
+        toToken: overrides.toToken || toToken,
+        editingFromOrToAmount
       }
 
-      if (overrides.toAmount === '') {
-        const token = overrides.toToken || toToken
-        if (token) {
-          setToAmount(
-            new Amount(quote.outAmount)
-              .divideByDecimals(token.decimals)
-              .format(6)
-          )
-        }
+      if (params.fromAmount && !params.toAmount) {
+        params.editingFromOrToAmount = 'from'
+      } else if (params.toAmount && !params.fromAmount) {
+        params.editingFromOrToAmount = 'to'
       }
-    },
-    [jupiter, toToken, fromToken]
-  )
-  const handleJupiterQuoteRefresh = useDebouncedCallback(
-    async (overrides: Partial<SwapParams>) => {
-      await handleJupiterQuoteRefreshInternal(overrides)
-    },
-    700
-  )
 
-  const handleZeroExQuoteRefreshInternal = useCallback(
-    async (overrides: Partial<SwapParams>) => {
-      const quote = await zeroEx.refresh(overrides)
-      if (!quote) {
+      if (!params.fromToken || !params.toToken) {
         return
       }
 
-      if (overrides.fromAmount === '') {
-        const token = overrides.fromToken || fromToken
-        if (token) {
-          setFromAmount(
-            new Amount(quote.sellAmount)
-              .divideByDecimals(token.decimals)
-              .format(6)
-          )
+      const fromAmountWrapped = new Amount(params.fromAmount)
+      const toAmountWrapped = new Amount(params.toAmount)
+      const isFromAmountEmpty =
+        fromAmountWrapped.isZero() ||
+        fromAmountWrapped.isNaN() ||
+        fromAmountWrapped.isUndefined()
+      const isToAmountEmpty =
+        toAmountWrapped.isZero() ||
+        toAmountWrapped.isNaN() ||
+        toAmountWrapped.isUndefined()
+
+      if (isFromAmountEmpty && isToAmountEmpty) {
+        reset()
+        return
+      }
+
+      const controller = new AbortController()
+      setAbortController(controller)
+      setIsFetchingQuote(true)
+
+      let quoteResponse
+      try {
+        quoteResponse = await generateSwapQuote({
+          fromAccountId: fromAccount.accountId,
+          fromChainId: params.fromToken.chainId,
+          fromAmount:
+            params.editingFromOrToAmount === 'from' && params.fromAmount
+              ? new Amount(params.fromAmount)
+                  .multiplyByDecimals(params.fromToken.decimals)
+                  .format()
+              : '',
+          fromToken: params.fromToken.contractAddress,
+          toAccountId,
+          toChainId: params.toToken.chainId,
+          toAmount:
+            params.editingFromOrToAmount === 'to' && params.toAmount
+              ? new Amount(params.toAmount)
+                  .multiplyByDecimals(params.toToken.decimals)
+                  .format()
+              : '',
+          toToken: params.toToken.contractAddress,
+          slippagePercentage: slippageTolerance,
+          routePriority: BraveWallet.RoutePriority.kRecommended
+        }).unwrap()
+      } catch (e) {
+        console.error(`generateSwapQuote failed: ${e}`)
+      }
+
+      if (controller.signal.aborted) {
+        setIsFetchingQuote(false)
+        setAbortController(undefined)
+        return
+      }
+
+      if (quoteResponse?.error) {
+        setQuoteErrorUnion(quoteResponse.error)
+      }
+
+      if (quoteResponse?.response) {
+        setQuoteUnion(quoteResponse.response)
+
+        if (quoteResponse.response.jupiterQuote) {
+          if (params.editingFromOrToAmount === 'from') {
+            setToAmount(
+              getJupiterToAmount({
+                quote: quoteResponse.response.jupiterQuote,
+                toToken: params.toToken
+              }).format(6)
+            )
+          } else {
+            setFromAmount(
+              getJupiterFromAmount({
+                quote: quoteResponse.response.jupiterQuote,
+                fromToken: params.fromToken
+              }).format(6)
+            )
+          }
+        }
+
+        if (quoteResponse.response.zeroExQuote) {
+          if (params.editingFromOrToAmount === 'from') {
+            setToAmount(
+              getZeroExToAmount({
+                quote: quoteResponse.response.zeroExQuote,
+                toToken: params.toToken
+              }).format(6)
+            )
+          } else {
+            setFromAmount(
+              getZeroExFromAmount({
+                quote: quoteResponse.response.zeroExQuote,
+                fromToken: params.fromToken
+              }).format(6)
+            )
+          }
+
+          await zeroEx.checkAllowance(quoteResponse.response.zeroExQuote)
         }
       }
 
-      if (overrides.toAmount === '') {
-        const token = overrides.toToken || toToken
-        if (token) {
-          setToAmount(
-            new Amount(quote.buyAmount)
-              .divideByDecimals(token.decimals)
-              .format(6)
-          )
-        }
+      if (quoteResponse?.fees) {
+        setSwapFees(quoteResponse?.fees)
       }
+
+      setIsFetchingQuote(false)
+      setAbortController(undefined)
     },
-    [zeroEx, toToken, fromToken]
+    [
+      editingFromOrToAmount,
+      fromAccount,
+      fromAmount,
+      fromToken,
+      toAmount,
+      toToken,
+      generateSwapQuote,
+      slippageTolerance
+    ]
   )
 
-  const handleZeroExQuoteRefresh = useDebouncedCallback(
-    async (overrides: Partial<SwapParams>) => {
-      await handleZeroExQuoteRefreshInternal(overrides)
+  const handleQuoteRefresh = useDebouncedCallback(
+    async (overrides: SwapParamsOverrides) => {
+      await handleQuoteRefreshInternal(overrides)
     },
     700
   )
@@ -303,23 +438,17 @@ export const useSwap = () => {
   const handleOnSetFromAmount = useCallback(
     async (value: string) => {
       setFromAmount(value)
+      setEditingFromOrToAmount('from')
       if (!value) {
         setToAmount('')
       }
 
-      if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-        await handleJupiterQuoteRefresh({
-          fromAmount: value,
-          toAmount: ''
-        })
-      } else {
-        await handleZeroExQuoteRefresh({
-          fromAmount: value,
-          toAmount: ''
-        })
-      }
+      await handleQuoteRefresh({
+        fromAmount: value,
+        toAmount: ''
+      })
     },
-    [selectedNetwork?.coin, handleJupiterQuoteRefresh, handleZeroExQuoteRefresh]
+    [handleQuoteRefresh]
   )
 
   // Changing the To amount does the following:
@@ -329,36 +458,30 @@ export const useSwap = () => {
   const handleOnSetToAmount = useCallback(
     async (value: string) => {
       setToAmount(value)
+      setEditingFromOrToAmount('to')
       if (!value) {
         setFromAmount('')
       }
 
-      if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-        await handleJupiterQuoteRefresh({
-          fromAmount: '',
-          toAmount: value
-        })
-      } else {
-        await handleZeroExQuoteRefresh({
-          fromAmount: '',
-          toAmount: value
-        })
-      }
+      await handleQuoteRefresh({
+        fromAmount: '',
+        toAmount: value
+      })
     },
-    [selectedNetwork?.coin, handleZeroExQuoteRefresh, handleJupiterQuoteRefresh]
+    [handleQuoteRefresh]
   )
 
   const getAssetBalance = useCallback(
     (token: BraveWallet.BlockchainToken): Amount => {
-      if (!selectedAccount) {
+      if (!fromAccount) {
         return Amount.zero()
       }
 
       return new Amount(
-        getBalance(selectedAccount.accountId, token, tokenBalancesRegistry)
+        getBalance(fromAccount.accountId, token, tokenBalancesRegistry)
       )
     },
-    [tokenBalancesRegistry, selectedAccount]
+    [tokenBalancesRegistry, fromAccount]
   )
 
   const fromAssetBalance = fromToken && getAssetBalance(fromToken)
@@ -368,14 +491,7 @@ export const useSwap = () => {
     setFromToken(toToken)
     setToToken(fromToken)
     await handleOnSetFromAmount('')
-  }, [
-    toToken,
-    fromToken,
-    handleOnSetFromAmount,
-    selectedAccount,
-    getAssetBalance,
-    selectedNetwork
-  ])
+  }, [toToken, fromToken, handleOnSetFromAmount])
 
   // Changing the To asset does the following:
   //  1. Update toToken right away.
@@ -386,31 +502,18 @@ export const useSwap = () => {
   //  5. Fetch spot price.
   const onSelectToToken = useCallback(
     async (token: BraveWallet.BlockchainToken) => {
+      setEditingFromOrToAmount('from')
       setToToken(token)
       setSelectingFromOrTo(undefined)
       setToAmount('')
 
-      if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-        await jupiter.reset()
-        await handleJupiterQuoteRefreshInternal({
-          toToken: token,
-          toAmount: ''
-        })
-      } else if (selectedNetwork?.coin === BraveWallet.CoinType.ETH) {
-        await zeroEx.reset()
-        await handleZeroExQuoteRefreshInternal({
-          toToken: token,
-          toAmount: ''
-        })
-      }
+      reset()
+      await handleQuoteRefreshInternal({
+        toToken: token,
+        toAmount: ''
+      })
     },
-    [
-      selectedNetwork?.coin,
-      jupiter,
-      handleJupiterQuoteRefreshInternal,
-      zeroEx,
-      handleZeroExQuoteRefreshInternal
-    ]
+    [handleQuoteRefreshInternal]
   )
 
   // Changing the From asset does the following:
@@ -423,26 +526,24 @@ export const useSwap = () => {
       token: BraveWallet.BlockchainToken,
       account?: BraveWallet.AccountInfo
     ) => {
+      setEditingFromOrToAmount('from')
       setFromToken(token)
-      setSelectedAccountState(account)
-      const tokensNetwork = supportedNetworks?.find(
-        (network) => network.chainId === token.chainId
-      )
-      setSelectedNetworkState(tokensNetwork)
-      setSelectingFromOrTo(undefined)
-      setFromAmount('')
-      setToAmount('')
-      if (toToken?.chainId !== tokensNetwork?.chainId) {
+      setFromAccount(account)
+
+      // TODO(onyb): remove this when we support cross-chain swaps
+      if (token.coin !== toToken?.coin || token.chainId !== toToken?.chainId) {
         setToToken(undefined)
       }
 
-      if (tokensNetwork?.coin === BraveWallet.CoinType.SOL) {
-        await jupiter.reset()
-      } else if (tokensNetwork?.coin === BraveWallet.CoinType.ETH) {
-        await zeroEx.reset()
-      }
+      // TODO(onyb): change this when we support swapping to different address
+      setToAccountId(account?.accountId)
+
+      setSelectingFromOrTo(undefined)
+      setFromAmount('')
+      setToAmount('')
+      reset()
     },
-    [zeroEx, jupiter, supportedNetworks, toToken?.chainId]
+    [toToken, reset]
   )
 
   const onSetSelectedSwapAndSendOption = useCallback((value: string) => {
@@ -465,13 +566,18 @@ export const useSwap = () => {
 
   // Memos
   const fiatValue = useMemo(() => {
-    if (!fromAmount || !fromToken || !spotPriceRegistry) {
+    if (
+      !fromAmount ||
+      !fromToken ||
+      !spotPriceRegistry ||
+      !defaultFiatCurrency
+    ) {
       return
     }
 
     const price = getTokenPriceAmountFromRegistry(spotPriceRegistry, fromToken)
     return new Amount(fromAmount).times(price).formatAsFiat(defaultFiatCurrency)
-  }, [spotPriceRegistry, fromAmount, defaultFiatCurrency])
+  }, [fromAmount, fromToken, spotPriceRegistry, defaultFiatCurrency])
 
   const gasEstimates: GasEstimate = useMemo(() => {
     // TODO(onyb): Setup getGasEstimate Methods
@@ -484,22 +590,12 @@ export const useSwap = () => {
   }, [])
 
   const feesWrapped = useMemo(() => {
-    if (selectedNetwork?.coin === BraveWallet.CoinType.ETH) {
-      if (zeroEx.networkFee.isUndefined()) {
-        return Amount.zero()
-      } else {
-        return zeroEx.networkFee
-      }
-    } else if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-      if (jupiter.networkFee.isUndefined()) {
-        return Amount.zero()
-      } else {
-        return jupiter.networkFee
-      }
+    if (quoteOptions.length) {
+      return quoteOptions[0].networkFee
     }
 
     return Amount.zero()
-  }, [selectedNetwork?.coin, zeroEx.networkFee, jupiter.networkFee])
+  }, [quoteOptions])
 
   const swapValidationError: SwapValidationErrorType | undefined =
     useMemo(() => {
@@ -543,23 +639,23 @@ export const useSwap = () => {
       }
 
       if (
-        fromToken.symbol === selectedNetwork?.symbol &&
+        !fromToken.contractAddress &&
         fromAmountWeiWrapped.plus(feesWrapped).gt(fromAssetBalance)
       ) {
         return 'insufficientFundsForGas'
       }
 
       // 0x specific validations
-      if (selectedNetwork?.coin === BraveWallet.CoinType.ETH) {
-        if (fromToken.contractAddress && !zeroEx.hasAllowance) {
-          return 'insufficientAllowance'
-        }
+      if (
+        quoteUnion?.zeroExQuote &&
+        fromToken.contractAddress &&
+        !zeroEx.hasAllowance
+      ) {
+        return 'insufficientAllowance'
+      }
 
-        if (zeroEx.error === undefined) {
-          return
-        }
-
-        if (zeroEx.error.isInsufficientLiquidity) {
+      if (quoteErrorUnion?.zeroExError) {
+        if (quoteErrorUnion.zeroExError.isInsufficientLiquidity) {
           return 'insufficientLiquidity'
         }
 
@@ -567,19 +663,16 @@ export const useSwap = () => {
       }
 
       // Jupiter specific validations
-      if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-        if (
-          jupiter.error?.isInsufficientLiquidity ||
-          jupiter.quote?.routePlan?.length === 0
-        ) {
+      if (quoteErrorUnion?.jupiterError) {
+        if (quoteErrorUnion.jupiterError.isInsufficientLiquidity) {
           return 'insufficientLiquidity'
         }
 
-        if (jupiter.error === undefined) {
-          return
-        }
-
         return 'unknownError'
+      }
+
+      if (quoteUnion?.jupiterQuote?.routePlan.length === 0) {
+        return 'insufficientLiquidity'
       }
 
       return undefined
@@ -588,34 +681,50 @@ export const useSwap = () => {
       fromAmount,
       toToken,
       toAmount,
-      selectedNetwork,
       feesWrapped,
       zeroEx,
-      jupiter,
       fromAssetBalance,
       nativeAssetBalance
     ])
 
   const onSubmit = useCallback(async () => {
-    if (selectedNetwork?.coin === BraveWallet.CoinType.ETH) {
+    if (!quoteUnion) {
+      return
+    }
+
+    setIsFetchingQuote(true)
+
+    if (quoteUnion.zeroExQuote) {
       if (zeroEx.hasAllowance) {
-        await zeroEx.exchange({}, async function () {
+        const error = await zeroEx.exchange()
+        if (error) {
+          setQuoteErrorUnion(error)
+        } else {
           setFromAmount('')
           setToAmount('')
-        })
+          reset()
+        }
       } else {
-        await zeroEx.approve()
+        await zeroEx.approve(quoteUnion.zeroExQuote)
       }
-    } else if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-      await jupiter.exchange(async function () {
+    }
+
+    if (quoteUnion.jupiterQuote) {
+      const error = await jupiter.exchange(quoteUnion.jupiterQuote)
+      if (error) {
+        setQuoteErrorUnion(error)
+      } else {
         setFromAmount('')
         setToAmount('')
-      })
+        reset()
+      }
     }
-  }, [selectedNetwork?.coin, zeroEx, jupiter])
+
+    setIsFetchingQuote(false)
+  }, [quoteUnion, zeroEx, jupiter, reset])
 
   const submitButtonText = useMemo(() => {
-    if (!fromToken) {
+    if (!fromToken || !fromNetwork) {
       return getLocale('braveSwapReviewOrder')
     }
 
@@ -629,17 +738,15 @@ export const useSwap = () => {
     if (swapValidationError === 'insufficientFundsForGas') {
       return getLocale('braveSwapInsufficientBalance').replace(
         '$1',
-        selectedNetwork?.symbol || ''
+        fromNetwork.symbol
       )
     }
 
-    if (selectedNetwork?.coin === BraveWallet.CoinType.ETH) {
-      if (swapValidationError === 'insufficientAllowance') {
-        return getLocale('braveSwapApproveToken').replace(
-          '$1',
-          fromToken.symbol
-        )
-      }
+    if (
+      fromNetwork.coin === BraveWallet.CoinType.ETH &&
+      swapValidationError === 'insufficientAllowance'
+    ) {
+      return getLocale('braveSwapApproveToken').replace('$1', fromToken.symbol)
     }
 
     if (swapValidationError === 'insufficientLiquidity') {
@@ -647,25 +754,20 @@ export const useSwap = () => {
     }
 
     return getLocale('braveSwapReviewOrder')
-  }, [fromToken, swapValidationError, selectedNetwork, getLocale])
+  }, [fromToken, fromNetwork, swapValidationError, getLocale])
 
   const isSubmitButtonDisabled = useMemo(() => {
     return (
-      !selectedNetwork ||
-      !selectedAccount ||
-      !networkSupportsAccount(selectedNetwork, selectedAccount.accountId) ||
+      !fromNetwork ||
+      !fromAccount ||
+      !networkSupportsAccount(fromNetwork, fromAccount.accountId) ||
+      !toNetwork ||
       // Prevent creating a swap transaction with stale parameters if fetching
       // of a new quote is in progress.
-      zeroEx.loading ||
-      jupiter.loading ||
-      // If 0x swap quote is empty, there's nothing to create the swap
-      // transaction with, so Swap button must be disabled.
-      (selectedNetwork.coin === BraveWallet.CoinType.ETH &&
-        zeroEx.quote === undefined) ||
-      // If Jupiter quote is empty, there's nothing to create the swap
-      // transaction with, so Swap button must be disabled.
-      (selectedNetwork.coin === BraveWallet.CoinType.SOL &&
-        jupiter.quote === undefined) ||
+      isFetchingQuote ||
+      // If quote is not set, there's nothing to create the swap with, so Swap
+      // button must be disabled.
+      quoteUnion === undefined ||
       // FROM/TO assets may be undefined during initialization of the swap
       // assets list.
       fromToken === undefined ||
@@ -685,21 +787,20 @@ export const useSwap = () => {
       // Unless the validation error is insufficientAllowance, in which case
       // the transaction is an ERC20Approve, Swap button must be disabled.
       (swapValidationError &&
-        selectedNetwork.coin === BraveWallet.CoinType.ETH &&
+        fromNetwork.coin === BraveWallet.CoinType.ETH &&
         swapValidationError !== 'insufficientAllowance') ||
-      (swapValidationError && selectedNetwork.coin === BraveWallet.CoinType.SOL)
+      (swapValidationError && fromNetwork.coin === BraveWallet.CoinType.SOL)
     )
   }, [
-    zeroEx.loading,
-    jupiter.loading,
-    zeroEx.quote,
-    jupiter.quote,
-    selectedNetwork,
-    selectedAccount,
+    fromNetwork,
+    fromAccount,
+    toNetwork,
+    isFetchingQuote,
+    quoteUnion,
     fromToken,
     toToken,
-    fromAmount,
     toAmount,
+    fromAmount,
     nativeAssetBalance,
     fromAssetBalance,
     swapValidationError
@@ -707,29 +808,24 @@ export const useSwap = () => {
 
   useEffect(() => {
     const interval = setInterval(async () => {
-      if (selectedNetwork?.coin === BraveWallet.CoinType.SOL) {
-        await handleJupiterQuoteRefresh({})
-      } else {
-        await handleZeroExQuoteRefresh({})
-      }
+      await handleQuoteRefresh({})
     }, 10000)
     return () => {
       clearInterval(interval)
     }
-  }, [
-    selectedNetwork?.coin,
-    handleJupiterQuoteRefresh,
-    handleZeroExQuoteRefresh
-  ])
+  }, [handleQuoteRefresh])
 
   return {
+    fromAccount,
     fromToken,
-    toToken,
     fromAmount,
+    fromNetwork,
+    toNetwork,
+    toToken,
     toAmount,
     fromAssetBalance: fromAssetBalance || Amount.zero(),
     fiatValue,
-    isFetchingQuote: zeroEx.loading || jupiter.loading,
+    isFetchingQuote,
     quoteOptions,
     selectedQuoteOptionIndex: 0,
     selectingFromOrTo,
@@ -742,6 +838,7 @@ export const useSwap = () => {
     slippageTolerance,
     useDirectRoute,
     gasEstimates,
+    swapFees,
     onSelectFromToken,
     onSelectToToken,
     onSelectQuoteOption,
@@ -762,9 +859,6 @@ export const useSwap = () => {
     isSubmitButtonDisabled,
     swapValidationError,
     spotPrices: spotPriceRegistry,
-    selectedNetwork,
-    setSelectedNetwork: setSelectedNetworkState,
-    selectedAccount,
     tokenBalancesRegistry,
     isLoadingBalances
   }

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useZeroEx.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useZeroEx.ts
@@ -3,284 +3,97 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 
 // Types / constants
-import { QuoteOption, SwapParams } from '../constants/types'
+import { SwapParams } from '../constants/types'
 import { BraveWallet } from '../../../../constants/types'
 
 import { MAX_UINT256 } from '../constants/magics'
-import { NATIVE_EVM_ASSET_CONTRACT_ADDRESS } from '../../../../common/constants/magics'
 
 // Utils
 import Amount from '../../../../utils/amount'
 import { hexStrToNumberArray } from '../../../../utils/hex-utils'
-import { getTokenPriceAmountFromRegistry } from '../../../../utils/pricing-utils'
-import { makeNetworkAsset } from '../../../../options/asset-options'
 import { toMojoUnion } from '../../../../utils/mojo-utils'
 
 // Query hooks
 import {
   useApproveERC20AllowanceMutation,
-  useGenerateBraveSwapFeeMutation,
-  useGenerateSwapQuoteMutation,
   useGenerateSwapTransactionMutation,
-  useGetDefaultFiatCurrencyQuery,
   useLazyGetERC20AllowanceQuery,
   useSendEvmTransactionMutation
 } from '../../../../common/slices/api.slice'
 
 export function useZeroEx(params: SwapParams) {
-  const { selectedNetwork, selectedAccount } = params
+  const {
+    fromAccount,
+    fromToken,
+    fromNetwork,
+    fromAmount,
+    toAccountId,
+    toToken,
+    toAmount,
+    slippageTolerance
+  } = params
 
   // Queries
   const [getERC20Allowance] = useLazyGetERC20AllowanceQuery()
-  // FIXME(onyb): what happens when defaultFiatCurrency is empty
-  const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()
-  const nativeAsset = useMemo(
-    () => makeNetworkAsset(selectedNetwork),
-    [selectedNetwork]
-  )
 
   // Mutations
   const [sendEvmTransaction] = useSendEvmTransactionMutation()
   const [approveERC20Allowance] = useApproveERC20AllowanceMutation()
-  const [generateSwapQuote] = useGenerateSwapQuoteMutation()
-  const [generateBraveSwapFee] = useGenerateBraveSwapFeeMutation()
   const [generateSwapTransaction] = useGenerateSwapTransactionMutation()
 
   // State
-  const [quote, setQuote] = useState<BraveWallet.ZeroExQuote | undefined>(
-    undefined
-  )
-  const [error, setError] = useState<BraveWallet.ZeroExError | undefined>(
-    undefined
-  )
   const [hasAllowance, setHasAllowance] = useState<boolean>(false)
-  const [loading, setLoading] = useState<boolean>(false)
-  const [braveFee, setBraveFee] = useState<
-    BraveWallet.BraveSwapFeeResponse | undefined
-  >(undefined)
-  const [abortController, setAbortController] = useState<
-    AbortController | undefined
-  >(undefined)
 
-  const reset = useCallback(
-    async (callback?: () => Promise<void>) => {
-      setQuote(undefined)
-      setError(undefined)
-      setLoading(false)
-      setBraveFee(undefined)
-      if (abortController) {
-        abortController.abort()
-      }
-
-      if (callback) {
-        await callback()
-      }
-    },
-    [abortController]
-  )
-
-  const refresh = useCallback(
-    async function (
-      overrides: Partial<SwapParams> = {}
-    ): Promise<BraveWallet.ZeroExQuote | undefined> {
-      const overriddenParams: SwapParams = {
-        ...params,
-        ...overrides
-      }
-
-      // Perform data validation and early-exit
-      if (selectedNetwork?.coin !== BraveWallet.CoinType.ETH) {
-        return
-      }
-      if (!overriddenParams.fromToken || !overriddenParams.toToken) {
-        return
-      }
-      if (!overriddenParams.fromAmount && !overriddenParams.toAmount) {
-        await reset()
-        return
-      }
-      const fromAmountWrapped = new Amount(overriddenParams.fromAmount)
-      const toAmountWrapped = new Amount(overriddenParams.toAmount)
-      const isFromAmountEmpty =
-        fromAmountWrapped.isZero() ||
-        fromAmountWrapped.isNaN() ||
-        fromAmountWrapped.isUndefined()
-      const isToAmountEmpty =
-        toAmountWrapped.isZero() ||
-        toAmountWrapped.isNaN() ||
-        toAmountWrapped.isUndefined()
-
-      if (isFromAmountEmpty && isToAmountEmpty) {
-        await reset()
+  const checkAllowance = useCallback(
+    async (zeroExQuote: BraveWallet.ZeroExQuote) => {
+      if (!fromAccount || !fromToken) {
         return
       }
 
-      if (!overriddenParams.fromAccount) {
+      if (!fromToken.contractAddress) {
+        setHasAllowance(true)
         return
-      }
-
-      const controller = new AbortController()
-      setAbortController(controller)
-
-      setLoading(true)
-
-      let quoteResponse
-      try {
-        quoteResponse = await generateSwapQuote({
-          fromAccountId: overriddenParams.fromAccount.accountId,
-          fromChainId: selectedNetwork.chainId,
-          fromAmount:
-            overriddenParams.fromAmount &&
-            new Amount(overriddenParams.fromAmount)
-              .multiplyByDecimals(overriddenParams.fromToken.decimals)
-              .format(),
-          fromToken:
-            overriddenParams.fromToken.contractAddress ||
-            NATIVE_EVM_ASSET_CONTRACT_ADDRESS,
-
-          toAccountId: overriddenParams.fromAccount.accountId,
-          toChainId: selectedNetwork.chainId,
-          toAmount:
-            overriddenParams.toAmount &&
-            new Amount(overriddenParams.toAmount)
-              .multiplyByDecimals(overriddenParams.toToken.decimals)
-              .format(),
-          toToken:
-            overriddenParams.toToken.contractAddress ||
-            NATIVE_EVM_ASSET_CONTRACT_ADDRESS,
-          slippagePercentage: overriddenParams.slippageTolerance,
-          routePriority: BraveWallet.RoutePriority.kRecommended
-        }).unwrap()
-      } catch (e) {
-        console.log(`Error getting 0x quote: ${e}`)
       }
 
       try {
-        const { response: braveFeeResponse } = await generateBraveSwapFee({
-          chainId: selectedNetwork.chainId,
-          inputToken:
-            overriddenParams.fromToken.contractAddress ||
-            NATIVE_EVM_ASSET_CONTRACT_ADDRESS,
-          outputToken:
-            overriddenParams.toToken.contractAddress ||
-            NATIVE_EVM_ASSET_CONTRACT_ADDRESS,
-          taker: overriddenParams.fromAccount.address
+        const allowance = await getERC20Allowance({
+          contractAddress: zeroExQuote.sellTokenAddress,
+          ownerAddress: fromAccount.address,
+          spenderAddress: zeroExQuote.allowanceTarget,
+          chainId: fromToken.chainId
         }).unwrap()
 
-        if (quoteResponse?.response?.zeroExQuote && braveFeeResponse) {
-          setBraveFee({
-            ...braveFeeResponse,
-            protocolFeePct: quoteResponse.response.zeroExQuote.fees.zeroExFee
-              ? braveFeeResponse.protocolFeePct
-              : '0'
-          })
-        }
+        setHasAllowance(new Amount(allowance).gte(zeroExQuote.sellAmount))
       } catch (e) {
-        console.log(
-          `Error getting Brave fee (0x):
-          ${overriddenParams.toToken.symbol}`
-        )
+        // bubble up error
+        console.log(`Error getting ERC20 allowance: ${e}`)
+        setHasAllowance(false)
       }
-
-      let hasAllowanceResult = false
-
-      // Native asset does not have allowance requirements, so we always
-      // default to true.
-      if (!overriddenParams.fromToken.contractAddress) {
-        hasAllowanceResult = true
-      }
-
-      // Simulate that the token has enough allowance if the wallet is not
-      // connected yet.
-      if (!selectedAccount) {
-        hasAllowanceResult = true
-      }
-
-      if (
-        selectedAccount &&
-        quoteResponse?.response?.zeroExQuote &&
-        overriddenParams.fromToken.contractAddress
-      ) {
-        try {
-          const allowance = await getERC20Allowance({
-            contractAddress:
-              quoteResponse.response.zeroExQuote.sellTokenAddress,
-            ownerAddress: selectedAccount.address,
-            spenderAddress: quoteResponse.response.zeroExQuote.allowanceTarget,
-            chainId: selectedNetwork.chainId
-          }).unwrap()
-          hasAllowanceResult = new Amount(allowance).gte(
-            quoteResponse.response.zeroExQuote.sellAmount
-          )
-        } catch (e) {
-          // bubble up error
-          console.log(`Error getting ERC20 allowance: ${e}`)
-        }
-      }
-
-      if (controller.signal.aborted) {
-        setLoading(false)
-        setAbortController(undefined)
-        return
-      }
-
-      if (quoteResponse?.response?.zeroExQuote) {
-        setQuote(quoteResponse.response.zeroExQuote)
-      }
-
-      if (quoteResponse?.error) {
-        setError(quoteResponse.error.zeroExError)
-      }
-
-      setHasAllowance(hasAllowanceResult)
-
-      setLoading(false)
-      setAbortController(undefined)
-
-      // Return undefined if response is null.
-      return quoteResponse?.response?.zeroExQuote || undefined
     },
-    [
-      params,
-      selectedNetwork,
-      selectedAccount,
-      reset,
-      generateSwapQuote,
-      generateBraveSwapFee,
-      getERC20Allowance
-    ]
+    [fromAccount, fromToken, getERC20Allowance]
   )
 
   const exchange = useCallback(
-    async function (
-      overrides: Partial<SwapParams> = {},
-      callback?: () => Promise<void>
-    ) {
-      const overriddenParams: SwapParams = {
-        ...params,
-        ...overrides
-      }
-
-      // Perform data validation and early-exit
-      if (selectedNetwork?.coin !== BraveWallet.CoinType.ETH) {
-        return
-      }
-      if (!selectedAccount) {
-        // Wallet is not connected
-        return
-      }
-      if (!overriddenParams.fromToken || !overriddenParams.toToken) {
-        return
-      }
-      if (!overriddenParams.fromAmount && !overriddenParams.toAmount) {
+    async function () {
+      if (
+        !fromAccount ||
+        !toAccountId ||
+        !fromToken ||
+        !toToken ||
+        !fromNetwork
+      ) {
         return
       }
 
-      const fromAmountWrapped = new Amount(overriddenParams.fromAmount)
-      const toAmountWrapped = new Amount(overriddenParams.toAmount)
+      if (!fromAmount && !toAmount) {
+        return
+      }
+
+      const fromAmountWrapped = new Amount(fromAmount)
+      const toAmountWrapped = new Amount(toAmount)
       const isFromAmountEmpty =
         fromAmountWrapped.isZero() ||
         fromAmountWrapped.isNaN() ||
@@ -294,38 +107,29 @@ export function useZeroEx(params: SwapParams) {
         return
       }
 
-      if (!overriddenParams.fromAccount) {
-        return
-      }
-
-      setLoading(true)
       let transactionResponse
       try {
         transactionResponse = await generateSwapTransaction(
           toMojoUnion(
             {
               zeroExTransactionParams: {
-                fromAccountId: overriddenParams.fromAccount.accountId,
-                fromChainId: selectedNetwork.chainId,
-                fromAmount: new Amount(overriddenParams.fromAmount)
-                  .multiplyByDecimals(overriddenParams.fromToken.decimals)
+                fromAccountId: fromAccount.accountId,
+                fromChainId: fromToken.chainId,
+                fromAmount: fromAmount && new Amount(fromAmount)
+                  .multiplyByDecimals(fromToken.decimals)
                   .format(),
-                fromToken:
-                  overriddenParams.fromToken.contractAddress ||
-                  NATIVE_EVM_ASSET_CONTRACT_ADDRESS,
-
-                toAccountId: overriddenParams.fromAccount.accountId,
-                toChainId: selectedNetwork.chainId,
-                toAmount: new Amount(overriddenParams.toAmount)
-                  .multiplyByDecimals(overriddenParams.toToken.decimals)
+                fromToken: fromToken.contractAddress,
+                toAccountId,
+                toChainId: toToken.chainId,
+                toAmount: toAmount && new Amount(toAmount)
+                  .multiplyByDecimals(toToken.decimals)
                   .format(),
-                toToken:
-                  overriddenParams.toToken.contractAddress ||
-                  NATIVE_EVM_ASSET_CONTRACT_ADDRESS,
-                slippagePercentage: overriddenParams.slippageTolerance,
+                toToken: toToken.contractAddress,
+                slippagePercentage: slippageTolerance,
                 routePriority: BraveWallet.RoutePriority.kRecommended
               },
-              jupiterTransactionParams: undefined
+              jupiterTransactionParams: undefined,
+              lifiTransactionParams: undefined
             },
             'zeroExTransactionParams'
           )
@@ -334,12 +138,11 @@ export function useZeroEx(params: SwapParams) {
         console.log(`Error getting 0x swap quote: ${e}`)
       }
 
-      if (transactionResponse?.error?.zeroExError) {
-        setError(transactionResponse?.error.zeroExError)
+      if (transactionResponse?.error) {
+        return transactionResponse?.error
       }
 
       if (!transactionResponse?.response?.zeroExTransaction) {
-        setLoading(false)
         return
       }
 
@@ -348,147 +151,68 @@ export function useZeroEx(params: SwapParams) {
 
       try {
         await sendEvmTransaction({
-          fromAccount: selectedAccount,
+          fromAccount,
           to,
           value: new Amount(value).toHex(),
           gas: new Amount(estimatedGas).toHex(),
           data: hexStrToNumberArray(data),
-          network: selectedNetwork
+          network: fromNetwork
         })
-
-        await reset(callback)
       } catch (e) {
         // bubble up error
         console.error(`Error creating 0x transaction: ${e}`)
-        setLoading(false)
       }
+
+      return undefined
     },
     [
-      params,
-      selectedNetwork,
-      selectedAccount,
+      fromAccount,
+      fromAmount,
+      fromNetwork,
+      fromToken,
       generateSwapTransaction,
       sendEvmTransaction,
-      reset
+      slippageTolerance,
+      toAccountId,
+      toAmount,
+      toToken
     ]
   )
 
-  const approve = useCallback(async () => {
-    if (!quote || hasAllowance) {
-      return
-    }
-
-    // Typically when wallet has not been connected yet
-    if (!selectedAccount || !selectedNetwork) {
-      return
-    }
-
-    const { allowanceTarget, sellTokenAddress } = quote
-    try {
-      await approveERC20Allowance({
-        network: selectedNetwork,
-        fromAccount: selectedAccount,
-        contractAddress: sellTokenAddress,
-        spenderAddress: allowanceTarget,
-
-        // FIXME(onyb): reduce allowance to the minimum required amount
-        // for security reasons.
-        allowance: new Amount(MAX_UINT256).toHex()
-      })
-    } catch (e) {
-      // bubble up error
-      console.error(`Error creating ERC20 approve transaction: ${e}`)
-    }
-  }, [
-    quote,
-    hasAllowance,
-    selectedAccount,
-    selectedNetwork,
-    approveERC20Allowance
-  ])
-
-  const networkFee = useMemo(() => {
-    if (!quote || !selectedNetwork?.decimals) {
-      return Amount.empty()
-    }
-
-    return new Amount(quote.gasPrice)
-      .times(quote.gas)
-      .divideByDecimals(selectedNetwork.decimals)
-  }, [quote, selectedNetwork?.decimals])
-
-  const quoteOptions: QuoteOption[] = useMemo(() => {
-    if (
-      !params.fromToken ||
-      !params.toToken ||
-      !params.spotPrices ||
-      !nativeAsset
-    ) {
-      return []
-    }
-
-    if (quote === undefined) {
-      return []
-    }
-
-    return [
-      {
-        label: '',
-        fromAmount: new Amount(quote.sellAmount).divideByDecimals(
-          params.fromToken.decimals
-        ),
-        toAmount: new Amount(quote.buyAmount).divideByDecimals(
-          params.toToken.decimals
-        ),
-        minimumToAmount: undefined,
-        fromToken: params.fromToken,
-        toToken: params.toToken,
-        rate: new Amount(quote.buyAmount)
-          .divideByDecimals(params.toToken.decimals)
-          .div(
-            new Amount(quote.sellAmount).divideByDecimals(
-              params.fromToken.decimals
-            )
-          ),
-        impact: new Amount(quote.estimatedPriceImpact),
-        sources: quote.sources
-          .map((source) => ({
-            name: source.name,
-            proportion: new Amount(source.proportion)
-          }))
-          .filter((source) => source.proportion.gt(0)),
-        routing: 'split', // 0x supports split routing only
-        networkFee: networkFee.isUndefined()
-          ? ''
-          : networkFee
-              .times(
-                getTokenPriceAmountFromRegistry(params.spotPrices, nativeAsset)
-              )
-              .formatAsFiat(defaultFiatCurrency),
-        braveFee
+  const approve = useCallback(
+    async (quote: BraveWallet.ZeroExQuote) => {
+      if (hasAllowance) {
+        return
       }
-    ]
-  }, [
-    params.fromToken,
-    params.toToken,
-    quote,
-    defaultFiatCurrency,
-    networkFee,
-    params.spotPrices,
-    braveFee,
-    nativeAsset
-  ])
+
+      if (!fromAccount || !fromNetwork) {
+        return
+      }
+
+      const { allowanceTarget, sellTokenAddress } = quote
+      try {
+        await approveERC20Allowance({
+          network: fromNetwork,
+          fromAccount,
+          contractAddress: sellTokenAddress,
+          spenderAddress: allowanceTarget,
+
+          // FIXME(onyb): reduce allowance to the minimum required amount
+          // for security reasons.
+          allowance: new Amount(MAX_UINT256).toHex()
+        })
+      } catch (e) {
+        // bubble up error
+        console.error(`Error creating ERC20 approve transaction: ${e}`)
+      }
+    },
+    [approveERC20Allowance, fromAccount, fromNetwork, hasAllowance]
+  )
 
   return {
-    quote,
-    error,
+    checkAllowance,
     hasAllowance,
-    loading,
     exchange,
-    refresh,
-    reset,
-    approve,
-    quoteOptions,
-    networkFee
+    approve
   }
 }

--- a/components/brave_wallet_ui/page/screens/swap/swap.utils.ts
+++ b/components/brave_wallet_ui/page/screens/swap/swap.utils.ts
@@ -1,0 +1,193 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import { BraveWallet, SpotPriceRegistry } from '../../../constants/types'
+import { QuoteOption } from './constants/types'
+
+// Utils
+import Amount from '../../../utils/amount'
+import { getTokenPriceAmountFromRegistry } from '../../../utils/pricing-utils'
+import { makeNetworkAsset } from '../../../options/asset-options'
+
+function getZeroExNetworkFee({
+  quote,
+  fromNetwork
+}: {
+  quote: BraveWallet.ZeroExQuote
+  fromNetwork: BraveWallet.NetworkInfo
+}): Amount {
+  if (!fromNetwork) {
+    return Amount.empty()
+  }
+
+  return new Amount(quote.gasPrice)
+    .times(quote.gas)
+    .divideByDecimals(fromNetwork.decimals)
+}
+
+export function getZeroExFromAmount({
+  quote,
+  fromToken
+}: {
+  quote: BraveWallet.ZeroExQuote
+  fromToken: BraveWallet.BlockchainToken
+}): Amount {
+  return new Amount(quote.sellAmount).divideByDecimals(fromToken.decimals)
+}
+
+export function getZeroExToAmount({
+  quote,
+  toToken
+}: {
+  quote: BraveWallet.ZeroExQuote
+  toToken: BraveWallet.BlockchainToken
+}): Amount {
+  return new Amount(quote.buyAmount).divideByDecimals(toToken.decimals)
+}
+
+export function getZeroExQuoteOptions({
+  quote,
+  fromNetwork,
+  fromToken,
+  toToken,
+  spotPrices,
+  defaultFiatCurrency
+}: {
+  quote: BraveWallet.ZeroExQuote
+  fromNetwork: BraveWallet.NetworkInfo
+  fromToken: BraveWallet.BlockchainToken
+  toToken: BraveWallet.BlockchainToken
+  spotPrices: SpotPriceRegistry
+  defaultFiatCurrency: string
+}): QuoteOption[] {
+  const networkFee = getZeroExNetworkFee({ quote, fromNetwork })
+
+  return [
+    {
+      fromAmount: new Amount(quote.sellAmount).divideByDecimals(
+        fromToken.decimals
+      ),
+      toAmount: getZeroExToAmount({ quote, toToken }),
+      minimumToAmount: undefined,
+      fromToken,
+      toToken,
+      rate: new Amount(quote.buyAmount)
+        .divideByDecimals(toToken.decimals)
+        .div(new Amount(quote.sellAmount).divideByDecimals(fromToken.decimals)),
+      impact: new Amount(quote.estimatedPriceImpact),
+      sources: quote.sources
+        .map((source) => ({
+          name: source.name,
+          proportion: new Amount(source.proportion)
+        }))
+        .filter((source) => source.proportion.gt(0)),
+      routing: 'split', // 0x supports split routing only
+      networkFee,
+      networkFeeFiat: networkFee.isUndefined()
+        ? ''
+        : networkFee
+            .times(
+              getTokenPriceAmountFromRegistry(
+                spotPrices,
+                makeNetworkAsset(fromNetwork)
+              )
+            )
+            .formatAsFiat(defaultFiatCurrency)
+    }
+  ]
+}
+
+function getJupiterNetworkFee({
+  quote,
+  fromNetwork
+}: {
+  quote: BraveWallet.JupiterQuote
+  fromNetwork: BraveWallet.NetworkInfo
+}): Amount {
+  if (!fromNetwork) {
+    return Amount.empty()
+  }
+
+  return new Amount('0.000005')
+}
+
+export function getJupiterFromAmount({
+  quote,
+  fromToken
+}: {
+  quote: BraveWallet.JupiterQuote
+  fromToken: BraveWallet.BlockchainToken
+}): Amount {
+  return new Amount(quote.inAmount).divideByDecimals(fromToken.decimals)
+}
+
+export function getJupiterToAmount({
+  quote,
+  toToken
+}: {
+  quote: BraveWallet.JupiterQuote
+  toToken: BraveWallet.BlockchainToken
+}): Amount {
+  return new Amount(quote.outAmount).divideByDecimals(toToken.decimals)
+}
+
+export function getJupiterQuoteOptions({
+  quote,
+  fromNetwork,
+  fromToken,
+  toToken,
+  spotPrices,
+  defaultFiatCurrency
+}: {
+  quote: BraveWallet.JupiterQuote
+  fromNetwork: BraveWallet.NetworkInfo
+  fromToken: BraveWallet.BlockchainToken
+  toToken: BraveWallet.BlockchainToken
+  spotPrices: SpotPriceRegistry
+  defaultFiatCurrency: string
+}): QuoteOption[] {
+  const networkFee = getJupiterNetworkFee({ quote, fromNetwork })
+
+  return [
+    {
+      fromAmount: new Amount(quote.inAmount).divideByDecimals(
+        fromToken.decimals
+      ),
+      toAmount: getJupiterToAmount({ quote, toToken }),
+      // TODO: minimumToAmount is applicable only for ExactIn swapMode.
+      // Create a maximumFromAmount field for ExactOut swapMode if needed.
+      minimumToAmount: new Amount(quote.otherAmountThreshold).divideByDecimals(
+        toToken.decimals
+      ),
+      fromToken,
+      toToken,
+      rate: new Amount(quote.outAmount)
+        .divideByDecimals(toToken.decimals)
+        .div(new Amount(quote.inAmount).divideByDecimals(fromToken.decimals)),
+      impact: new Amount(quote.priceImpactPct),
+      sources: [
+        ...new Set(quote.routePlan.map((step) => step.swapInfo.label))
+      ].map((name) => ({
+        name,
+        // Jupiter doesn't provide split routing, so we assume 100% from each
+        // source.
+        proportion: new Amount(1)
+      })),
+      // TODO(onyb): this is a placeholder value until we have a better
+      // routing UI
+      routing: 'flow',
+      networkFee,
+      networkFeeFiat: networkFee.isUndefined()
+        ? ''
+        : networkFee
+            .times(
+              getTokenPriceAmountFromRegistry(
+                spotPrices,
+                makeNetworkAsset(fromNetwork)
+              )
+            )
+            .formatAsFiat(defaultFiatCurrency)
+    }
+  ]
+}

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -886,7 +886,6 @@
   <message name="IDS_BRAVE_SWAP_MINIMUM_RECEIVED_AFTER_SLIPPAGE" desc="Minimum guaranteed amount user will get after the swap">Minimum received after slippage</message>
   <message name="IDS_BRAVE_SWAP_NETWORK_FEE" desc="Text indicating network fees">Network fee</message>
   <message name="IDS_BRAVE_SWAP_BRAVE_FEE" desc="Text indicating Brave fee for swaps">Brave fee</message>
-  <message name="IDS_BRAVE_SWAP_PROTOCOL_FEE" desc="Text indicating protocol fee for swaps">Protocol fee</message>
   <message name="IDS_BRAVE_SWAP_FREE" desc="Text indicating free Brave fees for swaps">Free</message>
   <message name="IDS_BRAVE_SWAP_LIQUIDITY_PROVIDER" desc="Liquidity provider for the swap quote">Liquidity provider</message>
   <message name="IDS_BRAVE_SWAP_SWAP_AND_SEND" desc="Swap and send to a specific address in one transaction">Swap &amp; send</message>

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/BuySendSwap/SwapCryptoView.swift
@@ -241,6 +241,9 @@ struct SwapCryptoView: View {
 
   /// The DEX Aggregator for the current network.
   var dexAggregator: DEXAggregator {
+    // TODO(stephenheaps): Once LiFiQuote is supported, we need to
+    // update this disclaimer to include LiFi description & privacy
+    // policy https://github.com/brave/brave-browser/issues/36436
     networkStore.defaultSelectedChain.coin == .sol ? .jupiter : .zeroX
   }
 
@@ -537,7 +540,7 @@ struct SwapCryptoView: View {
   }
 
   @ViewBuilder private var feesFooter: some View {
-    if swapTokensStore.braveFeeForDisplay != nil || swapTokensStore.protocolFeeForDisplay != nil {
+    if swapTokensStore.braveFeeForDisplay != nil {
       VStack(spacing: 4) {
         if let braveFeeForDisplay = swapTokensStore.braveFeeForDisplay {
           if swapTokensStore.isBraveFeeVoided {
@@ -550,9 +553,6 @@ struct SwapCryptoView: View {
           } else {
             Text(String.localizedStringWithFormat(Strings.Wallet.braveFeeLabel, braveFeeForDisplay))
           }
-        }
-        if let protocolFee = swapTokensStore.protocolFeeForDisplay {
-          Text(String.localizedStringWithFormat(Strings.Wallet.protocolFeeLabel, protocolFee))
         }
       }
       .font(.footnote)

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SwapTokenStore.swift
@@ -57,10 +57,6 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   @Published var sellAmount = "" {
     didSet {
       if sellAmount != oldValue {
-        // sell amount changed, new quotes are needed
-        zeroExQuote = nil
-        jupiterQuote = nil
-        braveFee = nil
         // price quote requested for a different amount
         priceQuoteTask?.cancel()
       }
@@ -83,6 +79,10 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   /// The buy amount in this swap
   @Published var buyAmount = "" {
     didSet {
+      if buyAmount != oldValue {
+        // price quote requested for a different amount
+        priceQuoteTask?.cancel()
+      }
       guard !buyAmount.isEmpty, BDouble(buyAmount.normalizedDecimals) != nil else {
         state = .idle
         return
@@ -119,47 +119,42 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   @Published var isMakingTx = false
   /// A boolean indicating if this store is fetching updated price quote
   @Published var isUpdatingPriceQuote = false
-  /// The brave fee for the current price quote
-  @Published var braveFee: BraveWallet.BraveSwapFeeResponse?
-  /// The ZeroExQuote / price quote currently being displayed for Ethereum swap.
-  /// The quote needs preserved to know when to show `protocolFeesForDisplay` fees.
-  @Published var zeroExQuote: BraveWallet.ZeroExQuote?
+
+  struct CurrentSwapQuoteInfo {
+    /// If the quote was fetched based on sell/from amount or buy/to amount.
+    /// This needs stored so we can generate the Eth Swap Tx using the same
+    /// values as we fetched the quote for (support `exactOut` mode with 0x).
+    let base: SwapParamsBase
+    /// The current swap price quote
+    let swapQuote: BraveWallet.SwapQuoteUnion?
+    /// The swap fees for the current price quote
+    let swapFees: BraveWallet.SwapFees?
+  }
+  /// The details for the current swap quote on display
+  @Published var currentSwapQuoteInfo: CurrentSwapQuoteInfo?
 
   /// If the Brave Fee is voided for this swap.
   var isBraveFeeVoided: Bool {
-    guard let braveFee else { return false }
-    return braveFee.discountCode != .none && !braveFee.hasBraveFee
+    guard let swapFees = currentSwapQuoteInfo?.swapFees else { return false }
+    return swapFees.discountCode != .none && !swapFees.hasBraveFee
   }
 
   /// The brave fee percentage for this swap.
   /// When `isBraveFeeVoided`, will return the fee being voided (so Free can be displayed beside % value voided)
   var braveFeeForDisplay: String? {
-    guard let braveFee else { return nil }
+    guard let swapFees = currentSwapQuoteInfo?.swapFees else { return nil }
     let fee: String
-    if braveFee.discountCode == .none {
-      fee = braveFee.effectiveFeePct
+    if swapFees.discountCode == .none {
+      fee = swapFees.effectiveFeePct
     } else {
-      if braveFee.hasBraveFee {
-        fee = braveFee.effectiveFeePct
+      if swapFees.hasBraveFee {
+        fee = swapFees.effectiveFeePct
       } else {
-        // Display as `Free ~braveFee.braveFeePct%~`
-        fee = braveFee.braveFeePct
+        // Display as `Free ~braveFee.feePct%~`
+        fee = swapFees.feePct
       }
     }
     return String(format: "%@%%", fee.trimmingTrailingZeros)
-  }
-
-  /// The protocol fee percentage for this swap
-  var protocolFeeForDisplay: String? {
-    guard let braveFee,
-      let protocolFeePct = Double(braveFee.protocolFeePct),
-      !protocolFeePct.isZero
-    else { return nil }
-    if let zeroExQuote, zeroExQuote.fees.zeroExFee == nil {
-      // `protocolFeePct` should only be surfaced to users if `zeroExFee` is non-null.
-      return nil
-    }
-    return String(format: "%@%%", braveFee.protocolFeePct.trimmingTrailingZeros)
   }
 
   private let keyringService: BraveWalletKeyringService
@@ -189,8 +184,6 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   private let daiSymbol = "DAI"
   private let usdcSymbol = "USDC"
   private var prefilledToken: BraveWallet.BlockchainToken?
-  /// The JupiterQuote currently being displayed for Solana swap. The quote needs preserved to create the swap transaction.
-  private var jupiterQuote: BraveWallet.JupiterQuote?
   private var keyringServiceObserver: KeyringServiceObserver?
   private var rpcServiceObserver: JsonRpcServiceObserver?
 
@@ -380,8 +373,14 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     return swapQuoteParams
   }
 
+  private func clearAllAmount() {
+    sellAmount = ""
+    buyAmount = ""
+    selectedFromTokenPrice = "0"
+  }
+
   @MainActor private func createEthSwapTransaction() async -> Bool {
-    guard let accountInfo = self.accountInfo else {
+    guard let currentSwapQuoteInfo, let accountInfo else {
       self.state = .error(Strings.Wallet.unknownError)
       self.clearAllAmount()
       return false
@@ -390,7 +389,9 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     defer { self.isMakingTx = false }
     let coin = accountInfo.coin
     let network = await rpcService.network(coin: coin, origin: nil)
-    guard let swapQuoteParams = self.swapQuoteParameters(for: .perSellAsset, in: network) else {
+    guard
+      let swapQuoteParams = self.swapQuoteParameters(for: currentSwapQuoteInfo.base, in: network)
+    else {
       self.state = .error(Strings.Wallet.unknownError)
       self.clearAllAmount()
       return false
@@ -457,75 +458,6 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
       }
       return success
     }
-  }
-
-  private func clearAllAmount() {
-    sellAmount = ""
-    buyAmount = ""
-    selectedFromTokenPrice = "0"
-  }
-
-  /// Update price market and sell/buy amount fields based on `SwapParamsBase`
-  @MainActor private func handleEthPriceQuoteResponse(
-    _ response: BraveWallet.ZeroExQuote,
-    base: SwapParamsBase,
-    swapQuoteParams: BraveWallet.SwapQuoteParams
-  ) async {
-    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
-    switch base {
-    case .perSellAsset:
-      var decimal = 18
-      if let buyToken = selectedToToken {
-        decimal = Int(buyToken.decimals)
-      }
-      let decimalString =
-        weiFormatter.decimalString(for: response.buyAmount, decimals: decimal) ?? ""
-      if let bv = BDouble(decimalString) {
-        buyAmount = bv.decimalDescription
-      }
-    case .perBuyAsset:
-      var decimal = 18
-      if let sellToken = selectedFromToken {
-        decimal = Int(sellToken.decimals)
-      }
-      let decimalString =
-        weiFormatter.decimalString(for: response.sellAmount, decimals: decimal) ?? ""
-      if let bv = BDouble(decimalString) {
-        sellAmount = bv.decimalDescription
-      }
-    }
-
-    if let bv = BDouble(response.price) {
-      switch base {
-      case .perSellAsset:
-        selectedFromTokenPrice = bv.decimalDescription
-      case .perBuyAsset:
-        // will need to invert price if price quote is based on buyAmount
-        if bv != 0 {
-          selectedFromTokenPrice = (1 / bv).decimalDescription
-        }
-      }
-    }
-
-    self.zeroExQuote = response
-    let network = await rpcService.network(coin: selectedFromToken?.coin ?? .eth, origin: nil)
-    let (braveSwapFeeResponse, _) = await swapService.braveFee(
-      params: .init(
-        chainId: network.chainId,
-        inputToken: swapQuoteParams.fromToken,
-        outputToken: swapQuoteParams.toToken,
-        taker: swapQuoteParams.fromAccountId.address
-      )
-    )
-    if let braveSwapFeeResponse {
-      self.braveFee = braveSwapFeeResponse
-    } else {
-      self.state = .error(Strings.Wallet.unknownError)
-      self.clearAllAmount()
-      return
-    }
-
-    await checkBalanceShowError(swapResponse: response)
   }
 
   @MainActor private func createERC20ApprovalTransaction(
@@ -642,12 +574,12 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     return bumpedValue.rounded().asString(radix: 16)
   }
 
-  @MainActor private func checkBalanceShowError(swapResponse: BraveWallet.ZeroExQuote) async {
+  @MainActor private func checkBalanceShowError(zeroExQuote: BraveWallet.ZeroExQuote) async {
     guard
       let accountInfo = accountInfo,
       let sellAmountValue = BDouble(sellAmount.normalizedDecimals),
-      let gasLimit = BDouble(swapResponse.estimatedGas),
-      let gasPrice = BDouble(swapResponse.gasPrice, over: "1000000000000000000"),
+      let gasLimit = BDouble(zeroExQuote.estimatedGas),
+      let gasPrice = BDouble(zeroExQuote.gasPrice, over: "1000000000000000000"),
       let fromToken = selectedFromToken,
       let fromTokenBalance = selectedFromTokenBalance
     else { return }
@@ -690,7 +622,7 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
         await self.checkAllowance(
           network: network,
           ownerAddress: accountInfo.address,
-          spenderAddress: swapResponse.allowanceTarget,
+          spenderAddress: zeroExQuote.allowanceTarget,
           amountToSend: sellAmountValue,
           fromToken: fromToken
         )
@@ -730,50 +662,126 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     self.state = .lowAllowance(spenderAddress)
   }
 
-  @MainActor private func fetchSolPriceQuote(
-    swapQuoteParams: BraveWallet.SwapQuoteParams,
-    network: BraveWallet.NetworkInfo
+  // MARK: Price Quotes
+
+  @MainActor private func fetchEthPriceQuote(
+    base: SwapParamsBase,
+    swapQuoteParams: BraveWallet.SwapQuoteParams
   ) async {
     self.isUpdatingPriceQuote = true
-    let (swapQuoteUnion, swapQuoteErrorUnion, _) = await swapService.quote(params: swapQuoteParams)
     defer { self.isUpdatingPriceQuote = false }
+    let (swapQuoteUnion, swapFees, swapQuoteErrorUnion, _) = await swapService.quote(
+      params: swapQuoteParams
+    )
     guard !Task.isCancelled else { return }
-    if let jupiterQuote = swapQuoteUnion?.jupiterQuote {
-      await self.handleSolPriceQuoteResponse(jupiterQuote, swapQuoteParams: swapQuoteParams)
-    } else if let swapErrorResponse = swapQuoteErrorUnion?.jupiterError {
-      // check balance first because error can be caused by insufficient balance
-      if let sellTokenBalance = self.selectedFromTokenBalance,
-        let sellAmountValue = BDouble(self.sellAmount.normalizedDecimals),
-        sellTokenBalance < sellAmountValue
-      {
-        self.state = .error(Strings.Wallet.insufficientBalance)
-        return
-      }
-      // check if jupiterQuote fails due to insufficient liquidity
-      if swapErrorResponse.isInsufficientLiquidity {
-        self.state = .error(Strings.Wallet.insufficientLiquidity)
-        return
-      }
+    self.currentSwapQuoteInfo = .init(
+      base: base,
+      swapQuote: swapQuoteUnion,
+      swapFees: swapFees
+    )
+    if let swapQuoteUnion = swapQuoteUnion {
+      await self.handleSwapQuote(base: base, swapQuoteUnion: swapQuoteUnion)
+    } else if let swapQuoteErrorUnion = swapQuoteErrorUnion {
+      await self.handleSwapQuoteError(swapQuoteErrorUnion)
+    } else {  // unknown error, ex failed parsing zerox quote.
       self.state = .error(Strings.Wallet.unknownError)
       self.clearAllAmount()
+    }
+  }
+
+  @MainActor private func fetchSolPriceQuote(
+    base: SwapParamsBase,
+    swapQuoteParams: BraveWallet.SwapQuoteParams
+  ) async {
+    self.isUpdatingPriceQuote = true
+    defer { self.isUpdatingPriceQuote = false }
+    let (swapQuoteUnion, swapFees, swapQuoteErrorUnion, _) = await swapService.quote(
+      params: swapQuoteParams
+    )
+    guard !Task.isCancelled else { return }
+    self.currentSwapQuoteInfo = .init(
+      base: base,
+      swapQuote: swapQuoteUnion,
+      swapFees: swapFees
+    )
+    if let swapQuoteUnion = swapQuoteUnion {
+      await self.handleSwapQuote(base: base, swapQuoteUnion: swapQuoteUnion)
+    } else if let swapQuoteErrorUnion = swapQuoteErrorUnion {
+      await self.handleSwapQuoteError(swapQuoteErrorUnion)
     } else {  // unknown error, ex failed parsing jupiter quote.
       self.state = .error(Strings.Wallet.unknownError)
       self.clearAllAmount()
     }
   }
 
-  @MainActor private func handleSolPriceQuoteResponse(
-    _ response: BraveWallet.JupiterQuote,
-    swapQuoteParams: BraveWallet.SwapQuoteParams
+  @MainActor private func handleSwapQuote(
+    base: SwapParamsBase,
+    swapQuoteUnion: BraveWallet.SwapQuoteUnion
   ) async {
-    self.jupiterQuote = response
+    if let zeroExQuote = swapQuoteUnion.zeroExQuote {
+      await handleZeroExQuote(base: base, zeroExQuote: zeroExQuote)
+    } else if let jupiterQuote = swapQuoteUnion.jupiterQuote {
+      await handleJupiterQuote(jupiterQuote)
+    } else if let lifiQuote = swapQuoteUnion.lifiQuote {
+      await handleLifiQuote(base: base, lifiQuote)
+    }
+  }
 
+  /// Update price market and sell/buy amount fields based on `SwapParamsBase` & `ZeroExQuote`
+  @MainActor private func handleZeroExQuote(
+    base: SwapParamsBase,
+    zeroExQuote: BraveWallet.ZeroExQuote
+  ) async {
+    guard !Task.isCancelled else { return }
+    let weiFormatter = WeiFormatter(decimalFormatStyle: .decimals(precision: 18))
+    switch base {
+    case .perSellAsset:
+      var decimal = 18
+      if let buyToken = selectedToToken {
+        decimal = Int(buyToken.decimals)
+      }
+      let decimalString =
+        weiFormatter.decimalString(for: zeroExQuote.buyAmount, decimals: decimal) ?? ""
+      if let bv = BDouble(decimalString) {
+        buyAmount = bv.decimalDescription
+      }
+    case .perBuyAsset:
+      var decimal = 18
+      if let sellToken = selectedFromToken {
+        decimal = Int(sellToken.decimals)
+      }
+      let decimalString =
+        weiFormatter.decimalString(for: zeroExQuote.sellAmount, decimals: decimal) ?? ""
+      if let bv = BDouble(decimalString) {
+        sellAmount = bv.decimalDescription
+      }
+    }
+
+    if let bv = BDouble(zeroExQuote.price) {
+      switch base {
+      case .perSellAsset:
+        selectedFromTokenPrice = bv.decimalDescription
+      case .perBuyAsset:
+        // will need to invert price if price quote is based on buyAmount
+        if bv != 0 {
+          selectedFromTokenPrice = (1 / bv).decimalDescription
+        }
+      }
+    }
+
+    await checkBalanceShowError(zeroExQuote: zeroExQuote)
+  }
+
+  /// Update price market and sell/buy amount fields based on `JupiterQuote`
+  @MainActor private func handleJupiterQuote(
+    _ jupiterQuote: BraveWallet.JupiterQuote
+  ) async {
+    guard !Task.isCancelled else { return }
     let formatter = WeiFormatter(decimalFormatStyle: .balance)
     if let selectedToToken {
       buyAmount =
         formatter.decimalString(
-          for: response.outAmount,
-          radix: .decimal,
+          for: jupiterQuote.outAmount,
           decimals: Int(selectedToToken.decimals)
         ) ?? ""
     }
@@ -781,15 +789,13 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     // No exchange rate is returned by Jupiter API, so we estimate it from the quote.
     if let selectedFromToken,
       let newFromAmount = formatter.decimalString(
-        for: response.inAmount,
-        radix: .decimal,
+        for: jupiterQuote.inAmount,
         decimals: Int(selectedFromToken.decimals)
       ),
       let newFromAmountWrapped = BDouble(newFromAmount),
       let selectedToToken,
       let newToAmount = formatter.decimalString(
-        for: response.outAmount,
-        radix: .decimal,
+        for: jupiterQuote.outAmount,
         decimals: Int(selectedToToken.decimals)
       ),
       let newToAmountWrapped = BDouble(newToAmount),
@@ -799,27 +805,47 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
       selectedFromTokenPrice = rate.decimalDescription
     }
 
-    let network = await rpcService.network(coin: selectedFromToken?.coin ?? .sol, origin: nil)
-    let (braveSwapFeeResponse, _) = await swapService.braveFee(
-      params: .init(
-        chainId: network.chainId,
-        inputToken: swapQuoteParams.fromToken,
-        outputToken: swapQuoteParams.toToken,
-        taker: swapQuoteParams.fromAccountId.address
-      )
-    )
-    if let braveSwapFeeResponse {
-      self.braveFee = braveSwapFeeResponse
-    } else {
-      self.state = .error(Strings.Wallet.unknownError)
-      self.clearAllAmount()
+    await checkBalanceShowError()
+  }
+
+  @MainActor private func handleLifiQuote(
+    base: SwapParamsBase,
+    _ lifiQuote: BraveWallet.LiFiQuote
+  ) async {
+    self.state = .error(Strings.Wallet.unknownError)
+    // TODO(stephenheaps): Handle `LiFiQuote`
+    // https://github.com/brave/brave-browser/issues/36436
+  }
+
+  @MainActor private func handleSwapQuoteError(_ swapError: BraveWallet.SwapErrorUnion) async {
+    // check balance first because error can cause by insufficient balance
+    if let sellTokenBalance = self.selectedFromTokenBalance,
+      let sellAmountValue = BDouble(self.sellAmount.normalizedDecimals),
+      sellTokenBalance < sellAmountValue
+    {
+      self.state = .error(Strings.Wallet.insufficientBalance)
       return
     }
 
-    await checkBalanceShowError(jupiterQuote: response)
+    // check if price quote fails due to insufficient liquidity
+    if let zeroExError = swapError.zeroExError,
+      zeroExError.isInsufficientLiquidity
+    {
+      self.state = .error(Strings.Wallet.insufficientLiquidity)
+      return
+    } else if let jupiterError = swapError.jupiterError,
+      jupiterError.isInsufficientLiquidity
+    {
+      self.state = .error(Strings.Wallet.insufficientLiquidity)
+      return
+    }
+    // TODO(stephenheaps): Handle `LiFiError`
+    // https://github.com/brave/brave-browser/issues/36436
+    self.state = .error(Strings.Wallet.unknownError)
+    self.clearAllAmount()
   }
 
-  @MainActor private func checkBalanceShowError(jupiterQuote: BraveWallet.JupiterQuote) async {
+  @MainActor private func checkBalanceShowError() async {
     guard let sellAmountValue = BDouble(sellAmount.normalizedDecimals),
       let selectedFromTokenBalance
     else {
@@ -835,7 +861,7 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   }
 
   @MainActor private func createSolSwapTransaction() async -> Bool {
-    guard let jupiterQuote,
+    guard let jupiterQuote = currentSwapQuoteInfo?.swapQuote?.jupiterQuote,
       let accountInfo = self.accountInfo
     else {
       return false
@@ -933,10 +959,8 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
   func fetchPriceQuote(base: SwapParamsBase) {
     priceQuoteTask?.cancel()
     priceQuoteTask = Task { @MainActor in
-      // reset quotes before fetching new quote
-      zeroExQuote = nil
-      jupiterQuote = nil
-      braveFee = nil
+      // reset quote before fetching new quote
+      self.currentSwapQuoteInfo = nil
       guard let accountInfo else {
         self.state = .idle
         return
@@ -957,48 +981,12 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
       }
       switch accountInfo.coin {
       case .eth:
-        await fetchEthPriceQuote(base: base, swapQuoteParams: swapQuoteParams, network: network)
+        await fetchEthPriceQuote(base: base, swapQuoteParams: swapQuoteParams)
       case .sol:
-        await fetchSolPriceQuote(swapQuoteParams: swapQuoteParams, network: network)
+        await fetchSolPriceQuote(base: base, swapQuoteParams: swapQuoteParams)
       default:
         break
       }
-    }
-  }
-
-  @MainActor private func fetchEthPriceQuote(
-    base: SwapParamsBase,
-    swapQuoteParams: BraveWallet.SwapQuoteParams,
-    network: BraveWallet.NetworkInfo
-  ) async {
-    self.isUpdatingPriceQuote = true
-    defer { self.isUpdatingPriceQuote = false }
-    let (swapQuoteUnion, swapQuoteErrorUnion, _) = await swapService.quote(params: swapQuoteParams)
-    if let swapResponse = swapQuoteUnion?.zeroExQuote {
-      await self.handleEthPriceQuoteResponse(
-        swapResponse,
-        base: base,
-        swapQuoteParams: swapQuoteParams
-      )
-    } else if let swapErrorResponse = swapQuoteErrorUnion?.zeroExError {
-      // check balance first because error can cause by insufficient balance
-      if let sellTokenBalance = self.selectedFromTokenBalance,
-        let sellAmountValue = BDouble(self.sellAmount.normalizedDecimals),
-        sellTokenBalance < sellAmountValue
-      {
-        self.state = .error(Strings.Wallet.insufficientBalance)
-        return
-      }
-      // check if priceQuote fails due to insufficient liquidity
-      if swapErrorResponse.isInsufficientLiquidity {
-        self.state = .error(Strings.Wallet.insufficientLiquidity)
-        return
-      }
-      self.state = .error(Strings.Wallet.unknownError)
-      self.clearAllAmount()
-    } else {  // unknown error, ex failed parsing zerox quote.
-      self.state = .error(Strings.Wallet.unknownError)
-      self.clearAllAmount()
     }
   }
 
@@ -1162,7 +1150,7 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     selectedToToken: BraveWallet.BlockchainToken = .previewDaiToken,
     sellAmount: String? = "0.01",
     buyAmount: String? = nil,
-    jupiterQuote: BraveWallet.JupiterQuote? = nil
+    currentSwapQuoteInfo: CurrentSwapQuoteInfo? = nil
   ) {
     accountInfo = fromAccount
     self.selectedFromToken = selectedFromToken
@@ -1173,8 +1161,8 @@ public class SwapTokenStore: ObservableObject, WalletObserverStore {
     if let buyAmount {
       self.buyAmount = buyAmount
     }
-    if let jupiterQuote {
-      self.jupiterQuote = jupiterQuote
+    if let currentSwapQuoteInfo {
+      self.currentSwapQuoteInfo = currentSwapQuoteInfo
     }
     selectedFromTokenBalance = 0.02
   }

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -589,3 +589,16 @@ extension URL {
     return WalletConstants.supportedIPFSSchemes.contains(scheme)
   }
 }
+
+extension BraveWallet.SwapFees {
+  /// If swap has a Brave Fee that is not free.
+  var hasBraveFee: Bool {
+    guard let effectiveFeePct = Double(effectiveFeePct),
+      !effectiveFeePct.isZero
+    else {
+      // no fees / zero fees
+      return false
+    }
+    return true
+  }
+}

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -543,4 +543,27 @@ extension BraveWallet.CoinMarket {
     )
   }
 }
+
+extension BraveWallet.SwapFees {
+  static var mockJupiterFees: BraveWallet.SwapFees {
+    BraveWallet.SwapFees(
+      feeParam: "85",
+      feePct: "0.85",
+      discountPct: "0",
+      effectiveFeePct: "0.85",
+      discountCode: .none
+    )
+  }
+
+  static var mockZeroExFees: BraveWallet.SwapFees {
+    BraveWallet.SwapFees(
+      feeParam: "0.00875",
+      feePct: "0.875",
+      discountPct: "0",
+      effectiveFeePct: "0.875",
+      discountCode: .none
+    )
+  }
+}
+
 #endif

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockSwapService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockSwapService.swift
@@ -50,43 +50,11 @@ class MockSwapService: BraveWalletSwapService {
 
   func quote(
     params: BraveWallet.SwapQuoteParams,
-    completion: @escaping (BraveWallet.SwapQuoteUnion?, BraveWallet.SwapErrorUnion?, String) -> Void
+    completion: @escaping (
+      BraveWallet.SwapQuoteUnion?, BraveWallet.SwapFees?, BraveWallet.SwapErrorUnion?, String
+    ) -> Void
   ) {
-    completion(
-      .init(
-        zeroExQuote: .init(
-          price: "",
-          guaranteedPrice: "",
-          to: "",
-          data: "",
-          value: "",
-          gas: "",
-          estimatedGas: "",
-          gasPrice: "",
-          protocolFee: "",
-          minimumProtocolFee: "",
-          buyTokenAddress: "",
-          sellTokenAddress: "",
-          buyAmount: "",
-          sellAmount: "",
-          allowanceTarget: "",
-          sellTokenToEthRate: "",
-          buyTokenToEthRate: "",
-          estimatedPriceImpact: "",
-          sources: [],
-          fees: .init(zeroExFee: nil)
-        )
-      ),
-      nil,
-      ""
-    )
-  }
-
-  func braveFee(
-    params: BraveWallet.BraveSwapFeeParams,
-    completion: @escaping (BraveWallet.BraveSwapFeeResponse?, String) -> Void
-  ) {
-    completion(nil, "Error Message")
+    completion(nil, nil, nil, "Error Message")
   }
 }
 

--- a/ios/brave-ios/Tests/BraveWalletTests/SwapTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SwapTokenStoreTests.swift
@@ -317,9 +317,9 @@ class SwapStoreTests: XCTestCase {
     let swapService = BraveWallet.TestSwapService()
     swapService._quote = { _, completion in
       if coin == .eth {
-        completion(.init(zeroExQuote: .init()), nil, "")
+        completion(.init(zeroExQuote: .init()), nil, nil, "")
       } else if coin == .sol {
-        completion(.init(jupiterQuote: .init()), nil, "")
+        completion(.init(jupiterQuote: .init()), nil, nil, "")
       } else {
         XCTFail("Coin type is not supported for swap")
       }
@@ -332,9 +332,6 @@ class SwapStoreTests: XCTestCase {
       } else {
         XCTFail("Coin type is not supported for swap")
       }
-    }
-    swapService._braveFee = { params, completion in
-      completion(nil, "")
     }
     let txService = BraveWallet.TestTxService()
     txService._addUnapprovedTransaction = { $3(true, "tx-meta-id", "") }
@@ -399,19 +396,7 @@ class SwapStoreTests: XCTestCase {
       )
     )
     swapService._quote = { _, completion in
-      completion(.init(zeroExQuote: zeroExQuote), nil, "")
-    }
-    swapService._braveFee = { params, completion in
-      let feeResponse = BraveWallet.BraveSwapFeeResponse(
-        feeParam: "0.00875",
-        protocolFeePct: "0.15",
-        braveFeePct: "0.875",
-        discountOnBraveFeePct: "0",
-        effectiveFeePct: "0.875",
-        discountCode: .none,
-        hasBraveFee: true
-      )
-      completion(feeResponse, "")
+      completion(.init(zeroExQuote: zeroExQuote), .mockZeroExFees, nil, "")
     }
     let store = SwapTokenStore(
       keyringService: keyringService,
@@ -444,11 +429,10 @@ class SwapStoreTests: XCTestCase {
     XCTAssertTrue(store.buyAmount.isEmpty)
     // non-empty assignment to `sellAmount` calls fetchPriceQuote
     store.setUpTest(sellAmount: "0.01")
-    waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 2) { error in
       XCTAssertNil(error)
       // Verify fees
       XCTAssertEqual(store.braveFeeForDisplay, "0.875%")
-      XCTAssertEqual(store.protocolFeeForDisplay, "0.15%")
     }
   }
 
@@ -461,19 +445,7 @@ class SwapStoreTests: XCTestCase {
     let zeroExQuote: BraveWallet.ZeroExQuote = .init()
     zeroExQuote.sellAmount = "3000000000000000000"
     swapService._quote = { _, completion in
-      completion(.init(zeroExQuote: zeroExQuote), nil, "")
-    }
-    swapService._braveFee = { params, completion in
-      let feeResponse = BraveWallet.BraveSwapFeeResponse(
-        feeParam: "0.00875",
-        protocolFeePct: "0.15",
-        braveFeePct: "0.875",
-        discountOnBraveFeePct: "0",
-        effectiveFeePct: "0.875",
-        discountCode: .none,
-        hasBraveFee: true
-      )
-      completion(feeResponse, "")
+      completion(.init(zeroExQuote: zeroExQuote), .mockZeroExFees, nil, "")
     }
     let store = SwapTokenStore(
       keyringService: keyringService,
@@ -503,23 +475,30 @@ class SwapStoreTests: XCTestCase {
       }
       .store(in: &cancellables)
 
-    let braveFeeExpectation = expectation(description: "braveFeeExpectation")
-    store.$braveFee
-      .dropFirst()
-      .collect(3)
-      .sink { _ in
-        braveFeeExpectation.fulfill()
+    let currentSwapQuoteInfoExpectation = expectation(
+      description: "currentSwapQuoteInfoExpectation"
+    )
+    store.$currentSwapQuoteInfo
+      .dropFirst()  // initial state
+      .collect(2)  // fetchPriceQuote (nil), fetchEthPriceQuote (populated)
+      .sink { currentSwapQuoteInfos in
+        guard let currentSwapQuoteInfo = currentSwapQuoteInfos.last else {
+          XCTFail("Expected multiple assignments.")
+          return
+        }
+        XCTAssertNotNil(currentSwapQuoteInfo?.swapQuote)
+        XCTAssertNotNil(currentSwapQuoteInfo?.swapFees)
+        currentSwapQuoteInfoExpectation.fulfill()
       }
       .store(in: &cancellables)
 
     XCTAssertTrue(store.sellAmount.isEmpty)
     // calls fetchPriceQuote
     store.setUpTest(sellAmount: nil, buyAmount: "0.01")
-    waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 2) { error in
       XCTAssertNil(error)
       // Verify fees
       XCTAssertEqual(store.braveFeeForDisplay, "0.875%")
-      XCTAssertNil(store.protocolFeeForDisplay)
     }
   }
 
@@ -547,19 +526,7 @@ class SwapStoreTests: XCTestCase {
         priceImpactPct: "0",
         routePlan: []
       )
-      completion(.init(jupiterQuote: jupiterQuote), nil, "")
-    }
-    swapService._braveFee = { params, completion in
-      let feeResponse = BraveWallet.BraveSwapFeeResponse(
-        feeParam: "85",
-        protocolFeePct: "0",
-        braveFeePct: "0.85",
-        discountOnBraveFeePct: "0",
-        effectiveFeePct: "0.85",
-        discountCode: .none,
-        hasBraveFee: true
-      )
-      completion(feeResponse, "")
+      completion(.init(jupiterQuote: jupiterQuote), .mockJupiterFees, nil, "")
     }
     let store = SwapTokenStore(
       keyringService: keyringService,
@@ -589,12 +556,20 @@ class SwapStoreTests: XCTestCase {
       }
       .store(in: &cancellables)
 
-    let braveFeeExpectation = expectation(description: "braveFeeExpectation")
-    store.$braveFee
-      .dropFirst()
-      .collect(3)
-      .sink { _ in
-        braveFeeExpectation.fulfill()
+    let currentSwapQuoteInfoExpectation = expectation(
+      description: "currentSwapQuoteInfoExpectation"
+    )
+    store.$currentSwapQuoteInfo
+      .dropFirst()  // initial state
+      .collect(2)  // fetchPriceQuote (nil), fetchSolPriceQuote (populated)
+      .sink { currentSwapQuoteInfos in
+        guard let currentSwapQuoteInfo = currentSwapQuoteInfos.last else {
+          XCTFail("Expected multiple assignments.")
+          return
+        }
+        XCTAssertNotNil(currentSwapQuoteInfo?.swapQuote)
+        XCTAssertNotNil(currentSwapQuoteInfo?.swapFees)
+        currentSwapQuoteInfoExpectation.fulfill()
       }
       .store(in: &cancellables)
 
@@ -606,11 +581,10 @@ class SwapStoreTests: XCTestCase {
       selectedToToken: .mockSpdToken,
       sellAmount: "0.01"
     )
-    waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 2) { error in
       XCTAssertNil(error)
       // Verify fees
       XCTAssertEqual(store.braveFeeForDisplay, "0.85%")
-      XCTAssertNil(store.protocolFeeForDisplay)
     }
   }
 
@@ -632,7 +606,7 @@ class SwapStoreTests: XCTestCase {
           isInsufficientLiquidity: true
         )
       )
-      completion(nil, errorUnion, "")
+      completion(nil, nil, errorUnion, "")
     }
     let store = SwapTokenStore(
       keyringService: keyringService,
@@ -669,7 +643,7 @@ class SwapStoreTests: XCTestCase {
       selectedToToken: .mockSpdToken,
       sellAmount: "0.01"
     )
-    waitForExpectations(timeout: 1) { error in
+    waitForExpectations(timeout: 2) { error in
       XCTAssertNil(error)
     }
   }
@@ -763,7 +737,13 @@ class SwapStoreTests: XCTestCase {
       userAssetManager: mockAssetManager,
       prefilledToken: nil
     )
-    store.setUpTest()
+    store.setUpTest(
+      currentSwapQuoteInfo: .init(
+        base: .perSellAsset,
+        swapQuote: nil,
+        swapFees: nil
+      )
+    )
     store.state = .swap
 
     let success = await store.createSwapTransaction()
@@ -797,7 +777,13 @@ class SwapStoreTests: XCTestCase {
       userAssetManager: mockAssetManager,
       prefilledToken: nil
     )
-    store.setUpTest()
+    store.setUpTest(
+      currentSwapQuoteInfo: .init(
+        base: .perSellAsset,
+        swapQuote: nil,
+        swapFees: nil
+      )
+    )
     store.state = .swap
 
     let success = await store.createSwapTransaction()
@@ -856,7 +842,17 @@ class SwapStoreTests: XCTestCase {
       selectedFromToken: .mockSolToken,
       selectedToToken: .mockSpdToken,
       sellAmount: "0.01",
-      jupiterQuote: jupiterQuote
+      currentSwapQuoteInfo: .init(
+        base: .perSellAsset,
+        swapQuote: .init(jupiterQuote: jupiterQuote),
+        swapFees: .init(
+          feeParam: "",
+          feePct: "",
+          discountPct: "",
+          effectiveFeePct: "",
+          discountCode: .none
+        )
+      )
     )
     store.state = .swap
 


### PR DESCRIPTION
### Highlights

#### LiFi is now available as a swap provider

⚠️ Disabled until commercial agreement is signed and anon-proxy is setup. It will be enabled in a separate PR to minimise impact.

[LiFi](https://li.fi/) is now one of the swap providers for fetching quotes. This compliments 0x and Jupiter providers that we already support. The decision to use one swap provider over another is made by `SwapService` (core). The `useSwap` is refactored to take this into account.

#### Add support for "exact out" mode in 0x

We now allow swap users to specify an exact `buyAmount` that they want to receive in the trade. In such a case, the `sellAmount` is variable and depends upon the market conditions during execution of the swap.

#### Use anon-proxy for 0x instead of build flag

This is done for security reasons. Need a follow-up to remove the old keys from CI and rotate the current key.

#### Protocol fees are no longer displayed / computed

Since the protocol fees are already part of the Brave fee (if applicable), there's no need to display it and make the screen verbose.

#### `SwapService::GetBraveFee` has been removed

This is done to prevent extra effort on the clients to determine the fees associated with a certain swap. The swap fees are now returned directly in the response of `SwapService::GetQuote`.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>

<tr>
<td>
<pre>
interface SwapService {
  GetQuote(SwapQuoteParams params) =>
      (SwapQuoteUnion? response,
       SwapErrorUnion? error,
       string error_string);
  GetBraveFee(BraveSwapFeeParams params) =>
      (BraveSwapFees? response, string error_string);
}
</pre>
</td>
<td>
<pre>
interface SwapService {
  GetQuote(SwapQuoteParams params) =>
      (SwapQuoteUnion? response,
       SwapFees? fees,
       SwapErrorUnion? error,
       string error_string);
}
</pre>
</td>
</tr>
</table>

Resolves https://github.com/brave/brave-browser/issues/36335

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Existing 0x and Jupiter swaps should continue to work. LiFi cross-chain swaps are not enabled yet.
* Please test out "exact out" swaps for EVM swaps. You can do this by modifying the "To" amount and clicking on "Review" button. The panel should display the exact output amount that was entered in the previous screen.