### PR TITLE
Fixed wallet button visibility regressions

### DIFF
--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -8,6 +8,7 @@
 #include "base/no_destructor.h"
 #include "brave/browser/ui/bookmark/brave_bookmark_prefs.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
 #include "brave/components/constants/pref_names.h"
 #include "build/build_config.h"
 #include "chrome/common/pref_names.h"
@@ -30,6 +31,7 @@ const std::vector<const char*>& GetBravePersistentPrefNames() {
   static base::NoDestructor<std::vector<const char*>> brave_allowlist({
       kBraveAutofillPrivateWindows,
 #if !BUILDFLAG(IS_ANDROID)
+      kShowWalletIconOnToolbar,
       prefs::kSidePanelHorizontalAlignment,
       kTabMuteIndicatorNotClickable,
       brave_tabs::kVerticalTabsExpandedWidth,

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -46,7 +46,6 @@ class BraveToolbarView : public ToolbarView,
   void OnEditBookmarksEnabledChanged();
   void OnLocationBarIsWideChanged();
   void OnShowBookmarksButtonChanged();
-  void OnShowWalletButtonChanged();
   void ShowBookmarkBubble(const GURL& url, bool already_bookmarked) override;
   void ViewHierarchyChanged(
       const views::ViewHierarchyChangedDetails& details) override;
@@ -61,6 +60,8 @@ class BraveToolbarView : public ToolbarView,
   void OnProfileAdded(const base::FilePath& profile_path) override;
   void OnProfileWasRemoved(const base::FilePath& profile_path,
                            const std::u16string& profile_name) override;
+
+  void UpdateWalletButtonVisibility();
 
   raw_ptr<BraveBookmarkButton> bookmark_ = nullptr;
   // Tracks the preference to determine whether bookmark editing is allowed.
@@ -77,6 +78,7 @@ class BraveToolbarView : public ToolbarView,
   BooleanPrefMember show_bookmarks_button_;
 
   BooleanPrefMember show_wallet_button_;
+  BooleanPrefMember wallet_private_window_enabled_;
 
   BooleanPrefMember location_bar_is_wide_;
 

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -244,17 +244,35 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
 IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
                        WalletButtonCanBeToggledWithPrefInPrivateTabs) {
   auto* incognito_browser = CreateIncognitoBrowser(browser()->profile());
-  auto* prefs = incognito_browser->profile()->GetPrefs();
+  auto* incognito_prefs = incognito_browser->profile()->GetPrefs();
+  auto* normal_prefs = browser()->profile()->GetPrefs();
 
-  // By default, the button should be shown.
-  EXPECT_FALSE(prefs->GetBoolean(kBraveWalletPrivateWindowsEnabled));
+  // By default, the button in normal window should be shown.
+  EXPECT_TRUE(is_wallet_button_shown(browser()));
+
+  // By default, the button in private window should be hidden.
+  EXPECT_FALSE(incognito_prefs->GetBoolean(kBraveWalletPrivateWindowsEnabled));
   EXPECT_FALSE(is_wallet_button_shown(incognito_browser));
 
-  // Turn on brave wallet in private tabs should reveal the button.
-  prefs->SetBoolean(kBraveWalletPrivateWindowsEnabled, true);
+  // Turn on brave wallet in private tabs should reveal the button in private
+  // window.
+  incognito_prefs->SetBoolean(kBraveWalletPrivateWindowsEnabled, true);
+  EXPECT_TRUE(is_wallet_button_shown(incognito_browser));
+
+  // Turning off wallet icon should hide icon on both windows.
+  normal_prefs->SetBoolean(kShowWalletIconOnToolbar, false);
+  EXPECT_FALSE(is_wallet_button_shown(browser()));
+  EXPECT_FALSE(is_wallet_button_shown(incognito_browser));
+
+  // Turn on wallet icon should show icons on both windows.
+  incognito_prefs->SetBoolean(kShowWalletIconOnToolbar, true);
+  EXPECT_TRUE(is_wallet_button_shown(browser()));
   EXPECT_TRUE(is_wallet_button_shown(incognito_browser));
 
   // Turning off brave wallet in private tabs should hide it again.
-  prefs->SetBoolean(kBraveWalletPrivateWindowsEnabled, false);
+  incognito_prefs->SetBoolean(kBraveWalletPrivateWindowsEnabled, false);
   EXPECT_FALSE(is_wallet_button_shown(incognito_browser));
+
+  // Normal winwow still has visible button.
+  EXPECT_TRUE(is_wallet_button_shown(browser()));
 }

--- a/browser/ui/views/toolbar/wallet_button.cc
+++ b/browser/ui/views/toolbar/wallet_button.cc
@@ -129,11 +129,6 @@ WalletButton::WalletButton(View* backup_anchor_view, Profile* profile)
                    // already shows a panel on click
       prefs_(profile->GetPrefs()),
       backup_anchor_view_(backup_anchor_view) {
-  pref_change_registrar_.Init(prefs_);
-  pref_change_registrar_.Add(
-      kShowWalletIconOnToolbar,
-      base::BindRepeating(&WalletButton::OnPreferenceChanged,
-                          base::Unretained(this)));
   SetTooltipText(
       brave_l10n::GetLocalizedResourceUTF16String(IDS_TOOLTIP_WALLET));
 
@@ -146,8 +141,6 @@ WalletButton::WalletButton(View* backup_anchor_view, Profile* profile)
       std::make_unique<views::Button::DefaultButtonControllerDelegate>(this));
   menu_button_controller_ = menu_button_controller.get();
   SetButtonController(std::move(menu_button_controller));
-
-  UpdateVisibility();
 
   notification_source_ =
       std::make_unique<brave::WalletButtonNotificationSource>(
@@ -243,14 +236,6 @@ void WalletButton::UpdateImageAndText(bool activated) {
   SetImageModel(views::Button::STATE_NORMAL,
                 ui::ImageModel::FromImageSkia(
                     gfx::ImageSkia(std::move(image_source), preferred_size)));
-}
-
-void WalletButton::UpdateVisibility() {
-  SetVisible(prefs_->GetBoolean(kShowWalletIconOnToolbar));
-}
-
-void WalletButton ::OnPreferenceChanged() {
-  UpdateVisibility();
 }
 
 void WalletButton::ShowWalletBubble() {

--- a/browser/ui/views/toolbar/wallet_button.h
+++ b/browser/ui/views/toolbar/wallet_button.h
@@ -15,7 +15,6 @@
 #include "base/time/time.h"
 #include "brave/browser/ui/views/toolbar/wallet_button_notification_source.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_button.h"
-#include "components/prefs/pref_change_registrar.h"
 #include "content/public/browser/browser_context.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/controls/button/menu_button_controller.h"
@@ -39,14 +38,12 @@ class WalletButton : public ToolbarButton {
   bool IsBubbleClosedForTesting();
 
   void UpdateImageAndText(bool activated = false);
-  void UpdateVisibility();
 
   views::View* GetAsAnchorView();
 
  private:
   void AddedToWidget() override;
   std::string GetBadgeText();
-  void OnPreferenceChanged();
   void OnWalletPressed(const ui::Event& event);
   void OnNotificationUpdate(bool show_suggest_badge, size_t counter);
 
@@ -57,7 +54,6 @@ class WalletButton : public ToolbarButton {
   raw_ptr<PrefService> prefs_ = nullptr;
   raw_ptr<views::MenuButtonController> menu_button_controller_ = nullptr;
   raw_ptr<views::View> backup_anchor_view_ = nullptr;
-  PrefChangeRegistrar pref_change_registrar_;
 
   std::unique_ptr<brave::WalletButtonNotificationSource> notification_source_;
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/37367

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveToolbarViewTest.WalletButtonCanBeToggledWithPrefInPrivateTabs`

1. Launch brave with clean profile and check wallet button is visible
2. Open private window and check wallet button is hidden
3. Enable wallet in private window from brave://settings/web3
4. Check private window has visible wallet button
5. Hide wallet button from its context menu in private window
6. Check wallet button is hidden in normal/private window
7. Relaunch browser and still wallet button is hidden on both (normal/private)
8. Turn on wallet button from brave://settings/apperance
9. Check wallet button is shown on both windows