### PR TITLE
Synchronize pinned state on tiling tabs

### DIFF
--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -44,13 +44,16 @@ void SplitViewBrowserData::TileTabs(const Tile& tile) {
   tile_index_for_tab_[tile.second] = tiles_.size() - 1;
 
   if (tab_strip_model_adapter_) {
-    const bool synchronized_group =
-        model &&
-        tab_strip_model_adapter_->SynchronizeGroupedState(
-            tile, /*source=*/tile.first,
-            model->GetTabGroupForTab(model->GetIndexOfTab(tile.first)));
+    bool tabs_are_adjacent = false;
+    if (model) {
+      tabs_are_adjacent =
+          tab_strip_model_adapter_->SynchronizePinnedState(tile, tile.first);
+      tabs_are_adjacent |= tab_strip_model_adapter_->SynchronizeGroupedState(
+          tile, /*source=*/tile.first,
+          model->GetTabGroupForTab(model->GetIndexOfTab(tile.first)));
+    }
 
-    if (!synchronized_group) {
+    if (!tabs_are_adjacent) {
       tab_strip_model_adapter_->MakeTiledTabsAdjacent(tile);
     }
   }

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.h
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.h
@@ -27,6 +27,8 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
   bool SynchronizeGroupedState(const SplitViewBrowserData::Tile& tile,
                                const tabs::TabHandle& source,
                                std::optional<tab_groups::TabGroupId> group);
+  bool SynchronizePinnedState(const SplitViewBrowserData::Tile& tile,
+                              const tabs::TabHandle& source);
 
   void TabDragStarted();
   void TabDragEnded();

--- a/browser/ui/tabs/test/split_view_tab_strip_model_adapter_unittest.cc
+++ b/browser/ui/tabs/test/split_view_tab_strip_model_adapter_unittest.cc
@@ -154,6 +154,26 @@ TEST_F(SplitViewTabStripModelAdapterUnitTest,
 }
 
 TEST_F(SplitViewTabStripModelAdapterUnitTest,
+       TilingTabsSynchronizePinnedState_OnlyOneTabIsPinned) {
+  // Given that a tab is pinned
+  model().AddWebContents(CreateWebContents(), -1,
+                         ui::PageTransition::PAGE_TRANSITION_TYPED,
+                         /*add_types=*/0);
+  model().SetTabPinned(0, /*pinned*/ true);
+
+  // When tiling with unpinned tab
+  model().AppendWebContents(CreateWebContents(), /*foreground*/ true);
+  ASSERT_FALSE(model().IsTabPinned(1));
+  data().TileTabs({model().GetTabHandleAt(0), model().GetTabHandleAt(1)});
+  ASSERT_TRUE(data().IsTabTiled(model().GetTabHandleAt(0)));
+  ASSERT_TRUE(data().IsTabTiled(model().GetTabHandleAt(1)));
+  base::RunLoop().RunUntilIdle();
+
+  // Then the other tab should be pinned too
+  EXPECT_TRUE(model().IsTabPinned(1));
+}
+
+TEST_F(SplitViewTabStripModelAdapterUnitTest,
        OnTabInserted_MoveTabWhenInsertedBetweenTile) {
   // Given that two tabs are tiled
   model().AppendWebContents(CreateWebContents(), /*foreground*/ true);


### PR DESCRIPTION
When opening or create split view with a pinned tab, the other tab should be pinned too.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37761

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

