### PR TITLE
Add support for enabling experimental list by default

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -586,6 +586,17 @@
                                  kBraveAdblockMobileNotificationsListDefault), \
       },                                                                       \
       {                                                                        \
+          "brave-adblock-experimental-list-default",                           \
+          "Treat 'Brave Experimental Adblock Rules' as a default list "        \
+          "source",                                                            \
+                                                                               \
+          "Enables the 'Brave Experimental Adblock Rules' regional list if "   \
+          "its toggle in brave://adblock hasn't otherwise been modified",      \
+          kOsAll,                                                              \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_shields::features::kBraveAdblockExperimentalListDefault),  \
+      },                                                                       \
+      {                                                                        \
           "brave-adblock-scriptlet-debug-logs",                                \
           "Enable debug logging for scriptlet injections",                     \
           "Enable console debugging for scriptlets injected by cosmetic "      \

--- a/components/brave_shields/core/browser/ad_block_component_service_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_component_service_manager.cc
@@ -23,8 +23,8 @@
 #include "components/prefs/scoped_user_pref_update.h"
 
 using brave_shields::features::kBraveAdblockCookieListDefault;
-using brave_shields::features::kBraveAdblockMobileNotificationsListDefault;
 using brave_shields::features::kBraveAdblockExperimentalListDefault;
+using brave_shields::features::kBraveAdblockMobileNotificationsListDefault;
 
 namespace brave_shields {
 

--- a/components/brave_shields/core/browser/ad_block_component_service_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_component_service_manager.cc
@@ -24,6 +24,7 @@
 
 using brave_shields::features::kBraveAdblockCookieListDefault;
 using brave_shields::features::kBraveAdblockMobileNotificationsListDefault;
+using brave_shields::features::kBraveAdblockExperimentalListDefault;
 
 namespace brave_shields {
 
@@ -43,8 +44,14 @@ const ListDefaultOverrideConstants kMobileNotificationsListConstants{
         kBraveAdblockMobileNotificationsListDefault),
     .list_uuid = kMobileNotificationsListUuid};
 
-const ListDefaultOverrideConstants kOverrideConstants[2] = {
-    kCookieListConstants, kMobileNotificationsListConstants};
+const ListDefaultOverrideConstants kExperimentalListConstants{
+    .feature =
+        raw_ref<const base::Feature>(kBraveAdblockExperimentalListDefault),
+    .list_uuid = kExperimentalListUuid};
+
+const ListDefaultOverrideConstants kOverrideConstants[3] = {
+    kCookieListConstants, kMobileNotificationsListConstants,
+    kExperimentalListConstants};
 
 }  // namespace
 

--- a/components/brave_shields/core/common/brave_shield_constants.h
+++ b/components/brave_shields/core/common/brave_shield_constants.h
@@ -40,6 +40,7 @@ const base::FilePath::CharType kCustomSubscriptionListText[] =
 const char kCookieListUuid[] = "AC023D22-AE88-4060-A978-4FEEEC4221693";
 const char kMobileNotificationsListUuid[] =
     "2F3DCE16-A19A-493C-A88F-2E110FBD37D6";
+const char kExperimentalListUuid[] = "564C3B75-8731-404C-AD7C-5683258BA0B0";
 
 const char kCookieListEnabledHistogram[] = "Brave.Shields.CookieListEnabled";
 const char kCookieListPromptHistogram[] = "Brave.Shields.CookieListPrompt";

--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -52,6 +52,12 @@ BASE_FEATURE(kBraveAdblockCspRules,
 BASE_FEATURE(kBraveAdblockMobileNotificationsListDefault,
              "BraveAdblockMobileNotificationsListDefault",
              base::FEATURE_ENABLED_BY_DEFAULT);
+// When enabled, Brave will enable "Brave Experimental Adblock Rules" list by
+// default unless overridden by a locally set preference.
+// NOTE: this should only be turned on by default in Nightly and Beta.
+BASE_FEATURE(kBraveAdblockExperimentalListDefault,
+             "BraveAdblockExperimentalListDefault",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 // When enabled, Brave will block domains listed in the user's selected adblock
 // filters and present a security interstitial with choice to proceed and
 // optionally whitelist the domain.

--- a/components/brave_shields/core/common/features.h
+++ b/components/brave_shields/core/common/features.h
@@ -21,6 +21,7 @@ BASE_DECLARE_FEATURE(kBraveAdblockCosmeticFiltering);
 BASE_DECLARE_FEATURE(kBraveAdblockCspRules);
 BASE_DECLARE_FEATURE(kBraveAdblockDefault1pBlocking);
 BASE_DECLARE_FEATURE(kBraveAdblockMobileNotificationsListDefault);
+BASE_DECLARE_FEATURE(kBraveAdblockExperimentalListDefault);
 BASE_DECLARE_FEATURE(kBraveAdblockScriptletDebugLogs);
 BASE_DECLARE_FEATURE(kBraveDarkModeBlock);
 BASE_DECLARE_FEATURE(kBraveDomainBlock);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37225

We will enable the list via Griffin on Nightly and Beta.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. New feature flag: brave://flags/#brave-adblock-experimental-list-default
2. Turning it ON results in regional list `Brave Experimental Adblock Rules` being turned on in brave://settings/shields/filters
