### PR TITLE
Sets Andoid emulator version SDK to 27 to avoid timeouts (uplift to 1.63.x)

### DIFF
--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -341,7 +341,7 @@ program
   .option('--target_environment <target_environment>', 'target environment (device, catalyst, simulator)')
   .option('--run_disabled_tests', 'run disabled tests')
   .option('--manual_android_test_device', 'indicates that Android test device is run manually')
-  .option('--android_test_emulator_version <emulator_version>', 'set Android version for the emulator for tests', parseInteger, '30')
+  .option('--android_test_emulator_version <emulator_version>', 'set Android version for the emulator for tests', parseInteger, '27')
   .option('--use_remoteexec [arg]', 'whether to use RBE for building', JSON.parse)
   .option('--offline', 'use offline mode for RBE')
   .arguments('[build_config]')


### PR DESCRIPTION
Uplift of #22349
Resolves https://github.com/brave/brave-browser/issues/36405

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.