### PR TITLE
Fix bugs when Mica and vertical tabs are enabled

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -481,6 +481,8 @@ source_set("ui") {
         "views/frame/brave_browser_frame_view_win.cc",
         "views/frame/brave_browser_frame_view_win.h",
       ]
+
+      deps += [ "//chrome/browser:titlebar_config" ]
     }
 
     if (is_linux) {

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -13,7 +13,9 @@
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/frame/browser_caption_button_container_win.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/browser/win/titlebar_config.h"
 #include "ui/base/hit_test.h"
+#include "ui/compositor/layer.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
 #include "ui/gfx/scoped_canvas.h"
@@ -38,18 +40,16 @@ BraveBrowserFrameViewWin::BraveBrowserFrameViewWin(BrowserFrame* frame,
 
 BraveBrowserFrameViewWin::~BraveBrowserFrameViewWin() = default;
 
-void BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged() {
-  if (auto* widget = GetWidget();
-      widget && (widget->IsMaximized() || widget->IsFullscreen())) {
-    // In case the widget is maximized, the bounds of it doesn't change even
-    // though prefs change. But we need to lay out window controls again.
-    // https://github.com/brave/brave-browser/issues/31971
+bool BraveBrowserFrameViewWin::ShouldCaptionButtonsBeDrawnOverToolbar() const {
+  auto* browser = browser_view()->browser();
+  return tabs::utils::ShouldShowVerticalTabs(browser) &&
+         !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser);
+}
 
-    // As the LayoutManagerBase could have cached layout, we should call
-    // InvalidateLayout() first.
-    caption_button_container_->InvalidateLayout();
-    LayoutCaptionButtons();
-  }
+void BraveBrowserFrameViewWin::OnVerticalTabsPrefsChanged() {
+  caption_button_container_->UpdateButtons();
+  caption_button_container_->InvalidateLayout();
+  LayoutCaptionButtons();
 }
 
 void BraveBrowserFrameViewWin::OnPaint(gfx::Canvas* canvas) {
@@ -70,9 +70,17 @@ void BraveBrowserFrameViewWin::OnPaint(gfx::Canvas* canvas) {
 
 int BraveBrowserFrameViewWin::GetTopInset(bool restored) const {
   if (auto* browser = browser_view()->browser();
-      tabs::utils::ShouldShowVerticalTabs(browser) &&
-      !tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
-    return 0;
+      tabs::utils::ShouldShowVerticalTabs(browser)) {
+    if (!tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
+      return 0;
+    }
+
+    if (!ShouldBrowserCustomDrawTitlebar(browser_view())) {
+      // In case Mica enabled, we should extend top insets so that title bar can
+      // be visible.
+      return TopAreaHeight(restored) +
+             caption_button_container_->GetPreferredSize().height();
+    }
   }
 
   return BrowserFrameViewWin::GetTopInset(restored);
@@ -104,4 +112,37 @@ int BraveBrowserFrameViewWin::NonClientHitTest(const gfx::Point& point) {
   }
 
   return result;
+}
+
+bool BraveBrowserFrameViewWin::ShouldShowWindowTitle(TitlebarType type) const {
+  if (auto* browser = browser_view()->browser();
+      tabs::utils::ShouldShowVerticalTabs(browser) &&
+      tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser) &&
+      type == TitlebarType::kCustom &&
+      !ShouldBrowserCustomDrawTitlebar(browser_view())) {
+    // When using Mica, title won't be drawn by the OS. In this case, we
+    // should use our custom title
+    // TODO(sko) Possibly, there's code that setting HWND wndclass that
+    // prevents the OS from drawing the title
+    return true;
+  }
+
+  return BrowserFrameViewWin::ShouldShowWindowTitle(type);
+}
+
+void BraveBrowserFrameViewWin::LayoutCaptionButtons() {
+  BrowserFrameViewWin::LayoutCaptionButtons();
+
+  // This may look pretty weird because we're laying out
+  // |caption_button_container_| while ShouldBrowserCustomDrawTitlebar()
+  // is false. This is because when Win11's Mica titlebar is enabled, we need to
+  // show custom caption buttons over toolbar. We're forcing them visible in
+  // chromium_src/.../browser_caption_button_container_win.cc
+  if (ShouldCaptionButtonsBeDrawnOverToolbar() &&
+      !ShouldBrowserCustomDrawTitlebar(browser_view())) {
+    caption_button_container_->SetX(
+        CaptionButtonsOnLeadingEdge()
+            ? 0
+            : width() - caption_button_container_->width());
+  }
 }

--- a/browser/ui/views/frame/brave_browser_frame_view_win.cc
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.cc
@@ -72,7 +72,15 @@ int BraveBrowserFrameViewWin::GetTopInset(bool restored) const {
   if (auto* browser = browser_view()->browser();
       tabs::utils::ShouldShowVerticalTabs(browser)) {
     if (!tabs::utils::ShouldShowWindowTitleForVerticalTabs(browser)) {
-      return 0;
+      if (auto* widget = GetWidget(); !widget || !widget->IsMaximized()) {
+        return 0;
+      }
+
+      // In case maximized with Mica enabled, we should return system borders
+      // thickness.
+      return ShouldBrowserCustomDrawTitlebar(browser_view())
+                 ? 0
+                 : FrameTopBorderThickness(/*restored*/ false);
     }
 
     if (!ShouldBrowserCustomDrawTitlebar(browser_view())) {

--- a/browser/ui/views/frame/brave_browser_frame_view_win.h
+++ b/browser/ui/views/frame/brave_browser_frame_view_win.h
@@ -21,6 +21,8 @@ class BraveBrowserFrameViewWin : public BrowserFrameViewWin {
   BraveBrowserFrameViewWin(const BraveBrowserFrameViewWin&) = delete;
   BraveBrowserFrameViewWin& operator=(const BraveBrowserFrameViewWin&) = delete;
 
+  bool ShouldCaptionButtonsBeDrawnOverToolbar() const;
+
  private:
   void OnVerticalTabsPrefsChanged();
 
@@ -28,6 +30,8 @@ class BraveBrowserFrameViewWin : public BrowserFrameViewWin {
   void OnPaint(gfx::Canvas* canvas) override;
   int GetTopInset(bool restored) const override;
   int NonClientHitTest(const gfx::Point& point) override;
+  bool ShouldShowWindowTitle(TitlebarType type) const override;
+  void LayoutCaptionButtons() override;
 
   std::unique_ptr<BraveWindowFrameGraphic> frame_graphic_;
 

--- a/chromium_src/chrome/browser/ui/views/frame/browser_caption_button_container_win.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_caption_button_container_win.cc
@@ -5,14 +5,26 @@
 
 #include "chrome/browser/ui/views/frame/browser_caption_button_container_win.h"
 
+#include "brave/browser/ui/views/frame/brave_browser_frame_view_win.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/views/tab_search_bubble_host.h"
+#include "chrome/browser/win/titlebar_config.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 
 #define BrowserCaptionButtonContainer BrowserCaptionButtonContainer_ChromiumImpl
 
+// In case vertical tab is visible without window title bar, we should show
+// custom caption buttons over toolbar.
+#define ShouldBrowserCustomDrawTitlebar(browser_view)        \
+  (static_cast<BraveBrowserFrameViewWin*>(frame_view_.get()) \
+       ->ShouldCaptionButtonsBeDrawnOverToolbar() ||         \
+   ShouldBrowserCustomDrawTitlebar(browser_view))
+
 #include "src/chrome/browser/ui/views/frame/browser_caption_button_container_win.cc"
+
+#undef ShouldBrowserCustomDrawTitlebar
 #undef BrowserCaptionButtonContainer
 
 BrowserCaptionButtonContainer::BrowserCaptionButtonContainer(

--- a/chromium_src/chrome/browser/ui/views/frame/browser_caption_button_container_win.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_caption_button_container_win.h
@@ -12,8 +12,14 @@
 #include "ui/base/metadata/metadata_header_macros.h"
 
 #define BrowserCaptionButtonContainer BrowserCaptionButtonContainer_ChromiumImpl
+#define OnWindowControlsOverlayEnabledChanged     \
+  OnWindowControlsOverlayEnabledChanged_Unused(); \
+  friend class BraveBrowserFrameViewWin;          \
+  void OnWindowControlsOverlayEnabledChanged
 
 #include "src/chrome/browser/ui/views/frame/browser_caption_button_container_win.h"  // IWYU pragma: export
+
+#undef OnWindowControlsOverlayEnabledChanged
 #undef BrowserCaptionButtonContainer
 
 class BrowserCaptionButtonContainer

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.h
@@ -9,9 +9,13 @@
 #define client_view_bounds_ \
   client_view_bounds_;      \
   friend class BraveBrowserFrameViewWin
+#define ShouldShowWindowTitle virtual ShouldShowWindowTitle
+#define LayoutCaptionButtons virtual LayoutCaptionButtons
 
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_win.h"  // IWYU pragma: export
 
+#undef LayoutCaptionButtons
+#undef ShouldShowWindowTitle
 #undef client_view_bounds_
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_FRAME_BROWSER_FRAME_VIEW_WIN_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36868

* When window title is enabled, we should set enough top insets so that Mica title bar is visible

* When window title is disabled, we should show custom window caption buttons so that they can be drawn over toolbar

### when `show window title` is off
![image](https://github.com/brave/brave-core/assets/5474642/bc48d9a6-95c2-43bd-bb11-084a408d11f4)

### when `show window title` is on
![image](https://github.com/brave/brave-core/assets/5474642/bbf02859-56a0-44ab-8897-c14cfb816dcb)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
   1. enable win11 mica title bar brave://flags/#windows11-mica-titlebar
   2. use vertical tag strip from brave://settings
   3. window controls should be visible.
   4. in case "show window title" option is on, title also should be visible