### PR TITLE
Return custom values for TAB_STRIP_PADDING and TAB_STRIP_HEIGHT

### DIFF
--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -25,9 +25,21 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
   switch (constant) {
     case TAB_HEIGHT: {
       if (HorizontalTabsUpdateEnabled()) {
-        return brave_tabs::kHorizontalTabViewHeight;
+        return brave_tabs::kHorizontalTabHeight;
       }
       return (touch ? 41 : 30) + GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
+    }
+    case TAB_STRIP_HEIGHT: {
+      if (HorizontalTabsUpdateEnabled()) {
+        return brave_tabs::kHorizontalTabStripHeight;
+      }
+      return std::nullopt;
+    }
+    case TAB_STRIP_PADDING: {
+      if (HorizontalTabsUpdateEnabled()) {
+        return brave_tabs::kHorizontalTabVerticalSpacing;
+      }
+      return std::nullopt;
     }
     case TABSTRIP_TOOLBAR_OVERLAP: {
       if (!HorizontalTabsUpdateEnabled()) {

--- a/browser/ui/tabs/brave_tab_layout_constants.h
+++ b/browser/ui/tabs/brave_tab_layout_constants.h
@@ -15,10 +15,10 @@ namespace brave_tabs {
 // are given a small overlap. Rounded tab rectangles are drawn centered and
 // inset horizontally by an amount that will create the required visual gap.
 
-// The height of tab views in horizontal tabs mode. Note that the height of the
-// view may be greater than the visual height of the tab shape. See also
+// The visual height of tabs in horizontal tabs mode. Note that the height of
+// the view may be greater than the visual height of the tab shape. See also
 // `kHorizontalTabVerticalSpacing`.
-inline constexpr int kHorizontalTabViewHeight = 40;
+inline constexpr int kHorizontalTabHeight = 32;
 
 // The amount of space before the first tab view.
 inline constexpr int kHorizontalTabStripLeftMargin = 3;
@@ -27,6 +27,10 @@ inline constexpr int kHorizontalTabStripLeftMargin = 3;
 // bounds of the tab strip region. The portion of this space below tabs will be
 // occupied by tab group underlines.
 inline constexpr int kHorizontalTabVerticalSpacing = 4;
+
+// The height of the tab strip in horizontal mode.
+inline constexpr int kHorizontalTabStripHeight =
+    kHorizontalTabHeight + (kHorizontalTabVerticalSpacing * 2);
 
 // The visual gap between tabs.
 inline constexpr int kHorizontalTabGap = 4;

--- a/browser/ui/tabs/brave_tab_style.h
+++ b/browser/ui/tabs/brave_tab_style.h
@@ -50,9 +50,8 @@ class BraveTabStyle : public TabStyleBase {
     if (!tabs::features::HorizontalTabsUpdateEnabled()) {
       return TabStyleBase::GetPinnedWidth();
     }
-    const int shape_height = GetLayoutConstant(TAB_HEIGHT) -
-                             brave_tabs::kHorizontalTabVerticalSpacing * 2;
-    return shape_height + brave_tabs::kHorizontalTabInset * 2;
+    return brave_tabs::kHorizontalTabHeight +
+           brave_tabs::kHorizontalTabInset * 2;
   }
 
   int GetDragHandleExtension(int height) const override {

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
@@ -68,6 +68,15 @@ gfx::Insets TabGroupStyle::GetInsetsForHeaderChip(
   return insets;
 }
 
+gfx::Point TabGroupStyle::GetTitleChipOffset(
+    std::optional<int> text_height) const {
+  if (!tabs::features::HorizontalTabsUpdateEnabled()) {
+    return TabGroupStyle_ChromiumImpl::GetTitleChipOffset(text_height);
+  }
+  return gfx::Point(brave_tabs::kHorizontalTabInset,
+                    brave_tabs::kHorizontalTabVerticalSpacing);
+}
+
 bool TabGroupStyle::ShouldShowVerticalTabs() const {
   return tabs::utils::ShouldShowVerticalTabs(tab_group_views_->GetBrowser());
 }

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.h
@@ -24,6 +24,8 @@ class TabGroupStyle : public TabGroupStyle_ChromiumImpl {
 
   gfx::Insets GetInsetsForHeaderChip(bool should_show_sync_icon) const override;
 
+  gfx::Point GetTitleChipOffset(std::optional<int> text_height) const override;
+
   int GetChipCornerRadius() const override;
 
   float GetEmptyChipSize() const override;


### PR DESCRIPTION
Upstream has started using `TAB_STRIP_PADDING` to determine the amount of space to dedicate to the frame resize handle above the tabstrip on Windows. Return values for these layout constants that match the actual values we use when laying out and drawing the tabstrip.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

