### PR TITLE
[iOS] - Fix layout of WrappingHStack when text becomes multi-line

### DIFF
--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatSuggestionsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatSuggestionsView.swift
@@ -52,19 +52,19 @@ struct WrappingHStack: Layout {
     }
 
     var x = bounds.minX
-    var y = height / 2.0 + bounds.minY
+    var y = height + bounds.minY
 
     subviews.forEach { subview in
       x += subview.dimensions(in: proposal).width / 2.0
 
       if x + subview.dimensions(in: proposal).width / 2.0 > bounds.maxX {
         x = bounds.minX + subview.dimensions(in: proposal).width / 2.0
-        y += height + vSpacing
+        y += subview.dimensions(in: proposal).height + vSpacing
       }
 
       subview.place(
         at: CGPoint(x: x, y: y),
-        anchor: .center,
+        anchor: .init(x: 0.5, y: 1.0),
         proposal: ProposedViewSize(
           width: subview.dimensions(in: proposal).width,
           height: subview.dimensions(in: proposal).height
@@ -124,25 +124,23 @@ struct WrappingHStackOld<Model, V>: View where Model: Hashable, V: View {
     ZStack(alignment: .topLeading) {
       ForEach(models, id: \.self) { model in
         viewGenerator(model)
-          .padding(.horizontal, hSpacing)
-          .padding(.vertical, vSpacing)
           .alignmentGuide(
             .leading,
             computeValue: { dimension in
               if abs(width - dimension.width) > geometry.size.width {
                 width = 0.0
-                height -= dimension.height
+                height -= dimension.height + vSpacing
               }
 
               let result = width
-              width = model == models.last! ? 0.0 : width - dimension.width
+              width = model == models.last! ? 0.0 : width - dimension.width - hSpacing
               return result
             }
           )
           .alignmentGuide(
             .top,
             computeValue: { dimension in
-              let result = height
+              let result = height + dimension.height
               if model == models.last! {
                 height = 0.0
               }


### PR DESCRIPTION
Also fix spacing between items in the wrapping HStack on iOS 15 when line becomes multi-line.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36805

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

