### PR TITLE
[iOS] Add one-to-many language mapping for l10n scripts.

### DIFF
--- a/ios/brave-ios/App/l10n/tools/download-translations-from-transifex.swift
+++ b/ios/brave-ios/App/l10n/tools/download-translations-from-transifex.swift
@@ -7,6 +7,48 @@ guard let apiKey = ProcessInfo.processInfo.environment["PASSWORD"] else {
   exit(EXIT_FAILURE)
 }
 
+struct LanguageMapping {
+  /// The language code on the server.
+  let source: String
+  /// Sometimes we may want to have one language code to be used in many languages or dialects.
+  /// This array has a list of those additional languages.
+  /// For example German may have Swiss-German variant as their additional target.
+  /// This list is empty if there is no additional targets.
+  let additionalTargets: [String]
+
+  /// Returns base language code and all additional targets we want to support.
+  var targets: [String] {
+    [source] + additionalTargets
+  }
+
+  init(source: String, additionalTargets: [String] = []) {
+    self.source = source
+    self.additionalTargets = additionalTargets
+  }
+
+  static let allMappings: [LanguageMapping] = [
+    LanguageMapping(source: "fr"),
+    LanguageMapping(source: "pl"),
+    LanguageMapping(source: "ru"),
+    LanguageMapping(source: "de", additionalTargets: ["gsw"]),
+    LanguageMapping(source: "zh"),
+    LanguageMapping(source: "zh_TW"),
+    LanguageMapping(source: "id_ID"),
+    LanguageMapping(source: "it"),
+    LanguageMapping(source: "ja"),
+    LanguageMapping(source: "ko_KR"),
+    LanguageMapping(source: "ms"),
+    LanguageMapping(source: "pt_BR"),
+    LanguageMapping(source: "es"),
+    LanguageMapping(source: "uk"),
+    LanguageMapping(source: "nb"),
+    LanguageMapping(source: "sv"),
+    LanguageMapping(source: "tr"),
+    LanguageMapping(source: "ca"),
+    LanguageMapping(source: "nl"),
+  ]
+}
+
 @Sendable func validateResponse(_ response: HTTPURLResponse) {
   if response.statusCode == 401 {
     print("ERROR: Unauthorized access")
@@ -87,62 +129,86 @@ guard let apiKey = ProcessInfo.processInfo.environment["PASSWORD"] else {
   }
 }
 
-@Sendable func cleanupAndWriteResourceToDisk(xliffData: Data, languageCode: String) async {
+@Sendable func cleanupAndWriteResourceToDisk(xliffData: Data, languageCodes: [String]) async {
   let fileManager = FileManager.default
-  let xliffURL = fileManager.temporaryDirectory.appendingPathComponent("\(languageCode).xliff")
-  do {
-    try xliffData.write(to: xliffURL)
-  } catch {
-    print("ERROR: Failed to write xliff file")
-    exit(EXIT_FAILURE)
-  }
+  for languageCode in languageCodes {
+    let xliffURL = fileManager.temporaryDirectory.appendingPathComponent("\(languageCode).xliff")
+    do {
+      try xliffData.write(to: xliffURL)
 
-  let process = Process()
-  process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-  process.arguments = ["python3", "xliff-cleanup.py", xliffURL.path]
-  do {
-    try process.run()
-    process.waitUntilExit()
-  } catch {
-    print("Failed to run python process to cleanup xliff")
-  }
-
-  do {
-    let outputPath = URL(fileURLWithPath: fileManager.currentDirectoryPath).appendingPathComponent(
-      "translated-xliffs"
-    )
-    if !fileManager.fileExists(atPath: outputPath.path) {
-      try fileManager.createDirectory(at: outputPath, withIntermediateDirectories: true)
+      // If additional targets exist we have to update target language in the xliff xml.
+      if languageCodes.count > 1 {
+        try updateTargetLanguage(inXLIFFFileAtPath: xliffURL.path, newLanguage: languageCode)
+      }
+    } catch {
+      print("ERROR: Failed to write or modify xliff file for \(languageCode): \(error)")
+      exit(EXIT_FAILURE)
     }
-    try fileManager.moveItem(
-      at: xliffURL,
-      to: outputPath.appendingPathComponent("\(languageCode).xliff")
-    )
-  } catch {
-    print("ERROR: Failed to move files: \(String(describing: error))")
+
+    // Running an external Python script for XLIFF cleanup
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+    process.arguments = ["python3", "xliff-cleanup.py", xliffURL.path]
+    do {
+      try process.run()
+      process.waitUntilExit()
+    } catch {
+      print("Failed to run python process to cleanup xliff for \(languageCode): \(error)")
+    }
+
+    // Move the cleaned up XLIFF to a permanent directory
+    do {
+      let outputPath = URL(fileURLWithPath: fileManager.currentDirectoryPath)
+        .appendingPathComponent("translated-xliffs")
+      if !fileManager.fileExists(atPath: outputPath.path) {
+        try fileManager.createDirectory(at: outputPath, withIntermediateDirectories: true)
+      }
+      try fileManager.moveItem(
+        at: xliffURL,
+        to: outputPath.appendingPathComponent("\(languageCode).xliff")
+      )
+    } catch {
+      print("ERROR: Failed to move xliff file for \(languageCode): \(error)")
+    }
   }
 }
 
-let languageCodes = [
-  "fr", "pl", "ru", "de", "zh", "zh_TW", "id_ID", "it", "ja", "ko_KR", "ms", "pt_BR", "es", "uk",
-  "nb", "sv", "tr", "ca", "nl",
-]
+/// Replaces target language attribute in xliff to a new language.
+/// This is required for languages which are not on the server but we want to support them locally.
+/// The server has a base language xliff which we then 'copy' to another language,
+/// only changing the target-language attr.
+func updateTargetLanguage(inXLIFFFileAtPath path: String, newLanguage: String) throws {
+  let url = URL(fileURLWithPath: path)
+  let xmlData = try Data(contentsOf: url)
+  let xmlDoc = try XMLDocument(data: xmlData, options: .nodePreserveWhitespace)
+  let fileNodes = try xmlDoc.nodes(forXPath: "//file")
+
+  for case let fileNode as XMLElement in fileNodes {
+    if let targetLanguage = fileNode.attribute(forName: "target-language") {
+      targetLanguage.stringValue = newLanguage
+    }
+  }
+
+  let xmlOutputData = xmlDoc.xmlData(options: .nodePrettyPrint)
+  try xmlOutputData.write(to: url)
+}
+
 let resourceURLs: [String: URL] = await {
   var urls: [String: URL] = [:]
   // Prepare files for each language first
-  for code in languageCodes {
+  for mapping in LanguageMapping.allMappings {
     if Task.isCancelled {
       exit(EXIT_FAILURE)
     }
-    print("Preparing translations download for \(code)")
-    urls[code] = await fetchResourceURL(languageCode: code)
+    print("Preparing translations download for \(mapping.source)")
+    urls[mapping.source] = await fetchResourceURL(languageCode: mapping.source)
   }
   return urls
 }()
 
 // Then attempt to download each one
 try await withThrowingTaskGroup(of: Void.self) { group in
-  for code in languageCodes {
+  for code in LanguageMapping.allMappings.map(\.source) {
     guard let resourceURL = resourceURLs[code] else {
       return
     }
@@ -162,7 +228,9 @@ try await withThrowingTaskGroup(of: Void.self) { group in
           )
           try await Task.sleep(nanoseconds: NSEC_PER_SEC * 5)
         } catch {
-          await cleanupAndWriteResourceToDisk(xliffData: xliffData, languageCode: code)
+          // One language on the sever may may to multiple languages/dialects on the client.
+          let targets = LanguageMapping.allMappings.first { $0.source == code }?.targets ?? [code]
+          await cleanupAndWriteResourceToDisk(xliffData: xliffData, languageCodes: targets)
           print("Downloaded translations for \(code)")
           break
         }

--- a/ios/brave-ios/App/l10n/tools/download-translations-from-transifex.swift
+++ b/ios/brave-ios/App/l10n/tools/download-translations-from-transifex.swift
@@ -30,7 +30,7 @@ struct LanguageMapping {
     LanguageMapping(source: "fr"),
     LanguageMapping(source: "pl"),
     LanguageMapping(source: "ru"),
-    LanguageMapping(source: "de", additionalTargets: ["gsw"]),
+    LanguageMapping(source: "de"),
     LanguageMapping(source: "zh"),
     LanguageMapping(source: "zh_TW"),
     LanguageMapping(source: "id_ID"),


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/37721

Add an ability to download one language from transifex and populate it to other languages or dialects.
For example German(de) could be used for both Germany(de) and Swiss-German(gsw).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

