### PR TITLE
Add HTTPS upgrade checks

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -21,6 +21,7 @@ import("//brave/ios/browser/api/debounce/headers.gni")
 import("//brave/ios/browser/api/developer_options_code/headers.gni")
 import("//brave/ios/browser/api/favicon/headers.gni")
 import("//brave/ios/browser/api/features/headers.gni")
+import("//brave/ios/browser/api/https_upgrade_exceptions/headers.gni")
 import("//brave/ios/browser/api/ipfs/headers.gni")
 import("//brave/ios/browser/api/ntp_background_images/headers.gni")
 import("//brave/ios/browser/api/opentabs/headers.gni")
@@ -92,6 +93,8 @@ brave_core_public_headers += browser_api_url_sanitizer_public_headers
 brave_core_public_headers += browser_url_sanitizer_public_headers
 brave_core_public_headers += browser_api_de_amp_public_headers
 brave_core_public_headers += browser_api_debounce_public_headers
+brave_core_public_headers +=
+    browser_api_https_upgrade_exceptions_service_public_headers
 brave_core_public_headers += browser_debounce_public_headers
 brave_core_public_headers += brave_stats_public_headers
 brave_core_public_headers += brave_wallet_public_headers

--- a/ios/app/BUILD.gn
+++ b/ios/app/BUILD.gn
@@ -49,6 +49,7 @@ source_set("app") {
     "//brave/ios/browser/api/brave_wallet:wallet_mojom_wrappers",
     "//brave/ios/browser/api/de_amp",
     "//brave/ios/browser/api/history",
+    "//brave/ios/browser/api/https_upgrade_exceptions",
     "//brave/ios/browser/api/ipfs",
     "//brave/ios/browser/api/ntp_background_images",
     "//brave/ios/browser/api/opentabs",

--- a/ios/app/brave_core_main.h
+++ b/ios/app/brave_core_main.h
@@ -26,6 +26,7 @@
 @class NTPBackgroundImagesService;
 @class DeAmpPrefs;
 @class AIChat;
+@class HTTPSUpgradeExceptionsService;
 @protocol AIChatDelegate;
 @protocol IpfsAPI;
 
@@ -64,6 +65,9 @@ OBJC_EXPORT
 @property(nonatomic, readonly) BraveTabGeneratorAPI* tabGeneratorAPI;
 
 @property(nonatomic, readonly) WebImageDownloader* webImageDownloader;
+
+@property(nonatomic, readonly)
+    HTTPSUpgradeExceptionsService* httpsUpgradeExceptionsService;
 
 /// Sets the global log handler for Chromium & BraveCore logs.
 ///

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -34,6 +34,7 @@
 #include "brave/ios/browser/api/brave_wallet/brave_wallet_api+private.h"
 #include "brave/ios/browser/api/de_amp/de_amp_prefs+private.h"
 #include "brave/ios/browser/api/history/brave_history_api+private.h"
+#include "brave/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service+private.h"
 #include "brave/ios/browser/api/ipfs/ipfs_api+private.h"
 #include "brave/ios/browser/api/ntp_background_images/ntp_background_images_service_ios+private.h"
 #include "brave/ios/browser/api/opentabs/brave_opentabs_api+private.h"
@@ -126,6 +127,8 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
 @property(nonatomic) BraveP3AUtils* p3aUtils;
 @property(nonatomic) DeAmpPrefs* deAmpPrefs;
 @property(nonatomic) NTPBackgroundImagesService* backgroundImagesService;
+@property(nonatomic)
+    HTTPSUpgradeExceptionsService* httpsUpgradeExceptionsService;
 @end
 
 @implementation BraveCoreMain
@@ -469,6 +472,14 @@ static bool CustomLogHandler(int severity,
         [[BraveWalletAPI alloc] initWithBrowserState:_mainBrowserState];
   }
   return _braveWalletAPI;
+}
+
+- (HTTPSUpgradeExceptionsService*)httpsUpgradeExceptionsService {
+  if (!_httpsUpgradeExceptionsService) {
+    _httpsUpgradeExceptionsService =
+        [[HTTPSUpgradeExceptionsService alloc] init];
+  }
+  return _httpsUpgradeExceptionsService;
 }
 
 - (BraveStats*)braveStats {

--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -206,6 +206,7 @@ public class AppState {
       (IPFSSchemeHandler.path, IPFSSchemeHandler()),
       (Web3DomainHandler.path, Web3DomainHandler()),
       (BlockedDomainHandler.path, BlockedDomainHandler()),
+      (HTTPBlockedHandler.path, HTTPBlockedHandler()),
     ]
 
     responders.forEach { (path, responder) in

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -469,6 +469,7 @@ var braveTarget: PackageDescription.Target = .target(
     .copy("Assets/Fonts/NewYorkMedium-Regular.otf"),
     .copy("Assets/Fonts/NewYorkMedium-RegularItalic.otf"),
     .copy("Assets/Interstitial Pages/Pages/BlockedDomain.html"),
+    .copy("Assets/Interstitial Pages/Pages/HTTPBlocked.html"),
     .copy("Assets/Interstitial Pages/Pages/CertificateError.html"),
     .copy("Assets/Interstitial Pages/Pages/GenericError.html"),
     .copy("Assets/Interstitial Pages/Pages/NetworkError.html"),

--- a/ios/brave-ios/Sources/Brave/Assets/Interstitial Pages/Pages/HTTPBlocked.html
+++ b/ios/brave-ios/Sources/Brave/Assets/Interstitial Pages/Pages/HTTPBlocked.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Brave Authors. All rights reserved.
+  -- This Source Code Form is subject to the terms of the Mozilla Public
+  -- License, v. 2.0. If a copy of the MPL was not distributed with this
+  -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+
+<html lang="en">
+  <head>
+      <meta name='viewport' content='initial-scale=1, maximum-scale=1, viewport-fit=cover'>
+      <meta name="referrer" content="no-referrer">
+      <title>%page_title%</title>
+      <link rel="stylesheet" href="internal://local/interstitial-style/BlockedDomain.css">
+  </head>
+
+  <body dir="&locale.dir;" class="background content">
+    <div class="container post">
+      <img src="internal://local/interstitial-icon/warning-triangle-outline.svg" alt="Icon" class="icon">
+      </img>
+      <h1>%blocked_title%</h1>
+      <p class="description">
+        %blocked_description%
+        <a href="https://support.brave.com/hc/en-us/articles/15513090104717-Strict-HTTPS-Upgrade-Mode-in-Brave-Browser" target="_blank" rel="noopener">
+          %learn_more%
+        </a>
+      </p>
+      <div class="actions">
+        <button id="proceed-action" class="main-action">%proceed_action%</button>
+        <button id="go-back-action" class="secondary-action">%go_back_action%</button>
+      </div>
+    </div>
+    
+    <script>
+      (() => {
+        const sendAction = (action) => {
+          webkit.messageHandlers["%message_handler%"].postMessage({
+            "securityToken": "%security_token%",
+            "action": action
+          })
+        }
+        
+        document.getElementById('proceed-action').onclick = () => {
+          sendAction('didProceed')
+        }
+        
+        document.getElementById('go-back-action').onclick = () => {
+          sendAction('didGoBack')
+        }
+      })()
+    </script>
+  </body>
+</html>

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -502,6 +502,7 @@ public class BrowserViewController: UIViewController {
     Preferences.Playlist.syncSharedFoldersAutomatically.observe(from: self)
     Preferences.NewTabPage.backgroundSponsoredImages.observe(from: self)
     ShieldPreferences.blockAdsAndTrackingLevelRaw.observe(from: self)
+    ShieldPreferences.httpsUpgradeLevelRaw.observe(from: self)
     Preferences.Privacy.screenTimeEnabled.observe(from: self)
 
     pageZoomListener = NotificationCenter.default.addObserver(
@@ -2658,6 +2659,7 @@ extension BrowserViewController: TabDelegate {
       ErrorPageHelper(certStore: profile.certStore),
       SessionRestoreScriptHandler(tab: tab),
       BlockedDomainScriptHandler(tab: tab),
+      HTTPBlockedScriptHandler(tab: tab, exceptionService: braveCore.httpsUpgradeExceptionsService),
       PrintScriptHandler(browserController: self, tab: tab),
       CustomSearchScriptHandler(tab: tab),
       NightModeScriptHandler(tab: tab),
@@ -3313,7 +3315,7 @@ extension BrowserViewController: PreferencesObserver {
             ?? Preferences.General.defaultPageZoomLevel.value
         $0.webView?.setValue(zoomLevel, forKey: PageZoomHandler.propertyName)
       })
-    case Preferences.Shields.httpsEverywhere.key:
+    case ShieldPreferences.httpsUpgradeLevelRaw.key:
       tabManager.reset()
       tabManager.reloadSelectedTab()
     case Preferences.Privacy.blockAllCookies.key,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/HTTPBlockedHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/HTTPBlockedHandler.swift
@@ -1,0 +1,72 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShared
+import BraveShields
+import Foundation
+import Shared
+import WebKit
+
+public class HTTPBlockedHandler: InternalSchemeResponse {
+  public static let path = InternalURL.Path.httpBlocked.rawValue
+
+  public init() {}
+
+  public func response(forRequest request: URLRequest) -> (URLResponse, Data)? {
+    guard let url = request.url, let internalURL = InternalURL(url),
+      let originalURL = internalURL.extractedUrlParam
+    else { return nil }
+    let response = InternalSchemeHandler.response(forUrl: internalURL.url)
+
+    guard let asset = Bundle.module.path(forResource: "HTTPBlocked", ofType: "html") else {
+      assert(false)
+      return nil
+    }
+
+    var html = try? String(contentsOfFile: asset)
+      .replacingOccurrences(
+        of: "%page_title%",
+        with: Strings.Shields.siteIsNotSecure
+      )
+      .replacingOccurrences(
+        of: "%blocked_title%",
+        with: String.localizedStringWithFormat(
+          Strings.Shields.theConnectionIsNotSecure,
+          "<tt>\(originalURL.domainURL.absoluteDisplayString)</tt>"
+        )
+      )
+      .replacingOccurrences(
+        of: "%blocked_description%",
+        with: Strings.Shields.httpBlockedDescription
+      )
+      .replacingOccurrences(
+        of: "%learn_more%",
+        with: Strings.learnMore
+      )
+      .replacingOccurrences(
+        of: "%proceed_action%",
+        with: Strings.Shields.domainBlockedProceedAction
+      )
+      .replacingOccurrences(of: "%go_back_action%", with: Strings.Shields.domainBlockedGoBackAction)
+      .replacingOccurrences(
+        of: "%message_handler%",
+        with: HTTPBlockedScriptHandler.messageHandlerName
+      )
+      .replacingOccurrences(of: "%security_token%", with: UserScriptManager.securityToken)
+
+    if #available(iOS 16.0, *) {
+      html = html?.replacingOccurrences(
+        of: "<html lang=\"en\">",
+        with: "<html lang=\"\(Locale.current.language.minimalIdentifier)\">"
+      )
+    }
+
+    guard let data = html?.data(using: .utf8) else {
+      return nil
+    }
+
+    return (response, data)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShields
 import BraveWallet
 import CertificateUtilities
 import Data
@@ -463,7 +464,7 @@ class Tab: NSObject {
       configuration!.allowsInlineMediaPlayback = true
       // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
       configuration!.ignoresViewportScaleLimits = true
-      configuration!.upgradeKnownHostsToHTTPS = Preferences.Shields.httpsEverywhere.value
+      configuration!.upgradeKnownHostsToHTTPS = ShieldPreferences.httpsUpgradeLevel.isEnabled
       configuration!.enablePageTopColorSampling()
 
       if configuration!.urlSchemeHandler(forURLScheme: InternalURL.scheme) == nil {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -302,6 +302,10 @@ class Tab: NSObject {
   var playlistItem: PlaylistInfo?
   var playlistItemState: PlaylistItemAddedState = .none
 
+  /// This is the request that was upgraded to HTTPS
+  /// This allows us to rollback the upgrade when we encounter a 4xx+
+  var upgradedHTTPSRequest: URLRequest?
+
   /// The tabs new tab page controller.
   ///
   /// Should be setup in BVC then assigned here for future use.

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -77,6 +77,11 @@ import os
       }
     }
   }
+  @Published var httpsUpgradeLevel: HTTPSUpgradeLevel {
+    didSet {
+      ShieldPreferences.httpsUpgradeLevel = httpsUpgradeLevel
+    }
+  }
 
   typealias ClearDataCallback = @MainActor (Bool, Bool) -> Void
   @Published var clearableSettings: [ClearableSetting]
@@ -105,6 +110,7 @@ import os
     self.isP3AEnabled = p3aUtilities.isP3AEnabled
     self.clearDataCallback = clearDataCallback
     self.adBlockAndTrackingPreventionLevel = ShieldPreferences.blockAdsAndTrackingLevel
+    self.httpsUpgradeLevel = ShieldPreferences.httpsUpgradeLevel
     self.isDeAmpEnabled = deAmpPrefs.isDeAmpEnabled
     self.isDebounceEnabled = debounceService?.isEnabled ?? false
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
@@ -38,11 +38,20 @@ struct DefaultShieldsViewView: View {
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
 
-      OptionToggleView(
-        title: Strings.HTTPSEverywhere,
-        subtitle: Strings.HTTPSEverywhereDescription,
-        option: Preferences.Shields.httpsEverywhere
-      )
+      Picker(selection: $settings.httpsUpgradeLevel) {
+        ForEach(HTTPSUpgradeLevel.allCases) { level in
+          Text(level.localizedTitle)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .tag(level)
+        }
+      } label: {
+        LabelView(
+          title: Strings.Shields.upgradeConnectionsToHTTPS,
+          subtitle: nil
+        )
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+
       ToggleView(
         title: Strings.autoRedirectAMPPages,
         subtitle: Strings.autoRedirectAMPPagesDescription,
@@ -164,6 +173,20 @@ extension ShieldLevel: Identifiable {
   public var localizedTitle: String {
     switch self {
     case .aggressive: return Strings.Shields.trackersAndAdsBlockingAggressive
+    case .disabled: return Strings.Shields.trackersAndAdsBlockingDisabled
+    case .standard: return Strings.Shields.trackersAndAdsBlockingStandard
+    }
+  }
+}
+
+extension HTTPSUpgradeLevel: Identifiable {
+  public var id: String {
+    return rawValue
+  }
+
+  public var localizedTitle: String {
+    switch self {
+    case .strict: return Strings.Shields.httpsUpgradeLevelStrict
     case .disabled: return Strings.Shields.trackersAndAdsBlockingDisabled
     case .standard: return Strings.Shields.trackersAndAdsBlockingStandard
     }

--- a/ios/brave-ios/Sources/BraveShields/HTTPSUpgradeLevel.swift
+++ b/ios/brave-ios/Sources/BraveShields/HTTPSUpgradeLevel.swift
@@ -1,0 +1,32 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// A 3 part option for shield levels varying in strength of blocking content
+public enum HTTPSUpgradeLevel: String, CaseIterable, Hashable {
+  /// Always upgrade websites and block websites that cannot be upgraded
+  case strict
+  /// Always upgrade websites but allow http when it cannot be upgraded
+  case standard
+  /// Mode indicating this setting is disabled
+  case disabled
+
+  /// Wether this setting indicates that the shields are enabled or not
+  public var isEnabled: Bool {
+    switch self {
+    case .strict, .standard: return true
+    case .disabled: return false
+    }
+  }
+
+  /// Wether this setting indicates that the shields are aggressive or not
+  public var isStrict: Bool {
+    switch self {
+    case .strict: return true
+    case .disabled, .standard: return false
+    }
+  }
+}

--- a/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
@@ -6,8 +6,10 @@
 import Foundation
 import Preferences
 
+/// All the settings pertaining to shields and privacy
 public class ShieldPreferences {
   private static let defaultBlockAdsAndTrackingLevel: ShieldLevel = .standard
+  private static let defaultHTTPsUpgradeLevel: HTTPSUpgradeLevel = .standard
 
   /// Get the level of the adblock and tracking protection as a stored preference
   /// - Warning: You should not access this directly but  through ``blockAdsAndTrackingLevel``
@@ -16,12 +18,27 @@ public class ShieldPreferences {
     default: defaultBlockAdsAndTrackingLevel.rawValue
   )
 
+  /// Get the level of the https upgrade setting as a stored preference
+  /// - Warning: You should not access this directly but  through ``httpsUpgradeLevel``
+  public static var httpsUpgradeLevelRaw = Preferences.Option<String>(
+    key: "shields.https-upgrade-level",
+    default: defaultHTTPsUpgradeLevel.rawValue
+  )
+
   /// Get the level of the adblock and tracking protection
   public static var blockAdsAndTrackingLevel: ShieldLevel {
     get {
       ShieldLevel(rawValue: blockAdsAndTrackingLevelRaw.value) ?? defaultBlockAdsAndTrackingLevel
     }
     set { blockAdsAndTrackingLevelRaw.value = newValue.rawValue }
+  }
+
+  /// Get the level of HTTPS upgrades
+  public static var httpsUpgradeLevel: HTTPSUpgradeLevel {
+    get {
+      HTTPSUpgradeLevel(rawValue: httpsUpgradeLevelRaw.value) ?? defaultHTTPsUpgradeLevel
+    }
+    set { httpsUpgradeLevelRaw.value = newValue.rawValue }
   }
 
   /// A boolean value inidicating if GPC is enabled

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -317,3 +317,51 @@ extension Strings.Shields {
       "Text for a button in a blocked page info screen that takes you back where you came from"
   )
 }
+
+// MARK: - HTTPS Upgrades
+
+extension Strings.Shields {
+  /// The option the user can select to do aggressive ad and tracker blocking
+  public static let httpsUpgradeLevelStrict = NSLocalizedString(
+    "HttpsUpgradeLevelStrict",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Strict",
+    comment: "The option the user can select to do strict https upgrading"
+  )
+  /// The option the user can select for the type of https upgrading
+  public static let upgradeConnectionsToHTTPS = NSLocalizedString(
+    "UpgradeConnectionsToHTTPS",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Upgrade Connections to HTTPS",
+    comment: "The option the user can select for the type of https upgrading"
+  )
+
+  /// A page title for the warning page that appears when http was blocked
+  public static let siteIsNotSecure = NSLocalizedString(
+    "SiteIsNotSecure",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Site is not secure",
+    comment: "A page title for the warning page that appears when http was blocked"
+  )
+
+  /// A page title for the warning page that appears when http was blocked
+  public static let theConnectionIsNotSecure = NSLocalizedString(
+    "TheConnectionIsNotSecure",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "The connection to %@ is not secure",
+    comment: "A page title for the warning page that appears when http was blocked"
+  )
+
+  /// A tab title that appears when a page was blocked
+  public static let httpBlockedDescription = NSLocalizedString(
+    "YourConnectionIsNotPrivate",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "You are seeing this warning because this site does not support HTTPS.",
+    comment: "A description shown an a page where the http page was blocked"
+  )
+}

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -40,10 +40,8 @@ extension Preferences {
 
   public final class Shields {
     public static let allShields = [
-      httpsEverywhere, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages,
+      googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages,
     ]
-    /// Websites will be upgraded to HTTPS if a loaded page attempts to use HTTP
-    public static let httpsEverywhere = Option<Bool>(key: "shields.https-everywhere", default: true)
     /// Enable Google Safe Browsing
     public static let googleSafeBrowsing = Option<Bool>(
       key: "shields.google-safe-browsing",

--- a/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
@@ -467,6 +467,7 @@ public struct InternalURL {
     case sessionrestore
     case readermode = "reader-mode"
     case blocked
+    case httpBlocked = "http-blocked"
 
     func matches(_ string: String) -> Bool {
       return string.range(
@@ -545,6 +546,10 @@ public struct InternalURL {
 
   public var isBlockedPage: Bool {
     return InternalURL.Path.blocked.matches(url.path)
+  }
+
+  public var isHTTPBlockedPage: Bool {
+    return InternalURL.Path.httpBlocked.matches(url.path)
   }
 
   public var isReaderModePage: Bool {

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -49,11 +49,15 @@ class URLExtensionTests: XCTestCase {
 
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .readermode)?.strippedInternalURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
     )
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .blocked)?.strippedInternalURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
+    )
+    XCTAssertEqual(
+      embeddedURL.encodeEmbeddedInternalURL(for: .httpBlocked)?.strippedInternalURL,
+      embeddedURL
     )
     XCTAssertNil(embeddedURL.strippedInternalURL)
   }
@@ -116,15 +120,19 @@ class URLExtensionTests: XCTestCase {
 
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .readermode)?.displayURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
     )
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .blocked)?.displayURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
+    )
+    XCTAssertEqual(
+      embeddedURL.encodeEmbeddedInternalURL(for: .httpBlocked)?.displayURL,
+      embeddedURL
     )
     XCTAssertEqual(
       embeddedURL.displayURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
     )
   }
 }

--- a/ios/browser/api/https_upgrade_exceptions/BUILD.gn
+++ b/ios/browser/api/https_upgrade_exceptions/BUILD.gn
@@ -1,0 +1,21 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("https_upgrade_exceptions") {
+  sources = [
+    "https_upgrade_exceptions_service+private.h",
+    "https_upgrade_exceptions_service.h",
+    "https_upgrade_exceptions_service.mm",
+  ]
+  deps = [
+    "//base",
+    "//brave/components/https_upgrade_exceptions/browser",
+    "//brave/ios/browser/application_context",
+    "//ios/chrome/browser/shared/model/application_context",
+    "//net",
+    "//url",
+  ]
+  frameworks = [ "Foundation.framework" ]
+}

--- a/ios/browser/api/https_upgrade_exceptions/headers.gni
+++ b/ios/browser/api/https_upgrade_exceptions/headers.gni
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+browser_api_https_upgrade_exceptions_service_public_headers = [ "//brave/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service.h" ]

--- a/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service+private.h
+++ b/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service+private.h
@@ -1,0 +1,14 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_API_HTTPS_UPGRADE_EXCEPTIONS_HTTPS_UPGRADE_EXCEPTIONS_SERVICE_PRIVATE_H_
+#define BRAVE_IOS_BROWSER_API_HTTPS_UPGRADE_EXCEPTIONS_HTTPS_UPGRADE_EXCEPTIONS_SERVICE_PRIVATE_H_
+
+#include "brave/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service.h"
+
+@interface HTTPSUpgradeExceptionsService (Private)
+@end
+
+#endif  // BRAVE_IOS_BROWSER_API_HTTPS_UPGRADE_EXCEPTIONS_HTTPS_UPGRADE_EXCEPTIONS_SERVICE_PRIVATE_H_

--- a/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service.h
+++ b/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_API_HTTPS_UPGRADE_EXCEPTIONS_HTTPS_UPGRADE_EXCEPTIONS_SERVICE_H_
+#define BRAVE_IOS_BROWSER_API_HTTPS_UPGRADE_EXCEPTIONS_HTTPS_UPGRADE_EXCEPTIONS_SERVICE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+OBJC_EXPORT
+@interface HTTPSUpgradeExceptionsService : NSObject
+/// Tells us if the "HTTPS by default" feature is enabled
+@property(readonly) bool isHttpsByDefaultFeatureEnabled;
+
+- (instancetype)init;
+/// This returns a new URL with HTTPS if the url can be upgraded to HTTPS
+- (nullable NSURL*)upgradeToHTTPSForURL:(NSURL*)url;
+/// Add an exception for the URL so it will no longer upgrade it to HTTPS
+/// It will use the host of the URL to add the exception
+- (void)addExceptionForURL:(NSURL*)url;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_HTTPS_UPGRADE_EXCEPTIONS_HTTPS_UPGRADE_EXCEPTIONS_SERVICE_H_

--- a/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service.mm
+++ b/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service.mm
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/api/https_upgrade_exceptions/https_upgrade_exceptions_service+private.h"
+
+#include "base/containers/contains.h"
+#include "base/feature_list.h"
+#include "base/memory/raw_ptr.h"
+#include "brave/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.h"
+#include "brave/ios/browser/application_context/brave_application_context_impl.h"
+#include "ios/chrome/browser/shared/model/application_context/application_context.h"
+#include "net/base/apple/url_conversions.h"
+#include "net/base/features.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+@interface HTTPSUpgradeExceptionsService () {
+  /// set of domain exceptions
+  std::set<std::string> exceptional_domains_;
+}
+
+@property(nonatomic) bool isHttpsByDefaultFeatureEnabled;
+@end
+
+@implementation HTTPSUpgradeExceptionsService
+- (instancetype)init {
+  if ((self = [super init])) {
+  }
+  return self;
+}
+
+- (bool)isHttpsByDefaultFeatureEnabled {
+  return base::FeatureList::IsEnabled(net::features::kBraveHttpsByDefault);
+}
+
+- (NSURL*)upgradeToHTTPSForURL:(NSURL*)url {
+  GURL gurl = net::GURLWithNSURL(url);
+  if (![self isHttpsByDefaultFeatureEnabled]) {
+    return nil;
+  }
+
+  // Check url validity
+  if (!gurl.SchemeIs("http") || !gurl.is_valid()) {
+    return nil;
+  }
+
+  // Ensure we didn't add an exception for this domain
+  if (base::Contains(exceptional_domains_, gurl.host())) {
+    return nil;
+  }
+
+  // Finally ask the service if we should upgrade
+  BraveApplicationContextImpl* braveContext =
+      static_cast<BraveApplicationContextImpl*>(GetApplicationContext());
+  if (!braveContext->https_upgrade_exceptions_service()->CanUpgradeToHTTPS(
+          gurl)) {
+    return nil;
+  }
+
+  GURL::Replacements replacements;
+  replacements.SetSchemeStr("https");
+  GURL final_url = gurl.ReplaceComponents(replacements);
+
+  if (final_url.is_valid()) {
+    return net::NSURLWithGURL(final_url);
+  } else {
+    return nil;
+  }
+}
+
+- (void)addExceptionForURL:(NSURL*)url {
+  GURL gurl = net::GURLWithNSURL(url);
+
+  if (gurl.is_empty()) {
+    return;
+  }
+
+  exceptional_domains_.insert(gurl.host());
+}
+@end

--- a/ios/browser/application_context/BUILD.gn
+++ b/ios/browser/application_context/BUILD.gn
@@ -16,9 +16,11 @@ source_set("application_context") {
     "//brave/components/brave_component_updater/browser",
     "//brave/components/brave_wallet/browser",
     "//brave/components/debounce/core/browser",
+    "//brave/components/https_upgrade_exceptions/browser",
     "//brave/components/url_sanitizer/browser",
     "//brave/ios/browser/brave_wallet",
     "//ios/chrome/browser/application_context/model",
     "//ios/chrome/browser/shared/model/application_context",
+    "//net",
   ]
 }

--- a/ios/browser/application_context/brave_application_context_impl.h
+++ b/ios/browser/application_context/brave_application_context_impl.h
@@ -11,6 +11,7 @@
 
 #include "brave/components/brave_component_updater/browser/brave_component.h"
 #include "brave/components/debounce/core/browser/debounce_component_installer.h"
+#include "brave/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.h"
 #include "brave/components/url_sanitizer/browser/url_sanitizer_component_installer.h"
 #include "ios/chrome/browser/application_context/model/application_context_impl.h"
 
@@ -42,6 +43,8 @@ class BraveApplicationContextImpl : public ApplicationContextImpl {
   // BraveApplicationContextImpl
   brave::URLSanitizerComponentInstaller* url_sanitizer_component_installer();
   debounce::DebounceComponentInstaller* debounce_component_installer();
+  https_upgrade_exceptions::HttpsUpgradeExceptionsService*
+  https_upgrade_exceptions_service();
 
   // Start any services that we may need later
   void StartBraveServices();
@@ -59,6 +62,8 @@ class BraveApplicationContextImpl : public ApplicationContextImpl {
       url_sanitizer_component_installer_;
   std::unique_ptr<debounce::DebounceComponentInstaller>
       debounce_component_installer_;
+  std::unique_ptr<https_upgrade_exceptions::HttpsUpgradeExceptionsService>
+      https_upgrade_exceptions_service_;
 };
 
 #endif  // BRAVE_IOS_BROWSER_APPLICATION_CONTEXT_BRAVE_APPLICATION_CONTEXT_IMPL_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36408

Security review: https://github.com/brave/reviews/issues/1593

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Check that http://example.com upgrades correctly. Back and forth navigation buttons work as expected
2. Check that some made up website (ex: http://jfdskllfsjlks.com) does not upgrade. Back and forth buttons work as expected.

Note: I don't know of any sites that do exist in http but not in https. If you are able to come across one please test it.
