### PR TITLE
Move newly created tabs after tiles

### DIFF
--- a/browser/ui/tabs/test/split_view_tab_strip_model_adapter_unittest.cc
+++ b/browser/ui/tabs/test/split_view_tab_strip_model_adapter_unittest.cc
@@ -103,7 +103,7 @@ TEST_F(SplitViewTabStripModelAdapterUnitTest, TilingTabsMakesTabsAdjacent) {
 }
 
 TEST_F(SplitViewTabStripModelAdapterUnitTest,
-       OnTabInserted_BreaksTilesWhenInsertedBetweenTile) {
+       OnTabInserted_MoveTabWhenInsertedBetweenTile) {
   // Given that two tabs are tiled
   model().AppendWebContents(CreateWebContents(), /*foreground*/ true);
   model().AppendWebContents(CreateWebContents(), /*foreground*/ true);
@@ -114,12 +114,19 @@ TEST_F(SplitViewTabStripModelAdapterUnitTest,
   ASSERT_TRUE(data().IsTabTiled(tab2));
 
   // When inserting a tab in the middle of the tile,
-  model().InsertWebContentsAt(/*index*/ 1, CreateWebContents(),
+  auto new_contents = CreateWebContents();
+  auto* new_contents_ptr = new_contents.get();
+  model().InsertWebContentsAt(/*index*/ 1, std::move(new_contents),
                               /*add_type*/ 0);
+  base::RunLoop().RunUntilIdle();
 
-  // Then the tile should be broken.
-  EXPECT_FALSE(data().IsTabTiled(tab1));
-  EXPECT_FALSE(data().IsTabTiled(tab2));
+  // Then the tile should stay.
+  EXPECT_TRUE(data().IsTabTiled(tab1));
+  EXPECT_TRUE(data().IsTabTiled(tab2));
+
+  EXPECT_EQ(tab1, model().GetTabHandleAt(0));
+  EXPECT_EQ(tab2, model().GetTabHandleAt(1));
+  EXPECT_EQ(new_contents_ptr, model().GetWebContentsAt(2));
 }
 
 TEST_F(SplitViewTabStripModelAdapterUnitTest, OnTabMoved_MovesTiledTab) {


### PR DESCRIPTION
Opening new tab from split view (the first tab, not the second one), like cmd+click, locates the new tab between new tab and breaks tile. We don't want split view to be closed.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37326

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

