### PR TITLE
Sidebar Enabled by default test via griffin

### DIFF
--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -58,6 +58,7 @@
 
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/onboarding/onboarding_tab_helper.h"
+#include "brave/components/sidebar/pref_names.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -126,6 +127,8 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 
 #if defined(TOOLKIT_VIEWS)
   onboarding::RegisterLocalStatePrefs(registry);
+  registry->RegisterBooleanPref(sidebar::kTargetUserForSidebarEnabledTest,
+                                false);
 #endif
 
 #if BUILDFLAG(ENABLE_CRASH_DIALOG)

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -52,7 +52,6 @@
 #include "chrome/browser/prefs/session_startup_pref.h"
 #include "chrome/browser/preloading/preloading_prefs.h"
 #include "chrome/browser/ui/webui/new_tab_page/ntp_pref_names.h"
-#include "chrome/common/channel_info.h"
 #include "chrome/common/pref_names.h"
 #include "components/content_settings/core/common/pref_names.h"
 #include "components/embedder_support/pref_names.h"
@@ -124,7 +123,6 @@
 
 #if defined(TOOLKIT_VIEWS)
 #include "brave/components/sidebar/pref_names.h"
-#include "brave/components/sidebar/sidebar_service.h"
 #endif
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
@@ -434,10 +432,6 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 
 #if BUILDFLAG(ENABLE_TOR)
   tor::TorProfileService::RegisterProfilePrefs(registry);
-#endif
-
-#if defined(TOOLKIT_VIEWS)
-  sidebar::SidebarService::RegisterProfilePrefs(registry, chrome::GetChannel());
 #endif
 
 #if !BUILDFLAG(IS_ANDROID)

