### PR TITLE
Add Shields filter list & "forget first party" metrics

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -206,10 +206,11 @@ void RegisterProfilePrefsForMigration(
   // Added 2023-11
   brave_ads::RegisterProfilePrefsForMigration(registry);
 
-// Added 2024-04
+  // Added 2024-04
 #if BUILDFLAG(ENABLE_AI_CHAT)
   ai_chat::prefs::RegisterProfilePrefsForMigration(registry);
 #endif
+  brave_shields::RegisterShieldsP3AProfilePrefsForMigration(registry);
 }
 
 void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {

--- a/chromium_src/chrome/browser/prefs/browser_prefs.cc
+++ b/chromium_src/chrome/browser/prefs/browser_prefs.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_ads/core/public/prefs/obsolete_pref_util.h"
 #include "brave/components/brave_news/browser/brave_news_p3a.h"
 #include "brave/components/brave_search_conversion/p3a.h"
+#include "brave/components/brave_shields/content/browser/brave_shields_p3a.h"
 #include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_prefs.h"
 #include "brave/components/brave_wallet/browser/keyring_service.h"
@@ -170,6 +171,8 @@ void MigrateObsoleteProfilePrefs(PrefService* profile_prefs,
 
   // Added 2023-11
   brave_ads::MigrateObsoleteProfilePrefs(profile_prefs);
+
+  brave_shields::MigrateObsoleteProfilePrefs(profile_prefs);
 
 #if !BUILDFLAG(IS_ANDROID)
   // Added 2024-01

--- a/components/brave_shields/content/browser/ad_block_service.cc
+++ b/components/brave_shields/content/browser/ad_block_service.cc
@@ -291,6 +291,7 @@ AdBlockService::AdBlockService(
           std::move(subscription_download_manager_getter)),
       component_update_service_(cus),
       task_runner_(task_runner),
+      list_p3a_(local_state),
       default_engine_(std::unique_ptr<AdBlockEngine, base::OnTaskRunnerDeleter>(
           new AdBlockEngine(true /* is_default */),
           base::OnTaskRunnerDeleter(GetTaskRunner()))),
@@ -319,11 +320,11 @@ AdBlockService::AdBlockService(
 
   component_service_manager_ = std::make_unique<AdBlockComponentServiceManager>(
       local_state_, locale_, component_update_service_,
-      filter_list_catalog_provider_.get());
+      filter_list_catalog_provider_.get(), &list_p3a_);
   subscription_service_manager_ =
       std::make_unique<AdBlockSubscriptionServiceManager>(
           local_state_, std::move(subscription_download_manager_getter_),
-          profile_dir_);
+          profile_dir_, &list_p3a_);
   custom_filters_provider_ =
       std::make_unique<AdBlockCustomFiltersProvider>(local_state_);
 

--- a/components/brave_shields/content/browser/ad_block_service.h
+++ b/components/brave_shields/content/browser/ad_block_service.h
@@ -23,6 +23,7 @@
 #include "brave/components/brave_shields/content/browser/ad_block_subscription_download_manager.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
+#include "brave/components/brave_shields/core/browser/ad_block_list_p3a.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "third_party/blink/public/mojom/loader/resource_load_info.mojom-shared.h"
 #include "url/gurl.h"
@@ -167,6 +168,8 @@ class AdBlockService {
   raw_ptr<component_updater::ComponentUpdateService> component_update_service_;
 
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
+
+  AdBlockListP3A list_p3a_;
 
   std::unique_ptr<AdBlockDefaultResourceProvider> resource_provider_
       GUARDED_BY_CONTEXT(sequence_checker_);

--- a/components/brave_shields/content/browser/ad_block_subscription_service_manager.h
+++ b/components/brave_shields/content/browser/ad_block_subscription_service_manager.h
@@ -21,6 +21,7 @@
 #include "base/values.h"
 #include "brave/components/brave_shields/adblock/rs/src/lib.rs.h"
 #include "brave/components/brave_shields/content/browser/ad_block_subscription_download_manager.h"
+#include "brave/components/brave_shields/core/browser/ad_block_list_p3a.h"
 #include "components/component_updater/timer_update_scheduler.h"
 #include "components/prefs/pref_service.h"
 #include "url/gurl.h"
@@ -78,7 +79,9 @@ class AdBlockSubscriptionServiceManager {
   explicit AdBlockSubscriptionServiceManager(
       PrefService* local_state,
       AdBlockSubscriptionDownloadManager::DownloadManagerGetter getter,
-      const base::FilePath& profile_dir);
+      const base::FilePath& profile_dir,
+      AdBlockListP3A* list_p3a);
+
   ~AdBlockSubscriptionServiceManager();
 
   AdBlockSubscriptionServiceManager(const AdBlockSubscriptionServiceManager&) =
@@ -146,6 +149,8 @@ class AdBlockSubscriptionServiceManager {
       subscription_filters_providers_ GUARDED_BY_CONTEXT(sequence_checker_);
   std::unique_ptr<component_updater::TimerUpdateScheduler>
       subscription_update_timer_ GUARDED_BY_CONTEXT(sequence_checker_);
+
+  raw_ptr<AdBlockListP3A> list_p3a_;
 
   base::ObserverList<AdBlockSubscriptionServiceManagerObserver> observers_
       GUARDED_BY_CONTEXT(sequence_checker_);

--- a/components/brave_shields/content/browser/brave_shields_p3a.h
+++ b/components/brave_shields/content/browser/brave_shields_p3a.h
@@ -16,7 +16,9 @@ namespace brave_shields {
 
 inline constexpr char kUsagePrefName[] = "brave_shields.p3a_usage";
 inline constexpr char kFirstReportedPrefName[] =
-    "brave_shields.p3a_first_reported_v2";
+    "brave_shields.p3a_first_reported_v2";  // DEPRECATED
+inline constexpr char kFirstReportedRevisionPrefName[] =
+    "brave_shields.p3a_first_reported_revision";
 
 inline constexpr char kAdsStrictCountPrefName[] =
     "brave_shields.p3a_ads_strict_domain_count";
@@ -44,6 +46,8 @@ inline constexpr char kDomainFPSettingsAboveHistogramName[] =
     "Brave.Shields.DomainFingerprintSettingsAboveGlobal";
 inline constexpr char kDomainFPSettingsBelowHistogramName[] =
     "Brave.Shields.DomainFingerprintSettingsBelowGlobal";
+inline constexpr char kForgetFirstPartyHistogramName[] =
+    "Brave.Shields.ForgetFirstParty";
 // Note: append-only enumeration! Never remove any existing values, as this enum
 // is used to bucket a UMA histogram, and removing values breaks that.
 enum ShieldsIconUsage {
@@ -82,9 +86,15 @@ void RecordShieldsDomainSettingCountsWithChange(PrefService* profile_prefs,
                                                 ControlType* prev_setting,
                                                 ControlType new_setting);
 
+// Records global "forget me when I close this site" setting,
+// and any per-site exceptions.
+void RecordForgetFirstPartySetting(HostContentSettingsMap* map);
+
 void RegisterShieldsP3ALocalPrefs(PrefRegistrySimple* local_state);
 
-void RegisterShieldsP3AProfilePrefs(PrefRegistrySimple* local_state);
+void RegisterShieldsP3AProfilePrefs(PrefRegistrySimple* registry);
+void RegisterShieldsP3AProfilePrefsForMigration(PrefRegistrySimple* registry);
+void MigrateObsoleteProfilePrefs(PrefService* profile_prefs);
 
 // To be called at initialization. Will count all domain settings and
 // record to all histograms, if executed for the first time.

--- a/components/brave_shields/content/browser/brave_shields_util.cc
+++ b/components/brave_shields/content/browser/brave_shields_util.cc
@@ -789,6 +789,7 @@ void SetForgetFirstPartyStorageEnabled(HostContentSettingsMap* map,
       ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE,
       is_enabled ? CONTENT_SETTING_BLOCK : CONTENT_SETTING_ALLOW);
   RecordShieldsSettingChanged(local_state);
+  RecordForgetFirstPartySetting(map);
 }
 
 bool GetForgetFirstPartyStorageEnabled(HostContentSettingsMap* map,

--- a/components/brave_shields/core/browser/BUILD.gn
+++ b/components/brave_shields/core/browser/BUILD.gn
@@ -17,6 +17,8 @@ static_library("browser") {
     "ad_block_filters_provider.h",
     "ad_block_filters_provider_manager.cc",
     "ad_block_filters_provider_manager.h",
+    "ad_block_list_p3a.cc",
+    "ad_block_list_p3a.h",
     "ad_block_service_helper.cc",
     "ad_block_service_helper.h",
     "filter_list_catalog_entry.cc",

--- a/components/brave_shields/core/browser/ad_block_component_service_manager.h
+++ b/components/brave_shields/core/browser/ad_block_component_service_manager.h
@@ -17,6 +17,7 @@
 #include "base/values.h"
 #include "brave/components/brave_shields/core/browser/ad_block_component_filters_provider.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filter_list_catalog_provider.h"
+#include "brave/components/brave_shields/core/browser/ad_block_list_p3a.h"
 #include "components/prefs/pref_service.h"
 
 class AdBlockServiceTest;
@@ -34,7 +35,8 @@ class AdBlockComponentServiceManager
       PrefService* local_state,
       std::string locale,
       component_updater::ComponentUpdateService* cus,
-      AdBlockFilterListCatalogProvider* catalog_provider);
+      AdBlockFilterListCatalogProvider* catalog_provider,
+      AdBlockListP3A* list_p3a);
   AdBlockComponentServiceManager(const AdBlockComponentServiceManager&) =
       delete;
   AdBlockComponentServiceManager& operator=(
@@ -85,6 +87,8 @@ class AdBlockComponentServiceManager
       GUARDED_BY_CONTEXT(sequence_checker_);
   raw_ptr<AdBlockFilterListCatalogProvider> catalog_provider_
       GUARDED_BY_CONTEXT(sequence_checker_);
+
+  raw_ptr<AdBlockListP3A> list_p3a_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 

--- a/components/brave_shields/core/browser/ad_block_list_p3a.cc
+++ b/components/brave_shields/core/browser/ad_block_list_p3a.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/core/browser/ad_block_list_p3a.h"
+
+#include "base/metrics/histogram_macros.h"
+#include "brave/components/brave_shields/core/browser/filter_list_catalog_entry.h"
+#include "brave/components/brave_shields/core/common/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+namespace brave_shields {
+
+namespace {
+
+constexpr char kEnabledDictKey[] = "enabled";
+
+}  // namespace
+
+AdBlockListP3A::AdBlockListP3A(PrefService* local_state)
+    : local_state_(local_state) {}
+
+AdBlockListP3A::~AdBlockListP3A() = default;
+
+void AdBlockListP3A::ReportFilterListUsage() {
+  const auto& regional_filter_dict =
+      local_state_->GetDict(prefs::kAdBlockRegionalFilters);
+  const auto& subscription_filter_dict =
+      local_state_->GetDict(prefs::kAdBlockListSubscriptions);
+
+  bool regional_filter_enabled = false;
+  bool subscription_filter_enabled = false;
+
+  for (const auto [uuid, dict_value] : regional_filter_dict) {
+    const auto* dict = dict_value.GetIfDict();
+    if (!dict) {
+      continue;
+    }
+    if (!dict->FindBool(kEnabledDictKey).value_or(false)) {
+      break;
+    }
+    if (!default_filter_list_uuids_.contains(uuid)) {
+      regional_filter_enabled = true;
+      break;
+    }
+  }
+
+  for (const auto [_url, dict_value] : subscription_filter_dict) {
+    const auto* dict = dict_value.GetIfDict();
+    if (!dict) {
+      continue;
+    }
+    if (dict->FindBool(kEnabledDictKey).value_or(false)) {
+      subscription_filter_enabled = true;
+      break;
+    }
+  }
+
+  int answer = 0;
+  if (regional_filter_enabled && !subscription_filter_enabled) {
+    answer = 1;
+  } else if (!regional_filter_enabled && subscription_filter_enabled) {
+    answer = 2;
+  } else if (regional_filter_enabled && subscription_filter_enabled) {
+    answer = 3;
+  }
+
+  UMA_HISTOGRAM_EXACT_LINEAR(kFilterListUsageHistogramName, answer, 4);
+}
+
+void AdBlockListP3A::OnFilterListCatalogLoaded(
+    const std::vector<FilterListCatalogEntry>& entries) {
+  for (const auto& entry : entries) {
+    if (entry.default_enabled) {
+      default_filter_list_uuids_.insert(entry.uuid);
+    }
+  }
+  ReportFilterListUsage();
+}
+
+}  // namespace brave_shields

--- a/components/brave_shields/core/browser/ad_block_list_p3a.h
+++ b/components/brave_shields/core/browser/ad_block_list_p3a.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_BROWSER_AD_BLOCK_LIST_P3A_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_BROWSER_AD_BLOCK_LIST_P3A_H_
+
+#include <string>
+#include <vector>
+
+#include "base/containers/flat_set.h"
+
+class PrefService;
+
+namespace brave_shields {
+
+class FilterListCatalogEntry;
+
+inline constexpr char kFilterListUsageHistogramName[] =
+    "Brave.Shields.FilterLists";
+
+class AdBlockListP3A {
+ public:
+  explicit AdBlockListP3A(PrefService* local_state);
+  ~AdBlockListP3A();
+
+  AdBlockListP3A(const AdBlockListP3A&) = delete;
+  AdBlockListP3A& operator=(const AdBlockListP3A&) = delete;
+
+  void ReportFilterListUsage();
+
+  void OnFilterListCatalogLoaded(
+      const std::vector<FilterListCatalogEntry>& entries);
+
+ private:
+  raw_ptr<PrefService> local_state_;
+  base::flat_set<std::string> default_filter_list_uuids_;
+};
+
+}  // namespace brave_shields
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CORE_BROWSER_AD_BLOCK_LIST_P3A_H_

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -252,6 +252,8 @@ inline constexpr auto kCollectedSlowHistograms =
     "Brave.RequestOTR.SessionCount",
     "Brave.Rewards.PageViewCount",
     "Brave.Rewards.TipsSent.2",
+    "Brave.Shields.FilterLists",
+    "Brave.Shields.ForgetFirstParty",
     "Brave.Sync.EnabledTypes",
     "Brave.Sync.SyncedObjectsCount.2",
     "Brave.Today.ChannelCount",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37124

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For `Brave.Shields.FilterLists`:

0. Start with fresh profile, ensure metric has value 0.
1. Access the Shields content filtering settings, enable one or two additional filter lists. Ensure the metric value is 1.
2. Add a custom filter list (i.e. https://ads-for-open-source.readthedocs.io/en/latest/_static/lists/opensource-ads.txt). Ensure the metric value is 3.
3. Disable the additional filter lists. Ensure the value is 2.
4. Remove the custom filter lists, ensure the value is 0.

For `Brave.Shields.ForgetFirstParty`:

0. Start with fresh profile, ensure metric has value 0.
1. Enable the "Forget me when I close this site" global Shields setting. Ensure metric has value 1.
2. Access any site, disable the "forget me" setting for the particular site. Ensure the metric has value 2.
3. Disable the global setting. Ensure the metric has value 0.
4. Access another site, enable the "forget me" setting for a particular site. Ensure the metric has value 3.