### PR TITLE
[iOS] Fix potential xctest deadlock causing CI test failures (uplift to 1.64.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/ui/whats_new/whats_new_screenshot_view_controller.mm
+++ b/chromium_src/ios/chrome/browser/ui/whats_new/whats_new_screenshot_view_controller.mm
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This UI code isn't used in iOS at all anyways but causes a failure when
+// running unit tests due to a static initializer that references UIKit too
+// early.
+//
+// This chromium_src override can be removed in CR124+ as that static
+// initializer was removed
+// (https://chromium-review.googlesource.com/c/chromium/src/+/5315216)
+
+#import "ios/chrome/browser/ui/whats_new/whats_new_screenshot_view_controller.h"
+
+@implementation WhatsNewScreenshotViewController
+- (instancetype)initWithWhatsNewItem:(WhatsNewItem*)item {
+  return [super initWithNibName:nil bundle:nil];
+}
+@end


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/22446
Resolves https://github.com/brave/brave-browser/issues/36536

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.