### PR TITLE
fix(wallet): Make Send and Swap Action Views in Panel

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/panel-action-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/panel-action-header.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { useHistory } from 'react-router-dom'
+
+// Types
+import { WalletRoutes } from '../../../constants/types'
+
+// Utils
+import { openWalletRouteTab } from '../../../utils/routes-utils'
+
+// Styled Components
+import {
+  Button,
+  ButtonIcon,
+  LeftRightContainer
+} from './shared-panel-headers.style'
+import { Row } from '../../shared/style'
+import { HeaderTitle } from './shared-card-headers.style'
+
+interface Props {
+  title: string
+  expandRoute: WalletRoutes
+}
+
+export const PanelActionHeader = (props: Props) => {
+  const { title, expandRoute } = props
+
+  // Routing
+  const history = useHistory()
+
+  // Methods
+  const onClose = () => {
+    if (history.length > 1) {
+      history.goBack()
+      return
+    }
+    history.push(WalletRoutes.PortfolioAssets)
+  }
+
+  return (
+    <Row
+      padding='18px 16px'
+      justifyContent='space-between'
+    >
+      <LeftRightContainer
+        width='unset'
+        justifyContent='flex-start'
+      >
+        <Button onClick={() => openWalletRouteTab(expandRoute)}>
+          <ButtonIcon name='expand' />
+        </Button>
+      </LeftRightContainer>
+      <HeaderTitle isPanel={true}>{title}</HeaderTitle>
+      <LeftRightContainer
+        width='unset'
+        justifyContent='flex-end'
+      >
+        <Button onClick={onClose}>
+          <ButtonIcon name='close' />
+        </Button>
+      </LeftRightContainer>
+    </Row>
+  )
+}

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -79,8 +79,8 @@ import {
 import { ComposerControls } from '../../composer_ui/composer_controls/composer_controls'
 import { FromAsset } from '../../composer_ui/from_asset/from_asset'
 import {
-  DefaultPanelHeader //
-} from '../../../../components/desktop/card-headers/default-panel-header'
+  PanelActionHeader //
+} from '../../../../components/desktop/card-headers/panel-action-header'
 import {
   OrdinalsWarningMessage //
 } from '../components/ordinals-warning-message/ordinals-warning-message'
@@ -468,13 +468,13 @@ export const SendScreen = React.memo((props: Props) => {
       <WalletPageWrapper
         wrapContentInBox={true}
         noCardPadding={true}
-        hideNav={isAndroid}
+        hideNav={isAndroid || isPanel}
         hideHeader={isAndroid}
         noMinCardHeight={true}
         hideDivider={true}
         cardHeader={
           isPanel ? (
-            <DefaultPanelHeader
+            <PanelActionHeader
               title={getLocale('braveWalletSend')}
               expandRoute={WalletRoutes.Send}
             />

--- a/components/brave_wallet_ui/page/screens/swap/swap.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/swap.tsx
@@ -30,7 +30,7 @@ import {
 import { PrivacyModal } from './components/swap/privacy-modal/privacy-modal'
 import { ComposerControls } from '../composer_ui/composer_controls/composer_controls'
 import WalletPageWrapper from '../../../components/desktop/wallet-page-wrapper/wallet-page-wrapper'
-import { DefaultPanelHeader } from '../../../components/desktop/card-headers/default-panel-header'
+import { PanelActionHeader } from '../../../components/desktop/card-headers/panel-action-header'
 
 // Styled Components
 import { LeoSquaredButton } from '../../../components/shared/style'
@@ -116,9 +116,10 @@ export const Swap = () => {
         noCardPadding={true}
         noMinCardHeight={true}
         hideDivider={true}
+        hideNav={isPanel}
         cardHeader={
           isPanel ? (
-            <DefaultPanelHeader
+            <PanelActionHeader
               title={getLocale('braveWalletSwap')}
               expandRoute={WalletRoutes.Swap}
             />


### PR DESCRIPTION
## Description 
`Swap` and `Send` should now feel like a `Modal` in the Wallet `Panel`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37407>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the Wallet `Panel` and navigate to either `Swap` or `Send`
2. The `Swap` or `Send` view should now feel like a `Modal` with a `Close` button and an `Expand` button

https://github.com/brave/brave-core/assets/40611140/e79d3c34-8f9f-46ac-947c-8586b8a1b10e
