### PR TITLE
feat(wallet): add setting to change tx simulation opt-in status

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -11,6 +11,15 @@
   <message name="IDS_SETTINGS_RELAUNCH_BUTTON_LABEL" desc="Notifies the user that they need to relaunch Brave">
     Relaunch Now
   </message>
+  <message name="IDS_SETTINGS_SELECT_VALUE_YES" desc="Select value">
+    Yes
+  </message>
+  <message name="IDS_SETTINGS_SELECT_VALUE_NO" desc="Select value">
+    No
+  </message>
+  <message name="IDS_SETTINGS_SELECT_VALUE_ASK" desc="Select value">
+    Ask
+  </message>
 
   <!-- Settings / Get started -->
   <message name="IDS_SETTINGS_BRAVE_GET_STARTED_TITLE" desc="The title for the Get Started section in settings">
@@ -1158,6 +1167,9 @@
   </message>
   <message name="IDS_SETTINGS_WALLET_RESET_CONFIRMATION_PHRASE" desc="The phrase users should type to reset wallet">
     Yes
+  </message>
+  <message name="IDS_BRAVE_WALLET_TRANSACTION_SIMULATIONS_DESC" desc="The description for the user's opt-in status of the transaction simulations service">
+    See the results of transactions before you sign
   </message>
 
   <!-- Settings / Wallet / Networks -->

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1169,7 +1169,7 @@
     Yes
   </message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_SIMULATIONS_DESC" desc="The description for the user's opt-in status of the transaction simulations service">
-    See the results of transactions before you sign
+    See the results of transactions before you sign. <ph name="BEGIN_LINK">&lt;a target="_blank" href="$1"&gt;</ph>&lt;u&gt;Learn more&lt;/u&gt;<ph name="END_LINK">&lt;/a&gt;</ph> 
   </message>
 
   <!-- Settings / Wallet / Networks -->

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -256,6 +256,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[kBraveWalletAutoLockMinutes] =
       settings_api::PrefType::kNumber;
+  (*s_brave_allowlist)[kBraveWalletTransactionSimulationOptInStatus] =
+      settings_api::PrefType::kNumber;
   (*s_brave_allowlist)[kBraveWalletNftDiscoveryEnabled] =
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[kBraveWalletPrivateWindowsEnabled] =

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_browser_proxy.ts
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_browser_proxy.ts
@@ -37,15 +37,18 @@ export type NetworksList = {
   hiddenNetworks: string[]
 }
 
