### PR TITLE
refactor(wallet): remove redux state for collapsing portfolio groups

### DIFF
--- a/components/brave_wallet_ui/common/selectors/ui-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/ui-selectors.ts
@@ -15,7 +15,3 @@ export const isPanel = ({ ui }: State) => ui.isPanel
 // unsafe
 export const transactionProviderErrorRegistry = ({ ui }: State) =>
   ui.transactionProviderErrorRegistry
-export const collapsedPortfolioAccountIds = ({ ui }: State) =>
-  ui.collapsedPortfolioAccountIds
-export const collapsedPortfolioNetworkKeys = ({ ui }: State) =>
-  ui.collapsedPortfolioNetworkKeys

--- a/components/brave_wallet_ui/common/slices/ui.slice.ts
+++ b/components/brave_wallet_ui/common/slices/ui.slice.ts
@@ -9,21 +9,10 @@ import { BraveWallet, UIState } from '../../constants/types'
 import { walletApi } from './api.slice'
 import { SetTransactionProviderErrorType } from '../constants/action_types'
 
-// Utils
-import { parseJSONFromLocalStorage } from '../../utils/local-storage-utils'
-
 export const defaultUIState: UIState = {
   selectedPendingTransactionId: undefined,
   transactionProviderErrorRegistry: {},
-  isPanel: false,
-  collapsedPortfolioAccountIds: parseJSONFromLocalStorage(
-    'COLLAPSED_PORTFOLIO_ACCOUNT_IDS',
-    []
-  ),
-  collapsedPortfolioNetworkKeys: parseJSONFromLocalStorage(
-    'COLLAPSED_PORTFOLIO_NETWORK_KEYS',
-    []
-  )
+  isPanel: false
 }
 
 // slice
