### PR TITLE
[iOS] Fix crash when changing orientation on "view all version info" screen (uplift to 1.64.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -749,10 +749,14 @@ class SettingsViewController: TableViewController {
               let versionController = ChromeWebViewController(privateBrowsing: false).then {
                 $0.loadURL("brave://version/?show-variations-cmd")
               }
-              
-              actionSheet?.dismiss(animated: true, completion: {
-                self.present(versionController, animated: true)
-              })
+              versionController.title = version
+
+              actionSheet?.dismiss(
+                animated: true,
+                completion: {
+                  self.navigationController?.pushViewController(versionController, animated: true)
+                }
+              )
             }
 
             actionSheet.addAction(copyDebugInfoAction)


### PR DESCRIPTION
Uplift of #22497
Resolves https://github.com/brave/brave-browser/issues/36098

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.