### PR TITLE
Filter items being cached from "Keep for offline playing"

### DIFF
--- a/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceObserverImpl.java
+++ b/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceObserverImpl.java
@@ -123,6 +123,9 @@ public class PlaylistServiceObserverImpl implements PlaylistServiceObserver {
     }
 
     @Override
+    public void onMediaFileDownloadScheduled(String id) {}
+
+    @Override
     public void onMediaFileDownloadProgressed(
             String id,
             long totalBytes,

--- a/browser/playlist/test/mock_playlist_service_observer.h
+++ b/browser/playlist/test/mock_playlist_service_observer.h
@@ -61,6 +61,11 @@ class MockPlaylistServiceObserver
               (override));
 
   MOCK_METHOD(void,
+              OnMediaFileDownloadScheduled,
+              (const std::string& id),
+              (override));
+
+  MOCK_METHOD(void,
               OnMediaFileDownloadProgressed,
               (const std::string& id,
                int64_t total_bytes,

--- a/components/playlist/browser/playlist_service.cc
+++ b/components/playlist/browser/playlist_service.cc
@@ -389,6 +389,10 @@ void PlaylistService::DownloadMediaFile(const mojom::PlaylistItemPtr& item,
       update_media_src_and_retry_on_fail, std::move(callback));
 
   media_file_download_manager_->DownloadMediaFile(std::move(job));
+
+  for (auto& observer : observers_) {
+    observer->OnMediaFileDownloadScheduled(item->id);
+  }
 }
 
 base::FilePath PlaylistService::GetPlaylistItemDirPath(

--- a/components/playlist/browser/playlist_tab_helper.h
+++ b/components/playlist/browser/playlist_tab_helper.h
@@ -85,6 +85,7 @@ class PlaylistTabHelper
   void OnItemCached(mojom::PlaylistItemPtr item) override {}
   void OnItemUpdated(mojom::PlaylistItemPtr item) override {}
 
+  void OnMediaFileDownloadScheduled(const std::string& id) override {}
   void OnMediaFileDownloadProgressed(
       const std::string& id,
       int64_t total_bytes,

--- a/components/playlist/browser/resources/api/api.ts
+++ b/components/playlist/browser/resources/api/api.ts
@@ -147,6 +147,8 @@ class API {
     ) => void
   ) {
     this.#pageCallbackRouter.onMediaFileDownloadProgressed.addListener(listener)
+    this.#pageCallbackRouter.onMediaFileDownloadScheduled.addListener(
+      (id:string)=>listener(id, BigInt(0), BigInt(0), 0, ''))
   }
 
   addPlaylistUpdatedListener(listener: (playlist: Playlist) => void) {

--- a/components/playlist/browser/resources/components/contextualMenu.tsx
+++ b/components/playlist/browser/resources/components/contextualMenu.tsx
@@ -17,7 +17,7 @@ interface MenuItemProps {
 }
 
 interface MenuProps {
-  items: MenuItemProps[]
+  items: Array<MenuItemProps | undefined>
   visible: boolean
   onShowMenu?: () => void
   onDismissMenu?: () => void
@@ -40,7 +40,7 @@ const StyledButtonMenu = styled(ButtonMenu)<{ visible: boolean }>`
   color: ${color.text.secondary};
 `
 
-export default function ContextualMenuAnchorButton({
+export default function ContextualMenuAnchorButton ({
   items,
   visible,
   onShowMenu,
@@ -63,20 +63,22 @@ export default function ContextualMenuAnchorButton({
       <div slot='anchor-content'>
         <Icon name='more-horizontal' />
       </div>
-      {items.map((i) => (
-        <leo-menu-item
-          key={i.name}
-          onClick={(e) => {
-            e.stopPropagation()
-            i.onClick()
-          }}
-        >
-          <StyledRow>
-            <span>{i.name}</span>
-            <Icon name={i.iconName} />
-          </StyledRow>
-        </leo-menu-item>
-      ))}
+      {items
+        .filter((i) => i)
+        .map((i) => (
+          <leo-menu-item
+            key={i!.name}
+            onClick={(e) => {
+              e.stopPropagation()
+              i!.onClick()
+            }}
+          >
+            <StyledRow>
+              <span>{i!.name}</span>
+              <Icon name={i!.iconName} />
+            </StyledRow>
+          </leo-menu-item>
+        ))}
     </StyledButtonMenu>
   )
 }

--- a/components/playlist/browser/resources/components/header.tsx
+++ b/components/playlist/browser/resources/components/header.tsx
@@ -9,11 +9,20 @@ import styled, { css } from 'styled-components'
 import { Link } from 'react-router-dom'
 
 import Icon from '@brave/leo/react/icon'
-import { color, font, radius, spacing, icon, elevation } from '@brave/leo/tokens/css'
+import {
+  color,
+  font,
+  radius,
+  spacing,
+  icon,
+  elevation
+} from '@brave/leo/tokens/css'
 import LeoButton from '@brave/leo/react/button'
 
 import PlaylistInfo from './playlistInfo'
 import {
+  ApplicationState,
+  CachingProgress,
   PlaylistEditMode,
   usePlaylist,
   usePlaylistEditMode,
@@ -24,6 +33,7 @@ import ContextualMenuAnchorButton from './contextualMenu'
 import { getPlaylistAPI } from '../api/api'
 import { getLocalizedString } from '../utils/l10n'
 import { getPlaylistActions } from '../api/getPlaylistActions'
+import { useSelector } from 'react-redux'
 
 const StyledLink = styled(Link)`
   text-decoration: none;
@@ -106,7 +116,7 @@ const SaveButton = styled(StyledButton)`
   --leo-button-padding: 10px;
 `
 
-function BackButton({
+function BackButton ({
   playlistEditMode
 }: {
   playlistEditMode?: PlaylistEditMode
@@ -132,8 +142,13 @@ function BackButton({
   )
 }
 
-function PlaylistHeader({ playlistId }: { playlistId: string }) {
+function PlaylistHeader ({ playlistId }: { playlistId: string }) {
   const playlist = usePlaylist(playlistId)
+  const cachingProgress = useSelector<
+    ApplicationState,
+    Map<string, CachingProgress> | undefined
+  >((applicationState) => applicationState.playlistData?.cachingProgress)
+
   const contextualMenuItems = []
   if (playlist?.items.length) {
     contextualMenuItems.push({
@@ -146,7 +161,10 @@ function PlaylistHeader({ playlistId }: { playlistId: string }) {
     // TODO(sko) We don't support this yet.
     // contextualMenuItems.push({ name: 'Share', iconName: 'share-macos', onClick: () => {} })
 
-    const uncachedItems = playlist.items.filter((item) => !item.cached)
+    const uncachedItems = playlist.items.filter(
+      (item) => !item.cached && !cachingProgress?.has(item.id)
+    )
+
     if (uncachedItems.length) {
       contextualMenuItems.push({
         name: getLocalizedString(
@@ -273,7 +291,7 @@ function PlaylistHeader({ playlistId }: { playlistId: string }) {
   )
 }
 
-function NewPlaylistButton() {
+function NewPlaylistButton () {
   return (
     <StyledButton
       size='large'
@@ -291,7 +309,7 @@ function NewPlaylistButton() {
   )
 }
 
-function SettingButton() {
+function SettingButton () {
   return (
     <StyledButton
       size='large'
@@ -307,7 +325,7 @@ function SettingButton() {
   )
 }
 
-function CloseButton() {
+function CloseButton () {
   return (
     <StyledButton
       size='large'
@@ -323,7 +341,7 @@ function CloseButton() {
   )
 }
 
-function PlaylistsCatalogHeader() {
+function PlaylistsCatalogHeader () {
   return (
     <>
       <GradientIcon name='product-playlist-bold-add-color' />
@@ -338,7 +356,7 @@ function PlaylistsCatalogHeader() {
   )
 }
 
-export default function Header({ playlistId, className }: HeaderProps) {
+export default function Header ({ playlistId, className }: HeaderProps) {
   return (
     <HeaderContainer className={className}>
       {playlistId ? (

--- a/components/playlist/browser/resources/components/playlistItem.tsx
+++ b/components/playlist/browser/resources/components/playlistItem.tsx
@@ -178,7 +178,7 @@ const StyledCheckBox = styled(Icon)<{ checked: boolean }>`
   color: ${(p) => (p.checked ? color.icon.interactive : color.icon.default)};
 `
 
-function Thumbnail({
+function Thumbnail ({
   thumbnailUrl,
   isSelected,
   isPlaying,
@@ -211,7 +211,7 @@ function Thumbnail({
   )
 }
 
-export function PlaylistItem({
+export function PlaylistItem ({
   playlist,
   item,
   isEditing,
@@ -320,6 +320,8 @@ export function PlaylistItem({
                 iconName: 'cloud-off',
                 onClick: () => getPlaylistAPI().removeLocalData(id)
               }
+            : cachingProgress
+            ? undefined // TODO(sko) We may want to have "cancel caching".
             : {
                 name: getLocalizedString(
                   'bravePlaylistContextMenuKeepForOfflinePlaying'
@@ -352,7 +354,7 @@ export function PlaylistItem({
 }
 
 export const SortablePlaylistItem = React.forwardRef(
-  function SortablePlaylistItem(
+  function SortablePlaylistItem (
     props: Props,
     forwardedRef?: React.ForwardedRef<HTMLAnchorElement>
   ) {

--- a/components/playlist/common/mojom/playlist.mojom
+++ b/components/playlist/common/mojom/playlist.mojom
@@ -178,6 +178,7 @@ interface PlaylistServiceObserver {
 
   OnPlaylistUpdated(Playlist playlist);
 
+  OnMediaFileDownloadScheduled(string id);
   OnMediaFileDownloadProgressed(
       string id,
       int64 total_bytes,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37469

We shouldn't try to cache items that are already being cached.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Add a long video to playlist
* Open playlist ui -> go to the folder that the new item is stored.
* Open context menu for item
* "Keep for offline play" shouldn't exist for items that are being cached