### PR TITLE
style(wallet): Token List Padding Changes

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/index.tsx
@@ -204,7 +204,7 @@ export const PortfolioAssetItem = ({
         isGrouped={isGrouped}
       >
         {token.visible && (
-          <HoverArea isPanel={isPanel}>
+          <HoverArea isGrouped={isGrouped}>
             <Button
               disabled={isLoading}
               rightMargin={10}

--- a/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio-asset-item/style.ts
@@ -16,22 +16,28 @@ import {
   Column,
   Row
 } from '../../shared/style'
+import {
+  layoutPanelWidth //
+} from '../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const HoverArea = styled.div<{
-  isPanel?: boolean
   noHover?: boolean
+  isGrouped?: boolean
 }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
   flex-direction: row;
   width: 100%;
-  padding: 12px ${(p) => (p.isPanel ? 0 : 12)}px;
+  padding: 12px;
   border-radius: var(--hover-area-border-radius);
   transition: background-color 300ms ease-out;
   &:hover {
     background-color: ${(p) =>
       p.noHover ? 'none' : leo.color.page.background};
+  }
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: ${(p) => (p.isGrouped ? 12 : 8)}px;
   }
 `
 

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -50,7 +50,8 @@ import {
   ControlsWrapper,
   AssetsWrapper,
   NFTsWrapper,
-  TransactionsWrapper
+  TransactionsWrapper,
+  EmptyStateWrapper
 } from './style'
 import { Column, VerticalSpace, Text } from '../../../shared/style'
 import { EmptyTransactionsIcon } from '../portfolio/style'
@@ -423,43 +424,51 @@ export const Account = () => {
       </ControlsWrapper>
 
       {selectedTab === AccountPageTabs.AccountAssetsSub && (
-        <AssetsWrapper fullWidth={true}>
-          {fungibleTokensSortedByValue.map((asset) => (
-            <PortfolioAssetItem
-              key={getAssetIdKey(asset)}
-              action={() => onSelectAsset(asset)}
-              account={selectedAccount}
-              assetBalance={
-                isLoadingBalances
-                  ? ''
-                  : getBalance(
-                      selectedAccount.accountId,
-                      asset,
-                      tokenBalancesRegistry
-                    )
-              }
-              token={asset}
-              spotPrice={
-                spotPriceRegistry && !isLoadingSpotPrices
-                  ? getTokenPriceAmountFromRegistry(
-                      spotPriceRegistry,
-                      asset
-                    ).format()
-                  : ''
-              }
-              isAccountDetails={true}
-            />
-          ))}
-          {showAssetDiscoverySkeleton && <PortfolioAssetItemLoadingSkeleton />}
+        <>
+          <AssetsWrapper fullWidth={true}>
+            {fungibleTokensSortedByValue.map((asset) => (
+              <PortfolioAssetItem
+                key={getAssetIdKey(asset)}
+                action={() => onSelectAsset(asset)}
+                account={selectedAccount}
+                assetBalance={
+                  isLoadingBalances
+                    ? ''
+                    : getBalance(
+                        selectedAccount.accountId,
+                        asset,
+                        tokenBalancesRegistry
+                      )
+                }
+                token={asset}
+                spotPrice={
+                  spotPriceRegistry && !isLoadingSpotPrices
+                    ? getTokenPriceAmountFromRegistry(
+                        spotPriceRegistry,
+                        asset
+                      ).format()
+                    : ''
+                }
+                isAccountDetails={true}
+              />
+            ))}
+            {showAssetDiscoverySkeleton && (
+              <PortfolioAssetItemLoadingSkeleton />
+            )}
+          </AssetsWrapper>
           {fungibleTokensSortedByValue.length === 0 &&
             !isLoadingBalances &&
-            !isLoadingSpotPrices && <EmptyTokenListState />}
-        </AssetsWrapper>
+            !isLoadingSpotPrices && (
+              <EmptyStateWrapper>
+                <EmptyTokenListState />
+              </EmptyStateWrapper>
+            )}
+        </>
       )}
 
-      {selectedTab === AccountPageTabs.AccountNFTsSub && (
-        <NFTsWrapper fullWidth={true}>
-          {nonFungibleTokens?.length !== 0 ? (
+      {selectedTab === AccountPageTabs.AccountNFTsSub &&
+        (nonFungibleTokens?.length !== 0 ? (
+          <NFTsWrapper fullWidth={true}>
             <NftGrid>
               {nonFungibleTokens?.map((nft: BraveWallet.BlockchainToken) => (
                 <NFTGridViewItem
@@ -471,11 +480,12 @@ export const Account = () => {
                 />
               ))}
             </NftGrid>
-          ) : (
+          </NFTsWrapper>
+        ) : (
+          <EmptyStateWrapper>
             <NftsEmptyState onImportNft={() => setShowAddNftModal(true)} />
-          )}
-        </NFTsWrapper>
-      )}
+          </EmptyStateWrapper>
+        ))}
 
       {selectedTab === AccountPageTabs.AccountTransactionsSub && (
         <>

--- a/components/brave_wallet_ui/components/desktop/views/accounts/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/style.ts
@@ -16,16 +16,16 @@ export const ControlsWrapper = styled(Column)`
 `
 
 export const AssetsWrapper = styled(Column)`
-  padding: 16px 24px 24px 24px;
+  padding: 16px 20px 20px 20px;
   @media screen and (max-width: ${layoutPanelWidth}px) {
-    padding: 16px;
+    padding: 8px;
   }
 `
 
 export const NFTsWrapper = styled(Column)`
-  padding: 16px 32px 24px 32px;
+  padding: 16px;
   @media screen and (max-width: ${layoutPanelWidth}px) {
-    padding: 16px;
+    padding: 8px;
   }
 `
 
@@ -42,4 +42,11 @@ export const SectionTitle = styled.span`
   line-height: 24px;
   font-weight: 600;
   color: ${leo.color.text.secondary};
+`
+
+export const EmptyStateWrapper = styled(Column)`
+  padding: 32px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 16px;
+  }
 `

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.styles.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.styles.tsx
@@ -2,22 +2,28 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
+
 import styled from 'styled-components'
+
+// Shared Styles
+import { Row, ScrollableColumn } from '../../../../shared/style'
 import {
   layoutPanelWidth //
 } from '../../../wallet-page-wrapper/wallet-page-wrapper.style'
 
-export const NftGrid = styled.div`
+export const NftGrid = styled.div<{
+  padding?: string
+}>`
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   grid-gap: 16px;
   box-sizing: border-box;
   width: 100%;
-  padding: 16px;
+  padding: ${(p) => p.padding ?? '16px'};
   @media screen and (max-width: ${layoutPanelWidth}px) {
     grid-template-columns: repeat(2, 1fr);
     grid-gap: 8px;
-    padding: 8px;
+    padding: ${(p) => p.padding ?? '8px'};
   }
 `
 
@@ -27,4 +33,18 @@ export const EmptyStateText = styled.div`
   color: ${(p) => p.theme.color.text03};
   font-size: 14px;
   font-family: Poppins;
+`
+
+export const BannerWrapper = styled(Row)`
+  padding: 0px 32px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 0px 16px;
+  }
+`
+
+export const NFTListWrapper = styled(ScrollableColumn)`
+  padding: 0px 32px 32px 32px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 0px 16px 16px 16px;
+  }
 `

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -59,8 +59,8 @@ import { AutoDiscoveryEmptyState } from './auto-discovery-empty-state/auto-disco
 import { NftIpfsBanner } from '../../../nft-ipfs-banner/nft-ipfs-banner'
 
 // styles
-import { NftGrid } from './nfts.styles'
-import { Row, ScrollableColumn } from '../../../../shared/style'
+import { BannerWrapper, NFTListWrapper, NftGrid } from './nfts.styles'
+import { Row } from '../../../../shared/style'
 import { AddOrEditNftModal } from '../../../popup-modals/add-edit-nft-modal/add-edit-nft-modal'
 import { NftsEmptyState } from './nfts-empty-state/nfts-empty-state'
 import {
@@ -448,7 +448,7 @@ export const Nfts = (props: Props) => {
     ) : selectedGroupAssetsByItem === AccountsGroupByOption.id ? (
       listUiByAccounts
     ) : (
-      <NftGrid>
+      <NftGrid padding='0px'>
         {renderedList.map(renderGridViewItem)}
         {!assetAutoDiscoveryCompleted && <NftGridViewItemSkeleton />}
       </NftGrid>
@@ -477,14 +477,13 @@ export const Nfts = (props: Props) => {
       {isNftPinningFeatureEnabled &&
       isIpfsBannerVisible &&
       visibleNfts.length > 0 ? (
-        <Row
+        <BannerWrapper
           justifyContent='center'
           alignItems='center'
-          padding='0px 32px'
           marginBottom={16}
         >
           <NftIpfsBanner onDismiss={onToggleShowIpfsBanner} />
-        </Row>
+        </BannerWrapper>
       ) : null}
 
       <ControlBarWrapper
@@ -542,7 +541,7 @@ export const Nfts = (props: Props) => {
           )}
         </Row>
       </ControlBarWrapper>
-      <ScrollableColumn padding='0px 20px 20px 20px'>
+      <NFTListWrapper>
         {nftList.length === 0 &&
         userTokensRegistry?.hiddenTokenIds.length === 0 ? (
           isNftAutoDiscoveryEnabled ? (
@@ -557,7 +556,7 @@ export const Nfts = (props: Props) => {
         ) : (
           listUi
         )}
-      </ScrollableColumn>
+      </NFTListWrapper>
       {showAddNftModal && (
         <AddOrEditNftModal
           onClose={toggleShowAddNftModal}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.style.ts
@@ -3,9 +3,31 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
+import styled from 'styled-components'
+
+// Shared Styles
+import { Column } from '../../../../../shared/style'
+import {
+  layoutPanelWidth //
+} from '../../../../wallet-page-wrapper/wallet-page-wrapper.style'
+
 export const listItemInitialHeight = 76
 
 export const AutoSizerStyle: React.CSSProperties = {
   width: '100%',
   height: '100%'
 }
+
+export const FlatTokenListWrapper = styled(Column)`
+  padding: 0px 20px 20px 20px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 0px 8px 8px 8px;
+  }
+`
+
+export const GroupTokenListWrapper = styled(Column)`
+  padding: 0px 32px 32px 32px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 0px 16px 16px 16px;
+  }
+`

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/token-lists/token-list.tsx
@@ -88,12 +88,7 @@ import {
 } from '../../../../../../common/slices/entities/token-balance.entity'
 
 // Styled Components
-import {
-  Column,
-  Row,
-  ScrollableColumn,
-  Text
-} from '../../../../../shared/style'
+import { Row, ScrollableColumn, Text } from '../../../../../shared/style'
 import {
   PortfolioActionButton,
   ButtonIcon,
@@ -102,6 +97,7 @@ import {
   SearchButtonWrapper,
   ContentWrapper
 } from '../../style'
+import { FlatTokenListWrapper, GroupTokenListWrapper } from './token-list.style'
 
 interface Props {
   userAssetList: UserAssetInfoType[]
@@ -608,18 +604,22 @@ export const TokenLists = ({
 
   const listUi = React.useMemo(() => {
     return selectedGroupAssetsByItem === NetworksGroupByOption.id ? (
-      listUiByNetworks
+      <GroupTokenListWrapper fullWidth={true}>
+        {listUiByNetworks}
+      </GroupTokenListWrapper>
     ) : selectedGroupAssetsByItem === AccountsGroupByOption.id ? (
-      listUiByAccounts
+      <GroupTokenListWrapper fullWidth={true}>
+        {listUiByAccounts}
+      </GroupTokenListWrapper>
     ) : noNetworks ? (
       <EmptyTokenListState />
     ) : (
-      <>
+      <FlatTokenListWrapper fullWidth={true}>
         {getSortedFungibleTokensList(filteredAssetList).map((token, index) =>
           renderToken({ index, item: token, viewMode: 'list' })
         )}
         {!assetAutoDiscoveryCompleted && <PortfolioAssetItemLoadingSkeleton />}
-      </>
+      </FlatTokenListWrapper>
     )
   }, [
     selectedGroupAssetsByItem,
@@ -708,12 +708,7 @@ export const TokenLists = ({
           {listUi}
         </ScrollableColumn>
       ) : (
-        <Column
-          fullWidth={true}
-          padding='0px 24px 24px 24px'
-        >
-          {listUi}
-        </Column>
+        listUi
       )}
     </ContentWrapper>
   )

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -174,7 +174,7 @@ export const SelectTimelineWrapper = styled(Row)`
 export const ControlsRow = styled(Row)<{ controlsHidden?: boolean }>`
   box-shadow: 0px -1px 1px ${leo.color.elevation.primary};
   border-radius: 16px 16px 0px 0px;
-  padding: ${(p) => (p.controlsHidden ? '12px' : '24px 16px')};
+  padding: ${(p) => (p.controlsHidden ? '12px' : '24px 32px')};
   background-color: ${leo.color.container.background};
   @media screen and (max-width: ${layoutPanelWidth}px) {
     padding: ${(p) => (p.controlsHidden ? '8px' : '16px')};
@@ -253,7 +253,7 @@ export const ControlBarWrapper = styled(Row)<{
   margin-bottom: 16px;
   @media screen and (max-width: ${layoutPanelWidth}px) {
     padding: ${(p) => (p.showSearchBar ? (p.isNFTView ? '2px' : '0px') : '4px')}
-      24px 0px 24px;
+      16px 0px 16px;
     margin-bottom: ${(p) => (p.showSearchBar ? 12 : 16)}px;
   }
 `

--- a/components/brave_wallet_ui/page/screens/send/shared.styles.ts
+++ b/components/brave_wallet_ui/page/screens/send/shared.styles.ts
@@ -55,7 +55,6 @@ export const Text = styled.span<TextProps>`
   font-weight: ${(p) => (p.isBold ? 500 : 400)};
   height: ${(p) => (p.maintainHeight ? 'var(--line-height)' : 'unset')};
   line-height: var(--line-height);
-  letter-spacing: 0.02em;
   text-align: ${(p) => (p.textAlign ? p.textAlign : 'center')};
   word-wrap: wrap;
 `


### PR DESCRIPTION
## Description 
- Add's consistent `padding` to the `Tokens List` in the Wallet `Panel`
- Removes the `letter-spacing: 0.02em` from our shared `Text` styled component

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37525>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the Wallet `Panel` and navigate to the `Portfolio` view
2. The `Tokens List` horizontal padding should be consistent with everything else
3. Test the same thing in the `Account Details` view

Before:

![Screenshot](https://github.com/brave/brave-core/assets/40611140/f887c36a-2f86-430a-9fd5-5370c88ec6ca)

![Screenshot 1](https://github.com/brave/brave-core/assets/40611140/1601a6a6-f305-4592-ab93-5250804f4b96)

![Screenshot 2](https://github.com/brave/brave-core/assets/40611140/755aa6e0-f581-4e02-8f69-1576fb74993f)

![Screenshot 3](https://github.com/brave/brave-core/assets/40611140/d7004cc3-2e5e-41c6-b645-0d27cbca1636)

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/9be1d88d-6a3a-4f59-abf1-572d6b5d36c7)

![Screenshot 5](https://github.com/brave/brave-core/assets/40611140/7c9993bf-7412-45ef-aac9-980cec6fa7d1)

After:

![Screenshot](https://github.com/brave/brave-core/assets/40611140/594a24fc-1a16-4684-ab16-714e21c335ad)

![Screenshot 1](https://github.com/brave/brave-core/assets/40611140/d2db1d53-c3ab-476f-bfb7-5bf50db3e7f0)

![Screenshot 2](https://github.com/brave/brave-core/assets/40611140/91d439fe-ab75-4de9-a687-fb96913ffca1)

![Screenshot 3](https://github.com/brave/brave-core/assets/40611140/c9c86c61-fc53-4a8f-9dac-bf78c0476b61)

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/2fc4f1a0-eae7-4efa-8784-ec47fc64e481)

![Screenshot 5](https://github.com/brave/brave-core/assets/40611140/bea0b8fe-b8d3-4fc7-a55a-8f228adf97d5)
