### PR TITLE
Disable kDeprecateCookiesTreeModel feature (uplift to 1.65.x)

### DIFF
--- a/chromium_src/components/browsing_data/core/features.cc
+++ b/chromium_src/components/browsing_data/core/features.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/browsing_data/core/features.cc"
+
+#include "base/feature_override.h"
+
+namespace browsing_data::features {
+
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kDeprecateCookiesTreeModel, base::FEATURE_DISABLED_BY_DEFAULT},
+}});
+
+}  // namespace browsing_data::features


### PR DESCRIPTION
Uplift of #22823
Resolves https://github.com/brave/brave-browser/issues/37030

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.