### PR TITLE
Force Google Play to supply arm32 for Android 8/8.1

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -625,8 +625,17 @@ Config.prototype.buildArgs = function () {
 
     args.android_aab_to_apk = this.androidAabToApk
 
-    // This optimization causes crash on Android 8 and Android 8.1 arm64 devices.
-    args.use_relr_relocations = false
+    if (this.targetArch == "arm64") {
+      // Flag use_relr_relocations is incompatible with Android 8 arm64, but
+      // makes huge optimizations on Android 9 and above.
+      // Decision is to specify android:minSdkVersion=28 for arm64 and keep
+      // 26(default) for arm32.
+      // Then:
+      //   - for Android 8 and 8.1 GP will supply arm32 bundle;
+      //   - for Android 9 and above GP will supply arm64 and we can enable all
+      //     optimizations.
+      args.default_min_sdk_version = 28
+    }
 
     // These do not exist on android
     // TODO - recheck


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36390

This PR does 2 things:
1. increase `default_min_sdk_version` from default 26 (Android 8) to 28 (Android 9)
2. Reverts back `use_relr_relocations` optimization

This PR was tested using Brave Nightly Internal test track:
`1.65.300` - same as `master`
`1.65.301` - the bundles corresponding to this PR
`1.65.302` - same as `1.65.300`

Installed on Android 8 device, Note8:
```
=> 1.65.300/arm64 - OK
=> 1.65.301/arm32 - OK
=> 1.65.302/arm64 - OK
```
Version `1.65.301` was updated, launched with a proper 32-bit lib.
Update to `1.65.302` happened without issues, back to 64-bit un-optimized libs - in the case if we will want to revert the PR by any reason.

1.65.300-master|1.65.301-PR|1.65.302-master
--|--|--
![300-Screenshot_20240227-142855_Brave - Nightly](https://github.com/brave/brave-core/assets/24739341/d093163d-e8f3-4870-b32f-88887007b6de)|![301-Screenshot_20240227-143743_Brave - Nightly](https://github.com/brave/brave-core/assets/24739341/a9843efd-90bc-4e4a-b176-dd0181843d21)|![302-Screenshot_20240227-145507_Brave - Nightly](https://github.com/brave/brave-core/assets/24739341/80b3bf1d-9b8f-4c9d-ab62-2d276b7e5a97)



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:


#### I. Android 8/8.1 test

1. Take Android 8/8.1 device
4. Install Brave Nightly from Google Play
5. Launch app, expected not to crash
6. Open brave://version, expected to see `(32-bit)` phrase at the version info

#### II. Android 9 and above test

1. Take Android 9 or above device
2. Install Brave Nightly from Google Play
3. Launch app
4. Open brave://version, expected to see `(64-bit)` phrase at the version info



