### PR TITLE
Fix commander shortcut on Mac

### DIFF
--- a/chromium_src/chrome/browser/ui/cocoa/accelerators_cocoa.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/accelerators_cocoa.mm
@@ -10,12 +10,12 @@ constexpr int kNewWindowCmdID = IDC_NEW_WINDOW;
 }  // namespace
 
 #undef IDC_NEW_WINDOW
-#define IDC_NEW_WINDOW                                                    \
-  IDC_NEW_OFFTHERECORD_WINDOW_TOR, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN, \
-      ui::VKEY_N                                                          \
-  }                                                                       \
-  , {IDC_TOGGLE_TAB_MUTE, ui::EF_CONTROL_DOWN, ui::VKEY_M},               \
-      {IDC_COMMANDER, ui::EF_CONTROL_DOWN, ui::VKEY_SPACE}, {             \
+#define IDC_NEW_WINDOW                                                        \
+  IDC_NEW_OFFTHERECORD_WINDOW_TOR, ui::EF_COMMAND_DOWN | ui::EF_ALT_DOWN,     \
+      ui::VKEY_N                                                              \
+  }                                                                           \
+  , {IDC_TOGGLE_TAB_MUTE, ui::EF_CONTROL_DOWN, ui::VKEY_M},                   \
+      {IDC_COMMANDER, ui::EF_COMMAND_DOWN | ui::EF_SHIFT_DOWN, ui::VKEY_P}, { \
     kNewWindowCmdID
 
 #include "src/chrome/browser/ui/cocoa/accelerators_cocoa.mm"

--- a/chromium_src/chrome/browser/ui/cocoa/main_menu_builder.mm
+++ b/chromium_src/chrome/browser/ui/cocoa/main_menu_builder.mm
@@ -4,8 +4,11 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/app/brave_command_ids.h"
+#include "brave/browser/ui/commander/commander_service.h"
 #include "brave/grit/brave_generated_resources.h"
 #include "chrome/grit/generated_resources.h"
+#include "components/dom_distiller/core/dom_distiller_features.h"
+#include "components/grit/brave_components_strings.h"
 
 namespace {
 constexpr int kPasteMacResourceId = IDS_PASTE_MAC;
@@ -13,12 +16,12 @@ constexpr int kMuteSiteResourceId = IDS_MUTE_SITE_MAC;
 constexpr int kCloseOtherTabsResourceId = IDS_TAB_CXMENU_CLOSEOTHERTABS;
 }  // namespace
 
-#define BRAVE_BUILD_FILE_MENU                       \
-  Item(IDS_NEW_OFFTHERECORD_WINDOW_TOR)             \
+#define BRAVE_BUILD_FILE_MENU           \
+  Item(IDS_NEW_OFFTHERECORD_WINDOW_TOR) \
       .command_id(IDC_NEW_OFFTHERECORD_WINDOW_TOR),
 
-#define BRAVE_BUILD_HELP_MENU                         \
-  Item(IDS_REPORT_BROKEN_SITE_MAC)                    \
+#define BRAVE_BUILD_HELP_MENU      \
+  Item(IDS_REPORT_BROKEN_SITE_MAC) \
       .command_id(IDC_SHOW_BRAVE_WEBCOMPAT_REPORTER),
 
 #undef IDS_PASTE_MAC
@@ -37,7 +40,14 @@ IDS_MUTE_TAB_MAC).command_id(IDC_TOGGLE_TAB_MUTE), \
 IDS_TAB_CXMENU_CLOSE_DUPLICATE_TABS).command_id(IDC_CLOSE_DUPLICATE_TABS), \
               Item(kCloseOtherTabsResourceId
 
+// Insert Commander item right after "Reader mode" aka "Distill page"
+#define IsDomDistillerEnabled() IsDomDistillerEnabled()),                \
+    Item(IDS_IDC_COMMANDER).command_id(IDC_COMMANDER)                    \
+                           .remove_if(is_pwa || !commander::IsEnabled()
+
 #include "src/chrome/browser/ui/cocoa/main_menu_builder.mm"
+
+#undef IsDomDistillerEnabled
 #undef IDS_MUTE_SITE_MAC
 #define IDS_MUTE_SITE_MAC kMuteSiteResourceId
 #undef IDS_PASTE_MAC


### PR DESCRIPTION
* Change default shortcut to Cmd+Shift+P as Ctrl+Space could be occupied by input method change action.

* Add main menu item for the Commander. Without this, default shortcut won't be triggered.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36733

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Enable Brave commands flag
* Check if `main menu > view > Commander` exists
<img width="339" alt="image" src="https://github.com/brave/brave-core/assets/5474642/53a8ce63-b0e8-42cd-a883-ca4bdf3d01d8">


* Check if pressing `cmd + shift + p` opens command input mode in location bar
<img width="958" alt="image" src="https://github.com/brave/brave-core/assets/5474642/f9a94d1b-151a-4276-ab9c-f6e303b369b6">


