### PR TITLE
fix(wallet): Add Account not prompted if account exists for coin type on incorrect keyringId

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -133,7 +133,7 @@ struct AssetDetailView: View {
             let destination = WalletActionDestination(
               kind: .deposit(query: coinMarket.symbol)
             )
-            if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+            if assetDetailStore.allAccountsForToken.isEmpty {
               onAccountCreationNeeded(destination)
             } else {
               walletActionDestination = destination
@@ -230,7 +230,7 @@ struct AssetDetailView: View {
             kind: .buy,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             walletActionDestination = destination
@@ -243,7 +243,7 @@ struct AssetDetailView: View {
             kind: .send,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             walletActionDestination = destination
@@ -256,7 +256,7 @@ struct AssetDetailView: View {
             kind: .swap,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             walletActionDestination = destination
@@ -274,7 +274,7 @@ struct AssetDetailView: View {
               kind: .deposit(query: nil),
               initialToken: assetDetailStore.assetDetailToken
             )
-            if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+            if assetDetailStore.allAccountsForToken.isEmpty {
               onAccountCreationNeeded(destination)
             } else {
               walletActionDestination = destination
@@ -397,7 +397,7 @@ struct AssetDetailView: View {
                 kind: .deposit(query: nil),
                 initialToken: assetDetailStore.assetDetailToken
               )
-              if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+              if assetDetailStore.allAccountsForToken.isEmpty {
                 onAccountCreationNeeded(destination)
               } else {
                 walletActionDestination = destination

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -193,8 +193,11 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
     let allAccounts = await keyringService.allAccounts()
-    let allAccountsForNetworkCoin = allAccounts.accounts.filter { $0.coin == network.coin }
-    if allAccountsForNetworkCoin.isEmpty {
+    let allAccountsForNetwork = allAccounts.accounts.filter { account in
+      account.coin == network.coin
+        && network.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber)
+    }
+    if allAccountsForNetwork.isEmpty {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -193,10 +193,7 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
     let allAccounts = await keyringService.allAccounts()
-    let allAccountsForNetwork = allAccounts.accounts.filter { account in
-      account.coin == network.coin
-        && network.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber)
-    }
+    let allAccountsForNetwork = allAccounts.accounts.accountsFor(network: network)
     if allAccountsForNetwork.isEmpty {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -616,3 +616,12 @@ extension BraveWallet.SwapFees {
     return true
   }
 }
+
+extension Array where Element == BraveWallet.AccountInfo {
+  func accountsFor(network: BraveWallet.NetworkInfo) -> [BraveWallet.AccountInfo] {
+    filter { account in
+      account.coin == network.coin
+        && network.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber)
+    }
+  }
+}

--- a/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -134,6 +134,16 @@ import XCTest
 
   func testSetSelectedNetworkNoAccounts() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
+    keyringService._allAccounts = { completion in
+      completion(
+        .init(
+          accounts: [.previewAccount, .mockFilAccount],
+          selectedAccount: .previewAccount,
+          ethDappSelectedAccount: .previewAccount,
+          solDappSelectedAccount: nil
+        )
+      )
+    }
 
     let store = NetworkStore(
       keyringService: keyringService,
@@ -148,8 +158,9 @@ import XCTest
     XCTAssertEqual(error, .selectedChainHasNoAccounts, "Expected chain has no accounts error")
     XCTAssertNotEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockSolana.chainId)
 
+    // Verify `supportedKeyrings` is checked (Mainnet account exists, no testnet account)
     let selectFilecoinMainnetError = await store.setSelectedChain(
-      .mockFilecoinMainnet,
+      .mockFilecoinTestnet,
       isForOrigin: false
     )
     XCTAssertEqual(
@@ -159,7 +170,7 @@ import XCTest
     )
     XCTAssertNotEqual(
       store.defaultSelectedChainId,
-      BraveWallet.NetworkInfo.mockFilecoinMainnet.chainId
+      BraveWallet.NetworkInfo.mockFilecoinTestnet.chainId
     )
   }
 


### PR DESCRIPTION
- Check against `supportedKeyringIds` when validating an account exists before switching network, enabling existing add account flow before switching network.
- Check against `supportedKeyringIds` when validating an account exists before opening buy/deposit from Asset Details

Resolves https://github.com/brave/brave-browser/issues/37114

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Buy network selection:
1. Create a fresh wallet / restore wallet with no Filecoin accounts balance
2. Enable `Show Test Networks` in Web3 Settings -> Networks
3. In Accounts tab, add a Filecoin Mainnet account
4. Open Buy or Swap
5. Select Filecoin Testnet in network picker
6. Verify prompted to add Filecoin Testnet account and does not switch network to Filecoin Testnet without an account

https://github.com/brave/brave-core/assets/5314553/fbcf18e9-03ae-4b3d-8a82-061d864e72fb

Asset Detail View:
1. Create a fresh wallet / restore wallet with no Filecoin accounts balance
2. Enable `Show Test Networks` in Web3 Settings -> Networks
3. In Accounts tab, add a Filecoin Testnet account
4. Open Asset Detail View for FIL on Filecoin Mainnet (ex. open from Portfolio)
5. Tap Buy & Deposit, verify both prompt to add an account and does not open buy/deposit without an account


https://github.com/brave/brave-core/assets/5314553/30ae9ec9-8b69-47d5-9fc6-fbe1e8338486