### PR TITLE
refactor(wallet): remove redux state for hiding portfolio graph

### DIFF
--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -27,7 +27,6 @@ export const {
   setSelectedAccountFilterItem,
   setSelectedNetworkFilter,
   unlocked,
-  setHidePortfolioGraph,
   setIsRefreshingNetworksAndTokens,
   setAllowedNewWalletAccountTypeNetworkIds
 } = WalletActions

--- a/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
@@ -18,8 +18,6 @@ export const assetAutoDiscoveryCompleted = ({ wallet }: State) =>
   wallet.assetAutoDiscoveryCompleted
 export const isNftPinningFeatureEnabled = ({ wallet }: State) =>
   wallet.isNftPinningFeatureEnabled
-export const hidePortfolioGraph = ({ wallet }: State) =>
-  wallet.hidePortfolioGraph
 export const isAnkrBalancesFeatureEnabled = ({ wallet }: State) =>
   wallet.isAnkrBalancesFeatureEnabled
 export const allowedNewWalletAccountTypeNetworkIds = ({ wallet }: State) =>

--- a/components/brave_wallet_ui/common/slices/wallet.slice.ts
+++ b/components/brave_wallet_ui/common/slices/wallet.slice.ts
@@ -21,7 +21,6 @@ import {
   DefaultBaseCryptocurrencyChanged,
   DefaultBaseCurrencyChanged
 } from '../constants/action_types'
-import { LOCAL_STORAGE_KEYS } from '../../common/constants/local-storage-keys'
 
 // Utils
 import { parseJSONFromLocalStorage } from '../../utils/local-storage-utils'
@@ -51,10 +50,6 @@ const defaultState: WalletState = {
   assetAutoDiscoveryCompleted: true,
   isNftPinningFeatureEnabled: false,
   isAnkrBalancesFeatureEnabled: false,
-  hidePortfolioGraph:
-    window.localStorage.getItem(
-      LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN
-    ) === 'true',
   isRefreshingNetworksAndTokens: false
 }
 
