### PR TITLE
[Uplift 1.66.x] #23044 fix(News): Wait until preferences are seeded before sending the Feed …

### DIFF
--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -162,6 +162,7 @@ class BraveNewsController
   void CheckForPublishersUpdate();
   void Prefetch();
   void MaybeInitPrefs();
+  void OnInitializingPrefsComplete();
 
   void NotifyPublishersChanged(mojom::PublishersEventPtr event);
   void NotifyChannelsChanged(mojom::ChannelsEventPtr event);
@@ -188,6 +189,13 @@ class BraveNewsController
   base::OneShotTimer timer_prefetch_;
   base::RepeatingTimer timer_feed_update_;
   base::RepeatingTimer timer_publishers_update_;
+  // Subscribe to this to know when the initial initializing (and seeding) of
+  // preferences is ensured. This happens after the feature is (re-)enabled
+  // and after locales and sources are fetched. A valid feed and list of
+  // channels might only be available after this event has fired. If News is
+  // already enabled and this event has already signalled, then they are already
+  // available.
+  base::OneShotEvent on_initializing_prefs_complete_;
   base::CancelableTaskTracker task_tracker_;
 
   base::ScopedObservation<BraveNewsPrefManager,


### PR DESCRIPTION
- Uplift of https://github.com/brave/brave-core/pull/23044
- Resolves https://github.com/brave/brave-browser/issues/37156
- Resolves https://github.com/brave/brave-browser/issues/37569
- Resolves https://github.com/brave/brave-browser/issues/37570