### PR TITLE
Improved brave_sync::Prefs::AddLeaveChainDetail

### DIFF
--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -163,8 +163,6 @@ void BraveSyncWorker::ResetSync(JNIEnv* env) {
   if (!sync_service)
     return;
 
-  sync_service->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
-
   auto* device_info_sync_service =
       DeviceInfoSyncServiceFactory::GetForProfile(profile_);
   brave_sync::ResetSync(sync_service, device_info_sync_service,
@@ -259,8 +257,6 @@ void BraveSyncWorker::PermanentlyDeleteAccount(
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
   auto* sync_service = GetSyncService();
   CHECK_NE(sync_service, nullptr);
-
-  sync_service->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
 
   base::android::ScopedJavaGlobalRef<jobject> java_callback;
   java_callback.Reset(env, callback);

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -10,6 +10,7 @@
 #include "base/base64.h"
 #include "base/files/file_path.h"
 #include "base/logging.h"
+#include "base/strings/strcat.h"
 #include "build/build_config.h"
 #include "components/os_crypt/sync/os_crypt.h"
 #include "components/prefs/pref_registry_simple.h"
@@ -189,7 +190,7 @@ void Prefs::AddLeaveChainDetail(const char* file, int line, const char* func) {
          << base::FilePath::FromASCII(file).BaseName() << "(" << line << ") "
          << func << std::endl;
 
-  std::string updated_details = details + stream.str();
+  std::string updated_details = base::StrCat({details, stream.str()});
 
   if (updated_details.size() > kLeaveChainDetailsMaxLen) {
     updated_details.assign(updated_details.end() - kLeaveChainDetailsMaxLen,

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -48,6 +48,8 @@ class Prefs {
   void AddLeaveChainDetail(const char* file, int line, const char* func);
   std::string GetLeaveChainDetails() const;
   void ClearLeaveChainDetails();
+  static size_t GetLeaveChainDetailsMaxLenForTests();
+  static std::string LeaveChainDetailsPathForTests();
 
   void Clear();
 

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -45,16 +45,20 @@ class Prefs {
   bool IsFailedDecryptSeedNoticeDismissed() const;
   void DismissFailedDecryptSeedNotice();
 
+  enum class AddLeaveChainDetailBehaviour { kAdd, kIgnore };
   void AddLeaveChainDetail(const char* file, int line, const char* func);
   std::string GetLeaveChainDetails() const;
   void ClearLeaveChainDetails();
   static size_t GetLeaveChainDetailsMaxLenForTests();
-  static std::string LeaveChainDetailsPathForTests();
+  static std::string GetLeaveChainDetailsPathForTests();
+  void SetAddLeaveChainDetailBehaviourForTests(
+      AddLeaveChainDetailBehaviour add_leave_chain_detail_behaviour);
 
   void Clear();
 
  private:
   const raw_ref<PrefService> pref_service_;
+  AddLeaveChainDetailBehaviour add_leave_chain_detail_behaviour_;
 };
 
 void MigrateBraveSyncPrefs(PrefService* prefs);

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -111,18 +111,22 @@ TEST_F(BraveSyncPrefsDeathTest, MAYBE_GetSeedOutNullptrCHECK) {
   EXPECT_CHECK_DEATH(brave_sync_prefs()->GetSeed(nullptr));
 }
 
-TEST_F(BraveSyncPrefsTest, LeaveChainDetailsMaxLen) {
+TEST_F(BraveSyncPrefsTest, LeaveChainDetailsMaxLenIOS) {
+  brave_sync_prefs()->SetAddLeaveChainDetailBehaviourForTests(
+    brave_sync::Prefs::AddLeaveChainDetailBehaviour::kAdd);
+
   auto max_len = Prefs::GetLeaveChainDetailsMaxLenForTests();
 
   std::string details("a");
   brave_sync_prefs()->AddLeaveChainDetail("", 0, details.c_str());
   details = brave_sync_prefs()->GetLeaveChainDetails();
   EXPECT_LE(details.size(), max_len);
+  EXPECT_GE(details.size(), 1u);
 
   details.assign(max_len + 1, 'a');
   brave_sync_prefs()->AddLeaveChainDetail(__FILE__, __LINE__, details.c_str());
   details = brave_sync_prefs()->GetLeaveChainDetails();
-  EXPECT_LE(details.size(), max_len);
+  EXPECT_EQ(details.size(), max_len);
 }
 
 }  // namespace brave_sync

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -113,7 +113,7 @@ TEST_F(BraveSyncPrefsDeathTest, MAYBE_GetSeedOutNullptrCHECK) {
 
 TEST_F(BraveSyncPrefsTest, LeaveChainDetailsMaxLenIOS) {
   brave_sync_prefs()->SetAddLeaveChainDetailBehaviourForTests(
-    brave_sync::Prefs::AddLeaveChainDetailBehaviour::kAdd);
+      brave_sync::Prefs::AddLeaveChainDetailBehaviour::kAdd);
 
   auto max_len = Prefs::GetLeaveChainDetailsMaxLenForTests();
 

--- a/components/brave_sync/brave_sync_prefs_unittest.cc
+++ b/components/brave_sync/brave_sync_prefs_unittest.cc
@@ -111,4 +111,18 @@ TEST_F(BraveSyncPrefsDeathTest, MAYBE_GetSeedOutNullptrCHECK) {
   EXPECT_CHECK_DEATH(brave_sync_prefs()->GetSeed(nullptr));
 }
 
+TEST_F(BraveSyncPrefsTest, LeaveChainDetailsMaxLen) {
+  auto max_len = Prefs::GetLeaveChainDetailsMaxLenForTests();
+
+  std::string details("a");
+  brave_sync_prefs()->AddLeaveChainDetail("", 0, details.c_str());
+  details = brave_sync_prefs()->GetLeaveChainDetails();
+  EXPECT_LE(details.size(), max_len);
+
+  details.assign(max_len + 1, 'a');
+  brave_sync_prefs()->AddLeaveChainDetail(__FILE__, __LINE__, details.c_str());
+  details = brave_sync_prefs()->GetLeaveChainDetails();
+  EXPECT_LE(details.size(), max_len);
+}
+
 }  // namespace brave_sync

--- a/components/brave_sync/sync_service_impl_helper.cc
+++ b/components/brave_sync/sync_service_impl_helper.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "brave/components/sync/service/brave_sync_service_impl.h"
-#include "build/build_config.h"
 #include "components/sync_device_info/device_info_sync_service.h"
 #include "components/sync_device_info/device_info_tracker.h"
 #include "components/sync_device_info/local_device_info_provider.h"
@@ -19,9 +18,7 @@ namespace brave_sync {
 void ResetSync(syncer::BraveSyncServiceImpl* sync_service_impl,
                syncer::DeviceInfoSyncService* device_info_service,
                base::OnceClosure on_reset_done) {
-#if BUILDFLAG(IS_IOS)
   sync_service_impl->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
-#endif
   if (sync_service_impl->GetTransportState() !=
       syncer::SyncService::TransportState::ACTIVE) {
     sync_service_impl->OnSelfDeviceInfoDeleted(std::move(on_reset_done));

--- a/components/brave_sync/sync_service_impl_helper.cc
+++ b/components/brave_sync/sync_service_impl_helper.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "brave/components/sync/service/brave_sync_service_impl.h"
+#include "build/build_config.h"
 #include "components/sync_device_info/device_info_sync_service.h"
 #include "components/sync_device_info/device_info_tracker.h"
 #include "components/sync_device_info/local_device_info_provider.h"
@@ -18,7 +19,9 @@ namespace brave_sync {
 void ResetSync(syncer::BraveSyncServiceImpl* sync_service_impl,
                syncer::DeviceInfoSyncService* device_info_service,
                base::OnceClosure on_reset_done) {
+#if BUILDFLAG(IS_IOS)
   sync_service_impl->prefs().AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
   if (sync_service_impl->GetTransportState() !=
       syncer::SyncService::TransportState::ACTIVE) {
     sync_service_impl->OnSelfDeviceInfoDeleted(std::move(on_reset_done));

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -8,6 +8,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/auto_reset.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/strings/string_util.h"
@@ -48,7 +49,8 @@ BraveSyncServiceImpl::~BraveSyncServiceImpl() {
 }
 
 void BraveSyncServiceImpl::Initialize() {
-  executing_initialize_ = true;
+  base::AutoReset<bool> executing_initialize_resetter(&executing_initialize_,
+                                                      true);
 
   SyncServiceImpl::Initialize();
 
@@ -56,8 +58,6 @@ void BraveSyncServiceImpl::Initialize() {
   if (!user_settings_->IsInitialSyncFeatureSetupComplete()) {
     base::UmaHistogramExactLinear("Brave.Sync.Status.2", 0, 3);
   }
-
-  executing_initialize_ = false;
 }
 
 bool BraveSyncServiceImpl::IsSetupInProgress() const {

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_sync/crypto/crypto.h"
 #include "brave/components/sync/service/brave_sync_auth_manager.h"
 #include "brave/components/sync/service/sync_service_impl_delegate.h"
+#include "build/build_config.h"
 #include "components/prefs/pref_service.h"
 #include "components/sync/engine/sync_protocol_error.h"
 #include "components/sync/model/type_entities_count.h"
@@ -47,12 +48,21 @@ BraveSyncServiceImpl::~BraveSyncServiceImpl() {
 }
 
 void BraveSyncServiceImpl::Initialize() {
+#if BUILDFLAG(IS_IOS)
+  executing_initialize_ = true;
+#endif
   SyncServiceImpl::Initialize();
 
   // P3A ping for those who have sync disabled
   if (!user_settings_->IsInitialSyncFeatureSetupComplete()) {
     base::UmaHistogramExactLinear("Brave.Sync.Status.2", 0, 3);
   }
+
+#if BUILDFLAG(IS_IOS)
+  executing_initialize_ = false;
+#else
+  brave_sync_prefs_.ClearLeaveChainDetails();
+#endif
 }
 
 bool BraveSyncServiceImpl::IsSetupInProgress() const {
@@ -61,7 +71,14 @@ bool BraveSyncServiceImpl::IsSetupInProgress() const {
 }
 
 void BraveSyncServiceImpl::StopAndClear() {
-  brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+  // StopAndClear is invoked during |SyncServiceImpl::Initialize| even if sync
+  // is not enabled. This adds lots of useless lines into
+  // `brave_sync_v2.diag.leave_chain_details`
+#if BUILDFLAG(IS_IOS)
+  if (!executing_initialize_) {
+    brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+  }
+#endif
   // Clear prefs before StopAndClear() to make NotifyObservers() be invoked
   brave_sync_prefs_.Clear();
   SyncServiceImpl::StopAndClear();
@@ -108,7 +125,9 @@ bool BraveSyncServiceImpl::SetSyncCode(const std::string& sync_code) {
 }
 
 void BraveSyncServiceImpl::OnSelfDeviceInfoDeleted(base::OnceClosure cb) {
+#if BUILDFLAG(IS_IOS)
   brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
   initiated_self_device_info_deleted_ = true;
   // This function will follow normal reset process and set SyncRequested to
   // false
@@ -160,7 +179,9 @@ void BraveSyncServiceImpl::OnBraveSyncPrefsChanged(const std::string& path) {
       brave_sync_prefs_.ClearLeaveChainDetails();
     } else {
       VLOG(1) << "Brave sync seed cleared";
+#if BUILDFLAG(IS_IOS)
       brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
       GetBraveSyncAuthManager()->ResetKeys();
       // Send updated status here, because OnDeviceInfoChange is not triggered
       // when device leaves the chain by `Leave Sync Chain` button
@@ -220,7 +241,9 @@ void BraveSyncServiceImpl::OnAccountDeleted(
     const int current_attempt,
     base::OnceCallback<void(const SyncProtocolError&)> callback,
     const SyncProtocolError& sync_protocol_error) {
+#if BUILDFLAG(IS_IOS)
   brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
   if (sync_protocol_error.error_type == SYNC_SUCCESS) {
     std::move(callback).Run(sync_protocol_error);
     // If request succeded - reset and clear all in a forced way
@@ -246,7 +269,9 @@ void BraveSyncServiceImpl::OnAccountDeleted(
 void BraveSyncServiceImpl::PermanentlyDeleteAccountImpl(
     const int current_attempt,
     base::OnceCallback<void(const SyncProtocolError&)> callback) {
+#if BUILDFLAG(IS_IOS)
   brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
   if (!engine_) {
     // We can reach here if two devices almost at the same time will initiate
     // the deletion procedure
@@ -266,7 +291,9 @@ void BraveSyncServiceImpl::PermanentlyDeleteAccountImpl(
 
 void BraveSyncServiceImpl::PermanentlyDeleteAccount(
     base::OnceCallback<void(const SyncProtocolError&)> callback) {
+#if BUILDFLAG(IS_IOS)
   brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
   initiated_delete_account_ = true;
   PermanentlyDeleteAccountImpl(1, std::move(callback));
 }
@@ -283,14 +310,18 @@ void BraveSyncServiceImpl::ResetEngine(ShutdownReason shutdown_reason,
       reset_reason == ResetEngineReason::kDisabledAccount &&
       sync_disabled_by_admin_ && !initiated_delete_account_ &&
       !initiated_join_chain_) {
+#if BUILDFLAG(IS_IOS)
     brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
     brave_sync_prefs_.SetSyncAccountDeletedNoticePending(true);
     // Forcing stop and clear, because sync account was deleted
     BraveSyncServiceImpl::StopAndClear();
   } else if (shutdown_reason == ShutdownReason::DISABLE_SYNC_AND_CLEAR_DATA &&
              reset_reason == ResetEngineReason::kDisabledAccount &&
              sync_disabled_by_admin_ && initiated_join_chain_) {
+#if BUILDFLAG(IS_IOS)
     brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
+#endif
     // Forcing stop and clear, because we are trying to join the sync chain, but
     // sync account was deleted
     BraveSyncServiceImpl::StopAndClear();

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -49,8 +49,7 @@ BraveSyncServiceImpl::~BraveSyncServiceImpl() {
 }
 
 void BraveSyncServiceImpl::Initialize() {
-  base::AutoReset<bool> executing_initialize_resetter(&executing_initialize_,
-                                                      true);
+  base::AutoReset<bool> is_initializing_resetter(&is_initializing_, true);
 
   SyncServiceImpl::Initialize();
 
@@ -69,7 +68,7 @@ void BraveSyncServiceImpl::StopAndClear() {
   // StopAndClear is invoked during |SyncServiceImpl::Initialize| even if sync
   // is not enabled. This adds lots of useless lines into
   // `brave_sync_v2.diag.leave_chain_details`
-  if (!executing_initialize_) {
+  if (!is_initializing_) {
     brave_sync_prefs_.AddLeaveChainDetail(__FILE__, __LINE__, __func__);
   }
   // Clear prefs before StopAndClear() to make NotifyObservers() be invoked

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -13,6 +13,7 @@
 #include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
+#include "build/build_config.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/sync/engine/sync_protocol_error.h"
 #include "components/sync/service/sync_service_impl.h"
@@ -123,6 +124,10 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   bool initiated_self_device_info_deleted_ = false;
 
   int completed_cycles_count_ = 0;
+
+#if BUILDFLAG(IS_IOS)
+  bool executing_initialize_ = false;
+#endif
 
   std::unique_ptr<SyncServiceImplDelegate> sync_service_impl_delegate_;
   base::OnceCallback<void(bool)> join_chain_result_callback_;

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -127,7 +127,7 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
   // This flag is set to true during BraveSyncServiceImpl::Initialize call. The
   // reason is that upstream SyncServiceImpl::Initialize() can invoke
   // StopAndClear, but we don't want to invoke AddLeaveChainDetail in that case
-  bool executing_initialize_ = false;
+  bool is_initializing_ = false;
 
   std::unique_ptr<SyncServiceImplDelegate> sync_service_impl_delegate_;
   base::OnceCallback<void(bool)> join_chain_result_callback_;

--- a/components/sync/service/brave_sync_service_impl.h
+++ b/components/sync/service/brave_sync_service_impl.h
@@ -13,7 +13,6 @@
 #include "base/gtest_prod_util.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
-#include "build/build_config.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "components/sync/engine/sync_protocol_error.h"
 #include "components/sync/service/sync_service_impl.h"
@@ -125,9 +124,10 @@ class BraveSyncServiceImpl : public SyncServiceImpl {
 
   int completed_cycles_count_ = 0;
 
-#if BUILDFLAG(IS_IOS)
+  // This flag is set to true during BraveSyncServiceImpl::Initialize call. The
+  // reason is that upstream SyncServiceImpl::Initialize() can invoke
+  // StopAndClear, but we don't want to invoke AddLeaveChainDetail in that case
   bool executing_initialize_ = false;
-#endif
 
   std::unique_ptr<SyncServiceImplDelegate> sync_service_impl_delegate_;
   base::OnceCallback<void(bool)> join_chain_result_callback_;


### PR DESCRIPTION
- removed wrong add details at SyncServiceImpl::Initialize when sync chain wasn't enabled;
- limited AddLeaveChainDetail to iOS only;
- limited the length of details to 500 chars.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36513

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

#### I. iOS device
1. Enable Sync
2. Disable Sync
3. Open brave://sync-internals, ensure there is `Leave chain details` field

#### II. desktop device
1. Get browser pre-this PR
2. Disable Sync, if it was enabled
3. Launch browser, ensure there is `Leave chain details` field at brave://sync-internals
4. Update to the version wiht this PR
5. Launch browser, ensure there is no `Leave chain details` field at brave://sync-internals
6. Enable Sync, disable sync, ensure there still no `Leave chain details` field at brave://sync-internals
