### PR TITLE
Remember Playlist webui's last page location

### DIFF
--- a/components/playlist/browser/resources/components/app.v1.tsx
+++ b/components/playlist/browser/resources/components/app.v1.tsx
@@ -19,7 +19,7 @@ import {
   useLastPlayerState,
   usePlaylistEditMode
 } from '../reducers/states'
-import { useHistorySynchronization } from '../playerEventSink'
+import { HistoryContext } from './historyContext'
 
 const AppContainer = styled.div<{ isPlaylistPlayerPage: boolean }>`
   --header-height: ${({ isPlaylistPlayerPage }) =>
@@ -37,45 +37,45 @@ const StyledHeader = styled(Header)`
   height: var(--header-height);
 `
 
-export default function App() {
-  useHistorySynchronization()
-
+export default function App () {
   const lastPlayerState = useLastPlayerState()
   const editMode = usePlaylistEditMode()
 
   return (
-    <Route
-      path={'/playlist/:playlistId'}
-      children={({ match }) => {
-        const playlistId = match?.params.playlistId
-        return (
-          <AppContainer isPlaylistPlayerPage={!!playlistId}>
-            <StickyArea>
-              <StyledHeader playlistId={playlistId} />
-              <AlertCenter />
-              <VideoFrame
-                visible={
-                  !!lastPlayerState?.currentItem &&
-                  editMode !== PlaylistEditMode.BULK_EDIT
-                }
-                isMiniPlayer={lastPlayerState?.currentList?.id !== playlistId}
-              />
-            </StickyArea>
-            <section>
-              <Switch>
-                <Route
-                  path='/playlist/:playlistId'
-                  component={PlaylistFolder}
+    <HistoryContext>
+      <Route
+        path={'/playlist/:playlistId'}
+        children={({ match }) => {
+          const playlistId = match?.params.playlistId
+          return (
+            <AppContainer isPlaylistPlayerPage={!!playlistId}>
+              <StickyArea>
+                <StyledHeader playlistId={playlistId} />
+                <AlertCenter />
+                <VideoFrame
+                  visible={
+                    !!lastPlayerState?.currentItem &&
+                    editMode !== PlaylistEditMode.BULK_EDIT
+                  }
+                  isMiniPlayer={lastPlayerState?.currentList?.id !== playlistId}
                 />
-                <Route
-                  path='/'
-                  component={PlaylistsCatalog}
-                ></Route>
-              </Switch>
-            </section>
-          </AppContainer>
-        )
-      }}
-    />
+              </StickyArea>
+              <section>
+                <Switch>
+                  <Route
+                    path='/playlist/:playlistId'
+                    component={PlaylistFolder}
+                  />
+                  <Route
+                    path='/'
+                    component={PlaylistsCatalog}
+                  ></Route>
+                </Switch>
+              </section>
+            </AppContainer>
+          )
+        }}
+      />
+    </HistoryContext>
   )
 }

--- a/components/playlist/browser/resources/components/historyContext.tsx
+++ b/components/playlist/browser/resources/components/historyContext.tsx
@@ -1,0 +1,35 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { useHistory, useLocation } from 'react-router'
+import { History } from 'history'
+
+export let history: History | undefined
+
+export function HistoryContext (props: React.PropsWithChildren<{}>) {
+  const h = useHistory()
+  const location = useLocation()
+
+  React.useEffect(() => {
+    history = h
+    return () => (history = undefined)
+  }, [h])
+
+  // When the component mounts, restore the location from local storage
+  React.useEffect(() => {
+    const lastLocation = localStorage.getItem('lastLocation')
+    if (lastLocation) {
+      history?.replace(lastLocation)
+    }
+  }, [])
+
+  // Record the current location in local storage
+  React.useEffect(() => {
+    localStorage.setItem('lastLocation', location.pathname)
+  }, [location])
+
+  return <>{props.children}</>
+}

--- a/components/playlist/browser/resources/playerEventSink.ts
+++ b/components/playlist/browser/resources/playerEventSink.ts
@@ -3,17 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import { useHistory } from 'react-router'
 import { getPlaylistAPI } from './api/api'
 import { getPlaylistActions } from './api/getPlaylistActions'
 import { PlayerEventsPayload } from './api/playerEventsNotifier'
 import { types } from './constants/playlist_types'
-import { History } from 'history'
-import { useEffect } from 'react'
 import { showAlert } from '@brave/leo/react/alertCenter'
 import { getLocalizedString } from './utils/l10n'
-
-let history: History | undefined
+import { history } from './components/historyContext'
 
 function handlePlayerEvents(payload: PlayerEventsPayload) {
   switch (payload.type) {
@@ -74,14 +70,6 @@ function handlePlayerEvents(payload: PlayerEventsPayload) {
       break
     }
   }
-}
-
-export function useHistorySynchronization() {
-  const h = useHistory()
-  useEffect(() => {
-    history = h
-    return () => (history = undefined)
-  }, [h])
 }
 
 // Used to mirror state of Player from Playlist side.


### PR DESCRIPTION
Record the playlist's page location using `localStorage`, and recover it on reload. 
Besides, this PR includes refactoring that converts a hook to jsx context.
With this, other components don't use it repeatedly 
and we can keep the PlayerEventSync simple

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-core/pull/22592

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test plan:
* Open Playlist web ui
* Go to any folder
* close playlist web ui
* Reopen the playlist web ui

### Actual result:
Playlist webui always starts from the index page.

### Expected behavior
Should start from where it was closed last time.
