### PR TITLE
Disables Leo on Android when a global JS toggle set to blocked (uplift to 1.65.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
+++ b/android/java/org/chromium/chrome/browser/appmenu/BraveTabbedAppMenuPropertiesDelegate.java
@@ -26,10 +26,10 @@ import org.chromium.base.supplier.OneshotSupplier;
 import org.chromium.base.supplier.Supplier;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.ActivityTabProvider;
-import org.chromium.chrome.browser.BraveConfig;
 import org.chromium.chrome.browser.BraveRewardsNativeWorker;
 import org.chromium.chrome.browser.app.appmenu.AppMenuIconRowFooter;
 import org.chromium.chrome.browser.bookmarks.BookmarkModel;
+import org.chromium.chrome.browser.brave_leo.BraveLeoPrefUtils;
 import org.chromium.chrome.browser.feed.webfeed.WebFeedSnackbarController;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.incognito.reauth.IncognitoReauthController;
@@ -193,10 +193,7 @@ public class BraveTabbedAppMenuPropertiesDelegate extends TabbedAppMenuPropertie
         MenuItem braveLeo = menu.findItem(R.id.brave_leo_id);
         if (braveLeo != null) {
             Tab tab = mActivityTabProvider.get();
-            if (BraveConfig.AI_CHAT_ENABLED
-                    && ChromeFeatureList.isEnabled(BraveFeatureList.AI_CHAT)
-                    && tab != null
-                    && !tab.isIncognito()) {
+            if (BraveLeoPrefUtils.isLeoEnabled() && tab != null && !tab.isIncognito()) {
                 braveLeo.setVisible(true);
                 if (shouldShowIconBeforeItem()) {
                     braveLeo.setIcon(

--- a/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoPrefUtils.java
+++ b/android/java/org/chromium/chrome/browser/brave_leo/BraveLeoPrefUtils.java
@@ -5,11 +5,16 @@
 
 package org.chromium.chrome.browser.brave_leo;
 
+import org.chromium.base.BraveFeatureList;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
+import org.chromium.chrome.browser.BraveConfig;
 import org.chromium.chrome.browser.app.BraveActivity;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.preferences.BravePref;
 import org.chromium.chrome.browser.profiles.Profile;
+import org.chromium.components.browser_ui.site_settings.WebsitePreferenceBridge;
+import org.chromium.components.content_settings.ContentSettingsType;
 import org.chromium.components.prefs.PrefService;
 import org.chromium.components.user_prefs.UserPrefs;
 
@@ -127,5 +132,24 @@ public class BraveLeoPrefUtils {
             return;
         }
         UserPrefs.get(profileToUse).setString(BravePref.DEFAULT_MODEL_KEY, modelKey);
+    }
+
+    public static boolean isLeoEnabled() {
+        if (!BraveConfig.AI_CHAT_ENABLED
+                || !ChromeFeatureList.isEnabled(BraveFeatureList.AI_CHAT)) {
+            return false;
+        }
+
+        Profile profileToUse = BraveLeoPrefUtils.getProfile();
+        if (profileToUse == null) {
+            Log.e(TAG, "BraveLeoPrefUtils.isLeoEnabled profile is null");
+            // JS is enabled for most users
+            return true;
+        }
+
+        // Disables Leo when a global JAVASCRIPT toggle set to blocked.
+        // We want to fix that in the future.
+        return WebsitePreferenceBridge.isCategoryEnabled(
+                profileToUse, ContentSettingsType.JAVASCRIPT);
     }
 }

--- a/android/java/org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteMediator.java
+++ b/android/java/org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteMediator.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import org.chromium.base.Callback;
 import org.chromium.base.supplier.Supplier;
 import org.chromium.chrome.browser.BraveConfig;
+import org.chromium.chrome.browser.brave_leo.BraveLeoPrefUtils;
 import org.chromium.chrome.browser.brave_leo.BraveLeoUtils;
 import org.chromium.chrome.browser.omnibox.LocationBarDataProvider;
 import org.chromium.chrome.browser.omnibox.UrlBarEditingTextStateProvider;
@@ -106,6 +107,11 @@ class BraveAutocompleteMediator extends AutocompleteMediator
             }
         }
         super.initDefaultProcessors();
+    }
+
+    @Override
+    public boolean isLeoEnabled() {
+        return BraveLeoPrefUtils.isLeoEnabled();
     }
 
     @Override

--- a/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveMainPreferencesBase.java
@@ -18,8 +18,8 @@ import androidx.preference.Preference;
 import org.chromium.base.BraveFeatureList;
 import org.chromium.base.ContextUtils;
 import org.chromium.chrome.R;
-import org.chromium.chrome.browser.BraveConfig;
 import org.chromium.chrome.browser.BraveLaunchIntentDispatcher;
+import org.chromium.chrome.browser.brave_leo.BraveLeoPrefUtils;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.homepage.settings.BraveHomepageSettings;
 import org.chromium.chrome.browser.notifications.BraveNotificationWarningDialog;
@@ -289,8 +289,7 @@ public class BraveMainPreferencesBase
             removePreferenceIfPresent(PREF_BRAVE_VPN);
         }
 
-        if (BraveConfig.AI_CHAT_ENABLED
-                && ChromeFeatureList.isEnabled(BraveFeatureList.AI_CHAT)) {
+        if (BraveLeoPrefUtils.isLeoEnabled()) {
             findPreference(PREF_BRAVE_LEO).setOrder(++firstSectionOrder);
         } else {
             removePreferenceIfPresent(PREF_BRAVE_LEO);

--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
@@ -161,7 +161,7 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
     private boolean isBraveLeoEnabled() {
         Tab tab = mActivityTabSupplier.get();
         if (mLeoAutocompleteDelegate != null
-                && ChromeFeatureList.isEnabled(BraveFeatureList.AI_CHAT)
+                && mLeoAutocompleteDelegate.isLeoEnabled()
                 && tab != null
                 && !tab.isIncognito()
                 && ChromeSharedPreferences.getInstance()

--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveLeoAutocompleteDelegate.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveLeoAutocompleteDelegate.java
@@ -11,5 +11,7 @@ import org.chromium.content_public.browser.WebContents;
  * Provides additional functionality to trigger and interact with Brave Leo autocomplete suggestion.
  */
 public interface BraveLeoAutocompleteDelegate {
+    boolean isLeoEnabled();
+
     void openLeoQuery(WebContents webContents, String query);
 }


### PR DESCRIPTION
Uplift of #22820
Resolves https://github.com/brave/brave-browser/issues/37146

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.