### PR TITLE
Backporting `--ozone-platform-hint` fix (uplift to 1.65.x)

### DIFF
--- a/patches/chrome-app-chrome_main_delegate.cc.patch
+++ b/patches/chrome-app-chrome_main_delegate.cc.patch
@@ -1,0 +1,24 @@
+diff --git a/chrome/app/chrome_main_delegate.cc b/chrome/app/chrome_main_delegate.cc
+index 73b6ab0934b14609c5b4eba55b4cd0d0c09673af..0b4c44be679d0e92f9f3c206c98efd9cb37191bd 100644
+--- a/chrome/app/chrome_main_delegate.cc
++++ b/chrome/app/chrome_main_delegate.cc
+@@ -249,6 +249,9 @@
+ #include "base/scoped_add_feature_flags.h"
+ #include "ui/base/ui_base_features.h"
+ #include "ui/ozone/public/ozone_platform.h"
++#if BUILDFLAG(IS_LINUX)
++#include "chrome/browser/chrome_browser_main_extra_parts_linux.h"
++#endif
+ #endif  // BUILDFLAG(IS_OZONE)
+ 
+ base::LazyInstance<ChromeContentGpuClient>::DestructorAtExit
+@@ -959,6 +962,9 @@ std::optional<int> ChromeMainDelegate::PostEarlyInitialization(
+   // Initialize Ozone platform and add required feature flags as per platform's
+   // properties. Must be added before feature list is created otherwise the
+   // added flag won't be picked up.
++#if BUILDFLAG(IS_LINUX)
++  ChromeBrowserMainExtraPartsLinux::InitOzonePlatformHint();
++#endif
+   ui::OzonePlatform::PreEarlyInitialization();
+   AddFeatureFlagsToCommandLine();
+ #endif  // BUILDFLAG(IS_OZONE)

--- a/patches/chrome-browser-chrome_browser_main_extra_parts_linux.cc.patch
+++ b/patches/chrome-browser-chrome_browser_main_extra_parts_linux.cc.patch
@@ -1,0 +1,28 @@
+diff --git a/chrome/browser/chrome_browser_main_extra_parts_linux.cc b/chrome/browser/chrome_browser_main_extra_parts_linux.cc
+index dba7b116ecaa07b8dd085284b5bd38b172a8f250..ea0487022dcdcf45aac35bf6170a27141bcb1157 100644
+--- a/chrome/browser/chrome_browser_main_extra_parts_linux.cc
++++ b/chrome/browser/chrome_browser_main_extra_parts_linux.cc
+@@ -168,7 +168,13 @@ ChromeBrowserMainExtraPartsLinux::ChromeBrowserMainExtraPartsLinux() = default;
+ 
+ ChromeBrowserMainExtraPartsLinux::~ChromeBrowserMainExtraPartsLinux() = default;
+ 
+-void ChromeBrowserMainExtraPartsLinux::PreEarlyInitialization() {
++void ChromeBrowserMainExtraPartsLinux::PostBrowserStart() {
++  RecordDisplayServerProtocolSupport();
++  ChromeBrowserMainExtraPartsOzone::PostBrowserStart();
++}
++
++// static
++void ChromeBrowserMainExtraPartsLinux::InitOzonePlatformHint() {
+ #if BUILDFLAG(IS_LINUX)
+   // On the desktop, we fix the platform name if necessary.
+   // See https://crbug.com/1246928.
+@@ -189,8 +195,3 @@ void ChromeBrowserMainExtraPartsLinux::PreEarlyInitialization() {
+   }
+ #endif  // BUILDFLAG(IS_LINUX)
+ }
+-
+-void ChromeBrowserMainExtraPartsLinux::PostBrowserStart() {
+-  RecordDisplayServerProtocolSupport();
+-  ChromeBrowserMainExtraPartsOzone::PostBrowserStart();
+-}

--- a/patches/chrome-browser-chrome_browser_main_extra_parts_linux.h.patch
+++ b/patches/chrome-browser-chrome_browser_main_extra_parts_linux.h.patch
@@ -1,0 +1,16 @@
+diff --git a/chrome/browser/chrome_browser_main_extra_parts_linux.h b/chrome/browser/chrome_browser_main_extra_parts_linux.h
+index 3847bd2090e282486717fb211308915ec9251abe..4f188a7bdfe3867bcdf83ce9e442e94a002095b6 100644
+--- a/chrome/browser/chrome_browser_main_extra_parts_linux.h
++++ b/chrome/browser/chrome_browser_main_extra_parts_linux.h
+@@ -17,9 +17,10 @@ class ChromeBrowserMainExtraPartsLinux
+       const ChromeBrowserMainExtraPartsLinux&) = delete;
+   ~ChromeBrowserMainExtraPartsLinux() override;
+ 
++  static void InitOzonePlatformHint();
++
+  private:
+   // ChromeBrowserMainExtraParts overrides.
+-  void PreEarlyInitialization() override;
+   void PostBrowserStart() override;
+ };
+ 


### PR DESCRIPTION
Uplift of #23166
Resolves https://github.com/brave/brave-browser/issues/37498

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.