### PR TITLE
[Leo] Implement rewrite in place from context menu rewrite actions 

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -448,9 +448,18 @@
       kOsWin | kOsMac | kOsLinux,                            \
       FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory), \
   })
+#define BRAVE_AI_CHAT_CONTEXT_MENU_REWRITE_IN_PLACE                      \
+  EXPAND_FEATURE_ENTRIES({                                               \
+      "brave-ai-chat-context-menu-rewrite-in-place",                     \
+      "Brave AI Chat Rewrite In Place From Context Menu",                \
+      "Enables AI Chat rewrite in place feature from the context menu",  \
+      kOsDesktop,                                                        \
+      FEATURE_VALUE_TYPE(ai_chat::features::kContextMenuRewriteInPlace), \
+  })
 #else
 #define BRAVE_AI_CHAT
 #define BRAVE_AI_CHAT_HISTORY
+#define BRAVE_AI_CHAT_CONTEXT_MENU_REWRITE_IN_PLACE
 #endif
 
 #define BRAVE_OMNIBOX_FEATURES                                                \
@@ -1000,6 +1009,7 @@
   BRAVE_TABS_FEATURE_ENTRIES                                                   \
   BRAVE_AI_CHAT                                                                \
   BRAVE_AI_CHAT_HISTORY                                                        \
+  BRAVE_AI_CHAT_CONTEXT_MENU_REWRITE_IN_PLACE                                  \
   BRAVE_OMNIBOX_FEATURES                                                       \
   BRAVE_PLAYER_FEATURE_ENTRIES                                                 \
   BRAVE_MIDDLE_CLICK_AUTOSCROLL_FEATURE_ENTRY                                  \