-export type SolanaProvider = {
+export type Option = {
   name: string
   value: number
 }
+
+export type SolanaProvider = Option
 
 export interface BraveWalletBrowserProxy {
   setBraveWalletEnabled(value: boolean): void
   getWeb3ProviderList(): Promise<string>
   getSolanaProviderOptions(): Promise<SolanaProvider[]>
+  getTransactionSimulationOptInStatusOptions(): Promise<Option[]>
   isNativeWalletEnabled(): Promise<boolean>
   isNftPinningEnabled(): Promise<boolean>
   isBitcoinEnabled(): Promise<boolean>
@@ -61,6 +64,7 @@ export interface BraveWalletBrowserProxy {
   resetTransactionInfo (): void
   getPinnedNftCount(): Promise<number>
   clearPinnedNft(): Promise<boolean>
+  isTransactionSimulationsFeatureEnabled(): Promise<boolean>
 }
 
 export class BraveWalletBrowserProxyImpl implements BraveWalletBrowserProxy {
@@ -142,6 +146,14 @@ export class BraveWalletBrowserProxyImpl implements BraveWalletBrowserProxy {
 
   clearPinnedNft() {
     return sendWithPromise('clearPinnedNft')
+  }
+
+  getTransactionSimulationOptInStatusOptions() {
+    return sendWithPromise('getTransactionSimulationOptInStatusOptions')
+  }
+
+  isTransactionSimulationsFeatureEnabled() {
+    return sendWithPromise('isTransactionSimulationsFeatureEnabled')
   }
 
   static getInstance() {

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -61,7 +61,7 @@
     </settings-dropdown-menu>
   </div>
   <div class="settings-box" hidden="[[!isTransactionSimulationsFeatureEnabled]]">
-    <div class="start">$i18n{transactionSimulationDesc}</div>
+    <div class="start">$i18nRaw{transactionSimulationDesc}</div>
       <settings-dropdown-menu id="transactionSimulationOptInStatus"
         class="narrow-drop-down"
         pref="{{prefs.brave.wallet.transaction_simulation_opt_in_status}}"

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -60,6 +60,14 @@
                             menu-options="[[cryptocurrency_list_]]">
     </settings-dropdown-menu>
   </div>
+  <div class="settings-box" hidden="[[!isTransactionSimulationsFeatureEnabled]]">
+    <div class="start">$i18n{transactionSimulationDesc}</div>
+      <settings-dropdown-menu id="transactionSimulationOptInStatus"
+        class="narrow-drop-down"
+        pref="{{prefs.brave.wallet.transaction_simulation_opt_in_status}}"
+        menu-options="[[transaction_simulation_opt_in_options_]]">
+    </settings-dropdown-menu>
+  </div>
   <template is="dom-if" if="[[isNativeWalletEnabled_]]" restamp>
     <settings-toggle-button id="enableNftDiscovery"
         class="cr-row"

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.ts
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.ts
@@ -102,9 +102,10 @@ class SettingsBraveWalletPage extends SettingsBraveWalletPageBase {
     this.browserProxy_.isTransactionSimulationsFeatureEnabled().then(val => {
       this.isTransactionSimulationsFeatureEnabled = val
     });
-    this.browserProxy_.getTransactionSimulationOptInStatusOptions().then(list => {
-      this.transaction_simulation_opt_in_options_ = list
-    });
+    this.browserProxy_.getTransactionSimulationOptInStatusOptions()
+      .then(list => {
+        this.transaction_simulation_opt_in_options_ = list
+      });
 
     this.cryptocurrency_list_ = [
       { value: "BTC" },

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.ts
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.ts
@@ -63,6 +63,12 @@ class SettingsBraveWalletPage extends SettingsBraveWalletPageBase {
         type: Number,
         value: 0,
       },
+
+      isTransactionSimulationsFeatureEnabled: {
+        type: Boolean,
+        value: false,
+      },
+
     }
   }
 
@@ -92,6 +98,12 @@ class SettingsBraveWalletPage extends SettingsBraveWalletPageBase {
     })
     this.browserProxy_.isNftPinningEnabled().then(val => {
       this.isNftPinningEnabled_ = val
+    });
+    this.browserProxy_.isTransactionSimulationsFeatureEnabled().then(val => {
+      this.isTransactionSimulationsFeatureEnabled = val
+    });
+    this.browserProxy_.getTransactionSimulationOptInStatusOptions().then(list => {
+      this.transaction_simulation_opt_in_options_ = list
     });
 
     this.cryptocurrency_list_ = [

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -727,8 +727,6 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SHORTCUTS_PAGE_CANCEL_ADD_SHORTCUT},
       {"shortcutsPageSaveAddShortcut", IDS_SHORTCUTS_PAGE_SAVE_ADD_SHORTCUT},
       {"shortcutsPageAddShortcut", IDS_SHORTCUTS_PAGE_ADD_SHORTCUT},
-      {"transactionSimulationDesc",
-       IDS_BRAVE_WALLET_TRANSACTION_SIMULATIONS_DESC},
       {"settingsSelectValueYes", IDS_SETTINGS_SELECT_VALUE_YES},
       {"settingsSelectValueNo", IDS_SETTINGS_SELECT_VALUE_NO},
       {"settingsSelectValueAsk", IDS_SETTINGS_SELECT_VALUE_ASK},
@@ -779,6 +777,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
   html_source->AddString("ipfsMethodDesc", l10n_util::GetStringFUTF16(
                                                IDS_SETTINGS_IPFS_METHOD_DESC,
                                                ipfs::kIPFSLearnMorePrivacyURL));
+
+  html_source->AddString(
+      "transactionSimulationDesc",
+      l10n_util::GetStringFUTF16(IDS_BRAVE_WALLET_TRANSACTION_SIMULATIONS_DESC,
+                                 kTransactionSimulationLearnMoreURL));
 
   html_source->AddString("resolveUnstoppableDomainsSubDesc",
                          l10n_util::GetStringFUTF16(

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -727,6 +727,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SHORTCUTS_PAGE_CANCEL_ADD_SHORTCUT},
       {"shortcutsPageSaveAddShortcut", IDS_SHORTCUTS_PAGE_SAVE_ADD_SHORTCUT},
       {"shortcutsPageAddShortcut", IDS_SHORTCUTS_PAGE_ADD_SHORTCUT},
+      {"transactionSimulationDesc",
+       IDS_BRAVE_WALLET_TRANSACTION_SIMULATIONS_DESC},
+      {"settingsSelectValueYes", IDS_SETTINGS_SELECT_VALUE_YES},
+      {"settingsSelectValueNo", IDS_SETTINGS_SELECT_VALUE_NO},
+      {"settingsSelectValueAsk", IDS_SETTINGS_SELECT_VALUE_ASK},
   };
 
   html_source->AddLocalizedStrings(localized_strings);

--- a/browser/ui/webui/settings/brave_wallet_handler.h
+++ b/browser/ui/webui/settings/brave_wallet_handler.h
@@ -40,6 +40,8 @@ class BraveWalletHandler : public settings::SettingsPageUIHandler {
 
   void GetAutoLockMinutes(const base::Value::List& args);
   void GetSolanaProviderOptions(const base::Value::List& args);
+  void GetTransactionSimulationOptInStatusOptions(
+      const base::Value::List& args);
   void RemoveChain(const base::Value::List& args);
   void ResetChain(const base::Value::List& args);
   void GetNetworksList(const base::Value::List& args);
@@ -51,6 +53,7 @@ class BraveWalletHandler : public settings::SettingsPageUIHandler {
   void IsNftPinningEnabled(const base::Value::List& args);
   void IsBitcoinEnabled(const base::Value::List& args);
   void IsZCashEnabled(const base::Value::List& args);
+  void IsTransactionSimulationsEnabled(const base::Value::List& args);
   void GetPinnedNftCount(const base::Value::List& args);
   void ClearPinnedNft(const base::Value::List& args);
 

--- a/components/brave_wallet/browser/brave_wallet_prefs.cc
+++ b/components/brave_wallet/browser/brave_wallet_prefs.cc
@@ -202,6 +202,10 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
   registry->RegisterStringPref(kBraveWalletSelectedWalletAccount, "");
   registry->RegisterStringPref(kBraveWalletSelectedEthDappAccount, "");
   registry->RegisterStringPref(kBraveWalletSelectedSolDappAccount, "");
+
+  registry->RegisterIntegerPref(
+      kBraveWalletTransactionSimulationOptInStatus,
+      static_cast<int>(brave_wallet::mojom::BlowfishOptInStatus::kUnset));
 }
 
 void RegisterLocalStatePrefsForMigration(PrefRegistrySimple* registry) {

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -26,6 +26,7 @@
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
 #include "brave/components/brave_wallet/browser/wallet_data_files_installer.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_response_helpers.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
@@ -1570,6 +1571,17 @@ void BraveWalletService::GetAnkrSupportedChainIds(
 
 void BraveWalletService::IsPrivateWindow(IsPrivateWindowCallback callback) {
   std::move(callback).Run(is_private_window_);
+}
+
+void BraveWalletService::GetTransactionSimulationOptInStatus(
+    GetTransactionSimulationOptInStatusCallback callback) {
+  std::move(callback).Run(
+      ::brave_wallet::GetTransactionSimulationOptInStatus(profile_prefs_));
+}
+
+void BraveWalletService::SetTransactionSimulationOptInStatus(
+    mojom::BlowfishOptInStatus status) {
+  ::brave_wallet::SetTransactionSimulationOptInStatus(profile_prefs_, status);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_service.cc
+++ b/components/brave_wallet/browser/brave_wallet_service.cc
@@ -26,7 +26,6 @@
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/brave_wallet/browser/tx_service.h"
 #include "brave/components/brave_wallet/browser/wallet_data_files_installer.h"
-#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_response_helpers.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"

--- a/components/brave_wallet/browser/brave_wallet_service.h
+++ b/components/brave_wallet/browser/brave_wallet_service.h
@@ -245,6 +245,12 @@ class BraveWalletService : public KeyedService,
 
   void IsPrivateWindow(IsPrivateWindowCallback callback) override;
 
+  void GetTransactionSimulationOptInStatus(
+      GetTransactionSimulationOptInStatusCallback callback) override;
+
+  void SetTransactionSimulationOptInStatus(
+      mojom::BlowfishOptInStatus status) override;
+
   // BraveWalletServiceDelegate::Observer:
   void OnActiveOriginChanged(const mojom::OriginInfoPtr& origin_info) override;
 

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -27,6 +27,7 @@
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 #include "brave/components/brave_wallet/common/buildflags.h"
@@ -2108,6 +2109,19 @@ mojom::BlockchainTokenPtr GetZcashNativeToken(const std::string& chain_id) {
   }
 
   return result;
+}
+
+mojom::BlowfishOptInStatus GetTransactionSimulationOptInStatus(
+    PrefService* prefs) {
+  return static_cast<mojom::BlowfishOptInStatus>(
+      prefs->GetInteger(kBraveWalletTransactionSimulationOptInStatus));
+}
+
+void SetTransactionSimulationOptInStatus(
+    PrefService* prefs,
+    const mojom::BlowfishOptInStatus& status) {
+  prefs->SetInteger(kBraveWalletTransactionSimulationOptInStatus,
+                    static_cast<int>(status));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_utils.cc
+++ b/components/brave_wallet/browser/brave_wallet_utils.cc
@@ -27,7 +27,6 @@
 #include "base/values.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_constants.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
-#include "brave/components/brave_wallet/common/brave_wallet.mojom-shared.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/brave_wallet_types.h"
 #include "brave/components/brave_wallet/common/buildflags.h"

--- a/components/brave_wallet/browser/brave_wallet_utils.h
+++ b/components/brave_wallet/browser/brave_wallet_utils.h
@@ -190,6 +190,13 @@ std::string WalletInternalErrorMessage();
 mojom::BlockchainTokenPtr GetBitcoinNativeToken(const std::string& chain_id);
 mojom::BlockchainTokenPtr GetZcashNativeToken(const std::string& chain_id);
 
+mojom::BlowfishOptInStatus GetTransactionSimulationOptInStatus(
+    PrefService* prefs);
+
+void SetTransactionSimulationOptInStatus(
+    PrefService* prefs,
+    const mojom::BlowfishOptInStatus& status);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_BRAVE_WALLET_UTILS_H_

--- a/components/brave_wallet/browser/pref_names.h
+++ b/components/brave_wallet/browser/pref_names.h
@@ -80,6 +80,8 @@ inline constexpr char kPinnedNFTAssets[] = "brave.wallet.user_pin_data";
 inline constexpr char kAutoPinEnabled[] = "brave.wallet.auto_pin_enabled";
 inline constexpr char kBraveWalletPrivateWindowsEnabled[] =
     "brave.wallet.private_windows_enabled";
+inline constexpr char kBraveWalletTransactionSimulationOptInStatus[] =
+    "brave.wallet.transaction_simulation_opt_in_status";
 
 // Added 02/2023 to migrate transactions to contain the
 // chain_id for each one.

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -2181,6 +2181,10 @@ interface BraveWalletService {
   GetAnkrSupportedChainIds() => (array<string> chain_ids);
 
   IsPrivateWindow() => (bool is_private_window);
+
+  GetTransactionSimulationOptInStatus() => (BlowfishOptInStatus status);
+
+  SetTransactionSimulationOptInStatus(BlowfishOptInStatus status);
 };
 
 // For reporting wallet related P3A metrics.
@@ -2572,6 +2576,12 @@ enum BlowfishSolanaErrorKind {
 enum BlowfishSuggestedColor {
   kCredit,
   kDebit
+};
+
+enum BlowfishOptInStatus {
+  kUnset = 1,
+  kAllowed = 2,
+  kDenied = 3,
 };
 
 struct BlowfishPrice {

--- a/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
+++ b/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
@@ -11,7 +11,7 @@ import { createStore, combineReducers } from 'redux'
 import { createWalletReducer } from '../../slices/wallet.slice'
 
 // types
-import { BraveWallet, TxSimulationOptInStatus } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 import { WalletActions } from '../../actions'
 import type WalletApiProxy from '../../wallet_api_proxy'
 
@@ -126,7 +126,8 @@ export class MockedWalletApiProxy {
 
   svmSimulationResponse: BraveWallet.SolanaSimulationResponse | null = null
 
-  txSimulationOptInStatus: TxSimulationOptInStatus = 'allowed'
+  txSimulationOptInStatus: BraveWallet.BlowfishOptInStatus =
+    BraveWallet.BlowfishOptInStatus.kAllowed
 
   /**
    * balance = [accountAddress][chainId]

--- a/components/brave_wallet_ui/components/extension/enable_transaction_simulations/enable_transaction_simulations.tsx
+++ b/components/brave_wallet_ui/components/extension/enable_transaction_simulations/enable_transaction_simulations.tsx
@@ -6,6 +6,9 @@
 import * as React from 'react'
 import Icon from '@brave/leo/react/icon'
 
+// types
+import { BraveWallet } from '../../../constants/types'
+
 // utils
 import { getLocale, getLocaleWithTag } from '../../../../common/locale'
 
@@ -107,7 +110,9 @@ export const EnableTransactionSimulations: React.FC = () => {
               <LeoSquaredButton
                 kind='plain-faint'
                 onClick={async () => {
-                  await optInOrOut('denied').unwrap()
+                  await optInOrOut(
+                    BraveWallet.BlowfishOptInStatus.kDenied
+                  ).unwrap()
                 }}
               >
                 {getLocale('braveWalletButtonNoThanks')}
@@ -115,7 +120,9 @@ export const EnableTransactionSimulations: React.FC = () => {
               <LeoSquaredButton
                 kind='filled'
                 onClick={async () => {
-                  await optInOrOut('allowed').unwrap()
+                  await optInOrOut(
+                    BraveWallet.BlowfishOptInStatus.kAllowed
+                  ).unwrap()
                 }}
               >
                 {getLocale('braveWalletButtonEnable')}

--- a/components/brave_wallet_ui/constants/testing_types.ts
+++ b/components/brave_wallet_ui/constants/testing_types.ts
@@ -7,11 +7,7 @@ import {
   NativeAssetBalanceRegistry,
   TokenBalanceRegistry
 } from '../common/constants/mocks'
-import {
-  BraveWallet,
-  RewardsExternalWallet,
-  TxSimulationOptInStatus
-} from './types'
+import { BraveWallet, RewardsExternalWallet } from './types'
 
 export interface WalletApiDataOverrides {
   selectedCoin?: BraveWallet.CoinType
@@ -25,7 +21,7 @@ export interface WalletApiDataOverrides {
   accountInfos?: BraveWallet.AccountInfo[]
   nativeBalanceRegistry?: NativeAssetBalanceRegistry
   tokenBalanceRegistry?: TokenBalanceRegistry
-  simulationOptInStatus?: TxSimulationOptInStatus
+  simulationOptInStatus?: BraveWallet.BlowfishOptInStatus
   evmSimulationResponse?: BraveWallet.EVMSimulationResponse | null
   svmSimulationResponse?: BraveWallet.SolanaSimulationResponse | null
 }

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -1048,8 +1048,6 @@ export type SwapAndSend = {
   name: string
 }
 
-export type TxSimulationOptInStatus = 'allowed' | 'denied' | 'unset'
-
 export enum SignDataSteps {
   SignRisk = 0,
   SignData = 1

--- a/components/constants/webui_url_constants.h
+++ b/components/constants/webui_url_constants.h
@@ -84,4 +84,7 @@ inline constexpr char kShortcutsURL[] = "chrome://settings/system/shortcuts";
 inline constexpr char kChatUIURL[] = "chrome-untrusted://chat/";
 inline constexpr char kChatUIHost[] = "chat";
 
+inline constexpr char16_t kTransactionSimulationLearnMoreURL[] =
+    u"https://github.com/brave/brave-browser/wiki/Transaction-Simulation";
+
 #endif  // BRAVE_COMPONENTS_CONSTANTS_WEBUI_URL_CONSTANTS_H_

--- a/components/definitions/chrome_brave_wallet.d.ts
+++ b/components/definitions/chrome_brave_wallet.d.ts
@@ -5,7 +5,9 @@
 
 declare namespace chrome.braveWallet {
   const ready: () => void
-  const shouldPromptForSetup: (callback: (shouldPrompt: boolean) => void) => void
+  const shouldPromptForSetup: (
+    callback: (shouldPrompt: boolean) => void
+  ) => void
   const loadUI: (callback: () => void) => void
   const isNativeWalletEnabled: (callback: (enabled: boolean) => void) => void
   const isNftPinningEnabled: (callback: (enabled: boolean) => void) => void

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -393,5 +393,14 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
 
   func discoverAssetsOnAllSupportedChains(bypassRateLimit: Bool) {
   }
+
+  func transactionSimulationOptInStatus(
+    completion: @escaping (BraveWallet.BlowfishOptInStatus?) -> Void
+  ) {
+    completion(.unset)
+  }
+
+  func setTransactionSimulationOptInStatus(_ status: BraveWallet.BlowfishOptInStatus) {
+  }
 }
 #endif

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockBraveWalletService.swift
@@ -395,7 +395,7 @@ class MockBraveWalletService: BraveWalletBraveWalletService {
   }
 
   func transactionSimulationOptInStatus(
-    completion: @escaping (BraveWallet.BlowfishOptInStatus?) -> Void
+    completion: @escaping (BraveWallet.BlowfishOptInStatus) -> Void
   ) {
     completion(.unset)
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36509

Security/Privacy review: https://github.com/brave/reviews/issues/1530

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The drop-down for changing the opt-in status for transaction simulations should be shown in brave://settings/web3 when the  [#brave-wallet-enable-transaction-simulations](chrome://flags/#brave-wallet-enable-transaction-simulations) flag is enabled

Changing the dropdown should update the "transaction_simulation_opt_in_status" in brave://prefs-internals/


