### PR TITLE
Support OnDemandUpdate with multiple components at once.

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -11,6 +11,7 @@
 #include "base/command_line.h"
 #include "brave/browser/browsing_data/brave_clear_browsing_data.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_rewards/common/rewards_flags.h"
 #include "brave/components/brave_rewards/common/rewards_util.h"
 #include "brave/components/brave_sync/features.h"
@@ -20,8 +21,10 @@
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "brave/components/translate/core/common/brave_translate_features.h"
 #include "build/build_config.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/common/chrome_features.h"
+#include "components/component_updater/component_updater_service.h"
 #include "components/prefs/pref_service.h"
 #include "components/sync/base/command_line_switches.h"
 #include "components/translate/core/browser/translate_language_list.h"
@@ -60,15 +63,19 @@
 #include "brave/browser/android/preferences/features.h"
 #endif
 
-#if BUILDFLAG(ENABLE_TOR) || !BUILDFLAG(IS_ANDROID)
-#include "chrome/browser/browser_process.h"
-#endif
-
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED) && BUILDFLAG(ENABLE_EXTENSIONS)
 #include "brave/browser/extensions/brave_component_loader.h"
 #include "chrome/browser/extensions/extension_service.h"
 #include "extensions/browser/extension_system.h"
 #endif
+
+int BraveBrowserMainParts::PreMainMessageLoopRun() {
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()
+      ->RegisterOnDemandUpdater(
+          &g_browser_process->component_updater()->GetOnDemandUpdater());
+
+  return ChromeBrowserMainParts::PreMainMessageLoopRun();
+}
 
 void BraveBrowserMainParts::PreBrowserStart() {
 #if BUILDFLAG(ENABLE_SPEEDREADER)

--- a/browser/brave_browser_main_parts.h
+++ b/browser/brave_browser_main_parts.h
@@ -16,6 +16,7 @@ class BraveBrowserMainParts : public ChromeBrowserMainParts {
   BraveBrowserMainParts& operator=(const BraveBrowserMainParts&) = delete;
   ~BraveBrowserMainParts() override = default;
 
+  int PreMainMessageLoopRun() override;
   void PreBrowserStart() override;
   void PostBrowserStart() override;
   void PreShutdown() override;

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -25,7 +25,6 @@
 #include "brave/common/brave_channel_info.h"
 #include "brave/components/brave_ads/browser/component_updater/resource_component.h"
 #include "brave/components/brave_component_updater/browser/brave_component_updater_delegate.h"
-#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_service.h"
 #include "brave/components/brave_referrals/browser/brave_referrals_service.h"
 #include "brave/components/brave_shields/content/browser/ad_block_service.h"
@@ -53,7 +52,6 @@
 #include "chrome/common/channel_info.h"
 #include "chrome/common/chrome_paths.h"
 #include "chrome/common/pref_names.h"
-#include "components/component_updater/component_updater_service.h"
 #include "components/component_updater/timer_update_scheduler.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/child_process_security_policy.h"
@@ -153,9 +151,6 @@ void BraveBrowserProcessImpl::Init() {
   content::ChildProcessSecurityPolicy::GetInstance()->RegisterWebSafeScheme(
       ipfs::kIPNSScheme);
 #endif
-  brave_component_updater::BraveOnDemandUpdater::GetInstance()
-      ->RegisterOnDemandUpdateCallback(
-          base::BindRepeating(&component_updater::BraveOnDemandUpdate));
   UpdateBraveDarkMode();
   pref_change_registrar_.Add(
       kBraveDarkMode,

--- a/chromium_src/chrome/browser/component_updater/component_updater_utils.cc
+++ b/chromium_src/chrome/browser/component_updater/component_updater_utils.cc
@@ -5,18 +5,13 @@
 
 #include "src/chrome/browser/component_updater/component_updater_utils.cc"
 
-#include "base/functional/callback.h"
-#include "chrome/browser/browser_process.h"
-#include "components/component_updater/component_updater_service.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 
 namespace component_updater {
 
 void BraveOnDemandUpdate(const std::string& component_id) {
-  component_updater::ComponentUpdateService* cus =
-      g_browser_process->component_updater();
-  cus->GetOnDemandUpdater().OnDemandUpdate(
-      component_id, component_updater::OnDemandUpdater::Priority::FOREGROUND,
-      component_updater::Callback());
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+      component_id);
 }
 
 }  // namespace component_updater

--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -15,6 +15,10 @@
 
 namespace component_updater {
 
+bool ComponentInstallerPolicy::IsBraveComponent() const {
+  return false;
+}
+
 void ComponentInstaller::Register(ComponentUpdateService* cus,
                                   base::OnceClosure callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -57,6 +61,10 @@ void ComponentInstaller::Register(
   }
   Register_ChromiumImpl(std::move(register_callback), std::move(callback),
                         registered_version, max_previous_product_version);
+}
+
+bool ComponentInstaller::IsBraveComponent() const {
+  return installer_policy_->IsBraveComponent();
 }
 
 }  // namespace component_updater

--- a/chromium_src/components/component_updater/component_installer.h
+++ b/chromium_src/components/component_updater/component_installer.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_COMPONENT_UPDATER_COMPONENT_INSTALLER_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_COMPONENT_UPDATER_COMPONENT_INSTALLER_H_
 
-// Prevent CrxInstaller::OnUpdateError from being redefined by the below
-// #define.
 #include "components/update_client/update_client.h"
 
 // We can't redefine Register() here because that would change two methods at
@@ -22,10 +20,16 @@
       const base::Version& registered_version = base::Version(kNullVersion), \
       const base::Version& max_previous_product_version =                    \
           base::Version(kNullVersion));                                      \
+  bool IsBraveComponent() const override;                                    \
   void OnUpdateError
+
+#define AllowUpdatesOnMeteredConnections \
+  IsBraveComponent() const;              \
+  virtual bool AllowUpdatesOnMeteredConnections
 
 #include "src/components/component_updater/component_installer.h"  // IWYU pragma: export
 
 #undef OnUpdateError
+#undef AllowUpdatesOnMeteredConnections
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_COMPONENT_UPDATER_COMPONENT_INSTALLER_H_

--- a/chromium_src/components/component_updater/component_updater_service.cc
+++ b/chromium_src/components/component_updater/component_updater_service.cc
@@ -1,0 +1,48 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/component_updater/component_updater_service.h"
+
+#include "base/notreached.h"
+#include "components/component_updater/component_updater_service_internal.h"
+
+#include "src/components/component_updater/component_updater_service.cc"
+
+namespace component_updater {
+
+void CrxUpdateService::OnDemandUpdate(const std::vector<std::string>& ids,
+                                      Priority priority,
+                                      Callback callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  for (const auto& id : ids) {
+    if (!GetComponent(id)) {
+      if (callback) {
+        base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+            FROM_HERE, base::BindOnce(std::move(callback),
+                                      update_client::Error::INVALID_ARGUMENT));
+      }
+      return;
+    }
+  }
+
+  auto crx_data_callback = base::BindOnce(&CrxUpdateService::GetCrxComponents,
+                                          base::Unretained(this));
+  auto update_complete_callback = base::BindOnce(
+      &CrxUpdateService::OnUpdateComplete, base::Unretained(this),
+      std::move(callback), base::TimeTicks::Now());
+
+  update_client_->Update(ids, std::move(crx_data_callback), {},
+                         priority == Priority::FOREGROUND,
+                         std::move(update_complete_callback));
+}
+
+void OnDemandUpdater::OnDemandUpdate(const std::vector<std::string>& ids,
+                                     Priority priority,
+                                     Callback callback) {
+  NOTREACHED_NORETURN();
+}
+
+}  // namespace component_updater

--- a/chromium_src/components/component_updater/component_updater_service.h
+++ b/chromium_src/components/component_updater/component_updater_service.h
@@ -14,21 +14,25 @@ class BraveComponentUpdaterAndroid;
 }
 }  // namespace chrome
 
