### PR TITLE
perf(wallet): do not wait for pending decrypt reqs when initing panel

### DIFF
--- a/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
+++ b/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
@@ -63,6 +63,7 @@ import { mockOriginInfo } from '../../../stories/mock-data/mock-origin-info'
 import { WalletApiDataOverrides } from '../../../constants/testing_types'
 import {
   mockAddChainRequest,
+  mockDecryptRequest,
   mockSwitchChainRequest
 } from '../../../stories/mock-data/mock-eth-requests'
 
@@ -214,6 +215,10 @@ export class MockedWalletApiProxy {
   private pendingAddChainRequests = [mockAddChainRequest]
   private pendingSwitchChainRequests: BraveWallet.SwitchChainRequest[] = [
     mockSwitchChainRequest
+  ]
+
+  private pendingDecryptRequests: BraveWallet.DecryptRequest[] = [
+    mockDecryptRequest
   ]
 
   constructor(overrides?: WalletApiDataOverrides | undefined) {
@@ -408,6 +413,16 @@ export class MockedWalletApiProxy {
         getAssetIdKey(t) === tokenId ? { ...t, visible } : t
       )
       return { success: true }
+    },
+    getPendingDecryptRequests: async () => {
+      return {
+        requests: this.pendingDecryptRequests
+      }
+    },
+    notifyDecryptRequestProcessed: (requestId, approved) => {
+      this.pendingDecryptRequests = this.pendingDecryptRequests.filter(
+        (req) => req.requestId !== requestId
+      )
     }
   }
 

--- a/components/brave_wallet_ui/common/slices/api-base.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api-base.slice.ts
@@ -69,7 +69,8 @@ export function createWalletApiBase() {
       'IsMetaMaskInstalled',
       'IsPrivateWindow',
       'PendingAddChainRequests',
-      'PendingSwitchChainRequests'
+      'PendingSwitchChainRequests',
+      'PendingDecryptRequest'
     ],
     endpoints: ({ mutation, query }) => ({})
   })

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -46,6 +46,7 @@ import { fiatCurrencyEndpoints } from './endpoints/fiat_currency.endpoints'
 import { sitePermissionEndpoints } from './endpoints/site_permissions.endpoints'
 import { transactionEndpoints } from './endpoints/transaction.endpoints'
 import { swapEndpoints } from './endpoints/swap.endpoints'
+import { encryptionEndpoints } from './endpoints/encryption.endpoints'
 
 export function createWalletApi() {
   // base to add endpoints to
@@ -148,6 +149,8 @@ export function createWalletApi() {
       .injectEndpoints({ endpoints: sitePermissionEndpoints })
       // Brave Swap endpoints
       .injectEndpoints({ endpoints: swapEndpoints })
+      // Encryption endpoints
+      .injectEndpoints({ endpoints: encryptionEndpoints })
   )
 }
 
