### PR TITLE
chore(wallet): use anon-proxy to access LiFi and Jupiter APIs

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1423,7 +1423,7 @@ inline constexpr char kZeroExNativeAssetContractAddress[] =
     "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
 
 // Jupiter swap constants
-inline constexpr char kJupiterBaseAPIURL[] = "https://quote-api.jup.ag";
+inline constexpr char kJupiterBaseAPIURL[] = "https://jupiter.wallet.brave.com";
 inline constexpr double kSolanaBuyTokenFeePercentage = 0.85;
 inline constexpr char kJupiterReferralKey[] =
     "7yke2kxg6ewNsun61qBkdsLdxuXcUiB8CMB47Zv39Aoy";
@@ -1440,7 +1440,7 @@ inline constexpr char kBlowfishAPIVersionHeader[] = "X-Api-Version";
 inline constexpr char kBlowfishAPIVersion[] = "2023-06-05";
 
 // LiFi constants
-inline constexpr char kLiFiBaseAPIURL[] = "https://li.quest";
+inline constexpr char kLiFiBaseAPIURL[] = "https://lifi.wallet.brave.com";
 inline constexpr char kLiFiIntegratorID[] = "brave";
 inline constexpr char kLiFiNativeAssetContractAddress[] =
     "0x0000000000000000000000000000000000000000";

--- a/components/brave_wallet/browser/swap_service.cc
+++ b/components/brave_wallet/browser/swap_service.cc
@@ -408,7 +408,7 @@ void SwapService::GetQuote(mojom::SwapQuoteParamsPtr params,
 
     api_request_helper_.Request(net::HttpRequestHeaders::kGetMethod,
                                 GetJupiterQuoteURL(*params, fee_param), "", "",
-                                std::move(internal_callback), {}, {},
+                                std::move(internal_callback), GetHeaders(), {},
                                 std::move(conversion_callback));
 
     return;
@@ -435,8 +435,8 @@ void SwapService::GetQuote(mojom::SwapQuoteParamsPtr params,
 
     api_request_helper_.Request(
         net::HttpRequestHeaders::kPostMethod, GetLiFiQuoteURL(),
-        *encoded_params, "application/json", std::move(internal_callback), {},
-        {}, std::move(conversion_callback));
+        *encoded_params, "application/json", std::move(internal_callback),
+        GetHeaders(), {}, std::move(conversion_callback));
     return;
   }
 
@@ -566,8 +566,8 @@ void SwapService::GetTransaction(mojom::SwapTransactionParamsUnionPtr params,
     api_request_helper_.Request(
         net::HttpRequestHeaders::kPostMethod,
         GetJupiterTransactionURL(jupiter_transaction_params->chain_id),
-        *encoded_params, "application/json", std::move(internal_callback), {},
-        {});
+        *encoded_params, "application/json", std::move(internal_callback),
+        GetHeaders(), {});
 
     return;
   }
@@ -591,7 +591,7 @@ void SwapService::GetTransaction(mojom::SwapTransactionParamsUnionPtr params,
     api_request_helper_.Request(net::HttpRequestHeaders::kPostMethod,
                                 GetLiFiTransactionURL(), *encoded_params,
                                 "application/json",
-                                std::move(internal_callback), {}, {});
+                                std::move(internal_callback), GetHeaders(), {});
 
     return;
   }

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -1008,7 +1008,7 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuoteURL) {
   // OK: with fees
   auto url = swap_service_->GetJupiterQuoteURL(*params, "85");
   EXPECT_EQ(url,
-            "https://quote-api.jup.ag/v6/quote?"
+            "https://jupiter.wallet.brave.com/v6/quote?"
             "inputMint=So11111111111111111111111111111111111111112&"
             "outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&"
             "amount=10000&"
@@ -1019,7 +1019,7 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuoteURL) {
   // OK: no fees
   url = swap_service_->GetJupiterQuoteURL(*params, "");
   EXPECT_EQ(url,
-            "https://quote-api.jup.ag/v6/quote?"
+            "https://jupiter.wallet.brave.com/v6/quote?"
             "inputMint=So11111111111111111111111111111111111111112&"
             "outputMint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&"
             "amount=10000&"
@@ -1029,7 +1029,7 @@ TEST_F(SwapServiceUnitTest, GetJupiterQuoteURL) {
 
 TEST_F(SwapServiceUnitTest, GetJupiterTransactionURL) {
   auto url = swap_service_->GetJupiterTransactionURL(mojom::kSolanaMainnet);
-  EXPECT_EQ(url, "https://quote-api.jup.ag/v6/swap");
+  EXPECT_EQ(url, "https://jupiter.wallet.brave.com/v6/swap");
 }
 
 TEST_F(SwapServiceUnitTest, GetJupiterQuote) {
@@ -1129,12 +1129,12 @@ TEST_F(SwapServiceUnitTest, GetJupiterTransaction) {
 
 TEST_F(SwapServiceUnitTest, GetLiFiQuoteURL) {
   auto url = swap_service_->GetLiFiQuoteURL();
-  EXPECT_EQ(url, "https://li.quest/v1/advanced/routes");
+  EXPECT_EQ(url, "https://lifi.wallet.brave.com/v1/advanced/routes");
 }
 
 TEST_F(SwapServiceUnitTest, GetLiFiTransactionURL) {
   auto url = swap_service_->GetLiFiTransactionURL();
-  EXPECT_EQ(url, "https://li.quest/v1/advanced/stepTransaction");
+  EXPECT_EQ(url, "https://lifi.wallet.brave.com/v1/advanced/stepTransaction");
 }
 
 TEST_F(SwapServiceUnitTest, GetLiFiQuote) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36839

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Jupiter swaps should continue to work as normal. LiFi is currently not enabled yet, so no need to test that.