### PR TITLE
Create a first prototype of auto-updates with Omaha 4 on macOS

### DIFF
--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -1,8 +1,16 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/build/config.gni")
 import("//brave/build/mac/config.gni")
+import("//brave/updater/config.gni")
 import("//build/util/branding.gni")
 import("//chrome/common/features.gni")
+import("//chrome/updater/branding.gni")
 import("//chrome/version.gni")
+import("//components/crx_file/crx3.gni")
 import("//third_party/widevine/cdm/widevine.gni")
 
 packaging_dir = "$brave_packaging_base_dir/" +
@@ -411,6 +419,16 @@ action("create_dmg") {
   outputs = [ unsigned_dmg_path ]
 
   deps = [ ":finalize_app" ]
+
+  if (brave_enable_updater) {
+    args += [
+      "--copy",
+      rebase_path(
+          "$root_out_dir/$browser_product_name Packaging/updater/.install",
+          root_build_dir),
+    ]
+    deps += [ "//chrome/updater/mac:browser_install_script" ]
+  }
 }
 
 action("sign_dmg") {
@@ -566,4 +584,18 @@ copy("copy_dmg_pkg") {
   }
 
   outputs = [ "$root_out_dir/{{source_file_part}}" ]
+}
+
+if (brave_enable_updater) {
+  crx3("crx") {
+    inputs = [ target_dmg_path ]
+    output = "$root_out_dir/$chrome_product_full_name.crx3"
+    base_dir = get_path_info(target_dmg_path, "dir")
+
+    # The private key file is not in Git for obvious reasons. It needs to be
+    # copied into this directory manually. Changing the private key requires
+    # also changing kBravePublisherKeyHash in crx_verifier.cc.
+    key = "//brave/updater/crx-private-key.der"
+    deps = [ ":copy_dmg_pkg" ]
+  }
 }

