### PR TITLE
Disabled simplified bookmarks bubble (uplift to 1.63.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc
+++ b/chromium_src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc
@@ -3,8 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#define BRAVE_BOOKMARK_BUBBLE_VIEW \
+#define BRAVE_BOOKMARK_BUBBLE_VIEW_SHOW_BUBBLE_SET_ARROW \
   bubble->SetArrow(views::BubbleBorder::TOP_LEFT);
 
+#define BRAVE_BOOKMARK_BUBBLE_VIEW_SHOW_BUBBLE_SHOW_SIMPLIFIED \
+  show_simplified_flow = false;
+
 #include "src/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc"
-#undef BRAVE_BOOKMARK_BUBBLE_VIEW
+#undef BRAVE_BOOKMARK_BUBBLE_VIEW_SHOW_BUBBLE_SHOW_SIMPLIFIED
+#undef BRAVE_BOOKMARK_BUBBLE_VIEW_SHOW_BUBBLE_SET_ARROW

--- a/patches/chrome-browser-ui-views-bookmarks-bookmark_bubble_view.cc.patch
+++ b/patches/chrome-browser-ui-views-bookmarks-bookmark_bubble_view.cc.patch
@@ -1,12 +1,20 @@
 diff --git a/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc b/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc
-index 6c809c86fbac23a26151b19b03159627320a294e..f6286652e3d3de3a0ef34c89b232265075d9d455 100644
+index 6c809c86fbac23a26151b19b03159627320a294e..a4b907f598832a782fba10629f19fd2fc4a77ba4 100644
 --- a/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc
 +++ b/chrome/browser/ui/views/bookmarks/bookmark_bubble_view.cc
-@@ -509,6 +509,7 @@ void BookmarkBubbleView::ShowBubble(
+@@ -378,6 +378,7 @@ void BookmarkBubbleView::ShowBubble(
+                                        bookmark_node);
+ 
+   bool show_simplified_flow = !already_bookmarked;
++  BRAVE_BOOKMARK_BUBBLE_VIEW_SHOW_BUBBLE_SHOW_SIMPLIFIED
+ 
+   auto bubble_delegate_unique = std::make_unique<BookmarkBubbleDelegate>(
+       std::move(delegate), browser, url, show_simplified_flow);
+@@ -509,6 +510,7 @@ void BookmarkBubbleView::ShowBubble(
    auto bubble = std::make_unique<views::BubbleDialogModelHost>(
        std::move(dialog_model), anchor_view, views::BubbleBorder::TOP_RIGHT);
    bookmark_bubble_ = bubble.get();
-+  BRAVE_BOOKMARK_BUBBLE_VIEW
++  BRAVE_BOOKMARK_BUBBLE_VIEW_SHOW_BUBBLE_SET_ARROW
    if (highlighted_button)
      bubble->SetHighlightedButton(highlighted_button);
  


### PR DESCRIPTION
Uplift of #22489
fix https://github.com/brave/brave-browser/issues/35594

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.