### PR TITLE
Break tile when moved tabs are between tiles

### DIFF
--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -53,8 +53,9 @@ void SplitViewBrowserData::TileTabs(const Tile& tile) {
 
 void SplitViewBrowserData::BreakTile(const tabs::TabHandle& tab) {
   if (auto iter = FindTile(tab); iter != tiles_.end()) {
+    auto tile_to_break = *iter;
     for (auto& observer : observers_) {
-      observer.OnWillBreakTile(*iter);
+      observer.OnWillBreakTile(tile_to_break);
     }
 
     auto index = tile_index_for_tab_[iter->first];
@@ -67,6 +68,10 @@ void SplitViewBrowserData::BreakTile(const tabs::TabHandle& tab) {
     }
 
     tiles_.erase(iter);
+
+    for (auto& observer : observers_) {
+      observer.OnDidBreakTile(tile_to_break);
+    }
   } else {
     NOTREACHED() << "Tile doesn't exist";
   }

--- a/browser/ui/tabs/split_view_browser_data.h
+++ b/browser/ui/tabs/split_view_browser_data.h
@@ -58,7 +58,7 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
 
     base::WeakPtr<SplitViewBrowserData> data_;
 
-    std::unique_ptr<base::ScopedClosureRunner> closure_;
+    base::ScopedClosureRunner closure_;
   };
   [[nodiscard]] OnTabDragEndedClosure TabDragStarted();
 

--- a/browser/ui/tabs/split_view_browser_data.h
+++ b/browser/ui/tabs/split_view_browser_data.h
@@ -11,6 +11,9 @@
 #include <utility>
 #include <vector>
 
+#include "base/functional/callback_forward.h"
+#include "base/functional/callback_helpers.h"
+#include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
 #include "chrome/browser/ui/browser_user_data.h"
 #include "chrome/browser/ui/tabs/tab_model.h"
@@ -39,6 +42,26 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
   void AddObserver(SplitViewBrowserDataObserver* observer);
   void RemoveObserver(SplitViewBrowserDataObserver* observer);
 
+  class OnTabDragEndedClosure {
+   public:
+    OnTabDragEndedClosure();
+    OnTabDragEndedClosure(base::WeakPtr<SplitViewBrowserData> data,
+                          base::OnceClosure closure);
+    OnTabDragEndedClosure(OnTabDragEndedClosure&& other) noexcept;
+    OnTabDragEndedClosure& operator=(OnTabDragEndedClosure&& other) noexcept;
+    ~OnTabDragEndedClosure();
+
+    void RunAndReset();
+
+   private:
+    void RunCurrentClosureIfNeededAndReplaceWith(OnTabDragEndedClosure&& other);
+
+    base::WeakPtr<SplitViewBrowserData> data_;
+
+    std::unique_ptr<base::ScopedClosureRunner> closure_;
+  };
+  [[nodiscard]] OnTabDragEndedClosure TabDragStarted();
+
  private:
   friend BrowserUserData;
   friend class SplitViewBrowserDataUnitTest;
@@ -66,6 +89,8 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
   base::ObserverList<SplitViewBrowserDataObserver> observers_;
 
   bool is_testing_ = false;
+
+  base::WeakPtrFactory<SplitViewBrowserData> weak_ptr_factory_{this};
 
   BROWSER_USER_DATA_KEY_DECL();
 };

--- a/browser/ui/tabs/split_view_browser_data_observer.h
+++ b/browser/ui/tabs/split_view_browser_data_observer.h
@@ -11,8 +11,9 @@
 
 class SplitViewBrowserDataObserver : public base::CheckedObserver {
  public:
-  virtual void OnTileTabs(const SplitViewBrowserData::Tile& tile) = 0;
-  virtual void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) = 0;
+  virtual void OnTileTabs(const SplitViewBrowserData::Tile& tile) {}
+  virtual void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) {}
+  virtual void OnDidBreakTile(const SplitViewBrowserData::Tile& tile) {}
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_SPLIT_VIEW_BROWSER_DATA_OBSERVER_H_

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -6,11 +6,13 @@
 #include "brave/browser/ui/tabs/split_view_tab_strip_model_adapter.h"
 
 #include "base/memory/weak_ptr.h"
