### PR TITLE
Fix crash when "New Private Window with Tor" is selected without a window open. (uplift to 1.66.x)

### DIFF
--- a/browser/brave_app_controller_mac.mm
+++ b/browser/brave_app_controller_mac.mm
@@ -201,7 +201,7 @@ class TorPrefObserver : public BooleanPrefMember {
 
 #if BUILDFLAG(ENABLE_TOR)
   if (tag == IDC_NEW_OFFTHERECORD_WINDOW_TOR) {
-    brave::NewOffTheRecordWindowTor([self getBrowser]);
+    brave::NewOffTheRecordWindowTor(profile);
     return;
   }
 #endif  // BUILDFLAG(ENABLE_TOR)

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -136,12 +136,17 @@ std::vector<int> GetSelectedIndices(Browser* browser) {
 
 void NewOffTheRecordWindowTor(Browser* browser) {
   CHECK(browser);
-  if (browser->profile()->IsTor()) {
-    chrome::OpenEmptyWindow(browser->profile());
+  NewOffTheRecordWindowTor(browser->profile());
+}
+
+void NewOffTheRecordWindowTor(Profile* profile) {
+  CHECK(profile);
+  if (profile->IsTor()) {
+    chrome::OpenEmptyWindow(profile);
     return;
   }
 
-  TorProfileManager::SwitchToTorProfile(browser->profile());
+  TorProfileManager::SwitchToTorProfile(profile);
 }
 
 void NewTorConnectionForSite(Browser* browser) {

--- a/browser/ui/browser_commands.h
+++ b/browser/ui/browser_commands.h
@@ -16,12 +16,15 @@
 
 class Browser;
 class GURL;
+class Profile;
 
 namespace brave {
 
 bool HasSelectedURL(Browser* browser);
 void CleanAndCopySelectedURL(Browser* browser);
-void NewOffTheRecordWindowTor(Browser*);
+void NewOffTheRecordWindowTor(Browser* browser);
+void NewOffTheRecordWindowTor(Profile* profile);
+
 void NewTorConnectionForSite(Browser*);
 void ShowWalletBubble(Browser* browser);
 void ShowApproveWalletBubble(Browser* browser);


### PR DESCRIPTION
Uplift of #23126
Resolves https://github.com/brave/brave-browser/issues/37649

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.