### PR TITLE
Introduce print preview extraction

### DIFF
--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -38,6 +38,7 @@ source_set("browser_tests") {
       "ai_chat_policy_browsertest.cc",
       "ai_chat_profile_browsertest.cc",
       "ai_chat_render_view_context_menu_browsertest.cc",
+      "ai_chat_ui_browsertest.cc",
       "page_content_fetcher_browsertest.cc",
     ]
     deps = [
@@ -54,6 +55,7 @@ source_set("browser_tests") {
       "//chrome/browser",
       "//chrome/test:test_support",
       "//chrome/test:test_support_ui",
+      "//printing/buildflags",
     ]
   }
 }

--- a/browser/ai_chat/DEPS
+++ b/browser/ai_chat/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  "+printing/buildflags",
+]
+

--- a/browser/ai_chat/ai_chat_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_ui_browsertest.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/constants/brave_paths.h"
 #include "brave/components/l10n/common/test/scoped_default_locale.h"
 #include "brave/components/text_recognition/common/buildflags/buildflags.h"
@@ -191,7 +192,7 @@ IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, PrintPreviewPagesLimit) {
   NavigateURL(
       https_server_.GetURL("docs.google.com", "/extra_long_canvas.html"));
   CreatePrintPreview(ai_chat_page_handler);
-  std::string expected_string(19, '\n');
+  std::string expected_string(ai_chat::kMaxPreviewPages - 1, '\n');
   base::StrAppend(&expected_string, {"This is the way."});
   FetchPageContent(FROM_HERE, chat_tab_helper, expected_string);
 }

