### PR TITLE
Tweak Wallet creation screen

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/BaseOnboardingWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/BaseOnboardingWalletFragment.java
@@ -5,9 +5,15 @@
 
 package org.chromium.chrome.browser.crypto_wallet.fragments.onboarding;
 
-import androidx.annotation.NonNull;
-import androidx.appcompat.widget.AppCompatButton;
+import android.graphics.drawable.AnimationDrawable;
+import android.view.View;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.AppCompatButton;
+import androidx.core.content.ContextCompat;
+
+import org.chromium.chrome.R;
 import org.chromium.chrome.browser.crypto_wallet.fragments.BaseWalletNextPageFragment;
 
 /**
@@ -28,6 +34,8 @@ public abstract class BaseOnboardingWalletFragment extends BaseWalletNextPageFra
         return true;
     }
 
+    @Nullable private AnimationDrawable mAnimationDrawable;
+
     @Override
     public void onResume() {
         super.onResume();
@@ -36,6 +44,29 @@ public abstract class BaseOnboardingWalletFragment extends BaseWalletNextPageFra
             mOnNextPage.showCloseButton(canBeClosed());
             // Show or hide back icon depending on the fragment configuration.
             mOnNextPage.showBackButton(canNavigateBack());
+        }
+        if (mAnimationDrawable != null) {
+            mAnimationDrawable.start();
+        }
+    }
+
+    @Override
+    public void onPause() {
+        super.onPause();
+        if (mAnimationDrawable != null) {
+            mAnimationDrawable.stop();
+        }
+    }
+
+    protected void setAnimatedBackground(@NonNull final View rootView) {
+        mAnimationDrawable =
+                (AnimationDrawable)
+                        ContextCompat.getDrawable(
+                                requireContext(), R.drawable.onboarding_gradient_animation);
+        if (mAnimationDrawable != null) {
+            rootView.setBackground(mAnimationDrawable);
+            mAnimationDrawable.setEnterFadeDuration(10);
+            mAnimationDrawable.setExitFadeDuration(5000);
         }
     }
 

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingCreatingWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingCreatingWalletFragment.java
@@ -35,6 +35,7 @@ public class OnboardingCreatingWalletFragment extends BaseOnboardingWalletFragme
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
+        setAnimatedBackground(view.findViewById(R.id.creating_wallet_root));
         mOnboardingViewModel =
                 new ViewModelProvider((ViewModelStoreOwner) requireActivity())
                         .get(OnboardingViewModel.class);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingInitWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingInitWalletFragment.java
@@ -6,7 +6,6 @@
 package org.chromium.chrome.browser.crypto_wallet.fragments.onboarding;
 
 import android.content.Intent;
-import android.graphics.drawable.AnimationDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -16,7 +15,6 @@ import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.cardview.widget.CardView;
-import androidx.core.content.ContextCompat;
 import androidx.fragment.app.FragmentActivity;
 
 import org.chromium.base.Log;
@@ -37,7 +35,6 @@ public class OnboardingInitWalletFragment extends BaseOnboardingWalletFragment {
     private boolean mRestartSetupAction;
     private boolean mRestartRestoreAction;
     private boolean mButtonClicked;
-    private AnimationDrawable mAnimationDrawable;
 
     public OnboardingInitWalletFragment(boolean restartSetupAction, boolean restartRestoreAction) {
         mRestartSetupAction = restartSetupAction;
@@ -63,13 +60,7 @@ public class OnboardingInitWalletFragment extends BaseOnboardingWalletFragment {
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-        mAnimationDrawable =
-                (AnimationDrawable)
-                        ContextCompat.getDrawable(
-                                requireContext(), R.drawable.onboarding_gradient_animation);
-        view.findViewById(R.id.setup_wallet_root).setBackground(mAnimationDrawable);
-        mAnimationDrawable.setEnterFadeDuration(10);
-        mAnimationDrawable.setExitFadeDuration(5000);
+        setAnimatedBackground(view.findViewById(R.id.setup_wallet_root));
 
         CardView newWallet = view.findViewById(R.id.new_wallet_card_view);
         newWallet.setOnClickListener(
@@ -121,13 +112,6 @@ public class OnboardingInitWalletFragment extends BaseOnboardingWalletFragment {
     public void onResume() {
         super.onResume();
         mButtonClicked = false;
-        mAnimationDrawable.start();
-    }
-
-    @Override
-    public void onPause() {
-        super.onPause();
-        mAnimationDrawable.stop();
     }
 
     @Override

--- a/android/java/res/layout/fragment_creating_wallet.xml
+++ b/android/java/res/layout/fragment_creating_wallet.xml
@@ -2,13 +2,11 @@
 <androidx.core.widget.NestedScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/creating_wallet_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scrollbars="vertical"
-    android:fadeScrollbars="false"
-    android:background="@color/wallet_bg"
-    android:fillViewport="true"
-    android:theme="@style/BraveWalletOnboarding">
+    android:scrollbars="none"
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -18,23 +16,33 @@
 
         <ProgressBar
             android:id="@+id/btn_loading"
-            style="?android:progressBarStyleLarge"
+            style="Widget.ProgressBar.Large"
             android:layout_width="40dp"
             android:layout_height="40dp"
-            android:layout_marginEnd="5dp"
+            android:layout_marginBottom="24dp"
             android:indeterminateTint="@color/brave_action_color"
             android:layout_gravity="center_horizontal" />
+
+        <TextView
+            style="@style/BraveWalletTextViewTitle"
+            android:layout_width="match_parent"
+            android:gravity="center_horizontal"
+            android:layout_marginHorizontal="32dp"
+            android:layout_marginBottom="8dp"
+            android:text="@string/creating_wallet_onboarding_text"
+            android:textColor="@color/wallet_text_color"
+            android:lineSpacingExtra="2sp"
+            android:textSize="22sp"/>
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center_horizontal"
-            android:layout_marginStart="32dp"
-            android:layout_marginEnd="32dp"
+            android:layout_marginHorizontal="32dp"
             android:layout_marginBottom="16dp"
-            android:text="@string/creating_wallet_onboarding_text"
-            android:textColor="@color/wallet_text_color"
-            android:textSize="32sp"/>
+            android:text="@string/creating_wallet_subtitle_text"
+            android:textColor="@color/wallet_onboarding_secondary_text_color"
+            android:lineSpacingExtra="4sp"
+            android:textSize="14sp"/>
     </LinearLayout>
-
 </androidx.core.widget.NestedScrollView>

--- a/android/java/res/layout/fragment_setup_wallet.xml
+++ b/android/java/res/layout/fragment_setup_wallet.xml
@@ -7,8 +7,7 @@
     android:layout_height="match_parent"
     android:scrollbars="vertical"
     android:fadeScrollbars="false"
-    android:fillViewport="true"
-    android:theme="@style/BraveWalletOnboarding">
+    android:fillViewport="true">
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2031,7 +2031,7 @@ Are you sure you want to do this?
       Verified password did not match
     </message>
     <message name="IDS_CREATING_WALLET_ONBOARDING_TEXT" desc="Text displayed along with a spinner during Brave Wallet creation or restoring.">
-      Creating Wallet
+      Creating your wallet…
     </message>
     <message name="IDS_CREATING_WALLET_SUBTITLE_TEXT" desc="Text displayed along with a spinner during Brave Wallet creation or restoring.">
       It may take a few seconds…

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -2031,7 +2031,10 @@ Are you sure you want to do this?
       Verified password did not match
     </message>
     <message name="IDS_CREATING_WALLET_ONBOARDING_TEXT" desc="Text displayed along with a spinner during Brave Wallet creation or restoring.">
-      Creating Wallet...
+      Creating Wallet
+    </message>
+    <message name="IDS_CREATING_WALLET_SUBTITLE_TEXT" desc="Text displayed along with a spinner during Brave Wallet creation or restoring.">
+      It may take a few seconds…
     </message>
     <message name="IDS_YOUR_WALLET_IS_RESTORING_PAGE_TITLE" desc="Text for a spinner page title during Brave Wallet restoring. It is not displayed anywhere" translateable="false">
       Your wallet is restoring...


### PR DESCRIPTION
<img src="https://github.com/brave/brave-core/assets/3308503/92a3ecd2-11c3-42e6-aac2-fe5a327c052b" width="500" />

## Resolves https://github.com/brave/brave-browser/issues/36606

⚠ **Note:** Change base branch to master once https://github.com/brave/brave-browser/issues/36552 is merged.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test plan:
- Create a new Wallet
- Accept terms of use
- Set a password and confirm it
- Observe the Wallet creation screen briefly appears before showing the backup screen
