### PR TITLE
[ads] Fixes ads fail to Initialise

### DIFF
--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -32,11 +32,6 @@ namespace {
 
 void FailedToInitialize(InitializeCallback callback) {
   BLOG(0, "Failed to initialize ads");
-
-  // TODO(https://github.com/brave/brave-browser/issues/32066): Remove migration
-  // failure dumps.
-  base::debug::DumpWithoutCrashing();
-
   std::move(callback).Run(/*success=*/false);
 }
 
@@ -79,6 +74,10 @@ void AdsImpl::Initialize(mojom::WalletInfoPtr wallet,
   BLOG(1, "Initializing ads");
 
   if (is_initialized_) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     BLOG(1, "Already initialized ads");
     return FailedToInitialize(std::move(callback));
   }
@@ -286,6 +285,10 @@ void AdsImpl::CreateOrOpenDatabaseCallback(mojom::WalletInfoPtr wallet,
                                            InitializeCallback callback,
                                            const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     BLOG(0, "Failed to create or open database");
     return FailedToInitialize(std::move(callback));
   }
@@ -299,6 +302,10 @@ void AdsImpl::PurgeExpiredAdEventsCallback(mojom::WalletInfoPtr wallet,
                                            InitializeCallback callback,
                                            const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     BLOG(0, "Failed to purge expired ad events");
     return FailedToInitialize(std::move(callback));
   }
@@ -312,6 +319,10 @@ void AdsImpl::PurgeOrphanedAdEventsCallback(mojom::WalletInfoPtr wallet,
                                             InitializeCallback callback,
                                             const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     BLOG(0, "Failed to purge orphaned ad events");
     return FailedToInitialize(std::move(callback));
   }
@@ -325,6 +336,10 @@ void AdsImpl::MigrateRewardsStateCallback(mojom::WalletInfoPtr wallet,
                                           InitializeCallback callback,
                                           const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return FailedToInitialize(std::move(callback));
   }
 
@@ -337,6 +352,10 @@ void AdsImpl::MigrateClientStateCallback(mojom::WalletInfoPtr wallet,
                                          InitializeCallback callback,
                                          const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return FailedToInitialize(std::move(callback));
   }
 
@@ -349,6 +368,10 @@ void AdsImpl::LoadClientStateCallback(mojom::WalletInfoPtr wallet,
                                       InitializeCallback callback,
                                       const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return FailedToInitialize(std::move(callback));
   }
 
@@ -361,6 +384,10 @@ void AdsImpl::MigrateConfirmationStateCallback(mojom::WalletInfoPtr wallet,
                                                InitializeCallback callback,
                                                const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return FailedToInitialize(std::move(callback));
   }
 
@@ -387,6 +414,10 @@ void AdsImpl::LoadConfirmationStateCallback(mojom::WalletInfoPtr wallet,
                                             InitializeCallback callback,
                                             const bool success) {
   if (!success) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return FailedToInitialize(std::move(callback));
   }
 

--- a/components/brave_ads/core/internal/deprecated/client/client_info.cc
+++ b/components/brave_ads/core/internal/deprecated/client/client_info.cc
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/check.h"
+#include "base/debug/dump_without_crashing.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
 #include "base/strings/string_number_conversions.h"
@@ -222,6 +223,10 @@ bool ClientInfo::FromJson(const std::string& json) {
       json, base::JSON_PARSE_CHROMIUM_EXTENSIONS |
                 base::JSONParserOptions::JSON_PARSE_RFC);
   if (!dict) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return false;
   }
 

--- a/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc
+++ b/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/debug/dump_without_crashing.h"
 #include "base/functional/bind.h"
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
@@ -107,15 +108,30 @@ std::string ConfirmationStateManager::ToJson() {
 bool ConfirmationStateManager::FromJson(const std::string& json) {
   const std::optional<base::Value::Dict> dict =
       base::JSONReader::ReadDict(json);
+  confirmation_tokens_.RemoveAll();
+  payment_tokens_.RemoveAllTokens();
+
   if (!dict) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     return false;
   }
 
   if (!ParseConfirmationTokensFromDictionary(*dict)) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     BLOG(1, "Failed to parse confirmation tokens");
   }
 
   if (!ParsePaymentTokensFromDictionary(*dict)) {
+    // TODO(https://github.com/brave/brave-browser/issues/32066):
+    // Remove migration failure dumps.
+    base::debug::DumpWithoutCrashing();
+
     BLOG(1, "Failed to parse payment tokens");
   }
 

