### PR TITLE
Add Nebula support for P3A/Constellation

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_metrics.cc
+++ b/components/ai_chat/core/browser/ai_chat_metrics.cc
@@ -313,6 +313,10 @@ void AIChatMetrics::ReportChatCounts() {
   p3a_utils::RecordToHistogramBucket(kAvgPromptCountHistogramName,
                                      kAvgPromptCountBuckets,
                                      average_prompts_per_chat);
+
+  // TODO(djandries): remove the following report when Nebula experiment is over
+  p3a_utils::RecordToHistogramBucket(kChatCountNebulaHistogramName,
+                                     kChatCountBuckets, chat_count);
 }
 
 #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)

--- a/components/ai_chat/core/browser/ai_chat_metrics.h
+++ b/components/ai_chat/core/browser/ai_chat_metrics.h
@@ -45,7 +45,6 @@ inline constexpr char kContextMenuFreeUsageCountHistogramName[] =
     "Brave.AIChat.ContextMenu.FreeUsages";
 inline constexpr char kContextMenuPremiumUsageCountHistogramName[] =
     "Brave.AIChat.ContextMenu.PremiumUsages";
-
 inline constexpr char kEnabledSidebarEnabledAHistogramName[] =
     "Brave.AIChat.Enabled.SidebarEnabledA";
 inline constexpr char kEnabledSidebarEnabledBHistogramName[] =
@@ -58,6 +57,8 @@ inline constexpr char kUsageWeeklySidebarEnabledAHistogramName[] =
     "Brave.AIChat.UsageWeekly.SidebarEnabledA";
 inline constexpr char kUsageWeeklySidebarEnabledBHistogramName[] =
     "Brave.AIChat.UsageWeekly.SidebarEnabledB";
