### PR TITLE
Backporting `--ozone-platform-hint` fix

### DIFF
--- a/patches/chrome-app-chrome_main_delegate.cc.patch
+++ b/patches/chrome-app-chrome_main_delegate.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/chrome/app/chrome_main_delegate.cc b/chrome/app/chrome_main_delegate.cc
+index 73b6ab0934b14609c5b4eba55b4cd0d0c09673af..0b4c44be679d0e92f9f3c206c98efd9cb37191bd 100644
+--- a/chrome/app/chrome_main_delegate.cc
++++ b/chrome/app/chrome_main_delegate.cc
+@@ -249,6 +249,9 @@
+ #include "base/scoped_add_feature_flags.h"
+ #include "ui/base/ui_base_features.h"
+ #include "ui/ozone/public/ozone_platform.h"
++#if BUILDFLAG(IS_LINUX)
++#include "chrome/browser/chrome_browser_main_extra_parts_linux.h"
++#endif
+ #endif  // BUILDFLAG(IS_OZONE)
+ 
+ base::LazyInstance<ChromeContentGpuClient>::DestructorAtExit
+@@ -959,6 +962,9 @@ std::optional<int> ChromeMainDelegate::PostEarlyInitialization(
+   // Initialize Ozone platform and add required feature flags as per platform's
+   // properties. Must be added before feature list is created otherwise the
+   // added flag won't be picked up.
++#if BUILDFLAG(IS_LINUX)
++  ChromeBrowserMainExtraPartsLinux::InitOzonePlatformHint();
++#endif
+   ui::OzonePlatform::PreEarlyInitialization();
+   AddFeatureFlagsToCommandLine();
+ #endif  // BUILDFLAG(IS_OZONE)

--- a/patches/chrome-browser-chrome_browser_main_extra_parts_linux.cc.patch
+++ b/patches/chrome-browser-chrome_browser_main_extra_parts_linux.cc.patch
@@ -1,0 +1,28 @@
+diff --git a/chrome/browser/chrome_browser_main_extra_parts_linux.cc b/chrome/browser/chrome_browser_main_extra_parts_linux.cc
+index dba7b116ecaa07b8dd085284b5bd38b172a8f250..ea0487022dcdcf45aac35bf6170a27141bcb1157 100644
+--- a/chrome/browser/chrome_browser_main_extra_parts_linux.cc
++++ b/chrome/browser/chrome_browser_main_extra_parts_linux.cc
+@@ -168,7 +168,13 @@ ChromeBrowserMainExtraPartsLinux::ChromeBrowserMainExtraPartsLinux() = default;
+ 
+ ChromeBrowserMainExtraPartsLinux::~ChromeBrowserMainExtraPartsLinux() = default;
+ 
+-void ChromeBrowserMainExtraPartsLinux::PreEarlyInitialization() {
++void ChromeBrowserMainExtraPartsLinux::PostBrowserStart() {
++  RecordDisplayServerProtocolSupport();
++  ChromeBrowserMainExtraPartsOzone::PostBrowserStart();
++}
++
++// static
++void ChromeBrowserMainExtraPartsLinux::InitOzonePlatformHint() {
+ #if BUILDFLAG(IS_LINUX)
+   // On the desktop, we fix the platform name if necessary.
+   // See https://crbug.com/1246928.
+@@ -189,8 +195,3 @@ void ChromeBrowserMainExtraPartsLinux::PreEarlyInitialization() {
+   }
+ #endif  // BUILDFLAG(IS_LINUX)
+ }
+-
+-void ChromeBrowserMainExtraPartsLinux::PostBrowserStart() {
+-  RecordDisplayServerProtocolSupport();
+-  ChromeBrowserMainExtraPartsOzone::PostBrowserStart();
+-}

--- a/patches/chrome-browser-chrome_browser_main_extra_parts_linux.h.patch
+++ b/patches/chrome-browser-chrome_browser_main_extra_parts_linux.h.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/browser/chrome_browser_main_extra_parts_linux.h b/chrome/browser/chrome_browser_main_extra_parts_linux.h
+index 3847bd2090e282486717fb211308915ec9251abe..4f188a7bdfe3867bcdf83ce9e442e94a002095b6 100644
+--- a/chrome/browser/chrome_browser_main_extra_parts_linux.h
++++ b/chrome/browser/chrome_browser_main_extra_parts_linux.h
+@@ -17,9 +17,10 @@ class ChromeBrowserMainExtraPartsLinux
+       const ChromeBrowserMainExtraPartsLinux&) = delete;
+   ~ChromeBrowserMainExtraPartsLinux() override;
+ 
++  static void InitOzonePlatformHint();
++
+  private:
+   // ChromeBrowserMainExtraParts overrides.
+-  void PreEarlyInitialization() override;
+   void PostBrowserStart() override;
+ };
+ 


### PR DESCRIPTION
This change is landing in down the line in chromium upstream, but for the moment current users of 1.66.x and 1.65.x are being affected.

https://chromium-review.googlesource.com/c/chromium/src/+/5375669

Chromium change:
https://chromium.googlesource.com/chromium/src/+/c7f4c58f896a651eba80ad805ebdb49d19ebdbd4

commit c7f4c58f896a651eba80ad805ebdb49d19ebdbd4
Author: Tom Anderson <thomasanderson@chromium.org>
Date:   Wed Mar 20 00:00:12 2024 +0000

    Fix --ozone-platform-hint

    This fixes a regression after r1269993 which moved ozone platform
    early initialization before the ozone platform hint flag was
    processed.  This CL ensures the flag processing happens even earlier.

    R=sky

    Change-Id: Icc9649beb0b86753265be2b6cdf3059611eb410f
    Bug: None

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

