### PR TITLE
[ads] Fixes new tab takeover ads do not land after n seconds (uplift to 1.66.x)

### DIFF
--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -250,7 +250,13 @@ void SiteVisit::OnTabDidChangeFocus(const int32_t tab_id) {
   MaybeSuspendOrResumePageLand(tab_id);
 }
 
+void SiteVisit::OnTabDidChange(const TabInfo& tab) {
+  // Maybe land when an ad is opened in the same tab.
+  MaybeLandOnPage(tab);
+}
+
 void SiteVisit::OnDidOpenNewTab(const TabInfo& tab) {
+  // Maybe land when an ad is opened in a new tab.
   MaybeLandOnPage(tab);
 }
 

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
@@ -81,6 +81,7 @@ class SiteVisit final : public TabManagerObserver {
 
   // TabManagerObserver:
   void OnTabDidChangeFocus(int32_t tab_id) override;
+  void OnTabDidChange(const TabInfo& tab) override;
   void OnDidOpenNewTab(const TabInfo& tab) override;
   void OnDidCloseTab(int32_t tab_id) override;
 


### PR DESCRIPTION
Uplift of #23086
Resolves https://github.com/brave/brave-browser/issues/37594

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.