--- a/browser/ai_chat/ai_chat_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_ui_browsertest.cc
@@ -1,0 +1,220 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/files/file_path.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
+#include "base/path_service.h"
+#include "base/run_loop.h"
+#include "base/strings/strcat.h"
+#include "base/test/bind.h"
+#include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
+#include "brave/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h"
+#include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
+#include "brave/components/constants/brave_paths.h"
+#include "brave/components/l10n/common/test/scoped_default_locale.h"
+#include "brave/components/text_recognition/common/buildflags/buildflags.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/side_panel/side_panel_ui.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_web_ui_view.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "net/dns/mock_host_resolver.h"
+#include "printing/buildflags/buildflags.h"
+#include "ui/compositor/compositor_switches.h"
+
+namespace {
+
+constexpr char kEmbeddedTestServerDirectory[] = "leo";
+}  // namespace
+
+class AIChatUIBrowserTest : public InProcessBrowserTest {
+ public:
+  AIChatUIBrowserTest() : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
+  void SetUpOnMainThread() override {
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    host_resolver()->AddRule("*", "127.0.0.1");
+    content::SetupCrossSiteRedirector(&https_server_);
+
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir;
+    test_data_dir = base::PathService::CheckedGet(brave::DIR_TEST_DATA);
+    test_data_dir = test_data_dir.AppendASCII(kEmbeddedTestServerDirectory);
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    ASSERT_TRUE(https_server_.Start());
+
+    // Set a smaller window size so we can have test data with more pages.
+    browser()->window()->SetContentsSize(gfx::Size(800, 600));
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
+    command_line->AppendSwitch(::switches::kEnablePixelOutputInTests);
+#endif
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+  }
+
+  content::WebContents* GetActiveWebContents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  void NavigateURL(const GURL& url) {
+    ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+    ASSERT_TRUE(WaitForLoadStop(GetActiveWebContents()));
+  }
+
+  void CreatePrintPreview(ai_chat::AIChatUIPageHandler* handler) {
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+    handler->MaybeCreatePrintPreview();
+#endif
+  }
+
+  ai_chat::AIChatUIPageHandler* OpenAIChatSidePanel() {
+    auto* side_panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser());
+    side_panel_ui->Show(SidePanelEntryId::kChatUI);
+    auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser());
+    auto* side_panel = browser_view->unified_side_panel();
+    auto* ai_chat_side_panel =
+        side_panel->GetViewByID(SidePanelWebUIView::kSidePanelWebViewId);
+    if (!ai_chat_side_panel) {
+      return nullptr;
+    }
+    auto* side_panel_web_contents =
+        (static_cast<views::WebView*>(ai_chat_side_panel))->web_contents();
+    if (!side_panel_web_contents) {
+      return nullptr;
+    }
+    content::WaitForLoadStop(side_panel_web_contents);
+
+    auto* web_ui = side_panel_web_contents->GetWebUI();
+    if (!web_ui) {
+      return nullptr;
+    }
+    auto* ai_chat_ui = web_ui->GetController()->GetAs<AIChatUI>();
+    if (!ai_chat_ui) {
+      return nullptr;
+    }
+    return ai_chat_ui->GetPageHandlerForTesting();
+  }
+
+  void FetchPageContent(const base::Location& location,
+                        ai_chat::AIChatTabHelper* helper,
+                        std::string_view expected_text) {
+    SCOPED_TRACE(testing::Message() << location.ToString());
+    base::RunLoop run_loop;
+    helper->GetPageContent(
+        base::BindLambdaForTesting(
+            [&run_loop, expected_text](std::string text, bool is_video,
+                                       std::string invalidation_token) {
+              EXPECT_FALSE(is_video);
+              EXPECT_EQ(text, expected_text);
+              run_loop.Quit();
+            }),
+        "");
+    run_loop.Run();
+  }
+
+ protected:
+  net::test_server::EmbeddedTestServer https_server_;
+
+ private:
+  content::ContentMockCertVerifier mock_cert_verifier_;
+};
+
+IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, PrintPreview) {
+  auto* chat_tab_helper =
+      ai_chat::AIChatTabHelper::FromWebContents(GetActiveWebContents());
+  ASSERT_TRUE(chat_tab_helper);
+  chat_tab_helper->SetUserOptedIn(true);
+  auto* ai_chat_page_handler = OpenAIChatSidePanel();
+  ASSERT_TRUE(ai_chat_page_handler);
+
+  NavigateURL(https_server_.GetURL("docs.google.com", "/long_canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
+  FetchPageContent(
+      FROM_HERE, chat_tab_helper,
+      "This is the way.\n\nI have spoken.\nWherever I Go, He Goes.");
+  // Panel is still active so we don't need to set it up again
+
+  // Page recognition host with a canvas element
+  NavigateURL(https_server_.GetURL("docs.google.com", "/canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+  FetchPageContent(FROM_HERE, chat_tab_helper, "this is the way");
+#if BUILDFLAG(IS_WIN)
+  // Unsupported locale should return no content for Windows only
+  // Other platforms do not use locale for extraction
+  const brave_l10n::test::ScopedDefaultLocale locale("xx_XX");
+  NavigateURL(https_server_.GetURL("docs.google.com", "/canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+  FetchPageContent(FROM_HERE, chat_tab_helper, "");
+#endif  // #if BUILDFLAG(IS_WIN)
+#else
+  FetchPageContent(FROM_HERE, chat_tab_helper, "");
+#endif
+
+  // Not supported on other hosts
+  NavigateURL(https_server_.GetURL("a.com", "/long_canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+  FetchPageContent(FROM_HERE, chat_tab_helper, "");
+}
+
+#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
+IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, PrintPreviewPagesLimit) {
+  auto* chat_tab_helper =
+      ai_chat::AIChatTabHelper::FromWebContents(GetActiveWebContents());
+  ASSERT_TRUE(chat_tab_helper);
+  chat_tab_helper->SetUserOptedIn(true);
+  auto* ai_chat_page_handler = OpenAIChatSidePanel();
+  ASSERT_TRUE(ai_chat_page_handler);
+
+  NavigateURL(
+      https_server_.GetURL("docs.google.com", "/extra_long_canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+  std::string expected_string(19, '\n');
+  base::StrAppend(&expected_string, {"This is the way."});
+  FetchPageContent(FROM_HERE, chat_tab_helper, expected_string);
+}
+
+IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest, PrintPreviewContextLimit) {
+  auto* chat_tab_helper =
+      ai_chat::AIChatTabHelper::FromWebContents(GetActiveWebContents());
+  ASSERT_TRUE(chat_tab_helper);
+  chat_tab_helper->SetUserOptedIn(true);
+  auto* ai_chat_page_handler = OpenAIChatSidePanel();
+  ASSERT_TRUE(ai_chat_page_handler);
+
+  ai_chat::AIChatTabHelper::SetMaxContentLengthForTesting(10);
+  NavigateURL(https_server_.GetURL("docs.google.com", "/long_canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+  FetchPageContent(FROM_HERE, chat_tab_helper, "This is the way.");
+
+  ai_chat::AIChatTabHelper::SetMaxContentLengthForTesting(20);
+  NavigateURL(https_server_.GetURL("docs.google.com", "/long_canvas.html"));
+  CreatePrintPreview(ai_chat_page_handler);
+  FetchPageContent(FROM_HERE, chat_tab_helper,
+                   "This is the way.\n\nI have spoken.");
+
+  ai_chat::AIChatTabHelper::SetMaxContentLengthForTesting(std::nullopt);
+}
+#endif

--- a/browser/ai_chat/page_content_fetcher_browsertest.cc
+++ b/browser/ai_chat/page_content_fetcher_browsertest.cc
@@ -14,8 +14,6 @@
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
 #include "brave/components/ai_chat/content/browser/page_content_fetcher.h"
 #include "brave/components/constants/brave_paths.h"
-#include "brave/components/l10n/common/test/scoped_default_locale.h"
-#include "brave/components/text_recognition/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -27,7 +25,6 @@
 #include "net/dns/mock_host_resolver.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "services/network/test/test_url_loader_factory.h"
-#include "ui/compositor/compositor_switches.h"
 
 namespace {
 
@@ -77,9 +74,6 @@ class PageContentFetcherBrowserTest : public InProcessBrowserTest {
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
     InProcessBrowserTest::SetUpCommandLine(command_line);
-#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-    command_line->AppendSwitch(::switches::kEnablePixelOutputInTests);
-#endif
     mock_cert_verifier_.SetUpCommandLine(command_line);
   }
 
@@ -109,7 +103,8 @@ class PageContentFetcherBrowserTest : public InProcessBrowserTest {
     SCOPED_TRACE(testing::Message() << location.ToString());
     base::RunLoop run_loop;
     ai_chat::FetchPageContent(
-        browser()->tab_strip_model()->GetActiveWebContents(), "",
+        browser()->tab_strip_model()->GetActiveWebContents(), "", std::nullopt,
+        4096,
         base::BindLambdaForTesting([&run_loop, &expected_text,
                                     &expected_is_video, &trim_whitespace](
                                        std::string text, bool is_video,
@@ -171,20 +166,8 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContent) {
   // Not a page extraction host and page with no text
   NavigateURL(https_server_.GetURL("a.com", "/canvas.html"));
   FetchPageContent(FROM_HERE, "", false);
-#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-  // Page recognition host with a canvas element
-  NavigateURL(https_server_.GetURL("docs.google.com", "/canvas.html"));
-  FetchPageContent(FROM_HERE, "this is the way", false);
-#if BUILDFLAG(IS_WIN)
-  // Unsupported locale should return no content for Windows only
-  // Other platforms do not use locale for extraction
-  const brave_l10n::test::ScopedDefaultLocale locale("xx_XX");
-  NavigateURL(https_server_.GetURL("docs.google.com", "/canvas.html"));
-  FetchPageContent(FROM_HERE, "", false);
-#endif  // #if BUILDFLAG(IS_WIN)
   NavigateURL(https_server_.GetURL("github.com", kGithubUrlPath));
   FetchPageContent(FROM_HERE, kGithubPatch, false);
-#endif  // #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
 }
 
 IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContentPDF) {

--- a/browser/ai_chat/page_content_fetcher_browsertest.cc
+++ b/browser/ai_chat/page_content_fetcher_browsertest.cc
@@ -103,8 +103,7 @@ class PageContentFetcherBrowserTest : public InProcessBrowserTest {
     SCOPED_TRACE(testing::Message() << location.ToString());
     base::RunLoop run_loop;
     ai_chat::FetchPageContent(
-        browser()->tab_strip_model()->GetActiveWebContents(), "", std::nullopt,
-        4096,
+        browser()->tab_strip_model()->GetActiveWebContents(), "",
         base::BindLambdaForTesting([&run_loop, &expected_text,
                                     &expected_is_video, &trim_whitespace](
                                        std::string text, bool is_video,

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -22,6 +22,7 @@ import("//build/config/features.gni")
 import("//chrome/common/features.gni")
 import("//components/gcm_driver/config.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
+import("//printing/buildflags/buildflags.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
 source_set("ui") {
@@ -84,6 +85,13 @@ source_set("ui") {
       "webui/ai_chat/ai_chat_ui_page_handler.cc",
       "webui/ai_chat/ai_chat_ui_page_handler.h",
     ]
+
+    if (enable_print_preview) {
+      deps += [
+        "//chrome/browser/pdf:pdf_pref_names",
+        "//chrome/services/printing/public/mojom",
+      ]
+    }
 
     if (is_android) {
       sources += [
@@ -714,9 +722,12 @@ source_set("ui") {
     "//components/optimization_guide/core:features",
     "//components/optimization_guide/optimization_guide_internals/webui:url_constants",
     "//components/prefs",
+    "//components/printing/browser",
+    "//components/printing/common:mojo_interfaces",
     "//components/qr_code_generator:bitmap_generator",
     "//components/resources:components_resources_grit",
     "//components/search_engines",
+    "//components/services/print_compositor/public/mojom",
     "//components/sessions",
     "//components/strings:components_strings",
     "//components/tab_groups",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -87,9 +87,16 @@ source_set("ui") {
     ]
 
     if (enable_print_preview) {
+      sources += [
+        "webui/ai_chat/print_preview_extractor.cc",
+        "webui/ai_chat/print_preview_extractor.h",
+      ]
       deps += [
         "//chrome/browser/pdf:pdf_pref_names",
         "//chrome/services/printing/public/mojom",
+        "//components/printing/browser",
+        "//components/printing/common:mojo_interfaces",
+        "//components/services/print_compositor/public/mojom",
       ]
     }
 
@@ -722,12 +729,9 @@ source_set("ui") {
     "//components/optimization_guide/core:features",
     "//components/optimization_guide/optimization_guide_internals/webui:url_constants",
     "//components/prefs",
-    "//components/printing/browser",
-    "//components/printing/common:mojo_interfaces",
     "//components/qr_code_generator:bitmap_generator",
     "//components/resources:components_resources_grit",
     "//components/search_engines",
-    "//components/services/print_compositor/public/mojom",
     "//components/sessions",
     "//components/strings:components_strings",
     "//components/tab_groups",

--- a/browser/ui/webui/ai_chat/DEPS
+++ b/browser/ui/webui/ai_chat/DEPS
@@ -1,0 +1,6 @@
+include_rules = [
+  "+brave/services/printing/public/mojom",
+  "+chrome/services/printing/public/mojom",
+  "+printing",
+]
+

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -22,27 +22,15 @@
 #include "components/grit/brave_components_resources.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
-#include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/common/url_constants.h"
-#include "mojo/public/cpp/bindings/callback_helpers.h"
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/ui/browser.h"
 #else
 #include "chrome/browser/ui/android/tab_model/tab_model.h"
 #include "chrome/browser/ui/android/tab_model/tab_model_list.h"
-#endif
-
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-#include "chrome/browser/printing/print_preview_data_service.h"
-#include "chrome/browser/printing/print_view_manager_common.h"
-#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
-#include "components/printing/browser/print_composite_client.h"
-#include "printing/print_job_constants.h"
-
-using printing::PrintCompositeClient;
 #endif
 
 #if BUILDFLAG(IS_ANDROID)
@@ -125,11 +113,7 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
       network::mojom::CSPDirectiveName::TrustedTypes, "trusted-types default;");
 }
 
-AIChatUI::~AIChatUI() {
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-  ClearPreviewUIId();
-#endif
-}
+AIChatUI::~AIChatUI() = default;
 
 void AIChatUI::BindInterface(
     mojo::PendingReceiver<ai_chat::mojom::PageHandler> receiver) {
@@ -140,212 +124,23 @@ void AIChatUI::BindInterface(
     embedder_->ShowUI();
   }
 
+  content::WebContents* web_contents = nullptr;
 #if !BUILDFLAG(IS_ANDROID)
   raw_ptr<Browser> browser =
       ai_chat::GetBrowserForWebContents(web_ui()->GetWebContents());
   DCHECK(browser);
   TabStripModel* tab_strip_model = browser->tab_strip_model();
   DCHECK(tab_strip_model);
-  web_contents_ = tab_strip_model->GetActiveWebContents();
+  web_contents = tab_strip_model->GetActiveWebContents();
 #else
-  web_contents_ = GetActiveWebContents(profile_);
+  web_contents = GetActiveWebContents(profile_);
 #endif
-  if (web_contents_ == web_ui()->GetWebContents()) {
-    web_contents_ = nullptr;
+  if (web_contents == web_ui()->GetWebContents()) {
+    web_contents = nullptr;
   }
   page_handler_ = std::make_unique<ai_chat::AIChatUIPageHandler>(
-      this, web_ui()->GetWebContents(), web_contents_.get(), profile_,
-      std::move(receiver));
+      web_ui()->GetWebContents(), web_contents, profile_, std::move(receiver));
 }
-
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-mojo::PendingAssociatedRemote<PrintPreviewUI> AIChatUI::BindPrintPreviewUI() {
-  return receiver_.BindNewEndpointAndPassRemote();
-}
-
-void AIChatUI::DisconnectPrintPrieviewUI() {
-  receiver_.reset();
-}
-
-bool AIChatUI::IsBound() const {
-  return receiver_.is_bound();
-}
-
-void AIChatUI::SetPreviewUIId() {
-  DCHECK(!print_preview_ui_id_);
-  print_preview_ui_id_ =
-      printing::PrintPreviewUI::GetPrintPreviewUIIdMap().Add(this);
-  printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap()
-      [*print_preview_ui_id_] = -1;
-}
-
-std::optional<int32_t> AIChatUI::GetPreviewUIId() {
-  return print_preview_ui_id_;
-}
-
-void AIChatUI::ClearPreviewUIId() {
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-
-  if (!print_preview_ui_id_) {
-    return;
-  }
-
-  DisconnectPrintPrieviewUI();
-  PrintPreviewDataService::GetInstance()->RemoveEntry(*print_preview_ui_id_);
-  printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap().erase(
-      *print_preview_ui_id_);
-  printing::PrintPreviewUI::GetPrintPreviewUIIdMap().Remove(
-      *print_preview_ui_id_);
-  print_preview_ui_id_.reset();
-}
-
-void AIChatUI::OnPrintPreviewRequest(int request_id) {
-  printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap()
-      [*print_preview_ui_id_] = request_id;
-}
-
-void AIChatUI::SetOptionsFromDocument(
-    const printing::mojom::OptionsFromDocumentParamsPtr params,
-    int32_t request_id) {}
-
-void AIChatUI::DidPrepareDocumentForPreview(int32_t document_cookie,
-                                            int32_t request_id) {
-  DVLOG(3) << __func__ << ": id=" << request_id;
-  // For case of print preview, page metafile is used to composite into
-  // the document PDF at same time.  Need to indicate that this scenario
-  // is at play for the compositor.
-  auto* client = PrintCompositeClient::FromWebContents(web_contents_);
-  DCHECK(client);
-  if (client->GetIsDocumentConcurrentlyComposited(document_cookie)) {
-    return;
-  }
-
-  content::RenderFrameHost* render_frame_host =
-      printing::GetFrameToPrint(web_contents_.get());
-  // |render_frame_host| could be null when the print preview dialog is closed.
-  if (!render_frame_host) {
-    return;
-  }
-
-  client->PrepareToCompositeDocument(
-      document_cookie, render_frame_host,
-      PrintCompositeClient::GetDocumentType(),
-      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
-          base::BindOnce(&AIChatUI::OnPrepareForDocumentToPdfDone,
-                         weak_ptr_factory_.GetWeakPtr(), request_id),
-          printing::mojom::PrintCompositor::Status::kCompositingFailure));
-}
-void AIChatUI::DidPreviewPage(printing::mojom::DidPreviewPageParamsPtr params,
-                              int32_t request_id) {
-  DVLOG(3) << __func__ << ": id=" << request_id;
-  uint32_t page_index = params->page_index;
-  const printing::mojom::DidPrintContentParams& content = *params->content;
-  if (page_index == printing::kInvalidPageIndex ||
-      !content.metafile_data_region.IsValid()) {
-    return;
-  }
-
-  auto* client = PrintCompositeClient::FromWebContents(web_contents_);
-  DCHECK(client);
-
-  content::RenderFrameHost* render_frame_host =
-      printing::GetFrameToPrint(web_contents_.get());
-  if (!render_frame_host) {
-    DLOG(ERROR) << "No render frame host for print preview";
-    return;
-  }
-
-  client->CompositePage(
-      params->document_cookie, render_frame_host, content,
-      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
-          base::BindOnce(&AIChatUI::OnCompositePdfPageDone,
-                         weak_ptr_factory_.GetWeakPtr(), page_index,
-                         params->document_cookie, request_id),
-          printing::mojom::PrintCompositor::Status::kCompositingFailure,
-          base::ReadOnlySharedMemoryRegion()));
-}
-void AIChatUI::MetafileReadyForPrinting(
-    printing::mojom::DidPreviewDocumentParamsPtr params,
-    int32_t request_id) {
-  DVLOG(3) << __func__ << ": id=" << request_id;
-  auto callback = base::BindOnce(&AIChatUI::OnCompositeToPdfDone,
-                                 weak_ptr_factory_.GetWeakPtr(),
-                                 params->document_cookie, request_id);
-
-  // Page metafile is used to composite into the document at same time.
-  // Need to provide particulars of how many pages are required before
-  // document will be completed.
-  auto* client = PrintCompositeClient::FromWebContents(web_contents_);
-  client->FinishDocumentComposition(
-      params->document_cookie, params->expected_pages_count,
-      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
-          std::move(callback),
-          printing::mojom::PrintCompositor::Status::kCompositingFailure,
-          base::ReadOnlySharedMemoryRegion()));
-}
-void AIChatUI::PrintPreviewFailed(int32_t document_cookie, int32_t request_id) {
-  DLOG(ERROR) << __func__ << ": id=" << request_id;
-  if (print_preview_ui_id_) {
-    printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap()
-        [*print_preview_ui_id_] = -1;
-  }
-}
-void AIChatUI::PrintPreviewCancelled(int32_t document_cookie,
-                                     int32_t request_id) {
-  DLOG(ERROR) << __func__ << ": id=" << request_id;
-}
-void AIChatUI::PrinterSettingsInvalid(int32_t document_cookie,
-                                      int32_t request_id) {
-  DLOG(ERROR) << __func__ << ": id=" << request_id;
-}
-
-void AIChatUI::DidGetDefaultPageLayout(
-    printing::mojom::PageSizeMarginsPtr page_layout_in_points,
-    const gfx::RectF& printable_area_in_points,
-    bool all_pages_have_custom_size,
-    bool all_pages_have_custom_orientation,
-    int32_t request_id) {}
-
-void AIChatUI::DidStartPreview(printing::mojom::DidStartPreviewParamsPtr params,
-                               int32_t request_id) {
-  DVLOG(3) << __func__ << ": id=" << request_id;
-}
-
-void AIChatUI::OnPrepareForDocumentToPdfDone(
-    int32_t request_id,
-    printing::mojom::PrintCompositor::Status status) {
-  DVLOG(3) << __func__ << ": id=" << request_id << " , status=" << status;
-}
-
-void AIChatUI::OnCompositePdfPageDone(
-    uint32_t page_index,
-    int document_cookie,
-    int32_t request_id,
-    printing::mojom::PrintCompositor::Status status,
-    base::ReadOnlySharedMemoryRegion region) {
-  DVLOG(3) << __func__ << ": id=" << request_id << " , status=" << status;
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  DCHECK(print_preview_ui_id_);
-
-  PrintPreviewDataService::GetInstance()->SetDataEntry(
-      *print_preview_ui_id_, page_index,
-      base::RefCountedSharedMemoryMapping::CreateFromWholeRegion(region));
-}
-
-void AIChatUI::OnCompositeToPdfDone(
-    int document_cookie,
-    int32_t request_id,
-    printing::mojom::PrintCompositor::Status status,
-    base::ReadOnlySharedMemoryRegion region) {
-  DVLOG(3) << __func__ << ": id=" << request_id << " , status=" << status;
-  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
-  DCHECK(print_preview_ui_id_);
-  PrintPreviewDataService::GetInstance()->SetDataEntry(
-      *print_preview_ui_id_, printing::COMPLETE_PREVIEW_DOCUMENT_INDEX,
-      base::RefCountedSharedMemoryMapping::CreateFromWholeRegion(region));
-  page_handler_->OnPreviewReady();
-}
-#endif
 
 std::unique_ptr<content::WebUIController>
 UntrustedChatUIConfig::CreateWebUIController(content::WebUI* web_ui,

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -17,21 +17,16 @@
 #include "brave/components/ai_chat/resources/page/grit/ai_chat_ui_generated_map.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/l10n/common/localization_util.h"
-#include "chrome/browser/printing/print_preview_data_service.h"
-#include "chrome/browser/printing/print_view_manager_common.h"
 #include "chrome/browser/profiles/profile.h"
-#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
 #include "chrome/browser/ui/webui/webui_util.h"
 #include "components/grit/brave_components_resources.h"
 #include "components/prefs/pref_service.h"
-#include "components/printing/browser/print_composite_client.h"
 #include "components/user_prefs/user_prefs.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "content/public/common/url_constants.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
-#include "printing/print_job_constants.h"
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/ui/browser.h"
@@ -40,7 +35,15 @@
 #include "chrome/browser/ui/android/tab_model/tab_model_list.h"
 #endif
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "chrome/browser/printing/print_preview_data_service.h"
+#include "chrome/browser/printing/print_view_manager_common.h"
+#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
+#include "components/printing/browser/print_composite_client.h"
+#include "printing/print_job_constants.h"
+
 using printing::PrintCompositeClient;
+#endif
 
 #if BUILDFLAG(IS_ANDROID)
 namespace {
@@ -123,7 +126,9 @@ AIChatUI::AIChatUI(content::WebUI* web_ui)
 }
 
 AIChatUI::~AIChatUI() {
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   ClearPreviewUIId();
+#endif
 }
 
 void AIChatUI::BindInterface(
@@ -153,6 +158,7 @@ void AIChatUI::BindInterface(
       std::move(receiver));
 }
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
 mojo::PendingAssociatedRemote<PrintPreviewUI> AIChatUI::BindPrintPreviewUI() {
   return receiver_.BindNewEndpointAndPassRemote();
 }
@@ -339,6 +345,7 @@ void AIChatUI::OnCompositeToPdfDone(
       base::RefCountedSharedMemoryMapping::CreateFromWholeRegion(region));
   page_handler_->OnPreviewReady();
 }
+#endif
 
 std::unique_ptr<content::WebUIController>
 UntrustedChatUIConfig::CreateWebUIController(content::WebUI* web_ui,

--- a/browser/ui/webui/ai_chat/ai_chat_ui.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.h
@@ -75,6 +75,10 @@ class AIChatUI : public ui::UntrustedWebUIController
 
   static constexpr std::string GetWebUIName() { return "AIChatPanel"; }
 
+  ai_chat::AIChatUIPageHandler* GetPageHandlerForTesting() {
+    return page_handler_.get();
+  }
+
  private:
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   // printing::mojo::PrintPreviewUI:

--- a/browser/ui/webui/ai_chat/ai_chat_ui.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.h
@@ -7,27 +7,14 @@
 #define BRAVE_BROWSER_UI_WEBUI_AI_CHAT_AI_CHAT_UI_H_
 
 #include <memory>
-#include <optional>
 #include <string>
 
-#include "base/memory/ref_counted_memory.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
-#include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_controller.h"
 #include "content/public/browser/webui_config.h"
-#include "printing/buildflags/buildflags.h"
 #include "ui/webui/mojo_bubble_web_ui_controller.h"
 #include "ui/webui/mojo_web_ui_controller.h"
 #include "ui/webui/untrusted_web_ui_controller.h"
-
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
-#include "components/printing/common/print.mojom.h"
-#include "components/services/print_compositor/public/mojom/print_compositor.mojom.h"
-#include "mojo/public/cpp/bindings/associated_receiver.h"
-
-using printing::mojom::PrintPreviewUI;
-#endif
 
 namespace content {
 class BrowserContext;
@@ -39,14 +26,7 @@ namespace ai_chat {
 class AIChatUIPageHandler;
 }  // namespace ai_chat
 
-class AIChatUI : public ui::UntrustedWebUIController
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-    ,
-                 public PrintPreviewUI {
-#else
-{
-#endif
-
+class AIChatUI : public ui::UntrustedWebUIController {
  public:
   explicit AIChatUI(content::WebUI* web_ui);
   AIChatUI(const AIChatUI&) = delete;
@@ -55,16 +35,6 @@ class AIChatUI : public ui::UntrustedWebUIController
 
   void BindInterface(
       mojo::PendingReceiver<ai_chat::mojom::PageHandler> receiver);
-
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-  mojo::PendingAssociatedRemote<PrintPreviewUI> BindPrintPreviewUI();
-  void DisconnectPrintPrieviewUI();
-  bool IsBound() const;
-  void SetPreviewUIId();
-  std::optional<int32_t> GetPreviewUIId();
-  void ClearPreviewUIId();
-  void OnPrintPreviewRequest(int request_id);
-#endif
 
   // Set by WebUIContentsWrapperT. MojoBubbleWebUIController provides default
   // implementation for this but we don't use it.
@@ -80,59 +50,11 @@ class AIChatUI : public ui::UntrustedWebUIController
   }
 
  private:
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-  // printing::mojo::PrintPreviewUI:
-  void SetOptionsFromDocument(
-      const printing::mojom::OptionsFromDocumentParamsPtr params,
-      int32_t request_id) override;
-  void DidPrepareDocumentForPreview(int32_t document_cookie,
-                                    int32_t request_id) override;
-  void DidPreviewPage(printing::mojom::DidPreviewPageParamsPtr params,
-                      int32_t request_id) override;
-  void MetafileReadyForPrinting(
-      printing::mojom::DidPreviewDocumentParamsPtr params,
-      int32_t request_id) override;
-  void PrintPreviewFailed(int32_t document_cookie, int32_t request_id) override;
-  void PrintPreviewCancelled(int32_t document_cookie,
-                             int32_t request_id) override;
-  void PrinterSettingsInvalid(int32_t document_cookie,
-                              int32_t request_id) override;
-  void DidGetDefaultPageLayout(
-      printing::mojom::PageSizeMarginsPtr page_layout_in_points,
-      const gfx::RectF& printable_area_in_points,
-      bool all_pages_have_custom_size,
-      bool all_pages_have_custom_orientation,
-      int32_t request_id) override;
-  void DidStartPreview(printing::mojom::DidStartPreviewParamsPtr params,
-                       int32_t request_id) override;
-
-  void OnPrepareForDocumentToPdfDone(
-      int32_t request_id,
-      printing::mojom::PrintCompositor::Status status);
-  void OnCompositePdfPageDone(uint32_t page_index,
-                              int32_t document_cookie,
-                              int32_t request_id,
-                              printing::mojom::PrintCompositor::Status status,
-                              base::ReadOnlySharedMemoryRegion region);
-  void OnCompositeToPdfDone(int document_cookie,
-                            int32_t request_id,
-                            printing::mojom::PrintCompositor::Status status,
-                            base::ReadOnlySharedMemoryRegion region);
-#endif
-
   std::unique_ptr<ai_chat::AIChatUIPageHandler> page_handler_;
 
   base::WeakPtr<ui::MojoBubbleWebUIController::Embedder> embedder_;
   raw_ptr<Profile> profile_ = nullptr;
-  raw_ptr<content::WebContents> web_contents_ = nullptr;
 
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-  // unique id to avoid conflicts with other print preview UIs
-  std::optional<int32_t> print_preview_ui_id_;
-  mojo::AssociatedReceiver<PrintPreviewUI> receiver_{this};
-#endif
-
-  base::WeakPtrFactory<AIChatUI> weak_ptr_factory_{this};
   WEB_UI_CONTROLLER_TYPE_DECL();
 };
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.h
@@ -7,14 +7,22 @@
 #define BRAVE_BROWSER_UI_WEBUI_AI_CHAT_AI_CHAT_UI_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 
+#include "base/memory/ref_counted_memory.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
+#include "components/printing/common/print.mojom.h"
+#include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_ui_controller.h"
 #include "content/public/browser/webui_config.h"
+#include "mojo/public/cpp/bindings/associated_receiver.h"
 #include "ui/webui/mojo_bubble_web_ui_controller.h"
 #include "ui/webui/mojo_web_ui_controller.h"
 #include "ui/webui/untrusted_web_ui_controller.h"
+
+#include "components/services/print_compositor/public/mojom/print_compositor.mojom.h"
 
 namespace content {
 class BrowserContext;
@@ -22,7 +30,13 @@ class BrowserContext;
 
 class Profile;
 
-class AIChatUI : public ui::UntrustedWebUIController {
+using printing::mojom::PrintPreviewUI;
+
+namespace ai_chat {
+class AIChatUIPageHandler;
+}  // namespace ai_chat
+
+class AIChatUI : public ui::UntrustedWebUIController, public PrintPreviewUI {
  public:
   explicit AIChatUI(content::WebUI* web_ui);
   AIChatUI(const AIChatUI&) = delete;
@@ -31,6 +45,14 @@ class AIChatUI : public ui::UntrustedWebUIController {
 
   void BindInterface(
       mojo::PendingReceiver<ai_chat::mojom::PageHandler> receiver);
+
+  mojo::PendingAssociatedRemote<PrintPreviewUI> BindPrintPreviewUI();
+  void DisconnectPrintPrieviewUI();
+  bool IsBound() const;
+  void SetPreviewUIId();
+  std::optional<int32_t> GetPreviewUIId();
+  void ClearPreviewUIId();
+  void OnPrintPreviewRequest(int request_id);
 
   // Set by WebUIContentsWrapperT. MojoBubbleWebUIController provides default
   // implementation for this but we don't use it.
@@ -42,11 +64,55 @@ class AIChatUI : public ui::UntrustedWebUIController {
   static constexpr std::string GetWebUIName() { return "AIChatPanel"; }
 
  private:
-  std::unique_ptr<ai_chat::mojom::PageHandler> page_handler_;
+  // printing::mojo::PrintPreviewUI:
+  void SetOptionsFromDocument(
+      const printing::mojom::OptionsFromDocumentParamsPtr params,
+      int32_t request_id) override;
+  void DidPrepareDocumentForPreview(int32_t document_cookie,
+                                    int32_t request_id) override;
+  void DidPreviewPage(printing::mojom::DidPreviewPageParamsPtr params,
+                      int32_t request_id) override;
+  void MetafileReadyForPrinting(
+      printing::mojom::DidPreviewDocumentParamsPtr params,
+      int32_t request_id) override;
+  void PrintPreviewFailed(int32_t document_cookie, int32_t request_id) override;
+  void PrintPreviewCancelled(int32_t document_cookie,
+                             int32_t request_id) override;
+  void PrinterSettingsInvalid(int32_t document_cookie,
+                              int32_t request_id) override;
+  void DidGetDefaultPageLayout(
+      printing::mojom::PageSizeMarginsPtr page_layout_in_points,
+      const gfx::RectF& printable_area_in_points,
+      bool all_pages_have_custom_size,
+      bool all_pages_have_custom_orientation,
+      int32_t request_id) override;
+  void DidStartPreview(printing::mojom::DidStartPreviewParamsPtr params,
+                       int32_t request_id) override;
+
+  void OnPrepareForDocumentToPdfDone(
+      int32_t request_id,
+      printing::mojom::PrintCompositor::Status status);
+  void OnCompositePdfPageDone(uint32_t page_index,
+                              int32_t document_cookie,
+                              int32_t request_id,
+                              printing::mojom::PrintCompositor::Status status,
+                              base::ReadOnlySharedMemoryRegion region);
+  void OnCompositeToPdfDone(int document_cookie,
+                            int32_t request_id,
+                            printing::mojom::PrintCompositor::Status status,
+                            base::ReadOnlySharedMemoryRegion region);
+
+  std::unique_ptr<ai_chat::AIChatUIPageHandler> page_handler_;
 
   base::WeakPtr<ui::MojoBubbleWebUIController::Embedder> embedder_;
   raw_ptr<Profile> profile_ = nullptr;
+  raw_ptr<content::WebContents> web_contents_ = nullptr;
 
+  // unique id to avoid conflicts with other print preview UIs
+  std::optional<int32_t> print_preview_ui_id_;
+  mojo::AssociatedReceiver<PrintPreviewUI> receiver_{this};
+
+  base::WeakPtrFactory<AIChatUI> weak_ptr_factory_{this};
   WEB_UI_CONTROLLER_TYPE_DECL();
 };
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.h
@@ -22,10 +22,6 @@ class BrowserContext;
 
 class Profile;
 
-namespace ai_chat {
-class AIChatUIPageHandler;
-}  // namespace ai_chat
-
 class AIChatUI : public ui::UntrustedWebUIController {
  public:
   explicit AIChatUI(content::WebUI* web_ui);
@@ -45,12 +41,8 @@ class AIChatUI : public ui::UntrustedWebUIController {
 
   static constexpr std::string GetWebUIName() { return "AIChatPanel"; }
 
-  ai_chat::AIChatUIPageHandler* GetPageHandlerForTesting() {
-    return page_handler_.get();
-  }
-
  private:
-  std::unique_ptr<ai_chat::AIChatUIPageHandler> page_handler_;
+  std::unique_ptr<ai_chat::mojom::PageHandler> page_handler_;
 
   base::WeakPtr<ui::MojoBubbleWebUIController::Embedder> embedder_;
   raw_ptr<Profile> profile_ = nullptr;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -18,9 +18,11 @@
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
 #include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/browser/models.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
+#include "brave/components/text_recognition/common/buildflags/buildflags.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
 #include "chrome/browser/pdf/pdf_pref_names.h"
 #include "chrome/browser/profiles/profile.h"
@@ -37,6 +39,7 @@
 #include "ui/base/l10n/l10n_util.h"
 
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom.h"
 #include "chrome/browser/printing/print_preview_data_service.h"
 #include "chrome/browser/printing/print_view_manager_common.h"
 #include "chrome/browser/printing/printing_service.h"
@@ -66,6 +69,107 @@ namespace ai_chat {
 using mojom::CharacterType;
 using mojom::ConversationTurn;
 using mojom::ConversationTurnVisibility;
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+class PreviewPageTextExtractor {
+ public:
+  PreviewPageTextExtractor(base::ReadOnlySharedMemoryRegion pdf_region,
+                           base::OnceCallback<void(std::string)> callback,
+                           uint32_t max_page_content_length,
+                           std::optional<bool> pdf_use_skia_renderer_enabled)
+      : pdf_region_(std::move(pdf_region)),
+        callback_(std::move(callback)),
+        max_page_content_length_(max_page_content_length) {
+    DCHECK(!pdf_to_bitmap_converter_.is_bound());
+    GetPrintingService()->BindPdfToBitmapConverter(
+        pdf_to_bitmap_converter_.BindNewPipeAndPassReceiver());
+    pdf_to_bitmap_converter_.set_disconnect_handler(
+        base::BindOnce(&PreviewPageTextExtractor::BitmapConverterDisconnected,
+                       base::Unretained(this)));
+    if (pdf_use_skia_renderer_enabled.has_value()) {
+      pdf_to_bitmap_converter_->SetUseSkiaRendererPolicy(
+          pdf_use_skia_renderer_enabled.value());
+    }
+  }
+
+  void StartExtract() {
+    pdf_to_bitmap_converter_->GetPdfPageCount(
+        pdf_region_.Duplicate(),
+        base::BindOnce(&PreviewPageTextExtractor::OnGetPageCount,
+                       base::Unretained(this)));
+  }
+
+  void ScheduleNextPageOrComplete() {
+    DCHECK_GT(total_page_count_, 0u);
+    if (current_page_index_ < total_page_count_) {
+      if (current_page_index_) {
+        preview_text_ << "\n";
+      }
+      pdf_to_bitmap_converter_->GetBitmap(
+          pdf_region_.Duplicate(), current_page_index_,
+          base::BindOnce(&PreviewPageTextExtractor::OnGetBitmap,
+                         base::Unretained(this)));
+    } else {
+      std::move(callback_).Run(preview_text_.str());
+    }
+  }
+
+  void OnGetPageCount(std::optional<uint32_t> page_count) {
+    if (!page_count.has_value() || !page_count.value()) {
+      std::move(callback_).Run("");
+      return;
+    }
+    total_page_count_ = page_count.value();
+    ScheduleNextPageOrComplete();
+  }
+
+  void OnGetBitmap(const SkBitmap& bitmap) {
+    if (bitmap.drawsNothing()) {
+      std::move(callback_).Run(preview_text_.str());
+      return;
+    }
+#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
+    GetOCRText(bitmap,
+               base::BindOnce(&PreviewPageTextExtractor::OnGetTextFromImage,
+                              weak_ptr_factory_.GetWeakPtr()));
+#else
+    std::move(callback_).Run("");
+#endif
+  }
+
+  void BitmapConverterDisconnected() {
+    DLOG(ERROR) << __func__;
+    if (callback_) {
+      std::move(callback_).Run(preview_text_.str());
+    }
+  }
+
+  void OnGetTextFromImage(std::string page_content) {
+    VLOG(4) << "Page index(" << current_page_index_
+            << ") content: " << page_content;
+    preview_text_ << page_content;
+    // Stop processing if we have reached the maximum number of pages or the
+    // maximum length of the content
+    if (current_page_index_ + 1 >= kMaxPreviewPages ||
+        preview_text_.str().length() >= max_page_content_length_) {
+      std::move(callback_).Run(preview_text_.str());
+      return;
+    }
+    ++current_page_index_;
+    ScheduleNextPageOrComplete();
+  }
+
+ private:
+  std::stringstream preview_text_;
+  size_t current_page_index_ = 0;
+  size_t total_page_count_ = 0;
+  base::ReadOnlySharedMemoryRegion pdf_region_;
+  base::OnceCallback<void(std::string)> callback_;
+  const uint32_t max_page_content_length_;
+  mojo::Remote<printing::mojom::PdfToBitmapConverter> pdf_to_bitmap_converter_;
+  base::WeakPtrFactory<PreviewPageTextExtractor> weak_ptr_factory_{this};
+};
+#endif
 
 AIChatUIPageHandler::AIChatUIPageHandler(
     AIChatUI* owner,
@@ -474,19 +578,6 @@ void AIChatUIPageHandler::OnGetPremiumStatus(
 }
 
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-void AIChatUIPageHandler::BitmapConverterDisconnected() {
-  DLOG(ERROR) << __func__;
-  PreviewCleanup();
-}
-
-void AIChatUIPageHandler::OnGetBitmaps(
-    const std::optional<std::vector<SkBitmap>>& bitmaps) {
-  VLOG(3) << __func__ << ": bitmap size: " << (bitmaps ? bitmaps->size() : -1);
-  pdf_to_bitmap_converter_.reset();
-  active_chat_tab_helper_->OnPreviewReady(bitmaps);
-  PreviewCleanup();
-}
-
 void AIChatUIPageHandler::PreviewCleanup() {
   auto preview_ui_id = owner_->GetPreviewUIId();
   CHECK(preview_ui_id);
@@ -511,22 +602,25 @@ void AIChatUIPageHandler::OnPreviewReady() {
     return;
   }
   memcpy(pdf_region.mapping.memory(), data->data(), data->size());
-  DCHECK(!pdf_to_bitmap_converter_.is_bound());
-  GetPrintingService()->BindPdfToBitmapConverter(
-      pdf_to_bitmap_converter_.BindNewPipeAndPassReceiver());
-  pdf_to_bitmap_converter_.set_disconnect_handler(
-      base::BindOnce(&AIChatUIPageHandler::BitmapConverterDisconnected,
-                     base::Unretained(this)));
+  std::optional<bool> pdf_use_skia_renderer_enabled;
   auto* prefs = profile_->GetPrefs();
   if (prefs &&
       prefs->IsManagedPreference(::prefs::kPdfUseSkiaRendererEnabled)) {
-    pdf_to_bitmap_converter_->SetUseSkiaRendererPolicy(
-        prefs->GetBoolean(::prefs::kPdfUseSkiaRendererEnabled));
+    pdf_use_skia_renderer_enabled =
+        prefs->GetBoolean(::prefs::kPdfUseSkiaRendererEnabled);
   }
-  pdf_to_bitmap_converter_->GetBitmap(
-      std::move(pdf_region.region), kMaxPreviewPages,
-      base::BindOnce(&AIChatUIPageHandler::OnGetBitmaps,
-                     base::Unretained(this)));
+  preview_page_text_extractor_ = std::make_unique<PreviewPageTextExtractor>(
+      std::move(pdf_region.region),
+      base::BindOnce(&AIChatUIPageHandler::OnGetOCRResult,
+                     weak_ptr_factory_.GetWeakPtr()),
+      active_chat_tab_helper_->GetMaxPageContentLength(),
+      pdf_use_skia_renderer_enabled);
+  preview_page_text_extractor_->StartExtract();
+}
+
+void AIChatUIPageHandler::OnGetOCRResult(std::string text) {
+  active_chat_tab_helper_->OnPreviewTextReady(std::move(text));
+  PreviewCleanup();
 }
 
 void AIChatUIPageHandler::MaybeCreatePrintPreview() {

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -535,6 +535,9 @@ void AIChatUIPageHandler::MaybeCreatePrintPreview() {
     if (!print_render_frame_.is_bound()) {
       rfh->GetRemoteAssociatedInterfaces()->GetInterface(&print_render_frame_);
     }
+
+    print_render_frame_->InitiatePrintPreview(false);
+
     if (!owner_->IsBound()) {
       print_render_frame_->SetPrintPreviewUI(owner_->BindPrintPreviewUI());
     }
@@ -544,8 +547,6 @@ void AIChatUIPageHandler::MaybeCreatePrintPreview() {
       preview_ui_id = owner_->GetPreviewUIId();
     }
     CHECK(preview_ui_id);
-
-    print_render_frame_->InitiatePrintPreview(false);
 
     // A mininum print setting to avoid PrinterSettingsInvalid
     auto settings = base::JSONReader::Read(R"({

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -524,7 +524,7 @@ void AIChatUIPageHandler::OnPreviewReady() {
         prefs->GetBoolean(::prefs::kPdfUseSkiaRendererEnabled));
   }
   pdf_to_bitmap_converter_->GetBitmap(
-      std::move(pdf_region.region),
+      std::move(pdf_region.region), kMaxPreviewPages,
       base::BindOnce(&AIChatUIPageHandler::OnGetBitmaps,
                      base::Unretained(this)));
 }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -530,7 +530,7 @@ void AIChatUIPageHandler::OnGetPremiumStatus(
 
 void AIChatUIPageHandler::BitmapConverterDisconnected() {
   DLOG(ERROR) << __func__;
-  // TODO(darkdh): cleanup
+  PreviewCleanup();
 }
 
 void AIChatUIPageHandler::OnGetBitmaps(
@@ -538,6 +538,10 @@ void AIChatUIPageHandler::OnGetBitmaps(
   VLOG(3) << __func__ << ": bitmap size: " << (bitmaps ? bitmaps->size() : -1);
   pdf_to_bitmap_converter_.reset();
   active_chat_tab_helper_->OnPreviewReady(bitmaps);
+  PreviewCleanup();
+}
+
+void AIChatUIPageHandler::PreviewCleanup() {
   auto preview_ui_id = owner_->GetPreviewUIId();
   CHECK(preview_ui_id);
   PrintPreviewDataService::GetInstance()->RemoveEntry(*preview_ui_id);

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -28,6 +28,7 @@
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/singleton_tabs.h"
+#include "chrome/common/pref_names.h"
 #include "components/favicon/core/favicon_service.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_context.h"
@@ -624,6 +625,12 @@ void AIChatUIPageHandler::OnGetOCRResult(std::string text) {
 }
 
 void AIChatUIPageHandler::MaybeCreatePrintPreview() {
+  const bool print_preview_disabled =
+      profile_->GetPrefs()->GetBoolean(::prefs::kPrintPreviewDisabled);
+  active_chat_tab_helper_->SetPrintPreviewDisabled(print_preview_disabled);
+  if (print_preview_disabled) {
+    return;
+  }
   auto url = active_chat_tab_helper_->web_contents()->GetLastCommittedURL();
   if (!base::Contains(kPrintPreviewRetrievalHosts, url.host_piece())) {
     return;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -23,13 +23,9 @@
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "chrome/browser/favicon/favicon_service_factory.h"
 #include "chrome/browser/pdf/pdf_pref_names.h"
-#include "chrome/browser/printing/print_preview_data_service.h"
-#include "chrome/browser/printing/print_view_manager_common.h"
-#include "chrome/browser/printing/printing_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/singleton_tabs.h"
-#include "chrome/services/printing/public/mojom/printing_service.mojom.h"
 #include "components/favicon/core/favicon_service.h"
 #include "components/prefs/pref_service.h"
 #include "content/public/browser/browser_context.h"
@@ -38,10 +34,17 @@
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/common/url_constants.h"
+#include "ui/base/l10n/l10n_util.h"
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "chrome/browser/printing/print_preview_data_service.h"
+#include "chrome/browser/printing/print_view_manager_common.h"
+#include "chrome/browser/printing/printing_service.h"
+#include "chrome/services/printing/public/mojom/printing_service.mojom.h"
 #include "printing/print_job_constants.h"
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
 #include "third_party/skia/include/core/SkBitmap.h"
-#include "ui/base/l10n/l10n_util.h"
+#endif
 
 #if BUILDFLAG(IS_ANDROID)
 #include "brave/browser/ui/android/ai_chat/brave_leo_settings_launcher_helper.h"
@@ -136,7 +139,9 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
       << "Should not be able to submit more"
       << "than a single human conversation turn at a time.";
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   MaybeCreatePrintPreview();
+#endif
 
   mojom::ConversationTurn turn = {
       CharacterType::HUMAN, mojom::ActionType::UNSPECIFIED,
@@ -468,6 +473,7 @@ void AIChatUIPageHandler::OnGetPremiumStatus(
   }
 }
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
 void AIChatUIPageHandler::BitmapConverterDisconnected() {
   DLOG(ERROR) << __func__;
   PreviewCleanup();
@@ -593,5 +599,6 @@ void AIChatUIPageHandler::MaybeCreatePrintPreview() {
     print_render_frame_->PrintPreview(std::move(dict));
   }
 }
+#endif
 
 }  // namespace ai_chat

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -102,6 +102,7 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   void OnPreviewReady();
   void BitmapConverterDisconnected();
   void OnGetBitmaps(const std::optional<std::vector<SkBitmap>>& bitmaps);
+  void PreviewCleanup();
 
  private:
   // AIChatTabHelper::Observer

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -37,7 +37,6 @@ namespace favicon {
 class FaviconService;
 }  // namespace favicon
 
-class AIChatUIBrowserTest;
 namespace ai_chat {
 class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
                             public AIChatTabHelper::Observer,
@@ -97,7 +96,6 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   void GetPremiumStatus(GetPremiumStatusCallback callback) override;
 
  private:
-  friend class ::AIChatUIBrowserTest;
   // AIChatTabHelper::Observer
   void OnHistoryUpdate() override;
   void OnAPIRequestInProgress(bool in_progress) override;
@@ -108,16 +106,13 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
       mojom::SuggestionGenerationStatus suggestion_generation_status) override;
   void OnFaviconImageDataChanged() override;
   void OnPageHasContent(mojom::SiteInfoPtr site_info) override;
+  void OnPrintPreviewRequested() override;
 
   void GetFaviconImageData(GetFaviconImageDataCallback callback) override;
 
   void OnGetPremiumStatus(GetPremiumStatusCallback callback,
                           ai_chat::mojom::PremiumStatus status,
                           ai_chat::mojom::PremiumInfoPtr info);
-
-#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-  void MaybeCreatePrintPreview();
-#endif
 
   mojo::Remote<ai_chat::mojom::ChatUIPage> page_;
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -122,6 +122,8 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
                           ai_chat::mojom::PremiumStatus status,
                           ai_chat::mojom::PremiumInfoPtr info);
 
+  void MaybeCreatePrintPreview();
+
   mojo::Remote<ai_chat::mojom::ChatUIPage> page_;
 
   // Used to transmit mojo interface method calls to the associated receiver.

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -42,6 +42,7 @@ class FaviconService;
 }  // namespace favicon
 
 class AIChatUI;
+class AIChatUIBrowserTest;
 namespace ai_chat {
 class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
                             public AIChatTabHelper::Observer,
@@ -109,6 +110,7 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
 #endif
 
  private:
+  friend class ::AIChatUIBrowserTest;
   // AIChatTabHelper::Observer
   void OnHistoryUpdate() override;
   void OnAPIRequestInProgress(bool in_progress) override;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -101,7 +101,7 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
 
   void OnPreviewReady();
   void BitmapConverterDisconnected();
-  void GotBitmap(const SkBitmap& bitmap);
+  void OnGetBitmaps(const std::optional<std::vector<SkBitmap>>& bitmaps);
 
  private:
   // AIChatTabHelper::Observer

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -28,7 +28,6 @@
 #include "printing/buildflags/buildflags.h"
 
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
-#include "brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom.h"
 #include "components/printing/common/print.mojom.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
 #endif
@@ -44,6 +43,9 @@ class FaviconService;
 class AIChatUI;
 class AIChatUIBrowserTest;
 namespace ai_chat {
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+class PreviewPageTextExtractor;
+#endif
 class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
                             public AIChatTabHelper::Observer,
                             public content::WebContentsObserver {
@@ -104,9 +106,8 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
 
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   void OnPreviewReady();
-  void BitmapConverterDisconnected();
-  void OnGetBitmaps(const std::optional<std::vector<SkBitmap>>& bitmaps);
   void PreviewCleanup();
+  void OnGetOCRResult(std::string text);
 #endif
 
  private:
@@ -146,7 +147,7 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
 
 #if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   int preview_request_id_ = -1;
-  mojo::Remote<printing::mojom::PdfToBitmapConverter> pdf_to_bitmap_converter_;
+  std::unique_ptr<PreviewPageTextExtractor> preview_page_text_extractor_;
   mojo::AssociatedRemote<printing::mojom::PrintRenderFrame> print_render_frame_;
 #endif
   mojo::Receiver<ai_chat::mojom::PageHandler> receiver_;

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -25,12 +25,14 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "printing/buildflags/buildflags.h"
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
 #include "brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom.h"
-#include "chrome/browser/printing/print_view_manager_base.h"
 #include "components/printing/common/print.mojom.h"
 #include "mojo/public/cpp/bindings/associated_remote.h"
-#include "mojo/public/cpp/bindings/remote.h"
+#endif
+
 namespace content {
 class WebContents;
 }
@@ -99,10 +101,12 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   void OnVisibilityChanged(content::Visibility visibility) override;
   void GetPremiumStatus(GetPremiumStatusCallback callback) override;
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   void OnPreviewReady();
   void BitmapConverterDisconnected();
   void OnGetBitmaps(const std::optional<std::vector<SkBitmap>>& bitmaps);
   void PreviewCleanup();
+#endif
 
  private:
   // AIChatTabHelper::Observer
@@ -122,12 +126,11 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
                           ai_chat::mojom::PremiumStatus status,
                           ai_chat::mojom::PremiumInfoPtr info);
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   void MaybeCreatePrintPreview();
+#endif
 
   mojo::Remote<ai_chat::mojom::ChatUIPage> page_;
-
-  // Used to transmit mojo interface method calls to the associated receiver.
-  mojo::AssociatedRemote<printing::mojom::PrintRenderFrame> print_render_frame_;
 
   raw_ptr<AIChatTabHelper> active_chat_tab_helper_ = nullptr;
   raw_ptr<AIChatUI> owner_ = nullptr;
@@ -139,8 +142,11 @@ class AIChatUIPageHandler : public ai_chat::mojom::PageHandler,
   base::ScopedObservation<AIChatTabHelper, AIChatTabHelper::Observer>
       chat_tab_helper_observation_{this};
 
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
   int preview_request_id_ = -1;
   mojo::Remote<printing::mojom::PdfToBitmapConverter> pdf_to_bitmap_converter_;
+  mojo::AssociatedRemote<printing::mojom::PrintRenderFrame> print_render_frame_;
+#endif
   mojo::Receiver<ai_chat::mojom::PageHandler> receiver_;
 
   base::WeakPtrFactory<AIChatUIPageHandler> weak_ptr_factory_{this};

--- a/browser/ui/webui/ai_chat/print_preview_extractor.cc
+++ b/browser/ui/webui/ai_chat/print_preview_extractor.cc
@@ -378,10 +378,8 @@ void PrintPreviewExtractor::OnGetOCRResult(std::string text) {
 }
 
 void PrintPreviewExtractor::CreatePrintPreview() {
-  const bool print_preview_disabled =
-      profile_->GetPrefs()->GetBoolean(::prefs::kPrintPreviewDisabled);
-  active_chat_tab_helper_->SetPrintPreviewDisabled(print_preview_disabled);
-  if (print_preview_disabled) {
+  if (profile_->GetPrefs()->GetBoolean(::prefs::kPrintPreviewDisabled)) {
+    active_chat_tab_helper_->OnPreviewTextReady("");
     return;
   }
   // TODO(darkdh): support pdf preview printing

--- a/browser/ui/webui/ai_chat/print_preview_extractor.cc
+++ b/browser/ui/webui/ai_chat/print_preview_extractor.cc
@@ -1,0 +1,450 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/ai_chat/print_preview_extractor.h"
+
+#include "base/json/json_reader.h"
+#include "base/strings/strcat.h"
+#include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/text_recognition/common/buildflags/buildflags.h"
+#include "brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom.h"
+#include "chrome/browser/pdf/pdf_pref_names.h"
+#include "chrome/browser/printing/print_preview_data_service.h"
+#include "chrome/browser/printing/print_view_manager_common.h"
+#include "chrome/browser/printing/printing_service.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
+#include "chrome/common/pref_names.h"
+#include "chrome/services/printing/public/mojom/printing_service.mojom.h"
+#include "components/prefs/pref_service.h"
+#include "components/printing/browser/print_composite_client.h"
+#include "content/public/browser/browser_thread.h"
+#include "mojo/public/cpp/bindings/callback_helpers.h"
+#include "printing/print_job_constants.h"
+#include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+
+static_assert(BUILDFLAG(ENABLE_PRINT_PREVIEW));
+
+using printing::PrintCompositeClient;
+using printing::mojom::PrintPreviewUI;
+
+namespace ai_chat {
+
+class PreviewPageTextExtractor {
+ public:
+  PreviewPageTextExtractor(base::ReadOnlySharedMemoryRegion pdf_region,
+                           base::OnceCallback<void(std::string)> callback,
+                           uint32_t max_page_content_length,
+                           std::optional<bool> pdf_use_skia_renderer_enabled)
+      : pdf_region_(std::move(pdf_region)),
+        callback_(std::move(callback)),
+        max_page_content_length_(max_page_content_length) {
+    DCHECK(!pdf_to_bitmap_converter_.is_bound());
+    GetPrintingService()->BindPdfToBitmapConverter(
+        pdf_to_bitmap_converter_.BindNewPipeAndPassReceiver());
+    pdf_to_bitmap_converter_.set_disconnect_handler(
+        base::BindOnce(&PreviewPageTextExtractor::BitmapConverterDisconnected,
+                       base::Unretained(this)));
+    if (pdf_use_skia_renderer_enabled.has_value()) {
+      pdf_to_bitmap_converter_->SetUseSkiaRendererPolicy(
+          pdf_use_skia_renderer_enabled.value());
+    }
+  }
+
+  void StartExtract() {
+    pdf_to_bitmap_converter_->GetPdfPageCount(
+        pdf_region_.Duplicate(),
+        base::BindOnce(&PreviewPageTextExtractor::OnGetPageCount,
+                       base::Unretained(this)));
+  }
+
+  void ScheduleNextPageOrComplete() {
+    DCHECK_GT(total_page_count_, 0u);
+    if (current_page_index_ < total_page_count_) {
+      if (current_page_index_) {
+        base::StrAppend(&preview_text_, {"\n"});
+      }
+      pdf_to_bitmap_converter_->GetBitmap(
+          pdf_region_.Duplicate(), current_page_index_,
+          base::BindOnce(&PreviewPageTextExtractor::OnGetBitmap,
+                         base::Unretained(this)));
+    } else {
+      std::move(callback_).Run(preview_text_);
+    }
+  }
+
+  void OnGetPageCount(std::optional<uint32_t> page_count) {
+    if (!page_count.has_value() || !page_count.value()) {
+      std::move(callback_).Run("");
+      return;
+    }
+    total_page_count_ = page_count.value();
+    ScheduleNextPageOrComplete();
+  }
+
+  void OnGetBitmap(const SkBitmap& bitmap) {
+    if (bitmap.drawsNothing()) {
+      std::move(callback_).Run(preview_text_);
+      return;
+    }
+#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
+    GetOCRText(bitmap,
+               base::BindOnce(&PreviewPageTextExtractor::OnGetTextFromImage,
+                              weak_ptr_factory_.GetWeakPtr()));
+#else
+    std::move(callback_).Run("");
+#endif
+  }
+
+  void BitmapConverterDisconnected() {
+    DLOG(ERROR) << __func__;
+    if (callback_) {
+      std::move(callback_).Run(preview_text_);
+    }
+  }
+
+  void OnGetTextFromImage(std::string page_content) {
+    VLOG(4) << "Page index(" << current_page_index_
+            << ") content: " << page_content;
+    base::StrAppend(&preview_text_, {page_content});
+    // Stop processing if we have reached the maximum number of pages or the
+    // maximum length of the content
+    if (current_page_index_ + 1 >= kMaxPreviewPages ||
+        preview_text_.length() >= max_page_content_length_) {
+      std::move(callback_).Run(preview_text_);
+      return;
+    }
+    ++current_page_index_;
+    ScheduleNextPageOrComplete();
+  }
+
+ private:
+  std::string preview_text_;
+  size_t current_page_index_ = 0;
+  size_t total_page_count_ = 0;
+  base::ReadOnlySharedMemoryRegion pdf_region_;
+  base::OnceCallback<void(std::string)> callback_;
+  const uint32_t max_page_content_length_;
+  mojo::Remote<printing::mojom::PdfToBitmapConverter> pdf_to_bitmap_converter_;
+  base::WeakPtrFactory<PreviewPageTextExtractor> weak_ptr_factory_{this};
+};
+
+PrintPreviewExtractor::PrintPreviewExtractor(content::WebContents* web_contents,
+                                             Profile* profile)
+    : web_contents_(web_contents),
+      profile_(profile),
+      active_chat_tab_helper_(AIChatTabHelper::FromWebContents(web_contents)) {
+  DCHECK(web_contents_);
+}
+
+PrintPreviewExtractor::~PrintPreviewExtractor() {
+  ClearPreviewUIId();
+}
+
+mojo::PendingAssociatedRemote<PrintPreviewUI>
+PrintPreviewExtractor::BindPrintPreviewUI() {
+  return print_preview_ui_receiver_.BindNewEndpointAndPassRemote();
+}
+
+void PrintPreviewExtractor::DisconnectPrintPrieviewUI() {
+  print_preview_ui_receiver_.reset();
+}
+
+bool PrintPreviewExtractor::IsPrintPreviewUIBound() const {
+  return print_preview_ui_receiver_.is_bound();
+}
+
+void PrintPreviewExtractor::SetPreviewUIId() {
+  DCHECK(!print_preview_ui_id_);
+  print_preview_ui_id_ =
+      printing::PrintPreviewUI::GetPrintPreviewUIIdMap().Add(this);
+  printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap()
+      [*print_preview_ui_id_] = -1;
+}
+
+void PrintPreviewExtractor::ClearPreviewUIId() {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+
+  if (!print_preview_ui_id_) {
+    return;
+  }
+
+  DisconnectPrintPrieviewUI();
+  PrintPreviewDataService::GetInstance()->RemoveEntry(*print_preview_ui_id_);
+  printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap().erase(
+      *print_preview_ui_id_);
+  printing::PrintPreviewUI::GetPrintPreviewUIIdMap().Remove(
+      *print_preview_ui_id_);
+  print_preview_ui_id_.reset();
+}
+
+void PrintPreviewExtractor::OnPrintPreviewRequest(int request_id) {
+  printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap()
+      [*print_preview_ui_id_] = request_id;
+}
+
+void PrintPreviewExtractor::SetOptionsFromDocument(
+    const printing::mojom::OptionsFromDocumentParamsPtr params,
+    int32_t request_id) {}
+
+void PrintPreviewExtractor::DidPrepareDocumentForPreview(
+    int32_t document_cookie,
+    int32_t request_id) {
+  DVLOG(3) << __func__ << ": id=" << request_id;
+  // For case of print preview, page metafile is used to composite into
+  // the document PDF at same time.  Need to indicate that this scenario
+  // is at play for the compositor.
+  auto* client = PrintCompositeClient::FromWebContents(web_contents_);
+  DCHECK(client);
+  if (client->GetIsDocumentConcurrentlyComposited(document_cookie)) {
+    return;
+  }
+
+  content::RenderFrameHost* render_frame_host =
+      printing::GetFrameToPrint(web_contents_.get());
+  // |render_frame_host| could be null when the print preview dialog is closed.
+  if (!render_frame_host) {
+    return;
+  }
+
+  client->PrepareToCompositeDocument(
+      document_cookie, render_frame_host,
+      PrintCompositeClient::GetDocumentType(),
+      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+          base::BindOnce(&PrintPreviewExtractor::OnPrepareForDocumentToPdfDone,
+                         weak_ptr_factory_.GetWeakPtr(), request_id),
+          printing::mojom::PrintCompositor::Status::kCompositingFailure));
+}
+void PrintPreviewExtractor::DidPreviewPage(
+    printing::mojom::DidPreviewPageParamsPtr params,
+    int32_t request_id) {
+  DVLOG(3) << __func__ << ": id=" << request_id;
+  uint32_t page_index = params->page_index;
+  const printing::mojom::DidPrintContentParams& content = *params->content;
+  if (page_index == printing::kInvalidPageIndex ||
+      !content.metafile_data_region.IsValid()) {
+    return;
+  }
+
+  auto* client = PrintCompositeClient::FromWebContents(web_contents_);
+  DCHECK(client);
+
+  content::RenderFrameHost* render_frame_host =
+      printing::GetFrameToPrint(web_contents_.get());
+  if (!render_frame_host) {
+    DLOG(ERROR) << "No render frame host for print preview";
+    return;
+  }
+
+  client->CompositePage(
+      params->document_cookie, render_frame_host, content,
+      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+          base::BindOnce(&PrintPreviewExtractor::OnCompositePdfPageDone,
+                         weak_ptr_factory_.GetWeakPtr(), page_index,
+                         params->document_cookie, request_id),
+          printing::mojom::PrintCompositor::Status::kCompositingFailure,
+          base::ReadOnlySharedMemoryRegion()));
+}
+void PrintPreviewExtractor::MetafileReadyForPrinting(
+    printing::mojom::DidPreviewDocumentParamsPtr params,
+    int32_t request_id) {
+  DVLOG(3) << __func__ << ": id=" << request_id;
+  auto callback = base::BindOnce(&PrintPreviewExtractor::OnCompositeToPdfDone,
+                                 weak_ptr_factory_.GetWeakPtr(),
+                                 params->document_cookie, request_id);
+
+  // Page metafile is used to composite into the document at same time.
+  // Need to provide particulars of how many pages are required before
+  // document will be completed.
+  auto* client = PrintCompositeClient::FromWebContents(web_contents_);
+  client->FinishDocumentComposition(
+      params->document_cookie, params->expected_pages_count,
+      mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+          std::move(callback),
+          printing::mojom::PrintCompositor::Status::kCompositingFailure,
+          base::ReadOnlySharedMemoryRegion()));
+}
+void PrintPreviewExtractor::PrintPreviewFailed(int32_t document_cookie,
+                                               int32_t request_id) {
+  DLOG(ERROR) << __func__ << ": id=" << request_id;
+  if (print_preview_ui_id_) {
+    printing::PrintPreviewUI::GetPrintPreviewUIRequestIdMap()
+        [*print_preview_ui_id_] = -1;
+  }
+}
+void PrintPreviewExtractor::PrintPreviewCancelled(int32_t document_cookie,
+                                                  int32_t request_id) {
+  DLOG(ERROR) << __func__ << ": id=" << request_id;
+}
+void PrintPreviewExtractor::PrinterSettingsInvalid(int32_t document_cookie,
+                                                   int32_t request_id) {
+  DLOG(ERROR) << __func__ << ": id=" << request_id;
+}
+
+void PrintPreviewExtractor::DidGetDefaultPageLayout(
+    printing::mojom::PageSizeMarginsPtr page_layout_in_points,
+    const gfx::RectF& printable_area_in_points,
+    bool all_pages_have_custom_size,
+    bool all_pages_have_custom_orientation,
+    int32_t request_id) {}
+
+void PrintPreviewExtractor::DidStartPreview(
+    printing::mojom::DidStartPreviewParamsPtr params,
+    int32_t request_id) {
+  DVLOG(3) << __func__ << ": id=" << request_id;
+}
+
+void PrintPreviewExtractor::OnPrepareForDocumentToPdfDone(
+    int32_t request_id,
+    printing::mojom::PrintCompositor::Status status) {
+  DVLOG(3) << __func__ << ": id=" << request_id << " , status=" << status;
+}
+
+void PrintPreviewExtractor::OnCompositePdfPageDone(
+    uint32_t page_index,
+    int document_cookie,
+    int32_t request_id,
+    printing::mojom::PrintCompositor::Status status,
+    base::ReadOnlySharedMemoryRegion region) {
+  DVLOG(3) << __func__ << ": id=" << request_id << " , status=" << status;
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(print_preview_ui_id_);
+
+  PrintPreviewDataService::GetInstance()->SetDataEntry(
+      *print_preview_ui_id_, page_index,
+      base::RefCountedSharedMemoryMapping::CreateFromWholeRegion(region));
+}
+
+void PrintPreviewExtractor::OnCompositeToPdfDone(
+    int document_cookie,
+    int32_t request_id,
+    printing::mojom::PrintCompositor::Status status,
+    base::ReadOnlySharedMemoryRegion region) {
+  DVLOG(3) << __func__ << ": id=" << request_id << " , status=" << status;
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  DCHECK(print_preview_ui_id_);
+  PrintPreviewDataService::GetInstance()->SetDataEntry(
+      *print_preview_ui_id_, printing::COMPLETE_PREVIEW_DOCUMENT_INDEX,
+      base::RefCountedSharedMemoryMapping::CreateFromWholeRegion(region));
+  OnPreviewReady();
+}
+
+void PrintPreviewExtractor::PreviewCleanup() {
+  CHECK(print_preview_ui_id_);
+  PrintPreviewDataService::GetInstance()->RemoveEntry(*print_preview_ui_id_);
+  print_render_frame_->OnPrintPreviewDialogClosed();
+  DisconnectPrintPrieviewUI();
+}
+
+void PrintPreviewExtractor::OnPreviewReady() {
+  scoped_refptr<base::RefCountedMemory> data;
+  CHECK(print_preview_ui_id_);
+  PrintPreviewDataService::GetInstance()->GetDataEntry(
+      *print_preview_ui_id_, printing::COMPLETE_PREVIEW_DOCUMENT_INDEX, &data);
+  if (!data.get()) {
+    DLOG(ERROR) << "no data from preview id: " << *print_preview_ui_id_;
+    return;
+  }
+  auto pdf_region = base::ReadOnlySharedMemoryRegion::Create(data->size());
+  if (!pdf_region.IsValid()) {
+    DLOG(ERROR) << "Failed allocate memory for PDF file";
+    return;
+  }
+  memcpy(pdf_region.mapping.memory(), data->data(), data->size());
+  std::optional<bool> pdf_use_skia_renderer_enabled;
+  auto* prefs = profile_->GetPrefs();
+  if (prefs &&
+      prefs->IsManagedPreference(::prefs::kPdfUseSkiaRendererEnabled)) {
+    pdf_use_skia_renderer_enabled =
+        prefs->GetBoolean(::prefs::kPdfUseSkiaRendererEnabled);
+  }
+  preview_page_text_extractor_ = std::make_unique<PreviewPageTextExtractor>(
+      std::move(pdf_region.region),
+      base::BindOnce(&PrintPreviewExtractor::OnGetOCRResult,
+                     weak_ptr_factory_.GetWeakPtr()),
+      active_chat_tab_helper_->GetMaxPageContentLength(),
+      pdf_use_skia_renderer_enabled);
+  preview_page_text_extractor_->StartExtract();
+}
+
+void PrintPreviewExtractor::OnGetOCRResult(std::string text) {
+  active_chat_tab_helper_->OnPreviewTextReady(std::move(text));
+  PreviewCleanup();
+}
+
+void PrintPreviewExtractor::CreatePrintPreview() {
+  const bool print_preview_disabled =
+      profile_->GetPrefs()->GetBoolean(::prefs::kPrintPreviewDisabled);
+  active_chat_tab_helper_->SetPrintPreviewDisabled(print_preview_disabled);
+  if (print_preview_disabled) {
+    return;
+  }
+  // TODO(darkdh): support pdf preview printing
+  content::RenderFrameHost* rfh = printing::GetFrameToPrint(web_contents_);
+  if (rfh) {
+    if (!print_render_frame_.is_bound()) {
+      rfh->GetRemoteAssociatedInterfaces()->GetInterface(&print_render_frame_);
+    }
+
+    print_render_frame_->InitiatePrintPreview(false);
+
+    if (!IsPrintPreviewUIBound()) {
+      print_render_frame_->SetPrintPreviewUI(BindPrintPreviewUI());
+    }
+    if (!print_preview_ui_id_) {
+      SetPreviewUIId();
+    }
+    CHECK(print_preview_ui_id_);
+
+    // A mininum print setting to avoid PrinterSettingsInvalid
+    auto settings = base::JSONReader::Read(R"({
+   "collate": true,
+   "color": 2,
+   "copies": 1,
+   "deviceName": "Save as PDF",
+   "dpiHorizontal": 300,
+   "dpiVertical": 300,
+   "duplex": 0,
+   "headerFooterEnabled": false,
+   "isFirstRequest": true,
+   "landscape": false,
+   "marginsType": 0,
+   "mediaSize": {
+      "custom_display_name": "Letter",
+      "height_microns": 279400,
+      "imageable_area_bottom_microns": 0,
+      "imageable_area_left_microns": 0,
+      "imageable_area_right_microns": 215900,
+      "imageable_area_top_microns": 279400,
+      "is_default": true,
+      "name": "NA_LETTER",
+      "width_microns": 215900
+   },
+   "pageRange": [  ],
+   "pagesPerSheet": 1,
+   "previewModifiable": true,
+   "printerType": 2,
+   "rasterizePDF": false,
+   "scaleFactor": 100,
+   "scalingType": 0,
+   "shouldPrintBackgrounds": false,
+   "shouldPrintSelectionOnly": false
+  })");
+    CHECK(settings);
+    auto dict = std::move(*settings).TakeDict();
+    dict.Set(printing::kPreviewUIID, print_preview_ui_id_.value());
+    dict.Set(printing::kPreviewRequestID, ++preview_request_id_);
+    dict.Set(printing::kSettingHeaderFooterTitle, web_contents_->GetTitle());
+    auto url = web_contents_->GetLastCommittedURL();
+    dict.Set(printing::kSettingHeaderFooterURL, url.spec());
+    OnPrintPreviewRequest(preview_request_id_);
+    print_render_frame_->PrintPreview(std::move(dict));
+  }
+}
+
+}  // namespace ai_chat

--- a/browser/ui/webui/ai_chat/print_preview_extractor.h
+++ b/browser/ui/webui/ai_chat/print_preview_extractor.h
@@ -1,0 +1,108 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_AI_CHAT_PRINT_PREVIEW_EXTRACTOR_H_
+#define BRAVE_BROWSER_UI_WEBUI_AI_CHAT_PRINT_PREVIEW_EXTRACTOR_H_
+
+#include <optional>
+
+#include "base/memory/ref_counted_memory.h"
+#include "base/memory/weak_ptr.h"
+#include "chrome/browser/ui/webui/print_preview/print_preview_ui.h"
+#include "components/printing/common/print.mojom.h"
+#include "components/services/print_compositor/public/mojom/print_compositor.mojom.h"
+#include "mojo/public/cpp/bindings/associated_receiver.h"
+#include "mojo/public/cpp/bindings/associated_remote.h"
+#include "printing/buildflags/buildflags.h"
+
+static_assert(BUILDFLAG(ENABLE_PRINT_PREVIEW));
+
+namespace content {
+class WebContents;
+}  // namespace content
+
+class Profile;
+
+namespace ai_chat {
+class AIChatTabHelper;
+class PreviewPageTextExtractor;
+
+class PrintPreviewExtractor : public printing::mojom::PrintPreviewUI {
+ public:
+  PrintPreviewExtractor(content::WebContents* web_contents, Profile* profile);
+  ~PrintPreviewExtractor() override;
+
+  PrintPreviewExtractor(const PrintPreviewExtractor&) = delete;
+  PrintPreviewExtractor& operator=(const PrintPreviewExtractor&) = delete;
+
+  void CreatePrintPreview();
+
+ private:
+  // printing::mojom::PrintPreviewUI:
+  void SetOptionsFromDocument(
+      const printing::mojom::OptionsFromDocumentParamsPtr params,
+      int32_t request_id) override;
+  void DidPrepareDocumentForPreview(int32_t document_cookie,
+                                    int32_t request_id) override;
+  void DidPreviewPage(printing::mojom::DidPreviewPageParamsPtr params,
+                      int32_t request_id) override;
+  void MetafileReadyForPrinting(
+      printing::mojom::DidPreviewDocumentParamsPtr params,
+      int32_t request_id) override;
+  void PrintPreviewFailed(int32_t document_cookie, int32_t request_id) override;
+  void PrintPreviewCancelled(int32_t document_cookie,
+                             int32_t request_id) override;
+  void PrinterSettingsInvalid(int32_t document_cookie,
+                              int32_t request_id) override;
+  void DidGetDefaultPageLayout(
+      printing::mojom::PageSizeMarginsPtr page_layout_in_points,
+      const gfx::RectF& printable_area_in_points,
+      bool all_pages_have_custom_size,
+      bool all_pages_have_custom_orientation,
+      int32_t request_id) override;
+  void DidStartPreview(printing::mojom::DidStartPreviewParamsPtr params,
+                       int32_t request_id) override;
+
+  mojo::PendingAssociatedRemote<PrintPreviewUI> BindPrintPreviewUI();
+  void DisconnectPrintPrieviewUI();
+  bool IsPrintPreviewUIBound() const;
+  void SetPreviewUIId();
+  void ClearPreviewUIId();
+  void OnPrintPreviewRequest(int request_id);
+
+  void OnPreviewReady();
+  void PreviewCleanup();
+  void OnGetOCRResult(std::string text);
+
+  void OnPrepareForDocumentToPdfDone(
+      int32_t request_id,
+      printing::mojom::PrintCompositor::Status status);
+  void OnCompositePdfPageDone(uint32_t page_index,
+                              int32_t document_cookie,
+                              int32_t request_id,
+                              printing::mojom::PrintCompositor::Status status,
+                              base::ReadOnlySharedMemoryRegion region);
+  void OnCompositeToPdfDone(int document_cookie,
+                            int32_t request_id,
+                            printing::mojom::PrintCompositor::Status status,
+                            base::ReadOnlySharedMemoryRegion region);
+
+  raw_ptr<content::WebContents> web_contents_ = nullptr;
+  raw_ptr<Profile> profile_ = nullptr;
+  raw_ptr<AIChatTabHelper> active_chat_tab_helper_ = nullptr;
+  // unique id to avoid conflicts with other print preview UIs
+  std::optional<int32_t> print_preview_ui_id_;
+  mojo::AssociatedReceiver<PrintPreviewUI> print_preview_ui_receiver_{this};
+
+  int preview_request_id_ = -1;
+  std::unique_ptr<PreviewPageTextExtractor> preview_page_text_extractor_;
+  mojo::AssociatedRemote<printing::mojom::PrintRenderFrame> print_render_frame_;
+
+  base::WeakPtrFactory<PrintPreviewExtractor> weak_ptr_factory_{this};
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_AI_CHAT_PRINT_PREVIEW_EXTRACTOR_H_

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -68,22 +68,12 @@ async function applyPatches() {
   Log.progressFinish('apply patches')
 }
 
-// Always rebuild typedef export to avoid linkage error.
-const isOverrideExportTypedef = (override) => {
-  const exportedHeaders = ['print_view_manager.h'];
-  if (exportedHeaders.includes(path.basename(override))) {
-    return true
-  }
-  return false
-}
-
 const isOverrideNewer = (original, override) => {
   return (fs.statSync(override).mtimeMs - fs.statSync(original).mtimeMs > 0)
 }
 
 const updateFileUTimesIfOverrideIsNewer = (original, override) => {
-  if (isOverrideNewer(original, override) ||
-      isOverrideExportTypedef(override)) {
+  if (isOverrideNewer(original, override)) {
     const date = new Date()
     fs.utimesSync(original, date, date)
     console.log(original + ' is touched.')

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -68,12 +68,22 @@ async function applyPatches() {
   Log.progressFinish('apply patches')
 }
 
+// Always rebuild typedef export to avoid linkage error.
+const isOverrideExportTypedef = (override) => {
+  const exportedHeaders = ['print_view_manager.h'];
+  if (exportedHeaders.includes(path.basename(override))) {
+    return true
+  }
+  return false
+}
+
 const isOverrideNewer = (original, override) => {
   return (fs.statSync(override).mtimeMs - fs.statSync(original).mtimeMs > 0)
 }
 
 const updateFileUTimesIfOverrideIsNewer = (original, override) => {
-  if (isOverrideNewer(original, override)) {
+  if (isOverrideNewer(original, override) ||
+      isOverrideExportTypedef(override)) {
     const date = new Date()
     fs.utimesSync(original, date, date)
     console.log(original + ' is touched.')

--- a/chromium_src/chrome/browser/printing/print_view_manager.cc
+++ b/chromium_src/chrome/browser/printing/print_view_manager.cc
@@ -1,0 +1,101 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/printing/print_view_manager.h"
+
+#define PrintViewManager PrintViewManager_ChromiumImpl
+#include "src/chrome/browser/printing/print_view_manager.cc"
+#undef PrintViewManager
+
+namespace printing {
+
+BravePrintViewManager::BravePrintViewManager(content::WebContents* web_contents)
+    : PrintViewManager_ChromiumImpl(web_contents) {}
+
+BravePrintViewManager::~BravePrintViewManager() = default;
+
+// static
+void BravePrintViewManager::CreateForWebContents(
+    content::WebContents* web_contents) {
+  if (!FromWebContents(web_contents)) {
+    web_contents->SetUserData(
+        PrintViewManager_ChromiumImpl::UserDataKey(),
+        std::make_unique<BravePrintViewManager>(web_contents));
+  }
+}
+
+// static
+BravePrintViewManager* BravePrintViewManager::FromWebContents(
+    content::WebContents* web_contents) {
+  return static_cast<BravePrintViewManager*>(
+      web_contents->GetUserData(PrintViewManager_ChromiumImpl::UserDataKey()));
+}
+
+// static
+void BravePrintViewManager::BindPrintManagerHost(
+    mojo::PendingAssociatedReceiver<mojom::PrintManagerHost> receiver,
+    content::RenderFrameHost* rfh) {
+  PrintViewManager_ChromiumImpl::BindPrintManagerHost(std::move(receiver), rfh);
+}
+
+bool BravePrintViewManager::PrintForSystemDialogNow(
+    base::OnceClosure dialog_shown_callback) {
+  return PrintViewManager_ChromiumImpl::PrintForSystemDialogNow(
+      std::move(dialog_shown_callback));
+}
+
+bool BravePrintViewManager::BasicPrint(content::RenderFrameHost* rfh) {
+  return PrintViewManager_ChromiumImpl::BasicPrint(rfh);
+}
+
+bool BravePrintViewManager::PrintPreviewNow(content::RenderFrameHost* rfh,
+                                            bool has_selection) {
+  return PrintViewManager_ChromiumImpl::PrintPreviewNow(rfh, has_selection);
+}
+
+#if BUILDFLAG(IS_CHROMEOS_ASH)
+bool BravePrintViewManager::PrintPreviewWithPrintRenderer(
+    content::RenderFrameHost* rfh,
+    mojo::PendingAssociatedRemote<mojom::PrintRenderer> print_renderer) {
+  return PrintViewManager_ChromiumImpl::PrintPreviewWithPrintRenderer(
+      rfh, std::move(print_renderer));
+}
+#endif
+
+void BravePrintViewManager::PrintPreviewForNodeUnderContextMenu(
+    content::RenderFrameHost* rfh) {
+  PrintViewManager_ChromiumImpl::PrintPreviewForNodeUnderContextMenu(rfh);
+}
+
+void BravePrintViewManager::PrintPreviewAlmostDone() {
+  PrintViewManager_ChromiumImpl::PrintPreviewAlmostDone();
+}
+
+void BravePrintViewManager::PrintPreviewDone() {
+  PrintViewManager_ChromiumImpl::PrintPreviewDone();
+}
+
+content::RenderFrameHost* BravePrintViewManager::print_preview_rfh() {
+  return PrintViewManager_ChromiumImpl::print_preview_rfh();
+}
+
+// static
+void BravePrintViewManager::SetReceiverImplForTesting(PrintManager* impl) {
+  PrintViewManager_ChromiumImpl::SetReceiverImplForTesting(impl);
+}
+
+void BravePrintViewManager::RejectPrintPreviewRequestIfRestricted(
+    content::GlobalRenderFrameHostId rfh_id,
+    base::OnceCallback<void(bool should_proceed)> callback) {
+  // Initiated from AIChatUI
+  if (print_preview_state_ == NOT_PREVIEWING && !g_receiver_for_testing) {
+    std::move(callback).Run(/*should_proceed=*/false);
+    return;
+  }
+  PrintViewManager_ChromiumImpl::RejectPrintPreviewRequestIfRestricted(
+      rfh_id, std::move(callback));
+}
+
+}  // namespace printing

--- a/chromium_src/chrome/browser/printing/print_view_manager.cc
+++ b/chromium_src/chrome/browser/printing/print_view_manager.cc
@@ -11,82 +11,28 @@
 
 namespace printing {
 
-BravePrintViewManager::BravePrintViewManager(content::WebContents* web_contents)
+PrintViewManager::PrintViewManager(content::WebContents* web_contents)
     : PrintViewManager_ChromiumImpl(web_contents) {}
 
-BravePrintViewManager::~BravePrintViewManager() = default;
+PrintViewManager::~PrintViewManager() = default;
 
 // static
-void BravePrintViewManager::CreateForWebContents(
+void PrintViewManager::CreateForWebContents(
     content::WebContents* web_contents) {
   if (!FromWebContents(web_contents)) {
-    web_contents->SetUserData(
-        PrintViewManager_ChromiumImpl::UserDataKey(),
-        std::make_unique<BravePrintViewManager>(web_contents));
+    web_contents->SetUserData(PrintViewManager_ChromiumImpl::UserDataKey(),
+                              std::make_unique<PrintViewManager>(web_contents));
   }
 }
 
 // static
-BravePrintViewManager* BravePrintViewManager::FromWebContents(
+PrintViewManager* PrintViewManager::FromWebContents(
     content::WebContents* web_contents) {
-  return static_cast<BravePrintViewManager*>(
+  return static_cast<PrintViewManager*>(
       web_contents->GetUserData(PrintViewManager_ChromiumImpl::UserDataKey()));
 }
 
-// static
-void BravePrintViewManager::BindPrintManagerHost(
-    mojo::PendingAssociatedReceiver<mojom::PrintManagerHost> receiver,
-    content::RenderFrameHost* rfh) {
-  PrintViewManager_ChromiumImpl::BindPrintManagerHost(std::move(receiver), rfh);
-}
-
-bool BravePrintViewManager::PrintForSystemDialogNow(
-    base::OnceClosure dialog_shown_callback) {
-  return PrintViewManager_ChromiumImpl::PrintForSystemDialogNow(
-      std::move(dialog_shown_callback));
-}
-
-bool BravePrintViewManager::BasicPrint(content::RenderFrameHost* rfh) {
-  return PrintViewManager_ChromiumImpl::BasicPrint(rfh);
-}
-
-bool BravePrintViewManager::PrintPreviewNow(content::RenderFrameHost* rfh,
-                                            bool has_selection) {
-  return PrintViewManager_ChromiumImpl::PrintPreviewNow(rfh, has_selection);
-}
-
-#if BUILDFLAG(IS_CHROMEOS_ASH)
-bool BravePrintViewManager::PrintPreviewWithPrintRenderer(
-    content::RenderFrameHost* rfh,
-    mojo::PendingAssociatedRemote<mojom::PrintRenderer> print_renderer) {
-  return PrintViewManager_ChromiumImpl::PrintPreviewWithPrintRenderer(
-      rfh, std::move(print_renderer));
-}
-#endif
-
-void BravePrintViewManager::PrintPreviewForNodeUnderContextMenu(
-    content::RenderFrameHost* rfh) {
-  PrintViewManager_ChromiumImpl::PrintPreviewForNodeUnderContextMenu(rfh);
-}
-
-void BravePrintViewManager::PrintPreviewAlmostDone() {
-  PrintViewManager_ChromiumImpl::PrintPreviewAlmostDone();
-}
-
-void BravePrintViewManager::PrintPreviewDone() {
-  PrintViewManager_ChromiumImpl::PrintPreviewDone();
-}
-
-content::RenderFrameHost* BravePrintViewManager::print_preview_rfh() {
-  return PrintViewManager_ChromiumImpl::print_preview_rfh();
-}
-
-// static
-void BravePrintViewManager::SetReceiverImplForTesting(PrintManager* impl) {
-  PrintViewManager_ChromiumImpl::SetReceiverImplForTesting(impl);
-}
-
-void BravePrintViewManager::RejectPrintPreviewRequestIfRestricted(
+void PrintViewManager::RejectPrintPreviewRequestIfRestricted(
     content::GlobalRenderFrameHostId rfh_id,
     base::OnceCallback<void(bool should_proceed)> callback) {
   // Initiated from AIChatUI

--- a/chromium_src/chrome/browser/printing/print_view_manager.h
+++ b/chromium_src/chrome/browser/printing/print_view_manager.h
@@ -1,0 +1,74 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_H_
+
+#define PrintViewManager PrintViewManager_ChromiumImpl
+#define PrintPreviewForWebNode        \
+  PrintPreviewForWebNodeUnused();     \
+  friend class BravePrintViewManager; \
+  void PrintPreviewForWebNode
+#include "src/chrome/browser/printing/print_view_manager.h"  // IWYU pragma: export
+#undef PrintPreviewForWebNode
+#undef PrintViewManager
+
+namespace printing {
+
+class BravePrintViewManager : public PrintViewManager_ChromiumImpl {
+ public:
+  explicit BravePrintViewManager(content::WebContents* web_contents);
+
+  BravePrintViewManager(const BravePrintViewManager&) = delete;
+  BravePrintViewManager& operator=(const BravePrintViewManager&) = delete;
+
+  ~BravePrintViewManager() override;
+
+  static void CreateForWebContents(content::WebContents* web_contents);
+
+  static BravePrintViewManager* FromWebContents(
+      content::WebContents* web_contents);
+
+  static void BindPrintManagerHost(
+      mojo::PendingAssociatedReceiver<mojom::PrintManagerHost> receiver,
+      content::RenderFrameHost* rfh);
+
+  bool PrintForSystemDialogNow(base::OnceClosure dialog_shown_callback);
+
+  bool BasicPrint(content::RenderFrameHost* rfh);
+
+  bool PrintPreviewNow(content::RenderFrameHost* rfh, bool has_selection);
+
+#if BUILDFLAG(IS_CHROMEOS_ASH)
+  bool PrintPreviewWithPrintRenderer(
+      content::RenderFrameHost* rfh,
+      mojo::PendingAssociatedRemote<mojom::PrintRenderer> print_renderer);
+#endif
+
+  void PrintPreviewForNodeUnderContextMenu(content::RenderFrameHost* rfh);
+
+  void PrintPreviewAlmostDone();
+
+  void PrintPreviewDone();
+
+  content::RenderFrameHost* print_preview_rfh();
+
+  static void SetReceiverImplForTesting(PrintManager* impl);
+
+ private:
+  void RejectPrintPreviewRequestIfRestricted(
+      content::GlobalRenderFrameHostId rfh_id,
+      base::OnceCallback<void(bool should_proceed)> callback) override;
+};
+
+// This main purpose of this is for adding `friend class PrintViewManager` to
+// upstream PrintViewManager to avoid
+// resursive macro expansion that leads to
+// `friend class PrintViewManager_ChromiumImpl`
+typedef BravePrintViewManager PrintViewManager;
+
+}  // namespace printing
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_H_

--- a/chromium_src/chrome/browser/printing/print_view_manager.h
+++ b/chromium_src/chrome/browser/printing/print_view_manager.h
@@ -6,10 +6,15 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_PRINTING_PRINT_VIEW_MANAGER_H_
 
+namespace printing {
+class PrintViewManager;
+using PrintViewManager_BraveImpl = PrintViewManager;
+}  // namespace printing
+
 #define PrintViewManager PrintViewManager_ChromiumImpl
-#define PrintPreviewForWebNode        \
-  PrintPreviewForWebNodeUnused();     \
-  friend class BravePrintViewManager; \
+#define PrintPreviewForWebNode       \
+  PrintPreviewForWebNodeUnused();    \
+  friend PrintViewManager_BraveImpl; \
   void PrintPreviewForWebNode
 #include "src/chrome/browser/printing/print_view_manager.h"  // IWYU pragma: export
 #undef PrintPreviewForWebNode
@@ -17,57 +22,24 @@
 
 namespace printing {
 
-class BravePrintViewManager : public PrintViewManager_ChromiumImpl {
+class PrintViewManager : public PrintViewManager_ChromiumImpl {
  public:
-  explicit BravePrintViewManager(content::WebContents* web_contents);
+  explicit PrintViewManager(content::WebContents* web_contents);
 
-  BravePrintViewManager(const BravePrintViewManager&) = delete;
-  BravePrintViewManager& operator=(const BravePrintViewManager&) = delete;
+  PrintViewManager(const PrintViewManager&) = delete;
+  PrintViewManager& operator=(const PrintViewManager&) = delete;
 
-  ~BravePrintViewManager() override;
+  ~PrintViewManager() override;
 
   static void CreateForWebContents(content::WebContents* web_contents);
 
-  static BravePrintViewManager* FromWebContents(
-      content::WebContents* web_contents);
-
-  static void BindPrintManagerHost(
-      mojo::PendingAssociatedReceiver<mojom::PrintManagerHost> receiver,
-      content::RenderFrameHost* rfh);
-
-  bool PrintForSystemDialogNow(base::OnceClosure dialog_shown_callback);
-
-  bool BasicPrint(content::RenderFrameHost* rfh);
-
-  bool PrintPreviewNow(content::RenderFrameHost* rfh, bool has_selection);
-
-#if BUILDFLAG(IS_CHROMEOS_ASH)
-  bool PrintPreviewWithPrintRenderer(
-      content::RenderFrameHost* rfh,
-      mojo::PendingAssociatedRemote<mojom::PrintRenderer> print_renderer);
-#endif
-
-  void PrintPreviewForNodeUnderContextMenu(content::RenderFrameHost* rfh);
-
-  void PrintPreviewAlmostDone();
-
-  void PrintPreviewDone();
-
-  content::RenderFrameHost* print_preview_rfh();
-
-  static void SetReceiverImplForTesting(PrintManager* impl);
+  static PrintViewManager* FromWebContents(content::WebContents* web_contents);
 
  private:
   void RejectPrintPreviewRequestIfRestricted(
       content::GlobalRenderFrameHostId rfh_id,
       base::OnceCallback<void(bool should_proceed)> callback) override;
 };
-
-// This main purpose of this is for adding `friend class PrintViewManager` to
-// upstream PrintViewManager to avoid
-// resursive macro expansion that leads to
-// `friend class PrintViewManager_ChromiumImpl`
-typedef BravePrintViewManager PrintViewManager;
 
 }  // namespace printing
 

--- a/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/chrome/browser/ui/webui/print_preview/print_preview_ui.cc"
+
+namespace printing {
+
+// static
+base::IDMap<mojom::PrintPreviewUI*>& PrintPreviewUI::GetPrintPreviewUIIdMap() {
+  return g_print_preview_ui_id_map.Get();
+}
+
+// static
+PrintPreviewRequestIdMap& PrintPreviewUI::GetPrintPreviewUIRequestIdMap() {
+  return GetPrintPreviewRequestIdMap();
+}
+
+}  // namespace printing

--- a/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui.h
+++ b/chromium_src/chrome/browser/ui/webui/print_preview/print_preview_ui.h
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_PRINT_PREVIEW_PRINT_PREVIEW_UI_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_PRINT_PREVIEW_PRINT_PREVIEW_UI_H_
+
+#include "base/containers/id_map.h"
+
+#define ClearPreviewUIId                                                \
+  ClearPreviewUIId_Unused();                                            \
+  static base::IDMap<mojom::PrintPreviewUI*>& GetPrintPreviewUIIdMap(); \
+  static base::flat_map<int, int>& GetPrintPreviewUIRequestIdMap();     \
+  void ClearPreviewUIId
+
+#include "src/chrome/browser/ui/webui/print_preview/print_preview_ui.h"  // IWYU pragma: export
+
+#undef ClearPreviewUIId
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_PRINT_PREVIEW_PRINT_PREVIEW_UI_H_

--- a/chromium_src/chrome/services/printing/DEPS
+++ b/chromium_src/chrome/services/printing/DEPS
@@ -1,4 +1,4 @@
 include_rules = [
   "+brave/services/printing",
-  "+third_party/skia/include",
 ]
+

--- a/chromium_src/chrome/services/printing/printing_service.cc
+++ b/chromium_src/chrome/services/printing/printing_service.cc
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "src/chrome/services/printing/printing_service.cc"
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+#include "brave/services/printing/pdf_to_bitmap_converter.h"
+#endif
+
+namespace printing {
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+void PrintingService::BindPdfToBitmapConverter(
+    mojo::PendingReceiver<mojom::PdfToBitmapConverter> receiver) {
+  mojo::MakeSelfOwnedReceiver(
+      std::make_unique<printing::PdfToBitmapConverter>(), std::move(receiver));
+}
+
+#endif
+}  // namespace printing

--- a/chromium_src/chrome/services/printing/printing_service.h
+++ b/chromium_src/chrome/services/printing/printing_service.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_SERVICES_PRINTING_PRINTING_SERVICE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_SERVICES_PRINTING_PRINTING_SERVICE_H_
+
+#include "chrome/services/printing/public/mojom/printing_service.mojom.h"
+
+// Note that BindPdfNupConverter is already guarded by ENABLE_PRINT_PREVIEW so
+// BindPdfToBitmapConverter is also guarded by the same flag.
+#define BindPdfNupConverter                                                  \
+  BindPdfToBitmapConverter(                                                  \
+      mojo::PendingReceiver<mojom::PdfToBitmapConverter> receiver) override; \
+  void BindPdfNupConverter
+#include "src/chrome/services/printing/printing_service.h"  // IWYU pragma: export
+#undef BindPdfNupConverter
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_SERVICES_PRINTING_PRINTING_SERVICE_H_

--- a/chromium_src/chrome/services/printing/public/mojom/printing_service.mojom
+++ b/chromium_src/chrome/services/printing/public/mojom/printing_service.mojom
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module printing.mojom;
+
+import "brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom";
+
+[BraveExtend]
+interface PrintingService {
+  [EnableIf=enable_print_preview]
+  BindPdfToBitmapConverter(pending_receiver<PdfToBitmapConverter> receiver);
+};

--- a/chromium_src/components/printing/renderer/print_render_frame_helper.cc
+++ b/chromium_src/components/printing/renderer/print_render_frame_helper.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/printing/renderer/print_render_frame_helper.h"
+
+#define SetPrintPreviewUI SetPrintPreviewUI_ChromiumImpl
+#include "src/components/printing/renderer/print_render_frame_helper.cc"
+#undef SetPrintPreviewUI
+
+namespace printing {
+
+#if BUILDFLAG(ENABLE_PRINT_PREVIEW)
+void PrintRenderFrameHelper::SetPrintPreviewUI(
+    mojo::PendingAssociatedRemote<mojom::PrintPreviewUI> preview) {
+  preview_ui_.reset();
+  SetPrintPreviewUI_ChromiumImpl(std::move(preview));
+}
+#endif  // BUILDFLAG(ENABLE_PRINT_PREVIEW)
+
+}  // namespace printing

--- a/chromium_src/components/printing/renderer/print_render_frame_helper.h
+++ b/chromium_src/components/printing/renderer/print_render_frame_helper.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_PRINTING_RENDERER_PRINT_RENDER_FRAME_HELPER_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_PRINTING_RENDERER_PRINT_RENDER_FRAME_HELPER_H_
+
+#include "components/printing/common/print.mojom.h"
+
+#define SetPrintPreviewUI                                            \
+  SetPrintPreviewUI_ChromiumImpl(                                    \
+      mojo::PendingAssociatedRemote<mojom::PrintPreviewUI> preview); \
+  void SetPrintPreviewUI
+#include "src/components/printing/renderer/print_render_frame_helper.h"  // IWYU pragma: export
+#undef SetPrintPreviewUI
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_PRINTING_RENDERER_PRINT_RENDER_FRAME_HELPER_H_

--- a/components/ai_chat/content/browser/BUILD.gn
+++ b/components/ai_chat/content/browser/BUILD.gn
@@ -44,8 +44,4 @@ static_library("browser") {
     "//ui/base",
     "//url",
   ]
-
-  if (enable_text_recognition) {
-    deps += [ "//brave/components/text_recognition/browser" ]
-  }
 }

--- a/components/ai_chat/content/browser/DEPS
+++ b/components/ai_chat/content/browser/DEPS
@@ -1,4 +1,3 @@
 include_rules = [
   "+brave/services/printing",
-  "+third_party/skia/include",
 ]

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -270,9 +270,9 @@ void AIChatTabHelper::GetPageContent(GetPageContentCallback callback,
     pending_get_page_content_callback_ = std::move(callback);
   } else {
     if (base::Contains(kPrintPreviewRetrievalHosts,
-                       GetPageURL().host_piece()) &&
-        !is_print_preview_disabled_) {
+                       GetPageURL().host_piece())) {
       pending_get_page_content_callback_ = std::move(callback);
+      OnPrintPreviewRequested();
     } else {
       FetchPageContent(web_contents(), invalidation_token, std::move(callback));
     }

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -19,6 +19,7 @@
 #include "base/strings/string_util.h"
 #include "brave/components/ai_chat/content/browser/page_content_fetcher.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_metrics.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
@@ -262,9 +263,14 @@ void AIChatTabHelper::GetPageContent(GetPageContentCallback callback,
     // invalidation_token doesn't matter for PDF extraction.
     pending_get_page_content_callback_ = std::move(callback);
   } else {
-    // FetchPageContent(web_contents(), invalidation_token,
-    // std::move(callback));
-    pending_get_page_content_callback_ = std::move(callback);
+    if (base::Contains(kPrintPreviewRetrievalHosts,
+                       GetPageURL().host_piece())) {
+      pending_get_page_content_callback_ = std::move(callback);
+    } else {
+      FetchPageContent(web_contents(), invalidation_token, std::nullopt,
+                       GetCurrentModel().max_page_content_length,
+                       std::move(callback));
+    }
   }
 }
 

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -123,7 +123,7 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
   DVLOG(3) << "PDF Loaded";
   is_pdf_a11y_info_loaded_ = true;
   if (pending_get_page_content_callback_) {
-    FetchPageContent(web_contents(), "", SkBitmap(),
+    FetchPageContent(web_contents(), "", std::nullopt,
                      std::move(pending_get_page_content_callback_));
   }
   pdf_load_observer_.reset();
@@ -132,9 +132,10 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
   }
 }
 
-void AIChatTabHelper::OnPreviewReady(const SkBitmap& bitmap) {
+void AIChatTabHelper::OnPreviewReady(
+    const std::optional<std::vector<SkBitmap>>& bitmaps) {
   if (pending_get_page_content_callback_) {
-    FetchPageContent(web_contents(), "", bitmap,
+    FetchPageContent(web_contents(), "", bitmaps,
                      std::move(pending_get_page_content_callback_));
   }
 }

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -37,7 +37,6 @@
 #include "content/public/browser/web_contents.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
 #include "pdf/buildflags.h"
-#include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/accessibility/ax_mode.h"
 #include "ui/base/l10n/l10n_util.h"
 
@@ -134,8 +133,7 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
   DVLOG(3) << "PDF Loaded";
   is_pdf_a11y_info_loaded_ = true;
   if (pending_get_page_content_callback_) {
-    FetchPageContent(web_contents(), "", std::nullopt,
-                     GetMaxPageContentLength(),
+    FetchPageContent(web_contents(), "",
                      std::move(pending_get_page_content_callback_));
   }
   pdf_load_observer_.reset();
@@ -144,11 +142,10 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
   }
 }
 
-void AIChatTabHelper::OnPreviewReady(
-    const std::optional<std::vector<SkBitmap>>& bitmaps) {
+void AIChatTabHelper::OnPreviewTextReady(std::string ocr_text) {
   if (pending_get_page_content_callback_) {
-    FetchPageContent(web_contents(), "", bitmaps, GetMaxPageContentLength(),
-                     std::move(pending_get_page_content_callback_));
+    std::move(pending_get_page_content_callback_)
+        .Run(std::move(ocr_text), false, "");
   }
 }
 
@@ -276,8 +273,7 @@ void AIChatTabHelper::GetPageContent(GetPageContentCallback callback,
                        GetPageURL().host_piece())) {
       pending_get_page_content_callback_ = std::move(callback);
     } else {
-      FetchPageContent(web_contents(), invalidation_token, std::nullopt,
-                       GetMaxPageContentLength(), std::move(callback));
+      FetchPageContent(web_contents(), invalidation_token, std::move(callback));
     }
   }
 }

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -35,6 +35,7 @@
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
+#include "include/core/SkBitmap.h"
 #include "pdf/buildflags.h"
 #include "ui/accessibility/ax_mode.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -122,12 +123,19 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
   DVLOG(3) << "PDF Loaded";
   is_pdf_a11y_info_loaded_ = true;
   if (pending_get_page_content_callback_) {
-    FetchPageContent(web_contents(), "",
+    FetchPageContent(web_contents(), "", SkBitmap(),
                      std::move(pending_get_page_content_callback_));
   }
   pdf_load_observer_.reset();
   if (on_pdf_a11y_info_loaded_cb_) {
     std::move(on_pdf_a11y_info_loaded_cb_).Run();
+  }
+}
+
+void AIChatTabHelper::OnPreviewReady(const SkBitmap& bitmap) {
+  if (pending_get_page_content_callback_) {
+    FetchPageContent(web_contents(), "", bitmap,
+                     std::move(pending_get_page_content_callback_));
   }
 }
 
@@ -251,7 +259,9 @@ void AIChatTabHelper::GetPageContent(GetPageContentCallback callback,
     // invalidation_token doesn't matter for PDF extraction.
     pending_get_page_content_callback_ = std::move(callback);
   } else {
-    FetchPageContent(web_contents(), invalidation_token, std::move(callback));
+    // FetchPageContent(web_contents(), invalidation_token,
+    // std::move(callback));
+    pending_get_page_content_callback_ = std::move(callback);
   }
 }
 

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -124,6 +124,7 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
   is_pdf_a11y_info_loaded_ = true;
   if (pending_get_page_content_callback_) {
     FetchPageContent(web_contents(), "", std::nullopt,
+                     GetCurrentModel().max_page_content_length,
                      std::move(pending_get_page_content_callback_));
   }
   pdf_load_observer_.reset();
@@ -136,6 +137,7 @@ void AIChatTabHelper::OnPreviewReady(
     const std::optional<std::vector<SkBitmap>>& bitmaps) {
   if (pending_get_page_content_callback_) {
     FetchPageContent(web_contents(), "", bitmaps,
+                     GetCurrentModel().max_page_content_length,
                      std::move(pending_get_page_content_callback_));
   }
 }

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -36,8 +36,8 @@
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "mojo/public/cpp/bindings/self_owned_receiver.h"
-#include "include/core/SkBitmap.h"
 #include "pdf/buildflags.h"
+#include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/accessibility/ax_mode.h"
 #include "ui/base/l10n/l10n_util.h"
 

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -270,7 +270,8 @@ void AIChatTabHelper::GetPageContent(GetPageContentCallback callback,
     pending_get_page_content_callback_ = std::move(callback);
   } else {
     if (base::Contains(kPrintPreviewRetrievalHosts,
-                       GetPageURL().host_piece())) {
+                       GetPageURL().host_piece()) &&
+        !is_print_preview_disabled_) {
       pending_get_page_content_callback_ = std::move(callback);
     } else {
       FetchPageContent(web_contents(), invalidation_token, std::move(callback));

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -56,6 +56,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // mojom::PageContentExtractorHost
   void OnInterceptedPageContentChanged() override;
+  // This will be called when print preview has been composited into image per
+  // page.
   void OnPreviewReady(const std::optional<std::vector<SkBitmap>>&);
 
  private:

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -65,8 +65,10 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void OnInterceptedPageContentChanged() override;
 
   // This will be called when print preview has been composited into image per
-  // page.
-  void OnPreviewReady(const std::optional<std::vector<SkBitmap>>&);
+  // page and finish OCR.
+  void OnPreviewTextReady(std::string ocr_text);
+
+  uint32_t GetMaxPageContentLength();
 
  private:
   friend class content::WebContentsUserData<AIChatTabHelper>;
@@ -121,8 +123,6 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void BindPageContentExtractorReceiver(
       mojo::PendingAssociatedReceiver<mojom::PageContentExtractorHost>
           receiver);
-
-  uint32_t GetMaxPageContentLength();
 
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
 

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -67,6 +67,9 @@ class AIChatTabHelper : public content::WebContentsObserver,
   // This will be called when print preview has been composited into image per
   // page and finish OCR.
   void OnPreviewTextReady(std::string ocr_text);
+  void SetPrintPreviewDisabled(bool disabled) {
+    is_print_preview_disabled_ = disabled;
+  }
 
   uint32_t GetMaxPageContentLength();
 
@@ -129,6 +132,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
   bool is_same_document_navigation_ = false;
   int64_t pending_navigation_id_;
   bool is_pdf_a11y_info_loaded_ = false;
+  bool is_print_preview_disabled_ = false;
   GetPageContentCallback pending_get_page_content_callback_;
 
   std::unique_ptr<PDFA11yInfoLoadObserver> pdf_load_observer_;

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -67,9 +67,6 @@ class AIChatTabHelper : public content::WebContentsObserver,
   // This will be called when print preview has been composited into image per
   // page and finish OCR.
   void OnPreviewTextReady(std::string ocr_text);
-  void SetPrintPreviewDisabled(bool disabled) {
-    is_print_preview_disabled_ = disabled;
-  }
 
   uint32_t GetMaxPageContentLength();
 
@@ -132,7 +129,6 @@ class AIChatTabHelper : public content::WebContentsObserver,
   bool is_same_document_navigation_ = false;
   int64_t pending_navigation_id_;
   bool is_pdf_a11y_info_loaded_ = false;
-  bool is_print_preview_disabled_ = false;
   GetPageContentCallback pending_get_page_content_callback_;
 
   std::unique_ptr<PDFA11yInfoLoadObserver> pdf_load_observer_;

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -56,6 +56,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // mojom::PageContentExtractorHost
   void OnInterceptedPageContentChanged() override;
+  void OnPreviewReady(const SkBitmap&);
 
  private:
   friend class content::WebContentsUserData<AIChatTabHelper>;

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -56,7 +56,7 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // mojom::PageContentExtractorHost
   void OnInterceptedPageContentChanged() override;
-  void OnPreviewReady(const SkBitmap&);
+  void OnPreviewReady(const std::optional<std::vector<SkBitmap>>&);
 
  private:
   friend class content::WebContentsUserData<AIChatTabHelper>;

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -33,6 +33,7 @@ namespace content {
 class ScopedAccessibilityMode;
 }
 
+class AIChatUIBrowserTest;
 namespace ai_chat {
 class AIChatMetrics;
 
@@ -48,6 +49,12 @@ class AIChatTabHelper : public content::WebContentsObserver,
       mojo::PendingAssociatedReceiver<mojom::PageContentExtractorHost>
           receiver);
 
+  // Maximum length can be exceeded, the length will determine that no more
+  // pages will be processed in print preview. Ex. if we reach the maximum
+  // length in the middle of the 5th page, the 5th page will be the last page
+  // and the rest of the pages will be ignored.
+  static void SetMaxContentLengthForTesting(std::optional<uint32_t> max_length);
+
   AIChatTabHelper(const AIChatTabHelper&) = delete;
   AIChatTabHelper& operator=(const AIChatTabHelper&) = delete;
   ~AIChatTabHelper() override;
@@ -56,12 +63,14 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // mojom::PageContentExtractorHost
   void OnInterceptedPageContentChanged() override;
+
   // This will be called when print preview has been composited into image per
   // page.
   void OnPreviewReady(const std::optional<std::vector<SkBitmap>>&);
 
  private:
   friend class content::WebContentsUserData<AIChatTabHelper>;
+  friend class ::AIChatUIBrowserTest;
 
   // To observe PDF InnerWebContents for "Finished loading PDF" event which
   // means PDF content has been loaded to an accessibility tree.
@@ -112,6 +121,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void BindPageContentExtractorReceiver(
       mojo::PendingAssociatedReceiver<mojom::PageContentExtractorHost>
           receiver);
+
+  uint32_t GetMaxPageContentLength();
 
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
 

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -445,6 +445,7 @@ std::optional<GURL> GetGithubPatchURLForPRURL(const GURL& url) {
 
 void FetchPageContent(content::WebContents* web_contents,
                       std::string_view invalidation_token,
+                      const SkBitmap& image,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory_for_test) {
@@ -489,6 +490,10 @@ void FetchPageContent(content::WebContents* web_contents,
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
   auto host = url.host();
   if (base::Contains(kScreenshotRetrievalHosts, host)) {
+    if (!image.empty()) {
+      OnScreenshot(std::move(callback), image);
+      return;
+    }
     content::RenderWidgetHostView* view =
         web_contents->GetRenderWidgetHostView();
     if (view) {

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -17,13 +17,8 @@
 #include "base/functional/bind.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_split.h"
-#include "base/strings/string_util.h"
-#include "base/task/bind_post_task.h"
-#include "base/task/single_thread_task_runner.h"
-#include "base/task/thread_pool.h"
-#include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
-#include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/text_recognition/common/buildflags/buildflags.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/render_process_host.h"
@@ -42,10 +37,6 @@
 #include "ui/accessibility/ax_node.h"
 #include "ui/accessibility/ax_tree_manager.h"
 #include "url/gurl.h"
-
-#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-#include "brave/components/text_recognition/browser/text_recognition.h"
-#endif
 
 namespace ai_chat {
 
@@ -347,44 +338,13 @@ class PageContentFetcher {
 };
 
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-void OnGetTextFromImage(
-    FetchPageContentCallback callback,
-    const std::pair<bool, std::vector<std::string>>& supported_strs) {
-  if (!supported_strs.first) {
-    std::move(callback).Run("", false, "");
-    return;
-  }
-
-  std::stringstream ss;
-  auto& strs = supported_strs.second;
-  for (size_t i = 0; i < strs.size(); ++i) {
-    ss << base::TrimWhitespaceASCII(strs[i], base::TrimPositions::TRIM_ALL);
-    if (i < strs.size() - 1) {
-      ss << "\n";
-    }
-  }
-  std::move(callback).Run(ss.str(), false, "");
-}
-
 void OnScreenshot(FetchPageContentCallback callback, const SkBitmap& image) {
-#if BUILDFLAG(IS_MAC)
-  base::ThreadPool::PostTaskAndReplyWithResult(
-      FROM_HERE,
-      {base::MayBlock(), base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
-      base::BindOnce(&text_recognition::GetTextFromImage, image),
-      base::BindOnce(&OnGetTextFromImage, std::move(callback)));
-#endif
-#if BUILDFLAG(IS_WIN)
-  const std::string& locale = brave_l10n::GetDefaultLocaleString();
-  const std::string language_code = brave_l10n::GetISOLanguageCode(locale);
-  base::ThreadPool::CreateCOMSTATaskRunner({base::MayBlock()})
-      ->PostTask(FROM_HERE,
-                 base::BindOnce(
-                     &text_recognition::GetTextFromImage, language_code, image,
-                     base::BindPostTaskToCurrentDefault(base::BindOnce(
-                         &OnGetTextFromImage, std::move(callback)))));
-
-#endif
+  GetOCRText(image,
+             base::BindOnce(
+                 [](FetchPageContentCallback callback, std::string text) {
+                   std::move(callback).Run(std::move(text), false, "");
+                 },
+                 std::move(callback)));
 }
 #endif  // #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
 
@@ -441,68 +401,10 @@ std::optional<GURL> GetGithubPatchURLForPRURL(const GURL& url) {
   return GURL(patch_url_str);
 }
 
-#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-class PreviewPageTextExtractor {
- public:
-  PreviewPageTextExtractor(const std::vector<SkBitmap>& pages,
-                           FetchPageContentCallback callback,
-                           uint32_t max_page_content_length)
-      : pages_(pages),
-        callback_(std::move(callback)),
-        max_page_content_length_(max_page_content_length) {}
-
-  void StartExtract() {
-    if (pages_.empty()) {
-      std::move(callback_).Run("", false, "");
-      delete this;
-      return;
-    }
-    OnScreenshot(base::BindOnce(&PreviewPageTextExtractor::OnGetTextFromImage,
-                                weak_ptr_factory_.GetWeakPtr()),
-                 pages_[current_page_index_]);
-  }
-
-  void OnGetTextFromImage(std::string page_content,
-                          bool is_video,
-                          std::string invalidation_token) {
-    VLOG(4) << "Page index(" << current_page_index_
-            << ") content: " << page_content;
-    preview_text_ << page_content;
-    // Stop processing if we have reached the maximum number of pages or the
-    // maximum length of the content
-    if (current_page_index_ + 1 >= kMaxPreviewPages ||
-        preview_text_.str().length() >= max_page_content_length_) {
-      std::move(callback_).Run(preview_text_.str(), false, "");
-      delete this;
-      return;
-    }
-    if (current_page_index_++ < pages_.size() - 1) {
-      preview_text_ << "\n";
-      OnScreenshot(base::BindOnce(&PreviewPageTextExtractor::OnGetTextFromImage,
-                                  weak_ptr_factory_.GetWeakPtr()),
-                   pages_[current_page_index_]);
-    } else {
-      std::move(callback_).Run(preview_text_.str(), false, "");
-      delete this;
-    }
-  }
-
- private:
-  std::stringstream preview_text_;
-  size_t current_page_index_ = 0;
-  std::vector<SkBitmap> pages_;
-  FetchPageContentCallback callback_;
-  uint32_t max_page_content_length_;
-  base::WeakPtrFactory<PreviewPageTextExtractor> weak_ptr_factory_{this};
-};
-#endif
-
 }  // namespace
 
 void FetchPageContent(content::WebContents* web_contents,
                       std::string_view invalidation_token,
-                      const std::optional<std::vector<SkBitmap>>& images,
-                      uint32_t max_page_content_length,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory_for_test) {
@@ -545,12 +447,6 @@ void FetchPageContent(content::WebContents* web_contents,
 
   auto url = web_contents->GetLastCommittedURL();
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-  if (images) {
-    auto* preview_page_text_extractor = new PreviewPageTextExtractor(
-        images.value(), std::move(callback), max_page_content_length);
-    preview_page_text_extractor->StartExtract();
-    return;
-  }
   if (base::Contains(kScreenshotRetrievalHosts, url.host_piece())) {
     content::RenderWidgetHostView* view =
         web_contents->GetRenderWidgetHostView();

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -55,7 +55,6 @@ namespace {
 constexpr auto kScreenshotRetrievalHosts =
     base::MakeFixedFlatSet<std::string_view>(base::sorted_unique,
                                              {
-                                                 "docs.google.com",
                                                  "twitter.com",
                                              });
 constexpr size_t kMaxPreviewPages = 20;
@@ -466,8 +465,8 @@ class PreviewPageTextExtractor {
   void OnGetTextFromImage(std::string page_content,
                           bool is_video,
                           std::string invalidation_token) {
-    VLOG(4) << "Page index(" << current_page_index_ << ") content: "
-            << page_content;
+    VLOG(4) << "Page index(" << current_page_index_
+            << ") content: " << page_content;
     preview_text_ << page_content;
     // Stop processing if we have reached the maximum number of pages or the
     // maximum length of the content
@@ -546,14 +545,13 @@ void FetchPageContent(content::WebContents* web_contents,
 
   auto url = web_contents->GetLastCommittedURL();
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-  auto host = url.host();
-  if (base::Contains(kScreenshotRetrievalHosts, host)) {
-    if (images) {
-      auto* preview_page_text_extractor = new PreviewPageTextExtractor(
-          images.value(), std::move(callback), max_page_content_length);
-      preview_page_text_extractor->StartExtract();
-      return;
-    }
+  if (images) {
+    auto* preview_page_text_extractor = new PreviewPageTextExtractor(
+        images.value(), std::move(callback), max_page_content_length);
+    preview_page_text_extractor->StartExtract();
+    return;
+  }
+  if (base::Contains(kScreenshotRetrievalHosts, url.host_piece())) {
     content::RenderWidgetHostView* view =
         web_contents->GetRenderWidgetHostView();
     if (view) {

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -21,6 +21,7 @@
 #include "base/task/bind_post_task.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/task/thread_pool.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/text_recognition/common/buildflags/buildflags.h"
@@ -57,7 +58,6 @@ constexpr auto kScreenshotRetrievalHosts =
                                              {
                                                  "twitter.com",
                                              });
-constexpr size_t kMaxPreviewPages = 20;
 #endif
 
 constexpr auto kVideoPageContentTypes =

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -10,6 +10,7 @@
 
 #include "base/functional/callback_forward.h"
 #include "base/memory/scoped_refptr.h"
+#include "include/core/SkBitmap.h"
 
 namespace content {
 class WebContents;
@@ -19,6 +20,7 @@ namespace network {
 class SharedURLLoaderFactory;
 }  // namespace network
 
+class SkBitmap;
 namespace ai_chat {
 
 using FetchPageContentCallback =
@@ -27,6 +29,7 @@ using FetchPageContentCallback =
                             std::string invalidation_token)>;
 void FetchPageContent(content::WebContents* web_contents,
                       std::string_view invalidation_token,
+                      const SkBitmap& image,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory = nullptr);

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PAGE_CONTENT_FETCHER_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PAGE_CONTENT_FETCHER_H_
 
+#include <cstdint>
 #include <string>
 
 #include "base/functional/callback_forward.h"
@@ -30,6 +31,7 @@ using FetchPageContentCallback =
 void FetchPageContent(content::WebContents* web_contents,
                       std::string_view invalidation_token,
                       const std::optional<std::vector<SkBitmap>>& images,
+                      uint32_t max_page_content_length,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory = nullptr);

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -29,7 +29,7 @@ using FetchPageContentCallback =
                             std::string invalidation_token)>;
 void FetchPageContent(content::WebContents* web_contents,
                       std::string_view invalidation_token,
-                      const SkBitmap& image,
+                      const std::optional<std::vector<SkBitmap>>& images,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory = nullptr);

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -8,10 +8,11 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "base/functional/callback_forward.h"
 #include "base/memory/scoped_refptr.h"
-#include "include/core/SkBitmap.h"
+#include "third_party/skia/include/core/SkBitmap.h"
 
 namespace content {
 class WebContents;

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -6,13 +6,10 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PAGE_CONTENT_FETCHER_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PAGE_CONTENT_FETCHER_H_
 
-#include <cstdint>
 #include <string>
-#include <vector>
 
 #include "base/functional/callback_forward.h"
 #include "base/memory/scoped_refptr.h"
-#include "third_party/skia/include/core/SkBitmap.h"
 
 namespace content {
 class WebContents;
@@ -22,7 +19,6 @@ namespace network {
 class SharedURLLoaderFactory;
 }  // namespace network
 
-class SkBitmap;
 namespace ai_chat {
 
 using FetchPageContentCallback =
@@ -31,8 +27,6 @@ using FetchPageContentCallback =
                             std::string invalidation_token)>;
 void FetchPageContent(content::WebContents* web_contents,
                       std::string_view invalidation_token,
-                      const std::optional<std::vector<SkBitmap>>& images,
-                      uint32_t max_page_content_length,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory = nullptr);

--- a/components/ai_chat/core/browser/BUILD.gn
+++ b/components/ai_chat/core/browser/BUILD.gn
@@ -4,6 +4,7 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+import("//brave/components/text_recognition/common/buildflags/buildflags.gni")
 
 assert(enable_ai_chat)
 
@@ -56,6 +57,7 @@ static_library("browser") {
     "//brave/components/resources:strings_grit",
     "//brave/components/sidebar/common",
     "//brave/components/skus/common:mojom",
+    "//brave/components/text_recognition/common/buildflags",
     "//brave/components/time_period_storage",
     "//components/prefs",
     "//components/user_prefs",
@@ -67,6 +69,10 @@ static_library("browser") {
     "//ui/base",
     "//url",
   ]
+
+  if (enable_text_recognition) {
+    deps += [ "//brave/components/text_recognition/browser" ]
+  }
 }
 
 if (!is_ios) {

--- a/components/ai_chat/core/browser/DEPS
+++ b/components/ai_chat/core/browser/DEPS
@@ -2,4 +2,5 @@ include_rules = [
   "+services/data_decoder/public",
   "+services/network/public",
   "+absl/types/optional.h",
+  "+third_party/skia/include",
 ]

--- a/components/ai_chat/core/browser/constants.cc
+++ b/components/ai_chat/core/browser/constants.cc
@@ -134,4 +134,10 @@ base::span<const webui::LocalizedString> GetLocalizedStrings() {
   return kLocalizedStrings;
 }
 
+const base::fixed_flat_set<std::string_view, 1> kPrintPreviewRetrievalHosts =
+    base::MakeFixedFlatSet<std::string_view>(base::sorted_unique,
+                                             {
+                                                 "docs.google.com",
+                                             });
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -6,12 +6,16 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONSTANTS_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONSTANTS_H_
 
+#include "base/containers/fixed_flat_set.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/webui/web_ui_util.h"
 
 namespace ai_chat {
 
 base::span<const webui::LocalizedString> GetLocalizedStrings();
+
+extern const base::fixed_flat_set<std::string_view, 1>
+    kPrintPreviewRetrievalHosts;
 
 }  // namespace ai_chat
 

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -17,6 +17,8 @@ base::span<const webui::LocalizedString> GetLocalizedStrings();
 extern const base::fixed_flat_set<std::string_view, 1>
     kPrintPreviewRetrievalHosts;
 
+constexpr uint8_t kMaxPreviewPages = 20;
+
 }  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONSTANTS_H_

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -17,7 +17,7 @@ base::span<const webui::LocalizedString> GetLocalizedStrings();
 extern const base::fixed_flat_set<std::string_view, 1>
     kPrintPreviewRetrievalHosts;
 
-constexpr uint8_t kMaxPreviewPages = 20;
+inline constexpr uint8_t kMaxPreviewPages = 20;
 
 }  // namespace ai_chat
 

--- a/components/ai_chat/core/browser/conversation_driver.cc
+++ b/components/ai_chat/core/browser/conversation_driver.cc
@@ -539,6 +539,12 @@ void ConversationDriver::OnNewPage(int64_t navigation_id) {
   CleanUp();
 }
 
+void ConversationDriver::OnPrintPreviewRequested() {
+  for (auto& obs : observers_) {
+    obs.OnPrintPreviewRequested();
+  }
+}
+
 void ConversationDriver::CleanUp() {
   DVLOG(1) << __func__;
   chat_history_.clear();

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -53,6 +53,7 @@ class ConversationDriver {
         mojom::SuggestionGenerationStatus suggestion_generation_status) {}
     virtual void OnFaviconImageDataChanged() {}
     virtual void OnPageHasContent(mojom::SiteInfoPtr site_info) {}
+    virtual void OnPrintPreviewRequested() {}
   };
 
   ConversationDriver(
@@ -170,6 +171,8 @@ class ConversationDriver {
   // To be called when a page navigation is detected and a new conversation
   // is expected.
   void OnNewPage(int64_t navigation_id);
+
+  void OnPrintPreviewRequested();
 
  private:
   void InitEngine();

--- a/components/ai_chat/core/browser/utils.h
+++ b/components/ai_chat/core/browser/utils.h
@@ -6,6 +6,10 @@
 #ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_UTILS_H_
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_UTILS_H_
 
+#include "base/functional/callback_forward.h"
+#include "brave/components/text_recognition/common/buildflags/buildflags.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+
 class PrefService;
 
 namespace ai_chat {
@@ -14,6 +18,11 @@ namespace ai_chat {
 bool IsAIChatEnabled(PrefService* prefs);
 bool HasUserOptedIn(PrefService* prefs);
 void SetUserOptedIn(PrefService* prefs, bool opted_in);
+
+#if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
+using GetOCRTextCallback = base::OnceCallback<void(std::string)>;
+void GetOCRText(const SkBitmap& image, GetOCRTextCallback callback);
+#endif
 
 }  // namespace ai_chat
 

--- a/patches/chrome-browser-ui-webui-print_preview-print_preview_ui.cc.patch
+++ b/patches/chrome-browser-ui-webui-print_preview-print_preview_ui.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/webui/print_preview/print_preview_ui.cc b/chrome/browser/ui/webui/print_preview/print_preview_ui.cc
+index b02c2e2e9b0505f4f1eb9a0cab6c48699928f052..db2332e3408540607a2b9ded0c7deb5a7416e0be 100644
+--- a/chrome/browser/ui/webui/print_preview/print_preview_ui.cc
++++ b/chrome/browser/ui/webui/print_preview/print_preview_ui.cc
+@@ -155,7 +155,7 @@ PrintPreviewRequestIdMap& GetPrintPreviewRequestIdMap() {
+ 
+ // PrintPreviewUI IDMap used to avoid exposing raw pointer addresses to WebUI.
+ // Only accessed on the UI thread.
+-base::LazyInstance<base::IDMap<PrintPreviewUI*>>::DestructorAtExit
++base::LazyInstance<base::IDMap<mojom::PrintPreviewUI*>>::DestructorAtExit
+     g_print_preview_ui_id_map = LAZY_INSTANCE_INITIALIZER;
+ 
+ void AddPrintPreviewStrings(content::WebUIDataSource* source) {

--- a/patches/chrome-services-printing-BUILD.gn.patch
+++ b/patches/chrome-services-printing-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/services/printing/BUILD.gn b/chrome/services/printing/BUILD.gn
+index fc2419815457a7a83668589cae9409bbf78d9895..907b174d3673cf63faa3136e0792fa9e45e80e05 100644
+--- a/chrome/services/printing/BUILD.gn
++++ b/chrome/services/printing/BUILD.gn
+@@ -37,6 +37,7 @@ source_set("lib") {
+       "//printing/mojom",
+     ]
+   }
++  import("//brave/services/printing/sources.gni") sources += brave_services_printing_sources deps += brave_services_printing_deps
+ 
+   if (is_chromeos) {
+     sources += [

--- a/patches/chrome-services-printing-public-mojom-BUILD.gn.patch
+++ b/patches/chrome-services-printing-public-mojom-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/services/printing/public/mojom/BUILD.gn b/chrome/services/printing/public/mojom/BUILD.gn
+index 86aa38b6343172871d18ecd8f7ba6302b7d9aacf..c940c1843c81473df3e9c52ff36be42152c49cb6 100644
+--- a/chrome/services/printing/public/mojom/BUILD.gn
++++ b/chrome/services/printing/public/mojom/BUILD.gn
+@@ -25,6 +25,7 @@ mojom("mojom") {
+     "//url/mojom:url_mojom_gurl",
+   ]
+ 
++  import("//brave/services/printing/public/mojom/sources.gni") sources += brave_services_printing_public_mojom_sources public_deps += brave_services_printing_public_mojom_public_deps
+   enabled_features = []
+ 
+   if (is_chromeos) {

--- a/services/printing/DEPS
+++ b/services/printing/DEPS
@@ -1,5 +1,6 @@
 include_rules = [
   "+pdf",
+  "+printing",
   "+third_party/skia/include",
   "+ui/gfx/geometry",
 ]

--- a/services/printing/DEPS
+++ b/services/printing/DEPS
@@ -1,4 +1,5 @@
 include_rules = [
-  "+brave/services/printing",
+  "+pdf",
   "+third_party/skia/include",
+  "+ui/gfx/geometry",
 ]

--- a/services/printing/pdf_to_bitmap_converter.cc
+++ b/services/printing/pdf_to_bitmap_converter.cc
@@ -1,0 +1,111 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/services/printing/pdf_to_bitmap_converter.h"
+
+#include <string.h>
+#include <utility>
+#include <vector>
+
+#include "base/containers/span.h"
+#include "base/logging.h"
+#include "base/memory/shared_memory_mapping.h"
+#include "pdf/pdf.h"
+#include "third_party/skia/include/core/SkBitmap.h"
+#include "ui/gfx/geometry/size_conversions.h"
+
+namespace printing {
+
+PdfToBitmapConverter::PdfToBitmapConverter() = default;
+
+PdfToBitmapConverter::~PdfToBitmapConverter() = default;
+
+void PdfToBitmapConverter::GetBitmap(
+    base::ReadOnlySharedMemoryRegion pdf_region,
+    GetBitmapCallback callback) {
+  // Decode memory region as PDF bytes.
+  base::ReadOnlySharedMemoryMapping pdf_map = pdf_region.Map();
+  if (!pdf_map.IsValid()) {
+    DLOG(ERROR) << "Failed to decode memory map for PDF thumbnail";
+    std::move(callback).Run(SkBitmap());
+    return;
+  }
+  auto pdf_buffer = pdf_map.GetMemoryAsSpan<const uint8_t>();
+
+  int page_count;
+  if (!chrome_pdf::GetPDFDocInfo(pdf_buffer, &page_count, nullptr)) {
+    DLOG(ERROR) << "Failed to get PDF document info";
+    std::move(callback).Run(SkBitmap());
+    return;
+  }
+
+  int32_t total_width = 0;
+  int32_t total_height = 0;
+  std::vector<SkBitmap> bitmaps;
+  for (int page_index = 0; page_index < page_count; page_index++) {
+    std::optional<gfx::SizeF> page_size =
+        chrome_pdf::GetPDFPageSizeByIndex(pdf_buffer, page_index);
+    if (!page_size.has_value()) {
+      DLOG(ERROR) << "Failed to get PDF page size";
+      std::move(callback).Run(SkBitmap());
+      return;
+    }
+    gfx::Size size = gfx::ToCeiledSize(*page_size);
+
+    SkBitmap bitmap;
+    const SkImageInfo info =
+        SkImageInfo::Make(size.width(), size.height(), kBGRA_8888_SkColorType,
+                          kOpaque_SkAlphaType);
+    if (!bitmap.tryAllocPixels(info, info.minRowBytes())) {
+      DLOG(ERROR) << "Failed to allocate bitmap pixels";
+      std::move(callback).Run(SkBitmap());
+      return;
+    }
+
+    // Convert PDF bytes into a bitmap
+    chrome_pdf::RenderOptions options = {
+        .stretch_to_bounds = false,
+        .keep_aspect_ratio = true,
+        .autorotate = false,
+        .use_color = true,
+        .render_device_type = chrome_pdf::RenderDeviceType::kDisplay,
+    };
+    if (!chrome_pdf::RenderPDFPageToBitmap(pdf_buffer, page_index,
+                                           bitmap.getPixels(), size,
+                                           gfx::Size(300, 300), options)) {
+      DLOG(ERROR) << "Failed to render PDF buffer as bitmap image";
+      std::move(callback).Run(SkBitmap());
+      return;
+    }
+    total_width = std::max(total_width, bitmap.width());
+    total_height += bitmap.height();
+    bitmaps.push_back(bitmap);
+  }
+
+  SkBitmap combined_bitmap;
+  SkImageInfo image_info = bitmaps[0]
+                               .info()
+                               .makeWH(total_width, total_height)
+                               .makeAlphaType(kPremul_SkAlphaType);
+
+  if (!combined_bitmap.tryAllocPixels(image_info)) {
+    DLOG(ERROR) << "Failed to allocate bitmap pixels";
+    std::move(callback).Run(SkBitmap());
+    return;
+  }
+  int32_t next_start_pixel = 0;
+  for (auto& bitmap : bitmaps) {
+    combined_bitmap.writePixels(bitmap.pixmap(), 0, next_start_pixel);
+    next_start_pixel += bitmap.dimensions().height();
+  }
+
+  std::move(callback).Run(combined_bitmap);
+}
+
+void PdfToBitmapConverter::SetUseSkiaRendererPolicy(bool use_skia) {
+  chrome_pdf::SetUseSkiaRendererPolicy(use_skia);
+}
+
+}  // namespace printing

--- a/services/printing/pdf_to_bitmap_converter.cc
+++ b/services/printing/pdf_to_bitmap_converter.cc
@@ -5,8 +5,8 @@
 
 #include "brave/services/printing/pdf_to_bitmap_converter.h"
 
+#include <optional>
 #include <utility>
-#include <vector>
 
 #include "base/logging.h"
 #include "base/memory/shared_memory_mapping.h"
@@ -20,70 +20,70 @@ PdfToBitmapConverter::PdfToBitmapConverter() = default;
 
 PdfToBitmapConverter::~PdfToBitmapConverter() = default;
 
-void PdfToBitmapConverter::GetBitmap(
+void PdfToBitmapConverter::GetPdfPageCount(
     base::ReadOnlySharedMemoryRegion pdf_region,
-    std::optional<uint8_t> max_pages,
-    GetBitmapCallback callback) {
-  // Decode memory region as PDF bytes.
+    GetPdfPageCountCallback callback) {
   base::ReadOnlySharedMemoryMapping pdf_map = pdf_region.Map();
   if (!pdf_map.IsValid()) {
-    DLOG(ERROR) << "Failed to decode memory map for PDF thumbnail";
+    DLOG(ERROR) << "Failed to decode memory map for PDF";
     std::move(callback).Run(std::nullopt);
-    return;
   }
   auto pdf_buffer = pdf_map.GetMemoryAsSpan<const uint8_t>();
-
   int page_count;
   if (!chrome_pdf::GetPDFDocInfo(pdf_buffer, &page_count, nullptr)) {
     DLOG(ERROR) << "Failed to get PDF document info";
     std::move(callback).Run(std::nullopt);
     return;
   }
+  std::move(callback).Run(page_count);
+}
 
-  if (max_pages.has_value() && *max_pages < page_count) {
-    page_count = *max_pages;
+void PdfToBitmapConverter::GetBitmap(
+    base::ReadOnlySharedMemoryRegion pdf_region,
+    uint32_t page_index,
+    GetBitmapCallback callback) {
+  base::ReadOnlySharedMemoryMapping pdf_map = pdf_region.Map();
+  if (!pdf_map.IsValid()) {
+    DLOG(ERROR) << "Failed to decode memory map for PDF";
+    std::move(callback).Run(SkBitmap());
+  }
+  auto pdf_buffer = pdf_map.GetMemoryAsSpan<const uint8_t>();
+
+  std::optional<gfx::SizeF> page_size =
+      chrome_pdf::GetPDFPageSizeByIndex(pdf_buffer, page_index);
+  if (!page_size.has_value()) {
+    DLOG(ERROR) << "Failed to get PDF page size";
+    std::move(callback).Run(SkBitmap());
+    return;
+  }
+  gfx::Size size = gfx::ToCeiledSize(*page_size);
+
+  SkBitmap bitmap;
+  const SkImageInfo info = SkImageInfo::Make(
+      size.width(), size.height(), kBGRA_8888_SkColorType, kOpaque_SkAlphaType);
+  if (!bitmap.tryAllocPixels(info, info.minRowBytes())) {
+    DLOG(ERROR) << "Failed to allocate bitmap pixels";
+    std::move(callback).Run(SkBitmap());
+    return;
   }
 
-  std::vector<SkBitmap> bitmaps;
-  for (int page_index = 0; page_index < page_count; page_index++) {
-    std::optional<gfx::SizeF> page_size =
-        chrome_pdf::GetPDFPageSizeByIndex(pdf_buffer, page_index);
-    if (!page_size.has_value()) {
-      DLOG(ERROR) << "Failed to get PDF page size";
-      std::move(callback).Run(std::nullopt);
-      return;
-    }
-    gfx::Size size = gfx::ToCeiledSize(*page_size);
-
-    SkBitmap bitmap;
-    const SkImageInfo info =
-        SkImageInfo::Make(size.width(), size.height(), kBGRA_8888_SkColorType,
-                          kOpaque_SkAlphaType);
-    if (!bitmap.tryAllocPixels(info, info.minRowBytes())) {
-      DLOG(ERROR) << "Failed to allocate bitmap pixels";
-      std::move(callback).Run(std::nullopt);
-      return;
-    }
-
-    // Convert PDF bytes into a bitmap
-    chrome_pdf::RenderOptions options = {
-        .stretch_to_bounds = false,
-        .keep_aspect_ratio = true,
-        .autorotate = false,
-        .use_color = true,
-        .render_device_type = chrome_pdf::RenderDeviceType::kDisplay,
-    };
-    if (!chrome_pdf::RenderPDFPageToBitmap(pdf_buffer, page_index,
-                                           bitmap.getPixels(), size,
-                                           gfx::Size(300, 300), options)) {
-      DLOG(ERROR) << "Failed to render PDF buffer as bitmap image";
-      std::move(callback).Run(std::nullopt);
-      return;
-    }
-    bitmaps.push_back(bitmap);
+  // Convert PDF bytes into a bitmap
+  chrome_pdf::RenderOptions options = {
+      .stretch_to_bounds = false,
+      .keep_aspect_ratio = true,
+      .autorotate = false,
+      .use_color = true,
+      .render_device_type = chrome_pdf::RenderDeviceType::kDisplay,
+  };
+  if (!chrome_pdf::RenderPDFPageToBitmap(pdf_buffer, page_index,
+                                         bitmap.getPixels(), size,
+                                         gfx::Size(300, 300), options)) {
+    DLOG(ERROR) << "Failed to render PDF buffer as bitmap image";
+    std::move(callback).Run(SkBitmap());
+    return;
   }
 
-  std::move(callback).Run(bitmaps);
+  std::move(callback).Run(std::move(bitmap));
 }
 
 void PdfToBitmapConverter::SetUseSkiaRendererPolicy(bool use_skia) {

--- a/services/printing/pdf_to_bitmap_converter.cc
+++ b/services/printing/pdf_to_bitmap_converter.cc
@@ -22,6 +22,7 @@ PdfToBitmapConverter::~PdfToBitmapConverter() = default;
 
 void PdfToBitmapConverter::GetBitmap(
     base::ReadOnlySharedMemoryRegion pdf_region,
+    std::optional<uint8_t> max_pages,
     GetBitmapCallback callback) {
   // Decode memory region as PDF bytes.
   base::ReadOnlySharedMemoryMapping pdf_map = pdf_region.Map();
@@ -37,6 +38,10 @@ void PdfToBitmapConverter::GetBitmap(
     DLOG(ERROR) << "Failed to get PDF document info";
     std::move(callback).Run(std::nullopt);
     return;
+  }
+
+  if (max_pages.has_value() && *max_pages < page_count) {
+    page_count = *max_pages;
   }
 
   std::vector<SkBitmap> bitmaps;

--- a/services/printing/pdf_to_bitmap_converter.cc
+++ b/services/printing/pdf_to_bitmap_converter.cc
@@ -11,6 +11,7 @@
 #include "base/logging.h"
 #include "base/memory/shared_memory_mapping.h"
 #include "pdf/pdf.h"
+#include "printing/units.h"
 #include "third_party/skia/include/core/SkBitmap.h"
 #include "ui/gfx/geometry/size_conversions.h"
 
@@ -49,6 +50,8 @@ void PdfToBitmapConverter::GetBitmap(
   }
   auto pdf_buffer = pdf_map.GetMemoryAsSpan<const uint8_t>();
 
+  // Get the original size of the PDF page in points. Each point is 1/72 inch
+  // per chrome_pdf::CalculatePosition and printing::kPointsPerInch.
   std::optional<gfx::SizeF> page_size =
       chrome_pdf::GetPDFPageSizeByIndex(pdf_buffer, page_index);
   if (!page_size.has_value()) {
@@ -56,8 +59,14 @@ void PdfToBitmapConverter::GetBitmap(
     std::move(callback).Run(SkBitmap());
     return;
   }
-  gfx::Size size = gfx::ToCeiledSize(*page_size);
+  // Scale up the page size from 72 dpi to 300 dpi
+  gfx::SizeF size_300dpi = gfx::ScaleSize(
+      page_size.value(),
+      static_cast<float>(printing::kDefaultPdfDpi) / printing::kPointsPerInch);
+  gfx::Size size = gfx::ToCeiledSize(size_300dpi);
 
+  // Allocate a bitmap with the scaled up size so it can fit in later rendered
+  // 300 dpi PDF page image.
   SkBitmap bitmap;
   const SkImageInfo info = SkImageInfo::Make(
       size.width(), size.height(), kBGRA_8888_SkColorType, kOpaque_SkAlphaType);
@@ -75,9 +84,11 @@ void PdfToBitmapConverter::GetBitmap(
       .use_color = true,
       .render_device_type = chrome_pdf::RenderDeviceType::kDisplay,
   };
-  if (!chrome_pdf::RenderPDFPageToBitmap(pdf_buffer, page_index,
-                                         bitmap.getPixels(), size,
-                                         gfx::Size(300, 300), options)) {
+  // Render the PDF page to a bitmap with 300 dpi with scaled up size.
+  if (!chrome_pdf::RenderPDFPageToBitmap(
+          pdf_buffer, page_index, bitmap.getPixels(), size,
+          gfx::Size(printing::kDefaultPdfDpi, printing::kDefaultPdfDpi),
+          options)) {
     DLOG(ERROR) << "Failed to render PDF buffer as bitmap image";
     std::move(callback).Run(SkBitmap());
     return;

--- a/services/printing/pdf_to_bitmap_converter.h
+++ b/services/printing/pdf_to_bitmap_converter.h
@@ -23,6 +23,7 @@ class PdfToBitmapConverter : public printing::mojom::PdfToBitmapConverter {
 
   // printing::mojom::PdfToBitmapConverter:
   void GetBitmap(base::ReadOnlySharedMemoryRegion pdf_region,
+                 std::optional<uint8_t> max_pages,
                  GetBitmapCallback callback) override;
 
   void SetUseSkiaRendererPolicy(bool use_skia) override;

--- a/services/printing/pdf_to_bitmap_converter.h
+++ b/services/printing/pdf_to_bitmap_converter.h
@@ -22,8 +22,10 @@ class PdfToBitmapConverter : public printing::mojom::PdfToBitmapConverter {
   PdfToBitmapConverter& operator=(const PdfToBitmapConverter&) = delete;
 
   // printing::mojom::PdfToBitmapConverter:
+  void GetPdfPageCount(base::ReadOnlySharedMemoryRegion pdf_region,
+                       GetPdfPageCountCallback callback) override;
   void GetBitmap(base::ReadOnlySharedMemoryRegion pdf_region,
-                 std::optional<uint8_t> max_pages,
+                 uint32_t page_index,
                  GetBitmapCallback callback) override;
 
   void SetUseSkiaRendererPolicy(bool use_skia) override;

--- a/services/printing/pdf_to_bitmap_converter.h
+++ b/services/printing/pdf_to_bitmap_converter.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_SERVICES_PRINTING_PDF_TO_BITMAP_CONVERTER_H_
+#define BRAVE_SERVICES_PRINTING_PDF_TO_BITMAP_CONVERTER_H_
+
+#include "base/memory/read_only_shared_memory_region.h"
+#include "brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom.h"
+
+namespace printing {
+
+// Implements mojom interface for generating images for each PDF pages.
+// The PDF file needs to be read and stored in a shared memory region.
+class PdfToBitmapConverter : public printing::mojom::PdfToBitmapConverter {
+ public:
+  PdfToBitmapConverter();
+  ~PdfToBitmapConverter() override;
+
+  PdfToBitmapConverter(const PdfToBitmapConverter&) = delete;
+  PdfToBitmapConverter& operator=(const PdfToBitmapConverter&) = delete;
+
+  // printing::mojom::PdfToBitmapConverter:
+  void GetBitmap(base::ReadOnlySharedMemoryRegion pdf_region,
+                 GetBitmapCallback callback) override;
+
+  void SetUseSkiaRendererPolicy(bool use_skia) override;
+};
+
+}  // namespace printing
+
+#endif  // BRAVE_SERVICES_PRINTING_PDF_TO_BITMAP_CONVERTER_H_

--- a/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
+++ b/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
@@ -11,7 +11,7 @@ import "ui/gfx/geometry/mojom/geometry.mojom";
 
 interface PdfToBitmapConverter {
   GetBitmap(mojo_base.mojom.ReadOnlySharedMemoryRegion pdf_region)
-      => (skia.mojom.BitmapN32? bitmap);
+      => (array<skia.mojom.BitmapN32>? bitmap);
 
   // Sets the status for enterprise policy `kPdfUseSkiaRendererEnabled`. It
   // should be called immediately once `mojom::PdfToBitmapConverter` remote

--- a/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
+++ b/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
@@ -1,0 +1,20 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module printing.mojom;
+
+import "mojo/public/mojom/base/shared_memory.mojom";
+import "skia/public/mojom/bitmap.mojom";
+import "ui/gfx/geometry/mojom/geometry.mojom";
+
+interface PdfToBitmapConverter {
+  GetBitmap(mojo_base.mojom.ReadOnlySharedMemoryRegion pdf_region)
+      => (skia.mojom.BitmapN32? bitmap);
+
+  // Sets the status for enterprise policy `kPdfUseSkiaRendererEnabled`. It
+  // should be called immediately once `mojom::PdfToBitmapConverter` remote
+  // is bound and only when this policy is managed.
+  SetUseSkiaRendererPolicy(bool use_skia);
+};

--- a/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
+++ b/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
@@ -10,9 +10,11 @@ import "skia/public/mojom/bitmap.mojom";
 import "ui/gfx/geometry/mojom/geometry.mojom";
 
 interface PdfToBitmapConverter {
-  // If max_pages is provided, the converter will process at most max_pages
+  GetPdfPageCount(mojo_base.mojom.ReadOnlySharedMemoryRegion pdf_region)
+    => (uint32? page_count);
+
   GetBitmap(mojo_base.mojom.ReadOnlySharedMemoryRegion pdf_region,
-    uint8? max_pages) => (array<skia.mojom.BitmapN32>? bitmap);
+    uint32 page_index) => (skia.mojom.BitmapN32? bitmap);
 
   // Sets the status for enterprise policy `kPdfUseSkiaRendererEnabled`. It
   // should be called immediately once `mojom::PdfToBitmapConverter` remote

--- a/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
+++ b/services/printing/public/mojom/pdf_to_bitmap_converter.mojom
@@ -10,8 +10,9 @@ import "skia/public/mojom/bitmap.mojom";
 import "ui/gfx/geometry/mojom/geometry.mojom";
 
 interface PdfToBitmapConverter {
-  GetBitmap(mojo_base.mojom.ReadOnlySharedMemoryRegion pdf_region)
-      => (array<skia.mojom.BitmapN32>? bitmap);
+  // If max_pages is provided, the converter will process at most max_pages
+  GetBitmap(mojo_base.mojom.ReadOnlySharedMemoryRegion pdf_region,
+    uint8? max_pages) => (array<skia.mojom.BitmapN32>? bitmap);
 
   // Sets the status for enterprise policy `kPdfUseSkiaRendererEnabled`. It
   // should be called immediately once `mojom::PdfToBitmapConverter` remote

--- a/services/printing/public/mojom/sources.gni
+++ b/services/printing/public/mojom/sources.gni
@@ -1,0 +1,9 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_services_printing_public_mojom_sources =
+    [ "//brave/services/printing/public/mojom/pdf_to_bitmap_converter.mojom" ]
+
+brave_services_printing_public_mojom_public_deps = [ "//skia/public/mojom" ]

--- a/services/printing/sources.gni
+++ b/services/printing/sources.gni
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_services_printing_sources = [
+  "//brave/services/printing/pdf_to_bitmap_converter.cc",
+  "//brave/services/printing/pdf_to_bitmap_converter.h",
+]
+
+brave_services_printing_deps = [ "//components/discardable_memory/client" ]

--- a/services/printing/sources.gni
+++ b/services/printing/sources.gni
@@ -8,4 +8,7 @@ brave_services_printing_sources = [
   "//brave/services/printing/pdf_to_bitmap_converter.h",
 ]
 
-brave_services_printing_deps = [ "//components/discardable_memory/client" ]
+brave_services_printing_deps = [
+  "//components/discardable_memory/client",
+  "//printing:printing_base",
+]

--- a/test/data/leo/extra_long_canvas.html
+++ b/test/data/leo/extra_long_canvas.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leo test</title>
+</head>
+<body>
+    <script>
+      // Here we create 21 pages to test kMaxPreviewPages which is 20.
+      for (let i = 0; i < 21; i++) {
+        const div = document.createElement('div');
+        div.style.width = '559px';
+        div.style.height = '794px';
+
+        const canvas = document.createElement('canvas');
+        const context = canvas.getContext('2d');
+        canvas.width = 559
+        canvas.height = 794
+        context.font = '30px Arial';
+        if (i == 19) {
+          // This should be the last page because of the truncation.
+          context.fillText('This is the way.', 50, 100);
+        } else if (i == 20) {
+          // This will be truncated.
+          context.fillText('There is no way.', 50, 100);
+        }
+
+        div.appendChild(canvas);
+        document.body.appendChild(div);
+      }
+    </script>
+</body>
+</html>
+

--- a/test/data/leo/long_canvas.html
+++ b/test/data/leo/long_canvas.html
@@ -26,14 +26,25 @@
       var context = canvas.getContext('2d');
       context.font = '30px Arial';
       context.fillText('This is the way.', 50, 100);
+
       // leave page 2 empty
+
       canvas = document.getElementById('page3');
       context = canvas.getContext('2d');
       context.font = '30px Arial';
       context.fillText('I have spoken.', 50, 100);
+
+      // smaller text with higher DPI
       canvas = document.getElementById('page4');
+      const dpr = 2;
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = rect.width * dpr;
+      canvas.height = rect.height * dpr;
+      canvas.style.width = `${rect.width}px`;
+      canvas.style.height = `${rect.height}px`;
       context = canvas.getContext('2d');
-      context.font = '30px Arial';
+      context.scale(dpr, dpr);
+      context.font = '15px Arial';
       context.fillText('Wherever I Go, He Goes.', 50, 100);
     </script>
 </body>

--- a/test/data/leo/long_canvas.html
+++ b/test/data/leo/long_canvas.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leo test</title>
+</head>
+<body>
+    <div style="width: 559px; height: 794px;">
+      <canvas id="page1" width="559" height="794">
+      </canvas>
+    </div>
+    <div style="width: 559px; height: 794px;">
+      <canvas id="page2" width="559" height="794">
+      </canvas>
+    </div>
+    <div style="width: 559px; height: 794px;">
+      <canvas id="page3" width="559" height="794">
+      </canvas>
+    </div>
+    <div style="width: 559px; height: 794px;">
+      <canvas id="page4" width="559" height="794">
+      </canvas>
+    </div>
+
+    <script>
+      var canvas = document.getElementById('page1');
+      var context = canvas.getContext('2d');
+      context.font = '30px Arial';
+      context.fillText('This is the way.', 50, 100);
+      // leave page 2 empty
+      canvas = document.getElementById('page3');
+      context = canvas.getContext('2d');
+      context.font = '30px Arial';
+      context.fillText('I have spoken.', 50, 100);
+      canvas = document.getElementById('page4');
+      context = canvas.getContext('2d');
+      context.font = '30px Arial';
+      context.fillText('Wherever I Go, He Goes.', 50, 100);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36649

In nutshell: 
This PR make AIChatPanel a `printing::mojom::PrintPreviewUI` in order to initiate print preview then we compose print preview result into a pdf and we convert each page of pdf into image and do OCR for each image, finally we concat the results from OCR. This feature will only be rolled out on `docs.google.com` initially, we will introduce it as general fallback in future PR.

Since there are two `PrintPreviewUI` sharing `printing::mojom::PrintRenderFrame`, we have to deal with
-  PrintPreviewUI ID and print preview requests ID conflicts
- `PrintRenderFrame` will be double bound if AIChatUI is doing print preview extraction with print dialog open.
- Print dialog shows up when AIChatUI initiate print preview extraction due to `PrintManagerHost::RequestPrintPreview` calling `PrintPreviewDialogController::PrintPreview`

Unlike print dialog, AIChatPanel will disconnect `PrintRenderFrame` when print preview is done or failed. 
We also introduce a new printing service(PdftoBitmapConverter) to convert the selected pdf page into a SkBitmap and 
since large context will be truncated, we short-circuit the per page OCR process if context limit is reached or page limit is reached.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan: (Windows and MacOS only)
### Regression test on previous google doc support
1. Open a google doc with only 1 page of content and summarize it
2. Summary should be relevant

### Test on full page google doc support
1. Open a google doc with only multiple pages of content and summarize it
2. Summary should be relevant

### Test on page limit (20)
1. Open a google doc with 19 pages of blank pages and 2 pages with completely different scoped of contents
2. Summarize the page
3. Summary should be only relevant to 20th page but not 21st page

### Compatibility with print dialog 
1. Open a google doc and print it
2. When print dialog is open, open Leo panel and summarize the page
3. Summary should show up
4. Close print dialog and trigger print again
5. Print dialog should still show up with print preview available
