### PR TITLE
Show diff on presubmit format check failure

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -129,10 +129,13 @@ def CheckPatchFormatted(input_api, output_api):
         if input_api.PRESUBMIT_FIX:
             raise RuntimeError('--fix was passed, but format has failed')
         short_path = input_api.basename(input_api.change.RepositoryRoot())
+        git_cl_format_cmd.remove('--dry-run')
+        git_cl_format_cmd.append('--diff')
+        _, diff_output = git_cl.RunGitWithCode(git_cl_format_cmd)
         return [
             output_api.PresubmitError(
                 f'The {short_path} directory requires source formatting. '
-                'Please run: npm run presubmit -- --fix')
+                f'Please run: npm run presubmit -- --fix.\n\n{diff_output}')
         ]
     return []
 

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -61,9 +61,13 @@ def CheckPatchFormatted(input_api, output_api):
         'cl',
         'format',
         '--presubmit',
+    ]
+
+    # Keep in sync with `npm run format` command.
+    git_cl_format_cmd.extend([
         '--python',
         '--no-rust-fmt',
-    ]
+    ])
 
     # Make sure the passed --upstream branch is applied to git cl format.
     if input_api.change.UpstreamBranch():

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -742,16 +742,11 @@ const util = {
     args = ['cl', 'format', '--upstream=' + options.base]
     if (options.full)
       args.push('--full')
-    if (options.js)
-      args.push('--js')
-    if (options.python)
-      args.push('--python')
-    if (options.rust)
-      args.push('--rust-fmt')
-    else
-      args.push('--no-rust-fmt')
-    if (options.swift)
-      args.push('--swift-format')
+
+    // Keep in sync with CheckPatchFormatted presubmit check.
+    args.push('--python')
+    args.push('--no-rust-fmt')
+
     util.run(cmd, args, cmd_options)
   },
 

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -740,12 +740,15 @@ const util = {
     cmd_options = mergeWithDefault(cmd_options)
     cmd = 'git'
     args = ['cl', 'format', '--upstream=' + options.base]
-    if (options.full)
-      args.push('--full')
 
     // Keep in sync with CheckPatchFormatted presubmit check.
     args.push('--python')
     args.push('--no-rust-fmt')
+
+    if (options.full)
+      args.push('--full')
+    if (options.diff)
+      args.push('--diff')
 
     util.run(cmd, args, cmd_options)
   },

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -360,11 +360,6 @@ program
   .command('format')
   .option('--base <base branch>', 'set the destination branch for the PR')
   .option('--full', 'format all lines in changed files instead of only the changed lines')
-  .option('--js', 'format javascript code with clang-format')
-  .option('--python', 'enable formating of Python file types using yapf')
-  .option('--rust', 'enables formatting of Rust file types using rustfmt')
-  .option('--swift',
-    'enables formatting of Swift file types using swift-format')
   .action(util.format)
 
 program

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -360,6 +360,7 @@ program
   .command('format')
   .option('--base <base branch>', 'set the destination branch for the PR')
   .option('--full', 'format all lines in changed files instead of only the changed lines')
+  .option('--diff', 'print diff to stdout rather than modifying files')
   .action(util.format)
 
 program


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Add diff output when the presubmit format check find issues.

Resolves https://github.com/brave/brave-browser/issues/36612

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

