### PR TITLE
Show which tabs are unloaded

### DIFF
--- a/chromium_src/chrome/browser/ui/tabs/tab_renderer_data.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_renderer_data.cc
@@ -50,8 +50,8 @@ TabRendererData TabRendererData::FromTabInModel(const TabStripModel* model,
   if (!data.should_show_discard_status) {
     content::WebContents* const contents = model->GetWebContentsAt(index);
     using resource_coordinator::TabLoadTracker;
-    const auto loaded_state = TabLoadTracker::Get()->GetLoadingState(contents);    
-    if (loaded_state == TabLoadTracker::LoadingState::UNLOADED) {
+    const auto loading_state = TabLoadTracker::Get()->GetLoadingState(contents);
+    if (loading_state == TabLoadTracker::LoadingState::UNLOADED) {
       data.should_show_discard_status = true;
     }
   }

--- a/chromium_src/chrome/browser/ui/tabs/tab_renderer_data.cc
+++ b/chromium_src/chrome/browser/ui/tabs/tab_renderer_data.cc
@@ -13,6 +13,7 @@
 #include "brave/browser/ui/tabs/shared_pinned_tab_service.h"
 #include "brave/browser/ui/tabs/shared_pinned_tab_service_factory.h"
 #include "brave/components/constants/webui_url_constants.h"
+#include "chrome/browser/resource_coordinator/tab_load_tracker.h"
 #include "url/gurl.h"
 
 TabRendererData TabRendererData::FromTabInModel(const TabStripModel* model,
@@ -42,6 +43,16 @@ TabRendererData TabRendererData::FromTabInModel(const TabStripModel* model,
         (url.host_piece() == kWelcomeHost ||
          url.host_piece() == kRewardsPageHost)) {
       data.should_themify_favicon = false;
+    }
+  }
+
+  // Show which tabs are unloaded.
+  if (!data.should_show_discard_status) {
+    content::WebContents* const contents = model->GetWebContentsAt(index);
+    using resource_coordinator::TabLoadTracker;
+    const auto loaded_state = TabLoadTracker::Get()->GetLoadingState(contents);    
+    if (loaded_state == TabLoadTracker::LoadingState::UNLOADED) {
+      data.should_show_discard_status = true;
     }
   }
   return data;

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -5,6 +5,11 @@
 ## why the filter is required and create an associated tracking issue if needed.
 ##
 
+# This test fails, because it expects an active tab's accessible name instead
+# of an inactive tab's.  It is an inactive tab, because Brave sets
+# `should_show_discard_status` for unloaded tabs.
+-TabStripBrowsertest.AccessibleName
+
 # This test fails because we call WebUI::OverrideTitle for new tab page which
 # returns the overridden title instead of the regular title that the test
 # expects.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Introduces Edge's simple and intuitive behavior in which unloaded tabs are distinguished from loaded tabs.  This behavior replaces Chromium's behavior in which unloaded tabs are not distinguished from loaded tabs except where a tab is proactively discarded.

Resolves https://github.com/brave/brave-browser/issues/36720.

I checked this PR locally. It is working. Your developer config however appears to be broken and so a few tests for unrelated things fail.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Restore a session so that we'll have unloaded tabs that weren't discarded.
2. Visit `brave://discards`.
3. Click `Urgent Discard` (under `Actions`) for one of those tabs.
4. Click `Proactive Discard` for another tab.
5. Right click `Tab Discard (Suspender)` and select `Discard active tab only`.
6. Click `Tab Discard (Suspender)` in another tab to externally discard it and quickly switch away to avoid reloading.
7. Unloaded tabs should be visually distinguishable instead of just proactively discarded tabs. Specifically, you can look at the favicon and if it's circular or not (there may be other changes - hard to see them).

<img width="960" alt="Screenshot 2024-03-29 205754" src="https://github.com/brave/brave-core/assets/87069698/b4044289-77ea-4dfd-b9bb-61306e7125ce">
