### PR TITLE
fix(wallet): Setup core services for Bitcoin on iOS

### DIFF
--- a/ios/browser/brave_wallet/BUILD.gn
+++ b/ios/browser/brave_wallet/BUILD.gn
@@ -7,6 +7,8 @@ source_set("brave_wallet") {
   sources = [
     "asset_ratio_service_factory.cc",
     "asset_ratio_service_factory.h",
+    "bitcoin_wallet_service_factory.cc",
+    "bitcoin_wallet_service_factory.h",
     "brave_wallet_factory_wrappers.h",
     "brave_wallet_factory_wrappers.mm",
     "brave_wallet_ipfs_service_factory.h",

--- a/ios/browser/brave_wallet/bitcoin_wallet_service_factory.cc
+++ b/ios/browser/brave_wallet/bitcoin_wallet_service_factory.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/ios/browser/brave_wallet/bitcoin_wallet_service_factory.h"
+
+#include <utility>
+
+#include "base/no_destructor.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/ios/browser/brave_wallet/keyring_service_factory.h"
+#include "components/keyed_service/core/keyed_service.h"
+#include "components/keyed_service/ios/browser_state_dependency_manager.h"
+#include "ios/chrome/browser/shared/model/browser_state/browser_state_otr_helper.h"
+#include "ios/chrome/browser/shared/model/browser_state/chrome_browser_state.h"
+#include "ios/web/public/thread/web_task_traits.h"
+#include "ios/web/public/thread/web_thread.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+namespace brave_wallet {
+
+// static
+mojo::PendingRemote<mojom::BitcoinWalletService>
+BitcoinWalletServiceFactory::GetForBrowserState(
+    ChromeBrowserState* browser_state) {
+  return static_cast<BitcoinWalletService*>(
+             GetInstance()->GetServiceForBrowserState(browser_state, true))
+      ->MakeRemote();
+}
+
+// static
+BitcoinWalletService* BitcoinWalletServiceFactory::GetServiceForState(
+    ChromeBrowserState* browser_state) {
+  return static_cast<BitcoinWalletService*>(
+      GetInstance()->GetServiceForBrowserState(browser_state, true));
+}
+
+// static
+BitcoinWalletServiceFactory* BitcoinWalletServiceFactory::GetInstance() {
+  static base::NoDestructor<BitcoinWalletServiceFactory> instance;
+  return instance.get();
+}
+
+BitcoinWalletServiceFactory::BitcoinWalletServiceFactory()
+    : BrowserStateKeyedServiceFactory(
+          "BitcoinWalletService",
+          BrowserStateDependencyManager::GetInstance()) {
+  DependsOn(KeyringServiceFactory::GetInstance());
+}
+
+BitcoinWalletServiceFactory::~BitcoinWalletServiceFactory() = default;
+
+std::unique_ptr<KeyedService>
+BitcoinWalletServiceFactory::BuildServiceInstanceFor(
+    web::BrowserState* context) const {
+  auto* browser_state = ChromeBrowserState::FromBrowserState(context);
+
+  std::unique_ptr<BitcoinWalletService> service(new BitcoinWalletService(
+      KeyringServiceFactory::GetServiceForState(browser_state),
+      browser_state->GetPrefs(), browser_state->GetSharedURLLoaderFactory()));
+
+  return service;
+}
+
+bool BitcoinWalletServiceFactory::ServiceIsNULLWhileTesting() const {
+  return true;
+}
+
+web::BrowserState* BitcoinWalletServiceFactory::GetBrowserStateToUse(
+    web::BrowserState* context) const {
+  return GetBrowserStateRedirectedInIncognito(context);
+}
+
+}  // namespace brave_wallet

--- a/ios/browser/brave_wallet/bitcoin_wallet_service_factory.h
+++ b/ios/browser/brave_wallet/bitcoin_wallet_service_factory.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_IOS_BROWSER_BRAVE_WALLET_BITCOIN_WALLET_SERVICE_FACTORY_H_
+#define BRAVE_IOS_BROWSER_BRAVE_WALLET_BITCOIN_WALLET_SERVICE_FACTORY_H_
+
+#include <memory>
+
+#include "brave/components/brave_wallet/browser/bitcoin/bitcoin_wallet_service.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
+#include "components/keyed_service/ios/browser_state_keyed_service_factory.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+class ChromeBrowserState;
+class KeyedService;
+
+namespace base {
+template <typename T>
+class NoDestructor;
+}  // namespace base
+
+namespace web {
+class BrowserState;
+}  // namespace web
+
+namespace brave_wallet {
+
+class BitcoinWalletServiceFactory : public BrowserStateKeyedServiceFactory {
+ public:
+  // Creates the service if it doesn't exist already for |browser_state|.
+  static mojo::PendingRemote<mojom::BitcoinWalletService> GetForBrowserState(
+      ChromeBrowserState* browser_state);
+  static BitcoinWalletService* GetServiceForState(
+      ChromeBrowserState* browser_state);
+
+  static BitcoinWalletServiceFactory* GetInstance();
+
+ private:
+  friend base::NoDestructor<BitcoinWalletServiceFactory>;
+
+  BitcoinWalletServiceFactory();
+  ~BitcoinWalletServiceFactory() override;
+
+  // BrowserContextKeyedServiceFactory:
+  // BrowserStateKeyedServiceFactory implementation.
+  std::unique_ptr<KeyedService> BuildServiceInstanceFor(
+      web::BrowserState* context) const override;
+  bool ServiceIsNULLWhileTesting() const override;
+  web::BrowserState* GetBrowserStateToUse(
+      web::BrowserState* context) const override;
+
+  BitcoinWalletServiceFactory(const BitcoinWalletServiceFactory&) = delete;
+  BitcoinWalletServiceFactory& operator=(const BitcoinWalletServiceFactory&) =
+      delete;
+};
+
+}  // namespace brave_wallet
+
+#endif  // BRAVE_IOS_BROWSER_BRAVE_WALLET_BITCOIN_WALLET_SERVICE_FACTORY_H_

--- a/ios/browser/brave_wallet/brave_wallet_factory_wrappers.h
+++ b/ios/browser/brave_wallet/brave_wallet_factory_wrappers.h
@@ -10,15 +10,22 @@
 #include "keyed_service_factory_wrapper.h"  // NOLINT
 
 @protocol BraveWalletAssetRatioService
-, BraveWalletBraveWalletService, BraveWalletJsonRpcService,
-    BraveWalletEthTxManagerProxy, BraveWalletSolanaTxManagerProxy,
-    BraveWalletTxService, BraveWalletKeyringService, BraveWalletSwapService,
-    BraveWalletIpfsService, BraveWalletZCashWalletService;
+, BraveWalletBraveWalletService, BraveWalletBitcoinWalletService,
+    BraveWalletJsonRpcService, BraveWalletEthTxManagerProxy,
+    BraveWalletSolanaTxManagerProxy, BraveWalletTxService,
+    BraveWalletKeyringService, BraveWalletSwapService, BraveWalletIpfsService,
+    BraveWalletZCashWalletService;
 
 OBJC_EXPORT
 NS_SWIFT_NAME(BraveWallet.AssetRatioServiceFactory)
 @interface BraveWalletAssetRatioServiceFactory
     : KeyedServiceFactoryWrapper <id <BraveWalletAssetRatioService>>
+@end
+
+OBJC_EXPORT
+NS_SWIFT_NAME(BraveWallet.BitcoinWalletServiceFactory)
+@interface BraveWalletBitcoinWalletServiceFactory
+    : KeyedServiceFactoryWrapper <id <BraveWalletBitcoinWalletService>>
 @end
 
 OBJC_EXPORT

--- a/ios/browser/brave_wallet/brave_wallet_factory_wrappers.mm
+++ b/ios/browser/brave_wallet/brave_wallet_factory_wrappers.mm
@@ -7,6 +7,7 @@
 
 #include "brave/ios/browser/api/brave_wallet/brave_wallet.mojom.objc+private.h"
 #include "brave/ios/browser/brave_wallet/asset_ratio_service_factory.h"
+#include "brave/ios/browser/brave_wallet/bitcoin_wallet_service_factory.h"
 #include "brave/ios/browser/brave_wallet/brave_wallet_ipfs_service_factory.h"
 #include "brave/ios/browser/brave_wallet/brave_wallet_service_factory.h"
 #include "brave/ios/browser/brave_wallet/json_rpc_service_factory.h"
@@ -30,6 +31,18 @@
   }
   return [[BraveWalletAssetRatioServiceMojoImpl alloc]
       initWithAssetRatioService:std::move(service)];
