### PR TITLE
[iOS] Bump swift-format to 510.1.0

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -136,7 +136,7 @@ hooks = [
     'name': 'download_swift_format',
     'pattern': '.',
     'condition': 'host_os == "mac"',
-    'action': ['python3', 'build/apple/download_swift_format.py', '509.0.0', '78daf8c0fb407f0de79a6ee042f9d92e634f876dbb6da366735752d1c1e696f7']
+    'action': ['python3', 'build/apple/download_swift_format.py', '510.1.0', '0ddbb486640cde862fa311dc0f7387e6c5171bdcc0ee0c89bc9a1f8a75e8bfaf']
   },
 ]
 

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/LabelView.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/LabelView.swift
@@ -8,12 +8,12 @@ import SwiftUI
 public struct LabelView: View {
   let title: String
   var subtitle: String?
-  
+
   public init(title: String, subtitle: String? = nil) {
     self.title = title
     self.subtitle = subtitle
   }
-  
+
   public var body: some View {
     VStack(alignment: .leading, spacing: 4) {
       Text(title)

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/OptionToggleView.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/OptionToggleView.swift
@@ -11,17 +11,19 @@ public struct OptionToggleView: View {
   var subtitle: String?
   @ObservedObject var option: Preferences.Option<Bool>
   let onChange: ToggleView.OnChangeCallback?
-  
- public init(title: String, 
-             subtitle: String? = nil,
-             option: Preferences.Option<Bool>, 
-             onChange: ToggleView.OnChangeCallback? = nil) {
+
+  public init(
+    title: String,
+    subtitle: String? = nil,
+    option: Preferences.Option<Bool>,
+    onChange: ToggleView.OnChangeCallback? = nil
+  ) {
     self.title = title
     self.subtitle = subtitle
     self.option = option
     self.onChange = onChange
   }
-  
+
   public var body: some View {
     ToggleView(
       title: title,

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/ToggleView.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/ToggleView.swift
@@ -8,22 +8,24 @@ import SwiftUI
 
 public struct ToggleView: View {
   public typealias OnChangeCallback = (Bool) -> Void
-  
+
   let title: String
   var subtitle: String?
   @Binding var toggle: Bool
   let onChange: OnChangeCallback?
-  
-  public init(title: String,
-              subtitle: String? = nil,
-              toggle: Binding<Bool>,
-              onChange: OnChangeCallback? = nil) {
+
+  public init(
+    title: String,
+    subtitle: String? = nil,
+    toggle: Binding<Bool>,
+    onChange: OnChangeCallback? = nil
+  ) {
     self.title = title
     self.subtitle = subtitle
     _toggle = toggle
     self.onChange = onChange
   }
-  
+
   public var body: some View {
     Toggle(isOn: $toggle) {
       LabelView(title: title, subtitle: subtitle)

--- a/ios/brave-ios/Sources/DesignSystem/Views/AppearanceExtensions.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Views/AppearanceExtensions.swift
@@ -3,8 +3,8 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import Foundation
-import UIKit
 import Then
+import UIKit
 
 extension UIView {
   /// Setup basic control defaults based on Brave design system colors

--- a/ios/brave-ios/Sources/Favicon/FaviconImage.swift
+++ b/ios/brave-ios/Sources/Favicon/FaviconImage.swift
@@ -24,17 +24,17 @@ public struct FaviconImage: View {
   let url: URL?
   private let isPrivateBrowsing: Bool
   @StateObject private var faviconLoader = FaviconHelper()
-  
+
   public init(url: String?, isPrivateBrowsing: Bool) {
     self.isPrivateBrowsing = isPrivateBrowsing
-    
+
     if let url = url {
       self.url = URL(string: url)
     } else {
       self.url = nil
     }
   }
-  
+
   public var body: some View {
     Image(uiImage: faviconLoader.image ?? Favicon.defaultImage)
       .resizable()

--- a/ios/brave-ios/Sources/SpeechRecognition/SpeechToTextInputView.swift
+++ b/ios/brave-ios/Sources/SpeechRecognition/SpeechToTextInputView.swift
@@ -13,16 +13,17 @@ public struct SpeechToTextInputView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
   @ObservedObject var speechModel: SpeechRecognizer
   let disclaimer: String
-  
+
   var onEnterSearchKeyword: (() -> Void)?
   var dismiss: (() -> Void)?
 
-  public init(speechModel: SpeechRecognizer, disclaimer: String, dismissAction: (() -> Void)? = nil) {
+  public init(speechModel: SpeechRecognizer, disclaimer: String, dismissAction: (() -> Void)? = nil)
+  {
     self.speechModel = speechModel
     self.disclaimer = disclaimer
     self.dismiss = dismissAction
   }
-  
+
   public var body: some View {
     inputView
   }
@@ -94,7 +95,7 @@ public struct SpeechToTextInputView: View {
     }
     .padding(.vertical, 45)
   }
-  
+
   private func dismissView() {
     dismiss?()
     speechModel.clearSearch()
@@ -102,8 +103,8 @@ public struct SpeechToTextInputView: View {
   }
 }
 
-public extension SpeechToTextInputView {
-    
+extension SpeechToTextInputView {
+
   private var outerCircleScale: CGFloat {
     switch speechModel.animationType {
     case .pulse(let scale):
@@ -135,27 +136,28 @@ extension UIColor {
 
 public struct SpeechToTextInputContentView: UIViewControllerRepresentable {
   @Binding var isPresented: Bool
-  
+
   var dismissAction: (() -> Void)?
-  
+
   var speechModel: SpeechRecognizer
   var disclaimer: String
-  
+
   public init(
     isPresented: Binding<Bool>,
     dismissAction: (() -> Void)? = nil,
     speechModel: SpeechRecognizer,
-    disclaimer: String) {
-      _isPresented = isPresented
-      self.dismissAction = dismissAction
-      self.speechModel = speechModel
-      self.disclaimer = disclaimer
+    disclaimer: String
+  ) {
+    _isPresented = isPresented
+    self.dismissAction = dismissAction
+    self.speechModel = speechModel
+    self.disclaimer = disclaimer
   }
-  
+
   public func makeUIViewController(context: Context) -> UIViewController {
     .init()
   }
-  
+
   public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
     if isPresented {
       if uiViewController.presentedViewController != nil {
@@ -166,22 +168,25 @@ public struct SpeechToTextInputContentView: UIViewControllerRepresentable {
         rootView: SpeechToTextInputView(
           speechModel: speechModel,
           disclaimer: disclaimer,
-          dismissAction: dismissAction))
-      
+          dismissAction: dismissAction
+        )
+      )
+
       context.coordinator.presentedViewController = .init(controller)
       uiViewController.present(controller, animated: true)
     } else {
       if let presentedViewController = context.coordinator.presentedViewController?.value,
-         presentedViewController == uiViewController.presentedViewController {
+        presentedViewController == uiViewController.presentedViewController
+      {
         uiViewController.presentedViewController?.dismiss(animated: true)
       }
     }
   }
-  
+
   public class Coordinator {
     var presentedViewController: WeakRef<UIViewController>?
   }
-  
+
   public func makeCoordinator() -> Coordinator {
     Coordinator()
   }

--- a/ios/brave-ios/Tests/BraveSharedTests/PasteboardTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/PasteboardTests.swift
@@ -3,9 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-import XCTest
-
 import BraveShared
+import XCTest
 
 class PasteboardTests: XCTestCase {
   func testExpiringSecureString() {


### PR DESCRIPTION
This version of swift-format adds support for Swift 5.10 introduced in Xcode 15.3 (https://github.com/apple/swift-format/releases/tag/510.1.0). A recursive format on the `ios/brave-ios` folder was also run to pick up any updated formatting.

Resolves https://github.com/brave/brave-browser/issues/37296

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

