### PR TITLE
fix(wallet): Add Account not prompted if account exists for coin type on incorrect keyringId (uplift to 1.64.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -192,7 +192,7 @@ struct AssetDetailView: View {
             kind: .buy,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -205,7 +205,7 @@ struct AssetDetailView: View {
             kind: .send,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination
@@ -218,7 +218,7 @@ struct AssetDetailView: View {
             kind: .swap,
             initialToken: assetDetailStore.assetDetailToken
           )
-          if assetDetailStore.allAccountsForTokenCoin.isEmpty {
+          if assetDetailStore.allAccountsForToken.isEmpty {
             onAccountCreationNeeded(destination)
           } else {
             buySendSwapDestination = destination

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -184,8 +184,8 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     isForOrigin: Bool
   ) async -> SetSelectedChainError? {
     let allAccounts = await keyringService.allAccounts()
-    let allAccountsForNetworkCoin = allAccounts.accounts.filter { $0.coin == network.coin }
-    if allAccountsForNetworkCoin.isEmpty {
+    let allAccountsForNetwork = allAccounts.accounts.accountsFor(network: network)
+    if allAccountsForNetwork.isEmpty {
       // Need to prompt user to create new account via alert
       return .selectedChainHasNoAccounts
     } else {

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -571,3 +571,12 @@ public extension URL {
     return WalletConstants.supportedIPFSSchemes.contains(scheme)
   }
 }
+
+extension Array where Element == BraveWallet.AccountInfo {
+  func accountsFor(network: BraveWallet.NetworkInfo) -> [BraveWallet.AccountInfo] {
+    filter { account in
+      account.coin == network.coin
+        && network.supportedKeyrings.contains(account.keyringId.rawValue as NSNumber)
+    }
+  }
+}


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/22799
Resolves https://github.com/brave/brave-browser/issues/37114

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.
