### PR TITLE
fix(wallet): Fix Add to Metamask on Coingecko / Ethereum provider `networkVersion` assignment

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Wallet.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Wallet.swift
@@ -495,7 +495,7 @@ extension Tab: BraveWalletEventsListener {
 
     let networkVersion = valueOrUndefined(Int(chainId.removingHexPrefix, radix: 16))
     await webView.evaluateSafeJavaScript(
-      functionName: "window.ethereum.networkVersion = \(networkVersion)",
+      functionName: "window.ethereum.networkVersion = \"\(networkVersion)\"",
       contentWorld: EthereumProviderScriptHandler.scriptSandbox,
       asFunction: false
     )

--- a/ios/brave-ios/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -568,7 +568,10 @@ struct WalletPanelView: View {
     )
     .onChange(of: cryptoStore.pendingRequest) { newValue in
       if newValue != nil {
-        presentWalletWithContext(.pendingRequests)
+        // Slight delay to allow dismissal of unlock modal before presenting pending request modal.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+          presentWalletWithContext(.pendingRequests)
+        }
       }
     }
     .onChange(of: keyringStore.selectedAccount) { _ in
@@ -619,7 +622,10 @@ struct WalletPanelView: View {
         )
       } else if cryptoStore.pendingRequest != nil {
         // race condition for when `pendingRequest` is assigned in CryptoStore before this view visible
-        presentWalletWithContext(.pendingRequests)
+        // Slight delay to allow dismissal of unlock modal before presenting pending request modal.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+          presentWalletWithContext(.pendingRequests)
+        }
       } else {
         cryptoStore.prepare()
       }


### PR DESCRIPTION
- `window.ethereum.networkVersion` was being assigned in javascript as an integer, when it should be a string. 
    - Desktop/Android implementation converts `chainId` to an integer, but assigns to property as a string:
https://github.com/brave/brave-core/blob/295b49e6d8891d671e4e10a1066eb74fd42297e8/components/brave_wallet/renderer/js_ethereum_provider.cc#L337-L350

- The delay to presenting `pendingRequests` context is due to an iOS quirk. When the wallet is locked, we first present a modal to unlock wallet, then dismiss that unlock wallet modal and attempt to present the pending Add Suggested Token modal. If we try and present too soon, we get an error on iOS for presenting on a view that is already presenting another view. 0.3s delay on the present works around this.

Resolves https://github.com/brave/brave-browser/issues/36797

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit [Coingecko.com](https://www.coingecko.com/)
2. Find an ethereum token to add, ex. [UNI](https://www.coingecko.com/en/coins/uniswap) token.
3. Tap the Metamask logo / Add to Metamask button
4. Verify Add Suggested Token modal is shown, allowing adding token to visible tokens in users wallet

https://github.com/brave/brave-core/assets/5314553/fc290aca-c7f3-43e7-b489-735a1ce96897
