### PR TITLE
Shows Leo auto suggestions on Android regardless the global autocomplete switch

### DIFF
--- a/android/java/org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteMediator.java
+++ b/android/java/org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteMediator.java
@@ -70,17 +70,6 @@ class BraveAutocompleteMediator extends AutocompleteMediator
     }
 
     @Override
-    public void onTextChanged(String textWithoutAutocomplete) {
-        if (ProfileManager.isInitialized()
-                && !UserPrefs.get(Profile.getLastUsedRegularProfile())
-                            .getBoolean(AUTOCOMPLETE_ENABLED)) {
-            return;
-        }
-
-        super.onTextChanged(textWithoutAutocomplete);
-    }
-
-    @Override
     public void onOmniboxSessionStateChange(boolean activated) {
         if (!mNativeInitialized) return;
 
@@ -107,6 +96,17 @@ class BraveAutocompleteMediator extends AutocompleteMediator
             }
         }
         super.initDefaultProcessors();
+    }
+
+    @Override
+    public boolean isAutoCompleteEnabled(WebContents webContents) {
+        if (ProfileManager.isInitialized()
+                && !UserPrefs.get(Profile.fromWebContents(webContents))
+                        .getBoolean(AUTOCOMPLETE_ENABLED)) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveDropdownItemViewInfoListBuilder.java
@@ -123,6 +123,17 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
         List<DropdownItemViewInfo> viewInfoList =
                 super.buildDropdownViewInfoList(autocompleteResult);
 
+        // We want to show Leo auto suggestion even if the whole auto complete feature
+        // is disabled
+        Tab tab = mActivityTabSupplier.get();
+        boolean autocompleteEnabled =
+                tab != null
+                        ? mLeoAutocompleteDelegate.isAutoCompleteEnabled(tab.getWebContents())
+                        : true;
+        if (!autocompleteEnabled) {
+            viewInfoList.clear();
+        }
+
         if (isBraveLeoEnabled()
                 && !mUrlBarEditingTextProvider.getTextWithoutAutocomplete().isEmpty()) {
             final PropertyModel leoModel = mBraveLeoSuggestionProcessor.createModel();
@@ -148,11 +159,12 @@ class BraveDropdownItemViewInfoListBuilder extends DropdownItemViewInfoListBuild
                     tileNavSuggestPosition,
                     new DropdownItemViewInfo(mBraveLeoSuggestionProcessor, leoModel, config));
         }
-        if (isBraveSearchPromoBanner()) {
+        if (isBraveSearchPromoBanner() && autocompleteEnabled) {
             final PropertyModel model = mBraveSearchBannerProcessor.createModel();
             mBraveSearchBannerProcessor.populateModel(model);
-            viewInfoList.add(new DropdownItemViewInfo(
-                    mBraveSearchBannerProcessor, model, GroupConfig.getDefaultInstance()));
+            viewInfoList.add(
+                    new DropdownItemViewInfo(
+                            mBraveSearchBannerProcessor, model, GroupConfig.getDefaultInstance()));
         }
 
         return viewInfoList;

--- a/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveLeoAutocompleteDelegate.java
+++ b/browser/ui/android/omnibox/java/src/org/chromium/chrome/browser/omnibox/suggestions/BraveLeoAutocompleteDelegate.java
@@ -13,5 +13,7 @@ import org.chromium.content_public.browser.WebContents;
 public interface BraveLeoAutocompleteDelegate {
     boolean isLeoEnabled();
 
+    boolean isAutoCompleteEnabled(WebContents webContents);
+
     void openLeoQuery(WebContents webContents, String query);
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36294
Resolves https://github.com/brave/brave-browser/issues/36542

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
As discussed in the issue we want to show Leo auto suggestions regardless top level autocomplete switch.
1. Make sure that Leo auto suggestions are visible by default
2. Go to `Settings->Brave Shields & privacy`
3. Turn off `Show autocomplete in address bar`
4. Go to the URL bar and start typing something
5. Make sure Leo auto suggestions are still visible
