### PR TITLE
[iOS] Add fastlane commands for building & testing separately

### DIFF
--- a/ios/brave-ios/fastlane/Fastfile
+++ b/ios/brave-ios/fastlane/Fastfile
@@ -7,46 +7,55 @@ fastlane_version "2.86.0"
 default_platform :ios
 
 platform :ios do
-  desc "Run Unit Tests"
+  desc "Deprecated: use build_for_testing and test_without_build"
   lane :test do |options|
-    run_tests(
-      project: "App/Client.xcodeproj",
-      scheme: "Debug",
+    defaultScanParams = scan_params()
+    run_tests(defaultScanParams.merge!({
       devices: ["iPhone 15"],
-      code_coverage: true,
-      output_types: "junit",
-      output_files: "junit.xml",
       ensure_devices_found: true,
-      derived_data_path: "../../../out/DerivedData",
-      skip_testing: [
-        "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
-        "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
-        "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission",
-        "BraveWalletTests/SendTokenStoreTests/testResolvedAddressUsedInSolTxIfAvailable",
-        "BraveWalletTests/SendTokenStoreTests/testResolvedAddressUsedInEthTxIfAvailable",
-        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionEthNetwork",
-        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionSolNetwork",
-        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionFailure",
-        "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionTokenChange",
-        "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareERC20Approve",
-        "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareTransactionNotOnSelectedNetwork"
-      ]
-    )
+      skip_testing: skipped_tests()
+    }))
 
-    run_tests(
-      project: "App/Client.xcodeproj",
-      scheme: "Debug",
+    run_tests(defaultScanParams.merge!({
       devices: ["iPad (10th generation)"],
-      code_coverage: true,
       ensure_devices_found: true,
-      output_types: "junit",
       output_files: "junit-ipad.xml",
-      derived_data_path: "../../../out/DerivedData",
       skip_testing: [
         "ClientTests/UserAgentTests"
       ],
       xcargs: "-testPlan Brave_iPad"
-    )
+    }))
+  end
+
+  desc "Builds the app for testing"
+  lane :build_for_testing do |options|
+    defaultScanParams = scan_params()
+    run_tests(defaultScanParams.merge!({
+      build_for_testing: true,
+      output_style: "raw" # Don't need xcpretty for the build
+    }))
+  end
+
+  desc "Runs unit tests on a previous build (assumes build_for_testing is run)"
+  lane :test_without_building do |options|
+    defaultScanParams = scan_params()
+    run_tests(defaultScanParams.merge!({
+      test_without_building: true,
+      devices: ["iPhone 15"],
+      ensure_devices_found: true,
+      skip_testing: skipped_tests()
+    }))
+
+    run_tests(defaultScanParams.merge!({
+      test_without_building: true,
+      devices: ["iPad (10th generation)"],
+      ensure_devices_found: true,
+      output_files: "junit-ipad.xml",
+      testplan: "Brave_iPad",
+      skip_testing: [
+        "ClientTests/UserAgentTests"
+      ]
+    }))
   end
 
   desc "Creates a Brave Beta build for TestFlight."
@@ -148,6 +157,33 @@ platform :ios do
       output_directory: "build",
       derived_data_path: "../../../out/DerivedData",
     }
+  end
+
+  private_lane :scan_params do
+    {
+      project: "App/Client.xcodeproj",
+      scheme: "Debug",
+      code_coverage: true,
+      output_types: "junit",
+      output_files: "junit.xml",
+      derived_data_path: "../../../out/DerivedData"
+    }
+  end
+
+  private_lane :skipped_tests do
+    [
+      "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemoveAllPermissions",
+      "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissions",
+      "BraveWalletTests/ManageSiteConnectionsStoreTests/testRemovePermissionsLastPermission",
+      "BraveWalletTests/SendTokenStoreTests/testResolvedAddressUsedInSolTxIfAvailable",
+      "BraveWalletTests/SendTokenStoreTests/testResolvedAddressUsedInEthTxIfAvailable",
+      "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionEthNetwork",
+      "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionSolNetwork",
+      "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionFailure",
+      "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionTokenChange",
+      "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareERC20Approve",
+      "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareTransactionNotOnSelectedNetwork"
+    ]
   end
 
 end


### PR DESCRIPTION
This introduces two new lanes: `build_for_testing` and `test_without_building` so that CI can perform these tasks separately in their respective stages (build-debug vs test). The former `test` lane will eventually be removed.

Resolves https://github.com/brave/brave-browser/issues/36391

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