--- a/build/mac/BUILD.gn
+++ b/build/mac/BUILD.gn
@@ -35,6 +35,8 @@ if (skip_signing) {
 notarized_dmg_path = "$root_out_dir/$mac_notarized_output_prefix/$brave_dmg"
 notarized_pkg_path = "$root_out_dir/$mac_notarized_output_prefix/$brave_pkg"
 
+target_dmg_path = "$root_out_dir/$brave_dmg"
+
 if (is_universal_binary) {
   action("universalize") {
     script = "//chrome/installer/mac/universalizer.py"
@@ -110,7 +112,6 @@ action("generate_dsa_sig_for_dmg") {
   } else {
     sign_update_path = "//build/mac_files/sparkle_binaries/sign_update_dsa"
   }
-  target_dmg_path = "$root_out_dir/$brave_dmg"
   output_dmg_dsa_path = "$root_out_dir/$brave_dmg.dsa"
 
   args = [
@@ -149,7 +150,6 @@ action("generate_eddsa_sig_for_dmg") {
     sign_update_path = "//build/mac_files/sparkle_binaries/sign_update"
   }
 
-  target_dmg_path = "$root_out_dir/$brave_dmg"
   output_dmg_eddsa_path = "$root_out_dir/$brave_dmg.eddsa"
 
   args = [
@@ -188,7 +188,6 @@ action("build_delta_installer") {
     binary_delta_path = "//build/mac_files/sparkle_binaries/BinaryDelta"
   }
 
-  target_dmg_path = "$root_out_dir/$brave_dmg"
   output_delta_path = "$root_out_dir/$brave_delta"
 
   args = [

--- a/chromium_src/chrome/browser/DEPS
+++ b/chromium_src/chrome/browser/DEPS
@@ -49,6 +49,7 @@ include_rules = [
   "+brave/components/version_info",
   "+brave/net",
   "+brave/services/network/public",
+  "+brave/updater/buildflags.h",
   "+chrome/android",
   "+chrome/app",
   "+chrome/common",

--- a/chromium_src/chrome/browser/ui/BUILD.gn
+++ b/chromium_src/chrome/browser/ui/BUILD.gn
@@ -13,6 +13,10 @@ group("ui") {
     "//brave/components/brave_vpn/common/buildflags",
   ]
 
+  if (is_mac) {
+    deps += [ "//brave/updater:buildflags" ]
+  }
+
   if (toolkit_views) {
     deps += [
       "//brave/components/ai_chat/core/common/buildflags",

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.h
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+/* Copyright (c) 2018 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
+++ b/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.mm
@@ -3,6 +3,12 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/updater/buildflags.h"
+
+#if BUILDFLAG(BRAVE_ENABLE_UPDATER)
+#include "src/chrome/browser/ui/webui/help/version_updater_mac.mm"
+#else
+
 #include "brave/chromium_src/chrome/browser/ui/webui/help/version_updater_mac.h"
 
 #include <memory>
@@ -74,8 +80,7 @@ VersionUpdaterMac::VersionUpdaterMac()
   show_promote_button_ = false;
 }
 
-VersionUpdaterMac::~VersionUpdaterMac() {
-}
+VersionUpdaterMac::~VersionUpdaterMac() {}
 
 void VersionUpdaterMac::CheckForUpdate(StatusCallback status_callback,
                                        PromoteCallback promote_callback) {
@@ -170,8 +175,8 @@ void VersionUpdaterMac::UpdateStatus(NSDictionary* dictionary) {
     case kAutoupdateCheckFailed:
     case kAutoupdateInstallFailed:
       status = FAILED;
-      message = l10n_util::GetStringFUTF16Int(IDS_UPGRADE_ERROR,
-                                              sparkle_status);
+      message =
+          l10n_util::GetStringFUTF16Int(IDS_UPGRADE_ERROR, sparkle_status);
       break;
 
     default:
@@ -199,11 +204,13 @@ void VersionUpdaterMac::UpdateStatus(NSDictionary* dictionary) {
     }
   }
 
-  if (!status_callback_.is_null())
+  if (!status_callback_.is_null()) {
     status_callback_.Run(status, 0, false, false, std::string(), 0, message);
+  }
 }
-
 
 void VersionUpdaterMac::UpdateShowPromoteButton() {
   NOTIMPLEMENTED();
 }
+
+#endif  // BUILDFLAG(BRAVE_ENABLE_UPDATER)

--- a/chromium_src/chrome/updater/branding.gni
+++ b/chromium_src/chrome/updater/branding.gni
@@ -57,4 +57,7 @@ brave_updater_branding = {
   IPolicyStatus3SystemGUID = "F7F9F3E7-4EAF-41B4-901F-250B8EBA8D6C"
   IPolicyStatusValueUserGUID = "63107867-A897-46C3-AC56-89A07C0A2044"
   IPolicyStatusValueSystemGUID = "2592AA42-E23E-43C8-829A-46ECE27A5AA3"
+
+  # Development server until we have set it up in Brave's AWS account:
+  update_check_url = "https://omaha4.omaha-consulting.com/6f797447-684d-40cf-8d90-075b21aba1f0/service/update2/json"
 }

--- a/chromium_src/components/crx_file/crx_verifier.cc
+++ b/chromium_src/components/crx_file/crx_verifier.cc
@@ -12,7 +12,10 @@
 
 namespace {
 
-// The brave publisher key in alternative to google one (kPublisherKeyHash).
+// The Brave publisher key that is accepted in addition to upstream's
+// kPublisherKeyHash. This key may be used to verify updates of the browser
+// itself. If you change this constant, then you will likely also need to change
+// the associated file crx-private-key.der, which is not in Git.
 constexpr uint8_t kBravePublisherKeyHash[] = {
     0x93, 0x74, 0xd6, 0x2a, 0x32, 0x76, 0x74, 0x74, 0xac, 0x99, 0xd9,
     0xc0, 0x55, 0xea, 0xf2, 0x6e, 0x10, 0x7,  0x45, 0x6,  0xb9, 0xd5,

--- a/chromium_src/components/update_client/DEPS
+++ b/chromium_src/components/update_client/DEPS
@@ -2,4 +2,5 @@ include_rules = [
   "+brave/components/constants",
   "+brave/components/widevine/constants.h",
   "+brave/components/widevine/static_buildflags.h",
+  "+brave/updater/buildflags.h",
 ]

--- a/chromium_src/components/update_client/request_sender.cc
+++ b/chromium_src/components/update_client/request_sender.cc
@@ -1,0 +1,61 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/updater/buildflags.h"
+
+#if BUILDFLAG(BRAVE_ENABLE_UPDATER)
+
+// The code below replaces Ecdsa::Create(kKeyVersion, kKeyPubBytesBase64) by
+// Ecdsa::Create(kBraveKeyVersion, kBraveKeyPubBytesBase64) in upstream's
+// request_sender.cc.
+
+#include "components/update_client/request_sender.h"
+
+#include "base/base64.h"
+#include "components/client_update_protocol/ecdsa.h"
+
+namespace {
+
+// If you change the following, then you will likely also need to update
+// RequestSenderTest::UsesBraveCUPKey.
+constexpr int kBraveKeyVersion = 1;
+constexpr char kBraveKeyPubBytesBase64[] =
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMZENJfFz9Jph//JXTejVdn5U+ALz"
+    "NT/Bht/fvkf2hZ5RionWCLzcxmjV3uh0R3MKLfsgI3w7ukou7m8VhkFQSg==";
+
+}  // namespace
+
+namespace client_update_protocol {
+
+class BraveEcdsa : public Ecdsa {
+ public:
+  static std::unique_ptr<Ecdsa> Create(int key_version,
+                                       const std::string_view& public_key) {
+    std::string base64_decoded = GetKey(kBraveKeyPubBytesBase64);
+    return Ecdsa::Create(kBraveKeyVersion, base64_decoded);
+  }
+
+ private:
+  static std::string GetKey(const char* key_bytes_base64) {
+    // This method is a copy of upstream's RequestSender::GetKey, which is
+    // unfortunately private.
+    std::string result;
+    return base::Base64Decode(std::string(key_bytes_base64), &result)
+               ? result
+               : std::string();
+  }
+};
+
+}  // namespace client_update_protocol
+
+#define Ecdsa BraveEcdsa
+
+#endif  // BUILDFLAG(BRAVE_ENABLE_UPDATER)
+
+#include "src/components/update_client/request_sender.cc"
+
+#if BUILDFLAG(BRAVE_ENABLE_UPDATER)
+#undef Ecdsa
+#endif

--- a/chromium_src/components/update_client/request_sender_unittest.cc
+++ b/chromium_src/components/update_client/request_sender_unittest.cc
@@ -1,0 +1,38 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/functional/bind.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#include "src/components/update_client/request_sender_unittest.cc"
+
+namespace update_client {
+
+class RequestSenderTest;
+
+TEST_F(RequestSenderTest, UsesBraveCUPKey) {
+  EXPECT_TRUE(post_interceptor_->ExpectRequest(
+      std::make_unique<PartialMatch>("test"),
+      GetTestFilePath("updatecheck_reply_1.json")));
+
+  const std::vector<GURL> urls = {GURL(kUrl1)};
+  request_sender_ = std::make_unique<RequestSender>(config_);
+  request_sender_->Send(
+      urls, {}, "test", true,
+      base::BindOnce(&RequestSenderTest::RequestSenderComplete,
+                     base::Unretained(this)));
+  RunThreads();
+
+  EXPECT_EQ(1, post_interceptor_->GetHitCount())
+      << post_interceptor_->GetRequestsAsString();
+  GURL request_url = std::get<2>(post_interceptor_->GetRequests()[0]);
+  // It's hard to check the key contents. But it is easy to check the key
+  // version. Ours differs from upstream. So we can use this as a proxy check
+  // that our key is indeed being used.
+  EXPECT_NE(request_url.query().find("cup2key=1:"), std::string::npos)
+      << request_url.query();
+}
+
+}  // namespace update_client

--- a/components/update_client/sources.gni
+++ b/components/update_client/sources.gni
@@ -10,3 +10,5 @@ brave_components_update_client_deps = [
 
 brave_components_update_client_public_deps =
     [ "//brave/components/update_client:buildflags" ]
+
+brave_components_update_client_deps += [ "//brave/updater:buildflags" ]

--- a/patches/components-crx_file-BUILD.gn.patch
+++ b/patches/components-crx_file-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/components/crx_file/BUILD.gn b/components/crx_file/BUILD.gn
+index 272b6f4f34e486804113475b9ae290b652236be8..b0fb4f603c196c86b1b6bffb275d03b70a789ded 100644
+--- a/components/crx_file/BUILD.gn
++++ b/components/crx_file/BUILD.gn
+@@ -75,7 +75,6 @@ proto_library("crx3_proto") {
+ 
+ if (host_toolchain == current_toolchain) {
+   executable("crx3_build_action") {
+-    testonly = true
+ 
+     sources = [ "crx_build_action_main.cc" ]
+ 

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -19,6 +19,7 @@ import("//brave/components/request_otr/common/buildflags/buildflags.gni")
 import("//brave/components/speedreader/common/buildflags/buildflags.gni")
 import("//brave/components/tor/buildflags/buildflags.gni")
 import("//brave/test/testing.gni")
+import("//brave/updater/config.gni")
 import("//chrome/common/features.gni")
 import("//components/captive_portal/core/features.gni")
 import("//components/gcm_driver/config.gni")
@@ -146,6 +147,9 @@ test("brave_unit_tests") {
     "//components/sync/service/sync_auth_manager_unittest.cc",
     "//components/sync_device_info/device_info_sync_bridge_unittest.cc",
   ]
+  if (brave_enable_updater) {
+    sources += [ "//brave/chromium_src/components/update_client/request_sender_unittest.cc" ]
+  }
 
   deps = [
     ":crypto_unittests",

--- a/updater/.gitignore
+++ b/updater/.gitignore
@@ -1,0 +1,1 @@
+crx-private-key.der

--- a/updater/BUILD.gn
+++ b/updater/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//build/buildflag_header.gni")
+import("config.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "BRAVE_ENABLE_UPDATER=$brave_enable_updater" ]
+}

--- a/updater/config.gni
+++ b/updater/config.gni
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  # In 2023, Chrome began switching to a new auto-update implementation
+  # ("Omaha 4"). As of this writing, Chrome uses Omaha 4 on macOS and is in the
+  # process of rolling it out on Windows. The new implementation is hidden
+  # behind upstream GN arg `enable_updater`. We set it to true to enable some
+  # integration points. But, as of this writing, we do not yet use Omaha 4. The
+  # arg below enables building our own Omaha 4 integration, which is still
+  # experimental.
+  brave_enable_updater = false
+}
+
+if (brave_enable_updater) {
+  assert(target_os == "mac",
+         "brave_enable_updater currently only takes effect on macOS.")
+}


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/36946. The new implementation is hidden behind a default-disabled build flag, `brave_enable_updater`. So there should (TM) not be any user-visible changes yet.

The implementation is a prototype with the following prerequisites:

 1. The Omaha 4 update client must already be installed on the system.
 2. Brave must have been registered with O4.

Both are manual steps as of this writing. But when they are done, then Brave can be updated with Omaha 4 via `brave://settings/help`.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

On macOS:

1. Please check that Brave's `.dmg` installer still works.
2. Please check that background updates still work.
3. Please check that component updates via `brave://components` still work.
4. Please check that extension updates via `brave://extensions` still work.