### PR TITLE
remove frame id from NodeDOMRoot, update changelog

### DIFF
--- a/third_party/blink/renderer/core/brave_page_graph/changelog.md
+++ b/third_party/blink/renderer/core/brave_page_graph/changelog.md
@@ -3,9 +3,15 @@
 This document shows all the changes and improvements made in each version of
 [Page Graph](https://github.com/brave/brave-browser/wiki/PageGraph).
 
+## Version 0.6.1
+
+Remove `frame id` from `NodeDOMRoot` instances. The `frame id` property
+on other nodes and edges should reference the `blink id` property
+on `NodeDOMRoot`.
+
 ## Version 0.6.0
 
-#### Tracking Frame ID For Many Edges / Actios
+#### Tracking Frame ID For Many Edges / Actions
 
 Add `frame id` properties for most edges, to resolve ambiguities in the
 graph when scripts modify or call API's in other frames (e.g., local frames)

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_dom_root.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_dom_root.cc
@@ -15,9 +15,8 @@ namespace brave_page_graph {
 
 NodeDOMRoot::NodeDOMRoot(GraphItemContext* context,
                          const DOMNodeId dom_node_id,
-                         const FrameId& frame_id,
                          const String& tag_name)
-    : NodeHTMLElement(context, dom_node_id, tag_name), frame_id_(frame_id) {}
+    : NodeHTMLElement(context, dom_node_id, tag_name) {}
 
 ItemName NodeDOMRoot::GetItemName() const {
   return "DOM root";
@@ -39,8 +38,6 @@ void NodeDOMRoot::AddGraphMLAttributes(xmlDocPtr doc,
   NodeHTMLElement::AddGraphMLAttributes(doc, parent_node);
   GraphMLAttrDefForType(kGraphMLAttrDefURL)
       ->AddValueNode(doc, parent_node, url_);
-  GraphMLAttrDefForType(kGraphMLAttrDefNodeFrameId)
-      ->AddValueNode(doc, parent_node, frame_id_);
 }
 
 bool NodeDOMRoot::IsNodeDOMRoot() const {

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_dom_root.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/node/html/node_dom_root.h
@@ -16,7 +16,6 @@ class NodeDOMRoot final : public NodeHTMLElement {
  public:
   NodeDOMRoot(GraphItemContext* context,
               const blink::DOMNodeId dom_node_id,
-              const FrameId& frame_id,
               const String& tag_name);
 
   void SetURL(const String& url) { url_ = url; }
@@ -32,7 +31,6 @@ class NodeDOMRoot final : public NodeHTMLElement {
 
  private:
   String url_;
-  FrameId frame_id_;
 };
 
 }  // namespace brave_page_graph

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.cc
@@ -186,7 +186,7 @@ namespace blink {
 
 namespace {
 
-constexpr char kPageGraphVersion[] = "0.6.0";
+constexpr char kPageGraphVersion[] = "0.6.1";
 constexpr char kPageGraphUrl[] =
     "https://github.com/brave/brave-browser/wiki/PageGraph";
 
@@ -1241,10 +1241,8 @@ void PageGraph::RegisterDocumentNodeCreated(blink::Document* document) {
     v8::page_graph::SetPageGraphDelegate(isolate, page_graph_delegate.get());
   }
 
-  FrameId frame_id = GetFrameId(document);
-
   const String local_tag_name(static_cast<blink::Node*>(document)->nodeName());
-  auto* dom_root = AddNode<NodeDOMRoot>(node_id, frame_id, local_tag_name);
+  auto* dom_root = AddNode<NodeDOMRoot>(node_id, local_tag_name);
   auto url = NormalizeUrl(document->Url());
   dom_root->SetURL(url.GetString());
   if (!source_url_ && url.IsValid() && url.ProtocolIsInHTTPFamily()) {
@@ -1273,6 +1271,7 @@ void PageGraph::RegisterDocumentNodeCreated(blink::Document* document) {
     AddEdge<EdgeStructure>(nodes.parser_node, dom_root);
   }
 
+  FrameId frame_id = GetFrameId(execution_context);
   AddEdge<EdgeNodeCreate>(GetCurrentActingNode(execution_context), dom_root,
                           frame_id);
 }


### PR DESCRIPTION
fixes brave/brave-browser#37711

Removes incorrect and not useful `frame id` property `DOMRootNode` instances, and updates changelog explaining why (its in some cases redundant, and in other cases empty).

Also fix an unrelated typo in the changelog.