### PR TITLE
Updated omnibox search promotion banner layout

### DIFF
--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -60,6 +60,7 @@ constexpr int kBannerTypeMargin = 12;
 // Use small margin because omnibox popup has its own bottom padding.
 constexpr int kBannerTypeMarginBottom = 4;
 constexpr int kBannerTypeRadius = 8;
+constexpr int kMaxBannerDescLines = 5;
 
 gfx::FontList GetFont(int font_size, gfx::Font::Weight weight) {
   gfx::FontList font_list;
@@ -536,8 +537,11 @@ void BraveSearchConversionPromotionView::ConfigureForBannerType() {
   views::Label::CustomFont desc_font = {GetFont(14, gfx::Font::Weight::NORMAL)};
   banner_type_description_ = banner_contents->AddChildView(
       std::make_unique<views::Label>(desc_label, desc_font));
+  // Give right margin to not overlap with background image.
   banner_type_description_->SetProperty(views::kMarginsKey,
-                                        gfx::Insets::TLBR(4, 0, 0, 0));
+                                        gfx::Insets::TLBR(4, 0, 0, 70));
+  banner_type_description_->SetMultiLine(true);
+  banner_type_description_->SetMaxLines(kMaxBannerDescLines);
   banner_type_description_->SetAutoColorReadabilityEnabled(false);
   banner_type_description_->SetHorizontalAlignment(gfx::ALIGN_LEFT);
 
@@ -632,6 +636,18 @@ gfx::Size BraveSearchConversionPromotionView::CalculatePreferredSize() const {
   auto size = active_child->GetPreferredSize();
   auto* margin = active_child->GetProperty(views::kMarginsKey);
   size.Enlarge(0, margin->height());
+
+  const auto lines = banner_type_description_->GetRequiredLines();
+  if (lines <= 1) {
+    return size;
+  } else if (lines <= kMaxBannerDescLines) {
+    // Updating preferred height to get proper height for multi-lined label.
+    size.Enlarge(0, banner_type_description_->GetLineHeight() * (lines - 1));
+  } else {
+    size.Enlarge(0, banner_type_description_->GetLineHeight() *
+                        (kMaxBannerDescLines - 1));
+  }
+
   return size;
 }
 

--- a/components/brave_search/browser/brave_search_default_host_unittest.cc
+++ b/components/brave_search/browser/brave_search_default_host_unittest.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "base/feature_list.h"
 #include "base/functional/callback_forward.h"
@@ -72,25 +73,11 @@ class BraveSearchDefaultHostTest : public ::testing::Test {
     pref_service_.registry()->RegisterListPref(prefs::kDailyAsked);
     pref_service_.registry()->RegisterIntegerPref(prefs::kTotalAsked, 0);
     brave_search_conversion::RegisterPrefs(pref_service_.registry());
-    PrepareFieldTrialParamsForBannerTypeC();
   }
 
   void TearDown() override {
     pref_service_.ClearPref(prefs::kDailyAsked);
     pref_service_.ClearPref(prefs::kTotalAsked);
-  }
-
-  void PrepareFieldTrialParamsForBannerTypeC() {
-    constexpr char kPromotionTrial[] = "BraveSearchPromotionBannerStudy";
-    constexpr char kBannerTypeParamName[] = "banner_type";
-    constexpr char kBannerTypeExperiements[] = "banner_type_c";
-
-    std::map<std::string, std::string> params;
-    params[kBannerTypeParamName] = "type_C";
-    ASSERT_TRUE(base::AssociateFieldTrialParams(
-        kPromotionTrial, kBannerTypeExperiements, params));
-    base::FieldTrialList::CreateFieldTrial(kPromotionTrial,
-                                           kBannerTypeExperiements);
   }
 
   std::unique_ptr<BraveSearchDefaultHost> GetAPIHost(const std::string& host) {
@@ -195,8 +182,9 @@ TEST_F(BraveSearchDefaultHostTest, CanSetDefaultAlwaysTestWithSearchPromotion) {
   host->GetCanSetDefaultSearchProvider(third.Get());
   host->GetCanSetDefaultSearchProvider(fourth.Get());
 
-  feature_list.InitAndEnableFeature(
-      brave_search_conversion::features::kOmniboxBanner);
+  feature_list.InitAndEnableFeatureWithParameters(
+      brave_search_conversion::features::kOmniboxBanner,
+      {{brave_search_conversion::features::kBannerTypeParamName, "type_C"}});
   host->SetCanAlwaysSetDefault();
 
   // Can set after calling SetCanAlwaysSetDefault() with omnibox banner

--- a/components/brave_search_conversion/brave_search_conversion_unittest.cc
+++ b/components/brave_search_conversion/brave_search_conversion_unittest.cc
@@ -42,21 +42,6 @@ class BraveSearchConversionTest : public testing::Test {
     provider_data = TemplateURLDataFromPrepopulatedEngine(
         TemplateURLPrepopulateData::brave_bing);
     bing_template_url_ = std::make_unique<TemplateURL>(*provider_data);
-
-    PrepareFieldTrialParamsForBannerTypeA();
-  }
-
-  void PrepareFieldTrialParamsForBannerTypeA() {
-    constexpr char kPromotionTrial[] = "BraveSearchPromotionBannerStudy";
-    constexpr char kBannerTypeParamName[] = "banner_type";
-    constexpr char kBannerTypeExperiements[] = "banner_type_a";
-
-    std::map<std::string, std::string> params;
-    params[kBannerTypeParamName] = "type_A";
-    ASSERT_TRUE(base::AssociateFieldTrialParams(
-        kPromotionTrial, kBannerTypeExperiements, params));
-    base::FieldTrialList::CreateFieldTrial(kPromotionTrial,
-                                           kBannerTypeExperiements);
   }
 
   void ConfigureBingAsDefaultProvider() {
@@ -109,7 +94,9 @@ TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
   ConfigureBingAsDefaultProvider();
 
   feature_list.Reset();
-  feature_list.InitAndEnableFeature(features::kOmniboxBanner);
+  feature_list.InitAndEnableFeatureWithParameters(
+      brave_search_conversion::features::kOmniboxBanner,
+      {{brave_search_conversion::features::kBannerTypeParamName, "type_A"}});
   EXPECT_EQ(ConversionType::kBannerTypeA,
             GetConversionType(&pref_service_, &template_url_service_));
 

--- a/components/brave_search_conversion/features.cc
+++ b/components/brave_search_conversion/features.cc
@@ -5,8 +5,6 @@
 
 #include "brave/components/brave_search_conversion/features.h"
 
-#include "base/feature_list.h"
-
 namespace brave_search_conversion {
 
 namespace features {
@@ -16,6 +14,9 @@ namespace features {
 BASE_FEATURE(kOmniboxBanner,
              "BraveSearchOmniboxBanner",
              base::FEATURE_DISABLED_BY_DEFAULT);
+
+const base::FeatureParam<std::string> kBannerType{&kOmniboxBanner,
+                                                  kBannerTypeParamName, ""};
 
 // Brave search promotion match located at second low in omnibox popup.
 // This looks very similar with other normal matches.

--- a/components/brave_search_conversion/features.h
+++ b/components/brave_search_conversion/features.h
@@ -6,12 +6,19 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_SEARCH_CONVERSION_FEATURES_H_
 #define BRAVE_COMPONENTS_BRAVE_SEARCH_CONVERSION_FEATURES_H_
 
+#include <string>
+
 #include "base/feature_list.h"
+#include "base/metrics/field_trial_params.h"
 
 namespace brave_search_conversion {
 namespace features {
 
+inline constexpr char kBannerTypeParamName[] = "banner_type";
+
 BASE_DECLARE_FEATURE(kOmniboxBanner);
+extern const base::FeatureParam<std::string> kBannerType;
+
 BASE_DECLARE_FEATURE(kOmniboxButton);
 BASE_DECLARE_FEATURE(kNTP);
 

--- a/components/brave_search_conversion/utils.cc
+++ b/components/brave_search_conversion/utils.cc
@@ -104,12 +104,7 @@ ConversionType GetConversionType(PrefService* prefs,
       return ConversionType::kNone;
     }
 
-    // Fetch banner type from griffin.
-    constexpr char kPromotionTrial[] = "BraveSearchPromotionBannerStudy";
-    constexpr char kBannerTypeParamName[] = "banner_type";
-    const std::string banner_type =
-        base::GetFieldTrialParamValue(kPromotionTrial, kBannerTypeParamName);
-    return GetConversionTypeFromBannerTypeParam(banner_type);
+    return GetConversionTypeFromBannerTypeParam(features::kBannerType.Get());
   }
 
   return ConversionType::kNone;

--- a/components/omnibox/browser/promotion_unittest.cc
+++ b/components/omnibox/browser/promotion_unittest.cc
@@ -88,21 +88,6 @@ class OmniboxPromotionTest : public testing::Test {
 
     scoped_default_locale_ =
         std::make_unique<brave_l10n::test::ScopedDefaultLocale>("en_US");
-
-    PrepareFieldTrialParamsForBannerTypeB();
-  }
-
-  void PrepareFieldTrialParamsForBannerTypeB() {
-    constexpr char kPromotionTrial[] = "BraveSearchPromotionBannerStudy";
-    constexpr char kBannerTypeParamName[] = "banner_type";
-    constexpr char kBannerTypeExperiements[] = "banner_type_b";
-
-    std::map<std::string, std::string> params;
-    params[kBannerTypeParamName] = "type_B";
-    ASSERT_TRUE(base::AssociateFieldTrialParams(
-        kPromotionTrial, kBannerTypeExperiements, params));
-    base::FieldTrialList::CreateFieldTrial(kPromotionTrial,
-                                           kBannerTypeExperiements);
   }
 
   void CreateController(bool incognito) {
@@ -209,8 +194,9 @@ TEST_F(OmniboxPromotionTest, PromotionEntrySortTest) {
   // Turn off button type and on banner type search conversion.
   feature_list_button.Reset();
   base::test::ScopedFeatureList feature_list_banner;
-  feature_list_banner.InitAndEnableFeature(
-      brave_search_conversion::features::kOmniboxBanner);
+  feature_list_banner.InitAndEnableFeatureWithParameters(
+      brave_search_conversion::features::kOmniboxBanner,
+      {{brave_search_conversion::features::kBannerTypeParamName, "type_B"}});
 
   CreateController(false);
   EXPECT_TRUE(controller_->result().empty());


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36748

first commit is for testing easily with cmd line. (see the below test plan)
Second commit is for layout changing.

https://github.com/brave/brave-core/assets/6786187/ba9400e1-1c9f-41ba-ae89-09f769ea3adf

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch browser with `--enable-features=BraveSearchOmniboxBanner:banner_type/type_A` command line params
2. Set non-brave search provider(ex, google)
3. Type any keyword in omnibox and check banner layout
