### PR TITLE
[iOS] Update secure content state update flow

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -82,7 +82,7 @@ extension BrowserViewController {
 
     // Toogle Reader Mode Activity
     // If the reader mode button is occluded due to a secure content state warning add it as an activity
-    if let tab = tabManager.selectedTab, tab.secureContentState.shouldDisplayWarning {
+    if let tab = tabManager.selectedTab, tab.lastKnownSecureContentState.shouldDisplayWarning {
       if tab.readerModeAvailableOrActive {
         activities.append(
           BasicMenuActivity(
@@ -292,10 +292,6 @@ extension BrowserViewController {
       tabManager.selectedTab?.webView?.serverTrust != nil
         || ErrorPageHelper.hasCertificates(for: tabURL)
     {
-      if let selectedTab = tabManager.selectedTab {
-        logSecureContentState(tab: selectedTab, details: "Display Certificate Activity Settings")
-      }
-
       activities.append(
         BasicMenuActivity(
           activityType: .displaySecurityCertificate

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -1012,7 +1012,7 @@ extension BrowserViewController: ToolbarDelegate {
       (tab.webView?.serverTrust ?? (try? ErrorPageHelper.serverTrust(from: url))) != nil
     let pageSecurityView = PageSecurityView(
       displayURL: urlBar.locationView.urlDisplayLabel.text ?? url.absoluteDisplayString,
-      secureState: tab.secureContentState,
+      secureState: tab.lastKnownSecureContentState,
       hasCertificate: hasCertificate,
       presentCertificateViewer: { [weak self] in
         self?.dismiss(animated: true)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -870,7 +870,6 @@ extension BrowserViewController: WKNavigationDelegate {
     // However, WebKit does NOT trigger the `serverTrust` observer when the URL changes, but the trust has not.
     // WebKit also does NOT trigger the `serverTrust` observer when the page is actually insecure (non-https).
     // So manually trigger it with the current trust.
-    logSecureContentState(tab: tab, details: "ObserveValue trigger in didCommit")
 
     observeValue(
       forKeyPath: KVOConstants.serverTrust.keyPath,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1986,6 +1986,14 @@ public class BrowserViewController: UIViewController {
       {
         topToolbar.updateProgressBar(Float(webView.estimatedProgress))
       }
+
+      Task {
+        await tab.updateSecureContentState()
+        self.logSecureContentState(tab: tab, path: .url)
+        if self.tabManager.selectedTab === tab {
+          self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
+        }
+      }
     case .title:
       // Ensure that the tab title *actually* changed to prevent repeated calls
       // to navigateInTab(tab:).
@@ -2009,218 +2017,20 @@ public class BrowserViewController: UIViewController {
 
       navigationToolbar.updateForwardStatus(canGoForward)
     case .hasOnlySecureContent:
-      guard let tab = tabManager[webView] else {
-        break
-      }
-
-      if tab.secureContentState == .secure, !webView.hasOnlySecureContent,
-        tab.url?.origin == tab.webView?.url?.origin
-      {
-        if let url = tab.webView?.url, url.isInternalURL(for: .readermode) {
-          break
+      Task {
+        await tab.updateSecureContentState()
+        self.logSecureContentState(tab: tab, path: .hasOnlySecureContent)
+        if tabManager.selectedTab === tab {
+          self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
         }
-
-        tab.secureContentState = .mixedContent
-        logSecureContentState(tab: tab, path: path)
-      }
-
-      if let url = tab.webView?.url,
-        InternalURL.isValid(url: url),
-        let internalUrl = InternalURL(url)
-      {
-
-        if internalUrl.isErrorPage {
-          if ErrorPageHelper.certificateError(for: url) != 0 {
-            // Cert validation takes precedence over all other errors
-            tab.secureContentState = .invalidCert
-            logSecureContentState(
-              tab: tab,
-              path: path,
-              details: "Cert validation takes precedence over all other errors"
-            )
-          } else if NetworkErrorPageHandler.isNetworkError(
-            errorCode: ErrorPageHelper.errorCode(for: url)
-          ) {
-            // Network error takes precedence over missing cert
-            // Because we cannot determine if a cert is missing yet, if we cannot connect to the server
-            // Our network interstitial page shows
-            tab.secureContentState = .localhost
-            logSecureContentState(
-              tab: tab,
-              path: path,
-              details: "Network error takes precedence over missing cert"
-            )
-          } else {
-            // Since it's not a cert error explicitly, and it's not a network error, and the cert is missing (no serverTrust),
-            // then we display .missingSSL
-            tab.secureContentState = .missingSSL
-            logSecureContentState(
-              tab: tab,
-              path: path,
-              details: "Certificate is missing (no serverTrust)"
-            )
-          }
-        } else if url.isInternalURL(for: .readermode) || InternalURL.isValid(url: url) {
-          tab.secureContentState = .localhost
-          logSecureContentState(tab: tab, path: path, details: "Reader Mode or Internal URL")
-        }
-      }
-
-      if tabManager.selectedTab === tab {
-        updateToolbarSecureContentState(tab.secureContentState)
       }
     case .serverTrust:
-      guard let tab = tabManager[webView] else {
-        break
-      }
-
-      tab.secureContentState = .unknown
-      logSecureContentState(tab: tab, path: path)
-
-      guard let url = webView.url,
-        let serverTrust = webView.serverTrust
-      else {
-        if let url = webView.url {
-          if InternalURL.isValid(url: url),
-            let internalUrl = InternalURL(url),
-            internalUrl.isAboutURL || internalUrl.isAboutHomeURL
-          {
-
-            tab.secureContentState = .localhost
-            logSecureContentState(
-              tab: tab,
-              path: path,
-              details: "Internal URL aboutURL or is aboutHomeURL"
-            )
-
-            if tabManager.selectedTab === tab {
-              updateToolbarSecureContentState(.localhost)
-            }
-            break
-          }
-
-          if InternalURL.isValid(url: url),
-            let internalUrl = InternalURL(url),
-            internalUrl.isErrorPage
-          {
-
-            if ErrorPageHelper.certificateError(for: url) != 0 {
-              // Cert validation takes precedence over all other errors
-              tab.secureContentState = .invalidCert
-              logSecureContentState(
-                tab: tab,
-                path: path,
-                details: "Cert validation takes precedence over all other errors"
-              )
-            } else if NetworkErrorPageHandler.isNetworkError(
-              errorCode: ErrorPageHelper.errorCode(for: url)
-            ) {
-              // Network error takes precedence over missing cert
-              // Because we cannot determine if a cert is missing yet, if we cannot connect to the server
-              // Our network interstitial page shows
-              tab.secureContentState = .localhost
-              logSecureContentState(
-                tab: tab,
-                path: path,
-                details: "Network error takes precedence over missing cert"
-              )
-            } else {
-              // Since it's not a cert error explicitly, and it's not a network error, and the cert is missing (no serverTrust),
-              // then we display .missingSSL
-              tab.secureContentState = .missingSSL
-              logSecureContentState(
-                tab: tab,
-                path: path,
-                details: "Certificate is missing (no serverTrust)"
-              )
-            }
-
-            if tabManager.selectedTab === tab {
-              updateToolbarSecureContentState(tab.secureContentState)
-            }
-            break
-          }
-
-          if url.isInternalURL(for: .readermode) || InternalURL.isValid(url: url) {
-            tab.secureContentState = .localhost
-            logSecureContentState(tab: tab, path: path, details: "Reader Mode or Internal URL")
-
-            if tabManager.selectedTab === tab {
-              updateToolbarSecureContentState(.localhost)
-            }
-            break
-          }
-
-          // All our checks failed, we show the page as insecure
-          tab.secureContentState = .missingSSL
-          logSecureContentState(
-            tab: tab,
-            path: path,
-            details: "All our checks failed, we show the page as insecure"
-          )
-        } else {
-          // When there is no URL, it's likely a new tab.
-          tab.secureContentState = .localhost
-          logSecureContentState(
-            tab: tab,
-            path: path,
-            details: "When there is no URL, it's likely a new tab"
-          )
+      Task {
+        await tab.updateSecureContentState()
+        self.logSecureContentState(tab: tab, path: .serverTrust)
+        if self.tabManager.selectedTab === tab {
+          self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
         }
-
-        if tabManager.selectedTab === tab {
-          updateToolbarSecureContentState(tab.secureContentState)
-        }
-        break
-      }
-
-      guard let scheme = url.scheme,
-        let host = url.host
-      else {
-        tab.secureContentState = .unknown
-        logSecureContentState(tab: tab, path: path, details: "No webview URL host scheme)")
-
-        self.updateURLBar()
-        return
-      }
-
-      let port: Int
-      if let urlPort = url.port {
-        port = urlPort
-      } else if scheme == "https" {
-        port = 443
-      } else {
-        port = 80
-      }
-
-      Task { @MainActor in
-        do {
-          let result = await BraveCertificateUtils.verifyTrust(serverTrust, host: host, port: port)
-
-          // Cert is valid!
-          if result == 0 {
-            tab.secureContentState = .secure
-            logSecureContentState(tab: tab, path: path, details: "Cert is valid!")
-          } else if result == Int32.min {
-            // Cert is valid but should be validated by the system
-            // Let the system handle it and we'll show an error if the system cannot validate it
-            try await BraveCertificateUtils.evaluateTrust(serverTrust, for: host)
-            tab.secureContentState = .secure
-            logSecureContentState(
-              tab: tab,
-              path: path,
-              details: "Cert is valid but should be validated by the system"
-            )
-          } else {
-            tab.secureContentState = .invalidCert
-            logSecureContentState(tab: tab, path: path, details: "Invalid Cert")
-          }
-        } catch {
-          tab.secureContentState = .invalidCert
-          logSecureContentState(tab: tab, path: path, details: "Verify Trust Error")
-        }
-
-        self.updateURLBar()
       }
     case ._sampledPageTopColor:
       updateStatusBarOverlayColor()
@@ -2229,19 +2039,24 @@ public class BrowserViewController: UIViewController {
     }
   }
 
-  func logSecureContentState(tab: Tab, path: KVOConstants? = nil, details: String? = nil) {
+  func logSecureContentState(tab: Tab, path: KVOConstants? = nil) {
     var text = """
       Tab URL: \(tab.url?.absoluteString ?? "Empty Tab URL")
-       Tab VebView URL: \(tab.webView?.url?.absoluteString ?? "Empty Webview URL")
-       Secure State: \(tab.secureContentState.rawValue)
+       Secure State: \(tab.lastKnownSecureContentState.rawValue)
       """
 
     if let keyPath = path?.keyPath {
       text.append("\n Value Observed: \(keyPath)\n")
     }
 
-    if let extraDetails = details {
-      text.append("\n Extra Details: \(extraDetails)\n")
+    if let webView = tab.webView {
+      text.append(
+        """
+         WebView url: \(webView.url?.absoluteString ?? "nil")
+         WebView hasOnlySecureContent: \(webView.hasOnlySecureContent ? "true" : "false")
+         WebView serverTrust: \(webView.serverTrust != nil ? "present" : "nil")
+        """
+      )
     }
 
     DebugLogger.log(for: .secureState, text: text)
@@ -2303,7 +2118,7 @@ public class BrowserViewController: UIViewController {
 
     updateToolbarCurrentURL(tab.url?.displayURL)
     if tabManager.selectedTab === tab {
-      updateToolbarSecureContentState(tab.secureContentState)
+      self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
     }
 
     let isPage = tab.url?.isWebPage() ?? false
@@ -3460,7 +3275,6 @@ extension BrowserViewController: NewTabPageDelegate {
       guard let self = self else { return }
 
       let viewRect = CGRect(origin: self.view.center, size: .zero)
-
       self.presentActivityViewController(
         url,
         sourceView: self.view,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1960,7 +1960,7 @@ public class BrowserViewController: UIViewController {
         // If navigation will start from NTP, tab display url will be nil until
         // didCommit is called and it will cause url bar be empty in that period
         // To fix this when tab display url is empty, webview url is used
-        if tab.url?.displayURL == nil {
+        if tab === tabManager.selectedTab, tab.url?.displayURL == nil {
           if let url = webView.url, !url.isLocal, !InternalURL.isValid(url: url) {
             updateToolbarCurrentURL(url.displayURL)
           }


### PR DESCRIPTION
This change moves all of the logic that used to happen in each KVO observation into one unified location so that it has all the data available each update. It also only updates the tab content state once per update which should fix possible races when updating the URL bar in other locations.

Resolves https://github.com/brave/brave-browser/issues/36951

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