--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -31,10 +31,13 @@ source_set("browser_tests") {
     testonly = true
     defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
     sources = [
+      "//chrome/browser/renderer_context_menu/render_view_context_menu_browsertest_util.cc",
+      "//chrome/browser/renderer_context_menu/render_view_context_menu_browsertest_util.h",
       "ai_chat_browsertests.cc",
       "ai_chat_metrics_browsertest.cc",
       "ai_chat_policy_browsertest.cc",
       "ai_chat_profile_browsertest.cc",
+      "ai_chat_render_view_context_menu_browsertest.cc",
       "page_content_fetcher_browsertest.cc",
     ]
     deps = [
@@ -42,6 +45,7 @@ source_set("browser_tests") {
       "//brave/browser/ui/sidebar",
       "//brave/components/ai_chat/content/browser",
       "//brave/components/ai_chat/core/browser",
+      "//brave/components/ai_chat/core/browser:test_support",
       "//brave/components/ai_chat/core/common",
       "//brave/components/ai_chat/core/common/mojom",
       "//brave/components/constants",

--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -1,0 +1,210 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/renderer_context_menu/render_view_context_menu.h"
+
+#include "base/path_service.h"
+#include "base/run_loop.h"
+#include "brave/app/brave_command_ids.h"
+#include "brave/browser/ui/brave_browser.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
+#include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
+#include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/core/browser/engine/mock_remote_completion_client.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/constants/brave_paths.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/renderer_context_menu/render_view_context_menu_browsertest_util.h"
+#include "chrome/browser/renderer_context_menu/render_view_context_menu_test_util.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/render_view_host.h"
+#include "content/public/browser/render_widget_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+using ::testing::_;
+
+namespace ai_chat {
+
+class AIChatRenderViewContextMenuBrowserTest : public InProcessBrowserTest {
+ public:
+  AIChatRenderViewContextMenuBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
+  ~AIChatRenderViewContextMenuBrowserTest() override = default;
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    host_resolver()->AddRule("*", "127.0.0.1");
+
+    brave::RegisterPathProvider();
+    base::FilePath test_data_dir =
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA)
+            .AppendASCII("ai_chat");
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    ASSERT_TRUE(https_server_.Start());
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+  }
+
+  content::WebContents* web_contents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  PrefService* GetPrefs() { return browser()->profile()->GetPrefs(); }
+
+  net::EmbeddedTestServer* https_server() { return &https_server_; }
+
+  void TestRewriteInPlace(
+      content::WebContents* web_contents,
+      MockRemoteCompletionClient* mock_client,
+      const std::string& element_id,
+      const std::string& expected_selected_text,
+      const std::vector<std::string>& received_data,
+      base::expected<std::string, mojom::APIError> completed_result,
+      const std::string& expected_updated_text) {
+    base::RunLoop run_loop;
+    EXPECT_CALL(*mock_client, QueryPrompt(_, _, _, _))
+        .WillOnce([&](const std::string& prompt,
+                      const std::vector<std::string>& history,
+                      EngineConsumer::GenerationCompletedCallback callback,
+                      EngineConsumer::GenerationDataCallback data_callback) {
+          ASSERT_TRUE(callback);
+          ASSERT_TRUE(data_callback);
+          for (const auto& data : received_data) {
+            data_callback.Run(data);
+          }
+          std::move(callback).Run(completed_result);
+          run_loop.Quit();
+        });
+
+    // Select text in the element and create context menu to execute a rewrite
+    // command.
+    std::string selected_text =
+        content::EvalJs(web_contents, base::StringPrintf("select_all('%s')",
+                                                         element_id.c_str()))
+            .ExtractString();
+    EXPECT_EQ(expected_selected_text, selected_text);
+
+    int x = content::EvalJs(
+                web_contents,
+                base::StringPrintf("getRectX('%s')", element_id.c_str()))
+                .ExtractInt();
+    int y = content::EvalJs(
+                web_contents,
+                base::StringPrintf("getRectY('%s')", element_id.c_str()))
+                .ExtractInt();
+
+    ContextMenuNotificationObserver context_menu_observer(
+        IDC_AI_CHAT_CONTEXT_SHORTEN);
+    web_contents->GetPrimaryMainFrame()
+        ->GetRenderViewHost()
+        ->GetWidget()
+        ->ShowContextMenuAtPoint(gfx::Point(x, y), ui::MENU_SOURCE_MOUSE);
+    run_loop.Run();
+    testing::Mock::VerifyAndClearExpectations(mock_client);
+
+    // Verify that the text is rewritten as expected.
+    std::string updated_text =
+        content::EvalJs(web_contents, base::StringPrintf("get_text('%s')",
+                                                         element_id.c_str()))
+            .ExtractString();
+    EXPECT_EQ(expected_updated_text, updated_text);
+  }
+
+  sidebar::SidebarController* GetSidebarController() {
+    auto* controller =
+        static_cast<BraveBrowser*>(browser())->sidebar_controller();
+    EXPECT_TRUE(controller);
+    return controller;
+  }
+
+  bool IsAIChatSidebarActive() {
+    auto* sidebar_controller = GetSidebarController();
+    auto index = sidebar_controller->model()->GetIndexOf(
+        sidebar::SidebarItem::BuiltInItemType::kChatUI);
+    return sidebar_controller->IsActiveIndex(index);
+  }
+
+ private:
+  content::ContentMockCertVerifier mock_cert_verifier_;
+  net::test_server::EmbeddedTestServer https_server_;
+};
+
+IN_PROC_BROWSER_TEST_F(AIChatRenderViewContextMenuBrowserTest, RewriteInPlace) {
+  // Mimic user opt-in by setting pref.
+  SetUserOptedIn(GetPrefs(), true);
+
+  // Load rewrite.html
+  GURL url = https_server()->GetURL("/rewrite.html");
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), url));
+  auto* contents = web_contents();
+
+  // Setup a mock completion client to handle the request.
+  ai_chat::AIChatTabHelper* helper =
+      ai_chat::AIChatTabHelper::FromWebContents(contents);
+  ASSERT_TRUE(helper);
+  auto* engine = helper->GetEngineForTesting();
+  ASSERT_TRUE(engine);
+  engine->SetAPIForTesting(
+      std::make_unique<MockRemoteCompletionClient>("mixtral-8x7b-instruct"));
+  auto* mock_client =
+      static_cast<MockRemoteCompletionClient*>(engine->GetAPIForTesting());
+
+  TestRewriteInPlace(contents, mock_client, "textarea", "I'm textarea.",
+                     {"O", "OK", "<", "</", "</r", "</re", "</response"}, "",
+                     "OK");
+
+  // Do the same again to make sure it still works at the second time.
+  TestRewriteInPlace(contents, mock_client, "textarea", "OK",
+                     {"O", "OK", "OK2"}, "", "OK2");
+
+  // Select text in text input and create context menu to execute a rewrite cmd.
+  // Verify that the text is rewritten.
+  TestRewriteInPlace(contents, mock_client, "input_text", "I'm input.",
+                     {"O", "OK", "OK3"}, "", "OK3");
+  TestRewriteInPlace(contents, mock_client, "contenteditable",
+                     "I'm contenteditable.", {"O", "OK", "OK4"}, "", "OK4");
+
+  // Error case handling tests and verify that the text is not rewritten.
+  // 1) Get error in completed callback immediately.
+  EXPECT_FALSE(IsAIChatSidebarActive());
+  TestRewriteInPlace(contents, mock_client, "textarea", "OK2", {},
+                     base::unexpected(mojom::APIError::ConnectionIssue), "OK2");
+  EXPECT_TRUE(IsAIChatSidebarActive());
+  GetSidebarController()->DeactivateCurrentPanel();
+
+  EXPECT_FALSE(IsAIChatSidebarActive());
+  // 2) Get partial streaming responses then error in completed callback.
+  TestRewriteInPlace(contents, mock_client, "textarea", "OK2", {"N", "O"},
+                     base::unexpected(mojom::APIError::ConnectionIssue), "OK2");
+  EXPECT_TRUE(IsAIChatSidebarActive());
+}
+
+}  // namespace ai_chat

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -5,6 +5,9 @@
 
 #include <optional>
 
+#include "base/containers/fixed_flat_map.h"
+#include "base/containers/fixed_flat_set.h"
+#include "base/strings/string_util.h"
 #include "brave/browser/autocomplete/brave_autocomplete_scheme_classifier.h"
 #include "brave/browser/ipfs/import/ipfs_import_controller.h"
 #include "brave/browser/profiles/profile_util.h"
@@ -21,6 +24,7 @@
 #include "components/omnibox/browser/autocomplete_classifier.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
 #include "components/omnibox/browser/autocomplete_match_type.h"
+#include "content/public/browser/web_contents.h"
 #include "net/base/filename_util.h"
 #include "ui/base/models/menu_separator_types.h"
 #include "ui/base/resource/resource_bundle.h"
