### PR TITLE
[ads] Start site visit/page lands timer once the document has loaded

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -169,6 +169,8 @@ void AdsTabHelper::DidFinishNavigation(
     is_error_page_ = true;
   }
 
+  TabUpdated();
+
   if (!navigation_handle->IsSameDocument()) {
     should_process_ = tab_not_restored;
     return;
@@ -185,17 +187,6 @@ void AdsTabHelper::DocumentOnLoadCompletedInPrimaryMainFrame() {
   if (should_process_) {
     RunIsolatedJavaScript(render_frame_host);
   }
-}
-
-void AdsTabHelper::DidFinishLoad(content::RenderFrameHost* render_frame_host,
-                                 const GURL& validated_url) {
-  CHECK(render_frame_host);
-
-  if (render_frame_host->GetParent()) {
-    return;
-  }
-
-  TabUpdated();
 }
 
 void AdsTabHelper::MediaStartedPlaying(const MediaPlayerInfo& video_type,

--- a/browser/brave_ads/tabs/ads_tab_helper.h
+++ b/browser/brave_ads/tabs/ads_tab_helper.h
@@ -54,8 +54,6 @@ class AdsTabHelper : public content::WebContentsObserver,
   void DidFinishNavigation(
       content::NavigationHandle* navigation_handle) override;
   void DocumentOnLoadCompletedInPrimaryMainFrame() override;
-  void DidFinishLoad(content::RenderFrameHost* render_frame_host,
-                     const GURL& validated_url) override;
   void MediaStartedPlaying(const MediaPlayerInfo& video_type,
                            const content::MediaPlayerId& id) override;
   void MediaStoppedPlaying(

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -294,7 +294,7 @@ void AdsServiceImpl::RegisterResourceComponentsForCurrentCountryCode() const {
   RegisterResourceComponentsForCountryCode(country_code);
 }
 
-bool AdsServiceImpl::UserHasOptedInToBraveRewards() const {
+bool AdsServiceImpl::UserHasJoinedBraveRewards() const {
   return profile_->GetPrefs()->GetBoolean(brave_rewards::prefs::kEnabled);
 }
 
@@ -342,9 +342,8 @@ void AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsServiceCallback(
 
 bool AdsServiceImpl::CanStartBatAdsService() const {
   return ShouldAlwaysRunService() || UserHasOptedInToBraveNewsAds() ||
-         (UserHasOptedInToBraveRewards() &&
-          (UserHasOptedInToNotificationAds() ||
-           UserHasOptedInToNewTabPageAds()));
+         (UserHasJoinedBraveRewards() && (UserHasOptedInToNotificationAds() ||
+                                          UserHasOptedInToNewTabPageAds()));
 }
 
 void AdsServiceImpl::MaybeStartBatAdsService() {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -107,7 +107,7 @@ class AdsServiceImpl : public AdsService,
 
   void Migrate();
 
-  bool UserHasOptedInToBraveRewards() const;
+  bool UserHasJoinedBraveRewards() const;
   bool UserHasOptedInToBraveNewsAds() const;
   bool UserHasOptedInToNewTabPageAds() const;
   bool UserHasOptedInToNotificationAds() const;

--- a/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util_unittest.cc
@@ -86,6 +86,4 @@ TEST_F(BraveAdsConfirmationQueueItemDelayTest,
                 confirmation_queue_item));
 }
 
-// TODO(tmancey): Add unit tests for `RebuildConfirmationQueueItem`.
-
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_unittest.cc
@@ -122,7 +122,7 @@ TEST_F(BraveAdsAdEventsTest, DoNotPurgeExpiredAdEventsOnTheCuspOfExpiry) {
       BuildAdEvent(ad, ConfirmationType::kServed, /*created_at=*/Now());
 
   base::MockCallback<AdEventCallback> record_ad_event_callback;
-  EXPECT_CALL(record_ad_event_callback, Run(/*success=*/true)).Times(1);
+  EXPECT_CALL(record_ad_event_callback, Run(/*success=*/true));
   RecordAdEvent(ad_event, record_ad_event_callback.Get());
 
   // Move the clock forward to just before the ad events expire.

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -542,6 +542,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/serving/prediction/model_based/scoring/last_seen/creative_ad_model_based_predictor_last_seen_scoring_unittest.cc",
     "//brave/components/brave_ads/core/internal/serving/prediction/model_based/scoring/segment/creative_ad_model_based_predictor_segment_scoring_unittest.cc",
     "//brave/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_ad_model_based_predictor_weights_builder_unittest.cc",
+    "//brave/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_inline_content_ad_model_based_predictor_weights_builder_unittest.cc",
     "//brave/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_new_tab_page_ad_model_based_predictor_weights_builder_unittest.cc",
     "//brave/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_notification_ad_model_based_predictor_weights_builder_unittest.cc",
     "//brave/components/brave_ads/core/internal/serving/prediction/model_based/weight/segment/creative_ad_model_based_predictor_segment_weight_unittest_util.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36948

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm user activity events are triggered (for non restored tabs)
- Confirm push notification ads are not shown if media is playing
- Confirm page content is classified (for non restored tabs)
- Confirm push notification ads are not shown if the browser is inactive
- Confirm site visit/page lands are working as expected