@@ -217,6 +220,7 @@ export const {
   useGetOnRampAssetsQuery,
   useGetOnRampFiatCurrenciesQuery,
   useGetPendingAddChainRequestQuery,
+  useGetPendingDecryptRequestQuery,
   useGetPendingSwitchChainRequestQuery,
   useGetPendingTokenSuggestionRequestsQuery,
   useGetPriceHistoryQuery,
@@ -280,6 +284,7 @@ export const {
   useNewUnapprovedTxAddedMutation,
   useOpenPanelUIMutation,
   usePrefetch,
+  useProcessPendingDecryptRequestMutation,
   useRefreshNetworkInfoMutation,
   useRejectTransactionsMutation,
   useRemoveAccountMutation,

--- a/components/brave_wallet_ui/common/slices/endpoints/encryption.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/encryption.endpoints.ts
@@ -1,0 +1,77 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// types
+import { BraveWallet } from '../../../constants/types'
+import { WalletApiEndpointBuilderParams } from '../api-base.slice'
+
+// utils
+import { handleEndpointError } from '../../../utils/api-utils'
+
+export const encryptionEndpoints = ({
+  mutation,
+  query
+}: WalletApiEndpointBuilderParams) => {
+  return {
+    getPendingDecryptRequest: query<BraveWallet.DecryptRequest | null, void>({
+      queryFn: async (arg, { endpoint }, extraOptions, baseQuery) => {
+        try {
+          const { data: api } = baseQuery(undefined)
+
+          const { requests } =
+            await api.braveWalletService.getPendingDecryptRequests()
+
+          return {
+            data: requests.length ? requests[0] : null
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Failed to get pending decrypt request',
+            error
+          )
+        }
+      },
+      providesTags: ['PendingDecryptRequest']
+    }),
+
+    processPendingDecryptRequest: mutation<
+      boolean,
+      {
+        requestId: string
+        approved: boolean
+      }
+    >({
+      queryFn: async (arg, { endpoint }, extraOptions, baseQuery) => {
+        try {
+          const { data: api } = baseQuery(undefined)
+
+          api.braveWalletService.notifyDecryptRequestProcessed(
+            arg.requestId,
+            arg.approved
+          )
+
+          const { requests } =
+            await api.braveWalletService.getPendingDecryptRequests()
+
+          if (!requests.length) {
+            api.panelHandler?.closeUI()
+          }
+
+          return {
+            data: true
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Failed to process pending decrypt request',
+            error
+          )
+        }
+      },
+      invalidatesTags: ['PendingDecryptRequest']
+    })
+  }
+}

--- a/components/brave_wallet_ui/components/extension/encryption-key-panel/index.tsx
+++ b/components/brave_wallet_ui/components/extension/encryption-key-panel/index.tsx
@@ -36,6 +36,7 @@ import { TabRow, URLText } from '../shared-panel-styles'
 // Hooks
 import { useAccountOrb } from '../../../common/hooks/use-orb'
 import { useAccountQuery } from '../../../common/slices/api.slice.extra'
+import { useProcessPendingDecryptRequestMutation } from '../../../common/slices/api.slice'
 
 export interface ProvidePubKeyPanelProps {
   payload: BraveWallet.GetEncryptionPublicKeyRequest
@@ -120,35 +121,31 @@ interface DecryptRequestPanelProps {
 }
 
 export function DecryptRequestPanel({ payload }: DecryptRequestPanelProps) {
-  // redux
-  const dispatch = useDispatch()
-
   // state
   const [isDecrypted, setIsDecrypted] = React.useState<boolean>(false)
 
   // queries
   const { account } = useAccountQuery(payload.accountId)
 
+  // mutations
+  const [processDecryptRequest] = useProcessPendingDecryptRequestMutation()
+
   // custom hooks
   const orb = useAccountOrb(account)
 
   // methods
-  const onAllow = () => {
-    dispatch(
-      PanelActions.decryptProcessed({
-        requestId: payload.requestId,
-        approved: true
-      })
-    )
+  const onAllow = async () => {
+    await processDecryptRequest({
+      requestId: payload.requestId,
+      approved: true
+    }).unwrap()
   }
 
-  const onCancel = () => {
-    dispatch(
-      PanelActions.decryptProcessed({
-        requestId: payload.requestId,
-        approved: false
-      })
-    )
+  const onCancel = async () => {
+    await processDecryptRequest({
+      requestId: payload.requestId,
+      approved: false
+    }).unwrap()
   }
 
   const onDecryptMessage = () => {

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -87,7 +87,6 @@ export type PanelHeaderSizes = 'regular' | 'slim'
 
 export type PanelTypes =
   | 'accounts'
-  | 'allowReadingEncryptedMessage' // For grep: 'decryptRequest'
   | 'approveTransaction'
   | 'assets'
   | 'buy'
@@ -222,7 +221,6 @@ export interface PanelState {
   getEncryptionPublicKeyRequest:
     | BraveWallet.GetEncryptionPublicKeyRequest
     | undefined
-  decryptRequest: BraveWallet.DecryptRequest | undefined
   hardwareWalletCode?: HardwareWalletResponseCodeType
   selectedTransactionId?: string
   signMessageErrorData: BraveWallet.SignMessageError[]

--- a/components/brave_wallet_ui/options/nav-options.ts
+++ b/components/brave_wallet_ui/options/nav-options.ts
@@ -16,7 +16,6 @@ import {
 
 const PANEL_TYPES: PanelTypes[] = [
   'accounts',
-  'allowReadingEncryptedMessage', // For grep: 'decryptRequest'
   'approveTransaction',
   'assets',
   'buy',

--- a/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
+++ b/components/brave_wallet_ui/panel/actions/wallet_panel_actions.ts
@@ -6,7 +6,6 @@
 import { createAction } from '@reduxjs/toolkit'
 import {
   GetEncryptionPublicKeyProcessedPayload,
-  DecryptProcessedPayload,
   ShowConnectToSitePayload,
   SignMessageProcessedPayload,
   SignAllTransactionsProcessedPayload,
@@ -48,9 +47,6 @@ export const getEncryptionPublicKeyProcessed =
   createAction<GetEncryptionPublicKeyProcessedPayload>(
     'getEncryptionPublicKeyProcessed'
   )
-export const decrypt = createAction<BraveWallet.DecryptRequest>('decrypt')
-export const decryptProcessed =
-  createAction<DecryptProcessedPayload>('decryptProcessed')
 export const setSelectedTransactionId = createAction<string | undefined>(
   'setSelectedTransactionId'
 )

--- a/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
+++ b/components/brave_wallet_ui/panel/async/wallet_panel_async_handler.ts
@@ -19,7 +19,6 @@ import {
   SignMessageProcessedPayload,
   SignAllTransactionsProcessedPayload,
   GetEncryptionPublicKeyProcessedPayload,
-  DecryptProcessedPayload,
   SignTransactionHardwarePayload,
   SignAllTransactionsHardwarePayload,
   SignMessageHardwarePayload
@@ -67,16 +66,6 @@ async function getPendingGetEncryptionPublicKeyRequest() {
   const requests = (
     await braveWalletService.getPendingGetEncryptionPublicKeyRequests()
   ).requests
-  if (requests && requests.length) {
-    return requests[0]
-  }
-  return null
-}
-
-async function getPendingDecryptRequest() {
-  const braveWalletService = getWalletPanelApiProxy().braveWalletService
-  const requests = (await braveWalletService.getPendingDecryptRequests())
-    .requests
   if (requests && requests.length) {
     return requests[0]
   }
@@ -212,12 +201,6 @@ handler.on(PanelActions.getEncryptionPublicKey.type, async (store: Store) => {
   apiProxy.panelHandler.showUI()
 })
 
-handler.on(PanelActions.decrypt.type, async (store: Store) => {
-  store.dispatch(PanelActions.navigateTo('allowReadingEncryptedMessage'))
-  const apiProxy = getWalletPanelApiProxy()
-  apiProxy.panelHandler.showUI()
-})
-
 handler.on(
   PanelActions.getEncryptionPublicKeyProcessed.type,
   async (store: Store, payload: GetEncryptionPublicKeyProcessedPayload) => {
@@ -233,24 +216,6 @@ handler.on(
       store.dispatch(
         PanelActions.getEncryptionPublicKey(getEncryptionPublicKeyRequest)
       )
-      return
-    }
-    apiProxy.panelHandler.closeUI()
-  }
-)
-
-handler.on(
-  PanelActions.decryptProcessed.type,
-  async (store: Store, payload: DecryptProcessedPayload) => {
-    const apiProxy = getWalletPanelApiProxy()
-    const braveWalletService = apiProxy.braveWalletService
-    braveWalletService.notifyDecryptRequestProcessed(
-      payload.requestId,
-      payload.approved
-    )
-    const decryptRequest = await getPendingDecryptRequest()
-    if (decryptRequest) {
-      store.dispatch(PanelActions.decrypt(decryptRequest))
       return
     }
     apiProxy.panelHandler.closeUI()
@@ -678,11 +643,6 @@ handler.on(WalletActions.initialize.type, async (store) => {
       store.dispatch(
         PanelActions.getEncryptionPublicKey(getEncryptionPublicKeyRequest)
       )
-      return
-    }
-    const decryptRequest = await getPendingDecryptRequest()
-    if (decryptRequest) {
-      store.dispatch(PanelActions.decrypt(decryptRequest))
       return
     }
   }

--- a/components/brave_wallet_ui/panel/constants/action_types.ts
+++ b/components/brave_wallet_ui/panel/constants/action_types.ts
@@ -38,11 +38,6 @@ export type GetEncryptionPublicKeyProcessedPayload = {
   approved: boolean
 }
 
-export type DecryptProcessedPayload = {
-  requestId: string
-  approved: boolean
-}
-
 export type SignTransactionHardwarePayload = {
   request: BraveWallet.SignTransactionRequest
   account: BraveWallet.AccountInfo

--- a/components/brave_wallet_ui/panel/container.tsx
+++ b/components/brave_wallet_ui/panel/container.tsx
@@ -4,6 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
+import ProgressRing from '@brave/leo/react/progressRing'
 
 // Components
 import {
@@ -31,6 +32,7 @@ import {
   ConnectWithSiteWrapper
 } from '../stories/style'
 import { PanelWrapper, WelcomePanelWrapper } from './style'
+import { FullScreenWrapper } from '../page/screens/page-screen.styles'
 
 import { TransactionStatus } from '../components/extension/post-confirmation'
 import {
@@ -42,6 +44,7 @@ import { WalletSelectors } from '../common/selectors'
 import { PanelSelectors } from './selectors'
 import {
   useGetPendingAddChainRequestQuery,
+  useGetPendingDecryptRequestQuery,
   useGetPendingSwitchChainRequestQuery,
   useGetPendingTokenSuggestionRequestsQuery
 } from '../common/slices/api.slice'
@@ -91,7 +94,6 @@ function Container() {
   const getEncryptionPublicKeyRequest = useUnsafePanelSelector(
     PanelSelectors.getEncryptionPublicKeyRequest
   )
-  const decryptRequest = useUnsafePanelSelector(PanelSelectors.decryptRequest)
   const connectingAccounts = useUnsafePanelSelector(
     PanelSelectors.connectingAccounts
   )
@@ -110,13 +112,23 @@ function Container() {
   const { data: selectedAccount } = useSelectedAccountQuery()
   const { data: addChainRequest } = useGetPendingAddChainRequestQuery()
   const { data: switchChainRequest } = useGetPendingSwitchChainRequestQuery()
+  const { data: decryptRequest } = useGetPendingDecryptRequestQuery()
   const { data: addTokenRequests = [] } =
     useGetPendingTokenSuggestionRequestsQuery()
 
   const selectedPendingTransaction = useSelectedPendingTransaction()
 
   if (!hasInitialized) {
-    return null
+    return (
+      <PanelWrapper
+        width={390}
+        height={650}
+      >
+        <FullScreenWrapper>
+          <ProgressRing mode='indeterminate' />
+        </FullScreenWrapper>
+      </PanelWrapper>
+    )
   }
 
   if (!isWalletCreated) {
@@ -183,9 +195,7 @@ function Container() {
     return (
       <PanelWrapper isLonger={true}>
         <LongWrapper>
-          <AllowAddChangeNetworkPanel
-            addChainRequest={addChainRequest}
-          />
+          <AllowAddChangeNetworkPanel addChainRequest={addChainRequest} />
         </LongWrapper>
       </PanelWrapper>
     )
@@ -195,9 +205,7 @@ function Container() {
     return (
       <PanelWrapper isLonger={true}>
         <LongWrapper>
-          <AllowAddChangeNetworkPanel
-            switchChainRequest={switchChainRequest}
-          />
+          <AllowAddChangeNetworkPanel switchChainRequest={switchChainRequest} />
         </LongWrapper>
       </PanelWrapper>
     )
@@ -224,7 +232,7 @@ function Container() {
     )
   }
 
-  if (selectedPanel === 'allowReadingEncryptedMessage' && decryptRequest) {
+  if (decryptRequest) {
     return (
       <PanelWrapper isLonger={true}>
         <LongWrapper>

--- a/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
+++ b/components/brave_wallet_ui/panel/reducers/panel_reducer.ts
@@ -38,7 +38,6 @@ const defaultState: PanelState = {
   signAllTransactionsRequests: [],
   signTransactionRequests: [],
   getEncryptionPublicKeyRequest: undefined,
-  decryptRequest: undefined,
   hardwareWalletCode: undefined,
   selectedTransactionId: undefined,
   signMessageErrorData: []
@@ -73,16 +72,6 @@ export const createPanelReducer = (initialState: PanelState) => {
       return {
         ...state,
         getEncryptionPublicKeyRequest: request
-      }
-    }
-  )
-
-  reducer.on(
-    PanelActions.decrypt.type,
-    (state: any, request: BraveWallet.DecryptRequest) => {
-      return {
-        ...state,
-        decryptRequest: request
       }
     }
   )

--- a/components/brave_wallet_ui/panel/selectors/panel-selectors.ts
+++ b/components/brave_wallet_ui/panel/selectors/panel-selectors.ts
@@ -16,7 +16,6 @@ export const selectedPanel = ({ panel }: State) => panel.selectedPanel
 export const connectToSiteOrigin = ({ panel }: State) =>
   panel.connectToSiteOrigin
 export const connectingAccounts = ({ panel }: State) => panel.connectingAccounts
-export const decryptRequest = ({ panel }: State) => panel.decryptRequest
 export const getEncryptionPublicKeyRequest = ({ panel }: State) =>
   panel.getEncryptionPublicKeyRequest
 export const hardwareWalletCode = ({ panel }: State) => panel.hardwareWalletCode

--- a/components/brave_wallet_ui/panel/style.ts
+++ b/components/brave_wallet_ui/panel/style.ts
@@ -9,6 +9,7 @@ export const PanelWrapper = styled.div<{
   width?: number
   height?: number
 }>`
+  position: relative;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/brave_wallet_ui/panel/wallet_panel.tsx
+++ b/components/brave_wallet_ui/panel/wallet_panel.tsx
@@ -57,12 +57,12 @@ function App() {
 
 function initialize() {
   initLocale(loadTimeData.data_)
+  render(<App />, document.getElementById('mountPoint'))
   store.dispatch(
     WalletActions.initialize({
       skipBalancesRefresh: true
     })
   )
-  render(<App />, document.getElementById('mountPoint'))
 }
 
 document.addEventListener('DOMContentLoaded', initialize)

--- a/components/brave_wallet_ui/stories/mock-data/mock-panel-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-panel-state.ts
@@ -10,8 +10,7 @@ import { PanelState } from '../../constants/types'
 import { mockOriginInfo } from './mock-origin-info'
 import {
   mockSignMessageRequest,
-  mockGetEncryptionPublicKeyRequest,
-  mockDecryptRequest
+  mockGetEncryptionPublicKeyRequest
 } from './mock-eth-requests'
 
 export const mockPanelState: PanelState = {
@@ -23,7 +22,6 @@ export const mockPanelState: PanelState = {
   signAllTransactionsRequests: [],
   signTransactionRequests: [],
   getEncryptionPublicKeyRequest: mockGetEncryptionPublicKeyRequest,
-  decryptRequest: mockDecryptRequest,
   hardwareWalletCode: undefined,
   selectedTransactionId: undefined,
   signMessageErrorData: [


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37094

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Use the [test dapp](https://metamask.github.io/test-dapp/) to ensure that encrypting and decrypting still works without regressions
<img width="548" alt="Screenshot 2024-03-26 at 2 06 28 PM" src="https://github.com/brave/brave-core/assets/30185185/04c27789-ad67-4899-b616-533495c6cb29">


