### PR TITLE
Layout split tabs vertically in vertical tab mode

### DIFF
--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -547,11 +547,6 @@ void BraveTabContainer::HandleDragExited() {
 
 void BraveTabContainer::OnTileTabs(const SplitViewBrowserData::Tile& tile) {
   SchedulePaint();
-
-  // This cancels StartInsertTabAnimation() triggered for the new tab to be
-  // paired in tile.
-  // TODO(sko) Can we animate this naturally on vertical tabs?
-  CompleteAnimationAndLayout();
 }
 
 void BraveTabContainer::OnDidBreakTile(const SplitViewBrowserData::Tile& tile) {

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -169,12 +169,12 @@ void BraveTabStrip::MaybeStartDrag(
       // Make a pair of tabs in a tile selected together so that they move
       // together during drag and drop.
       auto* tab_strip_model = controller_->GetBrowser()->tab_strip_model();
-      auto index = tab_strip_model->GetIndexOfTab(
-          IsFirstTabInTile(tab) ? tile->second : tile->first);
-      DCHECK_NE(index, TabStripModel::kNoTab);
-      new_selection.AddIndexToSelection(index);
+      // Make sure both tiled tabs are in selection.
+      new_selection.AddIndexToSelection(
+          tab_strip_model->GetIndexOfTab(tile->first));
+      new_selection.AddIndexToSelection(
+          tab_strip_model->GetIndexOfTab(tile->second));
       tab_strip_model->SetSelectionFromModel(new_selection);
-      DCHECK(IsTabSelected(tab_at(index)));
     }
   }
 

--- a/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
+++ b/browser/ui/views/tabs/brave_tab_strip_layout_helper.cc
@@ -101,19 +101,10 @@ void CalculateVerticalLayout(const TabLayoutConstants& layout_constants,
     rect.set_width(width.value_or(tab.GetPreferredWidth()) - rect.x() * 2);
     rect.set_height(tab.state().open() == TabOpen::kOpen ? kVerticalTabHeight
                                                          : 0);
-
-    const auto tiled_state = tab.state().tiled_state();
-    if (tiled_state == TabTiledState::kFirst) {
-      rect.set_width(rect.width() / 2);
-    } else if (tiled_state == TabTiledState::kSecond) {
-      rect.set_width(rect.width() / 2);
-      rect.set_x(rect.width() + 4);
-    }
     result->push_back(rect);
 
     // Update rect for the next tab.
-    if (tab.state().open() == TabOpen::kOpen &&
-        tiled_state != TabTiledState::kFirst) {
+    if (tab.state().open() == TabOpen::kOpen) {
       rect.set_y(rect.bottom() + kVerticalTabsSpacing);
     }
   }
@@ -175,20 +166,6 @@ std::vector<gfx::Rect> CalculateBoundsForVerticalDraggedViews(
         // In case it's a tab in a group, set left padding
         x = BraveTabGroupHeader::kPaddingForGroup;
         width -= x * 2;
-      }
-
-      // If a tab is tiled, we should lay out a pair of tabs in a row.
-      auto tab_index = tab_strip->GetModelIndexOf(view);
-      DCHECK(tab_index);
-      auto tile = static_cast<BraveTabStrip*>(tab_strip)->GetTiledStateForTab(
-          *tab_index);
-      if (tile != TabTiledState::kNone) {
-        width /= 2;
-        if (tile == TabTiledState::kSecond) {
-          x += width;
-        }
-        bounds.emplace_back(x, y, width, height);
-        continue;
       }
     }
     bounds.emplace_back(x, y, width, height);

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -222,12 +222,22 @@ SkPath BraveVerticalTabStyle::GetPath(
   }
 
   if (is_tab_tiled) {
-    constexpr auto padding_for_tile = 1;
-    tab_top += scale * padding_for_tile;
-    tab_bottom -= scale * padding_for_tile;
-    tab()->controller()->IsFirstTabInTile(tab())
-        ? tab_left += scale* padding_for_tile
-        : tab_right -= scale * padding_for_tile;
+    if (ShouldShowVerticalTabs()) {
+      constexpr auto kPaddingForVerticalTab = 4;
+      tab_top += scale * kPaddingForVerticalTab;
+      tab_bottom -= scale * kPaddingForVerticalTab;
+      tab_left += scale * kPaddingForVerticalTab;
+      tab_right -= scale * kPaddingForVerticalTab;
+    } else {
+      // As the horizontal tab has padding already we only gives 1 dip padding.
+      // Accumulative padding will be 4 dips.
+      constexpr auto kPaddingForHorizontalTab = 1;
+      tab_top += scale * kPaddingForHorizontalTab;
+      tab_bottom -= scale * kPaddingForHorizontalTab;
+      tab()->controller()->IsFirstTabInTile(tab())
+          ? tab_left += scale* kPaddingForHorizontalTab
+          : tab_right -= scale * kPaddingForHorizontalTab;
+    }
   }
 
   SkPath path;


### PR DESCRIPTION
The latest design has changed. Tabs in a tile should be laid out vertically

<img width="284" alt="image" src="https://github.com/brave/brave-core/assets/5474642/87adb2d4-2800-4223-9d50-29e20173758e">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37712

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