--- a/components/brave_ads/core/internal/legacy_migration/client/legacy_client_migration_unittest.cc
+++ b/components/brave_ads/core/internal/legacy_migration/client/legacy_client_migration_unittest.cc
@@ -39,17 +39,17 @@ TEST_F(BraveAdsLegacyClientMigrationTest, Migrate) {
   EXPECT_TRUE(HasMigratedClientState());
 }
 
-TEST_F(BraveAdsLegacyClientMigrationTest, InvalidState) {
+TEST_F(BraveAdsLegacyClientMigrationTest, ResetInvalidState) {
   // Arrange
   ASSERT_TRUE(CopyFileFromTestPathToTempPath(kInvalidJsonFilename,
                                              kClientStateFilename));
 
   // Act & Assert
   base::MockCallback<InitializeCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/false));
+  EXPECT_CALL(callback, Run(/*success=*/true));
   MigrateClientState(callback.Get());
 
-  EXPECT_FALSE(HasMigratedClientState());
+  EXPECT_TRUE(HasMigratedClientState());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/legacy_migration/confirmations/legacy_confirmation_migration_unittest.cc
+++ b/components/brave_ads/core/internal/legacy_migration/confirmations/legacy_confirmation_migration_unittest.cc
@@ -40,17 +40,17 @@ TEST_F(BraveAdsLegacyConfirmationMigrationTest, Migrate) {
   EXPECT_TRUE(HasMigratedConfirmation());
 }
 
-TEST_F(BraveAdsLegacyConfirmationMigrationTest, InvalidState) {
+TEST_F(BraveAdsLegacyConfirmationMigrationTest, ResetInvalidState) {
   // Arrange
   ASSERT_TRUE(CopyFileFromTestPathToTempPath(kInvalidJsonFilename,
                                              kConfirmationStateFilename));
 
   // Act & Assert
   base::MockCallback<InitializeCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/false));
+  EXPECT_CALL(callback, Run(/*success=*/true));
   MigrateConfirmationState(callback.Get());
 
-  EXPECT_FALSE(HasMigratedConfirmation());
+  EXPECT_TRUE(HasMigratedConfirmation());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/prefs/obsolete_pref_util.cc
+++ b/components/brave_ads/core/internal/prefs/obsolete_pref_util.cc
@@ -21,7 +21,7 @@ constexpr char kNotificationAdLastNormalizedDisplayCoordinateY[] =
 
 void RegisterProfilePrefsForMigration(
     user_prefs::PrefRegistrySyncable* registry) {
-  // Added 2023-11
+  // Added 11/2023.
   registry->RegisterDoublePref(kNotificationAdLastNormalizedDisplayCoordinateX,
                                0.0);
   registry->RegisterDoublePref(kNotificationAdLastNormalizedDisplayCoordinateY,
@@ -29,7 +29,7 @@ void RegisterProfilePrefsForMigration(
 }
 
 void MigrateObsoleteProfilePrefs(PrefService* prefs) {
-  // Added 2023-11
+  // Added 11/2023.
   prefs->ClearPref(kNotificationAdLastNormalizedDisplayCoordinateX);
   prefs->ClearPref(kNotificationAdLastNormalizedDisplayCoordinateY);
 }

--- a/components/brave_ads/core/public/prefs/pref_names.h
+++ b/components/brave_ads/core/public/prefs/pref_names.h
@@ -95,9 +95,9 @@ inline constexpr char kNextTokenRedemptionAt[] =
 
 // Stores migration status
 inline constexpr char kHasMigratedClientState[] =
-    "brave.brave_ads.state.has_migrated.client.v5";
+    "brave.brave_ads.state.has_migrated.client.v6";
 inline constexpr char kHasMigratedConfirmationState[] =
-    "brave.brave_ads.state.has_migrated.confirmations.v6";
+    "brave.brave_ads.state.has_migrated.confirmations.v7";
 inline constexpr char kHasMigratedConversionState[] =
     "brave.brave_ads.migrated.conversion_state";
 inline constexpr char kHasMigratedNotificationState[] =


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37390

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Verify that the legacy `ads_service/confirmations.json`/`confirmations` is migrated to the `ads_service/database.sqlite`/`confirmation_queue` database table. Ensure that upgrading resets `ads_service/client.json` to default values if it is corrupted (i.e., the file is not valid JSON). Also, confirm that upgrading resets `ads_service/confirmations.json` to default values if it is corrupted (i.e., the file is not valid JSON). This problem was limited to older browser versions, and since the state is no longer necessary, resetting it is safe to ensure the successful initialization of ads.