### PR TITLE
[iOS] Disable tests that spin up WKWebView's

### DIFF
--- a/ios/brave-ios/fastlane/Fastfile
+++ b/ios/brave-ios/fastlane/Fastfile
@@ -16,15 +16,15 @@ platform :ios do
       skip_testing: skipped_tests()
     }))
 
-    run_tests(defaultScanParams.merge!({
-      devices: ["iPad (10th generation)"],
-      ensure_devices_found: true,
-      output_files: "junit-ipad.xml",
-      skip_testing: [
-        "ClientTests/UserAgentTests"
-      ],
-      xcargs: "-testPlan Brave_iPad"
-    }))
+    # Temporarily disable iPad tests since it only tests UserAgentTests anyways
+    # which are disabled for CI stability.
+
+    # run_tests(defaultScanParams.merge!({
+    #   devices: ["iPad (10th generation)"],
+    #   ensure_devices_found: true,
+    #   output_files: "junit-ipad.xml",
+    #   xcargs: "-testPlan Brave_iPad"
+    # }))
   end
 
   desc "Builds the app for testing"
@@ -46,16 +46,16 @@ platform :ios do
       skip_testing: skipped_tests()
     }))
 
-    run_tests(defaultScanParams.merge!({
-      test_without_building: true,
-      devices: ["iPad (10th generation)"],
-      ensure_devices_found: true,
-      output_files: "junit-ipad.xml",
-      testplan: "Brave_iPad",
-      skip_testing: [
-        "ClientTests/UserAgentTests"
-      ]
-    }))
+    # Temporarily disable iPad tests since it only tests UserAgentTests anyways
+    # which are disabled for CI stability.
+
+    # run_tests(defaultScanParams.merge!({
+    #   test_without_building: true,
+    #   devices: ["iPad (10th generation)"],
+    #   ensure_devices_found: true,
+    #   output_files: "junit-ipad.xml",
+    #   testplan: "Brave_iPad"
+    # }))
   end
 
   desc "Creates a Brave Beta build for TestFlight."
@@ -182,7 +182,10 @@ platform :ios do
       "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionFailure",
       "BraveWalletTests/SendTokenStoreTests/testUDAddressResolutionTokenChange",
       "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareERC20Approve",
-      "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareTransactionNotOnSelectedNetwork"
+      "BraveWalletTests/TransactionConfirmationStoreTests/testPrepareTransactionNotOnSelectedNetwork",
+      # Disabled tests that spin up WKWebView's
+      "ClientTests/WKWebViewExtensionsTest/testGenerateJavascriptFunctionString",
+      "UserAgentTests/UserAgentTests"
     ]
   end
 


### PR DESCRIPTION
Hopefully addresses xctest crash

    xctest ([pid]) encountered an error (Test runner never began executing tests after launching)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

