### PR TITLE
style(wallet): Update Token List Background Hover State

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -83,6 +83,7 @@ interface Props {
   isPanel?: boolean
   isAccountDetails?: boolean
   spotPrice: string
+  isGrouped?: boolean
 }
 
 const ICON_CONFIG = { size: 'medium', marginLeft: 0, marginRight: 8 } as const
@@ -97,7 +98,8 @@ export const PortfolioAssetItem = ({
   isPanel,
   spotPrice,
   account,
-  isAccountDetails
+  isAccountDetails,
+  isGrouped
 }: Props) => {
   // queries
   const { data: defaultFiatCurrency = 'usd' } = useGetDefaultFiatCurrencyQuery()
@@ -199,6 +201,7 @@ export const PortfolioAssetItem = ({
       <Wrapper
         fullWidth={true}
         showBorder={isAccountDetails && showBalanceInfo}
+        isGrouped={isGrouped}
       >
         {token.visible && (
           <HoverArea isPanel={isPanel}>

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/portfolio-asset-item-loading-skeleton.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/portfolio-asset-item-loading-skeleton.tsx
@@ -21,7 +21,7 @@ import { IconsWrapper } from '../../shared/style'
 
 export const PortfolioAssetItemLoadingSkeleton = () => {
   return (
-    <HoverArea>
+    <HoverArea noHover={true}>
       <Button disabled={true}>
         <NameAndIcon>
           <IconsWrapper>

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
@@ -17,16 +17,21 @@ import {
   Row
 } from '../../shared/style'
 
-export const HoverArea = styled.div<{ isPanel?: boolean }>`
+export const HoverArea = styled.div<{
+  isPanel?: boolean
+  noHover?: boolean
+}>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-direction: row;
   width: 100%;
   padding: 12px ${(p) => (p.isPanel ? 0 : 12)}px;
-  border-radius: 10px;
+  border-radius: var(--hover-area-border-radius);
+  transition: background-color 300ms ease-out;
   &:hover {
-    background-color: ${(p) => p.theme.color.background01}85;
+    background-color: ${(p) =>
+      p.noHover ? 'none' : leo.color.page.background};
   }
 `
 
@@ -131,10 +136,16 @@ export const AssetMenuButtonIcon = styled(Icon).attrs({
 
 export const Wrapper = styled(Column)<{
   showBorder?: boolean
+  isGrouped?: boolean
 }>`
   border-radius: ${(p) => (p.showBorder ? 16 : 0)}px;
   border: ${(p) =>
     p.showBorder ? `1px solid ${leo.color.divider.subtle}` : 'none'};
+  --hover-area-border-radius: ${(p) => (p.isGrouped ? '0px' : '10px')};
+  &:last-child {
+    --hover-area-border-radius: ${(p) =>
+      p.isGrouped ? '0px 0px 10px 10px' : '10px'};
+  }
 `
 
 export const InfoBar = styled(Row)`

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -554,6 +554,7 @@ export const PortfolioOverview = () => {
                 ? '0'
                 : ''
             }
+            isGrouped={selectedGroupAssetsByItem !== NoneGroupByOption.id}
           />
         )}
       />

--- a/components/brave_wallet_ui/components/shared/market-grid/market-grid.style.ts
+++ b/components/brave_wallet_ui/components/shared/market-grid/market-grid.style.ts
@@ -91,8 +91,14 @@ export const GridRow = styled.div<{ templateColumns: string }>`
   display: grid;
   grid-template-columns: ${({ templateColumns }) => templateColumns};
   gap: 5px;
-  padding-top: 16px;
+  margin-top: 16px;
+  padding: 6px;
   cursor: pointer;
+  border-radius: 10px;
+  transition: background-color 300ms ease-out;
+  &:hover {
+    background-color: ${leo.color.page.background};
+  }
 `
 
 export const Cell = styled.div<{


### PR DESCRIPTION
## Description 
- Updates the `Token List` background hover state on the `Portfolio` view
- Adds the same background hover state to the `Market` token list

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37311>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Portfolio` view
2. The `Token List` should have the new background hover state
3. Navigate to the `Market` tab, the list items should have the same background hover state

https://github.com/brave/brave-core/assets/40611140/79b07ab6-a9ec-4dd9-bfeb-90415cc9828c
