### PR TITLE
Default modal for new conversations reverting to Mixtral after restarting Brave

### DIFF
--- a/components/ai_chat/core/browser/conversation_driver.cc
+++ b/components/ai_chat/core/browser/conversation_driver.cc
@@ -209,8 +209,7 @@ void ConversationDriver::SetDefaultModel(const std::string& model_key) {
     return;
   }
 
-  pref_service_->SetString(prefs::kDefaultModelKey,
-                                     model_key);
+  pref_service_->SetString(prefs::kDefaultModelKey, model_key);
 }
 
 const mojom::Model& ConversationDriver::GetCurrentModel() {

--- a/components/ai_chat/core/browser/conversation_driver.cc
+++ b/components/ai_chat/core/browser/conversation_driver.cc
@@ -197,22 +197,7 @@ void ConversationDriver::ChangeModel(const std::string& model_key) {
 }
 
 std::string ConversationDriver::GetDefaultModel() {
-  const std::string* current_default =
-      pref_service_->GetUserPrefValue(prefs::kDefaultModelKey)->GetIfString();
-  if (current_default) {
-    return *current_default;
-  }
-
-  if (last_premium_status_ == mojom::PremiumStatus::Active ||
-      last_premium_status_ == mojom::PremiumStatus::ActiveDisconnected) {
-    return features::kAIModelsPremiumDefaultKey.Get();
-  }
-
-  current_default = pref_service_->GetDefaultPrefValue(prefs::kDefaultModelKey)
-                        ->GetIfString();
-
-  return current_default ? *current_default
-                         : features::kAIModelsDefaultKey.Get();
+  return pref_service_->GetString(prefs::kDefaultModelKey);
 }
 
 void ConversationDriver::SetDefaultModel(const std::string& model_key) {
@@ -224,8 +209,8 @@ void ConversationDriver::SetDefaultModel(const std::string& model_key) {
     return;
   }
 
-  pref_service_->SetDefaultPrefValue(prefs::kDefaultModelKey,
-                                     base::Value(model_key));
+  pref_service_->SetString(prefs::kDefaultModelKey,
+                                     model_key);
 }
 
 const mojom::Model& ConversationDriver::GetCurrentModel() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36886

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Oopen Leo via the Hamburger Menu and run through the onboarding/T&S
Click on Hamburger Menu -> Settings -> Leo and tap on default modal for new conversations
Pick either Claude Instant or Llama 2 13b and close the Settings page
Restart Brave and you'll notice that Mixtral is once again selected as the default model