### PR TITLE
[iOS] Default modal for new conversations reverting to Mixtral after restarting Brave (uplift to 1.64.x)

### DIFF
--- a/components/ai_chat/core/browser/conversation_driver.cc
+++ b/components/ai_chat/core/browser/conversation_driver.cc
@@ -197,22 +197,7 @@ void ConversationDriver::ChangeModel(const std::string& model_key) {
 }
 
 std::string ConversationDriver::GetDefaultModel() {
-  const std::string* current_default =
-      pref_service_->GetUserPrefValue(prefs::kDefaultModelKey)->GetIfString();
-  if (current_default) {
-    return *current_default;
-  }
-
-  if (last_premium_status_ == mojom::PremiumStatus::Active ||
-      last_premium_status_ == mojom::PremiumStatus::ActiveDisconnected) {
-    return features::kAIModelsPremiumDefaultKey.Get();
-  }
-
-  current_default = pref_service_->GetDefaultPrefValue(prefs::kDefaultModelKey)
-                        ->GetIfString();
-
-  return current_default ? *current_default
-                         : features::kAIModelsDefaultKey.Get();
+  return pref_service_->GetString(prefs::kDefaultModelKey);
 }
 
 void ConversationDriver::SetDefaultModel(const std::string& model_key) {
@@ -224,8 +209,7 @@ void ConversationDriver::SetDefaultModel(const std::string& model_key) {
     return;
   }
 
-  pref_service_->SetDefaultPrefValue(prefs::kDefaultModelKey,
-                                     base::Value(model_key));
+  pref_service_->SetString(prefs::kDefaultModelKey, model_key);
 }
 
 const mojom::Model& ConversationDriver::GetCurrentModel() {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/22649
Resolves https://github.com/brave/brave-browser/issues/36886

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.

