### PR TITLE
[ads] Refactor tab helper, browser manager and tab manager

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -5,20 +5,18 @@
 
 #include "brave/browser/brave_ads/tabs/ads_tab_helper.h"
 
-#include <string>
-
 #include "brave/browser/brave_ads/ads_service_factory.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_isolated_world_ids.h"
 #include "components/prefs/pref_service.h"
 #include "components/sessions/content/session_tab_helper.h"
+#include "components/sessions/core/session_id.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "net/http/http_response_headers.h"
 #include "ui/base/page_transition_types.h"
-#include "url/gurl.h"
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/ui/browser.h"
@@ -30,23 +28,20 @@ namespace brave_ads {
 
 namespace {
 
-constexpr char16_t kGetDocumentHTMLScript[] =
+constexpr char16_t kSerializeDocumentToStringJavaScript[] =
     u"new XMLSerializer().serializeToString(document)";
 
-constexpr char16_t kGetInnerTextScript[] = u"document?.body?.innerText";
-
-bool UserHasOptedInToBraveRewards(const PrefService* prefs) {
-  return prefs->GetBoolean(brave_rewards::prefs::kEnabled);
-}
+constexpr char16_t kDocumentBodyInnerTextJavaScript[] =
+    u"document?.body?.innerText";
 
 }  // namespace
 
 AdsTabHelper::AdsTabHelper(content::WebContents* web_contents)
     : WebContentsObserver(web_contents),
       content::WebContentsUserData<AdsTabHelper>(*web_contents),
-      tab_id_(sessions::SessionTabHelper::IdForTab(web_contents)),
-      weak_factory_(this) {
+      tab_id_(sessions::SessionTabHelper::IdForTab(web_contents)) {
   if (!tab_id_.is_valid()) {
+    // `WebContents` is null or has no `SessionTabHelper`.
     return;
   }
 
@@ -58,9 +53,12 @@ AdsTabHelper::AdsTabHelper(content::WebContents* web_contents)
   }
 
 #if !BUILDFLAG(IS_ANDROID)
+  // See "background_helper_android.h" for Android.
   BrowserList::AddObserver(this);
+
   OnBrowserSetLastActive(BrowserList::GetInstance()->GetLastActive());
 #endif
+
   OnVisibilityChanged(web_contents->GetVisibility());
 }
 
@@ -70,213 +68,246 @@ AdsTabHelper::~AdsTabHelper() {
 #endif
 }
 
-void AdsTabHelper::TabUpdated() {
-  if (!ads_service_) {
-    return;
-  }
-
-  const bool is_visible = is_active_ && is_browser_active_;
-
-  ads_service_->NotifyTabDidChange(tab_id_.id(), redirect_chain_,
-                                   is_error_page_, is_visible);
+PrefService* AdsTabHelper::GetPrefs() const {
+  return Profile::FromBrowserContext(web_contents()->GetBrowserContext())
+      ->GetPrefs();
 }
 
-void AdsTabHelper::RunIsolatedJavaScript(
-    content::RenderFrameHost* render_frame_host) {
-  CHECK(render_frame_host);
-
-  const PrefService* prefs =
-      Profile::FromBrowserContext(web_contents()->GetBrowserContext())
-          ->GetPrefs();
-  if (!prefs) {
-    return;
-  }
-
-  render_frame_host->ExecuteJavaScriptInIsolatedWorld(
-      kGetDocumentHTMLScript,
-      base::BindOnce(&AdsTabHelper::OnJavaScriptHtmlResult,
-                     weak_factory_.GetWeakPtr()),
-      ISOLATED_WORLD_ID_BRAVE_INTERNAL);
-
-  if (UserHasOptedInToBraveRewards(prefs)) {
-    render_frame_host->ExecuteJavaScriptInIsolatedWorld(
-        kGetInnerTextScript,
-        base::BindOnce(&AdsTabHelper::OnJavaScriptTextResult,
-                       weak_factory_.GetWeakPtr()),
-        ISOLATED_WORLD_ID_BRAVE_INTERNAL);
-  }
+bool AdsTabHelper::UserHasJoinedBraveRewards() const {
+  return GetPrefs()->GetBoolean(brave_rewards::prefs::kEnabled);
 }
 
-void AdsTabHelper::OnJavaScriptHtmlResult(base::Value value) {
-  if (!ads_service_) {
-    return;
-  }
-
-  if (!value.is_string()) {
-    return;
-  }
-
-  const std::string& html = value.GetString();
-  ads_service_->NotifyTabHtmlContentDidChange(tab_id_.id(), redirect_chain_,
-                                              html);
+bool AdsTabHelper::IsVisible() const {
+  return is_web_contents_visible_ && is_browser_active_;
 }
 
-void AdsTabHelper::OnJavaScriptTextResult(base::Value value) {
-  if (!ads_service_) {
-    return;
-  }
-
-  if (!value.is_string()) {
-    return;
-  }
-
-  const std::string& text = value.GetString();
-  ads_service_->NotifyTabTextContentDidChange(tab_id_.id(), redirect_chain_,
-                                              text);
-}
-
-void AdsTabHelper::DidFinishNavigation(
-    content::NavigationHandle* navigation_handle) {
+bool AdsTabHelper::IsErrorPage(content::NavigationHandle* navigation_handle) {
   CHECK(navigation_handle);
 
-  if (!ads_service_ || !navigation_handle->IsInPrimaryMainFrame() ||
-      !navigation_handle->HasCommitted() || !tab_id_.is_valid()) {
-    return;
+  if (navigation_handle->IsErrorPage()) {
+    return true;
   }
 
-  const bool tab_not_restored =
-      navigation_handle->GetRestoreType() == content::RestoreType::kNotRestored;
-
-  // Some browser initiated navigations have HasUserGesture set to false. This
-  // should eventually be fixed in crbug.com/617904.
-  if (tab_not_restored && (navigation_handle->HasUserGesture() ||
-                           !navigation_handle->IsRendererInitiated())) {
-    ads_service_->NotifyUserGestureEventTriggered(
-        navigation_handle->GetPageTransition());
-  }
-
-  redirect_chain_ = navigation_handle->GetRedirectChain();
-
-  is_error_page_ = false;
   const net::HttpResponseHeaders* const response_headers =
       navigation_handle->GetResponseHeaders();
   if (response_headers) {
     const int response_code_class = response_headers->response_code() / 100;
-    is_error_page_ = response_code_class == 4 /*client error*/ ||
-                     response_code_class == 5 /*server error*/;
-  }
-  if (navigation_handle->IsErrorPage()) {
-    is_error_page_ = true;
+    return response_code_class == 4 /*client error*/ ||
+           response_code_class == 5 /*server error*/;
   }
 
-  TabUpdated();
+  return false;
+}
 
-  if (!navigation_handle->IsSameDocument()) {
-    should_process_ = tab_not_restored;
+void AdsTabHelper::ProcessNavigation() {
+  MaybeNotifyTabContentDidChange();
+
+  is_restoring_ = false;
+}
+
+void AdsTabHelper::MaybeNotifyBrowserDidBecomeActive() {
+  if (ads_service_) {
+    ads_service_->NotifyBrowserDidBecomeActive();
+  }
+}
+
+void AdsTabHelper::MaybeNotifyBrowserDidResignActive() {
+  if (ads_service_) {
+    ads_service_->NotifyBrowserDidResignActive();
+  }
+}
+
+void AdsTabHelper::MaybeNotifyUserGestureEventTriggered(
+    content::NavigationHandle* navigation_handle) {
+  CHECK(navigation_handle);
+
+  if (!ads_service_) {
     return;
   }
 
-  content::RenderFrameHost* render_frame_host =
-      navigation_handle->GetRenderFrameHost();
-  RunIsolatedJavaScript(render_frame_host);
+  if (is_restoring_) {
+    // Don't notify user gesture events for restored tabs.
+    return;
+  }
+
+  if (!navigation_handle->HasUserGesture() &&
+      navigation_handle->IsRendererInitiated()) {
+    // Some browser initiated navigations return `false` for `HasUserGesture` so
+    // we must also check `IsRendererInitiated`. See crbug.com/617904.
+    return;
+  }
+
+  const ui::PageTransition page_transition =
+      navigation_handle->GetPageTransition();
+  ads_service_->NotifyUserGestureEventTriggered(page_transition);
+}
+
+void AdsTabHelper::MaybeNotifyTabDidChange() {
+  if (!ads_service_) {
+    return;
+  }
+
+  if (is_restoring_) {
+    // Don't notify changes for restored tabs.
+    return;
+  }
+
+  ads_service_->NotifyTabDidChange(tab_id_.id(), redirect_chain_,
+                                   is_error_page_, IsVisible());
+}
+
+void AdsTabHelper::MaybeNotifyTabContentDidChange() {
+  if (is_restoring_ || is_error_page_) {
+    // Don't notify content changes for restored tabs or error pages.
+    return;
+  }
+
+  MaybeNotifyTabHtmlContentDidChange();
+  MaybeNotifyTabTextContentDidChange();
+}
+
+void AdsTabHelper::MaybeNotifyTabHtmlContentDidChange() {
+  web_contents()->GetPrimaryMainFrame()->ExecuteJavaScriptInIsolatedWorld(
+      kSerializeDocumentToStringJavaScript,
+      base::BindOnce(&AdsTabHelper::OnMaybeNotifyTabHtmlContentDidChange,
+                     weak_factory_.GetWeakPtr()),
+      ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+}
+
+void AdsTabHelper::OnMaybeNotifyTabHtmlContentDidChange(base::Value value) {
+  if (ads_service_ && value.is_string()) {
+    ads_service_->NotifyTabHtmlContentDidChange(tab_id_.id(), redirect_chain_,
+                                                /*html=*/value.GetString());
+  }
+}
+
+void AdsTabHelper::MaybeNotifyTabTextContentDidChange() {
+  if (!UserHasJoinedBraveRewards()) {
+    return;
+  }
+
+  web_contents()->GetPrimaryMainFrame()->ExecuteJavaScriptInIsolatedWorld(
+      kDocumentBodyInnerTextJavaScript,
+      base::BindOnce(&AdsTabHelper::OnMaybeNotifyTabTextContentDidChange,
+                     weak_factory_.GetWeakPtr()),
+      ISOLATED_WORLD_ID_BRAVE_INTERNAL);
+}
+
+void AdsTabHelper::OnMaybeNotifyTabTextContentDidChange(base::Value value) {
+  if (ads_service_ && value.is_string()) {
+    ads_service_->NotifyTabTextContentDidChange(tab_id_.id(), redirect_chain_,
+                                                /*text=*/value.GetString());
+  }
+}
+
+void AdsTabHelper::MaybeNotifyTabDidStartPlayingMedia() {
+  if (ads_service_) {
+    ads_service_->NotifyTabDidStopPlayingMedia(tab_id_.id());
+  }
+}
+
+void AdsTabHelper::MaybeNotifyTabDidStopPlayingMedia() {
+  if (ads_service_) {
+    ads_service_->NotifyTabDidStopPlayingMedia(tab_id_.id());
+  }
+}
+
+void AdsTabHelper::MaybeNotifyTabdidClose() {
+  if (ads_service_) {
+    ads_service_->NotifyDidCloseTab(tab_id_.id());
+  }
+}
+
+void AdsTabHelper::DidStartNavigation(
+    content::NavigationHandle* navigation_handle) {
+  if (!ads_service_ || !navigation_handle->IsInPrimaryMainFrame()) {
+    return;
+  }
+
+  is_restoring_ =
+      navigation_handle->GetRestoreType() == content::RestoreType::kRestored;
+
+  redirect_chain_.clear();
+
+  is_error_page_ = false;
+}
+
+void AdsTabHelper::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  if (!ads_service_ || !navigation_handle->IsInPrimaryMainFrame() ||
+      !navigation_handle->HasCommitted()) {
+    return;
+  }
+
+  redirect_chain_ = navigation_handle->GetRedirectChain();
+
+  is_error_page_ = IsErrorPage(navigation_handle);
+
+  MaybeNotifyUserGestureEventTriggered(navigation_handle);
+
+  MaybeNotifyTabDidChange();
+
+  // For navigations that lead to a document change,
+  // `MaybeNotifyTabContentDidChange` is called from
+  // `DocumentOnLoadCompletedInPrimaryMainFrame`.
+  if (navigation_handle->IsSameDocument()) {
+    ProcessNavigation();
+  }
 }
 
 void AdsTabHelper::DocumentOnLoadCompletedInPrimaryMainFrame() {
-  content::RenderFrameHost* render_frame_host =
-      web_contents()->GetPrimaryMainFrame();
-  if (should_process_) {
-    RunIsolatedJavaScript(render_frame_host);
-  }
+  ProcessNavigation();
 }
 
 void AdsTabHelper::MediaStartedPlaying(const MediaPlayerInfo& video_type,
                                        const content::MediaPlayerId& id) {
-  if (ads_service_) {
-    ads_service_->NotifyTabDidStartPlayingMedia(tab_id_.id());
-  }
+  MaybeNotifyTabDidStartPlayingMedia();
 }
 
 void AdsTabHelper::MediaStoppedPlaying(
     const MediaPlayerInfo& video_type,
     const content::MediaPlayerId& id,
     WebContentsObserver::MediaStoppedReason reason) {
-  if (ads_service_) {
-    ads_service_->NotifyTabDidStopPlayingMedia(tab_id_.id());
-  }
+  MaybeNotifyTabDidStopPlayingMedia();
 }
 
 void AdsTabHelper::OnVisibilityChanged(content::Visibility visibility) {
-  const bool old_is_active = is_active_;
+  const bool last_is_web_contents_visible = is_web_contents_visible_;
+  is_web_contents_visible_ = visibility == content::Visibility::VISIBLE;
 
-  switch (visibility) {
-    case content::Visibility::HIDDEN:
-    case content::Visibility::OCCLUDED: {
-      is_active_ = false;
-      break;
-    }
-
-    case content::Visibility::VISIBLE: {
-      is_active_ = true;
-      break;
-    }
-  }
-
-  if (old_is_active == is_active_) {
+  if (redirect_chain_.empty()) {
+    // Don't notify changes for tabs which have not finished loading.
     return;
   }
 
-  TabUpdated();
+  if (last_is_web_contents_visible != is_web_contents_visible_) {
+    MaybeNotifyTabDidChange();
+  }
 }
 
 void AdsTabHelper::WebContentsDestroyed() {
-  if (!ads_service_) {
-    return;
-  }
+  MaybeNotifyTabdidClose();
 
-  ads_service_->NotifyDidCloseTab(tab_id_.id());
   ads_service_ = nullptr;
 }
 
 #if !BUILDFLAG(IS_ANDROID)
-// "components/brave_ads/browser/background_helper_android.cc" handles Android
 void AdsTabHelper::OnBrowserSetLastActive(Browser* browser) {
-  if (!browser || !ads_service_) {
-    return;
+  const bool last_is_browser_active = is_browser_active_;
+  is_browser_active_ = browser->tab_strip_model()->GetIndexOfWebContents(
+                           web_contents()) != TabStripModel::kNoTab;
+  if (last_is_browser_active != is_browser_active_) {
+    MaybeNotifyBrowserDidBecomeActive();
   }
-
-  const bool old_is_browser_active = is_browser_active_;
-
-  if (browser->tab_strip_model()->GetIndexOfWebContents(web_contents()) !=
-      TabStripModel::kNoTab) {
-    is_browser_active_ = true;
-  }
-
-  if (old_is_browser_active == is_browser_active_) {
-    return;
-  }
-
-  ads_service_->NotifyBrowserDidBecomeActive();
 }
 
 void AdsTabHelper::OnBrowserNoLongerActive(Browser* browser) {
-  CHECK(browser);
-
-  if (!ads_service_) {
-    return;
+  const bool last_is_browser_active = is_browser_active_;
+  is_browser_active_ = browser->tab_strip_model()->GetIndexOfWebContents(
+                           web_contents()) == TabStripModel::kNoTab;
+  if (last_is_browser_active != is_browser_active_) {
+    MaybeNotifyBrowserDidResignActive();
   }
-
-  const bool old_is_browser_active = is_browser_active_;
-
-  if (browser->tab_strip_model()->GetIndexOfWebContents(web_contents()) !=
-      TabStripModel::kNoTab) {
-    is_browser_active_ = false;
-  }
-
-  if (old_is_browser_active == is_browser_active_) {
-    return;
-  }
-
-  ads_service_->NotifyBrowserDidResignActive();
 }
 #endif
 

--- a/components/brave_ads/core/internal/account/user_data/README.md
+++ b/components/brave_ads/core/internal/account/user_data/README.md
@@ -11,6 +11,7 @@ Included in the confirmation payload for non-Brave Rewards and Brave Rewards use
 | user data  | optional  | mutable  | description  |
 |---|---|---|---|
 | conversion  | yes  | no  | Conversion action and encrypted verifiable envelope.  |
+| httpResponseStatus  | yes  | no  | Whether the navigation committed an error page.  |
 
 ### Additional User Data Submitted for Brave Rewards Users
 
@@ -22,6 +23,7 @@ Should only be included in the confirmation payload for users who have joined Br
 | catalog  | no  | no  |  Catalog identifier.  |
 | createdAtTimestamp  | no  | no  | Privacy-preserving [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) timestamp.  |
 | diagnosticId  | yes  | yes  | Diagnostic id from [brave://rewards-internals](brave://rewards-internals) to help diagnose issues.  |
+| httpResponseStatus  | yes  | no  | Whether the navigation committed an error page.  |
 | locale  | yes  | no  | Privacy-preserving operating system locale  |
 | platform  | no  | no  | Operating system.  |
 | rotating_hash  | yes  | no  | Privacy-preserving time-based rotating hash.  |

--- a/components/brave_ads/core/internal/ad_units/user_data/page_land_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/ad_units/user_data/page_land_user_data_unittest.cc
@@ -26,6 +26,7 @@ TEST_F(BraveAdsPageLandUserDataTest,
                     })"),
             BuildPageLandUserData(
                 TabInfo{/*id=*/1,
+                        /*is_visible=*/true,
                         /*redirect_chain=*/{GURL("https://brave.com")},
                         /*is_error_page=*/true,
                         /*is_playing_media=*/false}));
@@ -36,6 +37,7 @@ TEST_F(BraveAdsPageLandUserDataTest,
   // Act & Assert
   EXPECT_TRUE(BuildPageLandUserData(
                   TabInfo{/*id=*/1,
+                          /*is_visible=*/true,
                           /*redirect_chain=*/{GURL("https://brave.com")},
                           /*is_error_page=*/false,
                           /*is_playing_media=*/false})

--- a/components/brave_ads/core/internal/application_state/browser_manager.cc
+++ b/components/brave_ads/core/internal/application_state/browser_manager.cc
@@ -50,11 +50,7 @@ void BrowserManager::NotifyBrowserDidResignActive() const {
 }
 
 void BrowserManager::LogBrowserActiveState() const {
-  if (is_active_) {
-    BLOG(1, "Browser did become active");
-  } else {
-    BLOG(1, "Browser did resign active");
-  }
+  BLOG(1, "Browser did " << (is_active_ ? "become" : "resign") << " active");
 }
 
 void BrowserManager::NotifyBrowserDidEnterForeground() const {
@@ -70,11 +66,8 @@ void BrowserManager::NotifyBrowserDidEnterBackground() const {
 }
 
 void BrowserManager::LogBrowserForegroundState() const {
-  if (is_in_foreground_) {
-    BLOG(1, "Browser did enter foreground");
-  } else {
-    BLOG(1, "Browser did enter background");
-  }
+  BLOG(1, "Browser did enter "
+              << (is_in_foreground_ ? "foreground" : "background"));
 }
 
 void BrowserManager::OnNotifyDidInitializeAds() {

--- a/components/brave_ads/core/internal/tabs/tab_info.cc
+++ b/components/brave_ads/core/internal/tabs/tab_info.cc
@@ -12,10 +12,12 @@ namespace brave_ads {
 TabInfo::TabInfo() = default;
 
 TabInfo::TabInfo(const int32_t id,
+                 const bool is_visible,
                  std::vector<GURL> redirect_chain,
                  const bool is_error_page,
                  const bool is_playing_media)
     : id(id),
+      is_visible(is_visible),
       redirect_chain(std::move(redirect_chain)),
       is_error_page(is_error_page),
       is_playing_media(is_playing_media) {}

--- a/components/brave_ads/core/internal/tabs/tab_info.h
+++ b/components/brave_ads/core/internal/tabs/tab_info.h
@@ -16,6 +16,7 @@ namespace brave_ads {
 struct TabInfo final {
   TabInfo();
   TabInfo(int32_t id,
+          bool is_visible,
           std::vector<GURL> redirect_chain,
           bool is_error_page,
           bool is_playing_media);
@@ -31,6 +32,7 @@ struct TabInfo final {
   bool operator==(const TabInfo&) const = default;
 
   int32_t id = 0;
+  bool is_visible = false;
   std::vector<GURL> redirect_chain;
   bool is_error_page = false;
   bool is_playing_media = false;

--- a/components/brave_ads/core/internal/tabs/tab_manager.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager.cc
@@ -40,19 +40,18 @@ void TabManager::RemoveObserver(TabManagerObserver* observer) {
 
 bool TabManager::IsVisible(const int32_t tab_id) const {
   if (!visible_tab_id_) {
+    // `OnNotifyTabDidChange` was not invoked for a tab that is currently
+    // visible in the browsing session.
     return false;
   }
 
   return visible_tab_id_ == tab_id;
 }
 
-bool TabManager::IsPlayingMedia(const int32_t tab_id) const {
-  const std::optional<TabInfo> tab = MaybeGetForId(tab_id);
-  return tab ? tab->is_playing_media : false;
-}
-
 std::optional<TabInfo> TabManager::GetVisible() const {
   if (!visible_tab_id_) {
+    // `OnNotifyTabDidChange` was not invoked for a tab that is currently
+    // visible in the browsing session.
     return std::nullopt;
   }
 
@@ -60,17 +59,27 @@ std::optional<TabInfo> TabManager::GetVisible() const {
 }
 
 std::optional<TabInfo> TabManager::MaybeGetForId(const int32_t tab_id) const {
-  if (!base::Contains(tabs_, tab_id)) {
+  if (!DoesExistForId(tab_id)) {
     return std::nullopt;
   }
 
   return tabs_.at(tab_id);
 }
 
+bool TabManager::IsPlayingMedia(const int32_t tab_id) const {
+  const std::optional<TabInfo> tab = MaybeGetForId(tab_id);
+  return tab ? tab->is_playing_media : false;
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
+bool TabManager::DoesExistForId(const int32_t tab_id) const {
+  return base::Contains(tabs_, tab_id);
+}
+
 TabInfo& TabManager::GetOrCreateForId(const int32_t tab_id) {
-  if (!base::Contains(tabs_, tab_id)) {
+  if (!DoesExistForId(tab_id)) {
+    // Create a new tab.
     TabInfo tab;
     tab.id = tab_id;
     tabs_[tab_id] = tab;
@@ -79,8 +88,13 @@ TabInfo& TabManager::GetOrCreateForId(const int32_t tab_id) {
   return tabs_[tab_id];
 }
 
-void TabManager::Remove(const int32_t tab_id) {
+void TabManager::RemoveForId(const int32_t tab_id) {
   tabs_.erase(tab_id);
+
+  if (tabs_.empty()) {
+    BLOG(2, "There are no tabs");
+    visible_tab_id_.reset();
+  }
 }
 
 void TabManager::NotifyTabDidChangeFocus(const int32_t tab_id) const {
@@ -144,12 +158,14 @@ void TabManager::OnNotifyTabHtmlContentDidChange(
   CHECK(!redirect_chain.empty());
 
   const uint32_t hash = base::FastHash(html);
-  if (hash != last_html_content_hash_) {
-    last_html_content_hash_ = hash;
-
-    BLOG(2, "Tab id " << tab_id << " HTML content changed");
-    NotifyHtmlContentDidChange(tab_id, redirect_chain, html);
+  if (hash == last_html_content_hash_) {
+    // No change.
+    return;
   }
+  last_html_content_hash_ = hash;
+
+  BLOG(2, "Tab id " << tab_id << " HTML content changed");
+  NotifyHtmlContentDidChange(tab_id, redirect_chain, html);
 }
 
 void TabManager::OnNotifyTabTextContentDidChange(
@@ -159,81 +175,88 @@ void TabManager::OnNotifyTabTextContentDidChange(
   CHECK(!redirect_chain.empty());
 
   const uint32_t hash = base::FastHash(text);
-  if (hash != last_text_content_hash_) {
-    last_text_content_hash_ = hash;
-
-    BLOG(2, "Tab id " << tab_id << " text content changed");
-    NotifyTextContentDidChange(tab_id, redirect_chain, text);
+  if (hash == last_text_content_hash_) {
+    // No change.
+    return;
   }
+  last_text_content_hash_ = hash;
+
+  BLOG(2, "Tab id " << tab_id << " text content changed");
+  NotifyTextContentDidChange(tab_id, redirect_chain, text);
 }
 
 void TabManager::OnNotifyTabDidStartPlayingMedia(const int32_t tab_id) {
   TabInfo& tab = GetOrCreateForId(tab_id);
-  if (!tab.is_playing_media) {
-    tab.is_playing_media = true;
-
-    BLOG(2, "Tab id " << tab_id << " started playing media");
-    NotifyTabDidStartPlayingMedia(tab_id);
+  if (tab.is_playing_media) {
+    // Already playing media.
+    return;
   }
+  tab.is_playing_media = true;
+
+  BLOG(2, "Tab id " << tab_id << " started playing media");
+  NotifyTabDidStartPlayingMedia(tab_id);
 }
 
 void TabManager::OnNotifyTabDidStopPlayingMedia(const int32_t tab_id) {
   TabInfo& tab = GetOrCreateForId(tab_id);
-  if (tab.is_playing_media) {
-    tab.is_playing_media = false;
-
-    BLOG(2, "Tab id " << tab_id << " stopped playing media");
-    NotifyTabDidStopPlayingMedia(tab_id);
+  if (!tab.is_playing_media) {
+    // Not playing media.
+    return;
   }
+  tab.is_playing_media = false;
+
+  BLOG(2, "Tab id " << tab_id << " stopped playing media");
+  NotifyTabDidStopPlayingMedia(tab_id);
 }
 
 void TabManager::OnNotifyTabDidChange(const int32_t tab_id,
                                       const std::vector<GURL>& redirect_chain,
                                       const bool is_error_page,
                                       const bool is_visible) {
-  const bool is_existing_tab = !!MaybeGetForId(tab_id);
+  CHECK(!redirect_chain.empty());
+
+  const bool does_exist = DoesExistForId(tab_id);
 
   TabInfo& tab = GetOrCreateForId(tab_id);
 
-  const bool redirect_chain_did_change = tab.redirect_chain != redirect_chain;
-  if (redirect_chain_did_change) {
-    tab.redirect_chain = redirect_chain;
-  }
+  // Check if the tab changed.
+  const bool did_change = does_exist && tab.redirect_chain != redirect_chain;
 
+  // Check if the tab changed focus.
+  const bool did_change_focus = !does_exist || tab.is_visible != is_visible;
+
+  // Update the tab.
+  tab.is_visible = is_visible;
+  tab.redirect_chain = redirect_chain;
   tab.is_error_page = is_error_page;
 
-  if (!is_visible) {
-    BLOG(7, "Tab id " << tab_id << " is occluded");
-    if (!redirect_chain_did_change) {
-      return;
-    }
+  if (is_visible) {
+    // Update the visible tab id.
+    visible_tab_id_ = tab_id;
+  }
 
+  // Notify observers.
+  if (!does_exist) {
+    BLOG(2, "Created tab with id " << tab_id);
+    NotifyDidOpenNewTab(tab);
+  }
+
+  if (did_change) {
     BLOG(2, "Tab id " << tab_id << " did change");
-    return NotifyTabDidChange(tab);
+    NotifyTabDidChange(tab);
   }
 
-  if (visible_tab_id_ == tab_id) {
-    BLOG(2, "Tab id " << tab_id << " did change");
-    return NotifyTabDidChange(tab);
+  if (did_change_focus) {
+    BLOG(2, "Tab id " << tab_id << " did become "
+                      << (is_visible ? "focused" : "occluded"));
+    NotifyTabDidChangeFocus(tab_id);
   }
-
-  BLOG(2, "Tab id " << tab_id << " is visible");
-
-  visible_tab_id_ = tab_id;
-
-  if (is_existing_tab) {
-    BLOG(2, "Focused on existing tab with id " << tab_id);
-    return NotifyTabDidChangeFocus(tab_id);
-  }
-
-  BLOG(2, "Opened a new tab with id " << tab_id);
-  NotifyDidOpenNewTab(tab);
 }
 
 void TabManager::OnNotifyDidCloseTab(const int32_t tab_id) {
   BLOG(2, "Tab id " << tab_id << " was closed");
 
-  Remove(tab_id);
+  RemoveForId(tab_id);
 
   NotifyDidCloseTab(tab_id);
 }

--- a/components/brave_ads/core/internal/tabs/tab_manager.h
+++ b/components/brave_ads/core/internal/tabs/tab_manager.h
@@ -39,16 +39,16 @@ class TabManager final : public AdsClientNotifierObserver {
   void RemoveObserver(TabManagerObserver* observer);
 
   bool IsVisible(int32_t tab_id) const;
-
-  bool IsPlayingMedia(int32_t tab_id) const;
-
   std::optional<TabInfo> GetVisible() const;
 
   std::optional<TabInfo> MaybeGetForId(int32_t tab_id) const;
 
+  bool IsPlayingMedia(int32_t tab_id) const;
+
  private:
+  bool DoesExistForId(int32_t tab_id) const;
   TabInfo& GetOrCreateForId(int32_t tab_id);
-  void Remove(int32_t tab_id);
+  void RemoveForId(int32_t tab_id);
 
   void NotifyTabDidChangeFocus(int32_t tab_id) const;
   void NotifyTabDidChange(const TabInfo& tab) const;
@@ -80,12 +80,12 @@ class TabManager final : public AdsClientNotifierObserver {
 
   base::ObserverList<TabManagerObserver> observers_;
 
-  uint32_t last_text_content_hash_ = 0;
-  uint32_t last_html_content_hash_ = 0;
-
   std::optional<int32_t> visible_tab_id_;
 
   std::map</*tab_id*/ int32_t, TabInfo> tabs_;
+
+  uint32_t last_text_content_hash_ = 0;
+  uint32_t last_html_content_hash_ = 0;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
@@ -7,6 +7,7 @@
 
 #include "brave/components/brave_ads/core/internal/common/unittest/unittest_base.h"
 #include "brave/components/brave_ads/core/internal/tabs/tab_manager_observer_mock.h"
+#include "net/http/http_status_code.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -26,35 +27,17 @@ class BraveAdsTabManagerTest : public UnitTestBase {
     UnitTestBase::TearDown();
   }
 
-  void OpenTab(const int32_t tab_id,
-               const std::vector<GURL>& redirect_chain,
-               const bool is_visible) {
-    const TabInfo tab(tab_id, redirect_chain,
-                      /*is_error_page=*/false,
-                      /*is_playing_media=*/false);
-
-    if (!is_visible) {
-      EXPECT_CALL(observer_mock_, OnTabDidChange(tab));
-    } else {
-      EXPECT_CALL(observer_mock_, OnDidOpenNewTab(tab));
-    }
-
-    NotifyTabDidChange(tab_id, redirect_chain,
-                       /*is_error_page=*/false, is_visible);
-  }
-
-  void PlayMedia(const int32_t tab_id) {
-    EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(tab_id));
-    NotifyTabDidStartPlayingMedia(tab_id);
-  }
-
   ::testing::StrictMock<TabManagerObserverMock> observer_mock_;
 };
 
 TEST_F(BraveAdsTabManagerTest, IsVisible) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_TRUE(TabManager::GetInstance().IsVisible(/*tab_id=*/1));
@@ -62,31 +45,15 @@ TEST_F(BraveAdsTabManagerTest, IsVisible) {
 
 TEST_F(BraveAdsTabManagerTest, IsOccluded) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/false);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/false);
 
   // Act & Assert
   EXPECT_FALSE(TabManager::GetInstance().IsVisible(/*tab_id=*/1));
-}
-
-TEST_F(BraveAdsTabManagerTest, IsPlayingMedia) {
-  // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
-
-  PlayMedia(/*tab_id=*/1);
-
-  // Act & Assert
-  EXPECT_TRUE(TabManager::GetInstance().IsPlayingMedia(/*tab_id=*/1));
-}
-
-TEST_F(BraveAdsTabManagerTest, IsNotPlayingMedia) {
-  // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
-
-  // Act & Assert
-  EXPECT_FALSE(TabManager::GetInstance().IsPlayingMedia(/*tab_id=*/1));
 }
 
 TEST_F(BraveAdsTabManagerTest, OpenNewTab) {
@@ -94,75 +61,106 @@ TEST_F(BraveAdsTabManagerTest, OpenNewTab) {
   EXPECT_CALL(
       observer_mock_,
       OnDidOpenNewTab(TabInfo{/*id=*/1,
+                              /*is_visible=*/true,
                               /*redirect_chain=*/{GURL("https://brave.com")},
                               /*is_error_page=*/false,
                               /*is_playing_media=*/false}));
-
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
       /*is_error_page=*/false,
       /*is_visible=*/true);
 }
 
-TEST_F(BraveAdsTabManagerTest, ChangeTab) {
+TEST_F(BraveAdsTabManagerTest, DoNotChangeOccludedTabIfMatchingRedirectChain) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/false);
 
   // Act & Assert
-  EXPECT_CALL(observer_mock_,
-              OnTabDidChange(TabInfo{
-                  /*id=*/1,
-                  /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-                  /*is_error_page=*/false,
-                  /*is_playing_media=*/false}));
-
+  EXPECT_CALL(observer_mock_, OnTabDidChange).Times(0);
   NotifyTabDidChange(
       /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_error_page=*/false,
+      /*is_visible=*/false);
+}
+
+TEST_F(BraveAdsTabManagerTest, DoNotChangeVisibleTabIfMatchingRedirectChain) {
+  // Arrange
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
+
+  // Act & Assert
+  EXPECT_CALL(observer_mock_, OnTabDidChange).Times(0);
+  NotifyTabDidChange(
+      /*tab_id=*/1,
+      /*redirect_chain=*/{GURL("https://brave.com")},
       /*is_error_page=*/false,
       /*is_visible=*/true);
 }
 
-TEST_F(BraveAdsTabManagerTest, ChangeTabFocus) {
+TEST_F(BraveAdsTabManagerTest, ChangeTabFocusToOccluded) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/false);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus(/*tab_id=*/1));
   NotifyTabDidChange(
       /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-      /*is_error_page=*/false,
-      /*is_visible=*/true);
-}
-
-TEST_F(BraveAdsTabManagerTest, DoNotUpdateExistingOccludedTabIfSameUrl) {
-  // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/false);
-
-  // Act & Assert
-  NotifyTabDidChange(
-      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*redirect_chain=*/{GURL("https://brave.com")},
       /*is_error_page=*/false,
       /*is_visible=*/false);
 }
 
-TEST_F(BraveAdsTabManagerTest, UpdateExistingOccludedTabIfDifferentUrl) {
+TEST_F(BraveAdsTabManagerTest, ChangeTabFocusToVisible) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/false);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/false);
+
+  // Act & Assert
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus(/*tab_id=*/1));
+  NotifyTabDidChange(
+      /*tab_id=*/1,
+      /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_error_page=*/false,
+      /*is_visible=*/true);
+}
+
+TEST_F(BraveAdsTabManagerTest, ChangeOccudedTabIfMismatchingRedirectChain) {
+  // Arrange
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/false);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_,
               OnTabDidChange(TabInfo{
                   /*id=*/1,
+                  /*is_visible=*/false,
                   /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
                   /*is_error_page=*/false,
                   /*is_playing_media=*/false}));
-
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
@@ -170,37 +168,23 @@ TEST_F(BraveAdsTabManagerTest, UpdateExistingOccludedTabIfDifferentUrl) {
       /*is_visible=*/false);
 }
 
-TEST_F(BraveAdsTabManagerTest, UpdateExistingVisibleTabIfSameUrl) {
+TEST_F(BraveAdsTabManagerTest, ChangeVisibleTabIfMismatchingRedirectChain) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
-
-  // Act & Assert
-  EXPECT_CALL(observer_mock_,
-              OnTabDidChange(TabInfo{
-                  /*id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-                  /*is_error_page=*/false,
-                  /*is_playing_media=*/false}));
-
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
   NotifyTabDidChange(/*tab_id=*/1,
                      /*redirect_chain=*/{GURL("https://brave.com")},
                      /*is_error_page=*/false,
                      /*is_visible=*/true);
-}
-
-TEST_F(BraveAdsTabManagerTest, DoNotUpdateExistingVisibleTabIfDifferentUrl) {
-  // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_,
               OnTabDidChange(TabInfo{
                   /*id=*/1,
+                  /*is_visible=*/true,
                   /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
                   /*is_error_page=*/false,
                   /*is_playing_media=*/false}));
-
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
@@ -208,51 +192,73 @@ TEST_F(BraveAdsTabManagerTest, DoNotUpdateExistingVisibleTabIfDifferentUrl) {
       /*is_visible=*/true);
 }
 
-TEST_F(BraveAdsTabManagerTest, UpdatedExistingVisibleTabIfDifferentUrl) {
-  // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
-
-  // Act & Assert
-  EXPECT_CALL(observer_mock_,
-              OnTabDidChange(TabInfo{
-                  /*id=*/1,
-                  /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-                  /*is_error_page=*/false,
-                  /*is_playing_media=*/false}));
-
-  NotifyTabDidChange(
-      /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-      /*is_error_page=*/false, /*is_visible=*/true);
-}
-
 TEST_F(BraveAdsTabManagerTest, CloseTab) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnDidCloseTab(/*tab_id=*/1));
   NotifyDidCloseTab(/*tab_id=*/1);
 }
 
-TEST_F(BraveAdsTabManagerTest, PlayMedia) {
+TEST_F(BraveAdsTabManagerTest, IsPlayingMedia) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
+
+  EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
+  NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
+
+  // Act & Assert
+  EXPECT_TRUE(TabManager::GetInstance().IsPlayingMedia(/*tab_id=*/1));
+}
+
+TEST_F(BraveAdsTabManagerTest, IsNotPlayingMedia) {
+  // Arrange
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
+
+  // Act & Assert
+  EXPECT_FALSE(TabManager::GetInstance().IsPlayingMedia(/*tab_id=*/1));
+}
+
+TEST_F(BraveAdsTabManagerTest, StartPlayingMedia) {
+  // Arrange
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 }
 
-TEST_F(BraveAdsTabManagerTest, AlreadyPlayingMedia) {
+TEST_F(BraveAdsTabManagerTest, DoNotStartPlayingMediaIfAlreadyPlaying) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
-
-  PlayMedia(/*tab_id=*/1);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
+  NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 
   // Act & Assert
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -260,57 +266,87 @@ TEST_F(BraveAdsTabManagerTest, AlreadyPlayingMedia) {
 
 TEST_F(BraveAdsTabManagerTest, StopPlayingMedia) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
-  PlayMedia(/*tab_id=*/1);
+  EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
+  NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidStopPlayingMedia(/*tab_id=*/1));
   NotifyTabDidStopPlayingMedia(/*tab_id=*/1);
 }
 
-TEST_F(BraveAdsTabManagerTest, GetVisible) {
+TEST_F(BraveAdsTabManagerTest, GetVisibleTab) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
-
-  OpenTab(/*tab_id=*/2,
-          /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
   // Act & Assert
-  const TabInfo tab{
-      /*id=*/2, /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-      /*is_error_page=*/false,
-      /*is_playing_media=*/false};
+  const TabInfo tab{/*id=*/1, /*is_visible=*/true,
+                    /*redirect_chain=*/{GURL("https://brave.com")},
+                    /*is_error_page=*/false,
+                    /*is_playing_media=*/false};
   EXPECT_EQ(tab, TabManager::GetInstance().GetVisible());
 }
 
-TEST_F(BraveAdsTabManagerTest, GetForId) {
-  // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+TEST_F(BraveAdsTabManagerTest, DoNotGetVisibleTabIfNoTabs) {
+  // Act & Assert
+  EXPECT_FALSE(TabManager::GetInstance().GetVisible());
+}
 
-  OpenTab(/*tab_id=*/2,
-          /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-          /*is_visible=*/true);
+TEST_F(BraveAdsTabManagerTest, GetTabForId) {
+  // Arrange
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
+
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(
+      /*tab_id=*/2,
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      /*is_error_page=*/false,
+      /*is_visible=*/true);
 
   // Act & Assert
   const TabInfo tab{
-      /*id=*/2, /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      /*id=*/2, /*is_visible=*/true,
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
       /*is_error_page=*/false,
       /*is_playing_media=*/false};
   EXPECT_EQ(tab, TabManager::GetInstance().MaybeGetForId(2));
 }
 
-TEST_F(BraveAdsTabManagerTest, DoNotGetForMissingId) {
+TEST_F(BraveAdsTabManagerTest, DoNotGetIfMissingTab) {
   // Arrange
-  OpenTab(/*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-          /*is_visible=*/true);
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
+  NotifyTabDidChange(/*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     /*is_error_page=*/false,
+                     /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_FALSE(TabManager::GetInstance().MaybeGetForId(2));
+}
+
+TEST_F(BraveAdsTabManagerTest, DoNotGetIfNoTabs) {
+  // Arrange
+
+  // Act & Assert
+  EXPECT_FALSE(TabManager::GetInstance().MaybeGetForId(1));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/purchase_intent_processor.cc
+++ b/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/purchase_intent_processor.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/purchase_intent/purchase_intent_processor.h"
 
+#include "base/check.h"
 #include "base/ranges/algorithm.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/search_engine/search_engine_results_page_util.h"
@@ -181,9 +182,7 @@ void PurchaseIntentProcessor::OnTextContentDidChange(
     const int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
     const std::string& /*text*/) {
-  if (redirect_chain.empty()) {
-    return;
-  }
+  CHECK(!redirect_chain.empty());
 
   const GURL& url = redirect_chain.back();
 

--- a/components/brave_ads/core/internal/targeting/contextual/text_classification/text_classification_processor.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_classification/text_classification_processor.cc
@@ -79,9 +79,7 @@ void TextClassificationProcessor::OnTextContentDidChange(
     const int32_t /*tab_id*/,
     const std::vector<GURL>& redirect_chain,
     const std::string& text) {
-  if (redirect_chain.empty()) {
-    return;
-  }
+  CHECK(!redirect_chain.empty());
 
   const GURL& url = redirect_chain.back();
 

--- a/components/brave_ads/core/internal/targeting/contextual/text_embedding/text_embedding_processor.cc
+++ b/components/brave_ads/core/internal/targeting/contextual/text_embedding/text_embedding_processor.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/check.h"
 #include "base/ranges/algorithm.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/search_engine/search_engine_results_page_util.h"
@@ -90,9 +91,7 @@ void TextEmbeddingProcessor::OnHtmlContentDidChange(
     const int32_t /*tab_id*/,
     const std::vector<GURL>& redirect_chain,
     const std::string& html) {
-  if (redirect_chain.empty()) {
-    return;
-  }
+  CHECK(!redirect_chain.empty());
 
   const GURL& url = redirect_chain.back();
 

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions.cc
@@ -50,9 +50,7 @@ void Conversions::RemoveObserver(ConversionsObserver* observer) {
 
 void Conversions::MaybeConvert(const std::vector<GURL>& redirect_chain,
                                const std::string& html) {
-  if (redirect_chain.empty()) {
-    return;
-  }
+  CHECK(!redirect_chain.empty());
 
   BLOG(1, "Checking for conversions");
 

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_unittest.cc
@@ -585,25 +585,6 @@ TEST_F(BraveAdsConversionsTest, ConvertViewedAdAfterTheSameAdWasDismissed) {
   MaybeConvert(BuildRedirectChain(), kHtml);
 }
 
-TEST_F(BraveAdsConversionsTest, DoNotConvertAdsIfTheRedirectChainIsEmpty) {
-  // Arrange
-  const AdInfo ad = test::BuildAd(AdType::kNotificationAd,
-                                  /*should_use_random_uuids=*/false);
-
-  test::BuildAndSaveCreativeSetConversion(ad.creative_set_id,
-                                          kMatchingUrlPattern,
-                                          /*observation_window=*/base::Days(3));
-
-  RecordAdEventsAdvancingTheClockAfterEach(
-      ad, {ConfirmationType::kDismissed, ConfirmationType::kServed,
-           ConfirmationType::kLanded, ConfirmationType::kMarkAdAsInappropriate,
-           ConfirmationType::kSavedAd, ConfirmationType::kLikedAd,
-           ConfirmationType::kDislikedAd, ConfirmationType::kConversion});
-
-  // Act & Assert
-  MaybeConvert(/*redirect_chain=*/{}, kHtml);
-}
-
 TEST_F(BraveAdsConversionsTest,
        DoNotConvertAdsIfTheRedirectChainContainsAnUnsupportedUrl) {
   // Arrange

--- a/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_url_redirects_parser_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_url_redirects_parser_util_unittest.cc
@@ -43,12 +43,4 @@ TEST(BraveAdsVerifiableConversionIdUrlParserUtilTest,
       ConversionResourceIdPatternInfo{kUrlPattern, kSearchInType, kIdPattern}));
 }
 
-TEST(BraveAdsVerifiableConversionIdUrlParserUtilTest,
-     DoNotParseVerifableConversionIdFromEmptyUrlRedirects) {
-  // Act & Assert
-  EXPECT_FALSE(MaybeParseVerifableConversionIdFromUrlRedirects(
-      /*redirect_chain=*/{},
-      ConversionResourceIdPatternInfo{kUrlPattern, kSearchInType, kIdPattern}));
-}
-
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/verifiable_conversion_id_pattern_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/verifiable_conversion_id_pattern_util.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/verifiable_conversion_id_pattern_util.h"
 
+#include "base/check.h"
 #include "brave/components/brave_ads/core/internal/common/url/url_util.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/resource/conversion_resource_id_pattern_search_in_types.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/parsers/verifiable_conversion_id_html_meta_tag_parser_util.h"
@@ -20,7 +21,9 @@ std::optional<ConversionResourceIdPatternInfo>
 FindMatchingConversionResourceIdPattern(
     const ConversionResourceIdPatternMap& resource_id_patterns,
     const std::vector<GURL>& redirect_chain) {
-  if (resource_id_patterns.empty() || redirect_chain.empty()) {
+  CHECK(!redirect_chain.empty());
+
+  if (resource_id_patterns.empty()) {
     return std::nullopt;
   }
 

--- a/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/verifiable_conversion_id_pattern_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_id_pattern/verifiable_conversion_id_pattern_util_unittest.cc
@@ -71,7 +71,8 @@ TEST_F(BraveAdsVerifiableConversionIdPatternUtilTest,
        DoNotParseVerifiableConversionId) {
   // Act & Assert
   EXPECT_FALSE(MaybeParseVerifiableConversionId(
-      /*redirect_chain=*/{}, /*html=*/{}, /*resource_id_patterns=*/{}));
+      /*redirect_chain=*/{GURL("https://foo.com/bar?qux_id=xyzzy")},
+      /*html=*/{}, /*resource_id_patterns=*/{}));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
@@ -66,6 +66,7 @@ TEST_F(BraveAdsSiteVisitTest,
   site_visit_->SetLastClickedAd(ad);
   site_visit_->MaybeLandOnPage(
       TabInfo{/*id=*/1,
+              /*is_visible=*/true,
               /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
               /*is_error_page=*/false, /*is_playing_media=*/false});
 
@@ -80,6 +81,7 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheSameAdIsAlreadyLanding) {
       /*is_error_page=*/false, /*is_visible=*/true);
 
   const TabInfo tab{/*id=*/1,
+                    /*is_visible=*/true,
                     /*redirect_chain=*/{GURL("https://brave.com")},
                     /*is_error_page=*/false,
                     /*is_playing_media=*/false};
@@ -111,6 +113,7 @@ TEST_F(BraveAdsSiteVisitTest, LandOnPageIfAnotherAdIsAlreadyLanded) {
                 OnMaybeLandOnPage(ad_1, Now() + kPageLandAfter.Get()));
     site_visit_->MaybeLandOnPage(
         TabInfo{/*id=*/1,
+                /*is_visible=*/true,
                 /*redirect_chain=*/{GURL("https://brave.com")},
                 /*is_error_page=*/false,
                 /*is_playing_media=*/false});
@@ -122,6 +125,7 @@ TEST_F(BraveAdsSiteVisitTest, LandOnPageIfAnotherAdIsAlreadyLanded) {
         /*is_error_page=*/false, /*is_visible=*/true);
 
     const TabInfo tab{/*id=*/2,
+                      /*is_visible=*/true,
                       /*redirect_chain=*/{GURL("https://brave.com")},
                       /*is_error_page=*/false,
                       /*is_playing_media=*/false};
@@ -147,6 +151,7 @@ TEST_F(BraveAdsSiteVisitTest,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   const TabInfo tab{/*id=*/1,
+                    /*is_visible=*/true,
                     /*redirect_chain=*/{GURL("https://brave.com")},
                     /*is_error_page=*/false,
                     /*is_playing_media=*/false};
@@ -172,6 +177,7 @@ TEST_F(
       /*is_error_page=*/true, /*is_visible=*/true);
 
   const TabInfo tab{/*id=*/1,
+                    /*is_visible=*/true,
                     /*redirect_chain=*/{GURL("https://brave.com")},
                     /*is_error_page=*/true,
                     /*is_playing_media=*/false};
@@ -204,6 +210,7 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfNotVisible) {
   EXPECT_CALL(observer_mock_, OnDidNotLandOnPage(ad));
   site_visit_->MaybeLandOnPage(
       TabInfo{/*id=*/1,
+              /*is_visible=*/true,
               /*redirect_chain=*/{GURL("https://brave.com")},
               /*is_error_page=*/false,
               /*is_playing_media=*/false});
@@ -228,6 +235,7 @@ TEST_F(BraveAdsSiteVisitTest,
   EXPECT_CALL(observer_mock_, OnDidNotLandOnPage(ad));
   site_visit_->MaybeLandOnPage(
       TabInfo{/*id=*/1,
+              /*is_visible=*/true,
               /*redirect_chain=*/{GURL("https://brave.com")},
               /*is_error_page=*/false,
               /*is_playing_media=*/false});
@@ -250,6 +258,7 @@ TEST_F(BraveAdsSiteVisitTest, CancelPageLandIfTheTabIsClosed) {
   EXPECT_CALL(observer_mock_, OnCanceledPageLand(ad, /*tab_id=*/1));
   site_visit_->MaybeLandOnPage(
       TabInfo{/*id=*/1,
+              /*is_visible=*/true,
               /*redirect_chain=*/{GURL("https://brave.com")},
               /*is_error_page=*/false,
               /*is_playing_media=*/false});

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
@@ -44,18 +44,6 @@ TEST_F(BraveAdsSiteVisitUtilTest, DidNotLandOnClosedTab) {
                                          /*should_use_random_uuids=*/true)));
 }
 
-TEST_F(BraveAdsSiteVisitUtilTest, DidNotLandOnTabWithNoTabRedirectChain) {
-  // Arrange
-  NotifyTabDidChange(
-      /*tab_id=*/1, /*redirect_chain=*/{},
-      /*is_error_page=*/false, /*is_visible=*/true);
-
-  // Act & Assert
-  EXPECT_FALSE(DidLandOnPage(
-      /*tab_id=*/1, /*ad=*/test::BuildAd(AdType::kNotificationAd,
-                                         /*should_use_random_uuids=*/true)));
-}
-
 TEST_F(BraveAdsSiteVisitUtilTest, DidNotLandOnTabForMismatchingDomainOrHost) {
   // Arrange
   NotifyTabDidChange(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37039

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Please verify that:

- User idle detection.
- Page content is classified when visiting a website.
- Page content is not classified when restoring a tab.
- Page content is not classified when a page error occurs.
- User activity events are logged to the console.
- User activity events are not logged to the console upon tab restoration.
- Site visits and page landings are occurring.
- Conversions are triggered.
- Purchase intent is being tracked.
- Orphaned inline content ads are purged.
- Push notification ads are being served.
- The browser becomes/resigns active appropriately.
- The browser enters the foreground/background appropriately.
- Frequent tab switching should not cause race conditions.
- Close each tab individually.

These tests can be basic verifications; full tests are not necessary.

NOTES: There is a known legacy issue where the browser does not trigger "resign active" when closing the final tab. We will work on a fix in a follow up issue