+}
+@end
+
+@implementation BraveWalletBitcoinWalletServiceFactory
++ (nullable id)serviceForBrowserState:(ChromeBrowserState*)browserState {
+  auto service = brave_wallet::BitcoinWalletServiceFactory::GetForBrowserState(
+      browserState);
+  if (!service) {
+    return nil;
+  }
+  return [[BraveWalletBitcoinWalletServiceMojoImpl alloc]
+      initWithBitcoinWalletService:std::move(service)];
 }
 @end
 

--- a/ios/browser/brave_wallet/brave_wallet_service_factory.mm
+++ b/ios/browser/brave_wallet/brave_wallet_service_factory.mm
@@ -9,6 +9,7 @@
 
 #include "brave/components/brave_wallet/browser/brave_wallet_service.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_service_delegate.h"
+#include "brave/ios/browser/brave_wallet/bitcoin_wallet_service_factory.h"
 #include "brave/ios/browser/brave_wallet/json_rpc_service_factory.h"
 #include "brave/ios/browser/brave_wallet/keyring_service_factory.h"
 #include "brave/ios/browser/brave_wallet/tx_service_factory.h"
@@ -51,6 +52,7 @@ BraveWalletServiceFactory::BraveWalletServiceFactory()
           BrowserStateDependencyManager::GetInstance()) {
   DependsOn(KeyringServiceFactory::GetInstance());
   DependsOn(JsonRpcServiceFactory::GetInstance());
+  DependsOn(BitcoinWalletServiceFactory::GetInstance());
   DependsOn(TxServiceFactory::GetInstance());
   DependsOn(ZCashWalletServiceFactory::GetInstance());
 }
