### PR TITLE
[iOS] Exclude more paths for the old.reddit redirect.

### DIFF
--- a/ios/brave-ios/Sources/Brave/WebFilters/WebsiteRedirects.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/WebsiteRedirects.swift
@@ -30,10 +30,31 @@ struct WebsiteRedirects {
     ],
     additionalPredicates: [
       { url in
-        !url.path.hasPrefix("/media")
+        let excludedPathPatterns = [
+          #"^/media"#,
+          #"^/poll"#,
+          #"^/rpan"#,
+          #"^/settings"#,
+          #"^/topics"#,
+          #"^/community-points"#,
+          #"^/r/[a-z0-9_]+/s/.*"#,
+          #"^/appeals?(/.*)?"#,
+          #"^/r/[a-z0-9_]+/appeals?(/.*)?"#,
+        ]
+
+        let path = url.path
+        for pattern in excludedPathPatterns {
+          if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+            regex.firstMatch(in: path, range: NSRange(location: 0, length: path.utf16.count)) != nil
+          {
+            return false
+          }
+        }
+
+        return true
       }
     ],
-    excludedHosts: ["new.reddit.com"]
+    excludedHosts: ["new.reddit.com", "sh.reddit.com"]
   )
 
   private static let npr = Rule(

--- a/ios/brave-ios/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/Web Filters/WebsiteRedirectsTests.swift
@@ -45,6 +45,7 @@ class WebsiteRedirectsTests: XCTestCase {
 
   func testExcludedHosts() throws {
     XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://new.reddit.com/r/brave")))
+    XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://sh.reddit.com/r/brave")))
     XCTAssertNil(WebsiteRedirects.redirect(for: try url("https://account.npr.org/login")))
   }
 
@@ -119,6 +120,17 @@ class WebsiteRedirectsTests: XCTestCase {
       try url("https://old.reddit.com/r/brave")
     )
 
+    XCTAssertEqual(
+      WebsiteRedirects.redirect(
+        for: try url(
+          "https://www.reddit.com/r/BurlingtonON/comments/1aq8v6s/looking_for_a_burlington_resident/"
+        )
+      ),
+      try url(
+        "https://old.reddit.com/r/BurlingtonON/comments/1aq8v6s/looking_for_a_burlington_resident/"
+      )
+    )
+
     // Skip media redirect
 
     XCTAssertNil(
@@ -126,6 +138,29 @@ class WebsiteRedirectsTests: XCTestCase {
         for: try url("https://reddit.com/media?url=https%3A%2F%2Fi.redd.it%2Fimageid.jpg")
       )
     )
+  }
+
+  func testRedditExcludedPaths() throws {
+    let excludedPaths = [
+      "https://reddit.com/media/12345",
+      "https://reddit.com/poll/12345",
+      "https://reddit.com/rpan/12345",
+      "https://reddit.com/settings/12345",
+      "https://www.reddit.com/topics/12345",
+      "https://reddit.com/community-points",
+      "https://www.reddit.com/r/example/s/TjDGhcl22d",
+      "https://www.reddit.com/r/BurlingtonON/s/vqQEjKLKDm",
+      "https://www.reddit.com/appeal",
+      "https://reddit.com/r/example/appeals",
+      "https://www.reddit.com/r/example/s/anotherExample",
+    ]
+
+    for path in excludedPaths {
+      XCTAssertNil(
+        WebsiteRedirects.redirect(for: try url(path)),
+        "Expected no redirection for URL with excluded path: \(path)"
+      )
+    }
   }
 
   func testNpr() throws {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/36122 I also added sh.reddit.com as a host to exclude.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Enable reddit -> old.reddit redirect feature.
Open https://www.reddit.com/r/BurlingtonON/s/vqQEjKLKDm, verify it loaded the old.reddit.com variant