### PR TITLE
style(wallet): Fund Wallet Button Border Radius

### DIFF
--- a/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/deposit-funds.tsx
@@ -54,7 +54,8 @@ import {
   HorizontalSpace,
   LoadingIcon,
   Row,
-  VerticalSpace
+  VerticalSpace,
+  LeoSquaredButton
 } from '../../../components/shared/style'
 import {
   Description,
@@ -87,7 +88,6 @@ import SelectAccountItem from '../../../components/shared/select-account-item/in
 import SelectAccount from '../../../components/shared/select-account/index'
 import { BuyAssetOptionItem } from '../../../components/shared/buy-option/buy-asset-option'
 import { CopiedToClipboardConfirmation } from '../../../components/desktop/copied-to-clipboard-confirmation/copied-to-clipboard-confirmation'
-import { NavButton } from '../../../components/extension/buttons/nav-button/index'
 import CreateAccountTab from '../../../components/buy-send-swap/create-account/index'
 import SelectHeader from '../../../components/buy-send-swap/select-header/index'
 import {
@@ -455,16 +455,14 @@ function AssetSelection() {
       </SelectAssetWrapper>
 
       <NextButtonRow>
-        <NavButton
-          buttonType={'primary'}
-          text={
-            selectedAsset
-              ? getLocale('braveWalletButtonContinue')
-              : getLocale('braveWalletBuySelectAsset')
-          }
-          onSubmit={nextStep}
-          disabled={!isNextStepEnabled}
-        />
+        <LeoSquaredButton
+          onClick={nextStep}
+          isDisabled={!isNextStepEnabled}
+        >
+          {selectedAsset
+            ? getLocale('braveWalletButtonContinue')
+            : getLocale('braveWalletBuySelectAsset')}
+        </LeoSquaredButton>
       </NextButtonRow>
     </>
   )

--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund-wallet.tsx
@@ -53,7 +53,8 @@ import {
   Flex,
   LoadingIcon,
   Row,
-  VerticalSpace
+  VerticalSpace,
+  LeoSquaredButton
 } from '../../../components/shared/style'
 import { NextButtonRow } from '../onboarding/onboarding.style'
 import {
@@ -77,7 +78,6 @@ import SearchBar from '../../../components/shared/search-bar'
 import SelectAccountItem from '../../../components/shared/select-account-item'
 import SelectAccount from '../../../components/shared/select-account'
 import { BuyAssetOptionItem } from '../../../components/shared/buy-option/buy-asset-option'
-import { NavButton } from '../../../components/extension/buttons/nav-button/index'
 import CreateAccountTab from '../../../components/buy-send-swap/create-account'
 import {
   BuyAmountInput //
@@ -402,14 +402,8 @@ function AssetSelection({ isAndroid }: Props) {
         </SelectAssetWrapper>
 
         <NextButtonRow>
-          <NavButton
-            buttonType='primary'
-            text={
-              selectedAsset
-                ? getLocale('braveWalletBuyContinueButton')
-                : getLocale('braveWalletBuySelectAsset')
-            }
-            onSubmit={() => {
+          <LeoSquaredButton
+            onClick={() => {
               if (!selectedOnRampAssetId) {
                 return
               }
@@ -455,9 +449,12 @@ function AssetSelection({ isAndroid }: Props) {
                 })
               )
             }}
-            disabled={!isNextStepEnabled}
-            minWidth='360px'
-          />
+            isDisabled={!isNextStepEnabled}
+          >
+            {selectedAsset
+              ? getLocale('braveWalletBuyContinueButton')
+              : getLocale('braveWalletBuySelectAsset')}
+          </LeoSquaredButton>
         </NextButtonRow>
       </Column>
     </WalletPageWrapper>


### PR DESCRIPTION
## Description 
Updates the `Buy` and `Deposit` button `border-radius` to match new `figma` designs.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/36414>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Before:

![Screenshot 2](https://github.com/brave/brave-core/assets/40611140/3ab86131-0bff-493a-9aa1-9aed33bafa2d)

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/7e3f9b85-add0-446d-83b9-1bc27e6837f5)

After:

![Screenshot 5](https://github.com/brave/brave-core/assets/40611140/dabcc5f2-489b-42d4-bb9c-e8058abc49b9)

![Screenshot 6](https://github.com/brave/brave-core/assets/40611140/430f0237-114e-4f2b-95f0-9d7963479cf1)
