### PR TITLE
[ads] Implement Griffin support for disabling viewed and clicked event debouncing

### DIFF
--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -1141,6 +1141,8 @@ static_library("internal") {
     "user_engagement/ad_events/ad_event_cache.cc",
     "user_engagement/ad_events/ad_event_cache_util.cc",
     "user_engagement/ad_events/ad_event_cache_util.h",
+    "user_engagement/ad_events/ad_event_feature.cc",
+    "user_engagement/ad_events/ad_event_feature.h",
     "user_engagement/ad_events/ad_event_handler_util.cc",
     "user_engagement/ad_events/ad_event_handler_util.h",
     "user_engagement/ad_events/ad_event_info.cc",

--- a/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/exclusion_rule_util.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/exclusion_rules/exclusion_rule_util.cc
@@ -33,7 +33,7 @@ bool DoesRespectCampaignCap(const CreativeAdInfo& creative_ad,
 
   const size_t count = count_if_until(
       ad_events,
-      [&creative_ad, &confirmation_type, now,
+      [&creative_ad, confirmation_type, now,
        time_constraint](const AdEventInfo& ad_event) {
         return ad_event.confirmation_type == confirmation_type &&
                ad_event.campaign_id == creative_ad.campaign_id &&
@@ -65,7 +65,7 @@ bool DoesRespectCreativeSetCap(const CreativeAdInfo& creative_ad,
 
   const size_t count = count_if_until(
       ad_events,
-      [&creative_ad, &confirmation_type, now,
+      [&creative_ad, confirmation_type, now,
        time_constraint](const AdEventInfo& ad_event) {
         return ad_event.confirmation_type == confirmation_type &&
                ad_event.creative_set_id == creative_ad.creative_set_id &&
@@ -97,7 +97,7 @@ bool DoesRespectCreativeCap(const CreativeAdInfo& creative_ad,
 
   const size_t count = count_if_until(
       ad_events,
-      [&creative_ad, &confirmation_type, now,
+      [&creative_ad, confirmation_type, now,
        time_constraint](const AdEventInfo& ad_event) {
         return ad_event.confirmation_type == confirmation_type &&
                ad_event.creative_instance_id ==

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.h"
+
+namespace brave_ads {
+
+BASE_FEATURE(kAdEventFeature, "AdEvent", base::FEATURE_ENABLED_BY_DEFAULT);
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.h
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.h
@@ -1,0 +1,30 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_FEATURE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_FEATURE_H_
+
+#include "base/feature_list.h"
+#include "base/metrics/field_trial_params.h"
+
+namespace base {
+class TimeDelta;
+}  // namespace base
+
+namespace brave_ads {
+
+BASE_DECLARE_FEATURE(kAdEventFeature);
+
+// Set to 0 to always debounce viewed ad events.
+inline constexpr base::FeatureParam<base::TimeDelta> kDebounceViewedAdEventFor{
+    &kAdEventFeature, "debounce_viewed_ad_event_for", base::Seconds(0)};
+
+// Set to 0 to always debounce clicked ad events.
+inline constexpr base::FeatureParam<base::TimeDelta> kDebounceClickedAdEventFor{
+    &kAdEventFeature, "debounce_clicked_ad_event_for", base::Seconds(0)};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_FEATURE_H_

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature_unittest.cc
@@ -1,0 +1,77 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.h"
+
+#include "base/test/scoped_feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+TEST(BraveAdsAdEventFeatureTest, IsEnabled) {
+  // Act & Assert
+  EXPECT_TRUE(base::FeatureList::IsEnabled(kAdEventFeature));
+}
+
+TEST(BraveAdsAdEventFeatureTest, IsDisabled) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(kAdEventFeature);
+
+  // Act & Assert
+  EXPECT_FALSE(base::FeatureList::IsEnabled(kAdEventFeature));
+}
+
+TEST(BraveAdsAdEventFeatureTest, DebounceViewedAdEventFor) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      kAdEventFeature, {{"debounce_viewed_ad_event_for", "5s"}});
+
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(5), kDebounceViewedAdEventFor.Get());
+}
+
+TEST(BraveAdsAdEventFeatureTest, DefaultDebounceViewedAdEventFor) {
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(0), kDebounceViewedAdEventFor.Get());
+}
+
+TEST(BraveAdsAdEventFeatureTest, DefaultDebounceViewedAdEventForWhenDisabled) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(kAdEventFeature);
+
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(0), kDebounceViewedAdEventFor.Get());
+}
+
+TEST(BraveAdsAdEventFeatureTest, DebounceClickedAdEventFor) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      kAdEventFeature, {{"debounce_clicked_ad_event_for", "5s"}});
+
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(5), kDebounceClickedAdEventFor.Get());
+}
+
+TEST(BraveAdsAdEventFeatureTest, DefaultDebounceClickedAdEventFor) {
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(0), kDebounceClickedAdEventFor.Get());
+}
+
+TEST(BraveAdsAdEventFeatureTest, DefaultDebounceClickedAdEventForWhenDisabled) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(kAdEventFeature);
+
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(0), kDebounceClickedAdEventFor.Get());
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util.h"
 
 #include "base/ranges/algorithm.h"
+#include "base/time/time.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_info.h"
 
 namespace brave_ads {
@@ -14,9 +15,25 @@ bool HasFiredAdEvent(const AdInfo& ad,
                      const AdEventList& ad_events,
                      const ConfirmationType confirmation_type) {
   const auto iter = base::ranges::find_if(
-      ad_events, [&ad, &confirmation_type](const AdEventInfo& ad_event) {
+      ad_events, [&ad, confirmation_type](const AdEventInfo& ad_event) {
         return ad_event.placement_id == ad.placement_id &&
                ad_event.confirmation_type == confirmation_type;
+      });
+
+  return iter != ad_events.cend();
+}
+
+bool HasFiredAdEventWithinTimeWindow(const AdInfo& ad,
+                                     const AdEventList& ad_events,
+                                     const ConfirmationType confirmation_type,
+                                     const base::TimeDelta time_window) {
+  const auto iter = base::ranges::find_if(
+      ad_events,
+      [&ad, confirmation_type, time_window](const AdEventInfo& ad_event) {
+        return ad_event.placement_id == ad.placement_id &&
+               ad_event.confirmation_type == confirmation_type &&
+               (time_window.is_zero() ||
+                base::Time::Now() - ad_event.created_at <= time_window);
       });
 
   return iter != ad_events.cend();

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util.h
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util.h
@@ -6,9 +6,13 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_HANDLER_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_USER_ENGAGEMENT_AD_EVENTS_AD_EVENT_HANDLER_UTIL_H_
 
-#include "base/check.h"
+#include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_info.h"
 #include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
+
+namespace base {
+class TimeDelta;
+}  // namespace base
 
 namespace brave_ads {
 
@@ -18,10 +22,16 @@ bool HasFiredAdEvent(const AdInfo& ad,
                      const AdEventList& ad_events,
                      ConfirmationType confirmation_type);
 
+// Set `time_window` to 0 to ignore the time window.
+bool HasFiredAdEventWithinTimeWindow(const AdInfo& ad,
+                                     const AdEventList& ad_events,
+                                     ConfirmationType confirmation_type,
+                                     base::TimeDelta time_window);
+
 template <typename T>
 bool WasAdServed(const AdInfo& ad,
                  const AdEventList& ad_events,
-                 const T& event_type) {
+                 const T event_type) {
   return event_type == T::kServedImpression ||
          HasFiredAdEvent(ad, ad_events, ConfirmationType::kServedImpression);
 }
@@ -29,29 +39,27 @@ bool WasAdServed(const AdInfo& ad,
 template <typename T>
 bool ShouldDebounceViewedAdEvent(const AdInfo& ad,
                                  const AdEventList& ad_events,
-                                 const T& event_type) {
-  CHECK(WasAdServed(ad, ad_events, event_type));
-
+                                 const T event_type) {
   return event_type == T::kViewedImpression &&
-         HasFiredAdEvent(ad, ad_events, ConfirmationType::kViewedImpression);
+         HasFiredAdEventWithinTimeWindow(
+             ad, ad_events, ConfirmationType::kViewedImpression,
+             /*time_window=*/kDebounceViewedAdEventFor.Get());
 }
 
 template <typename T>
 bool ShouldDebounceClickedAdEvent(const AdInfo& ad,
                                   const AdEventList& ad_events,
-                                  const T& event_type) {
-  CHECK(WasAdServed(ad, ad_events, event_type));
-
+                                  const T event_type) {
   return event_type == T::kClicked &&
-         HasFiredAdEvent(ad, ad_events, ConfirmationType::kClicked);
+         HasFiredAdEventWithinTimeWindow(
+             ad, ad_events, ConfirmationType::kClicked,
+             /*time_window=*/kDebounceClickedAdEventFor.Get());
 }
 
 template <typename T>
 bool ShouldDebounceAdEvent(const AdInfo& ad,
                            const AdEventList& ad_events,
-                           const T& event_type) {
-  CHECK(WasAdServed(ad, ad_events, event_type));
-
+                           const T event_type) {
   return ShouldDebounceViewedAdEvent(ad, ad_events, event_type) ||
          ShouldDebounceClickedAdEvent(ad, ad_events, event_type);
 }

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -621,6 +621,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_builder_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_cache_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_cache_util_unittest.cc",
+    "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_feature_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_handler_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_unittest_util.cc",
     "//brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_unittest_util.h",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37568

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Ensure that when `AdEvent`/`debounce_viewed_ad_event_for` feature is set to `0s` (zero seconds), viewed events for an ad placement are always debounced
- Ensure that when `AdEvent`/`debounce_viewed_ad_event_for` feature is set to `5s` (five seconds), viewed events for an ad placement are only debounced for five seconds
- Ensure that when `AdEvent`/`debounce_clicked_ad_event_for` feature is set to `0s` (zero seconds), clicked events for an ad placement are always debounced
- Ensure that when `AdEvent`/`debounce_clicked_ad_event_for` feature is set to `5s` (five seconds), clicked events for an ad placement are only debounced for five seconds

I chose 5 seconds, but you can choose, `#s` for # seconds, .e.g `7s`, `#h` for # hours, .e.g, `3h`, `#d` for # days, e.g. `1d` etc.