@@ -53,6 +57,7 @@
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "components/grit/brave_components_strings.h"
+#include "third_party/re2/src/re2/re2.h"
 #endif
 
 // Our .h file creates a masquerade for RenderViewContextMenu.  Switch
@@ -180,6 +185,158 @@ void OnGetImageForTextCopy(base::WeakPtr<content::WebContents> web_contents,
   brave::ShowTextRecognitionDialog(web_contents.get(), image);
 }
 #endif
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+constexpr char kAIChatRewriteDataKey[] = "ai_chat_rewrite_data";
+constexpr char kResponseTagPattern[] =
+    "<\\/?(response|respons|respon|respo|resp|res|re|r)?$";
+
+struct AIChatRewriteData : public base::SupportsUserData::Data {
+  bool has_data_received = false;
+};
+
+bool IsRewriteCommand(int command) {
+  static constexpr auto kRewriteCommands = base::MakeFixedFlatSet<int>(
+      {IDC_AI_CHAT_CONTEXT_PARAPHRASE, IDC_AI_CHAT_CONTEXT_IMPROVE,
+       IDC_AI_CHAT_CONTEXT_ACADEMICIZE, IDC_AI_CHAT_CONTEXT_PROFESSIONALIZE,
+       IDC_AI_CHAT_CONTEXT_PERSUASIVE_TONE, IDC_AI_CHAT_CONTEXT_CASUALIZE,
+       IDC_AI_CHAT_CONTEXT_FUNNY_TONE, IDC_AI_CHAT_CONTEXT_SHORTEN,
+       IDC_AI_CHAT_CONTEXT_EXPAND});
+
+  return kRewriteCommands.contains(command);
+}
+
+std::pair<ai_chat::mojom::ActionType, ai_chat::ContextMenuAction>
+GetActionTypeAndP3A(int command) {
+  static constexpr auto kActionTypeMap = base::MakeFixedFlatMap<
+      int, std::pair<ai_chat::mojom::ActionType, ai_chat::ContextMenuAction>>(
+      {{IDC_AI_CHAT_CONTEXT_SUMMARIZE_TEXT,
+        {ai_chat::mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
+         ai_chat::ContextMenuAction::kSummarize}},
+       {IDC_AI_CHAT_CONTEXT_EXPLAIN,
+        {ai_chat::mojom::ActionType::EXPLAIN,
+         ai_chat::ContextMenuAction::kExplain}},
+       {IDC_AI_CHAT_CONTEXT_PARAPHRASE,
+        {ai_chat::mojom::ActionType::PARAPHRASE,
+         ai_chat::ContextMenuAction::kParaphrase}},
+       {IDC_AI_CHAT_CONTEXT_CREATE_TAGLINE,
+        {ai_chat::mojom::ActionType::CREATE_TAGLINE,
+         ai_chat::ContextMenuAction::kCreateTagline}},
+       {IDC_AI_CHAT_CONTEXT_CREATE_SOCIAL_MEDIA_COMMENT_SHORT,
+        {ai_chat::mojom::ActionType::CREATE_SOCIAL_MEDIA_COMMENT_SHORT,
+         ai_chat::ContextMenuAction::kCreateSocialMedia}},
+       {IDC_AI_CHAT_CONTEXT_CREATE_SOCIAL_MEDIA_COMMENT_LONG,
+        {ai_chat::mojom::ActionType::CREATE_SOCIAL_MEDIA_COMMENT_LONG,
+         ai_chat::ContextMenuAction::kCreateSocialMedia}},
+       {IDC_AI_CHAT_CONTEXT_IMPROVE,
+        {ai_chat::mojom::ActionType::IMPROVE,
+         ai_chat::ContextMenuAction::kImprove}},
+       {IDC_AI_CHAT_CONTEXT_ACADEMICIZE,
+        {ai_chat::mojom::ActionType::ACADEMICIZE,
+         ai_chat::ContextMenuAction::kChangeTone}},
+       {IDC_AI_CHAT_CONTEXT_PROFESSIONALIZE,
+        {ai_chat::mojom::ActionType::PROFESSIONALIZE,
+         ai_chat::ContextMenuAction::kChangeTone}},
+       {IDC_AI_CHAT_CONTEXT_PERSUASIVE_TONE,
+        {ai_chat::mojom::ActionType::PERSUASIVE_TONE,
+         ai_chat::ContextMenuAction::kChangeTone}},
+       {IDC_AI_CHAT_CONTEXT_CASUALIZE,
+        {ai_chat::mojom::ActionType::CASUALIZE,
+         ai_chat::ContextMenuAction::kChangeTone}},
+       {IDC_AI_CHAT_CONTEXT_FUNNY_TONE,
+        {ai_chat::mojom::ActionType::FUNNY_TONE,
+         ai_chat::ContextMenuAction::kChangeTone}},
+       {IDC_AI_CHAT_CONTEXT_SHORTEN,
+        {ai_chat::mojom::ActionType::SHORTEN,
+         ai_chat::ContextMenuAction::kChangeLength}},
+       {IDC_AI_CHAT_CONTEXT_EXPAND,
+        {ai_chat::mojom::ActionType::EXPAND,
+         ai_chat::ContextMenuAction::kChangeLength}}});
+  CHECK(kActionTypeMap.contains(command));
+  return kActionTypeMap.at(command);
+}
+
+void OnRewriteSuggestionDataReceived(
+    base::WeakPtr<content::WebContents> web_contents,
+    std::string suggestion) {
+  if (!web_contents) {
+    return;
+  }
+
+  base::TrimWhitespaceASCII(suggestion, base::TRIM_ALL, &suggestion);
+  if (suggestion.empty()) {
+    return;
+  }
+
+  // Avoid showing the ending tag.
+  if (RE2::PartialMatch(suggestion, kResponseTagPattern)) {
+    return;
+  }
+
+  auto* rewrite_data = static_cast<AIChatRewriteData*>(
+      web_contents->GetUserData(kAIChatRewriteDataKey));
+  if (!rewrite_data) {
+    return;
+  }
+
+  if (rewrite_data->has_data_received) {
+    // Subsequent data received, undo previous streaming result.
+    web_contents->Undo();
+  } else {
+    rewrite_data->has_data_received = true;
+  }
+
+  web_contents->Replace(base::UTF8ToUTF16(suggestion));
+}
+
+void OnRewriteSuggestionCompleted(
+    base::WeakPtr<content::WebContents> web_contents,
+    const std::string& selected_text,
+    ai_chat::mojom::ActionType action_type,
+    base::expected<std::string, ai_chat::mojom::APIError> result) {
+  if (!web_contents) {
+    return;
+  }
+
+  if (!result.has_value()) {
+    // If the content has been rewritten by previous streaming result, undo to
+    // get back to original text.
+    auto* rewrite_data = static_cast<AIChatRewriteData*>(
+        web_contents->GetUserData(kAIChatRewriteDataKey));
+    if (!rewrite_data) {
+      return;
+    }
+
+    if (rewrite_data->has_data_received) {
+      web_contents->Undo();
+    }
+
+    // Show the error in Leo side panel UI.
+    Browser* browser = chrome::FindBrowserWithTab(web_contents.get());
+    if (!browser) {
+      return;
+    }
+
+    ai_chat::AIChatTabHelper* helper =
+        ai_chat::AIChatTabHelper::FromWebContents(web_contents.get());
+    if (!helper) {
+      return;
+    }
+    helper->MaybeUnlinkPageContent();
+
+    auto* sidebar_controller =
+        static_cast<BraveBrowser*>(browser)->sidebar_controller();
+    CHECK(sidebar_controller);
+    sidebar_controller->ActivatePanelItem(
+        sidebar::SidebarItem::BuiltInItemType::kChatUI);
+
+    helper->AddSubmitSelectedTextError(selected_text, action_type,
+                                       result.error());
+  }
+
+  web_contents->RemoveUserData(kAIChatRewriteDataKey);
+}
+#endif  // BUILDFLAG(ENABLE_AI_CHAT)
 
 }  // namespace
 
