### PR TITLE
Reduce flakyness of Rewards contribution browser tests

### DIFF
--- a/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.h
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_contribution.h
@@ -73,17 +73,8 @@ class RewardsBrowserTestContribution : public RewardsServiceObserver {
 
   std::vector<mojom::Result> GetMultipleACStatus();
 
-  void SetUpUpholdWallet(
-      RewardsServiceImpl* rewards_service,
-      const double balance,
-      const mojom::WalletStatus status = mojom::WalletStatus::kConnected);
-
-#if BUILDFLAG(ENABLE_GEMINI_WALLET)
-  void SetUpGeminiWallet(
-      RewardsServiceImpl* rewards_service,
-      const double balance,
-      const mojom::WalletStatus status = mojom::WalletStatus::kConnected);
-#endif
+  void StartProcessWithConnectedWallet(RewardsServiceImpl* rewards_service,
+                                       double balance);
 
   std::vector<mojom::Result> GetMultipleTipStatus();
 

--- a/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
+++ b/components/brave_rewards/browser/test/rewards_contribution_browsertest.cc
@@ -203,10 +203,9 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
                        AutoContributionMultiplePublishersUphold) {
-  test_util::CreateRewardsWallet(rewards_service_);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
   rewards_service_->SetAutoContributeEnabled(true);
   context_helper_->LoadRewardsPage();
-  contribution_->SetUpUpholdWallet(rewards_service_, 50.0);
   SetSKUOrderResponse();
 
   context_helper_->VisitPublisher(
@@ -227,9 +226,7 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
                        TipVerifiedPublisherWithCustomAmount) {
-  test_util::CreateRewardsWallet(rewards_service_);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
-
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
   contribution_->TipPublisher(
       test_util::GetUrl(https_server_.get(), "duckduckgo.com"), false, 1, 0,
       1.25);
@@ -237,16 +234,13 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
                        RecurringTipForVerifiedPublisher) {
-  test_util::CreateRewardsWallet(rewards_service_);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
-
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
   contribution_->TipPublisher(
       test_util::GetUrl(https_server_.get(), "duckduckgo.com"), true, 1);
 }
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest, TipWithVerifiedWallet) {
-  test_util::CreateRewardsWallet(rewards_service_);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
 
   const double amount = 5.0;
   contribution_->TipViaCode("duckduckgo.com", amount,
@@ -261,8 +255,7 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest, TipWithVerifiedWallet) {
 IN_PROC_BROWSER_TEST_F(
     RewardsContributionBrowserTest,
     DISABLED_MultipleTipsProduceMultipleFeesWithVerifiedWallet) {
-  test_util::CreateRewardsWallet(rewards_service_);
-  contribution_->SetUpUpholdWallet(rewards_service_, 50.0);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 50);
 
   double total_amount = 0.0;
   const double amount = 5.0;
@@ -292,8 +285,7 @@ IN_PROC_BROWSER_TEST_F(
 
 // Ensure that we can make a one-time tip of a non-integral amount.
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest, TipNonIntegralAmount) {
-  test_util::CreateRewardsWallet(rewards_service_);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
 
   rewards_service_->SendContribution("duckduckgo.com", 2.5, false,
                                      base::DoNothing());
@@ -305,9 +297,8 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest, TipNonIntegralAmount) {
 // Ensure that we can make a recurring tip of a non-integral amount.
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
                        RecurringTipNonIntegralAmount) {
-  test_util::CreateRewardsWallet(rewards_service_);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
   rewards_service_->SetAutoContributeEnabled(true);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
 
   const bool verified = true;
   context_helper_->VisitPublisher(
@@ -324,9 +315,8 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
                        RecurringAndPartialAutoContribution) {
-  test_util::CreateRewardsWallet(rewards_service_);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
   rewards_service_->SetAutoContributeEnabled(true);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
   SetSKUOrderResponse();
 
   // Visit verified publisher
@@ -362,9 +352,8 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
                        MultipleRecurringOverBudgetAndPartialAutoContribution) {
-  test_util::CreateRewardsWallet(rewards_service_);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
   rewards_service_->SetAutoContributeEnabled(true);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
   SetSKUOrderResponse();
 
   contribution_->TipViaCode("duckduckgo.com", 3.0,
@@ -403,8 +392,7 @@ IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(RewardsContributionBrowserTest, PanelMonthlyTipAmount) {
-  test_util::CreateRewardsWallet(rewards_service_);
-  contribution_->SetUpUpholdWallet(rewards_service_, 30.0);
+  contribution_->StartProcessWithConnectedWallet(rewards_service_, 30);
 
   test_util::NavigateToPublisherAndWaitForUpdate(browser(), https_server_.get(),
                                                  "3zsistemi.si");


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37082
Resolves https://github.com/brave/brave-browser/issues/37012

Currently, browser tests start the Rewards engine and then change the user to a "connected" state by setting prefs. After this change, it will set the prefs first and then start the Rewards engine.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

