### PR TITLE
[Brave News]: Use BraveNews prefix for all brave news tests

### DIFF
--- a/components/brave_news/browser/channels_controller_unittest.cc
+++ b/components/brave_news/browser/channels_controller_unittest.cc
@@ -78,9 +78,9 @@ constexpr char kPublishersResponse[] = R"([
     }
 ])";
 
-class ChannelsControllerTest : public testing::Test {
+class BraveNewsChannelsControllerTest : public testing::Test {
  public:
-  ChannelsControllerTest()
+  BraveNewsChannelsControllerTest()
       : api_request_helper_(TRAFFIC_ANNOTATION_FOR_TESTS,
                             test_url_loader_factory_.GetSafeWeakWrapper()),
         direct_feed_controller_(profile_.GetPrefs(), nullptr),
@@ -138,7 +138,7 @@ class ChannelsControllerTest : public testing::Test {
   ChannelsController channels_controller_;
 };
 
-TEST_F(ChannelsControllerTest, CanGetAllChannels) {
+TEST_F(BraveNewsChannelsControllerTest, CanGetAllChannels) {
   test_url_loader_factory_.AddResponse(GetPublishersURL(), kPublishersResponse,
                                        net::HTTP_OK);
 
@@ -155,7 +155,7 @@ TEST_F(ChannelsControllerTest, CanGetAllChannels) {
   }
 }
 
-TEST_F(ChannelsControllerTest, GetAllChannelsLoadsSubscribedState) {
+TEST_F(BraveNewsChannelsControllerTest, GetAllChannelsLoadsSubscribedState) {
   channels_controller_.SetChannelSubscribed("en_US", "One", true);
   channels_controller_.SetChannelSubscribed("en_US", "Five", true);
 
@@ -182,7 +182,7 @@ TEST_F(ChannelsControllerTest, GetAllChannelsLoadsSubscribedState) {
   EXPECT_TRUE(base::Contains(five->second->subscribed_locales, "en_US"));
 }
 
-TEST_F(ChannelsControllerTest,
+TEST_F(BraveNewsChannelsControllerTest,
        GetAllChannelsLoadsCorrectLocaleSubscriptionStatus) {
   channels_controller_.SetChannelSubscribed("en_US", "One", true);
   channels_controller_.SetChannelSubscribed("ja_JA", "Five", true);
@@ -205,7 +205,7 @@ TEST_F(ChannelsControllerTest,
   }
 }
 
-TEST_F(ChannelsControllerTest, CanToggleChannelSubscribed) {
+TEST_F(BraveNewsChannelsControllerTest, CanToggleChannelSubscribed) {
   EXPECT_FALSE(channels_controller_.GetChannelSubscribed("en_US", "Test"));
 
   channels_controller_.SetChannelSubscribed("en_US", "Test", true);
@@ -215,7 +215,7 @@ TEST_F(ChannelsControllerTest, CanToggleChannelSubscribed) {
   EXPECT_FALSE(channels_controller_.GetChannelSubscribed("en_US", "Test"));
 }
 
-TEST_F(ChannelsControllerTest,
+TEST_F(BraveNewsChannelsControllerTest,
        ChangingAChannelInOneLocaleDoesNotAffectOtherLocales) {
   EXPECT_FALSE(channels_controller_.GetChannelSubscribed("en_US", "Test"));
   EXPECT_FALSE(channels_controller_.GetChannelSubscribed("ja_JA", "Test"));
@@ -237,11 +237,11 @@ TEST_F(ChannelsControllerTest,
   EXPECT_FALSE(channels_controller_.GetChannelSubscribed("ja_JA", "Test"));
 }
 
-TEST_F(ChannelsControllerTest, NoChannelsNoChannelLocales) {
+TEST_F(BraveNewsChannelsControllerTest, NoChannelsNoChannelLocales) {
   EXPECT_EQ(0u, channels_controller_.GetChannelLocales().size());
 }
 
-TEST_F(ChannelsControllerTest, SubscribedChannelLocalesIncluded) {
+TEST_F(BraveNewsChannelsControllerTest, SubscribedChannelLocalesIncluded) {
   channels_controller_.SetChannelSubscribed("en_US", "Test", true);
 
   auto locales = channels_controller_.GetChannelLocales();
@@ -259,7 +259,8 @@ TEST_F(ChannelsControllerTest, SubscribedChannelLocalesIncluded) {
   EXPECT_EQ("ja_JA", locales[1]);
 }
 
-TEST_F(ChannelsControllerTest, LocaleWithNoSubscribedChannelsIsNotIncluded) {
+TEST_F(BraveNewsChannelsControllerTest,
+       LocaleWithNoSubscribedChannelsIsNotIncluded) {
   channels_controller_.SetChannelSubscribed("en_US", "Test", true);
 
   auto locales = channels_controller_.GetChannelLocales();
@@ -271,7 +272,7 @@ TEST_F(ChannelsControllerTest, LocaleWithNoSubscribedChannelsIsNotIncluded) {
   EXPECT_EQ(0u, locales.size());
 }
 
-TEST_F(ChannelsControllerTest, ChannelMigrationsAreApplied) {
+TEST_F(BraveNewsChannelsControllerTest, ChannelMigrationsAreApplied) {
   channels_controller_.SetChannelSubscribed("en_US", "Tech News", true);
   channels_controller_.SetChannelSubscribed("en_US", "Sport", true);
 

--- a/components/brave_news/browser/locales_helper_unittest.cc
+++ b/components/brave_news/browser/locales_helper_unittest.cc
@@ -42,7 +42,7 @@ Publishers MakePublishers(
 }
 }  // namespace
 
-TEST(LocalesHelperTest, NoDuplicatesInAllLocales) {
+TEST(BraveNewsLocalesHelperTest, NoDuplicatesInAllLocales) {
   auto locales = brave_news::GetPublisherLocales(MakePublishers(
       {{"en_US", "es_MX"}, {"es_MX", "ja_JP"}, {"ja_JP", "en_US"}}));
   EXPECT_EQ(3u, locales.size());
@@ -53,14 +53,15 @@ TEST(LocalesHelperTest, NoDuplicatesInAllLocales) {
 
 // Even with no subscribed publishers, we should feeds for all locales we have
 // channels in.
-TEST(LocalesHelperTest, GetMinimalLocalesSetUsesChannelLocales) {
+TEST(BraveNewsLocalesHelperTest, GetMinimalLocalesSetUsesChannelLocales) {
   auto locales = GetMinimalLocalesSet({"en_US", "ja_JP"}, {});
   EXPECT_EQ(2u, locales.size());
   EXPECT_TRUE(base::Contains(locales, "en_US"));
   EXPECT_TRUE(base::Contains(locales, "ja_JP"));
 }
 
-TEST(LocalesHelperTest, LocaleIsNotIncludedIfChannelLocalesIncludePublisher) {
+TEST(BraveNewsLocalesHelperTest,
+     LocaleIsNotIncludedIfChannelLocalesIncludePublisher) {
   Publishers publishers = MakePublishers({{"en_US", "en_UK", "en_NZ"},
                                           {
                                               "en_US",
@@ -73,7 +74,7 @@ TEST(LocalesHelperTest, LocaleIsNotIncludedIfChannelLocalesIncludePublisher) {
   EXPECT_TRUE(base::Contains(locales, "en_NZ"));
 }
 
-TEST(LocalesHelperTest, AllRegionsAreCovered) {
+TEST(BraveNewsLocalesHelperTest, AllRegionsAreCovered) {
   Publishers publishers = MakePublishers({{
                                               "en_US",
                                           },
@@ -94,7 +95,7 @@ TEST(LocalesHelperTest, AllRegionsAreCovered) {
   EXPECT_TRUE(base::Contains(locales, "en_US"));
 }
 
-TEST(LocalesHelperTest, MostCommonPublisherIsPickedFirstSingleGroup) {
+TEST(BraveNewsLocalesHelperTest, MostCommonPublisherIsPickedFirstSingleGroup) {
   Publishers publishers = MakePublishers({{
                                               "en_AU",
                                               "en_NZ",
@@ -118,7 +119,7 @@ TEST(LocalesHelperTest, MostCommonPublisherIsPickedFirstSingleGroup) {
   EXPECT_TRUE(base::Contains(locales, "en_NZ"));
 }
 
-TEST(LocalesHelperTest, MostCommonPublisherIsPickedFirst) {
+TEST(BraveNewsLocalesHelperTest, MostCommonPublisherIsPickedFirst) {
   Publishers publishers = MakePublishers({{
                                               "en_AU",
                                               "en_NZ",
@@ -151,7 +152,7 @@ TEST(LocalesHelperTest, MostCommonPublisherIsPickedFirst) {
   EXPECT_TRUE(base::Contains(locales, "ja_JP"));
 }
 
-TEST(LocalesHelperTest, OnlyEnabledPublishersAreConsidered) {
+TEST(BraveNewsLocalesHelperTest, OnlyEnabledPublishersAreConsidered) {
   Publishers publishers = MakePublishers({
       {"en_NZ"},
       {"en_AU"},
@@ -168,7 +169,7 @@ TEST(LocalesHelperTest, OnlyEnabledPublishersAreConsidered) {
   EXPECT_TRUE(base::Contains(locales, "en_UK"));
 }
 
-TEST(LocalesHelperTest, NonEnabledPublishersDontAffectInclusions) {
+TEST(BraveNewsLocalesHelperTest, NonEnabledPublishersDontAffectInclusions) {
   Publishers publishers = MakePublishers({
       {"en_NZ"},
       {"en_US"},

--- a/components/brave_news/browser/publishers_controller_unittest.cc
+++ b/components/brave_news/browser/publishers_controller_unittest.cc
@@ -114,9 +114,9 @@ class WaitForPublishersChanged : public PublishersController::Observer {
   base::RunLoop loop_;
 };
 
-class PublishersControllerTest : public testing::Test {
+class BraveNewsPublishersControllerTest : public testing::Test {
  public:
-  PublishersControllerTest()
+  BraveNewsPublishersControllerTest()
       : api_request_helper_(TRAFFIC_ANNOTATION_FOR_TESTS,
                             test_url_loader_factory_.GetSafeWeakWrapper()),
         direct_feed_controller_(profile_.GetPrefs(), nullptr),
@@ -191,7 +191,7 @@ class PublishersControllerTest : public testing::Test {
   PublishersController publishers_controller_;
 };
 
-TEST_F(PublishersControllerTest, CanReceiveFeeds) {
+TEST_F(BraveNewsPublishersControllerTest, CanReceiveFeeds) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
   LOG(ERROR) << "Sources URL: " << GetSourcesUrl();
@@ -202,7 +202,7 @@ TEST_F(PublishersControllerTest, CanReceiveFeeds) {
   EXPECT_TRUE(base::Contains(result, "555"));
 }
 
-TEST_F(PublishersControllerTest, CanGetPublisherBySiteUrl) {
+TEST_F(BraveNewsPublishersControllerTest, CanGetPublisherBySiteUrl) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
   GetPublishers();
@@ -211,7 +211,8 @@ TEST_F(PublishersControllerTest, CanGetPublisherBySiteUrl) {
   EXPECT_EQ("555", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest, CantGetNonExistingPublisherBySiteUrl) {
+TEST_F(BraveNewsPublishersControllerTest,
+       CantGetNonExistingPublisherBySiteUrl) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
   GetPublishers();
@@ -220,7 +221,7 @@ TEST_F(PublishersControllerTest, CantGetNonExistingPublisherBySiteUrl) {
                          GURL("https://not-a-site.com")));
 }
 
-TEST_F(PublishersControllerTest, CanGetPublisherByFeedUrl) {
+TEST_F(BraveNewsPublishersControllerTest, CanGetPublisherByFeedUrl) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
   GetPublishers();
@@ -229,7 +230,7 @@ TEST_F(PublishersControllerTest, CanGetPublisherByFeedUrl) {
   EXPECT_EQ("555", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest,
+TEST_F(BraveNewsPublishersControllerTest,
        PublisherInDefaultLocaleIsPreferred_PreferredFirst) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), R"([
     {
@@ -285,7 +286,7 @@ TEST_F(PublishersControllerTest,
   EXPECT_EQ("111", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest,
+TEST_F(BraveNewsPublishersControllerTest,
        PublisherInDefaultLocaleIsPreferred_PreferredLast) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), R"([
     {
@@ -341,7 +342,7 @@ TEST_F(PublishersControllerTest,
   EXPECT_EQ("222", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest, NoPreferredLocale_ReturnsFirstMatch) {
+TEST_F(BraveNewsPublishersControllerTest, NoPreferredLocale_ReturnsFirstMatch) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), R"([
     {
         "publisher_id": "111",
@@ -396,7 +397,8 @@ TEST_F(PublishersControllerTest, NoPreferredLocale_ReturnsFirstMatch) {
   EXPECT_EQ("111", publisher->publisher_id);
 }
 
-TEST_F(PublishersControllerTest, CantGetNonExistingPublisherByFeedUrl) {
+TEST_F(BraveNewsPublishersControllerTest,
+       CantGetNonExistingPublisherByFeedUrl) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
   GetPublishers();
@@ -405,7 +407,7 @@ TEST_F(PublishersControllerTest, CantGetNonExistingPublisherByFeedUrl) {
                          GURL("https://tp5.example.com")));
 }
 
-TEST_F(PublishersControllerTest, CacheCanBeCleared) {
+TEST_F(BraveNewsPublishersControllerTest, CacheCanBeCleared) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
   GetPublishers();
@@ -421,7 +423,7 @@ TEST_F(PublishersControllerTest, CacheCanBeCleared) {
                          GURL("https://tp5.example.com/feed")));
 }
 
-TEST_F(PublishersControllerTest, LocaleDefaultsToENUS) {
+TEST_F(BraveNewsPublishersControllerTest, LocaleDefaultsToENUS) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), R"([
     {
         "publisher_id": "111",
@@ -449,7 +451,7 @@ TEST_F(PublishersControllerTest, LocaleDefaultsToENUS) {
   EXPECT_EQ("en_US", locale);
 }
 
-TEST_F(PublishersControllerTest, CanGetPublishers) {
+TEST_F(BraveNewsPublishersControllerTest, CanGetPublishers) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
 
@@ -457,7 +459,7 @@ TEST_F(PublishersControllerTest, CanGetPublishers) {
   EXPECT_EQ(3u, result.size());
 }
 
-TEST_F(PublishersControllerTest, DoesntFetchPublishersWhenNotOptedIn) {
+TEST_F(BraveNewsPublishersControllerTest, DoesntFetchPublishersWhenNotOptedIn) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
 
@@ -466,7 +468,7 @@ TEST_F(PublishersControllerTest, DoesntFetchPublishersWhenNotOptedIn) {
   EXPECT_EQ(0u, result.size());
 }
 
-TEST_F(PublishersControllerTest, DoesntFetchPublishersWhenNotShowing) {
+TEST_F(BraveNewsPublishersControllerTest, DoesntFetchPublishersWhenNotShowing) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);
 
@@ -476,7 +478,7 @@ TEST_F(PublishersControllerTest, DoesntFetchPublishersWhenNotShowing) {
   EXPECT_EQ(0u, result.size());
 }
 
-TEST_F(PublishersControllerTest,
+TEST_F(BraveNewsPublishersControllerTest,
        DoesntFetchPublishersWhenNotShowingAndNotOptedIn) {
   test_url_loader_factory_.AddResponse(GetSourcesUrl(), kPublishersResponse,
                                        net::HTTP_OK);

--- a/components/brave_news/browser/suggestions_controller.h
+++ b/components/brave_news/browser/suggestions_controller.h
@@ -47,7 +47,7 @@ class SuggestionsController {
   void EnsureSimilarityMatrixIsUpdating();
 
  private:
-  friend class SuggestionsControllerTest;
+  friend class BraveNewsSuggestionsControllerTest;
   void GetOrFetchSimilarityMatrix(base::OnceClosure callback);
   std::vector<std::string> GetSuggestedPublisherIdsWithHistory(
       const Publishers& publishers,

--- a/components/brave_news/browser/suggestions_controller_unittest.cc
+++ b/components/brave_news/browser/suggestions_controller_unittest.cc
@@ -58,9 +58,9 @@ history::QueryResults MakeQueryResults(const std::vector<std::string>& urls) {
 }
 }  // namespace
 
-class SuggestionsControllerTest : public testing::Test {
+class BraveNewsSuggestionsControllerTest : public testing::Test {
  public:
-  SuggestionsControllerTest()
+  BraveNewsSuggestionsControllerTest()
       : api_request_helper_(TRAFFIC_ANNOTATION_FOR_TESTS,
                             test_url_loader_factory_.GetSafeWeakWrapper()),
         direct_feed_controller_(profile_.GetPrefs(), nullptr),
@@ -77,7 +77,7 @@ class SuggestionsControllerTest : public testing::Test {
                                     true);
     SetLocale("en_US");
   }
-  ~SuggestionsControllerTest() override = default;
+  ~BraveNewsSuggestionsControllerTest() override = default;
 
  protected:
   std::vector<std::string> GetSuggestedPublisherIds(
@@ -106,7 +106,7 @@ class SuggestionsControllerTest : public testing::Test {
   SuggestionsController suggestions_controller_;
 };
 
-TEST_F(SuggestionsControllerTest, VisitedSourcesAreSuggested) {
+TEST_F(BraveNewsSuggestionsControllerTest, VisitedSourcesAreSuggested) {
   const auto& publishers = MakePublishers({
       "https://example.com",
       "https://bar.com",
@@ -123,7 +123,8 @@ TEST_F(SuggestionsControllerTest, VisitedSourcesAreSuggested) {
   EXPECT_EQ("3", suggestions[1]);
 }
 
-TEST_F(SuggestionsControllerTest, SubscribedVisitedSourcesAreNotSuggested) {
+TEST_F(BraveNewsSuggestionsControllerTest,
+       SubscribedVisitedSourcesAreNotSuggested) {
   const auto& publishers = MakePublishers({
       "https://example.com",
       "https://bar.com",
@@ -140,7 +141,8 @@ TEST_F(SuggestionsControllerTest, SubscribedVisitedSourcesAreNotSuggested) {
   EXPECT_EQ("3", suggestions[0]);
 }
 
-TEST_F(SuggestionsControllerTest, DisabledVisitedSourcesAreNotSuggested) {
+TEST_F(BraveNewsSuggestionsControllerTest,
+       DisabledVisitedSourcesAreNotSuggested) {
   const auto& publishers = MakePublishers({
       "https://example.com",
       "https://bar.com",
@@ -157,7 +159,7 @@ TEST_F(SuggestionsControllerTest, DisabledVisitedSourcesAreNotSuggested) {
   EXPECT_EQ("3", suggestions[0]);
 }
 
-TEST_F(SuggestionsControllerTest, SimilarSourcesAreSuggested) {
+TEST_F(BraveNewsSuggestionsControllerTest, SimilarSourcesAreSuggested) {
   const auto& publishers = MakePublishers({
       "https://example.com",
       "https://bar.com",
@@ -179,7 +181,8 @@ TEST_F(SuggestionsControllerTest, SimilarSourcesAreSuggested) {
   EXPECT_EQ("2", suggestions[1]);
 }
 
-TEST_F(SuggestionsControllerTest, SimilarToVisitedSourcesAreSuggested) {
+TEST_F(BraveNewsSuggestionsControllerTest,
+       SimilarToVisitedSourcesAreSuggested) {
   const auto& publishers = MakePublishers({
       "https://example.com",
       "https://bar.com",
@@ -203,7 +206,8 @@ TEST_F(SuggestionsControllerTest, SimilarToVisitedSourcesAreSuggested) {
   EXPECT_EQ("2", suggestions[2]);
 }
 
-TEST_F(SuggestionsControllerTest, VisitWeightingAltersSimilarToVisitWeighting) {
+TEST_F(BraveNewsSuggestionsControllerTest,
+       VisitWeightingAltersSimilarToVisitWeighting) {
   const auto& publishers = MakePublishers({
       "https://example.com",
       "https://bar.com",
@@ -228,7 +232,7 @@ TEST_F(SuggestionsControllerTest, VisitWeightingAltersSimilarToVisitWeighting) {
   EXPECT_EQ("4", suggestions[3]);  // Similar to P2 (which was visited once)
 }
 
-TEST_F(SuggestionsControllerTest,
+TEST_F(BraveNewsSuggestionsControllerTest,
        SuggestionsCanComeFromVistSimilarOrSimilarToVisit) {
   const auto& publishers = MakePublishers({
       "https://visited.com",
@@ -255,7 +259,8 @@ TEST_F(SuggestionsControllerTest,
       base::Contains(suggestions, "4"));  // Similar to P1 (which was visited)
 }
 
-TEST_F(SuggestionsControllerTest, SourcesFromDifferentLocalesAreNotSuggested) {
+TEST_F(BraveNewsSuggestionsControllerTest,
+       SourcesFromDifferentLocalesAreNotSuggested) {
   const auto& publishers = MakePublishers({
       "https://visited.com",
       "https://similar-to-visited.com",

--- a/components/brave_news/browser/topics_fetcher_unittest.cc
+++ b/components/brave_news/browser/topics_fetcher_unittest.cc
@@ -203,9 +203,9 @@ constexpr char kTopicsNewsResponse[] = R"([
   }
 ])";
 
-class TopicsFetcherTest : public testing::Test {
+class BraveNewsTopicsFetcherTest : public testing::Test {
  public:
-  TopicsFetcherTest()
+  BraveNewsTopicsFetcherTest()
       : fetcher_(test_url_loader_factory_.GetSafeWeakWrapper()) {}
 
   std::vector<TopicAndArticles> GetTopics() {
@@ -234,7 +234,7 @@ class TopicsFetcherTest : public testing::Test {
   TopicsFetcher fetcher_;
 };
 
-TEST_F(TopicsFetcherTest, TopicsAreJoinedAndParsedCorrectly) {
+TEST_F(BraveNewsTopicsFetcherTest, TopicsAreJoinedAndParsedCorrectly) {
   url_loader_factory().AddResponse(kTopicsUrl, kTopicsResponse, net::HTTP_OK);
   url_loader_factory().AddResponse(kTopicsNewsUrl, kTopicsNewsResponse,
                                    net::HTTP_OK);
@@ -286,7 +286,7 @@ TEST_F(TopicsFetcherTest, TopicsAreJoinedAndParsedCorrectly) {
   EXPECT_EQ("news", afghanistan_article.origin);
 }
 
-TEST_F(TopicsFetcherTest, NoResponseNoTopics) {
+TEST_F(BraveNewsTopicsFetcherTest, NoResponseNoTopics) {
   url_loader_factory().AddResponse(kTopicsUrl, "",
                                    net::HTTP_INTERNAL_SERVER_ERROR);
   url_loader_factory().AddResponse(kTopicsNewsUrl, "",
@@ -294,7 +294,7 @@ TEST_F(TopicsFetcherTest, NoResponseNoTopics) {
   EXPECT_EQ(0u, GetTopics().size());
 }
 
-TEST_F(TopicsFetcherTest, NoTopicsResponseButArticlesNoTopics) {
+TEST_F(BraveNewsTopicsFetcherTest, NoTopicsResponseButArticlesNoTopics) {
   url_loader_factory().AddResponse(kTopicsUrl, "",
                                    net::HTTP_INTERNAL_SERVER_ERROR);
   url_loader_factory().AddResponse(kTopicsNewsUrl, kTopicsNewsResponse,
@@ -302,14 +302,14 @@ TEST_F(TopicsFetcherTest, NoTopicsResponseButArticlesNoTopics) {
   EXPECT_EQ(0u, GetTopics().size());
 }
 
-TEST_F(TopicsFetcherTest, NoArticlesResponseButTopicsNoTopics) {
+TEST_F(BraveNewsTopicsFetcherTest, NoArticlesResponseButTopicsNoTopics) {
   url_loader_factory().AddResponse(kTopicsUrl, kTopicsResponse, net::HTTP_OK);
   url_loader_factory().AddResponse(kTopicsNewsUrl, "",
                                    net::HTTP_INTERNAL_SERVER_ERROR);
   EXPECT_EQ(0u, GetTopics().size());
 }
 
-TEST_F(TopicsFetcherTest, TopicsWithInvalidArticles) {
+TEST_F(BraveNewsTopicsFetcherTest, TopicsWithInvalidArticles) {
   url_loader_factory().AddResponse(kTopicsUrl, kTopicsResponse, net::HTTP_OK);
   url_loader_factory().AddResponse(kTopicsNewsUrl, "foo", net::HTTP_OK);
   EXPECT_EQ(0u, GetTopics().size());


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36526

**Note:** I haven't updated UnsupportedPublisherMigratorTest because it's being removed in #22440 and I didn't want a conflict

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

