### PR TITLE
Replace base::FeatureList::IsEnabled(kSplitView) with SplitViewBrowserData::FromBrowser()

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -368,7 +368,12 @@ bool BraveBrowserView::IsActiveWebContentsTiled(
 }
 
 void BraveBrowserView::UpdateSecondaryContentsWebViewVisibility() {
-  CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSplitView));
+  auto* split_view_browser_data =
+      SplitViewBrowserData::FromBrowser(browser_.get());
+  if (!split_view_browser_data) {
+    return;
+  }
+
   if (browser()->IsBrowserClosing()) {
     secondary_contents_web_view_->SetWebContents(nullptr);
     return;
@@ -376,8 +381,6 @@ void BraveBrowserView::UpdateSecondaryContentsWebViewVisibility() {
 
   auto active_tab_handle = GetActiveTabHandle();
 
-  auto* split_view_browser_data =
-      SplitViewBrowserData::FromBrowser(browser_.get());
   if (auto tile = split_view_browser_data->GetTile(active_tab_handle)) {
     const bool second_tile_is_active_web_contents =
         active_tab_handle == tile->second;

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -20,7 +20,6 @@ class BraveTabContainer : public TabContainerImpl,
                           public SplitViewBrowserDataObserver {
   METADATA_HEADER(BraveTabContainer, TabContainerImpl)
  public:
-
   BraveTabContainer(TabContainerController& controller,
                     TabHoverCardController* hover_card_controller,
                     TabDragContextBase* drag_context,
@@ -105,7 +104,8 @@ class BraveTabContainer : public TabContainerImpl,
 
   void UpdateLayoutOrientation();
 
-  void PaintBoundingBoxForTiles(gfx::Canvas& canvas);
+  void PaintBoundingBoxForTiles(gfx::Canvas& canvas,
+                                const SplitViewBrowserData* split_view_data);
   void PaintBoundingBoxForTile(gfx::Canvas& canvas,
                                const SplitViewBrowserData::Tile& tile);
 

--- a/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/tab_drag_controller.cc
@@ -332,7 +332,13 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
 
 [[nodiscard]] TabDragController::Liveness TabDragController::ContinueDragging(
     const gfx::Point& point_in_screen) {
-  if (!base::FeatureList::IsEnabled(tabs::features::kBraveSplitView)) {
+  auto* browser_widget = GetAttachedBrowserWidget();
+  auto* browser = BrowserView::GetBrowserViewForNativeWindow(
+                      browser_widget->GetNativeWindow())
+                      ->browser();
+  SplitViewBrowserData* split_view_browser_data =
+      SplitViewBrowserData::FromBrowser(browser);
+  if (!split_view_browser_data) {
     return TabDragControllerChromium::ContinueDragging(point_in_screen);
   }
 
@@ -352,12 +358,6 @@ gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
     return liveness;
   }
 
-  auto* browser_widget = GetAttachedBrowserWidget();
-  auto* browser = BrowserView::GetBrowserViewForNativeWindow(
-                      browser_widget->GetNativeWindow())
-                      ->browser();
-  SplitViewBrowserData* split_view_browser_data =
-      SplitViewBrowserData::FromBrowser(browser);
   const bool is_dragging_tabs = current_state_ == DragState::kDraggingTabs;
   if (is_dragging_tabs) {
     on_tab_drag_ended_closure_ = split_view_browser_data->TabDragStarted();


### PR DESCRIPTION
In favor of https://github.com/brave/brave-core/pull/22894#discussion_r1556327981, 
As the BrowserData is created only when the feature is enabled, we don't have to check both the feature and the BrowserData.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37577

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

