### PR TITLE
[ads] Fix a crash when the locale doesnt have an associated country code (uplift to 1.65.x)

### DIFF
--- a/components/l10n/browser/default_locale_util_ios.mm
+++ b/components/l10n/browser/default_locale_util_ios.mm
@@ -16,7 +16,7 @@ std::optional<std::string> MaybeGetDefaultLocaleString() {
   NSLocale* locale = NSLocale.currentLocale;
   NSString* localeIdentifier = [NSLocale localeIdentifierFromComponents:@{
     NSLocaleLanguageCode : locale.languageCode,
-    NSLocaleCountryCode : locale.countryCode
+    NSLocaleCountryCode : locale.countryCode ?: @"US"
   }];
   return base::SysNSStringToUTF8(localeIdentifier);
 }

--- a/components/l10n/browser/default_locale_util_mac.mm
+++ b/components/l10n/browser/default_locale_util_mac.mm
@@ -16,7 +16,7 @@ std::optional<std::string> MaybeGetDefaultLocaleString() {
   NSLocale* locale = NSLocale.currentLocale;
   NSString* localeIdentifier = [NSLocale localeIdentifierFromComponents:@{
     NSLocaleLanguageCode : locale.languageCode,
-    NSLocaleCountryCode : locale.countryCode
+    NSLocaleCountryCode : locale.countryCode ?: @"US"
   }];
   return base::SysNSStringToUTF8(localeIdentifier);
 }


### PR DESCRIPTION
Uplift of #22779
Resolves https://github.com/brave/brave-browser/issues/36990

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.