### PR TITLE
fix(wallet): Left-align DApp connections empty state label on iOS (uplift to 1.63.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Settings/DappsSettings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/DappsSettings.swift
@@ -97,15 +97,11 @@ struct DappsSettings: View {
       ) {
         Group {
           if visibleSiteConnections.isEmpty {
-            HStack {
-              Spacer()
-              Text(Strings.Wallet.dappsSettingsConnectedSitesSectionEmpty)
-                .foregroundColor(Color(.secondaryBraveLabel))
-                .font(.footnote)
-                .multilineTextAlignment(.center)
-              Spacer()
-            }
-            .padding(.vertical)
+            Text(Strings.Wallet.dappsSettingsConnectedSitesSectionEmpty)
+              .foregroundColor(Color(.secondaryBraveLabel))
+              .font(.footnote)
+              .multilineTextAlignment(.leading)
+              .padding(.vertical, 6)
           } else {
             ForEach(visibleSiteConnections) { siteConnection in
               NavigationLink(


### PR DESCRIPTION
Uplift of #22377
Resolves https://github.com/brave/brave-browser/issues/36429

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.