--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -102,6 +102,7 @@
 
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/onboarding/onboarding_tab_helper.h"
+#include "brave/browser/ui/sidebar/sidebar_tab_helper.h"
 #endif
 
 namespace brave {
@@ -187,6 +188,7 @@ void AttachTabHelpers(content::WebContents* web_contents) {
 
 #if defined(TOOLKIT_VIEWS)
   OnboardingTabHelper::MaybeCreateForWebContents(web_contents);
+  sidebar::SidebarTabHelper::MaybeCreateForWebContents(web_contents);
 #endif
 
   if (base::FeatureList::IsEnabled(net::features::kBraveEphemeralStorage)) {

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -21,16 +21,22 @@ source_set("sidebar") {
     "sidebar_model.h",
     "sidebar_service_factory.cc",
     "sidebar_service_factory.h",
+    "sidebar_tab_helper.cc",
+    "sidebar_tab_helper.h",
     "sidebar_utils.cc",
     "sidebar_utils.h",
   ]
 
   deps = [
     "//base",
+    "//brave/browser/profiles:util",
     "//brave/components/sidebar",
     "//chrome/browser/profiles",
+    "//chrome/common:channel_info",
     "//components/keyed_service/content",
     "//components/keyed_service/core",
+    "//components/prefs",
+    "//components/user_prefs",
     "//content/public/browser",
     "//content/public/common",
     "//extensions/buildflags",

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -34,6 +34,7 @@ source_set("sidebar") {
     "//brave/components/sidebar",
     "//chrome/browser/profiles",
     "//chrome/common:channel_info",
+    "//components/google/core/common",
     "//components/keyed_service/content",
     "//components/keyed_service/core",
     "//components/prefs",

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -30,6 +30,7 @@ source_set("sidebar") {
   deps = [
     "//base",
     "//brave/browser/profiles:util",
+    "//brave/components/constants",
     "//brave/components/sidebar",
     "//chrome/browser/profiles",
     "//chrome/common:channel_info",

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -106,6 +106,7 @@ source_set("unit_tests") {
     "//base",
     "//brave/browser/ui/sidebar",
     "//brave/common",
+    "//brave/components/ai_chat/core/common/buildflags",
     "//brave/components/playlist/common",
     "//brave/components/sidebar",
     "//chrome/browser/ui",

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -248,6 +248,20 @@ class SidebarBrowserTest : public InProcessBrowserTest {
     return item_count;
   }
 
+  int GetFirstPanelItemIndex() {
+    auto const items = model()->GetAllSidebarItems();
+    auto const iter =
+        base::ranges::find(items, true, &SidebarItem::open_in_panel);
+    return std::distance(items.cbegin(), iter);
+  }
+
+  int GetFirstWebItemIndex() {
+    const auto items = model()->GetAllSidebarItems();
+    auto const iter =
+        base::ranges::find(items, false, &SidebarItem::open_in_panel);
+    return std::distance(items.cbegin(), iter);
+  }
+
   raw_ptr<views::View> item_added_bubble_anchor_ = nullptr;
   std::unique_ptr<base::RunLoop> run_loop_;
   base::WeakPtrFactory<SidebarBrowserTest> weak_factory_{this};
@@ -275,28 +289,42 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, BasicTest) {
   auto expected_count = GetDefaultItemCount();
   EXPECT_EQ(expected_count, model()->GetAllSidebarItems().size());
   // Activate item that opens in panel.
-  controller()->ActivateItemAt(2);
-  EXPECT_THAT(model()->active_index(), Optional(2u));
-  EXPECT_TRUE(controller()->IsActiveIndex(2));
+  const size_t first_panel_item_index = GetFirstPanelItemIndex();
+  controller()->ActivateItemAt(first_panel_item_index);
+  EXPECT_THAT(model()->active_index(), Optional(first_panel_item_index));
+  EXPECT_TRUE(controller()->IsActiveIndex(first_panel_item_index));
 
   // Try to activate item at index 1.
   // Default item at index 1 opens in new tab. So, sidebar active index is not
   // changed. Still active index is 2.
-  const auto item = model()->GetAllSidebarItems()[1];
+
+  // Get first index of item that opens in panel.
+  const size_t first_web_item_index = GetFirstWebItemIndex();
+  const auto item = model()->GetAllSidebarItems()[first_web_item_index];
   EXPECT_FALSE(item.open_in_panel);
-  controller()->ActivateItemAt(1);
-  EXPECT_THAT(model()->active_index(), Optional(2u));
+  controller()->ActivateItemAt(first_web_item_index);
+  int active_item_index = first_panel_item_index;
+  EXPECT_THAT(model()->active_index(), Optional(active_item_index));
 
   // Setting std::nullopt means deactivate current active tab.
   controller()->ActivateItemAt(std::nullopt);
   EXPECT_THAT(model()->active_index(), Eq(std::nullopt));
 
-  controller()->ActivateItemAt(2);
+  controller()->ActivateItemAt(active_item_index);
 
-  // Remove Item at index 0 change active index from 3 to 2.
-  SidebarServiceFactory::GetForProfile(browser()->profile())->RemoveItemAt(0);
+  auto* sidebar_service =
+      SidebarServiceFactory::GetForProfile(browser()->profile());
+
+  // Move active item to the next index to make sure it's not the first item.
+  sidebar_service->MoveItem(first_panel_item_index, first_panel_item_index + 1);
+  active_item_index++;
+  EXPECT_THAT(model()->active_index(), Eq(active_item_index));
+
+  // Remove Item at index 0 to change active index.
+  sidebar_service->RemoveItemAt(0);
+  active_item_index--;
   EXPECT_EQ(--expected_count, model()->GetAllSidebarItems().size());
-  EXPECT_THAT(model()->active_index(), Optional(1u));
+  EXPECT_THAT(model()->active_index(), Optional(active_item_index));
 
   // If current active tab is not NTP, we can add current url to sidebar.
   EXPECT_TRUE(CanAddCurrentActiveTabToSidebar(browser()));
@@ -359,13 +387,19 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, WebTypePanelTest) {
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, IterateBuiltInWebTypeTest) {
   // Click builtin wallet item and it's loaded at current active tab.
-  auto item = model()->GetAllSidebarItems()[1];
-  EXPECT_FALSE(controller()->DoesBrowserHaveOpenedTabForItem(item));
-  SimulateSidebarItemClickAt(1);
-  EXPECT_TRUE(controller()->DoesBrowserHaveOpenedTabForItem(item));
+  const auto items = model()->GetAllSidebarItems();
+  const auto wallet_item_iter =
+      base::ranges::find(items, SidebarItem::BuiltInItemType::kWallet,
+                         &SidebarItem::built_in_item_type);
+  ASSERT_NE(wallet_item_iter, items.cend());
+  const int wallet_item_index = std::distance(items.cbegin(), wallet_item_iter);
+  auto wallet_item = model()->GetAllSidebarItems()[wallet_item_index];
+  EXPECT_FALSE(controller()->DoesBrowserHaveOpenedTabForItem(wallet_item));
+  SimulateSidebarItemClickAt(wallet_item_index);
+  EXPECT_TRUE(controller()->DoesBrowserHaveOpenedTabForItem(wallet_item));
   EXPECT_EQ(0, tab_model()->active_index());
   EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL().host(),
-            item.url.host());
+            wallet_item.url.host());
 
   // Create NTP and click wallet item. Then wallet tab(index 0) is activated.
   ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
@@ -374,11 +408,11 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, IterateBuiltInWebTypeTest) {
       ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
   // NTP is active tab.
   EXPECT_EQ(1, tab_model()->active_index());
-  SimulateSidebarItemClickAt(1);
+  SimulateSidebarItemClickAt(wallet_item_index);
   // Wallet tab is active tab.
   EXPECT_EQ(0, tab_model()->active_index());
   EXPECT_EQ(tab_model()->GetWebContentsAt(0)->GetVisibleURL().host(),
-            item.url.host());
+            wallet_item.url.host());
 
   // Create NTP.
   ASSERT_TRUE(ui_test_utils::NavigateToURLWithDisposition(
@@ -387,18 +421,18 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, IterateBuiltInWebTypeTest) {
       ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
   // NTP is active tab and load wallet on it.
   EXPECT_EQ(2, tab_model()->active_index());
-  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), item.url));
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), wallet_item.url));
 
   // Click wallet item and then first wallet tab(tab index 0) is activated.
-  SimulateSidebarItemClickAt(1);
+  SimulateSidebarItemClickAt(wallet_item_index);
   EXPECT_EQ(0, tab_model()->active_index());
 
   // Click wallet item and then second wallet tab(index 2) is activated.
-  SimulateSidebarItemClickAt(1);
+  SimulateSidebarItemClickAt(wallet_item_index);
   EXPECT_EQ(2, tab_model()->active_index());
 
   // Click wallet item and then first wallet tab(index 0) is activated.
-  SimulateSidebarItemClickAt(1);
+  SimulateSidebarItemClickAt(wallet_item_index);
   EXPECT_EQ(0, tab_model()->active_index());
 
   // Checking windows' activation state is flaky in browser tests.
@@ -409,7 +443,8 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, IterateBuiltInWebTypeTest) {
 
   // |browser2| doesn't have any wallet tab. So, clicking wallet sidebar item
   // activates other browser's first wallet tab.
-  static_cast<BraveBrowser*>(browser2)->sidebar_controller()->ActivateItemAt(1);
+  static_cast<BraveBrowser*>(browser2)->sidebar_controller()->ActivateItemAt(
+      wallet_item_index);
 
   // Wait till browser() is activated.
   WaitUntil(base::BindLambdaForTesting(

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -852,7 +852,7 @@ class SidebarBrowserTestWithkSidebarShowAlwaysOnStable
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
     SidebarBrowserTest::SetUpCommandLine(command_line);
-    command_line->AppendSwitch(switches::kDontShowAlwaysSidebarOnNonStable);
+    command_line->AppendSwitch(switches::kDontShowSidebarOnNonStable);
     command_line->AppendSwitch(switches::kForceFirstRun);
   }
 
@@ -871,9 +871,10 @@ IN_PROC_BROWSER_TEST_P(SidebarBrowserTestWithkSidebarShowAlwaysOnStable,
   EXPECT_EQ(SidebarService::ShowSidebarOption::kShowAlways,
             sidebar_service->GetSidebarShowOption());
 
-  // Check one shot leo panel is opened or not based on test parameter.
+#if BUILDFLAG(ENABLE_AI_CHAT)
+  // Check one shot Leo panel is opened or not based on test parameter.
   if (GetParam()) {
-    // If leo panel is opened, panel active index is changed.
+    // If Leo panel is opened, panel active index is changed.
     EXPECT_CALL(observer_, OnActiveIndexChanged(testing::_, testing::_))
         .Times(1);
   } else {
@@ -908,6 +909,7 @@ IN_PROC_BROWSER_TEST_P(SidebarBrowserTestWithkSidebarShowAlwaysOnStable,
       ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP));
 
   testing::Mock::VerifyAndClearExpectations(&observer_);
+#endif
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -14,8 +14,11 @@
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
+#include "brave/components/sidebar/features.h"
+#include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_service.h"
 #include "chrome/browser/history/history_service_factory.h"
+#include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_navigator.h"
 #include "chrome/browser/ui/browser_navigator_params.h"
@@ -25,6 +28,7 @@
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
 #include "chrome/browser/ui/singleton_tabs.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "components/prefs/pref_service.h"
 
 namespace sidebar {
 
@@ -92,6 +96,12 @@ void SidebarController::ActivateItemAt(std::optional<size_t> index,
   // Only an item for panel can get activated.
   if (item.open_in_panel) {
     sidebar_model_->SetActiveIndex(index);
+
+    if (sidebar::features::kOpenOneShotLeoPanel.Get() &&
+        item.built_in_item_type == SidebarItem::BuiltInItemType::kChatUI) {
+      // Prevent one-time leo panel open.
+      browser_->profile()->GetPrefs()->SetBoolean(kLeoPanelOneTimeOpen, true);
+    }
     return;
   }
 

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -99,8 +99,8 @@ void SidebarController::ActivateItemAt(std::optional<size_t> index,
 
     if (sidebar::features::kOpenOneShotLeoPanel.Get() &&
         item.built_in_item_type == SidebarItem::BuiltInItemType::kChatUI) {
-      // Prevent one-time leo panel open.
-      browser_->profile()->GetPrefs()->SetBoolean(kLeoPanelOneTimeOpen, true);
+      // Prevent one-time Leo panel open.
+      browser_->profile()->GetPrefs()->SetBoolean(kLeoPanelOneShotOpen, true);
     }
     return;
   }

--- a/browser/ui/sidebar/sidebar_service_factory.cc
+++ b/browser/ui/sidebar/sidebar_service_factory.cc
@@ -37,6 +37,7 @@ SidebarServiceFactory::SidebarServiceFactory()
     : BrowserContextKeyedServiceFactory(
           "SidebarService",
           BrowserContextDependencyManager::GetInstance()) {
+  // Early return if the preference is already set or not existed(in test).
   if (!g_browser_process || !g_browser_process->local_state()) {
     return;
   }
@@ -47,6 +48,7 @@ SidebarServiceFactory::SidebarServiceFactory()
     return;
   }
 
+  // Set target user(new user & feature enabled) flag only once.
   if (g_browser_process->local_state()->GetBoolean(
           kTargetUserForSidebarEnabledTest)) {
     return;

--- a/browser/ui/sidebar/sidebar_service_factory.cc
+++ b/browser/ui/sidebar/sidebar_service_factory.cc
@@ -7,10 +7,18 @@
 
 #include "base/no_destructor.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
+#include "brave/components/sidebar/features.h"
+#include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_service.h"
+#include "chrome/browser/browser_process.h"
+#include "chrome/browser/first_run/first_run.h"
 #include "chrome/browser/profiles/incognito_helpers.h"
 #include "chrome/browser/profiles/profile.h"
+#include "chrome/common/channel_info.h"
 #include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/pref_registry/pref_registry_syncable.h"
+#include "components/prefs/pref_service.h"
+#include "components/version_info/channel.h"
 
 namespace sidebar {
 
@@ -28,7 +36,30 @@ SidebarService* SidebarServiceFactory::GetForProfile(Profile* profile) {
 SidebarServiceFactory::SidebarServiceFactory()
     : BrowserContextKeyedServiceFactory(
           "SidebarService",
-          BrowserContextDependencyManager::GetInstance()) {}
+          BrowserContextDependencyManager::GetInstance()) {
+  if (!g_browser_process || !g_browser_process->local_state()) {
+    return;
+  }
+
+  auto* preference = g_browser_process->local_state()->FindPreference(
+      kTargetUserForSidebarEnabledTest);
+  if (!preference) {
+    return;
+  }
+
+  if (g_browser_process->local_state()->GetBoolean(
+          kTargetUserForSidebarEnabledTest)) {
+    return;
+  }
+
+  if (preference->IsDefaultValue()) {
+    g_browser_process->local_state()->SetBoolean(
+        kTargetUserForSidebarEnabledTest,
+        base::FeatureList::IsEnabled(
+            sidebar::features::kSidebarShowAlwaysOnStable) &&
+            first_run::IsChromeFirstRun());
+  }
+}
 
 SidebarServiceFactory::~SidebarServiceFactory() = default;
 
@@ -68,6 +99,12 @@ content::BrowserContext* SidebarServiceFactory::GetBrowserContextToUse(
     content::BrowserContext* context) const {
   // sidebar items list is not shared between normal and private windows.
   return chrome::GetBrowserContextOwnInstanceInIncognito(context);
+}
+
+void SidebarServiceFactory::RegisterProfilePrefs(
+    user_prefs::PrefRegistrySyncable* registry) {
+  SidebarService::RegisterProfilePrefs(
+      registry, GetDefaultShowSidebarOption(chrome::GetChannel()));
 }
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_service_factory.h
+++ b/browser/ui/sidebar/sidebar_service_factory.h
@@ -63,6 +63,8 @@ class SidebarServiceFactory : public BrowserContextKeyedServiceFactory {
       content::BrowserContext* context) const override;
   content::BrowserContext* GetBrowserContextToUse(
       content::BrowserContext* context) const override;
+  void RegisterProfilePrefs(
+      user_prefs::PrefRegistrySyncable* registry) override;
 };
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_service_factory.h
+++ b/browser/ui/sidebar/sidebar_service_factory.h
@@ -34,9 +34,9 @@ class SidebarServiceFactory : public BrowserContextKeyedServiceFactory {
 
   // This is the default display order
   static constexpr SidebarItem::BuiltInItemType kDefaultBuiltInItemTypes[] = {
+      SidebarItem::BuiltInItemType::kChatUI,
       SidebarItem::BuiltInItemType::kBraveTalk,
       SidebarItem::BuiltInItemType::kWallet,
-      SidebarItem::BuiltInItemType::kChatUI,
       SidebarItem::BuiltInItemType::kBookmarks,
       SidebarItem::BuiltInItemType::kReadingList,
       SidebarItem::BuiltInItemType::kHistory,

--- a/browser/ui/sidebar/sidebar_tab_helper.cc
+++ b/browser/ui/sidebar/sidebar_tab_helper.cc
@@ -14,6 +14,7 @@
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
 #include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "components/google/core/common/google_util.h"
 #include "components/prefs/pref_service.h"
 #include "components/search_engines/template_url_service.h"
 #include "components/user_prefs/user_prefs.h"
@@ -99,6 +100,12 @@ void SidebarTabHelper::PrimaryPageChanged(content::Page& page) {
 
   // If side panel is already opened, don't open leo panel now.
   if (side_panel_ui->GetCurrentEntryId()) {
+    return;
+  }
+
+  // TODO(simonhong): Curious why below GetTemplateURLs() doesn't
+  // include google search.
+  if (google_util::IsGoogleSearchUrl(url)) {
     return;
   }
 

--- a/browser/ui/sidebar/sidebar_tab_helper.cc
+++ b/browser/ui/sidebar/sidebar_tab_helper.cc
@@ -9,6 +9,7 @@
 #include "brave/browser/profiles/profile_util.h"
 #include "brave/components/sidebar/features.h"
 #include "brave/components/sidebar/pref_names.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
@@ -30,6 +31,15 @@ bool IsLeoPanelAlreadyOpened(content::WebContents* contents) {
 // static
 void SidebarTabHelper::MaybeCreateForWebContents(
     content::WebContents* contents) {
+  if (!g_browser_process || !g_browser_process->local_state()) {
+    return;
+  }
+
+  if (!g_browser_process->local_state()->GetBoolean(
+          kTargetUserForSidebarEnabledTest)) {
+    return;
+  }
+
   if (!sidebar::features::kOpenOneShotLeoPanel.Get()) {
     return;
   }

--- a/browser/ui/sidebar/sidebar_tab_helper.cc
+++ b/browser/ui/sidebar/sidebar_tab_helper.cc
@@ -1,0 +1,113 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/sidebar/sidebar_tab_helper.h"
+
+#include "base/metrics/field_trial_params.h"
+#include "brave/browser/profiles/profile_util.h"
+#include "brave/components/sidebar/features.h"
+#include "brave/components/sidebar/pref_names.h"
+#include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/side_panel/side_panel_entry_id.h"
+#include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "components/prefs/pref_service.h"
+#include "components/search_engines/template_url_service.h"
+#include "components/user_prefs/user_prefs.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/web_contents.h"
+#include "url/gurl.h"
+
+namespace sidebar {
+
+bool IsLeoPanelAlreadyOpened(content::WebContents* contents) {
+  auto* prefs = user_prefs::UserPrefs::Get(contents->GetBrowserContext());
+  return prefs->GetBoolean(kLeoPanelOneTimeOpen);
+}
+
+// static
+void SidebarTabHelper::MaybeCreateForWebContents(
+    content::WebContents* contents) {
+  if (!sidebar::features::kOpenOneShotLeoPanel.Get()) {
+    return;
+  }
+
+  // For now, we only support leo panel for regular profile.
+  auto* context = contents->GetBrowserContext();
+  if (!brave::IsRegularProfile(context)) {
+    return;
+  }
+
+  if (IsLeoPanelAlreadyOpened(contents)) {
+    return;
+  }
+
+  content::WebContentsUserData<SidebarTabHelper>::CreateForWebContents(
+      contents);
+}
+
+SidebarTabHelper::SidebarTabHelper(content::WebContents* contents)
+    : WebContentsUserData(*contents) {
+  Observe(contents);
+}
+
+SidebarTabHelper::~SidebarTabHelper() = default;
+
+void SidebarTabHelper::PrimaryPageChanged(content::Page& page) {
+  // It could be opened from other tabs after this helper is created.
+  if (IsLeoPanelAlreadyOpened(web_contents())) {
+    return;
+  }
+
+  const auto url = web_contents()->GetLastCommittedURL();
+  if (!url.is_valid()) {
+    return;
+  }
+
+  if (!url.SchemeIsHTTPOrHTTPS()) {
+    return;
+  }
+
+  Browser* browser = chrome::FindBrowserWithTab(web_contents());
+  if (!browser) {
+    return;
+  }
+
+  auto* profile =
+      Profile::FromBrowserContext(web_contents()->GetBrowserContext());
+  auto* service = TemplateURLServiceFactory::GetForProfile(profile);
+  if (!service || !service->loaded()) {
+    return;
+  }
+
+  auto* side_panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser);
+  if (!side_panel_ui) {
+    return;
+  }
+
+  // If side panel is already opened, don't open leo panel now.
+  if (side_panel_ui->GetCurrentEntryId()) {
+    return;
+  }
+
+  // Check this page to open one-time leo panel only for non-SERP page.
+  for (TemplateURL* turl : service->GetTemplateURLs()) {
+    GURL search_url(turl->url());
+    if (!search_url.is_valid()) {
+      continue;
+    }
+
+    // Don't launch leo panel for SERP page.
+    if (search_url.host() == url.host()) {
+      return;
+    }
+  }
+
+  side_panel_ui->Show(SidePanelEntryId::kChatUI);
+}
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(SidebarTabHelper);
+
+}  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_tab_helper.h
+++ b/browser/ui/sidebar/sidebar_tab_helper.h
@@ -11,7 +11,7 @@
 
 namespace sidebar {
 
-// Helper to launch the leo panel one time.
+// Helper to launch the Leo panel one time.
 class SidebarTabHelper : public content::WebContentsUserData<SidebarTabHelper>,
                          public content::WebContentsObserver {
  public:

--- a/browser/ui/sidebar/sidebar_tab_helper.h
+++ b/browser/ui/sidebar/sidebar_tab_helper.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_TAB_HELPER_H_
+#define BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_TAB_HELPER_H_
+
+#include "content/public/browser/web_contents_observer.h"
+#include "content/public/browser/web_contents_user_data.h"
+
+namespace sidebar {
+
+// Helper to launch the leo panel one time.
+class SidebarTabHelper : public content::WebContentsUserData<SidebarTabHelper>,
+                         public content::WebContentsObserver {
+ public:
+  static void MaybeCreateForWebContents(content::WebContents* contents);
+
+  ~SidebarTabHelper() override;
+
+ private:
+  explicit SidebarTabHelper(content::WebContents* contents);
+
+  // content::WebContentsObserver overrides:
+  void PrimaryPageChanged(content::Page& page) override;
+
+  friend WebContentsUserData;
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+};
+
+}  // namespace sidebar
+
+#endif  // BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_TAB_HELPER_H_

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -21,6 +21,7 @@
 #include "chrome/test/base/testing_profile.h"
 #include "components/prefs/pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "components/version_info/channel.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gmock/include/gmock/gmock-matchers.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -68,6 +69,9 @@ class SidebarModelTest : public testing::Test {
   ~SidebarModelTest() override = default;
 
   void SetUp() override {
+    // Instantiate SidebarServiceFactory before creating TestingProfile
+    // as SidebarServiceFactory registers profile prefs.
+    SidebarServiceFactory::GetInstance();
     profile_ = std::make_unique<TestingProfile>();
     service_ = SidebarServiceFactory::GetForProfile(profile_.get());
     model_ = std::make_unique<SidebarModel>(profile_.get());
@@ -212,6 +216,15 @@ TEST_F(SidebarModelTest, TopItemTest) {
   EXPECT_EQ(first_item.built_in_item_type,
             SidebarItem::BuiltInItemType::kChatUI);
 #endif
+}
+
+TEST(SidebarUtilTest, SidebarShowOptionsDefaultTest) {
+  EXPECT_EQ(SidebarService::ShowSidebarOption::kShowNever,
+            GetDefaultShowSidebarOption(version_info::Channel::STABLE));
+  EXPECT_EQ(SidebarService::ShowSidebarOption::kShowAlways,
+            GetDefaultShowSidebarOption(version_info::Channel::BETA));
+  EXPECT_EQ(SidebarService::ShowSidebarOption::kShowAlways,
+            GetDefaultShowSidebarOption(version_info::Channel::CANARY));
 }
 
 TEST(SidebarUtilTest, ConvertURLToBuiltInItemURLTest) {

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -209,12 +209,16 @@ TEST_F(SidebarModelTest, ActiveIndexChangedAfterItemAdded) {
   EXPECT_THAT(model()->active_index(), Optional(2u));
 }
 
-// Check leo item is top-most item.
+// Check Leo item is top-most item.
 TEST_F(SidebarModelTest, TopItemTest) {
 #if BUILDFLAG(ENABLE_AI_CHAT)
   const auto first_item = service()->items()[0];
   EXPECT_EQ(first_item.built_in_item_type,
             SidebarItem::BuiltInItemType::kChatUI);
+#else
+  const auto first_item = service()->items()[0];
+  EXPECT_EQ(first_item.built_in_item_type,
+            SidebarItem::BuiltInItemType::kReadingList);
 #endif
 }
 

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check_is_test.h"
 #include "base/command_line.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
@@ -242,6 +243,7 @@ SidebarService::ShowSidebarOption GetDefaultShowSidebarOption(
   }
 
   if (!g_browser_process) {
+    CHECK_IS_TEST();
     return ShowSidebarOption::kShowAlways;
   }
 

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -7,10 +7,12 @@
 
 #include <optional>
 
+#include "base/command_line.h"
 #include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/sidebar/sidebar_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
+#include "brave/components/constants/brave_switches.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/sidebar/constants.h"
 #include "brave/components/sidebar/features.h"
@@ -233,7 +235,9 @@ bool IsDisabledItemForGuest(SidebarItem::BuiltInItemType type) {
 
 SidebarService::ShowSidebarOption GetDefaultShowSidebarOption(
     version_info::Channel channel) {
-  if (channel != version_info::Channel::STABLE) {
+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kDontShowAlwaysSidebarOnNonStable) &&
+      channel != version_info::Channel::STABLE) {
     return ShowSidebarOption::kShowAlways;
   }
 

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -237,7 +237,7 @@ bool IsDisabledItemForGuest(SidebarItem::BuiltInItemType type) {
 SidebarService::ShowSidebarOption GetDefaultShowSidebarOption(
     version_info::Channel channel) {
   if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kDontShowAlwaysSidebarOnNonStable) &&
+          switches::kDontShowSidebarOnNonStable) &&
       channel != version_info::Channel::STABLE) {
     return ShowSidebarOption::kShowAlways;
   }

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -13,8 +13,9 @@
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/sidebar/constants.h"
+#include "brave/components/sidebar/features.h"
 #include "brave/components/sidebar/pref_names.h"
-#include "brave/components/sidebar/sidebar_service.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search/search.h"
 #include "chrome/browser/ui/browser.h"
@@ -31,6 +32,7 @@
 namespace sidebar {
 
 using BuiltInItemType = SidebarItem::BuiltInItemType;
+using ShowSidebarOption = SidebarService::ShowSidebarOption;
 
 namespace {
 
@@ -227,6 +229,25 @@ bool IsDisabledItemForGuest(SidebarItem::BuiltInItemType type) {
       break;
   }
   return false;
+}
+
+SidebarService::ShowSidebarOption GetDefaultShowSidebarOption(
+    version_info::Channel channel) {
+  if (channel != version_info::Channel::STABLE) {
+    return ShowSidebarOption::kShowAlways;
+  }
+
+  if (!g_browser_process) {
+    return ShowSidebarOption::kShowAlways;
+  }
+
+  if (auto* local_state = g_browser_process->local_state()) {
+    return local_state->GetBoolean(kTargetUserForSidebarEnabledTest)
+               ? ShowSidebarOption::kShowAlways
+               : ShowSidebarOption::kShowNever;
+  }
+
+  return ShowSidebarOption::kShowNever;
 }
 
 }  // namespace sidebar

--- a/browser/ui/sidebar/sidebar_utils.h
+++ b/browser/ui/sidebar/sidebar_utils.h
@@ -9,6 +9,8 @@
 #include <optional>
 
 #include "brave/components/sidebar/sidebar_item.h"
+#include "brave/components/sidebar/sidebar_service.h"
+#include "components/version_info/channel.h"
 
 class Browser;
 class GURL;
@@ -16,8 +18,6 @@ class PrefService;
 enum class SidePanelEntryId;
 
 namespace sidebar {
-
-class SidebarService;
 
 bool CanUseSidebar(Browser* browser);
 bool CanAddCurrentActiveTabToSidebar(Browser* browser);
@@ -39,6 +39,9 @@ std::optional<SidebarItem> AddItemForSidePanelIdIfNeeded(Browser* browser,
 
 bool IsDisabledItemForPrivate(SidebarItem::BuiltInItemType type);
 bool IsDisabledItemForGuest(SidebarItem::BuiltInItemType type);
+
+SidebarService::ShowSidebarOption GetDefaultShowSidebarOption(
+    version_info::Channel channel);
 }  // namespace sidebar
 
 #endif  // BRAVE_BROWSER_UI_SIDEBAR_SIDEBAR_UTILS_H_

--- a/components/constants/brave_switches.h
+++ b/components/constants/brave_switches.h
@@ -54,8 +54,8 @@ inline constexpr char kUpdateFeedURL[] = "update-feed-url";
 
 // Don't set kShowAlways for non-stable channel.
 // It's useful to test SidebarShowAlwaysOnStable w/o griffin.
-inline constexpr char kDontShowAlwaysSidebarOnNonStable[] =
-    "dont-show-always-on-sidebar-non-stable";
+inline constexpr char kDontShowSidebarOnNonStable[] =
+    "dont-show-on-sidebar-non-stable";
 
 }  // namespace switches
 

--- a/components/constants/brave_switches.h
+++ b/components/constants/brave_switches.h
@@ -52,6 +52,11 @@ inline constexpr char kTor[] = "tor";
 // Override update feed url. Only valid on macOS.
 inline constexpr char kUpdateFeedURL[] = "update-feed-url";
 
+// Don't set kShowAlways for non-stable channel.
+// It's useful to test SidebarShowAlwaysOnStable w/o griffin.
+inline constexpr char kDontShowAlwaysSidebarOnNonStable[] =
+    "dont-show-always-on-sidebar-non-stable";
+
 }  // namespace switches
 
 #endif  // BRAVE_COMPONENTS_CONSTANTS_BRAVE_SWITCHES_H_

--- a/components/sidebar/BUILD.gn
+++ b/components/sidebar/BUILD.gn
@@ -12,6 +12,8 @@ assert(toolkit_views)
 static_library("sidebar") {
   sources = [
     "constants.h",
+    "features.cc",
+    "features.h",
     "pref_names.h",
     "sidebar_item.cc",
     "sidebar_item.h",

--- a/components/sidebar/features.cc
+++ b/components/sidebar/features.cc
@@ -13,7 +13,7 @@ BASE_FEATURE(kSidebarShowAlwaysOnStable,
 
 const base::FeatureParam<bool> kOpenOneShotLeoPanel{
     &kSidebarShowAlwaysOnStable,
-    /*name=*/"OpenOneShotLeoPanel",
+    /*name=*/"open_one_shot_leo_panel",
     /*default_value=*/false};
 
 }  // namespace sidebar::features

--- a/components/sidebar/features.cc
+++ b/components/sidebar/features.cc
@@ -11,4 +11,9 @@ BASE_FEATURE(kSidebarShowAlwaysOnStable,
              "SidebarShowAlwaysOnStable",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+const base::FeatureParam<bool> kOpenOneShotLeoPanel{
+    &kSidebarShowAlwaysOnStable,
+    /*name=*/"OpenOneShotLeoPanel",
+    /*default_value=*/false};
+
 }  // namespace sidebar::features

--- a/components/sidebar/features.cc
+++ b/components/sidebar/features.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/sidebar/features.h"
+
+namespace sidebar::features {
+
+BASE_FEATURE(kSidebarShowAlwaysOnStable,
+             "SidebarShowAlwaysOnStable",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+}  // namespace sidebar::features

--- a/components/sidebar/features.h
+++ b/components/sidebar/features.h
@@ -14,7 +14,7 @@ namespace sidebar::features {
 // Whether to show the sidebar always on stable channel.
 BASE_DECLARE_FEATURE(kSidebarShowAlwaysOnStable);
 
-// Whether to open the leo panel only once.
+// Whether to open the Leo panel only once.
 extern const base::FeatureParam<bool> kOpenOneShotLeoPanel;
 
 }  // namespace sidebar::features

--- a/components/sidebar/features.h
+++ b/components/sidebar/features.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SIDEBAR_FEATURES_H_
+#define BRAVE_COMPONENTS_SIDEBAR_FEATURES_H_
+
+#include "base/feature_list.h"
+
+namespace sidebar::features {
+
+// Whether to show the sidebar always on stable channel.
+BASE_DECLARE_FEATURE(kSidebarShowAlwaysOnStable);
+
+}  // namespace sidebar::features
+
+#endif  // BRAVE_COMPONENTS_SIDEBAR_FEATURES_H_

--- a/components/sidebar/features.h
+++ b/components/sidebar/features.h
@@ -7,11 +7,15 @@
 #define BRAVE_COMPONENTS_SIDEBAR_FEATURES_H_
 
 #include "base/feature_list.h"
+#include "base/metrics/field_trial_params.h"
 
 namespace sidebar::features {
 
 // Whether to show the sidebar always on stable channel.
 BASE_DECLARE_FEATURE(kSidebarShowAlwaysOnStable);
+
+// Whether to open the leo panel only once.
+extern const base::FeatureParam<bool> kOpenOneShotLeoPanel;
 
 }  // namespace sidebar::features
 

--- a/components/sidebar/pref_names.h
+++ b/components/sidebar/pref_names.h
@@ -24,6 +24,11 @@ inline constexpr char kLastUsedBuiltInItemType[] =
 inline constexpr char kLeoPanelOneTimeOpen[] =
     "brave.sidebar.leo_panel_one_time_open";
 
+// Indicates that it's target user for Sidebar Enabled-by-default test via
+// griffin. local state pref.
+inline constexpr char kTargetUserForSidebarEnabledTest[] =
+    "brave.sidebar.target_user_for_sidebar_enabled_test";
+
 // Indicates that sidebar alignment was changed by the browser itself, not by
 // users.
 inline constexpr char kSidebarAlignmentChangedTemporarily[] =

--- a/components/sidebar/pref_names.h
+++ b/components/sidebar/pref_names.h
@@ -19,6 +19,11 @@ inline constexpr char kSidePanelWidth[] = "brave.sidebar.side_panel_width";
 inline constexpr char kLastUsedBuiltInItemType[] =
     "brave.sidebar.last_used_built_in_item_type";
 
+// Indicates that the leo side panel is opened once for Sidebar Enabled-by
+// -default test via griffin.
+inline constexpr char kLeoPanelOneTimeOpen[] =
+    "brave.sidebar.leo_panel_one_time_open";
+
 // Indicates that sidebar alignment was changed by the browser itself, not by
 // users.
 inline constexpr char kSidebarAlignmentChangedTemporarily[] =

--- a/components/sidebar/pref_names.h
+++ b/components/sidebar/pref_names.h
@@ -19,10 +19,10 @@ inline constexpr char kSidePanelWidth[] = "brave.sidebar.side_panel_width";
 inline constexpr char kLastUsedBuiltInItemType[] =
     "brave.sidebar.last_used_built_in_item_type";
 
-// Indicates that the leo side panel is opened once for Sidebar Enabled-by
+// Indicates that the Leo side panel is opened once for Sidebar Enabled-by
 // -default test via griffin.
-inline constexpr char kLeoPanelOneTimeOpen[] =
-    "brave.sidebar.leo_panel_one_time_open";
+inline constexpr char kLeoPanelOneShotOpen[] =
+    "brave.sidebar.leo_panel_one_shot_shot";
 
 // Indicates that it's target user for Sidebar Enabled-by-default test via
 // griffin. local state pref.

--- a/components/sidebar/sidebar_p3a.cc
+++ b/components/sidebar/sidebar_p3a.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/sidebar/sidebar_p3a.h"
 
+#include "base/check_is_test.h"
 #include "base/metrics/histogram_macros.h"
 #include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_service.h"
@@ -26,6 +27,12 @@ SidebarP3A::SidebarP3A(PrefService* profile_prefs)
 SidebarP3A::~SidebarP3A() = default;
 
 void SidebarP3A::RecordEnabledSetting() {
+  // Some non-sidebar unittest could not register the prefs.
+  if (!profile_prefs_->FindPreference(kSidebarShowOption)) {
+    CHECK_IS_TEST();
+    return;
+  }
+
   bool is_enabled =
       profile_prefs_->GetInteger(kSidebarShowOption) !=
       static_cast<int>(SidebarService::ShowSidebarOption::kShowNever);

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -27,6 +27,7 @@
 #include "brave/components/l10n/common/localization_util.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/constants.h"
+#include "brave/components/sidebar/features.h"
 #include "brave/components/sidebar/pref_names.h"
 #include "brave/components/sidebar/sidebar_item.h"
 #include "components/grit/brave_components_strings.h"
@@ -84,11 +85,13 @@ void SidebarService::RegisterProfilePrefs(PrefRegistrySimple* registry,
                                           version_info::Channel channel) {
   registry->RegisterListPref(kSidebarItems);
   registry->RegisterListPref(kSidebarHiddenBuiltInItems);
-  registry->RegisterIntegerPref(
-      kSidebarShowOption,
-      channel == Channel::STABLE
-          ? static_cast<int>(ShowSidebarOption::kShowNever)
-          : static_cast<int>(ShowSidebarOption::kShowAlways));
+
+  ShowSidebarOption option = ShowSidebarOption::kShowAlways;
+  if (channel == Channel::STABLE &&
+      !base::FeatureList::IsEnabled(features::kSidebarShowAlwaysOnStable)) {
+    option = ShowSidebarOption::kShowNever;
+  }
+  registry->RegisterIntegerPref(kSidebarShowOption, static_cast<int>(option));
   registry->RegisterIntegerPref(kSidebarItemAddedFeedbackBubbleShowCount, 0);
   registry->RegisterIntegerPref(kSidePanelWidth, kDefaultSidePanelWidth);
   registry->RegisterIntegerPref(

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -84,7 +84,7 @@ void SidebarService::RegisterProfilePrefs(
     ShowSidebarOption default_show_option) {
   registry->RegisterListPref(kSidebarItems);
   registry->RegisterListPref(kSidebarHiddenBuiltInItems);
-  registry->RegisterBooleanPref(kLeoPanelOneTimeOpen, false);
+  registry->RegisterBooleanPref(kLeoPanelOneShotOpen, false);
   registry->RegisterIntegerPref(kSidebarShowOption,
                                 static_cast<int>(default_show_option));
   registry->RegisterIntegerPref(kSidebarItemAddedFeedbackBubbleShowCount, 0);

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -91,6 +91,7 @@ void SidebarService::RegisterProfilePrefs(PrefRegistrySimple* registry,
       !base::FeatureList::IsEnabled(features::kSidebarShowAlwaysOnStable)) {
     option = ShowSidebarOption::kShowNever;
   }
+  registry->RegisterBooleanPref(kLeoPanelOneTimeOpen, false);
   registry->RegisterIntegerPref(kSidebarShowOption, static_cast<int>(option));
   registry->RegisterIntegerPref(kSidebarItemAddedFeedbackBubbleShowCount, 0);
   registry->RegisterIntegerPref(kSidePanelWidth, kDefaultSidePanelWidth);

--- a/components/sidebar/sidebar_service.cc
+++ b/components/sidebar/sidebar_service.cc
@@ -440,10 +440,10 @@ std::optional<SidebarItem> SidebarService::GetDefaultPanelItem() const {
   // Use this order for picking active panel when panel is opened as
   // we don't cache previous active panel.
   constexpr SidebarItem::BuiltInItemType kPreferredPanelOrder[] = {
+      SidebarItem::BuiltInItemType::kChatUI,
       SidebarItem::BuiltInItemType::kReadingList,
       SidebarItem::BuiltInItemType::kBookmarks,
-      SidebarItem::BuiltInItemType::kPlaylist,
-      SidebarItem::BuiltInItemType::kChatUI};
+      SidebarItem::BuiltInItemType::kPlaylist};
 
   std::optional<SidebarItem> default_item;
   for (const auto& type : kPreferredPanelOrder) {

--- a/components/sidebar/sidebar_service.h
+++ b/components/sidebar/sidebar_service.h
@@ -18,7 +18,6 @@
 #include "brave/components/sidebar/sidebar_p3a.h"
 #include "components/keyed_service/core/keyed_service.h"
 #include "components/prefs/pref_change_registrar.h"
-#include "components/version_info/channel.h"
 
 class PrefRegistrySimple;
 class PrefService;
@@ -58,7 +57,7 @@ class SidebarService : public KeyedService {
   };
 
   static void RegisterProfilePrefs(PrefRegistrySimple* registry,
-                                   version_info::Channel channel);
+                                   ShowSidebarOption default_show_option);
 
   SidebarService(
       PrefService* prefs,

--- a/components/sidebar/sidebar_service_unittest.cc
+++ b/components/sidebar/sidebar_service_unittest.cc
@@ -215,6 +215,10 @@ class SidebarServiceTest : public testing::Test {
 
   ~SidebarServiceTest() override = default;
 
+  void SetUp() override {
+    SidebarService::RegisterProfilePrefs(
+        prefs_.registry(), SidebarService::ShowSidebarOption::kShowAlways);
+  }
   void TearDown() override { ResetService(); }
 
   void InitService() {
@@ -256,7 +260,6 @@ class SidebarServiceTest : public testing::Test {
 };
 
 TEST_F(SidebarServiceTest, AddRemoveItems) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::CANARY);
   InitService();
 
   // Check the default items count.
@@ -298,7 +301,6 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
 }
 
 TEST_F(SidebarServiceTest, MoveItem) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::DEV);
   InitService();
 
   // Add one more item to test with 5 items.
@@ -361,7 +363,6 @@ TEST(SidebarItemTest, SidebarItemValidation) {
 }
 
 TEST_F(SidebarServiceTest, UpdateItem) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::DEV);
   InitService();
 
   // Added webtype item at last.
@@ -414,7 +415,6 @@ TEST_F(SidebarServiceTest, UpdateItem) {
 }
 
 TEST_F(SidebarServiceTest, MoveItemSavedToPrefs) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::DEV);
   InitService();
 
   // Add one more item to test.
@@ -439,7 +439,6 @@ TEST_F(SidebarServiceTest, MoveItemSavedToPrefs) {
 }
 
 TEST_F(SidebarServiceTest, HideBuiltInItem) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::DEV);
   // Have prefs which contain a custom item and hides 1 built-in item
   {
     base::Value::List list;
@@ -473,7 +472,6 @@ TEST_F(SidebarServiceTest, HideBuiltInItem) {
 }
 
 TEST_F(SidebarServiceTest, NewDefaultItemAdded) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::DEV);
   std::vector<SidebarItem::BuiltInItemType> hidden_builtin_types{
       SidebarItem::BuiltInItemType::kBookmarks};
   // Have prefs which contain a custom item and hides 1 built-in item
@@ -566,7 +564,6 @@ TEST_F(SidebarServiceTest, NewDefaultItemAdded) {
 }
 
 TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsSomeHidden) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Make prefs already have old-style builtin items before service
   // initialization.
   {
@@ -613,7 +610,6 @@ TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsSomeHidden) {
 }
 
 TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsNoneHidden) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Make prefs already have ALL old-style builtin items before service
   // initialization. This tests that when not adding anything to the new pref
   // that re-migration will not break anything.
@@ -706,7 +702,6 @@ TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsNoneHidden) {
 // Verify service has migrated the previous pref format where built-in items
 // had url stored and not built-in-item-type.
 TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsNoType) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Make prefs already have old-style builtin items before service
   // initialization.
   {
@@ -761,7 +756,6 @@ TEST_F(SidebarServiceTest, MigratePrefSidebarBuiltInItemsNoType) {
 }
 
 TEST_F(SidebarServiceTest, HidesBuiltInItemsViaPref) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Verify default state
   InitService();
   auto items = service_->items();
@@ -785,7 +779,6 @@ TEST_F(SidebarServiceTest, HidesBuiltInItemsViaPref) {
 }
 
 TEST_F(SidebarServiceTest, HidesBuiltInItemsViaService) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Verify default state
   InitService();
   auto items = service_->items();
@@ -812,7 +805,6 @@ TEST_F(SidebarServiceTest, HidesBuiltInItemsViaService) {
 }
 
 TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Make prefs already have builtin items before service initialization.
   // And it has old url in old pref format (storing built-in items).
   {
@@ -860,7 +852,6 @@ TEST_F(SidebarServiceTest, BuiltInItemUpdateTestWithBuiltInItemTypeKey) {
 }
 
 TEST_F(SidebarServiceTest, BuiltInItemDoesntHaveHistoryItem) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   // Make prefs already have builtin items before service initialization.
   // And it has history item.
   {
@@ -891,7 +882,6 @@ TEST_F(SidebarServiceTest, BuiltInItemDoesntHaveHistoryItem) {
 }
 
 TEST_F(SidebarServiceTest, SidebarShowOptionsDeprecationTest) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::STABLE);
   // Show on click is deprecated.
   // Treat it as a show on mouse over.
   prefs_.SetInteger(
@@ -903,22 +893,13 @@ TEST_F(SidebarServiceTest, SidebarShowOptionsDeprecationTest) {
             service_->GetSidebarShowOption());
 }
 
-TEST_F(SidebarServiceTest, SidebarShowOptionsDefaultTestStable) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::STABLE);
-  InitService();
-  EXPECT_EQ(SidebarService::ShowSidebarOption::kShowNever,
-            service_->GetSidebarShowOption());
-}
-
 TEST_F(SidebarServiceTest, SidebarShowOptionsDefaultTestNonStable) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   InitService();
   EXPECT_EQ(SidebarService::ShowSidebarOption::kShowAlways,
             service_->GetSidebarShowOption());
 }
 
 TEST_F(SidebarServiceTest, SidebarEnabledHistogram) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   InitService();
   histogram_tester_.ExpectUniqueSample(p3a::kSidebarEnabledHistogramName, 1, 1);
 
@@ -972,7 +953,6 @@ class SidebarServiceTestWithPlaylist : public SidebarServiceTest {
 
 // Check GetDefaultPanelItem() returns valid panel item.
 TEST_F(SidebarServiceTestWithPlaylist, GetDefaultPanelItem) {
-  SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::BETA);
   InitService();
 
   while (SidebarHasDefaultPanelItem()) {
@@ -996,10 +976,10 @@ class SidebarServiceOrderingTest : public SidebarServiceTest {
   ~SidebarServiceOrderingTest() override = default;
 
   void SetUp() override {
+    SidebarServiceTest::SetUp();
 #if BUILDFLAG(ENABLE_AI_CHAT)
     scoped_feature_list_.InitAndEnableFeature(ai_chat::features::kAIChat);
 #endif  // BUILDFLAG(ENABLE_AI_CHAT)
-    SidebarService::RegisterProfilePrefs(prefs_.registry(), Channel::CANARY);
   }
 
   bool ValidateBuiltInTypesOrdering(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36339
Resolves https://github.com/brave/brave-browser/issues/32601

When `SidebarShowAlwaysOnStable` is enabled, sidebar is shown by default.
So far, we set `never` by default on stable channel.
When `open_one_shot_leo_panel` feature param is set to `true`, leo panel is opened only once.
To make target users with new user with `SidebarShowAlwaysOnStable`,
 `kTargetUserForSidebarEnabledTest` local state is set to true at first run.

Also default sidebar panel item is leo.
If there is no previously used panel, leo is opened when clicking sidebar toolbar button.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTestWithkSidebarShowAlwaysOnStable.*`

### Default item test
1. Launch with clean profile
2. Click sidebar toolbar button
3. Check leo panel is opened
4. Close and open bookmarks panel
5. Re-launch and click sidebar toolbar button
6. Check bookmarks panel is opened

### SidebarShowAlwaysOnStable feature test
```
Group A:
Show Sidebar = Enabled (Always), Show on the Right
Show Sidebar button = Enabled
Group B:
Show Sidebar = Enabled (Always), Show on the Right
Show Sidebar button = Enabled
Open Sidebar panel one time. Show Sidebar panel in the opened state upon viewing the first non-SERP web page.
Do not repeat. Default selection is Leo. If user already saw leo panel, we don’t show one-shot leo panel
```
This PR's change works with `SidebarShowAlwaysOnStable` griffin study's group A/B.
However, it's difficult to test with production griffin as both group only have 2% only at maximum.
Recommend to test release build(stable or any other channels) with below cmd args.
```
--enable-features=SidebarShowAlwaysOnStable:open_one_shot_leo_panel/true --dont-show-on-sidebar-non-stable
```
`open_one_shot_leo_panel/true` is for group B simulation. In group B, leo panel is opened once when non-SERP page is loaded. W/o `open_one_shot_leo_panel` param, only `show always` is set. It's common for group A/B.
`--dont-show-always-on-sidebar-non-stable` is useful to test this with non-stable channel.
As show always is default option for non-stable channel, we need to pass it to prevent it.

#### Test `group A` - launch brave in this test with `--enable-features=SidebarShowAlwaysOnStable --dont-show-on-sidebar-non-stable` in this test
1. Launch brave with clean profile
2. Check sidebar UI is shown by default
3. Load www.brave.com and check leo panel is not opened automatically

#### Test `group B`  - launch brave in this test with `--enable-features=SidebarShowAlwaysOnStable:open_one_shot_leo_panel/true --dont-show-on-sidebar-non-stable`
##### case 1
1. Launch brave with clean profile
2. Check sidebar UI is shown by default
3. Type any keyword in omnibox and and press enter
4. Confirm that search result page is loaded but leo panel is not opened
5. Load www.brave.com and confirm that leo panel is opened
6. Close leo panel and load github.com and check leo panel is not opened anymore

##### case 2
1. Launch brave with clean profile
2. Check sidebar UI is shown by default
3. Click sidebar toolbar button
4. Check leo panel is opened and close panel
5. Load www.brave.com and check leo panel is not opened.
   If user opened leo panel before loading any non-serp page,
  we don't open leo panel automatically anymore

##### case 3
1. Launch brave with clean profile
2. Check sidebar UI is shown by default
3. Open bookmarks panel
4. Load www.brave.com and check leo panel is not opened
5. Close bookmarks panel
6. Open NTP and load www.github.com and check leo panel is opened

##### case 4 - non-first user test. This change only targets new user
1. Launch previous version brave with clean profile and w/o above cmd params
2. Load any pages and shutdown
3. Launch brave with above cmd params
4. Check sidebar UI is not shown by default
5. Load www.brave.com and check leo panel is not opened