### PR TITLE
fix(wallet): Allow Biometric Unlock toggle not updating correctly after enabling

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -624,7 +624,20 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
 
   /// Stores the users wallet password in the keychain so that they may unlock using biometrics/passcode
   func storePasswordInKeychain(_ password: String) -> OSStatus {
-    keychain.storePasswordInKeychain(key: Self.passwordKeychainKey, password: password)
+    var osStatus = keychain.storePasswordInKeychain(
+      key: Self.passwordKeychainKey,
+      password: password
+    )
+    if osStatus == errSecDuplicateItem {
+      // Duplicate item is possible if brave-browser#36669 occurs again.
+      // Remove existing stored password & store updated password.
+      resetKeychainStoredPassword()
+      osStatus = keychain.storePasswordInKeychain(
+        key: Self.passwordKeychainKey,
+        password: password
+      )
+    }
+    return osStatus
   }
 
   @discardableResult

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SettingsStore.swift
@@ -19,14 +19,15 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
   }
 
   /// If we should attempt to unlock via biometrics (Face ID / Touch ID)
-  var isBiometricsUnlockEnabled: Bool {
-    keychain.isPasswordStoredInKeychain(key: KeyringStore.passwordKeychainKey)
-      && isBiometricsAvailable
-  }
+  @Published var isBiometricsUnlockEnabled: Bool = false
 
   /// If the device has biometrics available
   var isBiometricsAvailable: Bool {
     LAContext().canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+  }
+
+  private var isPasswordStoredInKeychain: Bool {
+    keychain.isPasswordStoredInKeychain(key: KeyringStore.passwordKeychainKey)
   }
 
   /// The current default base currency code
@@ -102,7 +103,6 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
     self.txService = txService
     self.ipfsApi = ipfsApi
     self.keychain = keychain
-
     self.setupObservers()
   }
 
@@ -143,6 +143,7 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
       self.udResolveMethod = await rpcService.unstoppableDomainsResolveMethod()
 
       self.isNFTDiscoveryEnabled = await walletService.nftDiscoveryEnabled()
+      self.isBiometricsUnlockEnabled = isPasswordStoredInKeychain && isBiometricsAvailable
     }
   }
 
@@ -192,6 +193,10 @@ public class SettingsStore: ObservableObject, WalletObserverStore {
 
   func closeManageSiteConnectionStore() {
     manageSiteConnectionsStore = nil
+  }
+
+  func updateBiometricsToggle() {
+    self.isBiometricsUnlockEnabled = isPasswordStoredInKeychain && isBiometricsAvailable
   }
 }
 

--- a/ios/brave-ios/Sources/BraveWallet/PasswordEntryView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/PasswordEntryView.swift
@@ -14,6 +14,7 @@ struct PasswordEntryError: LocalizedError, Equatable {
   var errorDescription: String? { message }
 
   static let incorrectPassword = Self(message: Strings.Wallet.incorrectPasswordErrorMessage)
+  static let failedToEnableBiometrics = Self(message: Strings.Wallet.biometricsSetupErrorMessage)
 }
 
 /// Field for entering wallet password, with optional biometrics support
