### PR TITLE
[iOS] Add support for displaying `brave://flags` from the omnibox

### DIFF
--- a/chromium_src/ios/chrome/browser/flags/BUILD.gn
+++ b/chromium_src/ios/chrome/browser/flags/BUILD.gn
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+group("flags") {
+  deps = [ "//brave/ios/browser/flags" ]
+}

--- a/chromium_src/ios/chrome/browser/flags/DEPS
+++ b/chromium_src/ios/chrome/browser/flags/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+brave/ios/browser/flags"
+]

--- a/chromium_src/ios/chrome/browser/flags/about_flags.mm
+++ b/chromium_src/ios/chrome/browser/flags/about_flags.mm
@@ -1,0 +1,7 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/flags/about_flags.mm"
+#include "src/ios/chrome/browser/flags/about_flags.mm"

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -938,24 +938,8 @@ class SettingsViewController: TableViewController {
               )
             }
 
-            let viewMoreDetails = UIAlertAction(title: Strings.viewAllVersionInfo, style: .default)
-            { [unowned self, weak actionSheet] _ in
-              let versionController = ChromeWebViewController(privateBrowsing: false).then {
-                $0.loadURL("brave://version/?show-variations-cmd")
-              }
-              versionController.title = version
-
-              actionSheet?.dismiss(
-                animated: true,
-                completion: {
-                  self.navigationController?.pushViewController(versionController, animated: true)
-                }
-              )
-            }
-
             actionSheet.addAction(copyDebugInfoAction)
             actionSheet.addAction(copyAppInfoAction)
-            actionSheet.addAction(viewMoreDetails)
             actionSheet.addAction(
               UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil)
             )
@@ -1089,62 +1073,6 @@ class SettingsViewController: TableViewController {
             PrivacyReportsManager.consolidateData(dayRange: -10)
           },
           cellClass: MultilineButtonCell.self
