### PR TITLE
[ads] New Tab Takeover video ads design fixes

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackgroundButtonsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackgroundButtonsView.swift
@@ -280,12 +280,14 @@ extension NewTabPageBackgroundButtonsView {
   }
   private class PlayButton: SpringButton {
     let imageView = UIImageView(
-      image: UIImage(braveSystemNamed: "leo.play.circle")!.applyingSymbolConfiguration(
-        .init(scale: .large)
-      )
+      image: UIImage(braveSystemNamed: "leo.play.circle")!.withAlignmentRectInsets(.zero)
     ).then {
       $0.tintColor = .white
       $0.contentMode = .scaleAspectFit
+      $0.preferredSymbolConfiguration = .init(
+        font: .preferredFont(for: .title1, weight: .regular),
+        scale: .large
+      )
     }
 
     private let backgroundView = UIVisualEffectView(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
@@ -38,8 +38,8 @@ class NewTabPageVideoButtonsView: UIView {
     addGestureRecognizer(tapGesture)
 
     cancelButton.snp.makeConstraints {
-      $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(20)
-      $0.right.equalTo(self.safeAreaLayoutGuide.snp.right).offset(-20)
+      $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(10)
+      $0.right.equalTo(self.safeAreaLayoutGuide.snp.right).offset(-10)
     }
     playPauseButtonImage.snp.makeConstraints {
       $0.centerX.equalToSuperview()
@@ -51,8 +51,8 @@ class NewTabPageVideoButtonsView: UIView {
     super.layoutSubviews()
 
     cancelButton.snp.remakeConstraints {
-      $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(20)
-      $0.right.equalTo(self.safeAreaLayoutGuide.snp.right).offset(-20)
+      $0.top.equalTo(self.safeAreaLayoutGuide.snp.top).offset(10)
+      $0.right.equalTo(self.safeAreaLayoutGuide.snp.right).offset(-10)
     }
   }
 
@@ -73,14 +73,10 @@ class NewTabPageVideoButtonsView: UIView {
 
     if playStarted {
       playPauseButtonImage.imageView.image = UIImage(braveSystemNamed: "leo.play.circle")!
-        .applyingSymbolConfiguration(
-          .init(scale: .large)
-        )
+        .withAlignmentRectInsets(.zero)
     } else {
       playPauseButtonImage.imageView.image = UIImage(braveSystemNamed: "leo.pause.circle")!
-        .applyingSymbolConfiguration(
-          .init(scale: .large)
-        )
+        .withAlignmentRectInsets(.zero)
     }
     showAndFadeOutImage(imageView: playPauseButtonImage)
   }
@@ -113,16 +109,18 @@ class NewTabPageVideoButtonsView: UIView {
 extension NewTabPageVideoButtonsView {
   private class CancelButton: SpringButton {
     let imageView = UIImageView(
-      image: UIImage(braveSystemNamed: "leo.close")!.applyingSymbolConfiguration(
-        .init(scale: .small)
-      )
+      image: UIImage(braveSystemNamed: "leo.close")!
     ).then {
       $0.tintColor = .white
       $0.contentMode = .scaleAspectFit
+      $0.preferredSymbolConfiguration = .init(
+        font: .preferredFont(for: .title3, weight: .regular),
+        scale: .small
+      )
     }
 
     private let backgroundView = UIVisualEffectView(
-      effect: UIBlurEffect(style: .systemThinMaterialDark)
+      effect: UIBlurEffect(style: .systemUltraThinMaterialDark)
     ).then {
       $0.clipsToBounds = true
       $0.isUserInteractionEnabled = false
@@ -143,7 +141,7 @@ extension NewTabPageVideoButtonsView {
         $0.width.equalTo(self.snp.height)
       }
       imageView.snp.makeConstraints {
-        $0.edges.equalToSuperview().inset(UIEdgeInsets(equalInset: 4))
+        $0.edges.equalToSuperview().inset(UIEdgeInsets(equalInset: 3))
       }
     }
 
@@ -164,6 +162,10 @@ extension NewTabPageVideoButtonsView {
     let imageView = UIImageView().then {
       $0.tintColor = .white
       $0.contentMode = .scaleAspectFit
+      $0.preferredSymbolConfiguration = .init(
+        font: .preferredFont(for: .title1, weight: .regular),
+        scale: .large
+      )
     }
 
     init() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37653

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Check that NTT video ads fits Figma design
* Check that we show stop keyframe after NTT video playback is finished
* Check that we show stop keyframe when user cancels the playback