@@ -407,103 +564,54 @@ void BraveRenderViewContextMenu::ExecuteAIChatCommand(int command) {
     return;
   }
 
-  // Before trying to activate the panel, unlink page content if needed.
-  // This needs to be called before activating the panel to check against the
-  // current state.
-  helper->MaybeUnlinkPageContent();
+  // To do rewrite in-place, the following conditions must be met:
+  // 1) Selected content is editable.
+  // 2) User has opted in to Leo.
+  // 3) SSE is enabled, it is required otherwise the UI update will be too slow.
+  // 4) The command is a rewrite command.
+  // 5) There's no in-progress in-place rewrite.
+  bool rewrite_in_place =
+      params_.is_editable &&
+      ai_chat::HasUserOptedIn(GetProfile()->GetPrefs()) &&
+      ai_chat::features::kAIChatSSE.Get() && IsRewriteCommand(command) &&
+      !source_web_contents_->GetUserData(kAIChatRewriteDataKey);
 
-  // Active the panel.
-  auto* sidebar_controller =
-      static_cast<BraveBrowser*>(browser)->sidebar_controller();
-  CHECK(sidebar_controller);
-  sidebar_controller->ActivatePanelItem(
-      sidebar::SidebarItem::BuiltInItemType::kChatUI);
+  if (!rewrite_in_place) {
+    // Before trying to activate the panel, unlink page content if needed.
+    // This needs to be called before activating the panel to check against the
+    // current state.
+    helper->MaybeUnlinkPageContent();
 
-  std::optional<ai_chat::ContextMenuAction> p3a_action;
-
-  switch (command) {
-    case IDC_AI_CHAT_CONTEXT_SUMMARIZE_TEXT:
-      p3a_action = ai_chat::ContextMenuAction::kSummarize;
-      helper->SubmitSelectedText(
-          base::UTF16ToUTF8(params_.selection_text),
-          ai_chat::mojom::ActionType::SUMMARIZE_SELECTED_TEXT);
-      break;
-    case IDC_AI_CHAT_CONTEXT_EXPLAIN:
-      p3a_action = ai_chat::ContextMenuAction::kExplain;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::EXPLAIN);
-      break;
-    case IDC_AI_CHAT_CONTEXT_PARAPHRASE:
-      p3a_action = ai_chat::ContextMenuAction::kParaphrase;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::PARAPHRASE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_CREATE_TAGLINE:
-      p3a_action = ai_chat::ContextMenuAction::kCreateTagline;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::CREATE_TAGLINE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_CREATE_SOCIAL_MEDIA_COMMENT_SHORT:
-      p3a_action = ai_chat::ContextMenuAction::kCreateSocialMedia;
-      helper->SubmitSelectedText(
-          base::UTF16ToUTF8(params_.selection_text),
-          ai_chat::mojom::ActionType::CREATE_SOCIAL_MEDIA_COMMENT_SHORT);
-      break;
-    case IDC_AI_CHAT_CONTEXT_CREATE_SOCIAL_MEDIA_COMMENT_LONG:
-      p3a_action = ai_chat::ContextMenuAction::kCreateSocialMedia;
-      helper->SubmitSelectedText(
-          base::UTF16ToUTF8(params_.selection_text),
-          ai_chat::mojom::ActionType::CREATE_SOCIAL_MEDIA_COMMENT_LONG);
-      break;
-    case IDC_AI_CHAT_CONTEXT_IMPROVE:
-      p3a_action = ai_chat::ContextMenuAction::kImprove;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::IMPROVE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_ACADEMICIZE:
-      p3a_action = ai_chat::ContextMenuAction::kChangeTone;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::ACADEMICIZE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_PROFESSIONALIZE:
-      p3a_action = ai_chat::ContextMenuAction::kChangeTone;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::PROFESSIONALIZE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_PERSUASIVE_TONE:
-      p3a_action = ai_chat::ContextMenuAction::kChangeTone;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::PERSUASIVE_TONE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_CASUALIZE:
-      p3a_action = ai_chat::ContextMenuAction::kChangeTone;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::CASUALIZE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_FUNNY_TONE:
-      p3a_action = ai_chat::ContextMenuAction::kChangeTone;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::FUNNY_TONE);
-      break;
-    case IDC_AI_CHAT_CONTEXT_SHORTEN:
-      p3a_action = ai_chat::ContextMenuAction::kChangeLength;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::SHORTEN);
-      break;
-    case IDC_AI_CHAT_CONTEXT_EXPAND:
-      p3a_action = ai_chat::ContextMenuAction::kChangeLength;
-      helper->SubmitSelectedText(base::UTF16ToUTF8(params_.selection_text),
-                                 ai_chat::mojom::ActionType::EXPAND);
-      break;
-    default:
-      NOTREACHED_NORETURN();
+    // Active the panel.
+    auto* sidebar_controller =
+        static_cast<BraveBrowser*>(browser)->sidebar_controller();
+    CHECK(sidebar_controller);
+    sidebar_controller->ActivatePanelItem(
+        sidebar::SidebarItem::BuiltInItemType::kChatUI);
+  } else {
+    source_web_contents_->SetUserData(kAIChatRewriteDataKey,
+                                      std::make_unique<AIChatRewriteData>());
   }
 