@@ -132,13 +127,6 @@ export const createWalletSlice = (initialState: WalletState = defaultState) => {
         { payload }: PayloadAction<number>
       ) {
         state.passwordAttempts = payload
-      },
-
-      setHidePortfolioGraph(
-        state: WalletState,
-        { payload }: PayloadAction<boolean>
-      ) {
-        state.hidePortfolioGraph = payload
       },
 
       setIsRefreshingNetworksAndTokens: (

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -11,11 +11,10 @@ import { Route, Switch, Redirect } from 'react-router-dom'
 
 // selectors
 import {
-  useSafeWalletSelector,
   useUnsafePageSelector,
   useSafeUISelector
 } from '../../../../common/hooks/use-safe-selector'
-import { UISelectors, WalletSelectors } from '../../../../common/selectors'
+import { UISelectors } from '../../../../common/selectors'
 import { PageSelectors } from '../../../../page/selectors'
 
 // hooks
@@ -148,13 +147,14 @@ export const PortfolioOverview = () => {
     LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
     false
   )
+  const [hidePortfolioGraph] = useSyncedLocalStorage(
+    LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
+    false
+  )
 
   // redux
   const dispatch = useDispatch()
   const nftMetadata = useUnsafePageSelector(PageSelectors.nftMetadata)
-  const hidePortfolioGraph = useSafeWalletSelector(
-    WalletSelectors.hidePortfolioGraph
-  )
   const isPanel = useSafeUISelector(UISelectors.isPanel)
 
   // queries

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
@@ -5,12 +5,7 @@
 
 import * as React from 'react'
 import { useLocation, useHistory } from 'react-router-dom'
-import { useDispatch } from 'react-redux'
 import Toggle from '@brave/leo/react/toggle'
-
-// Selectors
-import { useSafeWalletSelector } from '../../../common/hooks/use-safe-selector'
-import { WalletSelectors } from '../../../common/selectors'
 
 // Types
 import {
@@ -23,9 +18,6 @@ import {
 import {
   LOCAL_STORAGE_KEYS //
 } from '../../../common/constants/local-storage-keys'
-
-// actions
-import { WalletActions } from '../../../common/actions'
 
 // Options
 import { CreateAccountOptions } from '../../../options/nav-options'
@@ -68,13 +60,9 @@ export const DefaultPanelMenu = (props: Props) => {
     LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
     false
   )
-
-  // redux
-  const dispatch = useDispatch()
-
-  // selectors
-  const hidePortfolioGraph = useSafeWalletSelector(
-    WalletSelectors.hidePortfolioGraph
+  const [hidePortfolioGraph, setHidePortfolioGraph] = useSyncedLocalStorage(
+    LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
+    false
   )
 
   // queries
@@ -129,12 +117,8 @@ export const DefaultPanelMenu = (props: Props) => {
 
   // Methods
   const onToggleHideGraph = React.useCallback(() => {
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
-      hidePortfolioGraph ? 'false' : 'true'
-    )
-    dispatch(WalletActions.setHidePortfolioGraph(!hidePortfolioGraph))
-  }, [dispatch, hidePortfolioGraph])
+    setHidePortfolioGraph((prev) => !prev)
+  }, [setHidePortfolioGraph])
 
   const onToggleHideBalances = React.useCallback(() => {
     setHidePortfolioBalances((prev) => !prev)

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
@@ -4,19 +4,11 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useDispatch } from 'react-redux'
 import { useHistory, useLocation } from 'react-router-dom'
 import Toggle from '@brave/leo/react/toggle'
 
 // Types
 import { WalletRoutes } from '../../../constants/types'
-
-// Actions
-import { WalletActions } from '../../../common/actions'
-
-// Selectors
-import { useSafeWalletSelector } from '../../../common/hooks/use-safe-selector'
-import { WalletSelectors } from '../../../common/selectors'
 
 // Utils
 import { getLocale } from '../../../../common/locale'
@@ -48,22 +40,15 @@ export const PortfolioOverviewMenu = () => {
     LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
     false
   )
-
-  // Redux
-  const dispatch = useDispatch()
-
-  const hidePortfolioGraph = useSafeWalletSelector(
-    WalletSelectors.hidePortfolioGraph
+  const [hidePortfolioGraph, setHidePortfolioGraph] = useSyncedLocalStorage(
+    LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
+    false
   )
 
   // Methods
   const onToggleHideGraph = React.useCallback(() => {
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN,
-      hidePortfolioGraph ? 'false' : 'true'
-    )
-    dispatch(WalletActions.setHidePortfolioGraph(!hidePortfolioGraph))
-  }, [dispatch, hidePortfolioGraph])
+    setHidePortfolioGraph((prev) => !prev)
+  }, [setHidePortfolioGraph])
 
   const onToggleHideBalances = React.useCallback(() => {
     setHidePortfolioBalances((prev) => !prev)

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -204,7 +204,6 @@ export interface WalletState {
   assetAutoDiscoveryCompleted: boolean
   isNftPinningFeatureEnabled: boolean
   isAnkrBalancesFeatureEnabled: boolean
-  hidePortfolioGraph: boolean
   isRefreshingNetworksAndTokens: boolean
 }
 

--- a/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
@@ -62,6 +62,5 @@ export const mockWalletState: WalletState = {
   passwordAttempts: 0,
   assetAutoDiscoveryCompleted: false,
   isNftPinningFeatureEnabled: false,
-  hidePortfolioGraph: false,
   isRefreshingNetworksAndTokens: false
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37098

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The toggle for hiding/showing the portfolio graph should continue to work without regressions

<img width="782" alt="Screenshot 2024-03-26 at 6 30 47 PM" src="https://github.com/brave/brave-core/assets/30185185/10bd0ec3-1cbf-4720-a85d-826ee9f7d25e">