-namespace brave_shields {
-class AdBlockComponentFiltersProvider;
+namespace brave_component_updater {
+class BraveOnDemandUpdater;
 }
 
 #define BRAVE_COMPONENT_UPDATER_SERVICE_H_ \
   friend class ::IPFSDOMHandler;           \
   friend class ::chrome::android::BraveComponentUpdaterAndroid;
 
-#define BRAVE_COMPONENT_UPDATER_SERVICE_H_ON_DEMAND_UPDATER    \
- private:                                                      \
-  friend void BraveOnDemandUpdate(const std::string&);         \
-  friend class brave_shields::AdBlockComponentFiltersProvider; \
-                                                               \
+#define BRAVE_COMPONENT_UPDATER_SERVICE_H_ON_DEMAND_UPDATER          \
+ private:                                                            \
+  friend class brave_component_updater::BraveOnDemandUpdater;        \
+                                                                     \
+  virtual void OnDemandUpdate(const std::vector<std::string>& ids,   \
+                              Priority priority, Callback callback); \
+                                                                     \
  public:
+
 #include "src/components/component_updater/component_updater_service.h"  // IWYU pragma: export
+
 #undef BRAVE_COMPONENT_UPDATER_SERVICE_H_ON_DEMAND_UPDATER
 #undef BRAVE_COMPONENT_UPDATER_SERVICE_H_
 

--- a/chromium_src/components/component_updater/component_updater_service_internal.h
+++ b/chromium_src/components/component_updater/component_updater_service_internal.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_COMPONENT_UPDATER_COMPONENT_UPDATER_SERVICE_INTERNAL_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_COMPONENT_UPDATER_COMPONENT_UPDATER_SERVICE_INTERNAL_H_
+
+#include "components/component_updater/component_updater_service.h"
+
+#define OnDemandUpdate                                                   \
+  OnDemandUpdate(const std::vector<std::string>& ids, Priority priority, \
+                 Callback callback) override;                            \
+  void OnDemandUpdate
+
+#include "src/components/component_updater/component_updater_service_internal.h"  // IWYU pragma: export
+
+#undef OnDemandUpdate
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_COMPONENT_UPDATER_COMPONENT_UPDATER_SERVICE_INTERNAL_H_

--- a/chromium_src/components/update_client/update_client.cc
+++ b/chromium_src/components/update_client/update_client.cc
@@ -13,6 +13,10 @@
 
 namespace update_client {
 
+bool CrxInstaller::IsBraveComponent() const {
+  return false;
+}
+
 scoped_refptr<UpdateClient> UpdateClientFactory(
     scoped_refptr<Configurator> config) {
   VLOG(3) << "Brave UpdateClientFactory called";

--- a/chromium_src/components/update_client/update_client.h
+++ b/chromium_src/components/update_client/update_client.h
@@ -6,12 +6,17 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_UPDATE_CLIENT_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_UPDATE_CLIENT_H_
 
+#define GetInstalledFile(...) \
+  IsBraveComponent() const;   \
+  virtual bool GetInstalledFile(__VA_ARGS__)
+
 #define UpdateClientFactory                                             \
   UpdateClientFactory_ChromiumImpl(scoped_refptr<Configurator> config); \
   scoped_refptr<UpdateClient> UpdateClientFactory
 
 #include "src/components/update_client/update_client.h"  // IWYU pragma: export
 
+#undef GetInstalledFile
 #undef UpdateClientFactory
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_UPDATE_CLIENT_UPDATE_CLIENT_H_

--- a/components/brave_component_updater/browser/BUILD.gn
+++ b/components/brave_component_updater/browser/BUILD.gn
@@ -35,3 +35,19 @@ static_library("browser") {
     "//crypto",
   ]
 }
+
+source_set("test_support") {
+  testonly = true
+
+  sources = [
+    "mock_on_demand_updater.cc",
+    "mock_on_demand_updater.h",
+  ]
+
+  deps = [
+    ":browser",
+    "//base",
+    "//components/component_updater",
+    "//testing/gmock",
+  ]
+}

--- a/components/brave_component_updater/browser/brave_component_installer.cc
+++ b/components/brave_component_updater/browser/brave_component_installer.cc
@@ -139,6 +139,10 @@ BraveComponentInstallerPolicy::GetInstallerAttributes() const {
   return update_client::InstallerAttributes();
 }
 
+bool BraveComponentInstallerPolicy::IsBraveComponent() const {
+  return true;
+}
+
 void RegisterComponent(component_updater::ComponentUpdateService* cus,
                        const std::string& name,
                        const std::string& base64_public_key,

--- a/components/brave_component_updater/browser/brave_component_installer.h
+++ b/components/brave_component_updater/browser/brave_component_installer.h
@@ -51,6 +51,7 @@ class BraveComponentInstallerPolicy
   void GetHash(std::vector<uint8_t>* hash) const override;
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
 
   std::string name_;
   std::string base64_public_key_;

--- a/components/brave_component_updater/browser/brave_on_demand_updater.cc
+++ b/components/brave_component_updater/browser/brave_on_demand_updater.cc
@@ -6,7 +6,10 @@
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 
 #include <string>
+#include <utility>
 
+#include "base/check_is_test.h"
+#include "base/functional/callback.h"  // IWYU pragma: keep
 #include "base/no_destructor.h"
 
 namespace brave_component_updater {
@@ -20,14 +23,34 @@ BraveOnDemandUpdater::BraveOnDemandUpdater() = default;
 
 BraveOnDemandUpdater::~BraveOnDemandUpdater() = default;
 
+component_updater::OnDemandUpdater*
+BraveOnDemandUpdater::RegisterOnDemandUpdater(
+    component_updater::OnDemandUpdater* on_demand_updater) {
+  if (!on_demand_updater) {
+    CHECK_IS_TEST();
+  }
+  return std::exchange(on_demand_updater_, on_demand_updater);
+}
+
 void BraveOnDemandUpdater::OnDemandUpdate(const std::string& id) {
-  DCHECK(!on_demand_update_callback_.is_null());
-  on_demand_update_callback_.Run(id);
+  OnDemandUpdate(id, component_updater::OnDemandUpdater::Priority::FOREGROUND,
+                 component_updater::Callback());
 }
 
-void BraveOnDemandUpdater::RegisterOnDemandUpdateCallback(Callback callback) {
-  on_demand_update_callback_ = callback;
+void BraveOnDemandUpdater::OnDemandUpdate(
+    const std::string& id,
+    component_updater::OnDemandUpdater::Priority priority,
+    component_updater::Callback callback) {
+  CHECK(on_demand_updater_);
+  on_demand_updater_->OnDemandUpdate(id, priority, std::move(callback));
 }
 
+void BraveOnDemandUpdater::OnDemandUpdate(
+    const std::vector<std::string>& ids,
+    component_updater::OnDemandUpdater::Priority priority,
+    component_updater::Callback callback) {
+  CHECK(on_demand_updater_);
+  on_demand_updater_->OnDemandUpdate(ids, priority, std::move(callback));
+}
 
 }  // namespace brave_component_updater

--- a/components/brave_component_updater/browser/brave_on_demand_updater.h
+++ b/components/brave_component_updater/browser/brave_on_demand_updater.h
@@ -7,8 +7,9 @@
 #define BRAVE_COMPONENTS_BRAVE_COMPONENT_UPDATER_BROWSER_BRAVE_ON_DEMAND_UPDATER_H_
 
 #include <string>
+#include <vector>
 
-#include "base/functional/callback.h"
+#include "components/component_updater/component_updater_service.h"
 
 namespace base {
 template <typename T>
@@ -19,21 +20,29 @@ namespace brave_component_updater {
 
 class BraveOnDemandUpdater {
  public:
-  using Callback = base::RepeatingCallback<void(const std::string&)>;
   static BraveOnDemandUpdater* GetInstance();
 
   BraveOnDemandUpdater(const BraveOnDemandUpdater&) = delete;
   BraveOnDemandUpdater& operator=(const BraveOnDemandUpdater&) = delete;
-  ~BraveOnDemandUpdater();
+
+  component_updater::OnDemandUpdater* RegisterOnDemandUpdater(
+      component_updater::OnDemandUpdater* on_demand_updater);
+
   void OnDemandUpdate(const std::string& id);
 
-  void RegisterOnDemandUpdateCallback(Callback callback);
+  void OnDemandUpdate(const std::string& id,
+                      component_updater::OnDemandUpdater::Priority priority,
+                      component_updater::Callback callback);
+  void OnDemandUpdate(const std::vector<std::string>& ids,
+                      component_updater::OnDemandUpdater::Priority priority,
+                      component_updater::Callback callback);
 
  private:
   friend base::NoDestructor<BraveOnDemandUpdater>;
   BraveOnDemandUpdater();
+  ~BraveOnDemandUpdater();
 
-  Callback on_demand_update_callback_;
+  raw_ptr<component_updater::OnDemandUpdater> on_demand_updater_ = nullptr;
 };
 
 }  // namespace brave_component_updater

--- a/components/brave_component_updater/browser/mock_on_demand_updater.cc
+++ b/components/brave_component_updater/browser/mock_on_demand_updater.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_component_updater/browser/mock_on_demand_updater.h"
+
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
+
+namespace brave_component_updater {
+
+MockOnDemandUpdater::MockOnDemandUpdater() {
+  prev_on_demand_updater_ =
+      BraveOnDemandUpdater::GetInstance()->RegisterOnDemandUpdater(this);
+}
+
+MockOnDemandUpdater::~MockOnDemandUpdater() {
+  BraveOnDemandUpdater::GetInstance()->RegisterOnDemandUpdater(
+      prev_on_demand_updater_);
+}
+
+}  // namespace brave_component_updater

--- a/components/brave_component_updater/browser/mock_on_demand_updater.h
+++ b/components/brave_component_updater/browser/mock_on_demand_updater.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_COMPONENT_UPDATER_BROWSER_MOCK_ON_DEMAND_UPDATER_H_
+#define BRAVE_COMPONENTS_BRAVE_COMPONENT_UPDATER_BROWSER_MOCK_ON_DEMAND_UPDATER_H_
+
+#include <string>
+#include <vector>
+
+#include "base/functional/callback.h"
+#include "components/component_updater/component_updater_service.h"
+#include "testing/gmock/include/gmock/gmock.h"
+
+namespace brave_component_updater {
+
+class MockOnDemandUpdater : public component_updater::OnDemandUpdater {
+ public:
+  MockOnDemandUpdater();
+  ~MockOnDemandUpdater() override;
+
+  MOCK_METHOD(void,
+              OnDemandUpdate,
+              (const std::string& id,
+               component_updater::OnDemandUpdater::Priority priority,
+               component_updater::Callback callback),
+              (override));
+  MOCK_METHOD(void,
+              OnDemandUpdate,
+              (const std::vector<std::string>& ids,
+               component_updater::OnDemandUpdater::Priority priority,
+               component_updater::Callback callback),
+              (override));
+
+ private:
+  raw_ptr<component_updater::OnDemandUpdater> prev_on_demand_updater_ = nullptr;
+};
+
+}  // namespace brave_component_updater
+
+#endif  // BRAVE_COMPONENTS_BRAVE_COMPONENT_UPDATER_BROWSER_MOCK_ON_DEMAND_UPDATER_H_

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
@@ -125,21 +125,4 @@ void AdBlockComponentFiltersProvider::LoadFilterSet(
       base::BindOnce(&OnReadDATFileData, std::move(cb), permission_mask_));
 }
 
-void AdBlockComponentFiltersProvider::UpdateComponent(
-    base::OnceCallback<void(bool)> callback) {
-  if (!component_updater_service_) {
-    std::move(callback).Run(false);
-    return;
-  }
-
-  auto on_updated = [](decltype(callback) cb, update_client::Error error) {
-    std::move(cb).Run(error == update_client::Error::NONE ||
-                      error == update_client::Error::UPDATE_IN_PROGRESS);
-  };
-
-  component_updater_service_->GetOnDemandUpdater().OnDemandUpdate(
-      component_id_, component_updater::OnDemandUpdater::Priority::FOREGROUND,
-      base::BindOnce(on_updated, std::move(callback)));
-}
-
 }  // namespace brave_shields

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.h
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.h
@@ -51,13 +51,11 @@ class AdBlockComponentFiltersProvider : public AdBlockFiltersProvider {
   AdBlockComponentFiltersProvider& operator=(
       const AdBlockComponentFiltersProvider&) = delete;
 
+  const std::string& component_id() const { return component_id_; }
+
   void LoadFilterSet(
       base::OnceCallback<void(
           base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)>) override;
-
-  // Updates the component, and when complete executes the specified callback
-  // with a value indicating success or failure.
-  void UpdateComponent(base::OnceCallback<void(bool)> callback);
 
   // Remove the component. This will force it to be redownloaded next time it
   // is registered.

--- a/components/brave_shields/core/browser/ad_block_component_installer.cc
+++ b/components/brave_shields/core/browser/ad_block_component_installer.cc
@@ -82,6 +82,7 @@ class AdBlockComponentInstallerPolicy
   void GetHash(std::vector<uint8_t>* hash) const override;
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
 
  private:
   const std::string component_id_;
@@ -153,6 +154,10 @@ std::string AdBlockComponentInstallerPolicy::GetName() const {
 update_client::InstallerAttributes
 AdBlockComponentInstallerPolicy::GetInstallerAttributes() const {
   return update_client::InstallerAttributes();
+}
+
+bool AdBlockComponentInstallerPolicy::IsBraveComponent() const {
+  return true;
 }
 
 void OnRegistered(const std::string& component_id) {

--- a/components/brave_shields/core/browser/ad_block_component_service_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_component_service_manager.cc
@@ -9,7 +9,6 @@
 #include <utility>
 #include <vector>
 
-#include "base/barrier_callback.h"
 #include "base/feature_list.h"
 #include "base/memory/raw_ref.h"
 #include "base/metrics/histogram_macros.h"

--- a/components/brave_wallet/browser/test/BUILD.gn
+++ b/components/brave_wallet/browser/test/BUILD.gn
@@ -119,6 +119,7 @@ source_set("brave_wallet_unit_tests") {
     ":test_support",
     "//base/test:test_support",
     "//brave/components/brave_component_updater/browser",
+    "//brave/components/brave_component_updater/browser:test_support",
     "//brave/components/brave_wallet/browser",
     "//brave/components/brave_wallet/browser:constants",
     "//brave/components/brave_wallet/browser:generated_bitcoin_rpc_responses",

--- a/components/brave_wallet/browser/wallet_data_files_installer.cc
+++ b/components/brave_wallet/browser/wallet_data_files_installer.cc
@@ -71,6 +71,7 @@ class WalletDataFilesInstallerPolicy
   void GetHash(std::vector<uint8_t>* hash) const override;
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
 
   WalletDataFilesInstallerPolicy(const WalletDataFilesInstallerPolicy&) =
       delete;
@@ -130,6 +131,10 @@ std::string WalletDataFilesInstallerPolicy::GetName() const {
 update_client::InstallerAttributes
 WalletDataFilesInstallerPolicy::GetInstallerAttributes() const {
   return update_client::InstallerAttributes();
+}
+
+bool WalletDataFilesInstallerPolicy::IsBraveComponent() const {
+  return true;
 }
 
 std::optional<base::Version> GetLastInstalledWalletVersion() {

--- a/components/ntp_background_images/browser/ntp_background_images_component_installer.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_component_installer.cc
@@ -66,6 +66,7 @@ class NTPBackgroundImagesComponentInstallerPolicy
   void GetHash(std::vector<uint8_t>* hash) const override;
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
 
  private:
   const std::string component_id_;
@@ -141,6 +142,10 @@ std::string NTPBackgroundImagesComponentInstallerPolicy::GetName() const {
 update_client::InstallerAttributes
 NTPBackgroundImagesComponentInstallerPolicy::GetInstallerAttributes() const {
   return update_client::InstallerAttributes();
+}
+
+bool NTPBackgroundImagesComponentInstallerPolicy::IsBraveComponent() const {
+  return true;
 }
 
 void OnRegistered(const std::string& component_id) {

--- a/components/playlist/browser/media_detector_component_installer.cc
+++ b/components/playlist/browser/media_detector_component_installer.cc
@@ -53,6 +53,7 @@ class MediaDetectorComponentInstallerPolicy
   void GetHash(std::vector<uint8_t>* hash) const override;
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
 
  private:
   static constexpr size_t kHashSize = 32;
@@ -134,6 +135,10 @@ std::string MediaDetectorComponentInstallerPolicy::GetName() const {
 update_client::InstallerAttributes
 MediaDetectorComponentInstallerPolicy::GetInstallerAttributes() const {
   return update_client::InstallerAttributes();
+}
+
+bool MediaDetectorComponentInstallerPolicy::IsBraveComponent() const {
+  return true;
 }
 
 void OnRegisteredToComponentUpdateService() {

--- a/components/psst/browser/core/psst_component_installer.cc
+++ b/components/psst/browser/core/psst_component_installer.cc
@@ -78,6 +78,7 @@ class PsstComponentInstallerPolicy
   void GetHash(std::vector<uint8_t>* hash) const override;
   std::string GetName() const override;
   update_client::InstallerAttributes GetInstallerAttributes() const override;
+  bool IsBraveComponent() const override;
 
  private:
   const std::string component_id_;
@@ -138,6 +139,10 @@ std::string PsstComponentInstallerPolicy::GetName() const {
 update_client::InstallerAttributes
 PsstComponentInstallerPolicy::GetInstallerAttributes() const {
   return update_client::InstallerAttributes();
+}
+
+bool PsstComponentInstallerPolicy::IsBraveComponent() const {
+  return true;
 }
 
 void RegisterPsstComponent(

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -243,9 +243,11 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
     component_updater::ComponentUpdateService* cus =
         GetApplicationContext()->GetComponentUpdateService();
     DCHECK(cus);
+    brave_component_updater::BraveOnDemandUpdater::GetInstance()
+        ->RegisterOnDemandUpdater(&cus->GetOnDemandUpdater());
+    [self registerComponentsForUpdate:cus];
 
     _adblockService = [[AdblockService alloc] initWithComponentUpdater:cus];
-    [self registerComponentsForUpdate:cus];
 
     _backgroundImagesService = [[NTPBackgroundImagesService alloc]
         initWithBackgroundImagesService:
@@ -335,10 +337,6 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
 
 - (void)registerComponentsForUpdate:
     (component_updater::ComponentUpdateService*)cus {
-  brave_component_updater::BraveOnDemandUpdater::GetInstance()
-      ->RegisterOnDemandUpdateCallback(
-          base::BindRepeating(&component_updater::BraveOnDemandUpdate));
-
   RegisterSafetyTipsComponent(cus);
   brave_wallet::WalletDataFilesInstaller::GetInstance()
       .MaybeRegisterWalletDataFilesComponent(

--- a/ios/browser/component_updater/BUILD.gn
+++ b/ios/browser/component_updater/BUILD.gn
@@ -10,7 +10,6 @@ source_set("component_updater") {
   ]
   deps = [
     "//base",
-    "//components/component_updater",
-    "//ios/chrome/browser/shared/model/application_context",
+    "//brave/components/brave_component_updater/browser",
   ]
 }

--- a/ios/browser/component_updater/component_updater_utils.mm
+++ b/ios/browser/component_updater/component_updater_utils.mm
@@ -5,18 +5,13 @@
 
 #include "brave/ios/browser/component_updater/component_updater_utils.h"
 
-#include "base/functional/callback.h"
-#include "components/component_updater/component_updater_service.h"
-#include "ios/chrome/browser/shared/model/application_context/application_context.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 
 namespace component_updater {
 
 void BraveOnDemandUpdate(const std::string& component_id) {
-  component_updater::ComponentUpdateService* cus =
-      GetApplicationContext()->GetComponentUpdateService();
-  cus->GetOnDemandUpdater().OnDemandUpdate(
-      component_id, component_updater::OnDemandUpdater::Priority::FOREGROUND,
-      component_updater::Callback());
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+      component_id);
 }
 
 }  // namespace component_updater


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Changes in this PR:
1. The `CrxInstaller` now includes the overridable `IsBraveComponent()` function. This allows us to distinguish Brave/non-Brave components and let the updater to batch multiple update requests into a single request to `go-updater`. This is possible because Brave components are always managed by the `go-updater` and are never redirected to an upstream updater.
2. The `brave_component_updater::BraveOnDemandUpdater` is now the sole entry point for all Brave-specific "OnDemand" component updates.
3. The initialization sequence of `BraveOnDemandUpdater` has been altered to directly use `OnDemandUpdater` interface.

This PR will be followed with a few more to:
1. Cleanup `component_updater::BraveOnDemandUpdate`.
2. Replace `OnDemandUpdate` with conditional `Install` calls when a component is not installed. Currently, we perform unnecessary on demand updates at each startup. The `ComponentUpdateService` should manage most updates (and batch them) using the standard schedule.

Resolves https://github.com/brave/brave-browser/issues/37370

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

