### PR TITLE
Enable Forgetful Browsing by default (uplift to 1.64.x)

### DIFF
--- a/chromium_src/net/base/features.cc
+++ b/chromium_src/net/base/features.cc
@@ -86,7 +86,7 @@ constexpr base::FeatureParam<DohFallbackEndpointType>
 // website is closed.
 BASE_FEATURE(kBraveForgetFirstPartyStorage,
              "BraveForgetFirstPartyStorage",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 const base::FeatureParam<int>
     kBraveForgetFirstPartyStorageStartupCleanupDelayInSeconds = {


### PR DESCRIPTION
Uplift of #22713
Resolves https://github.com/brave/brave-browser/issues/36999

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.