### PR TITLE
Fix calculation of top frame resize area on Windows (uplift to 1.65.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame_view_win.cc
@@ -3,7 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "chrome/browser/ui/layout_constants.h"
 #include "ui/base/ui_base_features.h"
 
 namespace features {
@@ -14,12 +16,31 @@ bool BraveHorizontalTabsUpdateEnabled() {
 
 }  // namespace features
 
+namespace {
+
+int BraveGetLayoutConstant(LayoutConstant layout_constant) {
+  if (layout_constant == TAB_STRIP_PADDING &&
+      tabs::features::HorizontalTabsUpdateEnabled()) {
+    return brave_tabs::kHorizontalTabVerticalSpacing;
+  }
+  return GetLayoutConstant(layout_constant);
+}
+
+}  // namespace
+
 // When updated horizontal tabs are enabled, we want to use the same layout
 // logic as upstream's "Refresh2023" for tab strip positioning and for the
 // window caption button height. When upstream's feature flag is removed, this
 // define can also be removed.
 #define IsChromeRefresh2023 BraveHorizontalTabsUpdateEnabled
 
+// Upstream was modified to use `TAB_STRIP_PADDING` when calculating the amount
+// of space to dedicate to the frame resize handle above the tabstrip. When the
+// "Refresh2023" flag is not enabled, this value is zero. Override
+// `GetLayoutConstant` to return a non-zero value for this constant.
+#define GetLayoutConstant BraveGetLayoutConstant
+
 #include "src/chrome/browser/ui/views/frame/browser_frame_view_win.cc"  // IWYU pragma: export
 
+#undef GetLayoutConstant
 #undef IsChromeRefresh2023


### PR DESCRIPTION
Uplift of #23176
Resolves https://github.com/brave/brave-browser/issues/37702

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.