### PR TITLE
Wait for adblock components to be fully initialized before loading engines (uplift to 1.64.x)

### DIFF
--- a/components/brave_shields/content/test/test_filters_provider.cc
+++ b/components/brave_shields/content/test/test_filters_provider.cc
@@ -28,11 +28,13 @@ TestFiltersProvider::TestFiltersProvider(const std::string& rules,
 TestFiltersProvider::TestFiltersProvider(const std::string& rules,
                                          const std::string& resources,
                                          bool engine_is_default,
-                                         uint8_t permission_mask)
+                                         uint8_t permission_mask,
+                                         bool is_initialized)
     : AdBlockFiltersProvider(engine_is_default),
       rules_(rules),
       resources_(resources),
-      permission_mask_(permission_mask) {}
+      permission_mask_(permission_mask),
+      is_initialized_(is_initialized) {}
 
 TestFiltersProvider::~TestFiltersProvider() = default;
 
@@ -51,6 +53,16 @@ void TestFiltersProvider::LoadFilterSet(
 void TestFiltersProvider::LoadResources(
     base::OnceCallback<void(const std::string& resources_json)> cb) {
   std::move(cb).Run(resources_);
+}
+
+void TestFiltersProvider::Initialize() {
+  CHECK(!is_initialized_);
+  is_initialized_ = true;
+  NotifyObservers(engine_is_default_);
+}
+
+bool TestFiltersProvider::IsInitialized() const {
+  return is_initialized_;
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/content/test/test_filters_provider.h
+++ b/components/brave_shields/content/test/test_filters_provider.h
@@ -25,7 +25,8 @@ class TestFiltersProvider : public AdBlockFiltersProvider,
   TestFiltersProvider(const std::string& rules,
                       const std::string& resources,
                       bool engine_is_default,
-                      uint8_t permission_mask = 0);
+                      uint8_t permission_mask = 0,
+                      bool is_initialized = true);
   ~TestFiltersProvider() override;
 
   void LoadFilterSet(
@@ -35,12 +36,16 @@ class TestFiltersProvider : public AdBlockFiltersProvider,
   void LoadResources(
       base::OnceCallback<void(const std::string& resources_json)> cb) override;
 
+  void Initialize();
+  bool IsInitialized() const override;
+
   std::string GetNameForDebugging() override;
 
  private:
   std::string rules_;
   std::string resources_;
   uint8_t permission_mask_;
+  bool is_initialized_;
 };
 
 }  // namespace brave_shields

--- a/components/brave_shields/core/browser/BUILD.gn
+++ b/components/brave_shields/core/browser/BUILD.gn
@@ -31,4 +31,5 @@ static_library("browser") {
     "//components/prefs",
     "//crypto",
   ]
+  public_deps = [ "//base" ]
 }

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
@@ -95,6 +95,10 @@ void AdBlockComponentFiltersProvider::OnComponentReady(
   NotifyObservers(engine_is_default_);
 }
 
+bool AdBlockComponentFiltersProvider::IsInitialized() const {
+  return !component_path_.empty();
+}
+
 void AdBlockComponentFiltersProvider::LoadFilterSet(
     base::OnceCallback<
         void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb) {

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.h
@@ -61,6 +61,8 @@ class AdBlockComponentFiltersProvider : public AdBlockFiltersProvider {
 
   std::string GetNameForDebugging() override;
 
+  bool IsInitialized() const override;
+
  private:
   friend class ::AdBlockServiceTest;
   friend class ::DebounceBrowserTest;

--- a/components/brave_shields/core/browser/ad_block_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider.cc
@@ -45,6 +45,10 @@ void AdBlockFiltersProvider::NotifyObservers(bool is_for_default_engine) {
   }
 }
 
+bool AdBlockFiltersProvider::IsInitialized() const {
+  return true;
+}
+
 base::WeakPtr<AdBlockFiltersProvider> AdBlockFiltersProvider::AsWeakPtr() {
   return weak_factory_.GetWeakPtr();
 }

--- a/components/brave_shields/core/browser/ad_block_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_filters_provider.h
@@ -46,6 +46,10 @@ class AdBlockFiltersProvider {
 
   virtual std::string GetNameForDebugging() = 0;
 
+  // Intended to be overridden if the provider implementation is not immediately
+  // ready at creation time.
+  virtual bool IsInitialized() const;
+
  protected:
   bool engine_is_default_;
 

--- a/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
@@ -55,6 +55,14 @@ std::string AdBlockFiltersProviderManager::GetNameForDebugging() {
 }
 
 void AdBlockFiltersProviderManager::OnChanged(bool is_for_default_engine) {
+  auto& filters_providers = is_for_default_engine
+                                ? default_engine_filters_providers_
+                                : additional_engine_filters_providers_;
+  for (auto*& provider : filters_providers) {
+    if (!provider->IsInitialized()) {
+      return;
+    }
+  }
   NotifyObservers(is_for_default_engine);
 }
 

--- a/components/brave_shields/core/test/BUILD.gn
+++ b/components/brave_shields/core/test/BUILD.gn
@@ -8,8 +8,12 @@ import("//testing/test.gni")
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "ad_block_component_service_unittest.cc" ]
+  sources = [
+    "ad_block_component_service_unittest.cc",
+    "ad_block_filters_provider_manager_unittest.cc",
+  ]
   deps = [
+    "//brave/components/brave_shields/content/test:test_support",
     "//brave/components/brave_shields/core/browser",
     "//testing/gtest",
   ]

--- a/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
+++ b/components/brave_shields/core/test/ad_block_filters_provider_manager_unittest.cc
@@ -1,0 +1,37 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#include "brave/components/brave_shields/content/test/test_filters_provider.h"
+
+class FiltersProviderManagerTestObserver
+    : public brave_shields::AdBlockFiltersProvider::Observer {
+ public:
+  FiltersProviderManagerTestObserver() = default;
+
+  // AdBlockFiltersProvider::Observer
+  void OnChanged(bool is_default_engine) override { changed_count += 1; }
+
+  int changed_count = 0;
+};
+
+TEST(AdBlockFiltersProviderManagerTest, WaitUntilInitialized) {
+  FiltersProviderManagerTestObserver test_observer;
+  brave_shields::AdBlockFiltersProviderManager::GetInstance()->AddObserver(
+      &test_observer);
+
+  brave_shields::TestFiltersProvider provider1("", "", true, 0, false);
+  brave_shields::TestFiltersProvider provider2("", "", true, 0, false);
+  brave_shields::TestFiltersProvider provider3("", "", true, 0, false);
+
+  provider1.Initialize();
+  EXPECT_EQ(test_observer.changed_count, 0);
+  provider2.Initialize();
+  EXPECT_EQ(test_observer.changed_count, 0);
+  provider3.Initialize();
+  EXPECT_EQ(test_observer.changed_count, 1);
+}


### PR DESCRIPTION
Uplift of #22082
Resolves https://github.com/brave/brave-browser/issues/35922

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.