### PR TITLE
fix(wallet): Only show user visible assets in Account Details on iOS

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -102,6 +102,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
 
   func setupObservers() {
     guard !isObserving else { return }
+    self.assetManager.addUserAssetDataObserver(self)
     self.keyringServiceObserver = KeyringServiceObserver(
       keyringService: keyringService,
       _accountsChanged: {
@@ -308,7 +309,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
     var updatedUserAssets: [AssetViewModel] = []
     var updatedUserNFTs: [NFTAssetViewModel] = []
     for networkAssets in userNetworkAssets {
-      for token in networkAssets.tokens {
+      for token in networkAssets.tokens where token.visible {
         if token.isErc721 || token.isNft {
           guard Int(tokenBalances[token.id] ?? 0) > 0 else {
             // only show NFTs belonging to this account
@@ -429,5 +430,16 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
   func closeTransactionDetailsStore() {
     self.transactionDetailsStore?.tearDown()
     self.transactionDetailsStore = nil
+  }
+}
+
+extension AccountActivityStore: WalletUserAssetDataObserver {
+  public func cachedBalanceRefreshed() {
+  }
+
+  public func userAssetUpdated() {
+    // auto-discovery found new asset, user changed
+    // visibility status, or added new custom asset
+    update()
   }
 }

--- a/ios/brave-ios/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -214,6 +214,8 @@ class AccountActivityStoreTests: XCTestCase {
             BraveWallet.NetworkInfo.mockMainnet.nativeToken.copy(asVisibleAsset: true),
             .mockERC721NFTToken.copy(asVisibleAsset: true),
             .mockUSDCToken.copy(asVisibleAsset: true),
+            // To verify brave/brave-browser#36806
+            .previewDaiToken.copy(asVisibleAsset: false),
           ],
           sortOrder: 0
         ),
@@ -274,6 +276,12 @@ class AccountActivityStoreTests: XCTestCase {
         XCTAssertEqual(lastUpdatedAssets[2].network, BraveWallet.NetworkInfo.mockGoerli)
         XCTAssertEqual(lastUpdatedAssets[2].totalBalance, 0)
         XCTAssertEqual(lastUpdatedAssets[2].price, self.mockAssetPrices[safe: 0]?.price ?? "")
+
+        // Verify brave/brave-browser#36806
+        let daiTokenVisible = lastUpdatedAssets.contains(where: {
+          $0.id == BraveWallet.BlockchainToken.previewDaiToken.id
+        })
+        XCTAssertFalse(daiTokenVisible)
       }
       .store(in: &cancellables)
 


### PR DESCRIPTION
We were fetching all assets for transaction display (in case user removed token/nft involved in a transaction, ex sending NFT to a friend), but not correctly filtering out non-visible assets for display in assets & NFTs list.

Resolves https://github.com/brave/brave-browser/issues/36806

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

  1. In Portfolio tab, open Edit User Assets screen
  2. Search for Pozzcoin on Solana Mainnet, or another asset not currently selected as visible
  3. Tap the coin to set as visible (you will see a checkmark). Tap cancel & done to dismiss (cancel first is iOS system UX change with search bar :( ).
  4. Switch to Accounts tab, tap any Solana account, if on v1.63 or later tap Assets row
  5. Verify asset from step 2 is displayed
  6. Switch back to Portfolio tab
  7. Open Edit User Assets screen, tap asset from step 2 row again to set as not visible (you should see checkmark removed). Tap cancel & done to dismiss.
  8. Switch to Accounts tab, tap any Solana account, if on v1.63 or later tap Assets row
  9. Verify Pozzcoin is no longer shown in assets list