### PR TITLE
refactor(wallet): remove redux state for hiding portfolio nft tab

### DIFF
--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -28,7 +28,6 @@ export const {
   setSelectedNetworkFilter,
   unlocked,
   setHidePortfolioGraph,
-  setHidePortfolioNFTsTab,
   setIsRefreshingNetworksAndTokens,
   setAllowedNewWalletAccountTypeNetworkIds
 } = WalletActions

--- a/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
@@ -20,8 +20,6 @@ export const isNftPinningFeatureEnabled = ({ wallet }: State) =>
   wallet.isNftPinningFeatureEnabled
 export const hidePortfolioGraph = ({ wallet }: State) =>
   wallet.hidePortfolioGraph
-export const hidePortfolioNFTsTab = ({ wallet }: State) =>
-  wallet.hidePortfolioNFTsTab
 export const isAnkrBalancesFeatureEnabled = ({ wallet }: State) =>
   wallet.isAnkrBalancesFeatureEnabled
 export const allowedNewWalletAccountTypeNetworkIds = ({ wallet }: State) =>

--- a/components/brave_wallet_ui/common/slices/wallet.slice.ts
+++ b/components/brave_wallet_ui/common/slices/wallet.slice.ts
@@ -55,9 +55,6 @@ const defaultState: WalletState = {
     window.localStorage.getItem(
       LOCAL_STORAGE_KEYS.IS_PORTFOLIO_OVERVIEW_GRAPH_HIDDEN
     ) === 'true',
-  hidePortfolioNFTsTab:
-    window.localStorage.getItem(LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB) ===
-    'true',
   isRefreshingNetworksAndTokens: false
 }
 
@@ -142,13 +139,6 @@ export const createWalletSlice = (initialState: WalletState = defaultState) => {
         { payload }: PayloadAction<boolean>
       ) {
         state.hidePortfolioGraph = payload
-      },
-
-      setHidePortfolioNFTsTab(
-        state: WalletState,
-        { payload }: PayloadAction<boolean>
-      ) {
-        state.hidePortfolioNFTsTab = payload
       },
 
       setIsRefreshingNetworksAndTokens: (

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -144,15 +144,16 @@ export const PortfolioOverview = () => {
     LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES,
     false
   )
+  const [hidePortfolioNFTsTab] = useSyncedLocalStorage(
+    LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
+    false
+  )
 
   // redux
   const dispatch = useDispatch()
   const nftMetadata = useUnsafePageSelector(PageSelectors.nftMetadata)
   const hidePortfolioGraph = useSafeWalletSelector(
     WalletSelectors.hidePortfolioGraph
-  )
-  const hidePortfolioNFTsTab = useSafeWalletSelector(
-    WalletSelectors.hidePortfolioNFTsTab
   )
   const isPanel = useSafeUISelector(UISelectors.isPanel)
 

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/default-panel-menu.tsx
@@ -64,6 +64,10 @@ export const DefaultPanelMenu = (props: Props) => {
   // local-storage
   const [hidePortfolioBalances, setHidePortfolioBalances] =
     useSyncedLocalStorage(LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES, false)
+  const [hidePortfolioNFTsTab, setHidePortfolioNFTsTab] = useSyncedLocalStorage(
+    LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
+    false
+  )
 
   // redux
   const dispatch = useDispatch()
@@ -71,9 +75,6 @@ export const DefaultPanelMenu = (props: Props) => {
   // selectors
   const hidePortfolioGraph = useSafeWalletSelector(
     WalletSelectors.hidePortfolioGraph
-  )
-  const hidePortfolioNFTsTab = useSafeWalletSelector(
-    WalletSelectors.hidePortfolioNFTsTab
   )
 
   // queries
@@ -143,12 +144,8 @@ export const DefaultPanelMenu = (props: Props) => {
     if (walletLocation.includes(WalletRoutes.PortfolioNFTs)) {
       history.push(WalletRoutes.PortfolioAssets)
     }
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
-      hidePortfolioNFTsTab ? 'false' : 'true'
-    )
-    dispatch(WalletActions.setHidePortfolioNFTsTab(!hidePortfolioNFTsTab))
-  }, [dispatch, hidePortfolioNFTsTab, history, walletLocation])
+    setHidePortfolioNFTsTab((prev) => !prev)
+  }, [history, setHidePortfolioNFTsTab, walletLocation])
 
   const onClickRoute = (route: WalletRoutes | AccountPageTabs) => {
     if (route === WalletRoutes.AddHardwareAccountModalStart) {

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/portfolio-overview-menu.tsx
@@ -44,15 +44,16 @@ export const PortfolioOverviewMenu = () => {
   // Local-Storage
   const [hidePortfolioBalances, setHidePortfolioBalances] =
     useSyncedLocalStorage(LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES, false)
+  const [hidePortfolioNFTsTab, setHidePortfolioNFTsTab] = useSyncedLocalStorage(
+    LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
+    false
+  )
 
   // Redux
   const dispatch = useDispatch()
 
   const hidePortfolioGraph = useSafeWalletSelector(
     WalletSelectors.hidePortfolioGraph
-  )
-  const hidePortfolioNFTsTab = useSafeWalletSelector(
-    WalletSelectors.hidePortfolioNFTsTab
   )
 
   // Methods
@@ -72,12 +73,8 @@ export const PortfolioOverviewMenu = () => {
     if (walletLocation.includes(WalletRoutes.PortfolioNFTs)) {
       history.push(WalletRoutes.PortfolioAssets)
     }
-    window.localStorage.setItem(
-      LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_NFTS_TAB,
-      hidePortfolioNFTsTab ? 'false' : 'true'
-    )
-    dispatch(WalletActions.setHidePortfolioNFTsTab(!hidePortfolioNFTsTab))
-  }, [dispatch, hidePortfolioNFTsTab, history, walletLocation])
+    setHidePortfolioNFTsTab((prev) => !prev)
+  }, [history, setHidePortfolioNFTsTab, walletLocation])
 
   return (
     <StyledWrapper yPosition={42}>

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -205,7 +205,6 @@ export interface WalletState {
   isNftPinningFeatureEnabled: boolean
   isAnkrBalancesFeatureEnabled: boolean
   hidePortfolioGraph: boolean
-  hidePortfolioNFTsTab: boolean
   isRefreshingNetworksAndTokens: boolean
 }
 

--- a/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
@@ -63,6 +63,5 @@ export const mockWalletState: WalletState = {
   assetAutoDiscoveryCompleted: false,
   isNftPinningFeatureEnabled: false,
   hidePortfolioGraph: false,
-  hidePortfolioNFTsTab: false,
   isRefreshingNetworksAndTokens: false
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37099

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

The toggle for hiding/showing the portfolio NFTs tab should continue to work without regressions

<img width="779" alt="Screenshot 2024-03-26 at 6 53 09 PM" src="https://github.com/brave/brave-core/assets/30185185/5ddba4d6-9c1a-4ee6-b4f8-07076d90980b">


