### PR TITLE
Refactor/cleanup search promotion ui

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -577,15 +577,6 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
           Don't ask me again
         </message>
         <!-- Brave search conversion promotion -->
-        <message name="IDS_BRAVE_SEARCH_CONVERSION_INPUT_APPEND_LABEL" desc="The text that appended to the input query in button type match">
-          - Brave Search
-        </message>
-        <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_DESC_LABEL" desc="The text for detailed description about brave search in promotion match">
-          Support independent search with better privacy. Brave search doesn't track you, your queries, or your clicks.
-        </message>
-        <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_DESC_LABEL_FIRST_PART" desc="The text for finding the first sentence from above. Both should have the same translation.">
-          Support independent search with better privacy.
-        </message>
         <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_B_TITLE" desc="The text for the banner type title">
           Don't Google it. Can't Bing it. Just Brave it.
         </message>

--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -586,12 +586,6 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_DESC_LABEL_FIRST_PART" desc="The text for finding the first sentence from above. Both should have the same translation.">
           Support independent search with better privacy.
         </message>
-        <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_A_TITLE" desc="The text for the banner type title">
-          Time to ditch big tech.
-        </message>
-        <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_A_DESC" desc="The text for the banner type description">
-          Brave doesn't track you, your queries, or your clicks. And it's 100% independent of Big Tech.
-        </message>
         <message name="IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_B_TITLE" desc="The text for the banner type title">
           Don't Google it. Can't Bing it. Just Brave it.
         </message>

--- a/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_popup_view_views.cc
@@ -28,5 +28,9 @@ gfx::Rect BraveOmniboxPopupViewViews::GetTargetBounds() const {
   return bounds;
 }
 
+int BraveOmniboxPopupViewViews::GetLocationBarViewWidth() const {
+  return location_bar_view()->width();
+}
+
 BEGIN_METADATA(BraveOmniboxPopupViewViews)
 END_METADATA

--- a/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h
+++ b/browser/ui/views/omnibox/brave_omnibox_popup_view_views.h
@@ -15,6 +15,8 @@ class BraveOmniboxPopupViewViews : public OmniboxPopupViewViews {
   using OmniboxPopupViewViews::OmniboxPopupViewViews;
   ~BraveOmniboxPopupViewViews() override;
 
+  int GetLocationBarViewWidth() const;
+
   // OmniboxPopupViewViews:
   gfx::Rect GetTargetBounds() const override;
 };

--- a/browser/ui/views/omnibox/brave_omnibox_result_view.h
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.h
@@ -12,6 +12,7 @@
 #include "ui/base/metadata/metadata_header_macros.h"
 
 class BraveSearchConversionPromotionView;
+class BraveOmniboxPopupViewViews;
 
 // This will render brave specific matches such as the braver search conversion
 // promotion.
