### PR TITLE
[iOS] Add support for displaying `brave://flags` from the omnibox (uplift to 1.64.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/flags/BUILD.gn
+++ b/chromium_src/ios/chrome/browser/flags/BUILD.gn
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+group("flags") {
+  deps = [ "//brave/ios/browser/flags" ]
+}

--- a/chromium_src/ios/chrome/browser/flags/DEPS
+++ b/chromium_src/ios/chrome/browser/flags/DEPS
@@ -1,0 +1,3 @@
+include_rules = [
+  "+brave/ios/browser/flags"
+]

--- a/chromium_src/ios/chrome/browser/flags/about_flags.mm
+++ b/chromium_src/ios/chrome/browser/flags/about_flags.mm
@@ -1,0 +1,7 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/flags/about_flags.mm"
+#include "src/ios/chrome/browser/flags/about_flags.mm"

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -228,47 +228,96 @@ extension BrowserViewController: TopToolbarDelegate {
       }
     }
   }
-  
+
   @MainActor private func submitValidURL(_ text: String, isUserDefinedURLNavigation: Bool) async -> Bool {
     if let url = URL(string: text), url.isIPFSScheme {
       return handleIPFSSchemeURL(url)
-    } else if let fixupURL = URIFixup.getURL(text) {
-      // Do not allow users to enter URLs with the following schemes.
-      // Instead, submit them to the search engine like Chrome-iOS does.
-      if !["file"].contains(fixupURL.scheme) {
-        // check text is decentralized DNS supported domain
-        if let decentralizedDNSHelper = self.decentralizedDNSHelperFor(url: fixupURL) {
-          topToolbar.leaveOverlayMode()
-          updateToolbarCurrentURL(fixupURL)
-          topToolbar.locationView.loading = true
-          let result = await decentralizedDNSHelper.lookup(domain: fixupURL.schemelessAbsoluteDisplayString)
-          topToolbar.locationView.loading = tabManager.selectedTab?.loading ?? false
-          guard !Task.isCancelled else { return true } // user pressed stop, or typed new url
-          switch result {
-          case let .loadInterstitial(service):
-            showWeb3ServiceInterstitialPage(service: service, originalURL: fixupURL)
+    }
+
+    if let url = URL(string: text), url.scheme == "brave" {
+      topToolbar.leaveOverlayMode()
+      return handleChromiumWebUIURL(url)
+    }
+
+    guard let fixupURL = URIFixup.getURL(text) else {
+      return false
+    }
+    // Do not allow users to enter URLs with the following schemes.
+    // Instead, submit them to the search engine like Chrome-iOS does.
+    if !["file"].contains(fixupURL.scheme) {
+      // check text is decentralized DNS supported domain
+      if let decentralizedDNSHelper = self.decentralizedDNSHelperFor(url: fixupURL) {
+        topToolbar.leaveOverlayMode()
+        updateToolbarCurrentURL(fixupURL)
+        topToolbar.locationView.loading = true
+        let result = await decentralizedDNSHelper.lookup(
+          domain: fixupURL.schemelessAbsoluteDisplayString
+        )
+        topToolbar.locationView.loading = tabManager.selectedTab?.loading ?? false
+        guard !Task.isCancelled else { return true }  // user pressed stop, or typed new url
+        switch result {
+        case .loadInterstitial(let service):
+          showWeb3ServiceInterstitialPage(service: service, originalURL: fixupURL)
+          return true
+        case .load(let resolvedURL):
+          if resolvedURL.isIPFSScheme {
+            return handleIPFSSchemeURL(resolvedURL)
+          } else {
+            finishEditingAndSubmit(resolvedURL)
             return true
-          case let .load(resolvedURL):
-            if resolvedURL.isIPFSScheme {
-              return handleIPFSSchemeURL(resolvedURL)
-            } else {
-              finishEditingAndSubmit(resolvedURL)
-              return true
-            }
-          case .none:
-            break
           }
+        case .none:
+          break
         }
-        
-        // The user entered a URL, so use it.
-        // Determine if url navigation is done from favourites or bookmarks
-        // To handle bookmarklets properly
-        finishEditingAndSubmit(fixupURL, isUserDefinedURLNavigation: isUserDefinedURLNavigation)
-        return true
       }
     }
-    
-    return false
+
+    // The user entered a URL, so use it.
+    // Determine if url navigation is done from favourites or bookmarks
+    // To handle bookmarklets properly
+    finishEditingAndSubmit(fixupURL, isUserDefinedURLNavigation: isUserDefinedURLNavigation)
+    return true
+  }
+
+  /// Handles displaying a Chromium web view for brave:// url that would display WebUI
+  func handleChromiumWebUIURL(_ url: URL) -> Bool {
+    let supportedPages = [
+      "flags",
+      "histograms",
+      "local-state",
+      "version",
+    ]
+    guard let host = url.host, supportedPages.contains(host) else {
+      return false
+    }
+    let controller = ChromeWebViewController(privateBrowsing: false)
+    controller.loadURL(url.absoluteString)
+    controller.title = url.host
+    if #available(iOS 16.0, *) {
+      let webView = controller.webView
+      webView.isFindInteractionEnabled = true
+      controller.navigationItem.rightBarButtonItem = UIBarButtonItem(
+        systemItem: .search,
+        primaryAction: .init { [weak webView] _ in
+          guard let findInteraction = webView?.findInteraction,
+            !findInteraction.isFindNavigatorVisible
+          else {
+            return
+          }
+          findInteraction.searchText = ""
+          findInteraction.presentFindNavigator(showingReplace: false)
+        }
+      )
+    }
+    let container = UINavigationController(rootViewController: controller)
+    controller.navigationItem.leftBarButtonItem = .init(
+      systemItem: .done,
+      primaryAction: .init { [unowned container] _ in
+        container.dismiss(animated: true)
+      }
+    )
+    self.present(container, animated: true)
+    return true
   }
 
   @discardableResult

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -791,25 +791,12 @@ class SettingsViewController: TableViewController {
               UIPasteboard.general.setSecureString(AppStorageDebugComposer.compose(),
                                                    expirationDate: Date().addingTimeInterval(2.minutes))
             }
-            
-            let viewMoreDetails = UIAlertAction(title: Strings.viewAllVersionInfo, style: .default) { [unowned self, weak actionSheet] _ in
-              let versionController = ChromeWebViewController(privateBrowsing: false).then {
-                $0.loadURL("brave://version/?show-variations-cmd")
-              }
-              versionController.title = version
-
-              actionSheet?.dismiss(
-                animated: true,
-                completion: {
-                  self.navigationController?.pushViewController(versionController, animated: true)
-                }
-              )
-            }
 
             actionSheet.addAction(copyDebugInfoAction)
             actionSheet.addAction(copyAppInfoAction)
-            actionSheet.addAction(viewMoreDetails)
-            actionSheet.addAction(UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil))
+            actionSheet.addAction(
+              UIAlertAction(title: Strings.cancelButtonTitle, style: .cancel, handler: nil)
+            )
             self.navigationController?.present(actionSheet, animated: true, completion: nil)
           }, cellClass: MultilineValue1Cell.self),
         Row(

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -1175,7 +1175,6 @@ extension Strings {
   NSLocalizedString("copyAppSizeInfoToClipboard", tableName: "BraveShared",
                     bundle: .module, value: "Copy app size info to clipboard.",
                     comment: "Copy app info to clipboard action sheet action.")
-  public static let viewAllVersionInfo = NSLocalizedString("viewAllVersionInfo", tableName: "BraveShared", bundle: .module, value: "View all version info.", comment: "View all version info action sheet action.")
   public static let blockThirdPartyCookies = NSLocalizedString("Block3rdPartyCookies", tableName: "BraveShared", bundle: .module, value: "Block 3rd party cookies", comment: "cookie settings option")
   public static let blockAllCookies = NSLocalizedString("BlockAllCookies", tableName: "BraveShared", bundle: .module, value: "Block all Cookies", comment: "Title for setting to block all website cookies.")
   public static let blockAllCookiesAction = NSLocalizedString("BlockAllCookiesAction", tableName: "BraveShared", bundle: .module, value: "Block All", comment: "block all cookies settings action title")

--- a/ios/browser/flags/BUILD.gn
+++ b/ios/browser/flags/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("flags") {
+  sources = [ "about_flags.mm" ]
+  deps = [
+    "//base",
+    "//brave/components/ai_chat/core/common/buildflags",
+    "//brave/components/brave_ads/core",
+    "//brave/components/brave_component_updater/browser",
+    "//brave/components/brave_rewards/common",
+    "//brave/components/brave_rewards/common/buildflags",
+    "//brave/components/brave_wallet/common",
+    "//brave/components/de_amp/common",
+    "//brave/components/debounce/core/common",
+    "//brave/components/ipfs/buildflags",
+    "//brave/components/ntp_background_images/browser",
+    "//brave/components/skus/common",
+    "//components/flags_ui",
+  ]
+}

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -1,0 +1,202 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This file is included into //ios/chrome/browser/flags/about_flags.mm
+
+#include "base/strings/string_util.h"
+#include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_ads/core/public/ads_feature.h"
+#include "brave/components/brave_component_updater/browser/features.h"
+#include "brave/components/brave_rewards/common/buildflags/buildflags.h"
+#include "brave/components/brave_rewards/common/features.h"
+#include "brave/components/brave_wallet/common/features.h"
+#include "brave/components/de_amp/common/features.h"
+#include "brave/components/debounce/core/common/features.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
+#include "brave/components/ntp_background_images/browser/features.h"
+#include "brave/components/skus/common/features.h"
+#include "build/build_config.h"
+#include "components/flags_ui/feature_entry_macros.h"
+#include "components/flags_ui/flags_state.h"
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/components/ai_chat/core/common/features.h"
+#endif
+
+#if BUILDFLAG(ENABLE_IPFS)
+#include "brave/components/ipfs/features.h"
+#endif
+
+#define EXPAND_FEATURE_ENTRIES(...) __VA_ARGS__,
+
+#define BRAVE_SKU_SDK_FEATURE_ENTRIES                   \
+  EXPAND_FEATURE_ENTRIES({                              \
+      "skus-sdk",                                       \
+      "Enable experimental SKU SDK",                    \
+      "Experimental SKU SDK support",                   \
+      flags_ui::kOsIos,                                 \
+      FEATURE_VALUE_TYPE(skus::features::kSkusFeature), \
+  })
+
+#define BRAVE_IPFS_FEATURE_ENTRIES                                   \
+  IF_BUILDFLAG(ENABLE_IPFS,                                          \
+               EXPAND_FEATURE_ENTRIES({                              \
+                   "brave-ipfs",                                     \
+                   "Enable IPFS",                                    \
+                   "Enable native support of IPFS.",                 \
+                   flags_ui::kOsIos,                                 \
+                   FEATURE_VALUE_TYPE(ipfs::features::kIpfsFeature), \
+               }))
+
+#define BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                   \
+  EXPAND_FEATURE_ENTRIES(                                                     \
+      {                                                                       \
+          "enable-nft-pinning",                                               \
+          "Enable NFT pinning",                                               \
+          "Enable NFT pinning for Brave Wallet",                              \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletNftPinningFeature),         \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-zcash",                                               \
+          "Enable BraveWallet ZCash support",                                 \
+          "Zcash support for native Brave Wallet",                            \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletZCashFeature),              \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-bitcoin",                                             \
+          "Enable Brave Wallet Bitcoin support",                              \
+          "Bitcoin support for native Brave Wallet",                          \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletBitcoinFeature),            \
+      },                                                                      \
+      {                                                                       \
+          "brave-wallet-enable-ankr-balances",                                \
+          "Enable Ankr balances",                                             \
+          "Enable usage of Ankr Advanced API for fetching balances in Brave " \
+          "Wallet",                                                           \
+          flags_ui::kOsIos,                                                   \
+          FEATURE_VALUE_TYPE(                                                 \
+              brave_wallet::features::kBraveWalletAnkrBalancesFeature),       \
+      })
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#define BRAVE_AI_CHAT                                          \
+  EXPAND_FEATURE_ENTRIES({                                     \
+      "brave-ai-chat",                                         \
+      "Brave AI Chat",                                         \
+      "Summarize articles and engage in conversation with AI", \
+      flags_ui::kOsIos,                                        \
+      FEATURE_VALUE_TYPE(ai_chat::features::kAIChat),          \
+  })
+#define BRAVE_AI_CHAT_HISTORY                                \
+  EXPAND_FEATURE_ENTRIES({                                   \
+      "brave-ai-chat-history",                               \
+      "Brave AI Chat History",                               \
+      "Enables AI Chat History persistence and management",  \
+      flags_ui::kOsIos,                                      \
+      FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory), \
+  })
+#else
+#define BRAVE_AI_CHAT
+#define BRAVE_AI_CHAT_HISTORY
+#endif
+
+// Keep the last item empty.
+#define LAST_BRAVE_FEATURE_ENTRIES_ITEM
+
+#define BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES                                      \
+  EXPAND_FEATURE_ENTRIES(                                                      \
+      {                                                                        \
+          "use-dev-updater-url",                                               \
+          "Use dev updater url",                                               \
+          "Use the dev url for the component updater. This is for internal "   \
+          "testing only.",                                                     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_component_updater::kUseDevUpdaterUrl),      \
+      },                                                                       \
+      {                                                                        \
+          "brave-ntp-branded-wallpaper-demo",                                  \
+          "New Tab Page Demo Branded Wallpaper",                               \
+          "Force dummy data for the Branded Wallpaper New Tab Page "           \
+          "Experience. View rate and user opt-in conditionals will still be "  \
+          "followed to decide when to display the Branded Wallpaper.",         \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              ntp_background_images::features::kBraveNTPBrandedWallpaperDemo), \
+      },                                                                       \
+      {                                                                        \
+          "brave-debounce",                                                    \
+          "Enable debouncing",                                                 \
+          "Enable support for skipping top-level redirect tracking URLs",      \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(debounce::features::kBraveDebounce),              \
+      },                                                                       \
+      {                                                                        \
+          "brave-de-amp",                                                      \
+          "Enable De-AMP",                                                     \
+          "Enable De-AMPing feature",                                          \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(de_amp::features::kBraveDeAMP),                   \
+      },                                                                       \
+      {                                                                        \
+          "brave-super-referral",                                              \
+          "Enable Brave Super Referral",                                       \
+          "Use custom theme for Brave Super Referral",                         \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(ntp_background_images::features::                 \
+                                 kBraveNTPSuperReferralWallpaper),             \
+      },                                                                       \
+      {                                                                        \
+          "brave-rewards-verbose-logging",                                     \
+          "Enable Brave Rewards verbose logging",                              \
+          "Enables detailed logging of Brave Rewards system events to a log "  \
+          "file stored on your device. Please note that this log file could "  \
+          "include information such as browsing history and credentials such " \
+          "as passwords and access tokens depending on your activity. Please " \
+          "do not share it unless asked to by Brave staff.",                   \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature), \
+      },                                                                       \
+      {                                                                        \
+          "brave-ads-should-always-run-brave-ads-service",                     \
+          "Should always run Brave Ads service",                               \
+          "Always run Brave Ads service to support triggering ad events when " \
+          "Brave Private Ads are disabled.",                                   \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_ads::kShouldAlwaysRunBraveAdsServiceFeature),              \
+      },                                                                       \
+      {                                                                        \
+          "brave-ads-should-always-trigger-new-tab-page-ad-events",            \
+          "Should always trigger new tab page ad events",                      \
+          "Support triggering new tab page ad events if Brave Private Ads "    \
+          "are disabled. Requires "                                            \
+          "#brave-ads-should-always-run-brave-ads-service to be enabled.",     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_ads::kShouldAlwaysTriggerBraveNewTabPageAdEventsFeature),  \
+      },                                                                       \
+      {                                                                        \
+          "brave-ads-should-always-trigger-search-result-ad-events",           \
+          "Should always trigger search result ad events",                     \
+          "Support triggering search result ad events if Brave Private Ads "   \
+          "are disabled. Requires "                                            \
+          "#brave-ads-should-always-run-brave-ads-service to be enabled.",     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_ads::                                                      \
+                  kShouldAlwaysTriggerBraveSearchResultAdEventsFeature),       \
+      })                                                                       \
+  BRAVE_IPFS_FEATURE_ENTRIES                                                   \
+  BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \
+  BRAVE_SKU_SDK_FEATURE_ENTRIES                                                \
+  BRAVE_AI_CHAT                                                                \
+  BRAVE_AI_CHAT_HISTORY                                                        \
+  LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.