@@ -67,7 +69,7 @@ BraveWalletServiceFactory::BuildServiceInstanceFor(
       KeyringServiceFactory::GetServiceForState(browser_state),
       JsonRpcServiceFactory::GetServiceForState(browser_state),
       TxServiceFactory::GetServiceForState(browser_state),
-      nullptr,  // TODO(apaymyshev): support bitcoin for ios.
+      BitcoinWalletServiceFactory::GetServiceForState(browser_state),
       ZCashWalletServiceFactory::GetServiceForState(browser_state),
       browser_state->GetPrefs(), GetApplicationContext()->GetLocalState(),
       browser_state->IsOffTheRecord()));

--- a/ios/browser/brave_wallet/tx_service_factory.cc
+++ b/ios/browser/brave_wallet/tx_service_factory.cc
@@ -10,6 +10,7 @@
 #include "base/no_destructor.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/ios/browser/brave_wallet/asset_ratio_service_factory.h"
+#include "brave/ios/browser/brave_wallet/bitcoin_wallet_service_factory.h"
 #include "brave/ios/browser/brave_wallet/json_rpc_service_factory.h"
 #include "brave/ios/browser/brave_wallet/keyring_service_factory.h"
 #include "brave/ios/browser/brave_wallet/zcash_wallet_service_factory.h"
@@ -66,6 +67,7 @@ TxServiceFactory::TxServiceFactory()
           "TxService",
           BrowserStateDependencyManager::GetInstance()) {
   DependsOn(JsonRpcServiceFactory::GetInstance());
+  DependsOn(BitcoinWalletServiceFactory::GetInstance());
   DependsOn(KeyringServiceFactory::GetInstance());
   DependsOn(AssetRatioServiceFactory::GetInstance());
   DependsOn(ZCashWalletServiceFactory::GetInstance());
@@ -80,13 +82,14 @@ std::unique_ptr<KeyedService> TxServiceFactory::BuildServiceInstanceFor(
       JsonRpcServiceFactory::GetServiceForState(browser_state);
   auto* keyring_service =
       KeyringServiceFactory::GetServiceForState(browser_state);
+  auto* bitcoin_wallet_service =
+      BitcoinWalletServiceFactory::GetServiceForState(browser_state);
   auto* zcash_wallet_service =
       ZCashWalletServiceFactory::GetServiceForState(browser_state);
-  // TODO(apaymyshev): support bitcoin for ios.
   std::unique_ptr<TxService> tx_service(new TxService(
-      json_rpc_service, /*bitcoin_wallet_service=*/nullptr,
-      zcash_wallet_service, keyring_service, browser_state->GetPrefs(),
-      browser_state->GetStatePath(), web::GetUIThreadTaskRunner({})));
+      json_rpc_service, bitcoin_wallet_service, zcash_wallet_service,
+      keyring_service, browser_state->GetPrefs(), browser_state->GetStatePath(),
+      web::GetUIThreadTaskRunner({})));
   return tx_service;
 }
 


### PR DESCRIPTION
- Initial work to setup `BitcoinService` for iOS in BraveCore, allowing enabling the Bitcoin feature flag on iOS without crashing for unavailable service(s). 
    - Sets up the `BitcoinWalletServiceFactory`
    - Provides the `BitcoinWalletService` to  `BraveWalletServiceFactory` & `TxServiceFactory` for instantiation with those services on iOS.
    - You will not be able to add an account, select network, or do _anything_ Bitcoin on iOS with these changes even with the feature flag enabled.
- Bitcoin will be handled in stages on iOS ([umbrella issue](https://github.com/brave/brave-browser/issues/32722)), and will share the BraveCore feature flag to restrict logic using the Features API now exported to iOS in https://github.com/brave/brave-core/pull/21559. This Bitcoin feature flag [remains **disabled** by default on iOS](https://github.com/brave/brave-core/blob/fe9b5d7462f1473106243f313deaa4d6c8351d7b/components/brave_wallet/common/config.gni#L11) and should remain that way until a full security & privacy review has been completed.
    - Conditional flag can be checked in Swift code via: `BraveCore.FeatureList.kBraveWalletBitcoinFeature.enabled`.

Resolves https://github.com/brave/brave-browser/issues/36807

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable Bitcoin feature flag, compile & run in Xcode with `BraveWalletBitcoin` feature flag enabled.
2. Verify no crash on launch, setup / restore a wallet. 
3. Verify Bitcoin unavailable on iOS (networks lists, add account types).