### PR TITLE
[PG] Fix intermittent issues in PG crawling.

### DIFF
--- a/chromium_src/third_party/blink/renderer/build/scripts/make_instrumenting_probes.py
+++ b/chromium_src/third_party/blink/renderer/build/scripts/make_instrumenting_probes.py
@@ -40,6 +40,7 @@ def _add_page_graph_to_config(config):
             "RegisterPageGraphEventListenerAdd",
             "RegisterPageGraphEventListenerRemove",
             "RegisterPageGraphJavaScriptUrl",
+            "ApplyCompilationModeOverride",
         ]
     }
 

--- a/third_party/blink/renderer/core/brave_page_graph/blink_converters.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/blink_converters.cc
@@ -64,7 +64,6 @@ base::Value ToPageGraphValue(ScriptState* script_state,
 template <>
 base::Value ToPageGraphValue(ScriptState* script_state,
                              const ScriptValue& script_value) {
-  ScriptState::Scope scope(script_state);
   v8::Local<v8::Value> value = script_value.V8Value();
   return ToPageGraphValue(script_state, value);
 }

--- a/third_party/blink/renderer/core/brave_page_graph/blink_converters.h
+++ b/third_party/blink/renderer/core/brave_page_graph/blink_converters.h
@@ -117,7 +117,6 @@ base::Value ToPageGraphValue(ScriptState* script_state, T& value) {
       return base::Value();
     }
   }
-  ScriptState::Scope scope(script_state);
   v8::Local<v8::Value> v8_value =
       ToV8Traits<pg_internal::strip_type_qualifiers_t<T>>::ToV8(script_state,
                                                                 value);
@@ -133,7 +132,6 @@ base::Value ToPageGraphValue(ScriptState* script_state, T& value) {
       return base::Value();
     }
   }
-  ScriptState::Scope scope(script_state);
   v8::Local<v8::Value> v8_value =
       ToV8Traits<pg_internal::strip_type_qualifiers_t<T>>::ToV8(script_state,
                                                                 &value);

--- a/third_party/blink/renderer/core/brave_page_graph/changelog.md
+++ b/third_party/blink/renderer/core/brave_page_graph/changelog.md
@@ -3,6 +3,16 @@
 This document shows all the changes and improvements made in each version of
 [Page Graph](https://github.com/brave/brave-browser/wiki/PageGraph).
 
+## Version 0.5.1
+
+#### Fix intermittent issues
+
+Remove `ScriptState::Scope` calls from args serialization. It fails in some edge
+cases, but it doesn't seem to be required at all right now.
+
+Disable v8 cache for external scripts. The cache should be disabled for most
+scripts, but here it was still active.
+
 ## Version 0.5.0
 
 #### Tracking resources redirects

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -185,7 +185,7 @@ namespace blink {
 
 namespace {
 
-constexpr char kPageGraphVersion[] = "0.5.0";
+constexpr char kPageGraphVersion[] = "0.5.1";
 constexpr char kPageGraphUrl[] =
     "https://github.com/brave/brave-browser/wiki/PageGraph";
 

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -642,6 +642,21 @@ void PageGraph::DidFailLoading(
   LOG(ERROR) << "DidFailLoading) untracked request id: " << identifier;
 }
 
+void PageGraph::ApplyCompilationModeOverride(
+    const blink::ClassicScript& classic_script,
+    v8::ScriptCompiler::CachedData**,
+    v8::ScriptCompiler::CompileOptions* compile_options) {
+  if (classic_script.SourceLocationType() !=
+          ScriptSourceLocationType::kExternalFile ||
+      classic_script.SourceUrl().IsEmpty()) {
+    return;
+  }
+  // When PageGraph is active, always compile external scripts eagerly. We want
+  // each DOM node to have its own script instance even if the underlying script
+  // is fetched from the same URL.
+  *compile_options = v8::ScriptCompiler::kEagerCompile;
+}
+
 void PageGraph::RegisterPageGraphScriptCompilation(
     blink::ExecutionContext* execution_context,
     const blink::ReferrerScriptInfo& referrer_info,

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -654,6 +654,7 @@ void PageGraph::ApplyCompilationModeOverride(
   // When PageGraph is active, always compile external scripts eagerly. We want
   // each DOM node to have its own script instance even if the underlying script
   // is fetched from the same URL.
+  CHECK(compile_options);
   *compile_options = v8::ScriptCompiler::kEagerCompile;
 }
 

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.h
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.h
@@ -173,6 +173,9 @@ class CORE_EXPORT PageGraph : public GarbageCollected<PageGraph>,
       const blink::ResourceError&,
       const base::UnguessableToken& devtools_frame_or_worker_token);
   // Script/module compilation tracking:
+  void ApplyCompilationModeOverride(const blink::ClassicScript&,
+                                    v8::ScriptCompiler::CachedData**,
+                                    v8::ScriptCompiler::CompileOptions*);
   void RegisterPageGraphScriptCompilation(
       blink::ExecutionContext* execution_context,
       const blink::ReferrerScriptInfo& referrer_info,

--- a/third_party/blink/renderer/core/brave_page_graph/scripts/script_tracker.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/scripts/script_tracker.cc
@@ -7,11 +7,11 @@
 
 #include <utility>
 
+#include "base/debug/alias.h"
 #include "base/no_destructor.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/graph_item/node/actor/node_script.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/page_graph_context.h"
 #include "brave/third_party/blink/renderer/core/brave_page_graph/types.h"
-#include "third_party/blink/renderer/bindings/core/v8/script_source_location_type.h"
 #include "third_party/blink/renderer/platform/wtf/hash_map.h"
 
 namespace brave_page_graph {
@@ -58,8 +58,18 @@ NodeScript* ScriptTracker::AddScriptNode(v8::Isolate* isolate,
         }
       }
     }
-    CHECK(is_valid_script_data) << "isolate: " << script_key.first
-                                << " script id: " << script_key.second;
+    if (!is_valid_script_data) {
+      const ScriptData script_data_copy = script_data;
+      const ScriptData cached_script_data_copy = cached_script_data;
+      DEBUG_ALIAS_FOR_CSTR(script_data_code, script_data.code.Ascii().c_str(),
+                           256);
+      DEBUG_ALIAS_FOR_CSTR(cached_script_data_code,
+                           script_data.code.Ascii().c_str(), 256);
+      base::debug::Alias(&script_data_copy);
+      base::debug::Alias(&cached_script_data_copy);
+      CHECK(false) << "Script data mismatch" << " isolate: " << script_key.first
+                   << " script id: " << script_key.second;
+    }
     return it->value;
   }
   auto* script_node =


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Fix few things:
1. Remove `ScriptState::Scope` calls from args serialization. It fails in some edge cases, but it doesn't seem to be required at all right now.
2. Disable v8 cache for external scripts. The cache should be disabled for most things, but here it was still active.

Resolves https://github.com/brave/brave-browser/issues/37503

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

