### PR TITLE
Layout secondary devtools view properly

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -508,7 +508,10 @@ source_set("ui") {
       "views/window_closing_confirm_dialog_view.h",
     ]
 
-    deps += [ "//components/bookmarks/browser" ]
+    deps += [
+      "//chrome/browser/devtools",
+      "//components/bookmarks/browser",
+    ]
 
     if (enable_brave_vpn) {
       if (is_win) {

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -416,6 +416,7 @@ void BraveBrowserView::UpdateSecondaryContentsWebViewVisibility() {
   } else {
     secondary_contents_web_view_->SetWebContents(nullptr);
     secondary_contents_web_view_->SetVisible(false);
+    secondary_devtools_web_view_->SetWebContents(nullptr);
     secondary_devtools_web_view_->SetVisible(false);
   }
 
@@ -427,10 +428,6 @@ void BraveBrowserView::UpdateSecondaryDevtoolsLayoutAndVisibility(
   DevToolsContentsResizingStrategy strategy;
   content::WebContents* devtools =
       DevToolsWindow::GetInTabWebContents(inspected_contents, &strategy);
-  if (secondary_devtools_web_view_->web_contents() != devtools) {
-    secondary_devtools_web_view_->SetWebContents(devtools);
-  }
-
   if (secondary_devtools_web_view_->web_contents() != devtools) {
     secondary_devtools_web_view_->SetWebContents(devtools);
   }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -184,7 +184,6 @@ class BraveBrowserView : public BrowserView,
   bool IsActiveWebContentsTiled(const SplitViewBrowserData::Tile& tile) const;
   void UpdateSecondaryContentsWebViewVisibility();
 
-  // Returns the content::WebContents* for devtools.
   void UpdateSecondaryDevtoolsLayoutAndVisibility(
       content::WebContents* inspected_contents);
 

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -184,6 +184,10 @@ class BraveBrowserView : public BrowserView,
   bool IsActiveWebContentsTiled(const SplitViewBrowserData::Tile& tile) const;
   void UpdateSecondaryContentsWebViewVisibility();
 
+  // Returns the content::WebContents* for devtools.
+  void UpdateSecondaryDevtoolsLayoutAndVisibility(
+      content::WebContents* inspected_contents);
+
   bool closing_confirm_dialog_activated_ = false;
   raw_ptr<BraveHelpBubbleHostView> brave_help_bubble_host_view_ = nullptr;
   raw_ptr<SidebarContainerView> sidebar_container_view_ = nullptr;

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -7,43 +7,58 @@
 
 #include "base/feature_list.h"
 #include "brave/browser/ui/tabs/features.h"
-#include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "ui/views/view.h"
 
 BraveContentsLayoutManager::~BraveContentsLayoutManager() = default;
 
+void BraveContentsLayoutManager::SetSecondaryContentsResizingStrategy(
+    const DevToolsContentsResizingStrategy& strategy) {
+  if (secondary_strategy_.Equals(strategy)) {
+    return;
+  }
+
+  secondary_strategy_.CopyFrom(strategy);
+  if (host_view()) {
+    host_view()->InvalidateLayout();
+  }
+}
+
 void BraveContentsLayoutManager::LayoutImpl() {
   if (!base::FeatureList::IsEnabled(tabs::features::kBraveSplitView) ||
-      !secondary_contents_view_ || !devtools_view_ ||
+      !secondary_contents_view_ || !secondary_devtools_view_ ||
       !secondary_contents_view_->GetVisible()) {
     ContentsLayoutManager::LayoutImpl();
     return;
   }
 
-  auto layout_web_contents_and_devtools = [this](gfx::Rect bounds,
-                                                 views::View* contents_view,
-                                                 views::View* devtools_view) {
-    gfx::Rect new_contents_bounds;
-    gfx::Rect new_devtools_bounds;
-    ApplyDevToolsContentsResizingStrategy(
-        strategy_, bounds.size(), &new_devtools_bounds, &new_contents_bounds);
-    new_contents_bounds.set_x(bounds.x() + new_contents_bounds.x());
-    new_devtools_bounds.set_x(bounds.x() + new_devtools_bounds.x());
+  auto layout_web_contents_and_devtools =
+      [](gfx::Rect bounds, views::View* contents_view,
+         views::View* devtools_view,
+         const DevToolsContentsResizingStrategy& strategy) {
+        gfx::Rect new_contents_bounds;
+        gfx::Rect new_devtools_bounds;
+        ApplyDevToolsContentsResizingStrategy(strategy, bounds.size(),
+                                              &new_devtools_bounds,
+                                              &new_contents_bounds);
+        new_contents_bounds.set_x(bounds.x() + new_contents_bounds.x());
+        new_devtools_bounds.set_x(bounds.x() + new_devtools_bounds.x());
 
-    // TODO(sko) We're ignoring dev tools specific position. Maybe we need to
-    // revisit this. On the other hand, I think we shouldn't let devtools on the
-    // side of split view as it's too confusing.
-    contents_view->SetBoundsRect(new_contents_bounds);
-    devtools_view->SetBoundsRect(new_devtools_bounds);
-  };
+        // TODO(sko) We're ignoring dev tools specific position. Maybe we need
+        // to revisit this. On the other hand, I think we shouldn't let devtools
+        // on the side of split view as it's too confusing.
+        contents_view->SetBoundsRect(new_contents_bounds);
+        devtools_view->SetBoundsRect(new_devtools_bounds);
+      };
 
   gfx::Rect bounds = host_view()->GetLocalBounds();
   bounds.set_width(bounds.width() / 2);
   if (show_main_web_contents_at_tail_) {
     layout_web_contents_and_devtools(bounds, secondary_contents_view_,
-                                     secondary_devtools_view_);
+                                     secondary_devtools_view_,
+                                     secondary_strategy_);
   } else {
-    layout_web_contents_and_devtools(bounds, contents_view_, devtools_view_);
+    layout_web_contents_and_devtools(bounds, contents_view_, devtools_view_,
+                                     strategy_);
   }
 
   // In case of odd width, give the remaining
@@ -51,9 +66,11 @@ void BraveContentsLayoutManager::LayoutImpl() {
   bounds.set_x(bounds.width());
   bounds.set_width(host_view()->width() - bounds.width());
   if (show_main_web_contents_at_tail_) {
-    layout_web_contents_and_devtools(bounds, contents_view_, devtools_view_);
+    layout_web_contents_and_devtools(bounds, contents_view_, devtools_view_,
+                                     strategy_);
   } else {
     layout_web_contents_and_devtools(bounds, secondary_contents_view_,
-                                     secondary_devtools_view_);
+                                     secondary_devtools_view_,
+                                     secondary_strategy_);
   }
 }

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -34,6 +34,10 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
     show_main_web_contents_at_tail_ = tail;
   }
 
+  // Sets the contents resizing strategy.
+  void SetSecondaryContentsResizingStrategy(
+      const DevToolsContentsResizingStrategy& strategy);
+
  protected:
   // ContentsLayoutManager:
   void LayoutImpl() override;
@@ -44,6 +48,8 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
   raw_ptr<SplitViewBrowserData> split_view_browser_data_ = nullptr;
   raw_ptr<views::View> secondary_contents_view_ = nullptr;
   raw_ptr<views::View> secondary_devtools_view_ = nullptr;
+
+  DevToolsContentsResizingStrategy secondary_strategy_;
 
   bool show_main_web_contents_at_tail_ = false;
 };


### PR DESCRIPTION
Set the resizing strategy for the secondary devtools view and update it during layout.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37413

<img width="1411" alt="image" src="https://github.com/brave/brave-core/assets/5474642/70a27ef1-700f-4873-be89-049baafe9637">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