@@ -56,6 +57,10 @@ struct PasswordEntryField: View {
         return Image(systemName: "faceid")
       case .touchID:
         return Image(systemName: "touchid")
+      #if swift(>=5.9)
+      case .opticID:
+        return Image(systemName: "opticid")
+      #endif
       case .none:
         return nil
       @unknown default:

--- a/ios/brave-ios/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -30,7 +30,7 @@ struct BiometricsPasscodeEntryView: View {
               // Failed to store password in keychain
               completion(.failedToEnableBiometrics)
             } else {
-              // Successfully stored password stored in keychain
+              // Successfully stored password in keychain
               completion(nil)
             }
           } else {  // incorrect/invalid password

--- a/ios/brave-ios/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/BiometricsPasscodeEntryView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct BiometricsPasscodeEntryView: View {
 
   @ObservedObject var keyringStore: KeyringStore
+  var settingsStore: SettingsStore
 
   var body: some View {
     PasswordEntryView(
@@ -17,22 +18,26 @@ struct BiometricsPasscodeEntryView: View {
       title: Strings.Wallet.enterPasswordForBiometricsNavTitle,
       message: Strings.Wallet.enterPasswordForBiometricsTitle,
       action: { password, completion in
-        keyringStore.validate(password: password) { isValid in
+        keyringStore.validate(password: password) { [weak settingsStore] isValid in
+          defer {
+            settingsStore?.updateBiometricsToggle()
+          }
           if isValid {
             // store password in keychain
             if case let status = keyringStore.storePasswordInKeychain(password),
               status != errSecSuccess
             {
-              completion(.incorrectPassword)
+              // Failed to store password in keychain
+              completion(.failedToEnableBiometrics)
             } else {
-              // password stored in keychain
+              // Successfully stored password stored in keychain
               completion(nil)
             }
-          } else {
+          } else {  // incorrect/invalid password
             // Conflict with the keyboard submit/dismissal that causes a bug
             // with SwiftUI animating the screen away...
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-              completion(.init(message: Strings.Wallet.incorrectPasswordErrorMessage))
+              completion(.incorrectPassword)
             }
           }
         }
@@ -45,7 +50,8 @@ struct BiometricsPasscodeEntryView: View {
 struct BiometricsPasscodeEntryView_Previews: PreviewProvider {
   static var previews: some View {
     BiometricsPasscodeEntryView(
-      keyringStore: .previewStore
+      keyringStore: .previewStore,
+      settingsStore: .previewStore
     )
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/Web3SettingsView.swift
@@ -144,8 +144,11 @@ public struct Web3SettingsView: View {
     .background(
       Color.clear
         .sheet(isPresented: $isShowingBiometricsPasswordEntry) {
-          if let keyringStore {
-            BiometricsPasscodeEntryView(keyringStore: keyringStore)
+          if let keyringStore, let settingsStore {
+            BiometricsPasscodeEntryView(
+              keyringStore: keyringStore,
+              settingsStore: settingsStore
+            )
           }
         }
     )
@@ -334,6 +337,7 @@ private struct WalletSettingsView: View {
       self.isShowingBiometricsPasswordEntry = true
     } else {
       keyringStore.resetKeychainStoredPassword()
+      settingsStore.updateBiometricsToggle()
     }
   }
 }


### PR DESCRIPTION
- Fixed `Allow Biometric Unlock` toggle not updating correctly after enabling.
    - Web3 Settings on iOS uses SwiftUI which requires publishing changes so the view knows when it needs to update. For `Allow Biometric Unlock` this was not occurring, so the view did not know to update the toggle. I've updated the `isBiometricsUnlockEnabled` property to be `@Published` so updates trigger a view re-draw to correctly update the toggle.
- Fixed error message when failing to store password in keychain (screenshot below).
    - This could occur when trying to store the password in keychain without previously removing it (duplicate keychain item error), which would occur after enabling `Allow Biometric Unlock` but the toggle did not update. Re-enabling the toggle would bring up the password confirmation modal again, however the password is already stored so we'd receive a `errSecDuplicateItem` error and then show incorrect error message (`Incorrect password` error message even though password may be valid). 
    - I added additional protection here in case the toggle bug returns; if we receive duplicate item unexpectedly, we will remove existing entry and add the new validated wallet password to keychain.
<img src="https://github.com/brave/brave-core/assets/5314553/34fb11cb-a2bc-40cf-9907-d3776a78711b" width="300">


Resolves https://github.com/brave/brave-browser/issues/36669

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Setup a wallet if not currently setup on a device that supports biometrics (Face ID / Touch ID).
2. Open Web3 Settings
3. Disable `Allow Biometric Unlock`. 
4. Open & close the Web3 Settings view, verify toggle remains in disabled position.
5. Enable `Allow Biometric Unlock`.
6. Enter incorrect password and tap `return` on keyboard or `Confirm` button on view.
7. Verify `Incorrect password` error message is correctly shown.
8. Enter correct password and tap `return` on keyboard or `Confirm` button on view.
9. Verify the modal is dismissed and the toggle is in the enabled position.