+inline constexpr char kChatCountNebulaHistogramName[] =
+    "Brave.AIChat.ChatCount";
 
 enum class AcquisitionSource {
   kOmnibox = 0,

--- a/components/ai_chat/core/browser/ai_chat_metrics.h
+++ b/components/ai_chat/core/browser/ai_chat_metrics.h
@@ -58,7 +58,7 @@ inline constexpr char kUsageWeeklySidebarEnabledAHistogramName[] =
 inline constexpr char kUsageWeeklySidebarEnabledBHistogramName[] =
     "Brave.AIChat.UsageWeekly.SidebarEnabledB";
 inline constexpr char kChatCountNebulaHistogramName[] =
-    "Brave.AIChat.ChatCount";
+    "Brave.AIChat.ChatCount.Nebula";
 
 enum class AcquisitionSource {
   kOmnibox = 0,

--- a/components/misc_metrics/general_browser_usage.cc
+++ b/components/misc_metrics/general_browser_usage.cc
@@ -60,6 +60,10 @@ void GeneralBrowserUsage::ReportWeeklyUse() {
   usage_storage_->ReplaceTodaysValueIfGreater(1);
   UMA_HISTOGRAM_EXACT_LINEAR(kWeeklyUseHistogramName,
                              usage_storage_->GetLastISOWeekSum(), 8);
+
+  // TODO(djandries): remove the following report when Nebula experiment is over
+  UMA_HISTOGRAM_EXACT_LINEAR(kWeeklyUseNebulaHistogramName,
+                             usage_storage_->GetLastISOWeekSum(), 8);
 }
 
 #if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_WIN)

--- a/components/misc_metrics/general_browser_usage.h
+++ b/components/misc_metrics/general_browser_usage.h
@@ -27,6 +27,10 @@ inline constexpr char kDayZeroInstallTimePrefix[] = "Brave.DayZero.";
 inline constexpr char kDayZeroInstallTimeSuffix[] = ".InstallTime";
 #endif  // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_WIN)
 
+// TODO(djandries): remove this metric when Nebula experiment is over
+inline constexpr char kWeeklyUseNebulaHistogramName[] =
+    "Brave.Core.WeeklyUsage.Nebula";
+
 class GeneralBrowserUsage {
  public:
   GeneralBrowserUsage(PrefService* local_state,

--- a/components/p3a/constellation_helper.cc
+++ b/components/p3a/constellation_helper.cc
@@ -32,8 +32,8 @@ constexpr double kNebulaScramblingRate = 0.05;
 
 bool CheckParticipationAndScrambleForNebula(std::vector<std::string>* layers) {
   bool should_participate = base::RandDouble() < kNebulaParticipationRate;
-  if (!should_participate) {
-    return false;
+  if (should_participate) {
+    return true;
   }
   bool should_scramble = base::RandDouble() < kNebulaScramblingRate;
   if (should_scramble) {
@@ -41,8 +41,9 @@ bool CheckParticipationAndScrambleForNebula(std::vector<std::string>* layers) {
     base::RandBytes(random_buffer);
 
     (*layers)[0] = base::Base64Encode(random_buffer);
+    return true;
   }
-  return true;
+  return false;
 }
 
 }  // namespace

--- a/components/p3a/constellation_helper.cc
+++ b/components/p3a/constellation_helper.cc
@@ -46,7 +46,15 @@ constexpr double kNebulaParticipationRate = 0.105;
 // be aggregated.
 constexpr double kNebulaScramblingRate = 0.05;
 
-bool CheckParticipationAndScrambleForNebula(std::vector<std::string>* layers) {
+// Check and prepare a response under the Nebula protocol
+//
+// Decides based on the probability constants above whether
+// to participate in the random sampling, and whether to
+// scramble the message vector before submission.
+//
+// The report should only be submitted if this function
+// returns true. Otherwise the message should be discarded.
+bool MaybeScrambleForNebula(std::vector<std::string>* layers) {
   bool should_participate = base::RandDouble() < kNebulaParticipationRate;
   if (should_participate) {
     return true;
@@ -111,7 +119,7 @@ bool ConstellationHelper::StartMessagePreparation(std::string histogram_name,
                         base::WhitespaceHandling::TRIM_WHITESPACE,
                         base::SplitResult::SPLIT_WANT_NONEMPTY);
 
-  if (is_nebula && !CheckParticipationAndScrambleForNebula(&layers)) {
+  if (is_nebula && !MaybeScrambleForNebula(&layers)) {
     // Do not send measurement since client is unable to participate,
     // but mark the request as successful so the client does not retry
     // transmission.

--- a/components/p3a/constellation_helper.cc
+++ b/components/p3a/constellation_helper.cc
@@ -56,6 +56,8 @@ bool CheckParticipationAndScrambleForNebula(std::vector<std::string>* layers) {
     std::vector<uint8_t> random_buffer(30);
     base::RandBytes(random_buffer);
 
+    CHECK(layers);
+    CHECK(!layers->empty());
     (*layers)[0] = base::Base64Encode(random_buffer);
     return true;
   }

--- a/components/p3a/constellation_helper.cc
+++ b/components/p3a/constellation_helper.cc
@@ -13,15 +13,13 @@
 #include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/rand_util.h"
-#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
-#include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/features.h"
+#include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/p3a_config.h"
 #include "brave/components/p3a/p3a_message.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
-#include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
 
@@ -29,9 +27,23 @@ namespace p3a {
 
 namespace {
 
-constexpr std::size_t kP3AConstellationCurrentThreshold = 50;
-constexpr std::size_t kP3ANebulaThreshold = 20;
-constexpr double kP3ANebulaSamplingRate = 0.105;
+constexpr double kNebulaParticipationRate = 0.105;
+constexpr double kNebulaScramblingRate = 0.05;
+
+bool CheckParticipationAndScrambleForNebula(std::vector<std::string>* layers) {
+  bool should_participate = base::RandDouble() < kNebulaParticipationRate;
+  if (!should_participate) {
+    return false;
+  }
+  bool should_scramble = base::RandDouble() < kNebulaScramblingRate;
+  if (should_scramble) {
+    std::vector<uint8_t> random_buffer(30);
+    base::RandBytes(random_buffer);
+
+    (*layers)[0] = base::Base64Encode(random_buffer);
+  }
+  return true;
+}
 
 }  // namespace
 
@@ -47,13 +59,11 @@ ConstellationHelper::ConstellationHelper(
                          config),
       rand_points_manager_(
           url_loader_factory,
-          base::BindRepeating(&ConstellationHelper::HandleRandomnessData,
-                              base::Unretained(this)),
           config),
       message_callback_(message_callback),
       null_public_key_(constellation::get_ppoprf_null_public_key()) {}
 
-ConstellationHelper::~ConstellationHelper() {}
+ConstellationHelper::~ConstellationHelper() = default;
 
 void ConstellationHelper::RegisterPrefs(PrefRegistrySimple* registry) {
   StarRandomnessMeta::RegisterPrefs(registry);
@@ -65,7 +75,8 @@ void ConstellationHelper::UpdateRandomnessServerInfo(MetricLogType log_type) {
 
 bool ConstellationHelper::StartMessagePreparation(std::string histogram_name,
                                                   MetricLogType log_type,
-                                                  std::string serialized_log) {
+                                                  std::string serialized_log,
+                                                  bool is_nebula) {
   auto* rnd_server_info =
       rand_meta_manager_.GetCachedRandomnessServerInfo(log_type);
   if (rnd_server_info == nullptr) {
@@ -73,22 +84,21 @@ bool ConstellationHelper::StartMessagePreparation(std::string histogram_name,
                   "unavailable server info";
     return false;
   }
+
+  uint8_t epoch = rnd_server_info->current_epoch;
+
   std::vector<std::string> layers =
       base::SplitString(serialized_log, kP3AMessageConstellationLayerSeparator,
                         base::WhitespaceHandling::TRIM_WHITESPACE,
                         base::SplitResult::SPLIT_WANT_NONEMPTY);
-  DLOG(INFO) << "Preparing P3A Constellation message:";
-  for (auto& layer: layers) {
-    DLOG(INFO) << "  " << layer;
-  }
-  bool sample = base::RandDouble() < kP3ANebulaSamplingRate;
-  DLOG(INFO) << "sampling:" << sample;
-  if (!sample) {
-    DCHECK(layers[0].starts_with("metric_name|"));
-    // TODO: poison submission
-  }
 
-  uint8_t epoch = rnd_server_info->current_epoch;
+  if (!CheckParticipationAndScrambleForNebula(&layers)) {
+    // Do not send measurement since client is unable to participate,
+    // but mark the request as successful so the client does not retry
+    // transmission.
+    message_callback_.Run(histogram_name, log_type, epoch, true, nullptr);
+    return true;
+  }
 
   auto prepare_res = constellation::prepare_measurement(layers, epoch);
   if (!prepare_res.error.empty()) {
@@ -99,13 +109,12 @@ bool ConstellationHelper::StartMessagePreparation(std::string histogram_name,
 
   auto req = constellation::construct_randomness_request(*prepare_res.state);
 
-  DLOG(INFO) << "Sending randomness request for points:";
-  for (const auto& point: req) {
-    DLOG(INFO) << "  " << base::Base64Encode(point.data);
-  }
   rand_points_manager_.SendRandomnessRequest(
-      histogram_name, log_type, rnd_server_info->current_epoch,
-      &rand_meta_manager_, std::move(prepare_res.state), req);
+      log_type, epoch, &rand_meta_manager_, req,
+      base::BindOnce(&ConstellationHelper::HandleRandomnessData,
+                     base::Unretained(this), histogram_name, log_type,
+                     rnd_server_info->current_epoch, is_nebula,
+                     std::move(prepare_res.state)));
 
   return true;
 }
@@ -114,32 +123,38 @@ void ConstellationHelper::HandleRandomnessData(
     std::string histogram_name,
     MetricLogType log_type,
     uint8_t epoch,
+    bool is_nebula,
     ::rust::Box<constellation::RandomnessRequestStateWrapper>
         randomness_request_state,
     std::unique_ptr<rust::Vec<constellation::VecU8>> resp_points,
     std::unique_ptr<rust::Vec<constellation::VecU8>> resp_proofs) {
   if (resp_points == nullptr || resp_proofs == nullptr) {
-    message_callback_.Run(histogram_name, log_type, epoch, nullptr);
+    message_callback_.Run(histogram_name, log_type, epoch, false, nullptr);
     return;
   }
   if (resp_points->empty()) {
     LOG(ERROR) << "ConstellationHelper: no points for randomness request";
-    message_callback_.Run(histogram_name, log_type, epoch, nullptr);
-    return;
-  }
-  std::string final_msg;
-  if (!ConstructFinalMessage(log_type, randomness_request_state, *resp_points,
-                             *resp_proofs, &final_msg)) {
-    message_callback_.Run(histogram_name, log_type, epoch, nullptr);
+    message_callback_.Run(histogram_name, log_type, epoch, false, nullptr);
     return;
   }
 
-  message_callback_.Run(histogram_name, log_type, epoch,
+  size_t threshold =
+      is_nebula ? kNebulaThreshold : kConstellationDefaultThreshold;
+
+  std::string final_msg;
+  if (!ConstructFinalMessage(log_type, threshold, randomness_request_state,
+                             *resp_points, *resp_proofs, &final_msg)) {
+    message_callback_.Run(histogram_name, log_type, epoch, false, nullptr);
+    return;
+  }
+
+  message_callback_.Run(histogram_name, log_type, epoch, true,
                         std::make_unique<std::string>(final_msg));
 }
 
 bool ConstellationHelper::ConstructFinalMessage(
     MetricLogType log_type,
+    size_t threshold,
     rust::Box<constellation::RandomnessRequestStateWrapper>&
         randomness_request_state,
     const rust::Vec<constellation::VecU8>& resp_points,
@@ -152,7 +167,6 @@ bool ConstellationHelper::ConstructFinalMessage(
                   "constructing message";
     return false;
   }
-  auto threshold = features::IsNebulaEnabled() ? kP3ANebulaThreshold : kP3AConstellationCurrentThreshold;
   auto msg_res = constellation::construct_message(
       resp_points, resp_proofs, *randomness_request_state,
       resp_proofs.empty() ? *null_public_key_ : *rnd_server_info->public_key,

--- a/components/p3a/constellation_helper.cc
+++ b/components/p3a/constellation_helper.cc
@@ -92,7 +92,7 @@ bool ConstellationHelper::StartMessagePreparation(std::string histogram_name,
                         base::WhitespaceHandling::TRIM_WHITESPACE,
                         base::SplitResult::SPLIT_WANT_NONEMPTY);
 
-  if (!CheckParticipationAndScrambleForNebula(&layers)) {
+  if (is_nebula && !CheckParticipationAndScrambleForNebula(&layers)) {
     // Do not send measurement since client is unable to participate,
     // but mark the request as successful so the client does not retry
     // transmission.

--- a/components/p3a/constellation_helper.cc
+++ b/components/p3a/constellation_helper.cc
@@ -27,7 +27,23 @@ namespace p3a {
 
 namespace {
 
+// Probability of submitting a true report in the Nebula protocol
+//
+// This is computed from the differential privacy budget ε = 1.0 as
+//
+//     kNebulaParticipationRate = alpha * (1 - exp(-epsilon))
+//
 constexpr double kNebulaParticipationRate = 0.105;
+
+// Probability of submitting a randomized response in the Nebula protocol
+//
+// This sets the fraction of clients not participating by submitting
+// a true report for threshold aggregration which instead submit a
+// privacy-enhancing dummy report. It must be sufficiently large to
+// provide privacy coverage for the size of the P3A question domain,
+// but values significantly less than 1.0 improve bandwidth efficiency
+// by reducing the number of reports clients must send which will not
+// be aggregated.
 constexpr double kNebulaScramblingRate = 0.05;
 
 bool CheckParticipationAndScrambleForNebula(std::vector<std::string>* layers) {

--- a/components/p3a/constellation_helper.h
+++ b/components/p3a/constellation_helper.h
@@ -25,7 +25,22 @@ class SharedURLLoaderFactory;
 
 namespace p3a {
 
+// Heuristic aggregation threshold used for STAR/Constellation
 inline constexpr size_t kConstellationDefaultThreshold = 50;
+
+// Aggregation threshold used for Nebula
+//
+// This is derived from the differential privacy paramaters
+// ε = 1.0 (the privacy budget) and δ = 1.0e-8 (should be
+// less than the reciprocal of the number of clients) along
+// with a parameter α = 1/6 which adjusts the tradeoff between
+// this threshold and the sampling probability.
+//
+// This aggregation threshold is computed as
+//
+//     kNebulaThreshold = ceil(log(1.0/delta) / Ca)
+//     where Ca = log(1.0/alpha) - 1.0 / (1.0 + alpha)
+//
 inline constexpr size_t kNebulaThreshold = 20;
 
 struct P3AConfig;

--- a/components/p3a/constellation_helper.h
+++ b/components/p3a/constellation_helper.h
@@ -25,6 +25,9 @@ class SharedURLLoaderFactory;
 
 namespace p3a {
 
+inline constexpr size_t kConstellationDefaultThreshold = 50;
+inline constexpr size_t kNebulaThreshold = 20;
+
 struct P3AConfig;
 
 // Class that contains high-level methods for preparing/generating
@@ -35,6 +38,7 @@ class ConstellationHelper {
       std::string histogram_name,
       MetricLogType log_type,
       uint8_t epoch,
+      bool is_success,
       std::unique_ptr<std::string> serialized_message)>;
 
   ConstellationHelper(
@@ -54,13 +58,15 @@ class ConstellationHelper {
 
   bool StartMessagePreparation(std::string histogram_name,
                                MetricLogType log_type,
-                               std::string serialized_log);
+                               std::string serialized_log,
+                               bool is_nebula);
 
  private:
   void HandleRandomnessData(
       std::string histogram_name,
       MetricLogType log_type,
       uint8_t epoch,
+      bool is_nebula,
       ::rust::Box<constellation::RandomnessRequestStateWrapper>
           randomness_request_state,
       std::unique_ptr<rust::Vec<constellation::VecU8>> resp_points,
@@ -68,6 +74,7 @@ class ConstellationHelper {
 
   bool ConstructFinalMessage(
       MetricLogType log_type,
+      size_t threshold,
       ::rust::Box<constellation::RandomnessRequestStateWrapper>&
           randomness_request_state,
       const rust::Vec<constellation::VecU8>& resp_points,

--- a/components/p3a/constellation_helper_unittest.cc
+++ b/components/p3a/constellation_helper_unittest.cc
@@ -45,6 +45,7 @@ constexpr char kTestSlowNextEpochTime[] = "2086-06-22T18:00:00Z";
 constexpr char kTestTypicalNextEpochTime[] = "2086-06-24T18:00:00Z";
 constexpr char kTestExpressNextEpochTime[] = "2086-07-01T18:00:00Z";
 constexpr char kTestHistogramName[] = "Brave.Test.Histogram";
+constexpr char kTestNebulaHistogramName[] = "Brave.Core.WeeklyUsage.Nebula";
 constexpr char kTestHost[] = "https://localhost:8443";
 
 }  // namespace
@@ -106,6 +107,7 @@ class P3AConstellationHelperTest : public testing::Test {
               histogram_name_from_callback_ = histogram_name;
               epoch_from_callback_ = epoch;
               serialized_message_from_callback_ = std::move(serialized_message);
+              is_success_from_callback_ = is_success;
             }),
         base::BindLambdaForTesting(
             [this](MetricLogType log_type, RandomnessServerInfo* server_info) {
@@ -169,6 +171,7 @@ class P3AConstellationHelperTest : public testing::Test {
 
   raw_ptr<RandomnessServerInfo> server_info_from_callback_ = nullptr;
   std::unique_ptr<std::string> serialized_message_from_callback_;
+  bool is_success_from_callback_ = false;
 
   std::string histogram_name_from_callback_;
   uint8_t epoch_from_callback_;
@@ -320,6 +323,57 @@ TEST_F(P3AConstellationHelperTest, IncludeRefcode) {
   EXPECT_EQ(refcode_layers.size(), 9U);
   EXPECT_EQ(refcode_layers.at(8), "ref|other");
 #endif  // !BUILDFLAG(IS_IOS)
+}
+
+TEST_F(P3AConstellationHelperTest, NebulaMessage) {
+  MessageMetainfo meta_info;
+  meta_info.Init(&local_state_, "release", "2022-01-01");
+
+  std::string message = GenerateP3AConstellationMessage(
+      kTestHistogramName, 3, meta_info, kP3AUploadType, false, true);
+  std::vector<std::string> no_refcode_layers =
+      base::SplitString(message, kP3AMessageConstellationLayerSeparator,
+                        base::WhitespaceHandling::TRIM_WHITESPACE,
+                        base::SplitResult::SPLIT_WANT_NONEMPTY);
+
+  EXPECT_EQ(no_refcode_layers.size(), 7U);
+  EXPECT_EQ(no_refcode_layers[0],
+            base::StrCat({"metric_name_and_value|", kTestHistogramName, "=3"}));
+}
+
+TEST_F(P3AConstellationHelperTest, NebulaSample) {
+  size_t points_request_count = 0;
+  for (int i = 0; i < 20; i++) {
+    SetUpHelper();
+
+    helper_->UpdateRandomnessServerInfo(MetricLogType::kTypical);
+    task_environment_.RunUntilIdle();
+
+    MessageMetainfo meta_info;
+    meta_info.Init(&local_state_, "release", "2022-01-01");
+
+    helper_->StartMessagePreparation(
+        kTestNebulaHistogramName, MetricLogType::kTypical,
+        GenerateP3AConstellationMessage(kTestNebulaHistogramName,
+                                        kTestTypicalEpoch, meta_info,
+                                        kP3AUploadType, false, true),
+        true);
+    task_environment_.RunUntilIdle();
+
+    if (points_request_made_[MetricLogType::kTypical]) {
+      points_request_made_[MetricLogType::kTypical] = false;
+      points_request_count++;
+      EXPECT_NE(serialized_message_from_callback_, nullptr);
+      EXPECT_NE(serialized_message_from_callback_->size(), 0U);
+    } else {
+      EXPECT_EQ(serialized_message_from_callback_, nullptr);
+    }
+    EXPECT_TRUE(is_success_from_callback_);
+    EXPECT_EQ(epoch_from_callback_, kTestTypicalEpoch);
+    EXPECT_EQ(histogram_name_from_callback_, kTestNebulaHistogramName);
+  }
+  EXPECT_GE(points_request_count, 1u);
+  EXPECT_LE(points_request_count, 4u);
 }
 
 }  // namespace p3a

--- a/components/p3a/constellation_helper_unittest.cc
+++ b/components/p3a/constellation_helper_unittest.cc
@@ -101,7 +101,7 @@ class P3AConstellationHelperTest : public testing::Test {
         &local_state_, shared_url_loader_factory_,
         base::BindLambdaForTesting(
             [this](std::string histogram_name, MetricLogType log_type,
-                   uint8_t epoch,
+                   uint8_t epoch, bool is_success,
                    std::unique_ptr<std::string> serialized_message) {
               histogram_name_from_callback_ = histogram_name;
               epoch_from_callback_ = epoch;
@@ -253,7 +253,9 @@ TEST_F(P3AConstellationHelperTest, GenerateBasicMessage) {
     helper_->StartMessagePreparation(
         kTestHistogramName, log_type,
         GenerateP3AConstellationMessage(kTestHistogramName, test_epoch,
-                                        meta_info, kP3AUploadType, false));
+                                        meta_info, kP3AUploadType, false,
+                                        false),
+        false);
     task_environment_.RunUntilIdle();
 
     CheckPointsRequestMade(log_type);
@@ -272,7 +274,7 @@ TEST_F(P3AConstellationHelperTest, IncludeRefcode) {
   meta_info.Init(&local_state_, "release", "2022-01-01");
 
   std::string message_with_no_refcode = GenerateP3AConstellationMessage(
-      kTestHistogramName, 0, meta_info, kP3AUploadType, false);
+      kTestHistogramName, 0, meta_info, kP3AUploadType, false, false);
   std::vector<std::string> no_refcode_layers = base::SplitString(
       message_with_no_refcode, kP3AMessageConstellationLayerSeparator,
       base::WhitespaceHandling::TRIM_WHITESPACE,
@@ -282,7 +284,7 @@ TEST_F(P3AConstellationHelperTest, IncludeRefcode) {
   EXPECT_FALSE(base::StartsWith(no_refcode_layers.at(7), "ref"));
 
   std::string message_with_refcode = GenerateP3AConstellationMessage(
-      kTestHistogramName, 0, meta_info, kP3AUploadType, true);
+      kTestHistogramName, 0, meta_info, kP3AUploadType, true, false);
   std::vector<std::string> refcode_layers = base::SplitString(
       message_with_refcode, kP3AMessageConstellationLayerSeparator,
       base::WhitespaceHandling::TRIM_WHITESPACE,
@@ -296,7 +298,7 @@ TEST_F(P3AConstellationHelperTest, IncludeRefcode) {
   meta_info.Init(&local_state_, "release", "2022-01-01");
 
   message_with_refcode = GenerateP3AConstellationMessage(
-      kTestHistogramName, 0, meta_info, kP3AUploadType, true);
+      kTestHistogramName, 0, meta_info, kP3AUploadType, true, false);
   refcode_layers = base::SplitString(message_with_refcode,
                                      kP3AMessageConstellationLayerSeparator,
                                      base::WhitespaceHandling::TRIM_WHITESPACE,
@@ -309,7 +311,7 @@ TEST_F(P3AConstellationHelperTest, IncludeRefcode) {
   meta_info.Init(&local_state_, "release", "2022-01-01");
 
   message_with_refcode = GenerateP3AConstellationMessage(
-      kTestHistogramName, 0, meta_info, kP3AUploadType, true);
+      kTestHistogramName, 0, meta_info, kP3AUploadType, true, false);
   refcode_layers = base::SplitString(message_with_refcode,
                                      kP3AMessageConstellationLayerSeparator,
                                      base::WhitespaceHandling::TRIM_WHITESPACE,

--- a/components/p3a/constellation_log_store.cc
+++ b/components/p3a/constellation_log_store.cc
@@ -124,6 +124,11 @@ std::string ConstellationLogStore::staged_log_type() const {
   return GetUploadType(staged_entry_key_->histogram_name);
 }
 
+const std::string& ConstellationLogStore::staged_log_histogram_name() const {
+  DCHECK(staged_entry_key_);
+  return staged_entry_key_->histogram_name;
+}
+
 const std::string& ConstellationLogStore::staged_log_hash() const {
   NOTREACHED();
   return staged_log_hash_;

--- a/components/p3a/constellation_log_store.h
+++ b/components/p3a/constellation_log_store.h
@@ -53,6 +53,7 @@ class ConstellationLogStore : public metrics::LogStore {
   bool has_staged_log() const override;
   const std::string& staged_log() const override;
   std::string staged_log_type() const;
+  const std::string& staged_log_histogram_name() const;
   const std::string& staged_log_hash() const override;
   const std::string& staged_log_signature() const override;
   std::optional<uint64_t> staged_log_user_id() const override;

--- a/components/p3a/features.cc
+++ b/components/p3a/features.cc
@@ -8,18 +8,27 @@
 
 namespace p3a::features {
 
+// Report answers to P3A questions encrypted to the STAR/Constellation
+// threshold aggregation scheme.
 BASE_FEATURE(kConstellation,
              "BraveP3AConstellation",
              base::FEATURE_ENABLED_BY_DEFAULT);
+// Verify Constellation randomness server secure enclave certificate.
 BASE_FEATURE(kConstellationEnclaveAttestation,
              "BraveP3AConstellationEnclaveAttestation",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// Disable reporting answers over direct https+json
+// for typical (weekly) cadence P3A questions.
 BASE_FEATURE(kTypicalJSONDeprecation,
              "BraveP3ATypicalJSONDeprecation",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// Disable reporting answers over direct https+json
+// for other (daily or monthly) cadence P3A questions.
 BASE_FEATURE(kOtherJSONDeprecation,
              "BraveP3AOtherJSONDeprecation",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// Report P3A responses with "Nebula" differential privacy
+// sampling enabled. See https://github.com/brave/brave-browser/issues/35841
 BASE_FEATURE(kNebula,
              "BraveP3ADifferentialSampling",
              base::FEATURE_DISABLED_BY_DEFAULT);

--- a/components/p3a/features.cc
+++ b/components/p3a/features.cc
@@ -20,6 +20,9 @@ BASE_FEATURE(kTypicalJSONDeprecation,
 BASE_FEATURE(kOtherJSONDeprecation,
              "BraveP3AOtherJSONDeprecation",
              base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE(kNebula,
+             "BraveP3ADifferentialSampling",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 
 bool IsConstellationEnabled() {
   return base::FeatureList::IsEnabled(features::kConstellation);
@@ -35,6 +38,10 @@ bool IsJSONDeprecated(MetricLogType log_type) {
     return base::FeatureList::IsEnabled(features::kTypicalJSONDeprecation);
   }
   return base::FeatureList::IsEnabled(features::kOtherJSONDeprecation);
+}
+
+bool IsNebulaEnabled() {
+  return base::FeatureList::IsEnabled(features::kNebula);
 }
 
 }  // namespace p3a::features

--- a/components/p3a/features.h
+++ b/components/p3a/features.h
@@ -23,9 +23,13 @@ BASE_DECLARE_FEATURE(kTypicalJSONDeprecation);
 // Disables JSON measurements for all other cadences.
 BASE_DECLARE_FEATURE(kOtherJSONDeprecation);
 
+// See https://github.com/brave/brave-browser/issues/35841 for more info.
+BASE_DECLARE_FEATURE(kNebula);
+
 bool IsConstellationEnabled();
 bool IsConstellationEnclaveAttestationEnabled();
 bool IsJSONDeprecated(MetricLogType log_type);
+bool IsNebulaEnabled();
 
 }  // namespace features
 }  // namespace p3a

--- a/components/p3a/message_manager.cc
+++ b/components/p3a/message_manager.cc
@@ -211,15 +211,20 @@ void MessageManager::OnNewConstellationMessage(
     std::string histogram_name,
     MetricLogType log_type,
     uint8_t epoch,
+    bool is_success,
     std::unique_ptr<std::string> serialized_message) {
-  VLOG(2) << "MessageManager::OnNewConstellationMessage: has val? "
-          << (serialized_message != nullptr);
-  if (!serialized_message) {
+  VLOG(2) << "MessageManager::OnNewConstellationMessage: is_success = "
+          << is_success << ", has msg = " << (serialized_message != nullptr);
+  if (!is_success) {
     constellation_prep_schedulers_[log_type]->UploadFinished(false);
     return;
   }
-  constellation_send_log_stores_[log_type]->UpdateMessage(histogram_name, epoch,
-                                                          *serialized_message);
+  // Message may not exist if client did not meet Nebula threshold,
+  // check accordingly
+  if (serialized_message) {
+    constellation_send_log_stores_[log_type]->UpdateMessage(
+        histogram_name, epoch, *serialized_message);
+  }
   constellation_prep_log_stores_[log_type]->DiscardStagedLog();
   constellation_prep_schedulers_[log_type]->UploadFinished(true);
   delegate_->OnMetricCycled(histogram_name, true);
@@ -259,6 +264,7 @@ void MessageManager::StartScheduledUpload(bool is_constellation,
       base::StrCat({"MessageManager::StartScheduledUpload (",
                     is_constellation ? "Constellation" : "JSON", ", ",
                     MetricLogTypeToString(log_type), ")"});
+
   if (is_constellation) {
     CHECK(features::IsConstellationEnabled());
     log_store = constellation_send_log_stores_[log_type].get();
@@ -299,8 +305,14 @@ void MessageManager::StartScheduledUpload(bool is_constellation,
       is_constellation
           ? constellation_send_log_stores_[log_type]->staged_log_type()
           : json_log_stores_[log_type]->staged_log_type();
+  bool is_nebula = is_constellation
+                       ? p3a::kNebulaOnlyHistograms.contains(
+                             constellation_send_log_stores_[log_type]
+                                 ->staged_log_histogram_name())
+                       : false;
+
   VLOG(2) << logging_prefix << " - Uploading " << log.size() << " bytes";
-  uploader_->UploadLog(log, upload_type, is_constellation, log_type);
+  uploader_->UploadLog(log, upload_type, is_constellation, is_nebula, log_type);
 }
 
 void MessageManager::StartScheduledConstellationPrep(MetricLogType log_type) {
@@ -338,8 +350,18 @@ void MessageManager::StartScheduledConstellationPrep(MetricLogType log_type) {
   VLOG(2) << "MessageManager::StartScheduledConstellationPrep - Requesting "
              "randomness for histogram: "
           << log_key;
+
+  bool is_nebula = p3a::kNebulaOnlyHistograms.contains(log_key);
+  if (is_nebula && !features::IsNebulaEnabled()) {
+    // Do not report if Nebula feature is not enabled,
+    // mark request as successful to avoid transmission.
+    constellation_prep_log_stores_[log_type]->DiscardStagedLog();
+    constellation_prep_schedulers_[log_type]->UploadFinished(true);
+    delegate_->OnMetricCycled(log_key, true);
+  }
+
   if (!constellation_helper_->StartMessagePreparation(log_key.c_str(), log_type,
-                                                      log)) {
+                                                      log, is_nebula)) {
     constellation_upload_schedulers_[log_type]->UploadFinished(false);
   }
 }
@@ -370,8 +392,10 @@ std::string MessageManager::SerializeLog(std::string_view histogram_name,
   if (is_constellation) {
     bool include_refcode =
         p3a::kHistogramsWithRefcodeIncluded.contains(histogram_name);
+    bool is_nebula = p3a::kNebulaOnlyHistograms.contains(histogram_name);
     return GenerateP3AConstellationMessage(histogram_name, value, message_meta_,
-                                           upload_type, include_refcode);
+                                           upload_type, include_refcode,
+                                           is_nebula);
   } else {
     base::Value::Dict p3a_json_value = GenerateP3AMessageDict(
         histogram_name, value, log_type, message_meta_, upload_type);

--- a/components/p3a/message_manager.cc
+++ b/components/p3a/message_manager.cc
@@ -358,6 +358,7 @@ void MessageManager::StartScheduledConstellationPrep(MetricLogType log_type) {
     constellation_prep_log_stores_[log_type]->DiscardStagedLog();
     constellation_prep_schedulers_[log_type]->UploadFinished(true);
     delegate_->OnMetricCycled(log_key, true);
+    return;
   }
 
   if (!constellation_helper_->StartMessagePreparation(log_key.c_str(), log_type,

--- a/components/p3a/message_manager.cc
+++ b/components/p3a/message_manager.cc
@@ -305,11 +305,11 @@ void MessageManager::StartScheduledUpload(bool is_constellation,
       is_constellation
           ? constellation_send_log_stores_[log_type]->staged_log_type()
           : json_log_stores_[log_type]->staged_log_type();
-  bool is_nebula = is_constellation
-                       ? p3a::kNebulaOnlyHistograms.contains(
-                             constellation_send_log_stores_[log_type]
-                                 ->staged_log_histogram_name())
-                       : false;
+  const bool is_nebula = is_constellation
+                             ? p3a::kNebulaOnlyHistograms.contains(
+                                   constellation_send_log_stores_[log_type]
+                                       ->staged_log_histogram_name())
+                             : false;
 
   VLOG(2) << logging_prefix << " - Uploading " << log.size() << " bytes";
   uploader_->UploadLog(log, upload_type, is_constellation, is_nebula, log_type);
@@ -351,7 +351,7 @@ void MessageManager::StartScheduledConstellationPrep(MetricLogType log_type) {
              "randomness for histogram: "
           << log_key;
 
-  bool is_nebula = p3a::kNebulaOnlyHistograms.contains(log_key);
+  const bool is_nebula = p3a::kNebulaOnlyHistograms.contains(log_key);
   if (is_nebula && !features::IsNebulaEnabled()) {
     // Do not report if Nebula feature is not enabled,
     // mark request as successful to avoid transmission.
@@ -390,9 +390,9 @@ std::string MessageManager::SerializeLog(std::string_view histogram_name,
   message_meta_.Update();
 
   if (is_constellation) {
-    bool include_refcode =
+    const bool include_refcode =
         p3a::kHistogramsWithRefcodeIncluded.contains(histogram_name);
-    bool is_nebula = p3a::kNebulaOnlyHistograms.contains(histogram_name);
+    const bool is_nebula = p3a::kNebulaOnlyHistograms.contains(histogram_name);
     return GenerateP3AConstellationMessage(histogram_name, value, message_meta_,
                                            upload_type, include_refcode,
                                            is_nebula);

--- a/components/p3a/message_manager.h
+++ b/components/p3a/message_manager.h
@@ -102,6 +102,7 @@ class MessageManager : public MetricLogStore::Delegate {
       std::string histogram_name,
       MetricLogType log_type,
       uint8_t epoch,
+      bool is_success,
       std::unique_ptr<std::string> serialized_message);
 
   void OnRandomnessServerInfoReady(MetricLogType log_type,

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -376,6 +376,12 @@ inline constexpr auto kHistogramsWithRefcodeIncluded =
 });
 
 // List of metrics that should be protected by Nebula.
+//
+// We intend to apply Nebula to all questions by default,
+// subject to verification that it behaves as expected.
+// This list tests a small number of questions to confirm
+// this, and should be removed or converted to an exception
+// list once we're satisfied with the implementation.
 inline constexpr auto kNebulaOnlyHistograms =
   base::MakeFixedFlatSet<std::string_view>(base::sorted_unique,{
     "Brave.AIChat.ChatCount.Nebula",

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -28,6 +28,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     "Brave.AIChat.AcquisitionSource",
     "Brave.AIChat.AvgPromptCount",
     "Brave.AIChat.ChatCount",
+    "Brave.AIChat.ChatCount.Nebula",
     "Brave.AIChat.ContextMenu.FreeUsages",
     "Brave.AIChat.ContextMenu.MostUsedAction",
     "Brave.AIChat.ContextMenu.PremiumUsages",

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -54,6 +54,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     "Brave.Core.TabCount",
     "Brave.Core.TorEverUsed",
     "Brave.Core.WeeklyUsage",
+    "Brave.Core.WeeklyUsage.Nebula",
     "Brave.Core.WindowCount.2",
     "Brave.DNS.AutoSecureRequests",
     "Brave.DNS.AutoSecureRequests.Cloudflare",
@@ -371,6 +372,13 @@ inline constexpr auto kHistogramsWithRefcodeIncluded =
   base::MakeFixedFlatSet<std::string_view>(base::sorted_unique,{
     "Brave.DayZero.A.InstallTime",
     "Brave.DayZero.B.InstallTime",
+});
+
+// List of metrics that should be protected by Nebula.
+inline constexpr auto kNebulaOnlyHistograms =
+  base::MakeFixedFlatSet<std::string_view>(base::sorted_unique,{
+    "Brave.AIChat.ChatCount.Nebula",
+    "Brave.Core.WeeklyUsage.Nebula",
 });
 
 // clang-format on

--- a/components/p3a/p3a_message.h
+++ b/components/p3a/p3a_message.h
@@ -18,6 +18,7 @@ class PrefService;
 
 namespace p3a {
 
+inline constexpr char kP3AMessageNebulaNameValueSeparator[] = "=";
 inline constexpr char kP3AMessageConstellationKeyValueSeparator[] = "|";
 inline constexpr char kP3AMessageConstellationLayerSeparator[] = ";";
 
@@ -71,7 +72,8 @@ std::string GenerateP3AConstellationMessage(std::string_view metric_name,
                                             uint64_t metric_value,
                                             const MessageMetainfo& meta,
                                             const std::string& upload_type,
-                                            bool include_refcode);
+                                            bool include_refcode,
+                                            bool is_nebula);
 
 }  // namespace p3a
 

--- a/components/p3a/star_randomness_points.h
+++ b/components/p3a/star_randomness_points.h
@@ -30,47 +30,33 @@ struct P3AConfig;
 // server in order to receive randomness point data for STAR measurements.
 class StarRandomnessPoints {
  public:
-  using RandomnessDataCallback = base::RepeatingCallback<void(
-      std::string metric_name,
-      MetricLogType log_type,
-      uint8_t epoch,
-      ::rust::Box<constellation::RandomnessRequestStateWrapper>
-          randomness_request_state,
+  using RandomnessDataCallback = base::OnceCallback<void(
       std::unique_ptr<rust::Vec<constellation::VecU8>> resp_points,
       std::unique_ptr<rust::Vec<constellation::VecU8>> resp_proofs)>;
 
   StarRandomnessPoints(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
-      RandomnessDataCallback data_callback,
       const P3AConfig* config);
   ~StarRandomnessPoints();
   StarRandomnessPoints(const StarRandomnessPoints&) = delete;
   StarRandomnessPoints& operator=(const StarRandomnessPoints&) = delete;
 
   void SendRandomnessRequest(
-      std::string metric_name,
       MetricLogType log_type,
       uint8_t epoch,
       StarRandomnessMeta* randomness_meta,
-      ::rust::Box<constellation::RandomnessRequestStateWrapper>
-          randomness_request_state,
-      const rust::Vec<constellation::VecU8>& rand_req_points);
+      const rust::Vec<constellation::VecU8>& rand_req_points,
+      RandomnessDataCallback callback);
 
  private:
-  void HandleRandomnessResponse(
-      std::string metric_name,
-      MetricLogType log_type,
-      uint8_t epoch,
-      StarRandomnessMeta* randomness_meta,
-      ::rust::Box<constellation::RandomnessRequestStateWrapper>
-          randomness_request_state,
-      std::unique_ptr<std::string> response_body);
+  void HandleRandomnessResponse(MetricLogType log_type,
+                                StarRandomnessMeta* randomness_meta,
+                                RandomnessDataCallback callback,
+                                std::unique_ptr<std::string> response_body);
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   base::flat_map<MetricLogType, std::unique_ptr<network::SimpleURLLoader>>
       url_loaders_;
-
-  RandomnessDataCallback data_callback_;
 
   const raw_ptr<const P3AConfig> config_;
 };

--- a/components/p3a/star_randomness_test_util.cc
+++ b/components/p3a/star_randomness_test_util.cc
@@ -57,7 +57,7 @@ std::string HandleRandomnessRequest(const network::ResourceRequest& request,
   rust::Vec<constellation::VecU8> req_points_rust;
   const base::Value::List* points_list = req_parsed_val.FindList("points");
 
-  EXPECT_GE(points_list->size(), 8U);
+  EXPECT_GE(points_list->size(), 7U);
   EXPECT_LE(points_list->size(), 9U);
 
   std::transform(
@@ -73,7 +73,7 @@ std::string HandleRandomnessRequest(const network::ResourceRequest& request,
   auto rand_result =
       constellation::generate_local_randomness(req_points_rust, expected_epoch);
 
-  EXPECT_GE(rand_result.points.size(), 8U);
+  EXPECT_GE(rand_result.points.size(), 7U);
   EXPECT_LE(rand_result.points.size(), 9U);
 
   base::Value::List resp_points_list;

--- a/components/p3a/uploader.cc
+++ b/components/p3a/uploader.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/strings/strcat.h"
+#include "brave/components/p3a/constellation_helper.h"
 #include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/network_annotations.h"
 #include "brave/components/p3a/p3a_config.h"
@@ -23,6 +24,8 @@ namespace {
 
 constexpr char kBraveP3AHeader[] = "X-Brave-P3A";
 constexpr char kBraveP3AVersionHeader[] = "Brave-P3A-Version";
+constexpr char kBraveP3AConstellationThresholdHeader[] =
+    "Brave-P3A-Constellation-Threshold";
 
 constexpr size_t kCurrentP3AVersionValue = 3;
 
@@ -53,6 +56,7 @@ Uploader::~Uploader() = default;
 void Uploader::UploadLog(const std::string& compressed_log_data,
                          const std::string& upload_type,
                          bool is_constellation,
+                         bool is_nebula,
                          MetricLogType log_type) {
   auto resource_request = std::make_unique<network::ResourceRequest>();
   if (upload_type == kP2AUploadType) {
@@ -63,7 +67,13 @@ void Uploader::UploadLog(const std::string& compressed_log_data,
       resource_request->url =
           GetConstellationUploadURL(config_, log_type, upload_type);
       resource_request->headers.SetHeader(
-          kBraveP3AVersionHeader, std::to_string(kCurrentP3AVersionValue));
+          kBraveP3AVersionHeader,
+          base::NumberToString(kCurrentP3AVersionValue));
+
+      size_t threshold =
+          is_nebula ? kNebulaThreshold : kConstellationDefaultThreshold;
+      resource_request->headers.SetHeader(kBraveP3AConstellationThresholdHeader,
+                                          base::NumberToString(threshold));
     } else {
       resource_request->url = upload_type == kP3ACreativeUploadType
                                   ? config_->p3a_creative_upload_url

--- a/components/p3a/uploader.cc
+++ b/components/p3a/uploader.cc
@@ -70,7 +70,7 @@ void Uploader::UploadLog(const std::string& compressed_log_data,
           kBraveP3AVersionHeader,
           base::NumberToString(kCurrentP3AVersionValue));
 
-      size_t threshold =
+      const size_t threshold =
           is_nebula ? kNebulaThreshold : kConstellationDefaultThreshold;
       resource_request->headers.SetHeader(kBraveP3AConstellationThresholdHeader,
                                           base::NumberToString(threshold));

--- a/components/p3a/uploader.h
+++ b/components/p3a/uploader.h
@@ -57,6 +57,7 @@ class Uploader {
   void UploadLog(const std::string& compressed_log_data,
                  const std::string& upload_type,
                  bool is_constellation,
+                 bool is_nebula,
                  MetricLogType log_type);
 
   void OnUploadComplete(bool is_constellation,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35841

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Ensure requests are being sent to `star-randsrv.bsg.brave.com` and `collector.bsg.brave.com` as usual. Each collector request should have the `Brave-P3A-Constellation-Threshold` header set with a value of 20 or 50. Ensure the metrics get marked as sent in local state as usual.