@@ -25,6 +26,7 @@ class BraveOmniboxResultView : public OmniboxResultView {
 
   void OpenMatch();
   void RefreshOmniboxResult();
+  BraveOmniboxPopupViewViews* GetPopupView();
 
   // OmniboxResultView overrides:
   void SetMatch(const AutocompleteMatch& match) override;
@@ -34,7 +36,7 @@ class BraveOmniboxResultView : public OmniboxResultView {
   void OnPaintBackground(gfx::Canvas* canvas) override;
 
  private:
-  void ResetChildrenVisibility();
+  void ResetChildren();
   void UpdateForBraveSearchConversion();
   void HandleSelectionStateChangedForPromotionView();
 

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -664,7 +664,7 @@ void BraveSearchConversionPromotionView::UpdateHoverState() {
 int BraveSearchConversionPromotionView::GetBannerTypeTitleStringResourceId() {
   switch (type_) {
     case ConversionType::kBannerTypeA:
-      return IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_A_TITLE;
+      NOTREACHED_NORETURN();
     case ConversionType::kBannerTypeB:
       return IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_B_TITLE;
     case ConversionType::kBannerTypeC:
@@ -681,7 +681,7 @@ int BraveSearchConversionPromotionView::GetBannerTypeTitleStringResourceId() {
 int BraveSearchConversionPromotionView::GetBannerTypeDescStringResourceId() {
   switch (type_) {
     case ConversionType::kBannerTypeA:
-      return IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_A_DESC;
+      NOTREACHED_NORETURN();
     case ConversionType::kBannerTypeB:
       return IDS_BRAVE_SEARCH_CONVERSION_PROMOTION_BANNER_TYPE_B_DESC;
     case ConversionType::kBannerTypeC:

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
@@ -45,13 +45,9 @@ class BraveSearchConversionPromotionView : public views::View {
   void OnThemeChanged() override;
 
  private:
-  void ConfigureForButtonType();
-  void UpdateButtonTypeState();
   void ConfigureForBannerType();
-  void UpdateBannerTypeState();
-  void ResetChildrenVisibility();
-  void UpdateHoverState();
   void UpdateState();
+  void UpdateHoverState();
   void OpenMatch();
   void Dismiss();
   void MaybeLater();
@@ -59,25 +55,12 @@ class BraveSearchConversionPromotionView : public views::View {
   int GetBannerTypeDescStringResourceId();
   SkColor GetCloseButtonColor() const;
 
-  // Gives buttton type background based on selected or hovered state.
-  std::unique_ptr<views::Background> GetButtonTypeBackground();
-
   raw_ptr<BraveOmniboxResultView> result_view_ = nullptr;
 
   // Children for button or banner type promotion.
   // Promotion view is implemented w/o using existing omnibox view controls
   // because our promotion view's layout, bg and text colors are slightly
-  // different. |button_type_container_| is child view that holds whole UI for
-  // buton type and |banner_type_container_| is for banner type. When current
-  // promotion type is button, |button_type_container_| is only visible.
-  // Otherwise, |banner_type_container_| is only visible view.
-
-  // Children for button type promotion.
-  raw_ptr<views::View> button_type_container_ = nullptr;
-  raw_ptr<views::View> button_type_selection_indicator_ = nullptr;
-  raw_ptr<views::Label> button_type_description_ = nullptr;
-  raw_ptr<views::Label> button_type_contents_input_ = nullptr;
-  raw_ptr<views::Label> append_for_input_ = nullptr;
+  // different. |banner_type_container_| is for banner type.
 
   // Children for banner type promotion.
   raw_ptr<views::View> banner_type_container_ = nullptr;

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.h
@@ -54,6 +54,7 @@ class BraveSearchConversionPromotionView : public views::View {
   int GetBannerTypeTitleStringResourceId();
   int GetBannerTypeDescStringResourceId();
   SkColor GetCloseButtonColor() const;
+  int GetOverallHorizontalMarginAroundDescription() const;
 
   raw_ptr<BraveOmniboxResultView> result_view_ = nullptr;
 

--- a/components/ai_chat/resources/page/chat_ui.tsx
+++ b/components/ai_chat/resources/page/chat_ui.tsx
@@ -4,7 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { initLocale } from 'brave-ui'
 import { setIconBasePath } from '@brave/leo/react/icon'
 
@@ -20,6 +20,10 @@ import DataContextProvider from './state/data-context-provider'
 setIconBasePath('chrome-untrusted://resources/brave-icons')
 
 function App () {
+  React.useEffect(() => {
+    document.getElementById('mountPoint')?.classList.add('loaded')
+  }, [])
+
   return (
     <DataContextProvider>
       <BraveCoreThemeProvider>
@@ -31,10 +35,8 @@ function App () {
 
 function initialize () {
   initLocale(loadTimeData.data_)
-  const mountPoint = document.getElementById('mountPoint')
-  render(<App />, mountPoint, () => {
-    mountPoint?.classList.add('loaded')
-  })
+  const root = createRoot(document.getElementById('mountPoint')!)
+  root.render(<App />)
 }
 
 document.addEventListener('DOMContentLoaded', initialize)

--- a/components/brave_search/browser/brave_search_default_host_unittest.cc
+++ b/components/brave_search/browser/brave_search_default_host_unittest.cc
@@ -170,8 +170,7 @@ TEST_F(BraveSearchDefaultHostTest, CanSetDefaultAlwaysTestWithSearchPromotion) {
   template_url_service_.SetUserSelectedDefaultSearchProvider(default_provider);
 
   // Failed at fourth try by default.
-  MockGetCanSetCallback first, second, third, fourth, fifth, sixth, seventh,
-      eighth;
+  MockGetCanSetCallback first, second, third, fourth, fifth, sixth, seventh;
   EXPECT_CALL(first, Run(true));
   EXPECT_CALL(second, Run(true));
   EXPECT_CALL(third, Run(true));
@@ -199,22 +198,13 @@ TEST_F(BraveSearchDefaultHostTest, CanSetDefaultAlwaysTestWithSearchPromotion) {
   EXPECT_CALL(sixth, Run(false));
   host->GetCanSetDefaultSearchProvider(sixth.Get());
 
-  // Test with omnibox button type conversion.
-  feature_list.InitAndEnableFeature(
-      brave_search_conversion::features::kOmniboxButton);
-  host->SetCanAlwaysSetDefault();
-
-  // Can set if omnibox button promotion feature is enabled.
-  EXPECT_CALL(seventh, Run(true));
-  host->GetCanSetDefaultSearchProvider(seventh.Get());
-
   feature_list.Reset();
   feature_list.InitAndEnableFeature(brave_search_conversion::features::kNTP);
   host->SetCanAlwaysSetDefault();
 
   // Can set if ntp promotion feature is enabled.
-  EXPECT_CALL(eighth, Run(true));
-  host->GetCanSetDefaultSearchProvider(eighth.Get());
+  EXPECT_CALL(seventh, Run(true));
+  host->GetCanSetDefaultSearchProvider(seventh.Get());
 }
 
 }  // namespace

--- a/components/brave_search_conversion/brave_search_conversion_unittest.cc
+++ b/components/brave_search_conversion/brave_search_conversion_unittest.cc
@@ -96,8 +96,8 @@ TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
   feature_list.Reset();
   feature_list.InitAndEnableFeatureWithParameters(
       brave_search_conversion::features::kOmniboxBanner,
-      {{brave_search_conversion::features::kBannerTypeParamName, "type_A"}});
-  EXPECT_EQ(ConversionType::kBannerTypeA,
+      {{brave_search_conversion::features::kBannerTypeParamName, "type_B"}});
+  EXPECT_EQ(ConversionType::kBannerTypeB,
             GetConversionType(&pref_service_, &template_url_service_));
 
   // Check conversion type is set again after 3days passed.
@@ -110,7 +110,7 @@ TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
             GetConversionType(&pref_service_, &template_url_service_));
 
   task_environment_.AdvanceClock(base::Days(1) + base::Milliseconds(1));
-  EXPECT_EQ(ConversionType::kBannerTypeA,
+  EXPECT_EQ(ConversionType::kBannerTypeB,
             GetConversionType(&pref_service_, &template_url_service_));
 
   // Set dismissed.

--- a/components/brave_search_conversion/brave_search_conversion_unittest.cc
+++ b/components/brave_search_conversion/brave_search_conversion_unittest.cc
@@ -64,7 +64,6 @@ class BraveSearchConversionTest : public testing::Test {
 };
 
 TEST_F(BraveSearchConversionTest, DefaultValueTest) {
-  EXPECT_FALSE(base::FeatureList::IsEnabled(features::kOmniboxButton));
   EXPECT_FALSE(base::FeatureList::IsEnabled(features::kOmniboxBanner));
   EXPECT_FALSE(base::FeatureList::IsEnabled(features::kNTP));
   EXPECT_EQ(ConversionType::kNone,
@@ -78,8 +77,10 @@ TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
 
   ConfigureBingAsDefaultProvider();
 
-  feature_list.InitAndEnableFeature(features::kOmniboxButton);
-  EXPECT_EQ(ConversionType::kButton,
+  feature_list.InitAndEnableFeatureWithParameters(
+      brave_search_conversion::features::kOmniboxBanner,
+      {{brave_search_conversion::features::kBannerTypeParamName, "type_B"}});
+  EXPECT_EQ(ConversionType::kBannerTypeB,
             GetConversionType(&pref_service_, &template_url_service_));
 
   // Check do not conversion when brave search(tor) is set as a default
@@ -92,13 +93,6 @@ TEST_F(BraveSearchConversionTest, ConversionTypeTest) {
             GetConversionType(&pref_service_, &template_url_service_));
 
   ConfigureBingAsDefaultProvider();
-
-  feature_list.Reset();
-  feature_list.InitAndEnableFeatureWithParameters(
-      brave_search_conversion::features::kOmniboxBanner,
-      {{brave_search_conversion::features::kBannerTypeParamName, "type_B"}});
-  EXPECT_EQ(ConversionType::kBannerTypeB,
-            GetConversionType(&pref_service_, &template_url_service_));
 
   // Check conversion type is set again after 3days passed.
   SetMaybeLater(&pref_service_);

--- a/components/brave_search_conversion/features.cc
+++ b/components/brave_search_conversion/features.cc
@@ -18,12 +18,6 @@ BASE_FEATURE(kOmniboxBanner,
 const base::FeatureParam<std::string> kBannerType{&kOmniboxBanner,
                                                   kBannerTypeParamName, ""};
 
-// Brave search promotion match located at second low in omnibox popup.
-// This looks very similar with other normal matches.
-BASE_FEATURE(kOmniboxButton,
-             "BraveSearchOmniboxButton",
-             base::FEATURE_DISABLED_BY_DEFAULT);
-
 // Brave search promotion at NTP.
 BASE_FEATURE(kNTP, "BraveSearchNTP", base::FEATURE_DISABLED_BY_DEFAULT);
 

--- a/components/brave_search_conversion/features.h
+++ b/components/brave_search_conversion/features.h
@@ -19,7 +19,6 @@ inline constexpr char kBannerTypeParamName[] = "banner_type";
 BASE_DECLARE_FEATURE(kOmniboxBanner);
 extern const base::FeatureParam<std::string> kBannerType;
 
-BASE_DECLARE_FEATURE(kOmniboxButton);
 BASE_DECLARE_FEATURE(kNTP);
 
 }  // namespace features

--- a/components/brave_search_conversion/p3a.cc
+++ b/components/brave_search_conversion/p3a.cc
@@ -24,8 +24,6 @@ const char kButtonShownKey[] = "button.shown";
 const char kButtonTriggeredKey[] = "button.triggered";
 const char kNTPShownKey[] = "ntp.shown";
 const char kNTPTriggeredKey[] = "ntp.triggered";
-const char kBannerAShownKey[] = "banner_a.shown";
-const char kBannerATriggeredKey[] = "banner_a.triggered";
 const char kBannerBShownKey[] = "banner_b.shown";
 const char kBannerBTriggeredKey[] = "banner_b.triggered";
 const char kBannerCShownKey[] = "banner_c.shown";
@@ -41,7 +39,7 @@ const int kQueriesBeforeChurnBuckets[] = {0, 1, 2, 5, 10, 20, 40};
 const char* GetPromoShownKeyName(ConversionType type) {
   switch (type) {
     case ConversionType::kBannerTypeA:
-      return kBannerAShownKey;
+      break;
     case ConversionType::kBannerTypeB:
       return kBannerBShownKey;
     case ConversionType::kBannerTypeC:
@@ -53,15 +51,15 @@ const char* GetPromoShownKeyName(ConversionType type) {
     case ConversionType::kNTP:
       return kNTPShownKey;
     default:
-      NOTREACHED();
-      return nullptr;
+      break;
   }
+  NOTREACHED_NORETURN();
 }
 
 const char* GetPromoTriggeredKeyName(ConversionType type) {
   switch (type) {
     case ConversionType::kBannerTypeA:
-      return kBannerATriggeredKey;
+      break;
     case ConversionType::kBannerTypeB:
       return kBannerBTriggeredKey;
     case ConversionType::kBannerTypeC:
@@ -73,15 +71,15 @@ const char* GetPromoTriggeredKeyName(ConversionType type) {
     case ConversionType::kNTP:
       return kNTPTriggeredKey;
     default:
-      NOTREACHED();
-      return nullptr;
+      break;
   }
+  NOTREACHED_NORETURN();
 }
 
 const char* GetPromoTypeHistogramName(ConversionType type) {
   switch (type) {
     case ConversionType::kBannerTypeA:
-      return kSearchPromoBannerAHistogramName;
+      break;
     case ConversionType::kBannerTypeB:
       return kSearchPromoBannerBHistogramName;
     case ConversionType::kBannerTypeC:
@@ -93,9 +91,9 @@ const char* GetPromoTypeHistogramName(ConversionType type) {
     case ConversionType::kNTP:
       return kSearchPromoNTPHistogramName;
     default:
-      NOTREACHED();
-      return nullptr;
+      break;
   }
+  NOTREACHED_NORETURN();
 }
 
 void UpdateHistograms(PrefService* prefs) {
@@ -104,9 +102,9 @@ void UpdateHistograms(PrefService* prefs) {
   UMA_HISTOGRAM_EXACT_LINEAR(kSwitchSearchEngineMetric, INT_MAX - 1, 8);
 
   const ConversionType types[] = {
-      ConversionType::kBannerTypeA, ConversionType::kBannerTypeB,
-      ConversionType::kBannerTypeC, ConversionType::kBannerTypeD,
-      ConversionType::kButton,      ConversionType::kNTP};
+      ConversionType::kBannerTypeB, ConversionType::kBannerTypeC,
+      ConversionType::kBannerTypeD, ConversionType::kButton,
+      ConversionType::kNTP};
 
   VLOG(1) << "SearchConversionP3A: updating histograms";
 

--- a/components/brave_search_conversion/p3a.cc
+++ b/components/brave_search_conversion/p3a.cc
@@ -67,6 +67,7 @@ const char* GetPromoTriggeredKeyName(ConversionType type) {
     case ConversionType::kBannerTypeD:
       return kBannerDTriggeredKey;
     case ConversionType::kButton:
+      // Deprecated but leave as it's used by migration code.
       return kButtonTriggeredKey;
     case ConversionType::kNTP:
       return kNTPTriggeredKey;
@@ -87,6 +88,7 @@ const char* GetPromoTypeHistogramName(ConversionType type) {
     case ConversionType::kBannerTypeD:
       return kSearchPromoBannerDHistogramName;
     case ConversionType::kButton:
+      // Deprecated but leave as it's used by migration code.
       return kSearchPromoButtonHistogramName;
     case ConversionType::kNTP:
       return kSearchPromoNTPHistogramName;
@@ -103,8 +105,7 @@ void UpdateHistograms(PrefService* prefs) {
 
   const ConversionType types[] = {
       ConversionType::kBannerTypeB, ConversionType::kBannerTypeC,
-      ConversionType::kBannerTypeD, ConversionType::kButton,
-      ConversionType::kNTP};
+      ConversionType::kBannerTypeD, ConversionType::kNTP};
 
   VLOG(1) << "SearchConversionP3A: updating histograms";
 

--- a/components/brave_search_conversion/p3a.h
+++ b/components/brave_search_conversion/p3a.h
@@ -16,8 +16,6 @@ namespace p3a {
 
 inline constexpr char kSearchPromoButtonHistogramName[] =
     "Brave.Search.Promo.Button";
-inline constexpr char kSearchPromoBannerAHistogramName[] =
-    "Brave.Search.Promo.BannerA";
 inline constexpr char kSearchPromoBannerBHistogramName[] =
     "Brave.Search.Promo.BannerB";
 inline constexpr char kSearchPromoBannerCHistogramName[] =

--- a/components/brave_search_conversion/p3a_unittest.cc
+++ b/components/brave_search_conversion/p3a_unittest.cc
@@ -32,10 +32,6 @@ const ConversionTypeInfo type_infos[] = {
         .histogram_name = kSearchPromoBannerDHistogramName,
     },
     {
-        .type = ConversionType::kButton,
-        .histogram_name = kSearchPromoButtonHistogramName,
-    },
-    {
         .type = ConversionType::kNTP,
         .histogram_name = kSearchPromoNTPHistogramName,
     }};

--- a/components/brave_search_conversion/p3a_unittest.cc
+++ b/components/brave_search_conversion/p3a_unittest.cc
@@ -20,10 +20,6 @@ struct ConversionTypeInfo {
 
 const ConversionTypeInfo type_infos[] = {
     {
-        .type = ConversionType::kBannerTypeA,
-        .histogram_name = kSearchPromoBannerAHistogramName,
-    },
-    {
         .type = ConversionType::kBannerTypeB,
         .histogram_name = kSearchPromoBannerBHistogramName,
     },

--- a/components/brave_search_conversion/types.h
+++ b/components/brave_search_conversion/types.h
@@ -10,7 +10,7 @@ namespace brave_search_conversion {
 
 enum class ConversionType {
   kNone = 0,
-  kButton,
+  kButton,  // deprecated.
   kNTP,
   kBannerTypeA,  // deprecated.
   kBannerTypeB,

--- a/components/brave_search_conversion/types.h
+++ b/components/brave_search_conversion/types.h
@@ -12,7 +12,7 @@ enum class ConversionType {
   kNone = 0,
   kButton,
   kNTP,
-  kBannerTypeA,
+  kBannerTypeA,  // deprecated.
   kBannerTypeB,
   kBannerTypeC,
   kBannerTypeD,

--- a/components/brave_search_conversion/utils.cc
+++ b/components/brave_search_conversion/utils.cc
@@ -89,10 +89,6 @@ ConversionType GetConversionType(PrefService* prefs,
     return ConversionType::kNone;
   }
 
-  if (base::FeatureList::IsEnabled(features::kOmniboxButton)) {
-    return ConversionType::kButton;
-  }
-
   if (base::FeatureList::IsEnabled(features::kOmniboxBanner)) {
     // Give conversion type after 3d passed since maybe later clicked time.
     auto clicked_time = prefs->GetTime(prefs::kMaybeLaterClickedTime);
@@ -133,8 +129,7 @@ GURL GetPromoURL(const std::string& search_term) {
 }
 
 bool IsBraveSearchConversionFeatureEnabled() {
-  return base::FeatureList::IsEnabled(features::kOmniboxButton) ||
-         base::FeatureList::IsEnabled(features::kOmniboxBanner);
+  return base::FeatureList::IsEnabled(features::kOmniboxBanner);
 }
 
 }  // namespace brave_search_conversion

--- a/components/brave_search_conversion/utils.cc
+++ b/components/brave_search_conversion/utils.cc
@@ -10,6 +10,7 @@
 #include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/notreached.h"
 #include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
@@ -29,10 +30,6 @@ namespace brave_search_conversion {
 namespace {
 
 ConversionType GetConversionTypeFromBannerTypeParam(const std::string& param) {
-  if (param == "type_A") {
-    return ConversionType::kBannerTypeA;
-  }
-
   if (param == "type_B") {
     return ConversionType::kBannerTypeB;
   }

--- a/components/omnibox/browser/promotion_unittest.cc
+++ b/components/omnibox/browser/promotion_unittest.cc
@@ -245,7 +245,7 @@ TEST_F(OmniboxPromotionTest, AutocompleteResultTest) {
   // Make 3rd match as banner type promotion and check that promotion is
   // reordered at last.
   matches[2].destination_url = GetPromoURL(input.text());
-  SetConversionTypeToMatch(ConversionType::kBannerTypeA, &matches[2]);
+  SetConversionTypeToMatch(ConversionType::kBannerTypeB, &matches[2]);
   result.AppendMatches(matches);
   SortBraveSearchPromotionMatch(&result);
   EXPECT_TRUE(IsBraveSearchPromotionMatch(*result.match_at(3)));
@@ -253,7 +253,7 @@ TEST_F(OmniboxPromotionTest, AutocompleteResultTest) {
   result.Reset();
   matches = CreateTestMatches();
   matches[2].destination_url = GetPromoURL(input.text());
-  SetConversionTypeToMatch(ConversionType::kBannerTypeA, &matches[2]);
+  SetConversionTypeToMatch(ConversionType::kBannerTypeB, &matches[2]);
   result.AppendMatches(matches);
   // Make first match is not search query with default provider.
   result.begin()->type = AutocompleteMatchType::NAVSUGGEST;

--- a/components/omnibox/browser/promotion_unittest.cc
+++ b/components/omnibox/browser/promotion_unittest.cc
@@ -145,8 +145,9 @@ class OmniboxPromotionTest : public testing::Test {
 // Promotion match should not be added for private profile.
 TEST_F(OmniboxPromotionTest, ProfileTest) {
   base::test::ScopedFeatureList feature_list;
-  feature_list.InitAndEnableFeature(
-      brave_search_conversion::features::kOmniboxButton);
+  feature_list.InitAndEnableFeatureWithParameters(
+      brave_search_conversion::features::kOmniboxBanner,
+      {{brave_search_conversion::features::kBannerTypeParamName, "type_B"}});
   CreateController(false);
   AutocompleteInput input(u"brave", metrics::OmniboxEventProto::OTHER,
                           classifier_);
@@ -160,39 +161,10 @@ TEST_F(OmniboxPromotionTest, ProfileTest) {
 
 TEST_F(OmniboxPromotionTest, PromotionEntrySortTest) {
   constexpr int kTotalMatchCount = 6;
-  base::test::ScopedFeatureList feature_list_button;
 
-  // Test button type search conversion.
-  feature_list_button.InitAndEnableFeature(
-      brave_search_conversion::features::kOmniboxButton);
-
-  CreateController(false);
-  EXPECT_TRUE(controller_->result().empty());
   AutocompleteInput input(u"brave", metrics::OmniboxEventProto::OTHER,
                           classifier_);
-  controller_->Start(input);
-  EXPECT_EQ(static_cast<size_t>(kTotalMatchCount),
-            controller_->result().size());
   int promotion_match_count = 0;
-  for (const auto& match : controller_->result()) {
-    if (IsBraveSearchPromotionMatch(match)) {
-      promotion_match_count++;
-    }
-  }
-
-  // There is one button promotion entry.
-  EXPECT_EQ(1, promotion_match_count);
-
-  auto brave_search_conversion_match =
-      base::ranges::find_if(controller_->result(), IsBraveSearchPromotionMatch);
-  EXPECT_NE(brave_search_conversion_match, controller_->result().end());
-
-  // Located as second entry for button type.
-  EXPECT_EQ(1, std::distance(controller_->result().begin(),
-                             brave_search_conversion_match));
-
-  // Turn off button type and on banner type search conversion.
-  feature_list_button.Reset();
   base::test::ScopedFeatureList feature_list_banner;
   feature_list_banner.InitAndEnableFeatureWithParameters(
       brave_search_conversion::features::kOmniboxBanner,
@@ -201,7 +173,6 @@ TEST_F(OmniboxPromotionTest, PromotionEntrySortTest) {
   CreateController(false);
   EXPECT_TRUE(controller_->result().empty());
   controller_->Start(input);
-  promotion_match_count = 0;
   for (const auto& match : controller_->result()) {
     if (IsBraveSearchPromotionMatch(match)) {
       promotion_match_count++;
@@ -211,7 +182,7 @@ TEST_F(OmniboxPromotionTest, PromotionEntrySortTest) {
   // There is one banner promotion entry.
   EXPECT_EQ(1, promotion_match_count);
 
-  brave_search_conversion_match =
+  auto brave_search_conversion_match =
       base::ranges::find_if(controller_->result(), IsBraveSearchPromotionMatch);
   EXPECT_NE(brave_search_conversion_match, controller_->result().end());
 
@@ -232,16 +203,6 @@ TEST_F(OmniboxPromotionTest, AutocompleteResultTest) {
 
   AutocompleteResult result;
   ACMatches matches = CreateTestMatches();
-  // Make 4th match as button type promotion and check that promotion is
-  // reordered at second.
-  matches[3].destination_url = GetPromoURL(input.text());
-  SetConversionTypeToMatch(ConversionType::kButton, &matches[3]);
-  result.AppendMatches(matches);
-  SortBraveSearchPromotionMatch(&result);
-  EXPECT_TRUE(IsBraveSearchPromotionMatch(*result.match_at(1)));
-
-  result.Reset();
-  matches = CreateTestMatches();
   // Make 3rd match as banner type promotion and check that promotion is
   // reordered at last.
   matches[2].destination_url = GetPromoURL(input.text());
@@ -257,7 +218,7 @@ TEST_F(OmniboxPromotionTest, AutocompleteResultTest) {
   result.AppendMatches(matches);
   // Make first match is not search query with default provider.
   result.begin()->type = AutocompleteMatchType::NAVSUGGEST;
-  // Check promotion match is deleted from |result| when
+  // Check promotion match is deleted from |result|.
   SortBraveSearchPromotionMatch(&result);
   for (const auto& match : result) {
     EXPECT_FALSE(IsBraveSearchPromotionMatch(match));

--- a/components/omnibox/browser/promotion_utils.cc
+++ b/components/omnibox/browser/promotion_utils.cc
@@ -68,7 +68,7 @@ ConversionType GetConversionTypeFromMatch(const AutocompleteMatch& match) {
     return ConversionType::kNone;
   const ConversionType type = static_cast<ConversionType>(type_int);
   DCHECK(type == ConversionType::kButton ||
-         (type >= ConversionType::kBannerTypeA &&
+         (type >= ConversionType::kBannerTypeB &&
           type <= ConversionType::kBannerTypeD));
   return type;
 }

--- a/components/omnibox/browser/promotion_utils.cc
+++ b/components/omnibox/browser/promotion_utils.cc
@@ -44,13 +44,8 @@ void SortBraveSearchPromotionMatch(AutocompleteResult* result) {
     return;
   }
 
-  // Put as a second match for button type. Otherwise, put at last.
-  const int target_index =
-      GetConversionTypeFromMatch(*brave_search_conversion_match) ==
-              ConversionType::kButton
-          ? 1
-          : -1;
-  result->ReorderMatch(brave_search_conversion_match, target_index);
+  // Put banner type match at last.
+  result->ReorderMatch(brave_search_conversion_match, -1);
 }
 
 bool IsBraveSearchPromotionMatch(const AutocompleteMatch& match) {
@@ -67,8 +62,7 @@ ConversionType GetConversionTypeFromMatch(const AutocompleteMatch& match) {
   if (!base::StringToInt(type_string, &type_int))
     return ConversionType::kNone;
   const ConversionType type = static_cast<ConversionType>(type_int);
-  DCHECK(type == ConversionType::kButton ||
-         (type >= ConversionType::kBannerTypeB &&
+  DCHECK((type >= ConversionType::kBannerTypeB &&
           type <= ConversionType::kBannerTypeD));
   return type;
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

fix https://github.com/brave/brave-browser/issues/36499
fix https://github.com/brave/brave-browser/issues/37531

Removed deprecated banner type A and button type promotions.
And fixed omnibox search promotion layout regression.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave with `--enable-features=BraveSearchOmniboxBanner:banner_type/type_A` or `--enable-features=BraveSearchOmniboxButton`
2. Change default search provider to non-brave search
3. Type anything and check promotion entry is not shown in omnibox popup
4. Relaunch brave with `--enable-features=BraveSearchOmniboxBanner:banner_type/type_B`
5. Check promotion entry is shown in omnibox