-  if (p3a_action) {
-    g_brave_browser_process->process_misc_metrics()
-        ->ai_chat_metrics()
-        ->RecordContextMenuUsage(*p3a_action);
-  }
+  auto [action_type, p3a_action] = GetActionTypeAndP3A(command);
+  auto selected_text = base::UTF16ToUTF8(params_.selection_text);
+  auto data_received_callback =
+      rewrite_in_place ? base::BindRepeating(&OnRewriteSuggestionDataReceived,
+                                             source_web_contents_->GetWeakPtr())
+                       : base::NullCallback();
+  auto completed_callback =
+      rewrite_in_place ? base::BindOnce(&OnRewriteSuggestionCompleted,
+                                        source_web_contents_->GetWeakPtr(),
+                                        selected_text, action_type)
+                       : base::NullCallback();
+
+  helper->SubmitSelectedText(selected_text, action_type,
+                             std::move(data_received_callback),
+                             std::move(completed_callback));
+
+  g_brave_browser_process->process_misc_metrics()
+      ->ai_chat_metrics()
+      ->RecordContextMenuUsage(p3a_action);
 }
 
 void BraveRenderViewContextMenu::BuildAIChatMenu() {

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -567,12 +567,14 @@ void BraveRenderViewContextMenu::ExecuteAIChatCommand(int command) {
   // To do rewrite in-place, the following conditions must be met:
   // 1) Selected content is editable.
   // 2) User has opted in to Leo.
-  // 3) SSE is enabled, it is required otherwise the UI update will be too slow.
-  // 4) The command is a rewrite command.
-  // 5) There's no in-progress in-place rewrite.
+  // 3) Context menu rewrite in place feature is enabled.
+  // 4) SSE is enabled, it is required otherwise the UI update will be too slow.
+  // 5) The command is a rewrite command.
+  // 6) There's no in-progress in-place rewrite.
   bool rewrite_in_place =
       params_.is_editable &&
       ai_chat::HasUserOptedIn(GetProfile()->GetPrefs()) &&
+      ai_chat::features::IsContextMenuRewriteInPlaceEnabled() &&
       ai_chat::features::kAIChatSSE.Get() && IsRewriteCommand(command) &&
       !source_web_contents_->GetUserData(kAIChatRewriteDataKey);
 

--- a/components/ai_chat/core/browser/conversation_driver.cc
+++ b/components/ai_chat/core/browser/conversation_driver.cc
@@ -26,6 +26,7 @@
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer_claude.h"
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer_llama.h"
 #include "brave/components/ai_chat/core/browser/models.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
@@ -91,6 +92,13 @@ GetActionTypeQuestionMap() {
            {mojom::ActionType::EXPAND,
             l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_EXPAND)}});
   return *map;
