### PR TITLE
fix(wallet): show correct spender address for erc20 approval txs

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -66,7 +66,6 @@ import {
   TabRow,
   Description,
   PanelTitle,
-  AccountCircle,
   AddressAndOrb,
   AddressText,
   WarningBox,
@@ -241,15 +240,14 @@ export const ConfirmTransactionPanel = () => {
           </PanelTitle>
           <AddressAndOrb>
             <Tooltip
-              text={transactionDetails.recipient}
+              text={transactionDetails.approvalTarget}
               isAddress={true}
               position={'right'}
             >
               <AddressText>
-                {reduceAddress(transactionDetails.recipient)}
+                {transactionDetails.approvalTargetLabel}
               </AddressText>
             </Tooltip>
-            <AccountCircle orb={toOrb} />
           </AddressAndOrb>
           <Description>
             {getLocale('braveWalletAllowSpendDescription').replace(

--- a/components/brave_wallet_ui/components/extension/shared-panel-styles.ts
+++ b/components/brave_wallet_ui/components/extension/shared-panel-styles.ts
@@ -48,14 +48,6 @@ export const AddressAndOrb = styled.div`
   flex-direction: row;
 `
 
-export const AccountCircle = styled.div<Partial<StyleProps>>`
-  width: 32px;
-  height: 32px;
-  border-radius: 100%;
-  background-image: url(${(p) => p.orb});
-  background-size: cover;
-`
-
 export const AddressText = styled.span`
   cursor: default;
   font-family: Poppins;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35007

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to the swap screen in the wallet
2. select a token to swap from that currently has no token allowance approval (Erc20)
3. click approve
4. observe the spend address in the confirmation panel
5. The spend address should be the contract that is requesting approval to spend the token, not the token address. The blockie should also no longer appear next to the address

Before: 
<img width="373" alt="Screenshot 2024-03-18 at 2 47 56 PM" src="https://github.com/brave/brave-core/assets/30185185/a28b90ab-d2a2-48be-b257-bdd97f0a7652">


After:
<img width="379" alt="Screenshot 2024-03-18 at 2 39 04 PM" src="https://github.com/brave/brave-core/assets/30185185/63d0b380-0701-4732-838e-7e86a97a1802">



