### PR TITLE
Fix intermittent crash in video overlay window (uplift to 1.63.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
+++ b/chromium_src/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
@@ -7,14 +7,9 @@
 #include "brave/browser/ui/views/overlay/brave_video_overlay_window_views.h"
 
 #define BRAVE_UPDATE_MAX_SIZE max_size_ = work_area.size();
-#define BRAVE_CREATE        \
-  overlay_window->Close();  \
-  overlay_window.release(); \
-  overlay_window = std::make_unique<BraveVideoOverlayWindowViews>(controller);
 #define BackToTabLabelButton BraveBackToTabLabelButton
 
 #include "src/chrome/browser/ui/views/overlay/video_overlay_window_views.cc"
 
 #undef BackToTabLabelButton
-#undef BRAVE_CREATE
 #undef BRAVE_UPDATE_MAX_SIZE

--- a/patches/chrome-browser-ui-views-overlay-video_overlay_window_views.cc.patch
+++ b/patches/chrome-browser-ui-views-overlay-video_overlay_window_views.cc.patch
@@ -1,16 +1,17 @@
 diff --git a/chrome/browser/ui/views/overlay/video_overlay_window_views.cc b/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
-index 8f486ad5ce3862038dc749148044876fbc7e9da2..2dbfe629bba872006f392c39560a6107fe7a5730 100644
+index 8f486ad5ce3862038dc749148044876fbc7e9da2..2dc639b85cdd81c867f7eee026bd707b7e5d2f84 100644
 --- a/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
 +++ b/chrome/browser/ui/views/overlay/video_overlay_window_views.cc
-@@ -268,6 +268,7 @@ std::unique_ptr<VideoOverlayWindowViews> VideoOverlayWindowViews::Create(
+@@ -267,7 +267,7 @@ std::unique_ptr<VideoOverlayWindowViews> VideoOverlayWindowViews::Create(
+   // constructor. It's important that the constructor be private, because it
    // doesn't initialize the object fully.
    auto overlay_window =
-       base::WrapUnique(new VideoOverlayWindowViews(controller));
-+  BRAVE_CREATE
+-      base::WrapUnique(new VideoOverlayWindowViews(controller));
++      base::WrapUnique(new BraveVideoOverlayWindowViews(controller));
  
    overlay_window->CalculateAndUpdateWindowBounds();
    overlay_window->SetUpViews();
-@@ -705,6 +706,7 @@ void VideoOverlayWindowViews::UpdateMaxSize(const gfx::Rect& work_area) {
+@@ -705,6 +705,7 @@ void VideoOverlayWindowViews::UpdateMaxSize(const gfx::Rect& work_area) {
  
    max_size_ = new_max_size;
  


### PR DESCRIPTION
Uplift of #22468
Resolves https://github.com/brave/brave-browser/issues/35528

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.