-        ),
-        Row(
-          text: "View Chromium Local State",
-          selection: { [unowned self] in
-            let localStateController = ChromeWebViewController(privateBrowsing: false).then {
-              $0.title = "Chromium Local State"
-              $0.loadURL("brave://local-state")
-            }
-            if #available(iOS 16.0, *) {
-              let webView = localStateController.webView
-              webView.isFindInteractionEnabled = true
-              localStateController.navigationItem.rightBarButtonItem = UIBarButtonItem(
-                systemItem: .search,
-                primaryAction: .init { [weak webView] _ in
-                  guard let findInteraction = webView?.findInteraction,
-                    !findInteraction.isFindNavigatorVisible
-                  else {
-                    return
-                  }
-                  findInteraction.searchText = ""
-                  findInteraction.presentFindNavigator(showingReplace: false)
-                }
-              )
-            }
-            self.navigationController?.pushViewController(localStateController, animated: true)
-          },
-          accessory: .disclosureIndicator,
-          cellClass: MultilineValue1Cell.self
-        ),
-        Row(
-          text: "View Brave Histogram (p3a) Logs",
-          selection: { [unowned self] in
-            let histogramsController = ChromeWebViewController(privateBrowsing: false).then {
-              $0.title = "Histograms (p3a)"
-              $0.loadURL("brave://histograms")
-            }
-            if #available(iOS 16.0, *) {
-              let webView = histogramsController.webView
-              webView.isFindInteractionEnabled = true
-              histogramsController.navigationItem.rightBarButtonItem = UIBarButtonItem(
-                systemItem: .search,
-                primaryAction: .init { [weak webView] _ in
-                  guard let findInteraction = webView?.findInteraction,
-                    !findInteraction.isFindNavigatorVisible
-                  else {
-                    return
-                  }
-                  findInteraction.searchText = ""
-                  findInteraction.presentFindNavigator(showingReplace: false)
-                }
-              )
-            }
-            self.navigationController?.pushViewController(histogramsController, animated: true)
-          },
-          accessory: .disclosureIndicator,
-          cellClass: MultilineValue1Cell.self
         ),
         Row(
           text: "VPN Logs",

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -3608,13 +3608,6 @@ extension Strings {
       value: "Copy app size info to clipboard.",
       comment: "Copy app info to clipboard action sheet action."
     )
-  public static let viewAllVersionInfo = NSLocalizedString(
-    "viewAllVersionInfo",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "View all version info.",
-    comment: "View all version info action sheet action."
-  )
   public static let blockThirdPartyCookies = NSLocalizedString(
     "Block3rdPartyCookies",
     tableName: "BraveShared",

--- a/ios/browser/flags/BUILD.gn
+++ b/ios/browser/flags/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("flags") {
+  sources = [ "about_flags.mm" ]
+  deps = [
+    "//base",
+    "//brave/components/ai_chat/core/common/buildflags",
+    "//brave/components/brave_ads/core",
+    "//brave/components/brave_component_updater/browser",
+    "//brave/components/brave_rewards/common",
+    "//brave/components/brave_rewards/common/buildflags",
+    "//brave/components/brave_wallet/common",
+    "//brave/components/de_amp/common",
+    "//brave/components/debounce/core/common",
+    "//brave/components/ipfs/buildflags",
+    "//brave/components/ntp_background_images/browser",
+    "//brave/components/skus/common",
+    "//components/flags_ui",
+  ]
+}

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -1,0 +1,211 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This file is included into //ios/chrome/browser/flags/about_flags.mm
+
+#include "base/strings/string_util.h"
+#include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_ads/core/public/ads_feature.h"
+#include "brave/components/brave_component_updater/browser/features.h"
+#include "brave/components/brave_rewards/common/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/common/features.h"
+#include "brave/components/brave_wallet/common/features.h"
+#include "brave/components/de_amp/common/features.h"
+#include "brave/components/debounce/core/common/features.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
+#include "brave/components/ntp_background_images/browser/features.h"
+#include "brave/components/skus/common/features.h"
+#include "build/build_config.h"
+#include "components/flags_ui/feature_entry_macros.h"
+#include "components/flags_ui/flags_state.h"
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_IPFS)
+#include "brave/components/ipfs/features.h"
+#endif
+
+#define EXPAND_FEATURE_ENTRIES(...) __VA_ARGS__,
+
+#define BRAVE_SKU_SDK_FEATURE_ENTRIES                   \
+  EXPAND_FEATURE_ENTRIES({                              \
+      "skus-sdk",                                       \
+      "Enable experimental SKU SDK",                    \
+      "Experimental SKU SDK support",                   \
+      flags_ui::kOsIos,                                 \
+      FEATURE_VALUE_TYPE(skus::features::kSkusFeature), \
+  })
+
+#define BRAVE_IPFS_FEATURE_ENTRIES                                   \
+  IF_BUILDFLAG(ENABLE_IPFS,                                          \
+               EXPAND_FEATURE_ENTRIES({                              \
+                   "brave-ipfs",                                     \
+                   "Enable IPFS",                                    \
+                   "Enable native support of IPFS.",                 \
+                   flags_ui::kOsIos,                                 \
+                   FEATURE_VALUE_TYPE(ipfs::features::kIpfsFeature), \
+               }))
+
+#define BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                   \
+  EXPAND_FEATURE_ENTRIES(                                                     \
+      {                                                                       \
+          "enable-nft-pinning",                                               \
+          "Enable NFT pinning",                                               \
+          "Enable NFT pinning for Brave Wallet",                              \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletNftPinningFeature),         \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-zcash",                                               \
+          "Enable BraveWallet ZCash support",                                 \
+          "Zcash support for native Brave Wallet",                            \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletZCashFeature),              \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-bitcoin",                                             \
+          "Enable Brave Wallet Bitcoin support",                              \
+          "Bitcoin support for native Brave Wallet",                          \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletBitcoinFeature),            \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-enable-ankr-balances",                                \
+          "Enable Ankr balances",                                             \
+          "Enable usage of Ankr Advanced API for fetching balances in Brave " \
+          "Wallet",                                                           \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletAnkrBalancesFeature),       \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-enable-transaction-simulations",                      \
+          "Enable transaction simulations",                                   \
+          "Enable usage of Blowfish API for running transaction simulations " \
+          "in Brave Wallet",                                                  \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(brave_wallet::features::                         \
+                                 kBraveWalletTransactionSimulationsFeature),  \
+      })
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#define BRAVE_AI_CHAT                                          \
+  EXPAND_FEATURE_ENTRIES({                                     \
+      "brave-ai-chat",                                         \
+      "Brave AI Chat",                                         \
+      "Summarize articles and engage in conversation with AI", \
+      flags_ui::kOsIos,                                        \
+      FEATURE_VALUE_TYPE(ai_chat::features::kAIChat),          \
+  })
+#define BRAVE_AI_CHAT_HISTORY                                \
+  EXPAND_FEATURE_ENTRIES({                                   \
+      "brave-ai-chat-history",                               \
+      "Brave AI Chat History",                               \
+      "Enables AI Chat History persistence and management",  \
+      flags_ui::kOsIos,                                      \
+      FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory), \
+  })
+#else
+#define BRAVE_AI_CHAT
+#define BRAVE_AI_CHAT_HISTORY
+#endif
+
+// Keep the last item empty.
+#define LAST_BRAVE_FEATURE_ENTRIES_ITEM
+
+#define BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES                                      \
+  EXPAND_FEATURE_ENTRIES(                                                      \
+      {                                                                        \
+          "use-dev-updater-url",                                               \
+          "Use dev updater url",                                               \
+          "Use the dev url for the component updater. This is for internal "   \
+          "testing only.",                                                     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_component_updater::kUseDevUpdaterUrl),      \
+      },                                                                       \
+      {                                                                        \
+          "brave-ntp-branded-wallpaper-demo",                                  \
+          "New Tab Page Demo Branded Wallpaper",                               \
+          "Force dummy data for the Branded Wallpaper New Tab Page "           \
+          "Experience. View rate and user opt-in conditionals will still be "  \
+          "followed to decide when to display the Branded Wallpaper.",         \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              ntp_background_images::features::kBraveNTPBrandedWallpaperDemo), \
+      },                                                                       \
+      {                                                                        \
+          "brave-debounce",                                                    \
+          "Enable debouncing",                                                 \
+          "Enable support for skipping top-level redirect tracking URLs",      \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(debounce::features::kBraveDebounce),              \
+      },                                                                       \
+      {                                                                        \
+          "brave-de-amp",                                                      \
+          "Enable De-AMP",                                                     \
+          "Enable De-AMPing feature",                                          \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(de_amp::features::kBraveDeAMP),                   \
+      },                                                                       \
+      {                                                                        \
+          "brave-super-referral",                                              \
+          "Enable Brave Super Referral",                                       \
+          "Use custom theme for Brave Super Referral",                         \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(ntp_background_images::features::                 \
+                                 kBraveNTPSuperReferralWallpaper),             \
+      },                                                                       \
+      {                                                                        \
+          "brave-rewards-verbose-logging",                                     \
+          "Enable Brave Rewards verbose logging",                              \
+          "Enables detailed logging of Brave Rewards system events to a log "  \
+          "file stored on your device. Please note that this log file could "  \
+          "include information such as browsing history and credentials such " \
+          "as passwords and access tokens depending on your activity. Please " \
+          "do not share it unless asked to by Brave staff.",                   \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature), \
+      },                                                                       \
+      {                                                                        \
+          "brave-ads-should-always-run-brave-ads-service",                     \
+          "Should always run Brave Ads service",                               \
+          "Always run Brave Ads service to support triggering ad events when " \
+          "Brave Private Ads are disabled.",                                   \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_ads::kShouldAlwaysRunBraveAdsServiceFeature),              \
+      },                                                                       \
+      {                                                                        \
+          "brave-ads-should-always-trigger-new-tab-page-ad-events",            \
+          "Should always trigger new tab page ad events",                      \
+          "Support triggering new tab page ad events if Brave Private Ads "    \
+          "are disabled. Requires "                                            \
+          "#brave-ads-should-always-run-brave-ads-service to be enabled.",     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_ads::kShouldAlwaysTriggerBraveNewTabPageAdEventsFeature),  \
+      },                                                                       \
+      {                                                                        \
+          "brave-ads-should-always-trigger-search-result-ad-events",           \
+          "Should always trigger search result ad events",                     \
+          "Support triggering search result ad events if Brave Private Ads "   \
+          "are disabled. Requires "                                            \
+          "#brave-ads-should-always-run-brave-ads-service to be enabled.",     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_ads::                                                      \
+                  kShouldAlwaysTriggerBraveSearchResultAdEventsFeature),       \
+      })                                                                       \
+  BRAVE_IPFS_FEATURE_ENTRIES                                                   \
+  BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \
+  BRAVE_SKU_SDK_FEATURE_ENTRIES                                                \
+  BRAVE_AI_CHAT                                                                \
+  BRAVE_AI_CHAT_HISTORY                                                        \
+  LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.

--- a/patches/ios-chrome-browser-flags-about_flags.mm.patch
+++ b/patches/ios-chrome-browser-flags-about_flags.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/ios/chrome/browser/flags/about_flags.mm b/ios/chrome/browser/flags/about_flags.mm
+index 6c79c4eda98b1d0e7dd43c4cf2301ae0ccffc21e..9e6d81aa1765779b5b51f5e49a0b17440790e153 100644
+--- a/ios/chrome/browser/flags/about_flags.mm
++++ b/ios/chrome/browser/flags/about_flags.mm
+@@ -778,6 +778,7 @@ const FeatureEntry::FeatureVariation kIOSDockingPromoVariations[] = {
+ //
+ // When adding a new choice, add it to the end of the list.
+ const flags_ui::FeatureEntry kFeatureEntries[] = {
++    BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES
+     {"in-product-help-demo-mode-choice",
+      flag_descriptions::kInProductHelpDemoModeName,
+      flag_descriptions::kInProductHelpDemoModeDescription, flags_ui::kOsIos,


### PR DESCRIPTION
This change also adds the ability to open `brave://histograms`, `brave://local-state` and `brave://version` from the omnibox.

Resolves https://github.com/brave/brave-browser/issues/37149

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