+}
+
+const std::string& GetActionTypeQuestion(mojom::ActionType action_type) {
+  const auto& map = GetActionTypeQuestionMap();
+  auto iter = map.find(action_type);
+  CHECK(iter != map.end());
+  return iter->second;
 }
 
 }  // namespace
@@ -301,18 +309,11 @@ void ConversationDriver::InitEngine() {
 }
 
 bool ConversationDriver::HasUserOptedIn() {
-  base::Time last_accepted_disclaimer =
-        pref_service_->GetTime(ai_chat::prefs::kLastAcceptedDisclaimer);
-  return !last_accepted_disclaimer.is_null();
+  return ::ai_chat::HasUserOptedIn(pref_service_);
 }
 
 void ConversationDriver::SetUserOptedIn(bool user_opted_in) {
-  if (user_opted_in) {
-    pref_service_->SetTime(ai_chat::prefs::kLastAcceptedDisclaimer,
-                           base::Time::Now());
-  } else {
-    pref_service_->ClearPref(ai_chat::prefs::kLastAcceptedDisclaimer);
-  }
+  ::ai_chat::SetUserOptedIn(pref_service_, user_opted_in);
 }
 
 void ConversationDriver::OnUserOptedIn() {
@@ -683,16 +684,43 @@ void ConversationDriver::MaybeUnlinkPageContent() {
   }
 }
 
