### PR TITLE
[Uplift 1.65.x] fix(News): Wait until preferences are seeded before sending the Feed …

### DIFF
--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -23,6 +23,7 @@
 #include "base/functional/callback_helpers.h"
 #include "base/location.h"
 #include "base/memory/weak_ptr.h"
+#include "base/one_shot_event.h"
 #include "base/time/time.h"
 #include "base/values.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
@@ -167,6 +168,16 @@ void BraveNewsController::GetFeed(GetFeedCallback callback) {
     std::move(callback).Run(brave_news::mojom::Feed::New());
     return;
   }
+  // If we're only recently opted-in but we haven't yet finished adding the
+  // top sources subscription (via the async functions in MaybeInitPrefs), we
+  // need to wait for that to complete before we can fetch the feed.
+  if (!on_initializing_prefs_complete_.is_signaled()) {
+    on_initializing_prefs_complete_.Post(
+        FROM_HERE,
+        base::BindOnce(&BraveNewsController::GetFeed,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+    return;
+  }
   feed_controller_.GetOrFetchFeed(pref_manager_.GetSubscriptions(),
                                   std::move(callback));
 }
@@ -217,6 +228,16 @@ void BraveNewsController::GetFeedV2(GetFeedV2Callback callback) {
     return;
   }
 
+  // If we're only recently opted-in but we haven't yet finished adding the
+  // top sources subscription (via the async functions in MaybeInitPrefs), we
+  // need to wait for that to complete before we can fetch the feed.
+  if (!on_initializing_prefs_complete_.is_signaled()) {
+    on_initializing_prefs_complete_.Post(
+        FROM_HERE,
+        base::BindOnce(&BraveNewsController::GetFeedV2,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+    return;
+  }
   feed_v2_builder_->BuildAllFeed(pref_manager_.GetSubscriptions(),
                                  std::move(callback));
 }
@@ -275,6 +296,13 @@ void BraveNewsController::FindFeeds(const GURL& possible_feed_or_site_url,
 void BraveNewsController::GetChannels(GetChannelsCallback callback) {
   if (!pref_manager_.IsEnabled()) {
     std::move(callback).Run({});
+    return;
+  }
+  if (!on_initializing_prefs_complete_.is_signaled()) {
+    on_initializing_prefs_complete_.Post(
+        FROM_HERE,
+        base::BindOnce(&BraveNewsController::GetChannels,
+                       weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
     return;
   }
   channels_controller_.GetAllChannels(pref_manager_.GetSubscriptions(),
@@ -745,28 +773,55 @@ void BraveNewsController::ConditionallyStartOrStopTimer() {
 }
 
 void BraveNewsController::MaybeInitPrefs() {
-  if (pref_manager_.IsEnabled()) {
-    const auto& channels = pref_manager_.GetSubscriptions().channels();
-    if (channels.empty()) {
-      publishers_controller_.GetLocale(
-          pref_manager_.GetSubscriptions(),
-          base::BindOnce(
-              [](base::WeakPtr<BraveNewsController> controller,
-                 const std::string& locale) {
-                if (!controller) {
-                  return;
-                }
-                // This could happen, if we're offline, or the API is down at
-                // the moment.
-                if (locale.empty()) {
-                  return;
-                }
-                controller->pref_manager_.SetChannelSubscribed(
-                    locale, kTopSourcesChannel, true);
-              },
-              weak_ptr_factory_.GetWeakPtr()));
-    }
+  // When first enabled, we need to create the initial "Top Sources" channel
+  // subscription for the revelant locale. We can't do this before opt-in as the
+  // list of supported locales needs to be fetched.
+  if (!pref_manager_.IsEnabled()) {
+    return;
   }
+
+  const auto& subscriptions = pref_manager_.GetSubscriptions();
+  if (!subscriptions.channels().empty() ||
+      !subscriptions.enabled_publishers().empty() ||
+      !subscriptions.direct_feeds().empty()) {
+    OnInitializingPrefsComplete();
+    return;
+  }
+
+  publishers_controller_.GetLocale(
+      pref_manager_.GetSubscriptions(),
+      base::BindOnce(
+          [](base::WeakPtr<BraveNewsController> controller,
+             const std::string& locale) {
+            if (!controller) {
+              return;
+            }
+            // This could happen, if we're offline, or the API is down at
+            // the moment.
+            if (locale.empty()) {
+              return;
+            }
+            controller->pref_manager_.SetChannelSubscribed(
+                locale, kTopSourcesChannel, true);
+            controller->OnInitializingPrefsComplete();
+          },
+          weak_ptr_factory_.GetWeakPtr()));
+}
+
+void BraveNewsController::OnInitializingPrefsComplete() {
+  if (!on_initializing_prefs_complete_.is_signaled()) {
+    on_initializing_prefs_complete_.Signal();
+  }
+  // Some listeners won't have channels yet because they registered before
+  // any were fetched.
+  GetChannels(
+      base::BindOnce([](Channels channels) {
+        auto event = brave_news::mojom::ChannelsEvent::New();
+        event->addedOrUpdated = std::move(channels);
+        return event;
+      })
+          .Then(base::BindOnce(&BraveNewsController::NotifyChannelsChanged,
+                               weak_ptr_factory_.GetWeakPtr())));
 }
 
 void BraveNewsController::OnNetworkChanged(

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -162,6 +162,7 @@ class BraveNewsController
   void CheckForPublishersUpdate();
   void Prefetch();
   void MaybeInitPrefs();
+  void OnInitializingPrefsComplete();
 
   void NotifyPublishersChanged(mojom::PublishersEventPtr event);
   void NotifyChannelsChanged(mojom::ChannelsEventPtr event);
@@ -188,6 +189,13 @@ class BraveNewsController
   base::OneShotTimer timer_prefetch_;
   base::RepeatingTimer timer_feed_update_;
   base::RepeatingTimer timer_publishers_update_;
+  // Subscribe to this to know when the initial initializing (and seeding) of
+  // preferences is ensured. This happens after the feature is (re-)enabled
+  // and after locales and sources are fetched. A valid feed and list of
+  // channels might only be available after this event has fired. If News is
+  // already enabled and this event has already signalled, then they are already
+  // available.
+  base::OneShotEvent on_initializing_prefs_complete_;
   base::CancelableTaskTracker task_tracker_;
 
   base::ScopedObservation<BraveNewsPrefManager,


### PR DESCRIPTION
- Uplift of https://github.com/brave/brave-core/pull/23044
- Resolves https://github.com/brave/brave-browser/issues/37156
- Resolves https://github.com/brave/brave-browser/issues/37569
- Resolves https://github.com/brave/brave-browser/issues/37570