+#include "base/ranges/algorithm.h"
 #include "base/task/sequenced_task_runner.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "chrome/browser/ui/tabs/tab_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "components/tab_groups/tab_group_id.h"
+#include "ui/gfx/range/range.h"
 
 SplitViewTabStripModelAdapter::SplitViewTabStripModelAdapter(
     SplitViewBrowserData& split_view_browser_data,
@@ -40,6 +42,41 @@ void SplitViewTabStripModelAdapter::MakeTiledTabsAdjacent(
   } else {
     model_->MoveWebContentsAt(index1, index2 - 1, /*select_after_move*/ false);
   }
+}
+
+void SplitViewTabStripModelAdapter::TabDragStarted() {
+  if (split_view_browser_data_->tiles().empty() || is_in_tab_dragging()) {
+    return;
+  }
+
+  is_in_tab_dragging_ = true;
+}
+
+void SplitViewTabStripModelAdapter::TabDragEnded() {
+  if (split_view_browser_data_->tiles().empty() || !is_in_tab_dragging()) {
+    return;
+  }
+
+  // Check if any tiles are separated after drag and drop session. Then break
+  // the tiles.
+  std::vector<SplitViewBrowserData::Tile> tiles_to_break;
+  for (const auto& tile : split_view_browser_data_->tiles()) {
+    auto [tab1, tab2] = tile;
+    int index1 = model_->GetIndexOfTab(tab1);
+    int index2 = model_->GetIndexOfTab(tab2);
+    if (index2 - index1 == 1) {
+      return;
+    }
+
+    tiles_to_break.push_back(tile);
+  }
+
+  while (!tiles_to_break.empty()) {
+    split_view_browser_data_->BreakTile(tiles_to_break.back().first);
+    tiles_to_break.pop_back();
+  }
+
+  is_in_tab_dragging_ = false;
 }
 
 void SplitViewTabStripModelAdapter::OnTabStripModelChanged(
@@ -125,9 +162,6 @@ void SplitViewTabStripModelAdapter::OnTabMoved(
       FROM_HERE,
       base::BindOnce(&SplitViewTabStripModelAdapter::MakeTiledTabsAdjacent,
                      weak_ptr_factory_.GetWeakPtr(), *tile, move_right_tab));
-
-  // TODO(sko) We should make sure that tab isn't moved between tiled tabs.
-  // Or we should break the tile when it happens.
 }
 
 void SplitViewTabStripModelAdapter::OnTabWillBeRemoved(

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -12,7 +12,6 @@
 #include "chrome/browser/ui/tabs/tab_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "components/tab_groups/tab_group_id.h"
-#include "ui/gfx/range/range.h"
 
 SplitViewTabStripModelAdapter::SplitViewTabStripModelAdapter(
     SplitViewBrowserData& split_view_browser_data,
@@ -53,10 +52,6 @@ void SplitViewTabStripModelAdapter::TabDragStarted() {
 }
 
 void SplitViewTabStripModelAdapter::TabDragEnded() {
-  if (split_view_browser_data_->tiles().empty() || !is_in_tab_dragging()) {
-    return;
-  }
-
   // Check if any tiles are separated after drag and drop session. Then break
   // the tiles.
   std::vector<SplitViewBrowserData::Tile> tiles_to_break;

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.h
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.h
@@ -25,6 +25,10 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
   void MakeTiledTabsAdjacent(const SplitViewBrowserData::Tile& tile,
                              bool move_right_tab = true);
 
+  void TabDragStarted();
+  void TabDragEnded();
+  bool is_in_tab_dragging() const { return is_in_tab_dragging_; }
+
   // TabStripModelObserver:
   void OnTabStripModelChanged(
       TabStripModel* tab_strip_model,
@@ -51,6 +55,8 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
 
   raw_ref<SplitViewBrowserData> split_view_browser_data_;  // owner
   raw_ref<TabStripModel> model_;
+
+  bool is_in_tab_dragging_ = false;
 
   base::WeakPtrFactory<SplitViewTabStripModelAdapter> weak_ptr_factory_{this};
 };

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -99,6 +99,15 @@ base::OnceClosure BraveTabContainer::LockLayout() {
                         base::Unretained(this));
 }
 
+void BraveTabContainer::AddedToWidget() {
+  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+    auto* split_view_data = SplitViewBrowserData::FromBrowser(
+        const_cast<Browser*>(tab_slot_controller_->GetBrowser()));
+    CHECK(split_view_data);
+    split_view_data_observation_.Observe(split_view_data);
+  }
+}
+
 gfx::Size BraveTabContainer::CalculatePreferredSize() const {
   // Note that we check this before checking currently we're in vertical tab
   // strip mode. We might be in the middle of changing orientation.
@@ -493,6 +502,14 @@ void BraveTabContainer::HandleDragExited() {
     return;
   }
   SetDropArrow({});
+}
+
+void BraveTabContainer::OnTileTabs(const SplitViewBrowserData::Tile& tile) {
+  SchedulePaint();
+}
+
+void BraveTabContainer::OnDidBreakTile(const SplitViewBrowserData::Tile& tile) {
+  SchedulePaint();
 }
 
 gfx::Rect BraveTabContainer::GetDropBounds(int drop_index,

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -10,12 +10,14 @@
 #include <optional>
 
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
+#include "brave/browser/ui/tabs/split_view_browser_data_observer.h"
 #include "chrome/browser/ui/tabs/tab_style.h"
 #include "chrome/browser/ui/views/tabs/tab_container_impl.h"
 #include "chrome/browser/ui/views/tabs/tab_drag_context.h"
 #include "ui/gfx/canvas.h"
 
-class BraveTabContainer : public TabContainerImpl {
+class BraveTabContainer : public TabContainerImpl,
+                          public SplitViewBrowserDataObserver {
   METADATA_HEADER(BraveTabContainer, TabContainerImpl)
  public:
 
@@ -34,6 +36,7 @@ class BraveTabContainer : public TabContainerImpl {
   base::OnceClosure LockLayout();
 
   // TabContainerImpl:
+  void AddedToWidget() override;
   gfx::Size CalculatePreferredSize() const override;
   void UpdateClosingModeOnRemovedTab(int model_index, bool was_active) override;
   gfx::Rect GetTargetBoundsForClosingTab(Tab* tab,
@@ -53,6 +56,10 @@ class BraveTabContainer : public TabContainerImpl {
   void HandleDragUpdate(
       const std::optional<BrowserRootView::DropIndex>& index) override;
   void HandleDragExited() override;
+
+  // SplitViewBrowserDataObserver:
+  void OnTileTabs(const SplitViewBrowserData::Tile& tile) override;
+  void OnDidBreakTile(const SplitViewBrowserData::Tile& tile) override;
 
  private:
   class DropArrow : public views::WidgetObserver {
@@ -129,6 +136,9 @@ class BraveTabContainer : public TabContainerImpl {
   BooleanPrefMember vertical_tabs_collapsed_;
 
   bool layout_locked_ = false;
+
+  base::ScopedObservation<SplitViewBrowserData, SplitViewBrowserDataObserver>
+      split_view_data_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_CONTAINER_H_

--- a/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/tab_drag_controller.cc
@@ -336,8 +336,15 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
     return TabDragControllerChromium::ContinueDragging(point_in_screen);
   }
 
+  auto weak = weak_factory_.GetWeakPtr();
   const auto liveness =
       TabDragControllerChromium::ContinueDragging(point_in_screen);
+
+  if (!weak) {
+    // In DragBrowserToNewTabStrip() could delete itself, so we need to check
+    // it's still alive first.
+    return liveness;
+  }
 
   if (!attached_context_) {
     // This is when drag session ends.

--- a/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/tab_drag_controller.cc
@@ -9,13 +9,16 @@
 #include <set>
 #include <utility>
 
+#include "base/feature_list.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/tabs/tab_group.h"
 #include "chrome/browser/ui/tabs/tab_group_model.h"
+#include "chrome/browser/ui/views/tabs/tab_drag_context.h"
 #include "chrome/browser/ui/views/tabs/window_finder.h"
 #include "ui/views/view_utils.h"
 
@@ -325,6 +328,39 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
   }
 
   return bounds;
+}
+
+[[nodiscard]] TabDragController::Liveness TabDragController::ContinueDragging(
+    const gfx::Point& point_in_screen) {
+  if (!base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+    return TabDragControllerChromium::ContinueDragging(point_in_screen);
+  }
+
+  const auto liveness =
+      TabDragControllerChromium::ContinueDragging(point_in_screen);
+
+  if (!attached_context_) {
+    // This is when drag session ends.
+    on_tab_drag_ended_closure_.RunAndReset();
+    return liveness;
+  }
+
+  auto* browser_widget = GetAttachedBrowserWidget();
+  auto* browser = BrowserView::GetBrowserViewForNativeWindow(
+                      browser_widget->GetNativeWindow())
+                      ->browser();
+  SplitViewBrowserData* split_view_browser_data =
+      SplitViewBrowserData::FromBrowser(browser);
+  const bool is_dragging_tabs = current_state_ == DragState::kDraggingTabs;
+  if (is_dragging_tabs) {
+    on_tab_drag_ended_closure_ = split_view_browser_data->TabDragStarted();
+  } else {
+    // This is a case where tabs are detached into new window and enters.
+    // Notifies that drag session ended to the old browser.
+    on_tab_drag_ended_closure_.RunAndReset();
+  }
+
+  return liveness;
 }
 
 gfx::Vector2d TabDragController::GetVerticalTabStripWidgetOffset() {

--- a/browser/ui/views/tabs/tab_drag_controller.h
+++ b/browser/ui/views/tabs/tab_drag_controller.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <vector>
 
+#include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "chrome/browser/ui/views/tabs/tab_drag_controller.h"
 
@@ -52,6 +53,8 @@ class TabDragController : public TabDragControllerChromium {
       TabDragContext* source,
       const gfx::Point& point_in_screen,
       std::vector<gfx::Rect>* drag_bounds) override;
+  [[nodiscard]] Liveness ContinueDragging(
+      const gfx::Point& point_in_screen) override;
 
   void InitDragData(TabSlotView* view, TabDragData* drag_data) override;
 
@@ -61,6 +64,8 @@ class TabDragController : public TabDragControllerChromium {
   bool is_showing_vertical_tabs_ = false;
 
   VerticalTabStripRegionView::ScopedStateResetter vertical_tab_state_resetter_;
+
+  SplitViewBrowserData::OnTabDragEndedClosure on_tab_drag_ended_closure_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_TAB_DRAG_CONTROLLER_H_

--- a/browser/ui/views/tabs/tab_drag_controller.h
+++ b/browser/ui/views/tabs/tab_drag_controller.h
@@ -66,6 +66,8 @@ class TabDragController : public TabDragControllerChromium {
   VerticalTabStripRegionView::ScopedStateResetter vertical_tab_state_resetter_;
 
   SplitViewBrowserData::OnTabDragEndedClosure on_tab_drag_ended_closure_;
+
+  base::WeakPtrFactory<TabDragController> weak_factory_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_TABS_TAB_DRAG_CONTROLLER_H_

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_drag_controller.h
@@ -31,10 +31,11 @@ using TabDragControllerBrave = TabDragController;
 #define CalculateNonMaximizedDraggedBrowserBounds \
   virtual CalculateNonMaximizedDraggedBrowserBounds
 #define CalculateDraggedBrowserBounds virtual CalculateDraggedBrowserBounds
+#define ContinueDragging virtual ContinueDragging
 
 #include "src/chrome/browser/ui/views/tabs/tab_drag_controller.h"  // IWYU pragma: export
 
-#undef InitDragData
+#undef ContinueDragging
 #undef CalculateDraggedBrowserBounds
 #undef CalculateNonMaximizedDraggedBrowserBounds
 #undef DetachAndAttachToNewContext


### PR DESCRIPTION
When dragging a tab and drop it between two tabs in a tile, it doesn't break the tile. This makes things awkward. We should break the tile.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37328

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

