### PR TITLE
Auto-load via IPFS notification isn't sticky when loading an IPFS/IPNS page (uplift to 1.64.x)

### DIFF
--- a/browser/ipfs/ipfs_tab_helper.cc
+++ b/browser/ipfs/ipfs_tab_helper.cc
@@ -458,6 +458,7 @@ void IPFSTabHelper::MaybeCheckDNSLinkRecord(
 
   if (!IsDNSLinkCheckEnabled() || !headers || ipfs_resolved_url_.is_valid() ||
       !CanResolveURL(dnslink_target)) {
+    UpdateLocationBar();
     return;
   }
   int response_code = headers->response_code();

--- a/test/data/client_side_redirect.html
+++ b/test/data/client_side_redirect.html
@@ -1,0 +1,9 @@
+<head>
+    <noscript>
+        <meta http-equiv="refresh" content="3; url=wiki/" />
+    </noscript>
+
+    <script>
+        location.replace('wiki/');
+    </script>
+</head>


### PR DESCRIPTION
Uplift of #22329
Resolves https://github.com/brave/brave-browser/issues/36347

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.