@@ -45,20 +34,6 @@ export const createUISlice = (initialState: UIState = defaultUIState) => {
       ) => {
         state.transactionProviderErrorRegistry[payload.transactionId] =
           payload.providerError
-      },
-
-      setCollapsedPortfolioAccountIds(
-        state: UIState,
-        { payload }: PayloadAction<string[]>
-      ) {
-        state.collapsedPortfolioAccountIds = payload
-      },
-
-      setCollapsedPortfolioNetworkKeys(
-        state: UIState,
-        { payload }: PayloadAction<string[]>
-      ) {
-        state.collapsedPortfolioNetworkKeys = payload
       }
     },
     extraReducers: (builder) => {

--- a/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
+++ b/components/brave_wallet_ui/components/desktop/asset-group-container/asset-group-container.tsx
@@ -4,11 +4,6 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { useDispatch } from 'react-redux'
-
-// Selectors
-import { useUnsafeUISelector } from '../../../common/hooks/use-safe-selector'
-import { UISelectors } from '../../../common/selectors'
 
 // Constants
 import {
@@ -16,7 +11,6 @@ import {
 } from '../../../common/constants/local-storage-keys'
 
 // Slices
-import { UIActions } from '../../../common/slices/ui.slice'
 import {
   networkEntityAdapter //
 } from '../../../common/slices/entities/network.entity'
@@ -24,7 +18,10 @@ import {
 // Utils
 import { reduceAddress } from '../../../utils/reduce-address'
 import { getLocale } from '../../../../common/locale'
-import { useSyncedLocalStorage } from '../../../common/hooks/use_local_storage'
+import {
+  useLocalStorage,
+  useSyncedLocalStorage
+} from '../../../common/hooks/use_local_storage'
 
 // Types
 import { BraveWallet } from '../../../constants/types'
@@ -79,22 +76,17 @@ export const AssetGroupContainer = (props: Props) => {
     externalProvider
   } = props
 
-  // Redux
-  const dispatch = useDispatch()
-
   // Local-Storage
   const [hidePortfolioBalances] = useSyncedLocalStorage(
     LOCAL_STORAGE_KEYS.HIDE_PORTFOLIO_BALANCES,
     false
   )
-
-  // Selectors
-  const collapsedAccounts = useUnsafeUISelector(
-    UISelectors.collapsedPortfolioAccountIds
-  )
-  const collapsedNetworks = useUnsafeUISelector(
-    UISelectors.collapsedPortfolioNetworkKeys
-  )
+  const [collapsedAccounts, setCollapsedPortfolioAccountIds] = useLocalStorage<
+    string[]
+  >(LOCAL_STORAGE_KEYS.COLLAPSED_PORTFOLIO_ACCOUNT_IDS, [])
+  const [collapsedNetworks, setCollapsedPortfolioNetworkKeys] = useLocalStorage<
+    string[]
+  >(LOCAL_STORAGE_KEYS.COLLAPSED_PORTFOLIO_NETWORK_KEYS, [])
 
   // Memos & Computed
   const externalRewardsDescription = network
@@ -124,14 +116,7 @@ export const AssetGroupContainer = (props: Props) => {
           )
         : [...collapsedAccounts, account.accountId.uniqueKey]
 
-      // Update Collapsed Account Ids in Local Storage
-      window.localStorage.setItem(
-        LOCAL_STORAGE_KEYS.COLLAPSED_PORTFOLIO_ACCOUNT_IDS,
-        JSON.stringify(newCollapsedAccounts)
-      )
-
-      // Update Collapsed Account Ids in Redux
-      dispatch(UIActions.setCollapsedPortfolioAccountIds(newCollapsedAccounts))
+      setCollapsedPortfolioAccountIds(newCollapsedAccounts)
     }
 
     if (network) {
@@ -142,22 +127,16 @@ export const AssetGroupContainer = (props: Props) => {
         ? collapsedNetworks.filter((networkKey) => networkKey !== networksKey)
         : [...collapsedNetworks, networksKey]
 
-      // Update Collapsed Network Keys in Local Storage
-      window.localStorage.setItem(
-        LOCAL_STORAGE_KEYS.COLLAPSED_PORTFOLIO_NETWORK_KEYS,
-        JSON.stringify(newCollapsedNetworks)
-      )
-
-      // Update Collapsed Network Keys in Redux
-      dispatch(UIActions.setCollapsedPortfolioNetworkKeys(newCollapsedNetworks))
+      setCollapsedPortfolioNetworkKeys(newCollapsedNetworks)
     }
   }, [
     account,
     network,
     isCollapsed,
     collapsedAccounts,
-    dispatch,
-    collapsedNetworks
+    setCollapsedPortfolioAccountIds,
+    collapsedNetworks,
+    setCollapsedPortfolioNetworkKeys
   ])
 
   return (

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -183,8 +183,6 @@ export interface UIState {
   selectedPendingTransactionId?: string | undefined
   transactionProviderErrorRegistry: TransactionProviderErrorRegistry
   isPanel: boolean
-  collapsedPortfolioAccountIds: string[]
-  collapsedPortfolioNetworkKeys: string[]
 }
 
 export interface WalletState {

--- a/components/brave_wallet_ui/stories/mock-data/mock-ui-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-ui-state.ts
@@ -9,7 +9,5 @@ import { mockedErc20ApprovalTransaction } from './mock-transaction-info'
 export const mockUiState: UIState = {
   transactionProviderErrorRegistry: {},
   selectedPendingTransactionId: mockedErc20ApprovalTransaction.id,
-  isPanel: false,
-  collapsedPortfolioAccountIds: [],
-  collapsedPortfolioNetworkKeys: []
+  isPanel: false
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37179

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Collapsing portfolio account and network groups should continue to work and persist between page loads without regressions. 

<img width="384" alt="Screenshot 2024-03-28 at 3 33 26 PM" src="https://github.com/brave/brave-core/assets/30185185/68ce435c-5672-41d0-8a13-906e950c5ac9">

<img width="499" alt="Screenshot 2024-03-28 at 3 41 11 PM" src="https://github.com/brave/brave-core/assets/30185185/ccc31656-c421-4d82-950a-05eb86abb2a0">
