### PR TITLE
fix(wallet): Add Account not prompted if account exists for coin type on incorrect keyringId (uplift to 1.65.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -211,7 +211,7 @@ struct AssetDetailView: View {
             kind: .buy,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -224,7 +224,7 @@ struct AssetDetailView: View {
             kind: .send,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -237,7 +237,7 @@ struct AssetDetailView: View {
             kind: .swap,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -193,8 +193,8 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
     let allAccounts = await keyringService.allAccounts()
-    let allAccountsForNetworkCoin = allAccounts.accounts.filter { $0.coin == network.coin }
-    if allAccountsForNetworkCoin.isEmpty {
+    let allAccountsForNetwork = allAccounts.accounts.accountsFor(network: network)
+    if allAccountsForNetwork.isEmpty {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -602,3 +602,12 @@ extension BraveWallet.SwapFees {
     return true
   }
 }
+
+extension Array where Element == BraveWallet.AccountInfo {
+  func accountsFor(network: BraveWallet.NetworkInfo) -> [BraveWallet.AccountInfo] {
+    filter { account in
+      account.coin == network.coin
+        && network.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber)
+    }
+  }
+}

--- a/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -134,6 +134,16 @@ import XCTest
 
   func testSetSelectedNetworkNoAccounts() async {
     let (keyringService, rpcService, walletService, swapService) = setupServices()
+    keyringService._allAccounts = { completion in
+      completion(
+        .init(
+          accounts: [.previewAccount, .mockFilAccount],
+          selectedAccount: .previewAccount,
+          ethDappSelectedAccount: .previewAccount,
+          solDappSelectedAccount: nil
+        )
+      )
+    }
 
     let store = NetworkStore(
       keyringService: keyringService,
@@ -148,8 +158,9 @@ import XCTest
     XCTAssertEqual(error, .selectedChainHasNoAccounts, "Expected chain has no accounts error")
     XCTAssertNotEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockSolana.chainId)
 
+    // Verify `supportedKeyrings` is checked (Mainnet account exists, no testnet account)
     let selectFilecoinMainnetError = await store.setSelectedChain(
-      .mockFilecoinMainnet,
+      .mockFilecoinTestnet,
       isForOrigin: false
     )
     XCTAssertEqual(
@@ -159,7 +170,7 @@ import XCTest
     )
     XCTAssertNotEqual(
       store.defaultSelectedChainId,
-      BraveWallet.NetworkInfo.mockFilecoinMainnet.chainId
+      BraveWallet.NetworkInfo.mockFilecoinTestnet.chainId
     )
   }
 


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/22799
Resolves https://github.com/brave/brave-browser/issues/37114

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
