### PR TITLE
[ads] Add 15 second delay after creating a confirmation before fetching the payment token

### DIFF
--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -205,6 +205,8 @@ static_library("internal") {
     "account/utility/redeem_confirmation/redeem_confirmation_factory.h",
     "account/utility/redeem_confirmation/reward/redeem_reward_confirmation.cc",
     "account/utility/redeem_confirmation/reward/redeem_reward_confirmation.h",
+    "account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.cc",
+    "account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h",
     "account/utility/redeem_confirmation/reward/redeem_reward_confirmation_util.cc",
     "account/utility/redeem_confirmation/reward/redeem_reward_confirmation_util.h",
     "account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder.cc",

--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 
+#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_unittest_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_delegate_mock.h"
@@ -21,6 +22,7 @@
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_unittest_constants.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/non_reward/redeem_non_reward_confirmation_unittest_util.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/non_reward/url_request_builders/create_non_reward_confirmation_url_request_builder_util.h"
+#include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest_util.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder_unittest_constants.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder_util.h"
@@ -81,6 +83,10 @@ TEST_F(BraveAdsConfirmationQueueTest, AddConfirmation) {
 
 TEST_F(BraveAdsConfirmationQueueTest, ProcessConfirmation) {
   // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      kRedeemRewardConfirmationFeature, {{"fetch_payment_token_after", "0s"}});
+
   test::BuildAndSetIssuers();
 
   test::MockTokenGenerator(token_generator_mock_, /*count=*/1);

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation.h
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation.h
@@ -14,6 +14,10 @@
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_delegate.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom-forward.h"
 
+namespace base {
+class TimeDelta;
+}  // namespace base
+
 namespace brave_ads {
 
 struct ConfirmationInfo;
@@ -47,6 +51,10 @@ class RedeemRewardConfirmation final {
       const ConfirmationInfo& confirmation,
       const mojom::UrlResponseInfo& url_response);
 
+  static void FetchPaymentTokenAfter(
+      base::TimeDelta delay,
+      RedeemRewardConfirmation redeem_confirmation,
+      const ConfirmationInfo& confirmation);
   static void FetchPaymentToken(RedeemRewardConfirmation redeem_confirmation,
                                 const ConfirmationInfo& confirmation);
   static void FetchPaymentTokenCallback(

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h"
+
+namespace brave_ads {
+
+BASE_FEATURE(kRedeemRewardConfirmationFeature,
+             "RedeemRewardConfirmation",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_UTILITY_REDEEM_CONFIRMATION_REWARD_REDEEM_REWARD_CONFIRMATION_FEATURE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_UTILITY_REDEEM_CONFIRMATION_REWARD_REDEEM_REWARD_CONFIRMATION_FEATURE_H_
+
+#include "base/feature_list.h"
+#include "base/metrics/field_trial_params.h"
+#include "base/time/time.h"
+
+namespace brave_ads {
+
+BASE_DECLARE_FEATURE(kRedeemRewardConfirmationFeature);
+
+inline constexpr base::FeatureParam<base::TimeDelta> kFetchPaymentTokenAfter{
+    &kRedeemRewardConfirmationFeature, "fetch_payment_token_after",
+    base::Seconds(15)};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ACCOUNT_UTILITY_REDEEM_CONFIRMATION_REWARD_REDEEM_REWARD_CONFIRMATION_FEATURE_H_

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature_unittest.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature_unittest.cc
@@ -1,0 +1,55 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h"
+
+#include "base/test/scoped_feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+TEST(BraveAdsRedeemRewardConfirmationFeatureTest, IsEnabled) {
+  // Act & Assert
+  EXPECT_TRUE(base::FeatureList::IsEnabled(kRedeemRewardConfirmationFeature));
+}
+
+TEST(BraveAdsRedeemRewardConfirmationFeatureTest, IsDisabled) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(kRedeemRewardConfirmationFeature);
+
+  // Act & Assert
+  EXPECT_FALSE(base::FeatureList::IsEnabled(kRedeemRewardConfirmationFeature));
+}
+
+TEST(BraveAdsRedeemRewardConfirmationFeatureTest, FetchPaymentTokenAfter) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      kRedeemRewardConfirmationFeature, {{"fetch_payment_token_after", "5s"}});
+
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(5), kFetchPaymentTokenAfter.Get());
+}
+
+TEST(BraveAdsRedeemRewardConfirmationFeatureTest,
+     DefaultFetchPaymentTokenAfter) {
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(15), kFetchPaymentTokenAfter.Get());
+}
+
+TEST(BraveAdsRedeemRewardConfirmationFeatureTest,
+     DefaultProcessConversionConfirmationAfterWhenDisabled) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(kRedeemRewardConfirmationFeature);
+
+  // Act & Assert
+  EXPECT_EQ(base::Seconds(15), kFetchPaymentTokenAfter.Get());
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest.cc
@@ -17,6 +17,7 @@
 #include "brave/components/brave_ads/core/internal/account/tokens/token_generator_unittest_util.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_unittest_constants.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_delegate_mock.h"
+#include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest_util.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder_unittest_constants.h"
 #include "brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/url_request_builders/create_reward_confirmation_url_request_builder_util.h"
@@ -67,6 +68,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest, Redeem) {
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest, RetryRedeemingIfNoIssuers) {
@@ -89,6 +92,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest, RetryRedeemingIfNoIssuers) {
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  EXPECT_FALSE(HasPendingTasks());
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -117,6 +122,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -151,6 +158,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -186,6 +195,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -220,6 +231,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -255,6 +268,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -289,6 +304,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -336,6 +353,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -384,6 +403,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -425,6 +446,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -472,6 +495,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -520,6 +545,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -567,6 +594,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -614,6 +643,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -662,6 +693,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -707,6 +740,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -752,6 +787,8 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
 }
 
 TEST_F(BraveAdsRedeemRewardConfirmationTest,
@@ -800,6 +837,38 @@ TEST_F(BraveAdsRedeemRewardConfirmationTest,
 
   RedeemRewardConfirmation::CreateAndRedeem(
       confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  FastForwardClockToNextPendingTask();
+}
+
+TEST_F(BraveAdsRedeemRewardConfirmationTest, FetchPaymentTokenAfter) {
+  // Arrange
+  test::BuildAndSetIssuers();
+
+  test::MockTokenGenerator(token_generator_mock_, /*count=*/1);
+
+  test::RefillConfirmationTokens(/*count=*/1);
+
+  const URLResponseMap url_responses = {
+      {BuildCreateRewardConfirmationUrlPath(
+           kTransactionId, kCreateRewardConfirmationCredential),
+       {{net::HTTP_CREATED,
+         test::BuildCreateRewardConfirmationUrlResponseBody()}}},
+      {BuildFetchPaymentTokenUrlPath(kTransactionId),
+       {{net::HTTP_OK, test::BuildFetchPaymentTokenUrlResponseBody()}}}};
+  MockUrlResponses(ads_client_mock_, url_responses);
+
+  const std::optional<ConfirmationInfo> confirmation =
+      test::BuildRewardConfirmation(&token_generator_mock_,
+                                    /*should_use_random_uuids=*/false);
+  ASSERT_TRUE(confirmation);
+
+  // Act & Assert
+  RedeemRewardConfirmation::CreateAndRedeem(
+      confirmation_delegate_weak_factory_.GetWeakPtr(), *confirmation);
+
+  EXPECT_EQ(kFetchPaymentTokenAfter.Get(), NextPendingTaskDelay());
+  EXPECT_EQ(1U, GetPendingTaskCount());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -113,6 +113,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/non_reward/url_request_builders/create_non_reward_confirmation_url_request_builder_util_unittest.cc",
     "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_delegate_mock.cc",
     "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_delegate_mock.h",
+    "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_feature_unittest.cc",
     "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest.cc",
     "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest_util.cc",
     "//brave/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation_unittest_util.h",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37334

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Fresh install
* Join Brave Rewards
* Trigger a New Tab Takeover ad
* Check that `Create Reward Confirmation` request is sent to the server
* Check that `Create Reward Confirmation` successful response received from the server
* Check that `Fetch payment token` request is started in 15 seconds after received `Create Reward Confirmation` response from the server
* Check that `Fetch payment token` successful response received from the server