--- a/patches/ios-chrome-browser-flags-about_flags.mm.patch
+++ b/patches/ios-chrome-browser-flags-about_flags.mm.patch
@@ -1,0 +1,12 @@
+diff --git a/ios/chrome/browser/flags/about_flags.mm b/ios/chrome/browser/flags/about_flags.mm
+index 6c79c4eda98b1d0e7dd43c4cf2301ae0ccffc21e..9e6d81aa1765779b5b51f5e49a0b17440790e153 100644
+--- a/ios/chrome/browser/flags/about_flags.mm
++++ b/ios/chrome/browser/flags/about_flags.mm
+@@ -778,6 +778,7 @@ const FeatureEntry::FeatureVariation kIOSDockingPromoVariations[] = {
+ //
+ // When adding a new choice, add it to the end of the list.
+ const flags_ui::FeatureEntry kFeatureEntries[] = {
++    BRAVE_ABOUT_FLAGS_FEATURE_ENTRIES
+     {"in-product-help-demo-mode-choice",
+      flag_descriptions::kInProductHelpDemoModeName,
+      flag_descriptions::kInProductHelpDemoModeDescription, flags_ui::kOsIos,


### PR DESCRIPTION
Uplift of #22835
Resolves https://github.com/brave/brave-browser/issues/37149

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.