### PR TITLE
Synchronize grouped state on tiling two tabs

### DIFF
--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -44,12 +44,15 @@ void SplitViewBrowserData::TileTabs(const Tile& tile) {
   tile_index_for_tab_[tile.second] = tiles_.size() - 1;
 
   if (tab_strip_model_adapter_) {
-    if (model) {
-      tab_strip_model_adapter_->SynchronizeGroupedState(
-          tile, /*source=*/tile.first,
-          model->GetTabGroupForTab(model->GetIndexOfTab(tile.first)));
+    const bool synchronized_group =
+        model &&
+        tab_strip_model_adapter_->SynchronizeGroupedState(
+            tile, /*source=*/tile.first,
+            model->GetTabGroupForTab(model->GetIndexOfTab(tile.first)));
+
+    if (!synchronized_group) {
+      tab_strip_model_adapter_->MakeTiledTabsAdjacent(tile);
     }
-    tab_strip_model_adapter_->MakeTiledTabsAdjacent(tile);
   }
 
   for (auto& observer : observers_) {

--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -31,8 +31,9 @@ void SplitViewBrowserData::TileTabs(const Tile& tile) {
   CHECK(!IsTabTiled(tile.first));
   CHECK(!IsTabTiled(tile.second));
 
-  if (!is_testing_) {
-    auto* model = GetBrowser().tab_strip_model();
+  TabStripModel* model = is_testing_ ? tab_strip_model_for_testing_.get()
+                                     : GetBrowser().tab_strip_model();
+  if (model) {
     CHECK_LT(model->GetIndexOfTab(tile.first),
              model->GetIndexOfTab(tile.second));
   }
@@ -43,6 +44,11 @@ void SplitViewBrowserData::TileTabs(const Tile& tile) {
   tile_index_for_tab_[tile.second] = tiles_.size() - 1;
 
   if (tab_strip_model_adapter_) {
+    if (model) {
+      tab_strip_model_adapter_->SynchronizeGroupedState(
+          tile, /*source=*/tile.first,
+          model->GetTabGroupForTab(model->GetIndexOfTab(tile.first)));
+    }
     tab_strip_model_adapter_->MakeTiledTabsAdjacent(tile);
   }
 

--- a/browser/ui/tabs/split_view_browser_data.h
+++ b/browser/ui/tabs/split_view_browser_data.h
@@ -89,6 +89,7 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
   base::ObserverList<SplitViewBrowserDataObserver> observers_;
 
   bool is_testing_ = false;
+  raw_ptr<TabStripModel> tab_strip_model_for_testing_ = nullptr;
 
   base::WeakPtrFactory<SplitViewBrowserData> weak_ptr_factory_{this};
 

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/tabs/split_view_tab_strip_model_adapter.h"
 
+#include "base/auto_reset.h"
 #include "base/compiler_specific.h"
 #include "base/memory/weak_ptr.h"
 #include "base/ranges/algorithm.h"
@@ -50,6 +51,29 @@ void SplitViewTabStripModelAdapter::TabDragStarted() {
   }
 
   is_in_tab_dragging_ = true;
+}
+
+void SplitViewTabStripModelAdapter::SynchronizeGroupedState(
+    const SplitViewBrowserData::Tile& tile,
+    const tabs::TabHandle& source,
+    std::optional<tab_groups::TabGroupId> group) {
+  DCHECK(!is_in_synch_grouped_state_);
+  base::AutoReset<bool> resetter(&is_in_synch_grouped_state_, true);
+  auto other_tab = tile.first == source ? tile.second : tile.first;
+  auto other_tab_index = model_->GetIndexOfTab(other_tab);
+  auto tab_group_for_secondary_tab = model_->GetTabGroupForTab(other_tab_index);
+  if (group == tab_group_for_secondary_tab) {
+    return;
+  }
+
+  auto tab_index = model_->GetIndexOfTab(other_tab);
+  if (group) {
+    model_->AddToExistingGroup({tab_index}, group.value());
+  } else {
+    model_->RemoveFromGroup({tab_index});
+  }
+
+  MakeTiledTabsAdjacent(tile, true);
 }
 
 void SplitViewTabStripModelAdapter::TabDragEnded() {
@@ -242,6 +266,10 @@ void SplitViewTabStripModelAdapter::TabGroupedStateChanged(
     std::optional<tab_groups::TabGroupId> group,
     content::WebContents* contents,
     int index) {
+  if (is_in_synch_grouped_state_) {
+    return;
+  }
+
   // In case a tiled tab is grouped or ungrouped, we need to synchronize the
   // other tab together.
   auto changed_tab_handle = model_->GetTabHandleAt(index);
@@ -250,39 +278,11 @@ void SplitViewTabStripModelAdapter::TabGroupedStateChanged(
     return;
   }
 
-  auto [tab1, other_tab] = *tile;
-  if (tab1 != changed_tab_handle) {
-    std::swap(tab1, other_tab);
-    CHECK(tab1 == changed_tab_handle);
-  }
-
-  auto other_tab_index = model_->GetIndexOfTab(other_tab);
-  auto tab_group_for_secondary_tab = model_->GetTabGroupForTab(other_tab_index);
-  if (group == tab_group_for_secondary_tab) {
-    return;
-  }
-
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
-      base::BindOnce(
-          [](base::WeakPtr<SplitViewTabStripModelAdapter> adapter,
-             std::optional<tab_groups::TabGroupId> group_id,
-             SplitViewBrowserData::Tile tile, tabs::TabHandle tab_to_move) {
-            if (!adapter) {
-              return;
-            }
-
-            auto tab_index = adapter->model_->GetIndexOfTab(tab_to_move);
-            if (group_id) {
-              adapter->model_->AddToExistingGroup({tab_index},
-                                                  group_id.value());
-            } else {
-              adapter->model_->RemoveFromGroup({tab_index});
-            }
-
-            adapter->MakeTiledTabsAdjacent(tile, true);
-          },
-          weak_ptr_factory_.GetWeakPtr(), group, *tile, other_tab));
+      base::BindOnce(&SplitViewTabStripModelAdapter::SynchronizeGroupedState,
+                     weak_ptr_factory_.GetWeakPtr(), *tile, changed_tab_handle,
+                     group));
 }
 
 void SplitViewTabStripModelAdapter::OnTabRemoved(

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.h
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.h
@@ -24,6 +24,9 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
 
   void MakeTiledTabsAdjacent(const SplitViewBrowserData::Tile& tile,
                              bool move_right_tab = true);
+  void SynchronizeGroupedState(const SplitViewBrowserData::Tile& tile,
+                               const tabs::TabHandle& source,
+                               std::optional<tab_groups::TabGroupId> group);
 
   void TabDragStarted();
   void TabDragEnded();
@@ -57,6 +60,8 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
   raw_ref<TabStripModel> model_;
 
   bool is_in_tab_dragging_ = false;
+
+  bool is_in_synch_grouped_state_ = false;
 
   base::WeakPtrFactory<SplitViewTabStripModelAdapter> weak_ptr_factory_{this};
 };

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.h
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.h
@@ -24,7 +24,7 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
 
   void MakeTiledTabsAdjacent(const SplitViewBrowserData::Tile& tile,
                              bool move_right_tab = true);
-  void SynchronizeGroupedState(const SplitViewBrowserData::Tile& tile,
+  bool SynchronizeGroupedState(const SplitViewBrowserData::Tile& tile,
                                const tabs::TabHandle& source,
                                std::optional<tab_groups::TabGroupId> group);
 


### PR DESCRIPTION
When tiling two tabs, if the first tab is in group, the second tab should move into the first tab's group.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37717

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

