### PR TITLE
Fixed wdp infobar is not shown properly after loading search.brave.com (uplift to 1.65.x)

### DIFF
--- a/browser/ui/views/infobars/custom_styled_label.cc
+++ b/browser/ui/views/infobars/custom_styled_label.cc
@@ -12,29 +12,6 @@
 
 CustomStyledLabel::~CustomStyledLabel() = default;
 
-void CustomStyledLabel::Layout(PassKey) {
-  // Link click doesn't work when StyledLabel is multilined.
-  // And there is upstream bug -
-  // https://bugs.chromium.org/p/chromium/issues/detail?id=1371538 Below code is
-  // copied from WIP
-  // PR(https://chromium-review.googlesource.com/c/chromium/src/+/3934027) to
-  // skip layout when it doesn't need layout. Layout() happens between
-  // OnMousePressed() and OnMouseReleased(). As Layout() deletes all children,
-  // RootView::mouse_pressed_handler_ is gone before OnMouseReleased(). So, any
-  // child can't get mouse release event.
-  // NOTE: There is another finding from @sangwoo.
-  // This Layout() comes from LinkFragment::RecalculateFont() whenever hovered
-  // over link in StyledLabel even we don't need to change font.
-  // For more details, please see
-  // https://github.com/brave/brave-core/pull/17121#discussion_r1101354123
-  if (last_layout_size_ == size()) {
-    return;
-  }
-
-  last_layout_size_ = size();
-  LayoutSuperclass<StyledLabel>(this);
-}
-
 std::unique_ptr<views::Label> CustomStyledLabel::CreateLabel(
     const std::u16string& text,
     const RangeStyleInfo& style_info,

--- a/browser/ui/views/infobars/custom_styled_label.h
+++ b/browser/ui/views/infobars/custom_styled_label.h
@@ -26,7 +26,6 @@ class CustomStyledLabel : public views::StyledLabel {
 
  private:
   // views::StyledLabel overrides:
-  void Layout(PassKey) override;
   std::unique_ptr<views::Label> CreateLabel(
       const std::u16string& text,
       const RangeStyleInfo& style_info,

--- a/browser/ui/views/infobars/web_discovery_infobar_content_view.cc
+++ b/browser/ui/views/infobars/web_discovery_infobar_content_view.cc
@@ -82,6 +82,8 @@ class InfoBarStyledLabel : public CustomStyledLabel {
   }
 
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override {
+    CustomStyledLabel::OnBoundsChanged(previous_bounds);
+
     auto height = GetHeightForWidth(width());
     SetSize({width(), height});
     SetPosition({x(), (parent()->height() - height) / 2});

--- a/browser/ui/views/infobars/web_discovery_infobar_content_view.cc
+++ b/browser/ui/views/infobars/web_discovery_infobar_content_view.cc
@@ -221,6 +221,14 @@ void WebDiscoveryInfoBarContentView::SwitchChildLayout() {
   if (wide_layout_min_width_ == 0 || narrow_layout_preferred_width_ == 0)
     return;
 
+  // TODO(simonhong): This is workaround to prevent re-layout from narrow layout
+  // to wide layout at startup as we have a regression that StyledLabel doesn't
+  // do proper layout when its width is growing. With this workaround, we can
+  // show wdp infobar w/o wrong layout.
+  if (width() == 0) {
+    return;
+  }
+
   // There are three layout.
   // - Wide layout with wide border
   // - Wide layout with narrow border


### PR DESCRIPTION
Uplift of #23186 https://github.com/brave/brave-core/pull/23193
fix https://github.com/brave/brave-browser/issues/37705
fix https://github.com/brave/brave-browser/issues/37758

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.