### PR TITLE
Fix omnibox search promotion layout regression

### DIFF
--- a/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
@@ -28,5 +28,9 @@ gfx::Rect BraveOmniboxPopupViewViews::GetTargetBounds() const {
   return bounds;
 }
 
+int BraveOmniboxPopupViewViews::GetLocationBarViewWidth() const {
+  return location_bar_view()->width();
+}
+
 BEGIN_METADATA(BraveOmniboxPopupViewViews)
 END_METADATA

--- a/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h
@@ -15,6 +15,8 @@ class BraveOmniboxPopupViewViews : public OmniboxPopupViewViews {
   using OmniboxPopupViewViews::OmniboxPopupViewViews;
   ~BraveOmniboxPopupViewViews() override;
 
+  int GetLocationBarViewWidth() const;
+
   // OmniboxPopupViewViews:
   gfx::Rect GetTargetBounds() const override;
 };

--- a/browser/ui/views/omnibox/brave_omnibox_result_view.h
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.h
@@ -12,6 +12,7 @@
 #include "ui/base/metadata/metadata_header_macros.h"
 
 class BraveSearchConversionPromotionView;
+class BraveOmniboxPopupViewViews;
 
 // This will render brave specific matches such as the braver search conversion
 // promotion.
@@ -25,6 +26,7 @@ class BraveOmniboxResultView : public OmniboxResultView {
 
   void OpenMatch();
   void RefreshOmniboxResult();
+  BraveOmniboxPopupViewViews* GetPopupView();
 
   // OmniboxResultView overrides:
   void SetMatch(const AutocompleteMatch& match) override;
@@ -34,7 +36,7 @@ class BraveOmniboxResultView : public OmniboxResultView {
   void OnPaintBackground(gfx::Canvas* canvas) override;
 
  private:
-  void ResetChildrenVisibility();
+  void ResetChildren();
   void UpdateForBraveSearchConversion();
   void HandleSelectionStateChangedForPromotionView();
 

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
@@ -54,6 +54,7 @@ class BraveSearchConversionPromotionView : public views::View {
   int GetBannerTypeTitleStringResourceId();
   int GetBannerTypeDescStringResourceId();
   SkColor GetCloseButtonColor() const;
+  int GetOverallHorizontalMarginAroundDescription() const;
 
   raw_ptr<BraveOmniboxResultView> result_view_ = nullptr;
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/37531

To know promotion result view's exact size, we need to know its
final width but we don't know when its CalculatePreferredSize().
Instead, calculate final width by using location bar's width.

This PR is based on https://github.com/brave/brave-core/pull/23123
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Run brave with `--enable-features=BraveSearchOmniboxBanner:banner_type/type_B`
2. Set non-brave default search provider
3. Type anything and check omnibox promotion result view layout is not broken