-void ConversationDriver::SubmitSelectedText(const std::string& selected_text,
-                                            mojom::ActionType action_type) {
-  const auto& action_type_question_map = GetActionTypeQuestionMap();
-  auto iter = action_type_question_map.find(action_type);
-  DCHECK(iter != action_type_question_map.end());
-
+void ConversationDriver::AddSubmitSelectedTextError(
+    const std::string& selected_text,
+    mojom::ActionType action_type,
+    mojom::APIError error) {
+  if (error == mojom::APIError::None) {
+    return;
+  }
+  const std::string& question = GetActionTypeQuestion(action_type);
   mojom::ConversationTurn turn = {CharacterType::HUMAN, action_type,
-                                  ConversationTurnVisibility::VISIBLE,
-                                  iter->second, selected_text};
-  SubmitHumanConversationEntry(turn);
+                                  ConversationTurnVisibility::VISIBLE, question,
+                                  selected_text};
+  AddToConversationHistory(std::move(turn));
+  SetAPIError(error);
+}
+
+void ConversationDriver::SubmitSelectedText(
+    const std::string& selected_text,
+    mojom::ActionType action_type,
+    EngineConsumer::GenerationDataCallback received_callback,
+    EngineConsumer::GenerationCompletedCallback completed_callback) {
+  const std::string& question = GetActionTypeQuestion(action_type);
+
+  if (received_callback && completed_callback) {
+    // Start a one-off request and replace in-place with the result.
+    engine_->GenerateRewriteSuggestion(selected_text, question,
+                                       std::move(received_callback),
+                                       std::move(completed_callback));
+  } else if (!received_callback && !completed_callback) {
+    // Use sidebar.
+    mojom::ConversationTurn turn = {CharacterType::HUMAN, action_type,
+                                    ConversationTurnVisibility::VISIBLE,
+                                    question, selected_text};
+
+    SubmitHumanConversationEntry(turn);
+  } else {
+    NOTREACHED_NORETURN() << "Both callbacks must be set or unset";
+  }
 }
 
 void ConversationDriver::SubmitHumanConversationEntry(

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -108,8 +108,17 @@ class ConversationDriver {
   mojom::SiteInfoPtr BuildSiteInfo();
   bool HasPendingConversationEntry();
 
-  void SubmitSelectedText(const std::string& selected_text,
-                          mojom::ActionType action_type);
+  void AddSubmitSelectedTextError(const std::string& selected_text,
+                                  mojom::ActionType action_type,
+                                  mojom::APIError error);
+
+  void SubmitSelectedText(
+      const std::string& selected_text,
+      mojom::ActionType action_type,
+      EngineConsumer::GenerationDataCallback received_callback =
+          base::NullCallback(),
+      EngineConsumer::GenerationCompletedCallback completed_callback =
+          base::NullCallback());
 
   void RateMessage(bool is_liked,
                    uint32_t turn_id,
@@ -129,6 +138,8 @@ class ConversationDriver {
 
   bool IsArticleTextEmptyForTesting() const { return article_text_.empty(); }
   bool IsSuggestionsEmptyForTesting() const { return suggestions_.empty(); }
+
+  EngineConsumer* GetEngineForTesting() { return engine_.get(); }
 
  protected:
   virtual GURL GetPageURL() const = 0;

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -56,6 +56,12 @@ class EngineConsumer {
       GenerationDataCallback data_received_callback,
       GenerationCompletedCallback completed_callback) = 0;
 
+  virtual void GenerateRewriteSuggestion(
+      std::string text,
+      const std::string& question,
+      GenerationDataCallback received_callback,
+      GenerationCompletedCallback completed_callback) {}
+
   // Prevent indirect prompt injections being sent to the AI model.
   // Include break-out strings contained in prompts, as well as the base
   // model command separators.

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
@@ -168,6 +168,27 @@ void EngineConsumerClaudeRemote::ClearAllQueries() {
   api_->ClearAllQueries();
 }
 
+void EngineConsumerClaudeRemote::GenerateRewriteSuggestion(
+    std::string text,
+    const std::string& question,
+    GenerationDataCallback received_callback,
+    GenerationCompletedCallback completed_callback) {
+  SanitizeInput(text);
+  const std::string& truncated_text = text.substr(0, max_page_content_length_);
+
+  std::string prompt = base::StrCat(
+      {kHumanPromptSequence,
+       base::ReplaceStringPlaceholders(
+           l10n_util::GetStringUTF8(
+               IDS_AI_CHAT_CLAUDE_GENERATE_REWRITE_SUGGESTION_PROMPT),
+           {truncated_text, question}, nullptr),
+       kAIPromptSequence, "<response>"});
+  CheckPrompt(prompt);
+
+  api_->QueryPrompt(prompt, {"</response>"}, std::move(completed_callback),
+                    std::move(received_callback));
+}
+
 void EngineConsumerClaudeRemote::GenerateQuestionSuggestions(
     const bool& is_video,
     const std::string& page_content,

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.h
@@ -51,6 +51,11 @@ class EngineConsumerClaudeRemote : public EngineConsumer {
       const std::string& human_input,
       GenerationDataCallback data_received_callback,
       GenerationCompletedCallback completed_callback) override;
+  void GenerateRewriteSuggestion(
+      std::string text,
+      const std::string& question,
+      GenerationDataCallback received_callback,
+      GenerationCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.h
@@ -51,6 +51,11 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
       const std::string& human_input,
       GenerationDataCallback data_received_callback,
       GenerationCompletedCallback completed_callback) override;
+  void GenerateRewriteSuggestion(
+      std::string text,
+      const std::string& question,
+      GenerationDataCallback received_callback,
+      GenerationCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
 

--- a/components/ai_chat/core/browser/utils.cc
+++ b/components/ai_chat/core/browser/utils.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/ai_chat/core/browser/utils.h"
 
+#include "base/time/time.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -25,6 +26,28 @@ bool IsDisabledByPolicy(PrefService* prefs) {
 bool IsAIChatEnabled(PrefService* prefs) {
   DCHECK(prefs);
   return features::IsAIChatEnabled() && !IsDisabledByPolicy(prefs);
+}
+
+bool HasUserOptedIn(PrefService* prefs) {
+  if (!prefs) {
+    return false;
+  }
+
+  base::Time last_accepted_disclaimer =
+      prefs->GetTime(prefs::kLastAcceptedDisclaimer);
+  return !last_accepted_disclaimer.is_null();
+}
+
+void SetUserOptedIn(PrefService* prefs, bool opted_in) {
+  if (!prefs) {
+    return;
+  }
+
+  if (opted_in) {
+    prefs->SetTime(prefs::kLastAcceptedDisclaimer, base::Time::Now());
+  } else {
+    prefs->ClearPref(prefs::kLastAcceptedDisclaimer);
+  }
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/utils.h
+++ b/components/ai_chat/core/browser/utils.h
@@ -12,6 +12,8 @@ namespace ai_chat {
 
 // Check both policy and feature flag to determine if AI Chat is enabled.
 bool IsAIChatEnabled(PrefService* prefs);
+bool HasUserOptedIn(PrefService* prefs);
+void SetUserOptedIn(PrefService* prefs, bool opted_in);
 
 }  // namespace ai_chat
 

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -43,4 +43,11 @@ bool IsAIChatHistoryEnabled() {
   return base::FeatureList::IsEnabled(features::kAIChatHistory);
 }
 
+BASE_FEATURE(kContextMenuRewriteInPlace,
+             "AIChatContextMenuRewriteInPlace",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+bool IsContextMenuRewriteInPlaceEnabled() {
+  return base::FeatureList::IsEnabled(features::kContextMenuRewriteInPlace);
+}
+
 }  // namespace ai_chat::features

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -30,6 +30,9 @@ BASE_DECLARE_FEATURE(kAIChatHistory);
 
 bool IsAIChatHistoryEnabled();
 
+BASE_DECLARE_FEATURE(kContextMenuRewriteInPlace);
+bool IsContextMenuRewriteInPlaceEnabled();
+
 }  // namespace ai_chat::features
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_FEATURES_H_

--- a/components/resources/ai_chat_prompts.grdp
+++ b/components/resources/ai_chat_prompts.grdp
@@ -65,6 +65,16 @@ Here is the conversational history (between the user and you) prior to the reque
 <message name="IDS_AI_CHAT_CLAUDE_QUESTION_PROMPT_SEGMENT" translateable="false">
 Propose up to 3 very short questions that a reader may ask about the content. Consider intriguing or unusual elements of the content, or structurally important. Separate each suggested question with the character "|". End the question list with a &lt;/response&gt; tag.</message>
 
+<message name="IDS_AI_CHAT_CLAUDE_GENERATE_REWRITE_SUGGESTION_PROMPT" translateable="false">
+This is an excerpt user selected to be rewritten:
+&lt;excerpt&gt;
+<ph name="EXCERPT">$1</ph>
+&lt;/excerpt&gt;
+
+<ph name="USER_REQUEST">$2</ph>
+Put your rewritten version of the excerpt in &lt;response&gt;&lt;/response&gt; tags.
+</message>
+
 <message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_PAGE" translateable="false">Provide a concise list of up to 6 bullets on the most important points of the page.</message>
 <message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_SELECTED_TEXT" translateable="false">Generate a summary of the excerpt.</message>
 <message name="IDS_AI_CHAT_QUESTION_SUMMARIZE_VIDEO" translateable="false">Provide a concise list of up to 6 bullets of the most important points of the video.</message>
@@ -149,6 +159,24 @@ Your goal is to answer the user's requests exactly in concise manner.
 
 <message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_QUESTIONS_RESPONSE_SEED" translateable="false">
 Sure, here are three intriguing or unusual questions that a reader may ask about the page: &lt;ul&gt; &lt;li&gt;
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_GENERATE_REWRITE_SUGGESTION_PROMPT" translateable="false">
+This is an excerpt user selected to be rewritten:
+&lt;excerpt&gt;
+<ph name="EXCERPT">$1</ph>
+&lt;/excerpt&gt;
+
+<ph name="USER_REQUEST">$2</ph>
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_REWRITE_SUGGESTION" translateable="false">
+Your name is Leo, a helpful, respectful and honest AI assistant created by the company Brave. You will be replying to a user of the Brave browser. Always respond in a neutral tone. Be polite and courteous. Answer concisely in no more than 50-80 words. Don't append word counts at the end of your replies.
+Your goal is to help user rewrite the excerpt and only include the rewritten texts so user can copy and paste your response without any modification.
+</message>
+
+<message name="IDS_AI_CHAT_LLAMA2_SYSTEM_MESSAGE_GENERATE_REWRITE_SUGGESTION_RESPONSE_SEED" translateable="false">
+Sure, here is the rewritten version of the excerpt: &lt;response&gt;
 </message>
 
 </grit-part>

--- a/test/data/ai_chat/rewrite.html
+++ b/test/data/ai_chat/rewrite.html
@@ -1,0 +1,67 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <title>Text Rewrite</title>
+  </head>
+  <style>
+    .container {
+      display: flex;
+      flex-direction: row;
+    }
+    .container > * {
+      margin-right: 200px;
+    }
+  </style>
+  </head>
+  <script>
+    function get_contenteditable_text() {
+      var contenteditable = document.getElementById("contenteditable");
+      var text = contenteditable.innerHTML;
+      return text;
+    }
+
+    function get_text(id) {
+      if (id === "contenteditable") {
+        return get_contenteditable_text();
+      }
+      var element = document.getElementById(id);
+      var text = element.value;
+      return text;
+    }
+
+    function select_all(id) {
+      var element = document.getElementById(id);
+      if (element.tagName === 'INPUT' || element.tagName === 'TEXTAREA') {
+        element.select();
+        return element.value.substring(
+            element.selectionStart, element.selectionEnd);
+      } else {
+        var selection = window.getSelection();
+        var range = document.createRange();
+        range.selectNodeContents(element);
+        selection.removeAllRanges();
+        selection.addRange(range);
+        return selection.toString();
+      }
+    }
+
+    function getRectX(id) {
+      var element = document.getElementById(id);
+      var rect = element.getBoundingClientRect();
+      return Math.ceil(rect.x);
+    }
+
+    function getRectY(id) {
+      var element = document.getElementById(id);
+      var rect = element.getBoundingClientRect();
+      return Math.ceil(rect.y);
+    }
+  </script>
+  <body>
+    <div class="container">
+      <div id="contenteditable" contenteditable="true">I'm contenteditable.</div>
+      <div><textarea id="textarea">I'm textarea.</textarea></div>
+      <div><input type="input_text" id="input_text" value="I'm input."></div>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36865

This PR implements rewrite in-place which only happens when
1) Selected content is editable.
2) User has opted in to Leo.
3) SSE is enabled, it is required otherwise the UI update will be too
   slow.
4) The command is a rewrite command.
5) There's no in-progress in-place rewrite.
6) Rewrite in-place feature flag is enabled.

If all above conditions are met, we will send an one-off request to AI engines
and rewrite in-place.

When there are error happened when doing rewrite, we will change back to
original selected text and show error via sidebar panel UI.


https://github.com/brave/brave-core/assets/4730197/cb2654a0-4be3-4eb2-bf33-dc6b075db017

When there is error:
<img width="1380" alt="Screenshot 2024-03-18 at 9 59 07 PM" src="https://github.com/brave/brave-core/assets/4730197/d299e1c8-00a2-4703-aacb-3b36b4777f29">

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1) Go to a webpage that has textarea, input text, or contenteditable elements.
I personally just use python simple http server to serve rewrite.html which has elements for each case. 
2) Without opting in to Leo, use one of the rewrite command from the context menu, sidebar should be opened and show the privacy notice. After accept, it will continue the conversation in the sidebar.
3) After opting in, do a rewrite command again from the context menu for some editable contents, now it should be rewritten in-place.
4) Trigger network error or rate limit error when trying to rewrite in-place, sidebar UI will be opened to present the error like the screenshot above. (Note that network error could take quite some time for timeout to happen tho.)