### PR TITLE
[Nala]: Override cr_elements in Debug builds

### DIFF
--- a/chromium_src/ui/webui/resources/tools/generate_grd.py
+++ b/chromium_src/ui/webui/resources/tools/generate_grd.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+REPLACE_CR_ELEMENTS = ["cr_button", "cr_toggle"]
+
+
+def generate_file_overrides():
+    overrides = dict()
+    gen_dir = '${root_gen_dir}/'
+    for el in REPLACE_CR_ELEMENTS:
+        path = f"ui/webui/resources/tsc/cr_elements/{el}/{el}"
+        exts = ['.html.js', '.js']
+        for ext in exts:
+            overrides[gen_dir + path + ext] = gen_dir + 'brave/' + path + ext
+
+    return overrides
+
+
+FILE_OVERRIDES = generate_file_overrides()
+
+import override_utils
+
+
+@override_utils.override_function(globals())
+def _generate_include_row(original_function, grd_prefix, filename, pathname, \
+                          resource_path_rewrites, resource_path_prefix):
+    if pathname in FILE_OVERRIDES:
+        pathname = FILE_OVERRIDES[pathname]
+
+    return original_function(grd_prefix, filename, pathname, \
+                            resource_path_rewrites, resource_path_prefix)

--- a/patches/ui-webui-resources-tools-generate_grd.py.patch
+++ b/patches/ui-webui-resources-tools-generate_grd.py.patch
@@ -1,0 +1,11 @@
+diff --git a/ui/webui/resources/tools/generate_grd.py b/ui/webui/resources/tools/generate_grd.py
+index 4627c198ac74d..6c10c51b3aba1 100644
+--- a/ui/webui/resources/tools/generate_grd.py
++++ b/ui/webui/resources/tools/generate_grd.py
+@@ -183,5 +183,6 @@ def main(argv):
+     return
+ 
+ 
++from brave_chromium_utils import inline_chromium_src_override; inline_chromium_src_override(globals(), locals())
+ if __name__ == '__main__':
+   main(sys.argv[1:])


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

Original PR: https://github.com/brave/brave-core/pull/22565 (doesn't work in Debug builds)

Currently the Nala overrides for cr_button and cr_toggle don't work in Debug builds, which is unfortunate. This is caused because Chromium doesn't apply bundling in Debug  builds.

My fix is to override the file_path in the generated `resources.grdp` file. I'd like to get some feedback (at the high level) on this approach.

This fix isn't final (which is why it's marked as a draft), as I'd like to have a shared source of truth for components to override in bundled and non-bundled builds (the elements to override are currently in two separate files).

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

