### PR TITLE
Use HTTP Range response for Playlist player

### DIFF
--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -9,6 +9,7 @@
 #include <limits>
 #include <memory>
 #include <utility>
+#include <vector>
 
 #include "base/containers/heap_array.h"
 #include "base/files/file.h"

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -40,7 +40,7 @@ namespace {
   CHECK(!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) \
       << "This must be called on a background thread."
 
-constexpr int64_t kMediaChunkSizeInByte = 1024 * 1024 * 10;  // 10MB
+constexpr int64_t kMediaChunkSizeInByte = 1024 * 1024 * 1;  // 1MB
 
 class RefCountedMemMap : public base::RefCountedMemory {
  public:

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -175,6 +175,7 @@ void PlaylistDataSource::StartDataRequest(
       break;
     case DataRequest::Type::kMedia:
       NOTREACHED() << "This request should call StartRangeDataRequest()";
+      std::move(got_data_callback).Run(nullptr);
       break;
   }
 }

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -131,11 +131,11 @@ PlaylistDataSource::DataRequest::DataRequest(const GURL& url) {
   id = paths.at(0);
   const auto& type_string = paths.at(1);
   if (type_string == "thumbnail") {
-    type = kThumbnail;
+    type = DataRequest::Type::kThumbnail;
   } else if (type_string == "media") {
-    type = kMedia;
+    type = DataRequest::Type::kMedia;
   } else if (type_string == "favicon") {
-    type = kFavicon;
+    type = DataRequest::Type::kFavicon;
   } else {
     NOTREACHED() << "type is not in {thumbnail,media,favicon}: " << type_string;
   }
@@ -164,13 +164,13 @@ void PlaylistDataSource::StartDataRequest(
   }
 
   switch (DataRequest data_request(url); data_request.type) {
-    case DataRequest::kThumbnail:
+    case DataRequest::Type::kThumbnail:
       GetThumbnail(data_request, wc_getter, std::move(got_data_callback));
       break;
-    case DataRequest::kFavicon:
+    case DataRequest::Type::kFavicon:
       GetFavicon(data_request, wc_getter, std::move(got_data_callback));
       break;
-    case DataRequest::kMedia:
+    case DataRequest::Type::kMedia:
       NOTREACHED() << "This request should call StartRangeDataRequest()";
       break;
   }
@@ -182,7 +182,7 @@ void PlaylistDataSource::StartRangeDataRequest(
     const net::HttpByteRange& range,
     GotRangeDataCallback callback) {
   DataRequest data_request(url);
-  CHECK_EQ(data_request.type, DataRequest::kMedia);
+  CHECK_EQ(data_request.type, DataRequest::Type::kMedia);
   CHECK(range.IsValid());
   GetMediaFile(data_request, wc_getter, range, std::move(callback));
 }
@@ -252,12 +252,12 @@ std::string PlaylistDataSource::GetMimeType(const GURL& url) {
   }
 
   switch (DataRequest data_request(url); data_request.type) {
-    case DataRequest::kThumbnail:
+    case DataRequest::Type::kThumbnail:
       return "image/png";
-    case DataRequest::kMedia:
+    case DataRequest::Type::kMedia:
       return "video/mp4";  //  Note that this will be fixed up based on the
                            //  actual file extension in WebUIUrlLoader.
-    case DataRequest::kFavicon:
+    case DataRequest::Type::kFavicon:
       return FaviconSource::GetMimeType(url);
   }
 
@@ -274,7 +274,7 @@ bool PlaylistDataSource::SupportsRangeRequests(const GURL& url) const {
     return false;
   }
 
-  return DataRequest(url).type == DataRequest::kMedia;
+  return DataRequest(url).type == DataRequest::Type::kMedia;
 }
 
 }  // namespace playlist

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -94,11 +94,13 @@ content::URLDataSource::RangeDataResult ReadFileRange(
   // Note that HTTP range's first and last position are inclusive.
   int64_t first_byte_position =
       range.HasFirstBytePosition() ? range.first_byte_position() : 0;
-  int64_t last_byte_position = range.HasLastBytePosition()
-                                   ? range.last_byte_position()
-                                   : std::numeric_limits<uint32_t>::max();
+  int64_t last_byte_position =
+      range.HasLastBytePosition()
+          ? range.last_byte_position()
+          : first_byte_position + kMediaChunkSizeInByte - 1;
   int64_t read_size = std::min(kMediaChunkSizeInByte,
                                last_byte_position - first_byte_position + 1);
+  CHECK_GE(read_size, 0);
 
   std::vector<unsigned char> buffer(read_size);
   auto read_result = file.Read(first_byte_position, buffer);

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -111,8 +111,7 @@ PlaylistDataSource::DataRequest::DataRequest(const GURL& url) {
   } else if (type_string == "favicon") {
     type = kFavicon;
   } else {
-    NOTREACHED() << "type is not in {thumbnail,media,favicon}/ : "
-                 << type_string;
+    NOTREACHED() << "type is not in {thumbnail,media,favicon}: " << type_string;
   }
 }
 

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -100,15 +100,16 @@ content::URLDataSource::RangeDataResult ReadFileRange(
   int64_t read_size = std::min(kMediaChunkSizeInByte,
                                last_byte_position - first_byte_position + 1);
 
-  auto buffer = base::HeapArray<uint8_t>::Uninit(read_size);
+  std::vector<unsigned char> buffer(read_size);
   auto read_result = file.Read(first_byte_position, buffer);
   if (!read_result.has_value()) {
     return {};
   }
   read_size = read_result.value();
+  buffer.resize(read_size);
 
   content::URLDataSource::RangeDataResult result;
-  result.buffer = base::MakeRefCounted<base::RefCountedBytes>(buffer);
+  result.buffer = base::RefCountedBytes::TakeVector(&buffer);
   result.file_size = file.GetLength();
   result.range = net::HttpByteRange::Bounded(
       first_byte_position, first_byte_position + read_size - 1);

--- a/browser/playlist/playlist_data_source.cc
+++ b/browser/playlist/playlist_data_source.cc
@@ -5,20 +5,28 @@
 
 #include "brave/browser/playlist/playlist_data_source.h"
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <utility>
 
+#include "base/containers/heap_array.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/memory/ref_counted_memory.h"
 #include "base/memory/scoped_refptr.h"
+#include "base/notreached.h"
 #include "base/strings/escape.h"
+#include "base/strings/string_split.h"
+#include "base/strings/utf_string_conversions.h"
 #include "base/task/thread_pool.h"
-#include "base/task/thread_pool/thread_pool_instance.h"
+#include "brave/components/playlist/browser/mime_util.h"
 #include "brave/components/playlist/browser/playlist_service.h"
 #include "components/favicon_base/favicon_url_parser.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/url_data_source.h"
 #include "net/base/filename_util.h"
 #include "url/gurl.h"
 
@@ -26,8 +34,16 @@ namespace playlist {
 
 namespace {
 
+#define CHECK_CURRENTLY_NOT_ON_UI_THREAD()                                \
+  CHECK(!content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) \
+      << "This must be called on a background thread."
+
+constexpr int64_t kMediaChunkSizeInByte = 1024 * 1024 * 10;  // 10MB
+
 scoped_refptr<base::RefCountedMemory> ReadFileToString(
     const base::FilePath& path) {
+  CHECK_CURRENTLY_NOT_ON_UI_THREAD();
+
   std::string contents;
   if (!base::ReadFileToString(path, &contents)) {
     VLOG(2) << __FUNCTION__ << " Failed to read " << path;
@@ -39,7 +55,68 @@ scoped_refptr<base::RefCountedMemory> ReadFileToString(
       contents.length());
 }
 
+content::URLDataSource::RangeDataResult ReadFileRange(
+    const base::FilePath& file_path,
+    net::HttpByteRange range) {
+  CHECK_CURRENTLY_NOT_ON_UI_THREAD();
+
+  base::File file(file_path,
+                  base::File::Flags::FLAG_OPEN | base::File::FLAG_READ);
+  if (!file.IsValid()) {
+    return {};
+  }
+
+  // Note that HTTP range's first and last position are inclusive.
+  int64_t first_byte_position =
+      range.HasFirstBytePosition() ? range.first_byte_position() : 0;
+  int64_t last_byte_position = range.HasLastBytePosition()
+                                   ? range.last_byte_position()
+                                   : std::numeric_limits<uint32_t>::max();
+  int64_t read_size = std::min(kMediaChunkSizeInByte,
+                               last_byte_position - first_byte_position + 1);
+
+  auto buffer = base::HeapArray<uint8_t>::Uninit(read_size);
+  auto read_result = file.Read(first_byte_position, buffer);
+  if (!read_result.has_value()) {
+    return {};
+  }
+  read_size = read_result.value();
+
+  content::URLDataSource::RangeDataResult result;
+  result.buffer = base::MakeRefCounted<base::RefCountedBytes>(buffer);
+  result.file_size = file.GetLength();
+  result.range = net::HttpByteRange::Bounded(
+      first_byte_position, first_byte_position + read_size - 1);
+  auto mime_type = playlist::mime_util::GetMimeTypeForFileExtension(
+                       file_path.FinalExtension())
+                       .value_or("video/mp4");
+  result.mime_type = mime_type;
+  return result;
+}
+
 }  // namespace
+
+PlaylistDataSource::DataRequest::DataRequest(const GURL& url) {
+  const auto full_path = content::URLDataSource::URLToRequestPath(url);
+  const auto paths = base::SplitStringPiece(
+      full_path, "/", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  CHECK_EQ(paths.size(), 2u);
+
+  id = paths.at(0);
+  const auto& type_string = paths.at(1);
+  if (type_string == "thumbnail") {
+    type = kThumbnail;
+  } else if (type_string == "media") {
+    type = kMedia;
+  } else if (type_string == "favicon") {
+    type = kFavicon;
+  } else {
+    NOTREACHED() << "type is not in {thumbnail,media,favicon}/ : "
+                 << type_string;
+  }
+}
+
+PlaylistDataSource::DataRequest::~DataRequest() = default;
 
 PlaylistDataSource::PlaylistDataSource(Profile* profile,
                                        PlaylistService* service)
@@ -60,113 +137,109 @@ void PlaylistDataSource::StartDataRequest(
     std::move(got_data_callback).Run(nullptr);
     return;
   }
-  std::string path = URLDataSource::URLToRequestPath(url);
-  std::string id;
-  std::string type_string;
-  if (auto pos = path.find("/"); pos != std::string::npos) {
-    id = std::string(path.begin(), path.begin() + pos);
-    type_string = std::string(path.begin() + pos, path.end());
-    type_string.erase(std::remove(type_string.begin(), type_string.end(), '/'),
-                      type_string.end());
-  } else {
-    NOTREACHED()
-        << "path is not in expected form: /id/{thumbnail,media,favicon}/ vs "
-        << path;
-    std::move(got_data_callback).Run(nullptr);
-    return;
+
+  switch (DataRequest data_request(url); data_request.type) {
+    case DataRequest::kThumbnail:
+      GetThumbnail(data_request, wc_getter, std::move(got_data_callback));
+      break;
+    case DataRequest::kFavicon:
+      GetFavicon(data_request, wc_getter, std::move(got_data_callback));
+      break;
+    case DataRequest::kMedia:
+      NOTREACHED() << "This request should call StartRangeDataRequest()";
+      break;
   }
-
-  base::FilePath data_path;
-  if (type_string == "thumbnail") {
-    if (!service_->GetThumbnailPath(id, &data_path)) {
-      std::move(got_data_callback).Run(nullptr);
-      return;
-    }
-  } else if (type_string == "media") {
-    if (!service_->HasPlaylistItem(id)) {
-      std::move(got_data_callback).Run(nullptr);
-      return;
-    }
-
-    auto item = service_->GetPlaylistItem(id);
-    DCHECK(item->cached);
-    if (!net::FileURLToFilePath(item->media_path, &data_path)) {
-      std::move(got_data_callback).Run(nullptr);
-    }
-  } else if (type_string == "favicon") {
-    if (!service_->HasPlaylistItem(id)) {
-      std::move(got_data_callback).Run(nullptr);
-      return;
-    }
-
-    auto item = service_->GetPlaylistItem(id);
-    GURL favicon_url(
-        "chrome://favicon2?allowGoogleServerFallback=0&size=32&pageUrl=" +
-        base::EscapeUrlEncodedData(item->page_source.spec(),
-                                   /*use_plus=*/false));
-    FaviconSource::StartDataRequest(favicon_url, wc_getter,
-                                    std::move(got_data_callback));
-    return;
-  } else {
-    NOTREACHED() << "type is not in {thumbnail,media,favicon}/ : "
-                 << type_string;
-    std::move(got_data_callback).Run(nullptr);
-    return;
-  }
-
-  GetDataFile(data_path, std::move(got_data_callback));
 }
 
-void PlaylistDataSource::GetDataFile(const base::FilePath& data_path,
-                                     GotDataCallback got_data_callback) {
+void PlaylistDataSource::StartRangeDataRequest(
+    const GURL& url,
+    const content::WebContents::Getter& wc_getter,
+    const net::HttpByteRange& range,
+    GotRangeDataCallback callback) {
+  DataRequest data_request(url);
+  CHECK_EQ(data_request.type, DataRequest::kMedia);
+  CHECK(range.IsValid());
+  GetMediaFile(data_request, wc_getter, range, std::move(callback));
+}
+
+void PlaylistDataSource::GetThumbnail(
+    const DataRequest& request,
+    const content::WebContents::Getter& wc_getter,
+    GotDataCallback got_data_callback) {
+  base::FilePath thumbnail_path;
+  if (!service_->GetThumbnailPath(request.id, &thumbnail_path)) {
+    std::move(got_data_callback).Run(nullptr);
+    return;
+  }
+
   base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE, base::MayBlock(), base::BindOnce(&ReadFileToString, data_path),
-      base::BindOnce(&PlaylistDataSource::OnGotDataFile,
-                     weak_factory_.GetWeakPtr(), std::move(got_data_callback)));
+      FROM_HERE, base::MayBlock(),
+      base::BindOnce(&ReadFileToString, thumbnail_path),
+      std::move(got_data_callback));
 }
 
-void PlaylistDataSource::OnGotDataFile(
-    GotDataCallback got_data_callback,
-    scoped_refptr<base::RefCountedMemory> input) {
-  std::move(got_data_callback).Run(input);
+void PlaylistDataSource::GetMediaFile(
+    const DataRequest& request,
+    const content::WebContents::Getter& wc_getter,
+    const net::HttpByteRange& range,
+    GotRangeDataCallback got_data_callback) {
+  base::FilePath media_path;
+  if (!service_->HasPlaylistItem(request.id)) {
+    std::move(got_data_callback).Run({});
+    return;
+  }
+
+  auto item = service_->GetPlaylistItem(request.id);
+  DCHECK(item->cached);
+  if (!net::FileURLToFilePath(item->media_path, &media_path)) {
+    std::move(got_data_callback).Run({});
+    return;
+  }
+
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, base::MayBlock(),
+      base::BindOnce(&ReadFileRange, media_path, range),
+      std::move(got_data_callback));
+}
+
+void PlaylistDataSource::GetFavicon(
+    const DataRequest& request,
+    const content::WebContents::Getter& wc_getter,
+    GotDataCallback got_data_callback) {
+  if (!service_->HasPlaylistItem(request.id)) {
+    std::move(got_data_callback).Run(nullptr);
+    return;
+  }
+
+  auto item = service_->GetPlaylistItem(request.id);
+  GURL favicon_url(
+      "chrome://favicon2?allowGoogleServerFallback=0&size=32&pageUrl=" +
+      base::EscapeUrlEncodedData(item->page_source.spec(),
+                                 /*use_plus=*/false));
+  FaviconSource::StartDataRequest(favicon_url, wc_getter,
+                                  std::move(got_data_callback));
 }
 
 std::string PlaylistDataSource::GetMimeType(const GURL& url) {
-  const std::string path = URLDataSource::URLToRequestPath(url);
-  std::string id;
-  std::string type_string;
-  if (auto pos = path.find("/"); pos != std::string::npos) {
-    id = std::string(path.begin(), path.begin() + pos);
-    type_string = std::string(path.begin() + pos, path.end());
-    type_string.erase(std::remove(type_string.begin(), type_string.end(), '/'),
-                      type_string.end());
-  } else {
-    NOTREACHED()
-        << "path is not in expected form: /id/{thumbnail,media,favicon}/ vs "
-        << path;
-    return std::string();
+  switch (DataRequest data_request(url); data_request.type) {
+    case DataRequest::kThumbnail:
+      return "image/png";
+    case DataRequest::kMedia:
+      return "video/mp4";  //  Note that this will be fixed up based on the
+                           //  actual file extension in WebUIUrlLoader.
+    case DataRequest::kFavicon:
+      return FaviconSource::GetMimeType(url);
   }
 
-  if (type_string == "thumbnail") {
-    return "image/png";
-  }
-
-  // TODO(sko) Decide mime type based on the file extension.
-  if (type_string == "media") {
-    return "video/mp4";
-  }
-
-  if (type_string == "favicon") {
-    return FaviconSource::GetMimeType(url);
-  }
-
-  NOTREACHED() << "type is neither of {thumbnail,media,favicon}/ : "
-               << type_string;
-  return std::string();
+  NOTREACHED_NORETURN();
 }
 
 bool PlaylistDataSource::AllowCaching() {
   return false;
+}
+
+bool PlaylistDataSource::SupportsRangeRequests(const GURL& url) const {
+  return DataRequest(url).type == DataRequest::kMedia;
 }
 
 }  // namespace playlist

--- a/browser/playlist/playlist_data_source.h
+++ b/browser/playlist/playlist_data_source.h
@@ -42,7 +42,7 @@ class PlaylistDataSource : public FaviconSource {
 
  private:
   struct DataRequest {
-    enum Type {
+    enum class Type {
       kThumbnail,
       kMedia,
       kFavicon,

--- a/browser/playlist/playlist_data_source.h
+++ b/browser/playlist/playlist_data_source.h
@@ -8,16 +8,10 @@
 
 #include <string>
 
-#include "base/memory/weak_ptr.h"
 #include "chrome/browser/ui/webui/favicon_source.h"
-#include "content/public/browser/url_data_source.h"
 
 class GURL;
 class Profile;
-
-namespace base {
-class FilePath;
-}  // namespace base
 
 namespace playlist {
 
@@ -38,18 +32,43 @@ class PlaylistDataSource : public FaviconSource {
   void StartDataRequest(const GURL& url,
                         const content::WebContents::Getter& wc_getter,
                         GotDataCallback got_data_callback) override;
+  void StartRangeDataRequest(const GURL& url,
+                             const content::WebContents::Getter& wc_getter,
+                             const net::HttpByteRange& range,
+                             GotRangeDataCallback callback) override;
   std::string GetMimeType(const GURL& url) override;
   bool AllowCaching() override;
+  bool SupportsRangeRequests(const GURL& url) const override;
 
  private:
-  void GetDataFile(const base::FilePath& data_path,
-                   GotDataCallback got_data_callback);
-  void OnGotDataFile(GotDataCallback got_data_callback,
-                     scoped_refptr<base::RefCountedMemory> input);
+  struct DataRequest {
+    enum Type {
+      kThumbnail,
+      kMedia,
+      kFavicon,
+    };
+
+    explicit DataRequest(const GURL& url);
+    DataRequest(const DataRequest&) = delete;
+    DataRequest& operator=(const DataRequest&) = delete;
+    ~DataRequest();
+
+    std::string id;
+    Type type;
+  };
+
+  void GetThumbnail(const DataRequest& request,
+                    const content::WebContents::Getter& wc_getter,
+                    GotDataCallback got_data_callback);
+  void GetFavicon(const DataRequest& request,
+                  const content::WebContents::Getter& wc_getter,
+                  GotDataCallback got_data_callback);
+  void GetMediaFile(const DataRequest& request,
+                    const content::WebContents::Getter& wc_getter,
+                    const net::HttpByteRange& range,
+                    GotRangeDataCallback got_data_callback);
 
   raw_ptr<PlaylistService> service_;
-
-  base::WeakPtrFactory<PlaylistDataSource> weak_factory_{this};
 };
 
 }  // namespace playlist

--- a/browser/playlist/playlist_data_source.h
+++ b/browser/playlist/playlist_data_source.h
@@ -68,7 +68,7 @@ class PlaylistDataSource : public FaviconSource {
                     const net::HttpByteRange& range,
                     GotRangeDataCallback got_data_callback);
 
-  raw_ptr<PlaylistService> service_;
+  raw_ptr<PlaylistService> service_ = nullptr;
 };
 
 }  // namespace playlist

--- a/browser/playlist/test/BUILD.gn
+++ b/browser/playlist/test/BUILD.gn
@@ -52,6 +52,7 @@ source_set("unit_tests") {
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
   sources = [
+    "mime_util_unittest.cc",
     "mock_playlist_service_observer.cc",
     "mock_playlist_service_observer.h",
     "playlist_download_requset_manager_unittest.cc",

--- a/browser/playlist/test/mime_util_unittest.cc
+++ b/browser/playlist/test/mime_util_unittest.cc
@@ -76,14 +76,14 @@ TEST(PlaylistMimeUtilUnitTest, GetMimeTypeForFileExtension) {
           .has_value());
 }
 
-TEST(PlaylistMimeUtilUnitTest, BothMapShouldBeInSync) {
+TEST(PlaylistMimeUtilUnitTest, BothMapsShouldBeInSync) {
   const auto supported_mimetypes = playlist::mime_util::GetSupportedMimetypes();
   ASSERT_FALSE(supported_mimetypes.empty());
 
   base::flat_map<base::FilePath::StringType, std::vector<std::string>>
       extension_to_mimes;
 
-  for (auto mimetype : supported_mimetypes) {
+  for (const auto& mimetype : supported_mimetypes) {
     auto extension = playlist::mime_util::GetFileExtensionForMimetype(mimetype);
     ASSERT_TRUE(extension.has_value());
     extension_to_mimes[extension.value()].push_back(mimetype);

--- a/browser/playlist/test/mime_util_unittest.cc
+++ b/browser/playlist/test/mime_util_unittest.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/playlist/browser/mime_util.h"
+
+#include "base/files/file_path.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+TEST(PlaylistMimeUtilUnitTest, GetFileExtensionForMimetype) {
+  auto compare_result = [](const auto& mimetype, const auto& extension) {
+    EXPECT_STREQ(playlist::mime_util::GetFileExtensionForMimetype(mimetype)
+                     .value()
+                     .c_str(),
+                 extension);
+  };
+
+  compare_result("application/ogg", FILE_PATH_LITERAL("ogx"));
+  compare_result("application/vnd.apple.mpegurl", FILE_PATH_LITERAL("m3u8"));
+  compare_result("application/x-mpegurl", FILE_PATH_LITERAL("m3u8"));
+  compare_result("audio/mpegurl", FILE_PATH_LITERAL("m3u8"));
+  compare_result("audio/x-mpegurl", FILE_PATH_LITERAL("m3u8"));
+  compare_result("audio/aac", FILE_PATH_LITERAL("aac"));
+  compare_result("audio/flac", FILE_PATH_LITERAL("flac"));
+  compare_result("audio/mp3", FILE_PATH_LITERAL("mp3"));
+  compare_result("audio/x-mp3", FILE_PATH_LITERAL("mp3"));
+  compare_result("audio/mpeg", FILE_PATH_LITERAL("mp3"));
+  compare_result("audio/ogg", FILE_PATH_LITERAL("oga"));
+  compare_result("audio/wav", FILE_PATH_LITERAL("wav"));
+  compare_result("audio/x-wav", FILE_PATH_LITERAL("wav"));
+  compare_result("video/webm", FILE_PATH_LITERAL("webm"));
+  compare_result("audio/webm", FILE_PATH_LITERAL("weba"));
+  compare_result("audio/x-m4a", FILE_PATH_LITERAL("m4a"));
+  compare_result("video/3gpp", FILE_PATH_LITERAL("3gp"));
+  compare_result("video/mp2t", FILE_PATH_LITERAL("ts"));
+  compare_result("audio/mp4", FILE_PATH_LITERAL("mp4"));
+  compare_result("video/mp4", FILE_PATH_LITERAL("mp4"));
+  compare_result("video/mpeg", FILE_PATH_LITERAL("mpeg"));
+  compare_result("video/ogg", FILE_PATH_LITERAL("ogv"));
+  compare_result("video/x-m4v", FILE_PATH_LITERAL("m4v"));
+
+  EXPECT_FALSE(
+      playlist::mime_util::GetFileExtensionForMimetype("foo").has_value());
+}
+
+TEST(PlaylistMimeUtilUnitTest, GetMimeTypeForFileExtension) {
+  auto compare_result = [](const auto& extension, const auto& mimetype) {
+    EXPECT_STREQ(playlist::mime_util::GetMimeTypeForFileExtension(extension)
+                     .value()
+                     .c_str(),
+                 mimetype);
+  };
+
+  compare_result(FILE_PATH_LITERAL("m3u8"), "application/x-mpegurl");
+  compare_result(FILE_PATH_LITERAL("aac"), "audio/aac");
+  compare_result(FILE_PATH_LITERAL("flac"), "audio/flac");
+  compare_result(FILE_PATH_LITERAL("mp3"), "audio/mp3");
+  compare_result(FILE_PATH_LITERAL("mp4"), "video/mp4");
+  compare_result(FILE_PATH_LITERAL("oga"), "audio/ogg");
+  compare_result(FILE_PATH_LITERAL("wav"), "audio/wav");
+  compare_result(FILE_PATH_LITERAL("weba"), "audio/webm");
+  compare_result(FILE_PATH_LITERAL("m4a"), "audio/x-m4a");
+  compare_result(FILE_PATH_LITERAL("3gp"), "video/3gpp");
+  compare_result(FILE_PATH_LITERAL("ts"), "video/mp2t");
+  compare_result(FILE_PATH_LITERAL("mpeg"), "video/mpeg");
+  compare_result(FILE_PATH_LITERAL("ogv"), "video/ogg");
+  compare_result(FILE_PATH_LITERAL("ogx"), "application/ogg");
+  compare_result(FILE_PATH_LITERAL("webm"), "video/webm");
+  compare_result(FILE_PATH_LITERAL("m4v"), "video/x-m4v");
+
+  EXPECT_FALSE(
+      playlist::mime_util::GetMimeTypeForFileExtension(FILE_PATH_LITERAL("foo"))
+          .has_value());
+}

--- a/chromium_src/content/browser/webui/web_ui_url_loader_factory.cc
+++ b/chromium_src/content/browser/webui/web_ui_url_loader_factory.cc
@@ -93,7 +93,9 @@ void RangeDataAvailable(
   // * "Content-length: 10000" (the size of the whole file. Note that this is
   //                            different with what MDN says. But when
   //                            Content-length contains the range's size, then
-  //                            the <video> won't be played)
+  //                            the <video> won't be played). See also,
+  //    https://source.chromium.org/chromium/chromium/src/+/main:content/browser/webui/web_ui_url_loader_factory.cc;l=143-147;drc=2af756c3ed38c6fb6472c821fc71d79b07984cac
+  //
   // * "Content-type": "video/mp4" (or the correct mime type)
   if (bytes && range.IsValid()) {
     headers->headers->UpdateWithNewRange(range, total_size,

--- a/chromium_src/content/browser/webui/web_ui_url_loader_factory.cc
+++ b/chromium_src/content/browser/webui/web_ui_url_loader_factory.cc
@@ -1,0 +1,172 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "content/public/browser/web_ui_url_loader_factory.h"
+
+#include "base/strings/string_number_conversions.h"
+#include "base/timer/elapsed_timer.h"
+#include "content/browser/webui/url_data_source_impl.h"
+#include "content/public/browser/url_data_source.h"
+#include "net/http/http_byte_range.h"
+#include "services/network/public/cpp/parsed_headers.h"
+#include "services/network/public/mojom/url_response_head.mojom.h"
+
+namespace content {
+namespace {
+void RangeDataAvailable(
+    const GURL& url,
+    network::mojom::URLResponseHeadPtr headers,
+    const ui::TemplateReplacements* replacements,
+    bool replace_in_js,
+    scoped_refptr<URLDataSourceImpl> source,
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client_remote,
+    std::optional<net::HttpByteRange> requested_range,
+    base::ElapsedTimer url_request_elapsed_timer,
+    URLDataSource::RangeDataResult result);
+}  // namespace
+}  // namespace content
+
+#define GotDataCallback                                                     \
+  GotDataCallback unused_callback;                                          \
+  if (range.has_value() &&                                                  \
+      source->source()->SupportsRangeRequests(request.url)) {               \
+    URLDataSource::GotRangeDataCallback callback = base::BindOnce(          \
+        RangeDataAvailable, request.url, std::move(resource_response),      \
+        replacements, replace_in_js, base::RetainedRef(source),             \
+        std::move(client_remote), range,                                    \
+        std::move(url_request_elapsed_timer));                              \
+    source->source()->StartRangeDataRequest(request.url, wc_getter, *range, \
+                                            std::move(callback));           \
+    return;                                                                 \
+  }                                                                         \
+  URLDataSource::GotDataCallback
+
+#include "src/content/browser/webui/web_ui_url_loader_factory.cc"
+
+#undef GotDataCallback
+
+namespace content {
+namespace {
+
+void ReadRangeData(
+    network::mojom::URLResponseHeadPtr headers,
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client_remote,
+    base::ElapsedTimer url_request_elapsed_timer,
+    scoped_refptr<base::RefCountedMemory> bytes) {
+  TRACE_EVENT0("ui", "WebUIURLLoader::ReadRangeData");
+  if (!bytes) {
+    CallOnError(std::move(client_remote), net::ERR_FAILED);
+    return;
+  }
+
+  // The use of MojoCreateDataPipeOptions below means we'll be using uint32_t
+  // for sizes / offsets.
+  if (!base::IsValueInRangeForNumericType<uint32_t>(bytes->size())) {
+    CallOnError(std::move(client_remote), net::ERR_INSUFFICIENT_RESOURCES);
+    return;
+  }
+
+  uint32_t output_size = base::checked_cast<uint32_t>(bytes->size());
+
+  MojoCreateDataPipeOptions options;
+  options.struct_size = sizeof(MojoCreateDataPipeOptions);
+  options.flags = MOJO_CREATE_DATA_PIPE_FLAG_NONE;
+  options.element_num_bytes = 1;
+  options.capacity_num_bytes = output_size;
+  mojo::ScopedDataPipeProducerHandle pipe_producer_handle;
+  mojo::ScopedDataPipeConsumerHandle pipe_consumer_handle;
+  MojoResult create_result = mojo::CreateDataPipe(
+      &options, pipe_producer_handle, pipe_consumer_handle);
+  CHECK_EQ(create_result, MOJO_RESULT_OK);
+
+  void* buffer = nullptr;
+  uint32_t num_bytes = output_size;
+  MojoResult result = pipe_producer_handle->BeginWriteData(
+      &buffer, &num_bytes, MOJO_WRITE_DATA_FLAG_NONE);
+  CHECK_EQ(result, MOJO_RESULT_OK);
+  CHECK_GE(num_bytes, output_size);
+
+  base::ranges::copy(base::span(*bytes), static_cast<char*>(buffer));
+  result = pipe_producer_handle->EndWriteData(output_size);
+  CHECK_EQ(result, MOJO_RESULT_OK);
+
+  mojo::Remote<network::mojom::URLLoaderClient> client(
+      std::move(client_remote));
+
+  client->OnReceiveResponse(std::move(headers), std::move(pipe_consumer_handle),
+                            std::nullopt);
+
+  network::URLLoaderCompletionStatus status(net::OK);
+  status.encoded_data_length = output_size;
+  status.encoded_body_length = output_size;
+  status.decoded_body_length = output_size;
+  client->OnComplete(status);
+
+  UMA_HISTOGRAM_TIMES("WebUI.WebUIURLLoaderFactory.URLRequestLoadTime",
+                      url_request_elapsed_timer.Elapsed());
+}
+
+void RangeDataAvailable(
+    const GURL& url,
+    network::mojom::URLResponseHeadPtr headers,
+    const ui::TemplateReplacements* replacements,
+    bool replace_in_js,
+    scoped_refptr<URLDataSourceImpl> source,
+    mojo::PendingRemote<network::mojom::URLLoaderClient> client_remote,
+    std::optional<net::HttpByteRange> requested_range,
+    base::ElapsedTimer url_request_elapsed_timer,
+    URLDataSource::RangeDataResult result) {
+  TRACE_EVENT0("ui", "WebUIURLLoader::RangeDataAvailable");
+  const auto& [bytes, range, total_size, mimetype] = result;
+  // Fix up the response header in a HTTP Range spec
+  // https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+  // The header should contain:
+  // * "HTTP/1.1 206 Partial Content"
+  // * "Accept-Ranges: bytes"
+  // * "Content-Range: bytes 0-100/10000"  (0-100 is the range, 10000 is the
+  //                                        total size. If total size is
+  //                                        unknown, use "*")
+  // * "Content-length: 10000" (the size of the whole file. Note that this is
+  //                            different with what MDN says. But when
+  //                            Content-length contains the range's size, then
+  //                            the <video> won't be played)
+  // * "Content-type": "video/mp4" (or the correct mime type)
+  if (bytes && range.IsValid()) {
+    headers->headers->UpdateWithNewRange(range, total_size,
+                                         /*replace_status_line*/ true);
+    headers->headers->SetHeader("Accept-Ranges", "bytes");
+    headers->headers->SetHeader("Content-Type", mimetype);
+    headers->headers->SetHeader("Content-Length",
+                                base::NumberToString(bytes->size()));
+    headers->content_length = bytes->size();
+    if (total_size > 0) {
+      headers->headers->SetHeader("Content-Length",
+                                  base::NumberToString(total_size));
+      headers->content_length = total_size;
+    }
+
+    headers->parsed_headers =
+        network::PopulateParsedHeaders(headers->headers.get(), url);
+
+    // Since the bytes are from the memory mapped resource file, copying the
+    // data can lead to disk access. Needs to be posted to a SequencedTaskRunner
+    // as Mojo requires a SequencedTaskRunner::CurrentDefaultHandle in scope.
+    base::ThreadPool::CreateSequencedTaskRunner(
+        {base::TaskPriority::USER_BLOCKING, base::MayBlock(),
+         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})
+        ->PostTask(FROM_HERE,
+                   base::BindOnce(ReadRangeData, std::move(headers),
+                                  std::move(client_remote),
+                                  std::move(url_request_elapsed_timer), bytes));
+    return;
+  }
+
+  DataAvailable(std::move(headers), replacements, replace_in_js, source,
+                std::move(client_remote), requested_range,
+                std::move(url_request_elapsed_timer), bytes);
+}
+
+}  // namespace
+}  // namespace content

--- a/chromium_src/content/public/browser/url_data_source.cc
+++ b/chromium_src/content/public/browser/url_data_source.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/content/public/browser/url_data_source.cc"
+
+namespace content {
+
+URLDataSource::RangeDataResult::RangeDataResult() = default;
+URLDataSource::RangeDataResult::RangeDataResult(RangeDataResult&&) noexcept =
+    default;
+URLDataSource::RangeDataResult& URLDataSource::RangeDataResult::operator=(
+    URLDataSource::RangeDataResult&&) noexcept = default;
+URLDataSource::RangeDataResult::~RangeDataResult() = default;
+
+bool URLDataSource::SupportsRangeRequests(const GURL& url) const {
+  return false;
+}
+
+}  // namespace content

--- a/chromium_src/content/public/browser/url_data_source.h
+++ b/chromium_src/content/public/browser/url_data_source.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_URL_DATA_SOURCE_H_
+#define BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_URL_DATA_SOURCE_H_
+
+#include <string>
+
+#include "base/memory/ref_counted_memory.h"
+#include "net/http/http_byte_range.h"
+
+#define StartDataRequest                                                  \
+  StartDataRequest_Unused() {}                                            \
+                                                                          \
+  struct CONTENT_EXPORT RangeDataResult {                                 \
+    RangeDataResult();                                                    \
+    RangeDataResult(RangeDataResult&&) noexcept;                          \
+    RangeDataResult& operator=(RangeDataResult&&) noexcept;               \
+    ~RangeDataResult();                                                   \
+                                                                          \
+    scoped_refptr<base::RefCountedMemory> buffer;                         \
+    net::HttpByteRange range;                                             \
+    int64_t file_size = 0;                                                \
+    std::string mime_type;                                                \
+  };                                                                      \
+  using GotRangeDataCallback = base::OnceCallback<void(RangeDataResult)>; \
+                                                                          \
+  virtual void StartRangeDataRequest(                                     \
+      const GURL& url, const WebContents::Getter& wc_getter,              \
+      const net::HttpByteRange& range, GotRangeDataCallback callback) {}  \
+                                                                          \
+  virtual bool SupportsRangeRequests(const GURL& url) const;              \
+                                                                          \
+  virtual void StartDataRequest
+
+#include "src/content/public/browser/url_data_source.h"  // IWYU pragma: export
+
+#undef StartDataRequest
+
+#endif  // BRAVE_CHROMIUM_SRC_CONTENT_PUBLIC_BROWSER_URL_DATA_SOURCE_H_

--- a/components/playlist/browser/BUILD.gn
+++ b/components/playlist/browser/BUILD.gn
@@ -16,6 +16,8 @@ static_library("browser") {
     "media_detector_component_installer.h",
     "media_detector_component_manager.cc",
     "media_detector_component_manager.h",
+    "mime_util.cc",
+    "mime_util.h",
     "playlist_background_webcontents_helper.cc",
     "playlist_background_webcontents_helper.h",
     "playlist_constants.h",

--- a/components/playlist/browser/mime_util.cc
+++ b/components/playlist/browser/mime_util.cc
@@ -1,0 +1,132 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/playlist/browser/mime_util.h"
+
+#include <optional>
+#include <utility>
+
+#include "base/containers/flat_map.h"
+#include "base/files/file_path.h"
+#include "base/no_destructor.h"
+
+namespace playlist {
+namespace {
+
+// References
+// * List of mimetypes registered to IANA
+//   * Video:
+//   https://www.iana.org/assignments/media-types/media-types.xhtml#video
+//   * Audio:
+//   https://www.iana.org/assignments/media-types/media-types.xhtml#audio
+// * Chromium media framework supports
+//   * media/base/mime_util_internal.cc
+// * Mimetype to extension
+//   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
+//
+// Note that methods in "net/base/mime_util.h" have different result.
+//
+constexpr std::pair<std::string_view, base::FilePath::StringPieceType>
+    kMimeToExtensionData[] = {
+        /*m3u8*/
+        {"application/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
+        {"application/vnd.apple.mpegurl", FILE_PATH_LITERAL("m3u8")},
+        {"audio/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
+        {"audio/mpegurl", FILE_PATH_LITERAL("m3u8")},
+        /*aac*/
+        {"audio/aac", FILE_PATH_LITERAL("aac")},
+        /*flac*/
+        {"audio/flac", FILE_PATH_LITERAL("flac")},
+        /*mp3*/
+        {"audio/mp3", FILE_PATH_LITERAL("mp3")},
+        {"audio/x-mp3", FILE_PATH_LITERAL("mp3")},
+        {"audio/mpeg", FILE_PATH_LITERAL("mp3")},
+        /*wav*/
+        {"audio/wav", FILE_PATH_LITERAL("wav")},
+        {"audio/x-wav", FILE_PATH_LITERAL("wav")},
+        /*webm*/
+        {"audio/webm", FILE_PATH_LITERAL("weba")},
+        {"video/webm", FILE_PATH_LITERAL("webm")},
+        /*m4a*/
+        {"audio/x-m4a", FILE_PATH_LITERAL("m4a")},
+        /*3gp*/
+        {"video/3gpp", FILE_PATH_LITERAL("3gp")},
+        /*mp2t*/
+        {"video/mp2t", FILE_PATH_LITERAL("ts")},
+        /*mp4*/
+        {"video/mp4", FILE_PATH_LITERAL("mp4")},
+        {"audio/mp4", FILE_PATH_LITERAL("mp4")},
+        /*mpeg*/
+        {"video/mpeg", FILE_PATH_LITERAL("mpeg")},
+        /*ogg*/
+        {"application/ogg", FILE_PATH_LITERAL("ogx")},
+        {"audio/ogg", FILE_PATH_LITERAL("oga")},
+        {"video/ogg", FILE_PATH_LITERAL("ogv")},
+        /*m4v*/
+        {"video/x-m4v", FILE_PATH_LITERAL("m4v")}};
+
+// Helper templates to build flat_map from array of pairs.
+template <typename T, size_t N, size_t... I>
+auto MakeMimeToExtensionMap(const T (&pairs)[N], std::index_sequence<I...>) {
+  return base::flat_map<std::string_view, base::FilePath::StringPieceType>(
+      {pairs[I]...});
+}
+
+template <typename T, size_t N>
+auto MakeMimeToExtensionMap(const T (&pairs)[N]) {
+  return MakeMimeToExtensionMap(pairs, std::make_index_sequence<N>());
+}
+
+// For extension to mime map, reverse the pair.
+template <typename T>
+auto ReversePair(const T& pair) {
+  return std::pair{pair.second, pair.first};
+}
+
+template <typename T, size_t N, size_t... I>
+auto MakeExtensionToMimeMap(const T (&pairs)[N], std::index_sequence<I...>) {
+  // base::flat_map discards duplicated key, so we can pass pairs without
+  // filtering. Only the first will be picked.
+  return base::flat_map<base::FilePath::StringPieceType, std::string_view>(
+      {ReversePair(pairs[I])...});
+}
+
+template <typename T, size_t N>
+auto MakeExtensionToMimeMap(const T (&pairs)[N]) {
+  return MakeExtensionToMimeMap(pairs, std::make_index_sequence<N>());
+}
+
+}  // namespace
+
+namespace mime_util {
+
+std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
+    std::string_view mime_type) {
+  static const base::NoDestructor<
+      base::flat_map<std::string_view, base::FilePath::StringPieceType>>
+      kMimeToExtensionMap(MakeMimeToExtensionMap(kMimeToExtensionData));
+
+  if (kMimeToExtensionMap->contains(mime_type)) {
+    return base::FilePath::StringType(kMimeToExtensionMap->at(mime_type));
+  }
+
+  return std::nullopt;
+}
+
+std::optional<std::string> GetMimeTypeForFileExtension(
+    base::FilePath::StringPieceType file_extention) {
+  static const base::NoDestructor<
+      base::flat_map<base::FilePath::StringPieceType, std::string_view>>
+      kExtensionToMimeMap(MakeExtensionToMimeMap(kMimeToExtensionData));
+
+  if (kExtensionToMimeMap->contains(file_extention)) {
+    return std::string(kExtensionToMimeMap->at(file_extention));
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace mime_util
+}  // namespace playlist

--- a/components/playlist/browser/mime_util.cc
+++ b/components/playlist/browser/mime_util.cc
@@ -8,7 +8,6 @@
 #include <optional>
 #include <utility>
 
-#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
@@ -28,75 +27,44 @@ namespace {
 // * Mimetype to extension
 //   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 //
-constexpr inline std::pair<std::string_view, base::FilePath::StringPieceType>
-    kMimeToExtensionData[] = {
-        /*m3u8*/
-        {"application/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
-        {"application/vnd.apple.mpegurl", FILE_PATH_LITERAL("m3u8")},
-        {"audio/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
-        {"audio/mpegurl", FILE_PATH_LITERAL("m3u8")},
-        /*aac*/
-        {"audio/aac", FILE_PATH_LITERAL("aac")},
-        /*flac*/
-        {"audio/flac", FILE_PATH_LITERAL("flac")},
-        /*mp3*/
-        {"audio/mp3", FILE_PATH_LITERAL("mp3")},
-        {"audio/x-mp3", FILE_PATH_LITERAL("mp3")},
-        {"audio/mpeg", FILE_PATH_LITERAL("mp3")},
-        /*wav*/
-        {"audio/wav", FILE_PATH_LITERAL("wav")},
-        {"audio/x-wav", FILE_PATH_LITERAL("wav")},
-        /*webm*/
-        {"audio/webm", FILE_PATH_LITERAL("weba")},
-        {"video/webm", FILE_PATH_LITERAL("webm")},
-        /*m4a*/
-        {"audio/x-m4a", FILE_PATH_LITERAL("m4a")},
-        /*3gp*/
-        {"video/3gpp", FILE_PATH_LITERAL("3gp")},
-        /*mp2t*/
-        {"video/mp2t", FILE_PATH_LITERAL("ts")},
-        /*mp4*/
-        {"video/mp4", FILE_PATH_LITERAL("mp4")},
-        {"audio/mp4", FILE_PATH_LITERAL("mp4")},
-        /*mpeg*/
-        {"video/mpeg", FILE_PATH_LITERAL("mpeg")},
-        /*ogg*/
-        {"application/ogg", FILE_PATH_LITERAL("ogx")},
-        {"audio/ogg", FILE_PATH_LITERAL("oga")},
-        {"video/ogg", FILE_PATH_LITERAL("ogv")},
-        /*m4v*/
-        {"video/x-m4v", FILE_PATH_LITERAL("m4v")}};
-
-// Helper templates to build flat_map from array of pairs.
-template <typename T, size_t N, size_t... I>
-auto MakeMimeToExtensionMap(const T (&pairs)[N], std::index_sequence<I...>) {
-  return base::flat_map<std::string_view, base::FilePath::StringPieceType>(
-      {pairs[I]...});
-}
-
-template <typename T, size_t N>
-auto MakeMimeToExtensionMap(const T (&pairs)[N]) {
-  return MakeMimeToExtensionMap(pairs, std::make_index_sequence<N>());
-}
-
-// For extension to mime map, reverse the pair.
-template <typename T>
-auto ReversePair(const T& pair) {
-  return std::pair{pair.second, pair.first};
-}
-
-template <typename T, size_t N, size_t... I>
-auto MakeExtensionToMimeMap(const T (&pairs)[N], std::index_sequence<I...>) {
-  // base::flat_map discards duplicated key, so we can pass pairs without
-  // filtering. Only the first will be picked.
-  return base::flat_map<base::FilePath::StringPieceType, std::string_view>(
-      {ReversePair(pairs[I])...});
-}
-
-template <typename T, size_t N>
-auto MakeExtensionToMimeMap(const T (&pairs)[N]) {
-  return MakeExtensionToMimeMap(pairs, std::make_index_sequence<N>());
-}
+constexpr auto kMimeToExtensionMap =
+    base::MakeFixedFlatMap<std::string_view, base::FilePath::StringPieceType>(
+        {/*m3u8*/
+         {"application/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
+         {"application/vnd.apple.mpegurl", FILE_PATH_LITERAL("m3u8")},
+         {"audio/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
+         {"audio/mpegurl", FILE_PATH_LITERAL("m3u8")},
+         /*aac*/
+         {"audio/aac", FILE_PATH_LITERAL("aac")},
+         /*flac*/
+         {"audio/flac", FILE_PATH_LITERAL("flac")},
+         /*mp3*/
+         {"audio/mp3", FILE_PATH_LITERAL("mp3")},
+         {"audio/x-mp3", FILE_PATH_LITERAL("mp3")},
+         {"audio/mpeg", FILE_PATH_LITERAL("mp3")},
+         /*wav*/
+         {"audio/wav", FILE_PATH_LITERAL("wav")},
+         {"audio/x-wav", FILE_PATH_LITERAL("wav")},
+         /*webm*/
+         {"audio/webm", FILE_PATH_LITERAL("weba")},
+         {"video/webm", FILE_PATH_LITERAL("webm")},
+         /*m4a*/
+         {"audio/x-m4a", FILE_PATH_LITERAL("m4a")},
+         /*3gp*/
+         {"video/3gpp", FILE_PATH_LITERAL("3gp")},
+         /*mp2t*/
+         {"video/mp2t", FILE_PATH_LITERAL("ts")},
+         /*mp4*/
+         {"video/mp4", FILE_PATH_LITERAL("mp4")},
+         {"audio/mp4", FILE_PATH_LITERAL("mp4")},
+         /*mpeg*/
+         {"video/mpeg", FILE_PATH_LITERAL("mpeg")},
+         /*ogg*/
+         {"application/ogg", FILE_PATH_LITERAL("ogx")},
+         {"audio/ogg", FILE_PATH_LITERAL("oga")},
+         {"video/ogg", FILE_PATH_LITERAL("ogv")},
+         /*m4v*/
+         {"video/x-m4v", FILE_PATH_LITERAL("m4v")}});
 
 }  // namespace
 
@@ -104,11 +72,9 @@ namespace mime_util {
 
 std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
     std::string_view mime_type) {
-  static const base::NoDestructor<
-      base::flat_map<std::string_view, base::FilePath::StringPieceType>>
-      kMimeToExtensionMap(MakeMimeToExtensionMap(kMimeToExtensionData));
-  if (auto iter = kMimeToExtensionMap->find(mime_type);
-      iter != kMimeToExtensionMap->end()) {
+  if (decltype(kMimeToExtensionMap)::const_iterator iter =
+          kMimeToExtensionMap.find(mime_type);
+      iter != kMimeToExtensionMap.end()) {
     return base::FilePath::StringType(iter->second);
   }
 
@@ -119,7 +85,13 @@ std::optional<std::string> GetMimeTypeForFileExtension(
     base::FilePath::StringPieceType file_extension) {
   static const base::NoDestructor<
       base::flat_map<base::FilePath::StringPieceType, std::string_view>>
-      kExtensionToMimeMap(MakeExtensionToMimeMap(kMimeToExtensionData));
+      kExtensionToMimeMap(([]() {
+        base::flat_map<base::FilePath::StringPieceType, std::string_view> map;
+        for (const auto& [mime, ext] : kMimeToExtensionMap) {
+          map[ext] = mime;
+        }
+        return map;
+      })());
 
   if (auto iter = kExtensionToMimeMap->find(file_extension);
       iter != kExtensionToMimeMap->end()) {

--- a/components/playlist/browser/mime_util.cc
+++ b/components/playlist/browser/mime_util.cc
@@ -6,22 +6,14 @@
 #include "brave/components/playlist/browser/mime_util.h"
 
 #include <optional>
-#include <utility>
 
 #include "base/containers/fixed_flat_map.h"
-#include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
-#include "base/no_destructor.h"
+#include "base/ranges/algorithm.h"
 
 namespace playlist {
 namespace {
 
-//  Pairs of mimetype and file extension. Note that there are extensions that
-//  have the same mimetype. In that case, the first one will be picked from
-//  base::flat_map when building ext=>mimetype map. Also that's the reason why
-//  base::fixed_flat_map isn't used directly here, as base::fixed_flat_map sorts
-//  inputs.
-//
 // References
 // * List of mimetypes registered to IANA
 //   * Video:
@@ -33,79 +25,63 @@ namespace {
 // * Mimetype to extension
 //   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 //
-constexpr std::pair<std::string_view, base::FilePath::StringPieceType>
-    kMimeToExtensionData[] = {
-        /*m3u8*/
-        {"application/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
-        {"application/vnd.apple.mpegurl", FILE_PATH_LITERAL("m3u8")},
-        {"audio/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
-        {"audio/mpegurl", FILE_PATH_LITERAL("m3u8")},
-        /*aac*/
-        {"audio/aac", FILE_PATH_LITERAL("aac")},
-        /*flac*/
-        {"audio/flac", FILE_PATH_LITERAL("flac")},
-        /*mp3*/
-        {"audio/mp3", FILE_PATH_LITERAL("mp3")},
-        {"audio/x-mp3", FILE_PATH_LITERAL("mp3")},
-        {"audio/mpeg", FILE_PATH_LITERAL("mp3")},
-        /*wav*/
-        {"audio/wav", FILE_PATH_LITERAL("wav")},
-        {"audio/x-wav", FILE_PATH_LITERAL("wav")},
-        /*webm*/
-        {"audio/webm", FILE_PATH_LITERAL("weba")},
-        {"video/webm", FILE_PATH_LITERAL("webm")},
-        /*m4a*/
-        {"audio/x-m4a", FILE_PATH_LITERAL("m4a")},
-        /*3gp*/
-        {"video/3gpp", FILE_PATH_LITERAL("3gp")},
-        /*mp2t*/
-        {"video/mp2t", FILE_PATH_LITERAL("ts")},
-        /*mp4*/
-        {"video/mp4", FILE_PATH_LITERAL("mp4")},
-        {"audio/mp4", FILE_PATH_LITERAL("mp4")},
-        /*mpeg*/
-        {"video/mpeg", FILE_PATH_LITERAL("mpeg")},
-        /*ogg*/
-        {"application/ogg", FILE_PATH_LITERAL("ogx")},
-        {"audio/ogg", FILE_PATH_LITERAL("oga")},
-        {"video/ogg", FILE_PATH_LITERAL("ogv")},
-        /*m4v*/
-        {"video/x-m4v", FILE_PATH_LITERAL("m4v")}};
-
-// Helper templates to build flat_map from array of pairs.
-template <typename T, size_t N, size_t... I>
-consteval auto MakeMimeToExtensionMap(const T (&pairs)[N],
-                                      std::index_sequence<I...>) {
-  return base::MakeFixedFlatMap<std::string_view,
-                                base::FilePath::StringPieceType>({pairs[I]...});
-}
-
-template <typename T, size_t N>
-consteval auto MakeMimeToExtensionMap(const T (&pairs)[N]) {
-  return MakeMimeToExtensionMap(pairs, std::make_index_sequence<N>());
-}
-
-// For extension to mime map, reverse the pair.
-template <typename T>
-auto ReversePair(const T& pair) {
-  return std::pair{pair.second, pair.first};
-}
-
-template <typename T, size_t N, size_t... I>
-auto MakeExtensionToMimeMap(const T (&pairs)[N], std::index_sequence<I...>) {
-  // base::flat_map discards duplicated key, so we can pass pairs without
-  // filtering. Only the first will be picked.
-  return base::flat_map<base::FilePath::StringPieceType, std::string_view>(
-      {ReversePair(pairs[I])...});
-}
-
-template <typename T, size_t N>
-auto MakeExtensionToMimeMap(const T (&pairs)[N]) {
-  return MakeExtensionToMimeMap(pairs, std::make_index_sequence<N>());
-}
-
 constexpr inline auto kMimeToExtensionMap =
-    MakeMimeToExtensionMap(kMimeToExtensionData);
+    base::MakeFixedFlatMap<std::string_view, base::FilePath::StringPieceType>(
+        {/*m3u8*/
+         {"application/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
+         {"application/vnd.apple.mpegurl", FILE_PATH_LITERAL("m3u8")},
+         {"audio/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
+         {"audio/mpegurl", FILE_PATH_LITERAL("m3u8")},
+         /*aac*/
+         {"audio/aac", FILE_PATH_LITERAL("aac")},
+         /*flac*/
+         {"audio/flac", FILE_PATH_LITERAL("flac")},
+         /*mp3*/
+         {"audio/mp3", FILE_PATH_LITERAL("mp3")},
+         {"audio/x-mp3", FILE_PATH_LITERAL("mp3")},
+         {"audio/mpeg", FILE_PATH_LITERAL("mp3")},
+         /*wav*/
+         {"audio/wav", FILE_PATH_LITERAL("wav")},
+         {"audio/x-wav", FILE_PATH_LITERAL("wav")},
+         /*webm*/
+         {"audio/webm", FILE_PATH_LITERAL("weba")},
+         {"video/webm", FILE_PATH_LITERAL("webm")},
+         /*m4a*/
+         {"audio/x-m4a", FILE_PATH_LITERAL("m4a")},
+         /*3gp*/
+         {"video/3gpp", FILE_PATH_LITERAL("3gp")},
+         /*mp2t*/
+         {"video/mp2t", FILE_PATH_LITERAL("ts")},
+         /*mp4*/
+         {"video/mp4", FILE_PATH_LITERAL("mp4")},
+         {"audio/mp4", FILE_PATH_LITERAL("mp4")},
+         /*mpeg*/
+         {"video/mpeg", FILE_PATH_LITERAL("mpeg")},
+         /*ogg*/
+         {"application/ogg", FILE_PATH_LITERAL("ogx")},
+         {"audio/ogg", FILE_PATH_LITERAL("oga")},
+         {"video/ogg", FILE_PATH_LITERAL("ogv")},
+         /*m4v*/
+         {"video/x-m4v", FILE_PATH_LITERAL("m4v")}});
+
+constexpr inline auto kExtensionToMimeMap =
+    base::MakeFixedFlatMap<base::FilePath::StringPieceType, std::string_view>(
+        {{FILE_PATH_LITERAL("m3u8"), "application/x-mpegurl"},
+         {FILE_PATH_LITERAL("aac"), "audio/aac"},
+         {FILE_PATH_LITERAL("flac"), "audio/flac"},
+         {FILE_PATH_LITERAL("mp3"), "audio/mp3"},
+         {FILE_PATH_LITERAL("wav"), "audio/wav"},
+         {FILE_PATH_LITERAL("weba"), "audio/webm"},
+         {FILE_PATH_LITERAL("webm"), "video/webm"},
+         {FILE_PATH_LITERAL("m4a"), "audio/x-m4a"},
+         {FILE_PATH_LITERAL("3gp"), "video/3gpp"},
+         {FILE_PATH_LITERAL("ts"), "video/mp2t"},
+         {FILE_PATH_LITERAL("mp4"), "video/mp4"},
+         {FILE_PATH_LITERAL("mpeg"), "video/mpeg"},
+         {FILE_PATH_LITERAL("ogx"), "application/ogg"},
+         {FILE_PATH_LITERAL("oga"), "audio/ogg"},
+         {FILE_PATH_LITERAL("ogv"), "video/ogg"},
+         {FILE_PATH_LITERAL("m4v"), "video/x-m4v"}});
 
 }  // namespace
 
@@ -124,16 +100,22 @@ std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
 
 std::optional<std::string> GetMimeTypeForFileExtension(
     base::FilePath::StringPieceType file_extension) {
-  static const base::NoDestructor<
-      base::flat_map<base::FilePath::StringPieceType, std::string_view>>
-      kExtensionToMimeMap(MakeExtensionToMimeMap(kMimeToExtensionData));
-
-  if (auto iter = kExtensionToMimeMap->find(file_extension);
-      iter != kExtensionToMimeMap->end()) {
+  if (decltype(kExtensionToMimeMap)::const_iterator iter =
+          kExtensionToMimeMap.find(file_extension);
+      iter != kExtensionToMimeMap.end()) {
     return std::string(iter->second);
   }
 
   return std::nullopt;
+}
+
+std::vector<std::string> GetSupportedMimetypes() {
+  std::vector<std::string> supported_mimetypes;
+  base::ranges::transform(
+      kMimeToExtensionMap,
+      std::inserter(supported_mimetypes, supported_mimetypes.end()),
+      [](const auto& pair) { return std::string(pair.first); });
+  return supported_mimetypes;
 }
 
 }  // namespace mime_util

--- a/components/playlist/browser/mime_util.cc
+++ b/components/playlist/browser/mime_util.cc
@@ -26,8 +26,6 @@ namespace {
 // * Mimetype to extension
 //   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 //
-// Note that methods in "net/base/mime_util.h" have different result.
-//
 constexpr std::pair<std::string_view, base::FilePath::StringPieceType>
     kMimeToExtensionData[] = {
         /*m3u8*/
@@ -116,13 +114,13 @@ std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
 }
 
 std::optional<std::string> GetMimeTypeForFileExtension(
-    base::FilePath::StringPieceType file_extention) {
+    base::FilePath::StringPieceType file_extension) {
   static const base::NoDestructor<
       base::flat_map<base::FilePath::StringPieceType, std::string_view>>
       kExtensionToMimeMap(MakeExtensionToMimeMap(kMimeToExtensionData));
 
-  if (kExtensionToMimeMap->contains(file_extention)) {
-    return std::string(kExtensionToMimeMap->at(file_extention));
+  if (kExtensionToMimeMap->contains(file_extension)) {
+    return std::string(kExtensionToMimeMap->at(file_extension));
   }
 
   return std::nullopt;

--- a/components/playlist/browser/mime_util.cc
+++ b/components/playlist/browser/mime_util.cc
@@ -8,6 +8,8 @@
 #include <optional>
 #include <utility>
 
+#include "base/containers/contains.h"
+#include "base/containers/fixed_flat_map.h"
 #include "base/containers/flat_map.h"
 #include "base/files/file_path.h"
 #include "base/no_destructor.h"
@@ -26,7 +28,7 @@ namespace {
 // * Mimetype to extension
 //   * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
 //
-constexpr std::pair<std::string_view, base::FilePath::StringPieceType>
+constexpr inline std::pair<std::string_view, base::FilePath::StringPieceType>
     kMimeToExtensionData[] = {
         /*m3u8*/
         {"application/x-mpegurl", FILE_PATH_LITERAL("m3u8")},
@@ -105,9 +107,9 @@ std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
   static const base::NoDestructor<
       base::flat_map<std::string_view, base::FilePath::StringPieceType>>
       kMimeToExtensionMap(MakeMimeToExtensionMap(kMimeToExtensionData));
-
-  if (kMimeToExtensionMap->contains(mime_type)) {
-    return base::FilePath::StringType(kMimeToExtensionMap->at(mime_type));
+  if (auto iter = kMimeToExtensionMap->find(mime_type);
+      iter != kMimeToExtensionMap->end()) {
+    return base::FilePath::StringType(iter->second);
   }
 
   return std::nullopt;
@@ -119,8 +121,9 @@ std::optional<std::string> GetMimeTypeForFileExtension(
       base::flat_map<base::FilePath::StringPieceType, std::string_view>>
       kExtensionToMimeMap(MakeExtensionToMimeMap(kMimeToExtensionData));
 
-  if (kExtensionToMimeMap->contains(file_extension)) {
-    return std::string(kExtensionToMimeMap->at(file_extension));
+  if (auto iter = kExtensionToMimeMap->find(file_extension);
+      iter != kExtensionToMimeMap->end()) {
+    return std::string(iter->second);
   }
 
   return std::nullopt;

--- a/components/playlist/browser/mime_util.h
+++ b/components/playlist/browser/mime_util.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_PLAYLIST_BROWSER_MIME_UTIL_H_
+#define BRAVE_COMPONENTS_PLAYLIST_BROWSER_MIME_UTIL_H_
+
+#include <optional>
+#include <string>
+
+#include "base/files/file_path.h"
+
+namespace playlist::mime_util {
+
+std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
+    std::string_view mime_type);
+
+std::optional<std::string> GetMimeTypeForFileExtension(
+    base::FilePath::StringPieceType file_extention);
+
+}  // namespace playlist::mime_util
+
+#endif  // BRAVE_COMPONENTS_PLAYLIST_BROWSER_MIME_UTIL_H_

--- a/components/playlist/browser/mime_util.h
+++ b/components/playlist/browser/mime_util.h
@@ -8,6 +8,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "base/files/file_path.h"
 
@@ -21,6 +22,8 @@ std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
 
 std::optional<std::string> GetMimeTypeForFileExtension(
     base::FilePath::StringPieceType file_extension);
+
+std::vector<std::string> GetSupportedMimetypes();
 
 }  // namespace playlist::mime_util
 

--- a/components/playlist/browser/mime_util.h
+++ b/components/playlist/browser/mime_util.h
@@ -11,13 +11,16 @@
 
 #include "base/files/file_path.h"
 
+// Utilities for Mime <-> File extension conversion.
+// These have more broader coverage than "net/base/mime_util.h" has as for the
+// media types.
 namespace playlist::mime_util {
 
 std::optional<base::FilePath::StringType> GetFileExtensionForMimetype(
     std::string_view mime_type);
 
 std::optional<std::string> GetMimeTypeForFileExtension(
-    base::FilePath::StringPieceType file_extention);
+    base::FilePath::StringPieceType file_extension);
 
 }  // namespace playlist::mime_util
 


### PR DESCRIPTION
For large videos, we should send data in small pieces. This patch adds supports for HTTP range requests to the `WebUIURLLoaderFactory` and serves the request in the `PlaylistDataSourcd` which inherits `content::URLDataSource`.

With this, we can serve videos without OOM crash.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/34614

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

