### PR TITLE
Fix layering violation in greaslion

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -16,7 +16,6 @@
 #include "brave/components/brave_sync/features.h"
 #include "brave/components/constants/brave_constants.h"
 #include "brave/components/constants/pref_names.h"
-#include "brave/components/greaselion/browser/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "brave/components/translate/core/common/brave_translate_features.h"
@@ -65,43 +64,10 @@
 #include "chrome/browser/browser_process.h"
 #endif
 
-#if BUILDFLAG(ENABLE_GREASELION)
-#include "brave/browser/greaselion/greaselion_service_factory.h"
-#include "brave/components/greaselion/browser/greaselion_service.h"
-#endif
-
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED) && BUILDFLAG(ENABLE_EXTENSIONS)
 #include "brave/browser/extensions/brave_component_loader.h"
 #include "chrome/browser/extensions/extension_service.h"
 #include "extensions/browser/extension_system.h"
-#endif
-
-#if BUILDFLAG(ENABLE_GREASELION)
-namespace {
-
-class GreaselionServiceDelegateImpl
-    : public greaselion::GreaselionService::Delegate {
- public:
-  explicit GreaselionServiceDelegateImpl(
-      extensions::ExtensionService* extension_service)
-      : extension_service_(extension_service) {
-    DCHECK(extension_service_);
-  }
-
-  void AddExtension(extensions::Extension* extension) override {
-    extension_service_->AddExtension(extension);
-  }
-
-  void UnloadExtension(const std::string& extension_id) override {
-    extension_service_->UnloadExtension(
-        extension_id, extensions::UnloadedExtensionReason::UPDATE);
-  }
-
- private:
-  raw_ptr<extensions::ExtensionService> extension_service_;  // Not owned
-};
-
-}  // namespace
 #endif
 
 void BraveBrowserMainParts::PreBrowserStart() {
@@ -217,17 +183,6 @@ void BraveBrowserMainParts::PostProfileInit(Profile* profile,
     content::RenderFrameHost::AllowInjectingJavaScript();
     auto* command_line = base::CommandLine::ForCurrentProcess();
     command_line->AppendSwitch(switches::kDisableBackgroundMediaSuspend);
-  }
-#endif
-
-#if BUILDFLAG(ENABLE_GREASELION)
-  if (auto* greaselion_service =
-          greaselion::GreaselionServiceFactory::GetForBrowserContext(profile)) {
-    extensions::ExtensionService* extension_service =
-        extensions::ExtensionSystem::Get(profile)->extension_service();
-    DCHECK(extension_service);
-    greaselion_service->SetDelegate(
-        std::make_unique<GreaselionServiceDelegateImpl>(extension_service));
   }
 #endif
 

--- a/components/greaselion/browser/BUILD.gn
+++ b/components/greaselion/browser/BUILD.gn
@@ -1,3 +1,8 @@
+# Copyright (c) 2019 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 import("//brave/build/config.gni")
 
 static_library("browser") {
@@ -15,13 +20,13 @@ static_library("browser") {
     "//brave/components/brave_component_updater/browser",
     "//brave/components/update_client:buildflags",
     "//brave/components/version_info",
-    "//chrome/browser/extensions:extensions",
     "//components/version_info",
     "//content/public/browser",
     "//content/public/common",
     "//crypto",
     "//extensions/browser",
     "//extensions/common",
+    "//extensions/common/api",
     "//third_party/abseil-cpp:absl",
     "//url",
   ]

--- a/components/greaselion/browser/DEPS
+++ b/components/greaselion/browser/DEPS
@@ -4,10 +4,3 @@ include_rules = [
   "+extensions/browser",
   "+extensions/common",
 ]
-
-# Existing exceptions
-specific_include_rules = {
-  "greaselion_service_impl.cc": [
-    "+chrome/browser/extensions/extension_service.h",
-  ],
-}

--- a/components/greaselion/browser/greaselion_service.h
+++ b/components/greaselion/browser/greaselion_service.h
@@ -1,12 +1,13 @@
 /* Copyright (c) 2019 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_GREASELION_BROWSER_GREASELION_SERVICE_H_
 #define BRAVE_COMPONENTS_GREASELION_BROWSER_GREASELION_SERVICE_H_
 
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -20,10 +21,6 @@ class GreaselionServiceTest;
 
 namespace base {
 class Version;
-}
-
-namespace extensions {
-class ExtensionService;
 }
 
 namespace greaselion {
@@ -42,6 +39,13 @@ typedef std::map<GreaselionFeature, bool> GreaselionFeatures;
 class GreaselionService : public KeyedService,
                           public extensions::ExtensionRegistryObserver {
  public:
+  class Delegate {
+   public:
+    virtual ~Delegate() = default;
+    virtual void AddExtension(extensions::Extension* extension) = 0;
+    virtual void UnloadExtension(const std::string& extension_id) = 0;
+  };
+
   GreaselionService() = default;
   GreaselionService(const GreaselionService&) = delete;
   GreaselionService& operator=(const GreaselionService&) = delete;
@@ -49,8 +53,7 @@ class GreaselionService : public KeyedService,
   // KeyedService
   void Shutdown() override {}
 
-  virtual void SetExtensionService(
-      extensions::ExtensionService* extension_service) = 0;
+  virtual void SetDelegate(std::unique_ptr<Delegate> delegate) = 0;
   virtual void SetFeatureEnabled(GreaselionFeature feature, bool enabled) = 0;
   virtual void UpdateInstalledExtensions() = 0;
   virtual bool IsGreaselionExtension(const std::string& id) = 0;

--- a/components/greaselion/browser/greaselion_service.h
+++ b/components/greaselion/browser/greaselion_service.h
@@ -53,7 +53,6 @@ class GreaselionService : public KeyedService,
   // KeyedService
   void Shutdown() override {}
 
-  virtual void SetDelegate(std::unique_ptr<Delegate> delegate) = 0;
   virtual void SetFeatureEnabled(GreaselionFeature feature, bool enabled) = 0;
   virtual void UpdateInstalledExtensions() = 0;
   virtual bool IsGreaselionExtension(const std::string& id) = 0;

--- a/components/greaselion/browser/greaselion_service_impl.h
+++ b/components/greaselion/browser/greaselion_service_impl.h
@@ -1,11 +1,12 @@
-/* Copyright 2016 The Brave Authors. All rights reserved.
+/* Copyright (c) 2016 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at http://mozilla.org/MPL/2.0/. */
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #ifndef BRAVE_COMPONENTS_GREASELION_BROWSER_GREASELION_SERVICE_IMPL_H_
 #define BRAVE_COMPONENTS_GREASELION_BROWSER_GREASELION_SERVICE_IMPL_H_
 
+#include <memory>
 #include <optional>
 #include <string>
 #include <utility>
@@ -27,7 +28,6 @@ class SequencedTaskRunner;
 namespace extensions {
 class Extension;
 class ExtensionRegistry;
-class ExtensionService;
 class ExtensionSystem;
 }  // namespace extensions
 
@@ -50,8 +50,7 @@ class GreaselionServiceImpl : public GreaselionService,
   void Shutdown() override;
 
   // GreaselionService overrides
-  void SetExtensionService(
-      extensions::ExtensionService* extension_service) override;
+  void SetDelegate(std::unique_ptr<Delegate> delegate) override;
   void SetFeatureEnabled(GreaselionFeature feature, bool enabled) override;
   void UpdateInstalledExtensions() override;
   bool IsGreaselionExtension(const std::string& id) override;
@@ -98,8 +97,7 @@ class GreaselionServiceImpl : public GreaselionService,
   std::vector<extensions::ExtensionId> greaselion_extensions_;
   std::vector<base::FilePath> extension_dirs_;
   base::Version browser_version_;
-  raw_ptr<extensions::ExtensionService> extension_service_ =
-      nullptr;  // NOT OWNED
+  std::unique_ptr<Delegate> delegate_;
   base::WeakPtrFactory<GreaselionServiceImpl> weak_factory_;
 };
 

--- a/components/greaselion/browser/greaselion_service_impl.h
+++ b/components/greaselion/browser/greaselion_service_impl.h
@@ -41,7 +41,8 @@ class GreaselionServiceImpl : public GreaselionService,
       const base::FilePath& install_directory,
       extensions::ExtensionSystem* extension_system,
       extensions::ExtensionRegistry* extension_registry,
-      scoped_refptr<base::SequencedTaskRunner> task_runner);
+      scoped_refptr<base::SequencedTaskRunner> task_runner,
+      std::unique_ptr<Delegate> delegate);
   GreaselionServiceImpl(const GreaselionServiceImpl&) = delete;
   GreaselionServiceImpl& operator=(const GreaselionServiceImpl&) = delete;
   ~GreaselionServiceImpl() override;
@@ -50,7 +51,6 @@ class GreaselionServiceImpl : public GreaselionService,
   void Shutdown() override;
 
   // GreaselionService overrides
-  void SetDelegate(std::unique_ptr<Delegate> delegate) override;
   void SetFeatureEnabled(GreaselionFeature feature, bool enabled) override;
   void UpdateInstalledExtensions() override;
   bool IsGreaselionExtension(const std::string& id) override;


### PR DESCRIPTION
`components` shouldn't depend on `chrome` layer directly. There's no intended behavior change.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37349

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

