### PR TITLE
[iOS] Update fastlane config to reject waiting for review builds (uplift to 1.64.x)

### DIFF
--- a/ios/brave-ios/fastlane/Fastfile
+++ b/ios/brave-ios/fastlane/Fastfile
@@ -127,6 +127,7 @@ platform :ios do
       changelog: "Bug fixes & improvements",
       distribute_external: true,
       skip_waiting_for_build_processing: false,
+      reject_build_waiting_for_review: true,
       ipa: "build/Client.ipa",
       groups: ["Brave Internal"]
     }


### PR DESCRIPTION
Uplift of #22778
Resolves https://github.com/brave/brave-browser/issues/37034

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.