### PR TITLE
Add additional Entry Point for Onboarding Debugging Menu

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/RetentionPreferencesDebugMenuViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/RetentionPreferencesDebugMenuViewController.swift
@@ -32,7 +32,7 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    title = "Onboarding Debug Preferences"
+    title = "Onboarding Debug Menu"
 
     dataSource.sections = [
       startOnboardingSection,

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/RetentionPreferencesDebugMenuViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/RetentionPreferencesDebugMenuViewController.swift
@@ -32,7 +32,7 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
-    title = "Retention Preferences"
+    title = "Onboarding Debug Preferences"
 
     dataSource.sections = [
       startOnboardingSection,
@@ -57,12 +57,12 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
   private lazy var startOnboardingSection: Static.Section = {
     var section = Static.Section(
       rows: [
-        .init(
+        Row(
           text: "Start Onboarding",
           selection: { [unowned self] in
             let onboardingController = WelcomeViewController(
               state: .loading,
-              p3aUtilities: self.p3aUtilities,
+              p3aUtilities: p3aUtilities,
               attributionManager: attributionManager
             )
             onboardingController.modalPresentationStyle = .fullScreen
@@ -70,7 +70,23 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
             present(onboardingController, animated: false)
           },
           cellClass: MultilineButtonCell.self
-        )
+        ),
+        Row(
+          text: "Start Day 0 JP Onboarding",
+          selection: { [unowned self] in
+            let welcomeView = FocusOnboardingView(
+              attributionManager: attributionManager,
+              p3aUtilities: p3aUtilities
+            )
+            let onboardingController = FocusOnboardingHostingController(rootView: welcomeView).then
+            {
+              $0.modalPresentationStyle = .fullScreen
+            }
+
+            present(onboardingController, animated: false)
+          },
+          cellClass: MultilineButtonCell.self
+        ),
       ]
     )
 
@@ -117,7 +133,7 @@ class RetentionPreferencesDebugMenuViewController: TableViewController {
 
   private lazy var retentionPreferenceFlags: Section = {
     var shields = Section(
-      header: .title("Retention Preferences"),
+      header: .title("Onboarding Debug Menu"),
       rows: [
         .boolRow(
           title: "Retention User",

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -1116,7 +1116,7 @@ class SettingsViewController: TableViewController {
           cellClass: MultilineValue1Cell.self
         ),
         Row(
-          text: "Retention Preferences Debug Menu",
+          text: "Onboarding Debug Menu",
           selection: { [unowned self] in
             self.navigationController?.pushViewController(
               RetentionPreferencesDebugMenuViewController(

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSliderContentView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSliderContentView.swift
@@ -82,7 +82,7 @@ struct SwipeDifferenceView<Leading: View, Trailing: View>: View {
   // CoreHaptics Engine and Player for slider progress value
   @State private var hapticsEngine: CHHapticEngine?
   @State private var hapticsPlayer: CHHapticPatternPlayer?
-  @State private var hapticsLevel: HapticsLevel = .high
+  @State private var hapticsLevel: HapticsLevel = .intense
 
   var leading: Leading
   var trailing: Trailing
@@ -204,9 +204,6 @@ struct SwipeDifferenceView<Leading: View, Trailing: View>: View {
         "[Focus Onboarding] - There was an error creating the engine: \(error.localizedDescription)"
       )
     }
-
-    // Create Initial Continous Feedback
-    createContinousHapticFeedback(intensity: hapticsLevel)
   }
 
   private func createContinousHapticFeedback(intensity: HapticsLevel) {
@@ -259,10 +256,12 @@ struct SwipeDifferenceView<Leading: View, Trailing: View>: View {
       return .low
     case 21..<71:
       return .medium
-    case 71..<100:
+    case 71..<95:
       return .high
+    case 95..<100:
+      return .intense
     default:
-      return .medium
+      return .high
     }
   }
 }

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusStepsScreenView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusStepsScreenView.swift
@@ -47,20 +47,17 @@ struct FocusStepsView: View {
   var body: some View {
     if shouldUseExtendedDesign {
       VStack(spacing: 40) {
-        VStack {
-          stepsContentView
-            .background(colorScheme == .dark ? .black : .white)
-        }
-        .clipShape(RoundedRectangle(cornerRadius: 16.0, style: .continuous))
-        .frame(maxWidth: 616, maxHeight: 895)
-        .shadow(color: .black.opacity(0.1), radius: 18, x: 0, y: 8)
-        .shadow(color: .black.opacity(0.05), radius: 0, x: 0, y: 1)
-        .overlay(alignment: .topTrailing) {
-          cancelButton
-            .frame(width: iconSize, height: iconSize)
-            .padding(24)
-        }
-
+        stepsContentView
+          .background(colorScheme == .dark ? .black : .white)
+          .clipShape(RoundedRectangle(cornerRadius: 16.0, style: .continuous))
+          .frame(maxWidth: 616, maxHeight: 895)
+          .shadow(color: .black.opacity(0.1), radius: 18, x: 0, y: 8)
+          .shadow(color: .black.opacity(0.05), radius: 0, x: 0, y: 1)
+          .overlay(alignment: .topTrailing) {
+            cancelButton
+              .frame(width: iconSize, height: iconSize)
+              .padding(24)
+          }
         FocusStepsPagingIndicator(totalPages: 4, activeIndex: .constant(2))
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -181,7 +178,7 @@ struct FocusStepsView: View {
       .onChange(of: indicatorIndex) { newValue in
         if indicatorIndex == 1 {
           Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { _ in
-            UIImpactFeedbackGenerator(style: .medium).vibrate()
+            UINotificationFeedbackGenerator().vibrate(style: .error)
           }
         }
       }

--- a/ios/brave-ios/Sources/Shared/Extensions/ImpactFeedbackGeneratorExtensions.swift
+++ b/ios/brave-ios/Sources/Shared/Extensions/ImpactFeedbackGeneratorExtensions.swift
@@ -22,5 +22,5 @@ extension UINotificationFeedbackGenerator {
     // Returned in case wanted for retaining to re-impact
     return self
   }
-  
+
 }

--- a/ios/brave-ios/Sources/Shared/Extensions/ImpactFeedbackGeneratorExtensions.swift
+++ b/ios/brave-ios/Sources/Shared/Extensions/ImpactFeedbackGeneratorExtensions.swift
@@ -13,3 +13,14 @@ extension UIImpactFeedbackGenerator {
     return self
   }
 }
+
+extension UINotificationFeedbackGenerator {
+  @discardableResult
+  public func vibrate(style: FeedbackType) -> Self {
+    self.prepare()
+    self.notificationOccurred(style)
+    // Returned in case wanted for retaining to re-impact
+    return self
+  }
+  
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37603 and some fine tuning for feedback, haptics, vibration changes.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:


Go under Debug Settings + Onboarding Debug Menu. This will allow tester to start old and new focus onboarding.



https://github.com/brave/brave-core/assets/6643505/d238a223-a749-41fb-a712-08cc9a0a627b


