### PR TITLE
Require relaunch when brave wallet in private windows setting changed

### DIFF
--- a/browser/resources/settings/brave_wallet_page/brave_wallet_browser_proxy.ts
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_browser_proxy.ts
@@ -65,6 +65,8 @@ export interface BraveWalletBrowserProxy {
   getPinnedNftCount(): Promise<number>
   clearPinnedNft(): Promise<boolean>
   isTransactionSimulationsFeatureEnabled(): Promise<boolean>
+  getWalletInPrivateWindowsEnabled(): Promise<boolean>
+  setWalletInPrivateWindowsEnabled(enabled: boolean): Promise<boolean>
 }
 
 export class BraveWalletBrowserProxyImpl implements BraveWalletBrowserProxy {
@@ -154,6 +156,14 @@ export class BraveWalletBrowserProxyImpl implements BraveWalletBrowserProxy {
 
   isTransactionSimulationsFeatureEnabled() {
     return sendWithPromise('isTransactionSimulationsFeatureEnabled')
+  }
+
+  getWalletInPrivateWindowsEnabled() {
+    return sendWithPromise('getWalletInPrivateWindowsEnabled')
+  }
+
+  setWalletInPrivateWindowsEnabled(value: boolean) {
+    return sendWithPromise('setWalletInPrivateWindowsEnabled', value)
   }
 
   static getInstance() {

--- a/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
+++ b/browser/resources/settings/brave_wallet_page/brave_wallet_page.html
@@ -26,7 +26,47 @@
     settings-dropdown-menu.narrow-drop-down {
       --md-select-width: 100px;
     }
+
+  #needsRestart {
+    background-color: #fff;
+    bottom: 0;
+    box-shadow: 0 -2px 2px 0 var(--shadow-color);
+    box-sizing: border-box;
+    left: 0;
+    opacity: 1;
+    padding: 16px;
+    position: fixed;
+    transform: translate(0);
+    transition: all 225ms var(--ease-in-out);
+    width: 100%;
+    z-index: 10;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    #needsRestart {
+      background-color: rgb(22, 23, 25);
+    }
+  }
+
+  #needsRestart .flex:last-child {
+    text-align: right;  /* csschecker-disable-line left-right */
+  }
+
+  .restart-notice {
+    font-size: .9375rem;
+    line-height: 1.4;
+  }
+
+  button.primary {
+    background: var(--interactive-color);
+    border: 0;
+    border-radius: 3px;
+    color: white;
+    font-size: .875rem;
+    padding: 14px 38px;
+  }
 </style>
+
 <div hidden="[[isNetworkEditor_]]">
   <div class="settings-box first">
     <div class="start">$i18n{defaultEthereumWalletDesc}</div>
@@ -78,7 +118,8 @@
     </settings-toggle-button>
     <settings-toggle-button id="enablePrivateWindows"
         class="cr-row"
-        pref="{{prefs.brave.wallet.private_windows_enabled}}"
+        pref="[[isPrivateWindowsEnabled_]]"
+        on-settings-boolean-control-change="onPrivateWindowsEnabled_"
         label="$i18n{enablePrivateWindowsLabel}"
         sub-label="$i18n{enablePrivateWindowsDesc}">
     </settings-toggle-button>
@@ -115,6 +156,18 @@
       </div>
   </template>
 </div>
+<template is="dom-if" if="{{ showRestartToast_ }}">
+  <div id="needsRestart">
+    <div class="flex-container">
+      <div class="flex restart-notice" jstcache="0">$i18n{restartNotice}</div>
+      <div class="flex">
+        <button id="restartButton" class="primary" tabindex="9" on-click="applyPrefChangesAndRestart">
+          $i18n{relaunchButtonLabel}
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
 <settings-animated-pages id="wallet-networks" section="wallet">
   <div route-path="default">
     <cr-link-row id="walletNetworksLinkRow"

--- a/browser/ui/webui/settings/brave_wallet_handler.cc
+++ b/browser/ui/webui/settings/brave_wallet_handler.cc
@@ -136,6 +136,14 @@ void BraveWalletHandler::RegisterMessages() {
   web_ui()->RegisterMessageCallback(
       "clearPinnedNft", base::BindRepeating(&BraveWalletHandler::ClearPinnedNft,
                                             base::Unretained(this)));
+  web_ui()->RegisterMessageCallback(
+      "setWalletInPrivateWindowsEnabled",
+      base::BindRepeating(&BraveWalletHandler::SetWalletInPrivateWindowsEnabled,
+                          base::Unretained(this)));
+  web_ui()->RegisterMessageCallback(
+      "getWalletInPrivateWindowsEnabled",
+      base::BindRepeating(&BraveWalletHandler::GetWalletInPrivateWindowsEnabled,
+                          base::Unretained(this)));
 }
 
 void BraveWalletHandler::GetAutoLockMinutes(const base::Value::List& args) {
@@ -425,6 +433,25 @@ void BraveWalletHandler::ClearPinnedNft(const base::Value::List& args) {
   service->Reset(
       base::BindOnce(&BraveWalletHandler::OnBraveWalletPinServiceReset,
                      weak_ptr_factory_.GetWeakPtr(), args[0].Clone()));
+}
+
+void BraveWalletHandler::SetWalletInPrivateWindowsEnabled(
+    const base::Value::List& args) {
+  CHECK_EQ(args.size(), 2U);
+  bool enabled = args[1].GetBool();
+  Profile::FromWebUI(web_ui())->GetPrefs()->SetBoolean(
+      kBraveWalletPrivateWindowsEnabled, enabled);
+  AllowJavascript();
+  ResolveJavascriptCallback(args[0], base::Value(true));
+}
+
+void BraveWalletHandler::GetWalletInPrivateWindowsEnabled(
+    const base::Value::List& args) {
+  CHECK_EQ(args.size(), 1U);
+  bool enabled = Profile::FromWebUI(web_ui())->GetPrefs()->GetBoolean(
+      kBraveWalletPrivateWindowsEnabled);
+  AllowJavascript();
+  ResolveJavascriptCallback(args[0], enabled);
 }
 
 void BraveWalletHandler::OnBraveWalletPinServiceReset(

--- a/browser/ui/webui/settings/brave_wallet_handler.h
+++ b/browser/ui/webui/settings/brave_wallet_handler.h
@@ -56,6 +56,8 @@ class BraveWalletHandler : public settings::SettingsPageUIHandler {
   void IsTransactionSimulationsEnabled(const base::Value::List& args);
   void GetPinnedNftCount(const base::Value::List& args);
   void ClearPinnedNft(const base::Value::List& args);
+  void SetWalletInPrivateWindowsEnabled(const base::Value::List& args);
+  void GetWalletInPrivateWindowsEnabled(const base::Value::List& args);
 
   PrefService* GetPrefs();
   brave_wallet::BraveWalletPinService* GetBraveWalletPinService();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37354.

Requiring a relaunch because the number of bound APIs changes if you go 'back', which is apparently breaks an invariant, and causes a browser crash.

The logic here is such that the pref is only updated if the user updates the switch, then clicks relaunch. Until the user relaunches, the changes are reflected in the UI (switch changed), but not applied (prefs are the same).  Doing so avoids a situation in which the user toggles the switch but does not relaunch - in that case they could reach the crash.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Verify that changes in the brave wallet in private tabs pref require a restart. Once the restart completes, the setting should have been applied and control the behavior (e.g. brave://wallet is accessible / usable in a private tab if on, or not if off). Please verify the switch value matches the pref value on initial load (search 'private_windows_enabled' in pref-internals).