### PR TITLE
Fix BraveSyncServiceImplTest.ForcedSetDecryptionPassphrase test for cr125.

### DIFF
--- a/chromium_src/components/sync/service/sync_service_impl.h
+++ b/chromium_src/components/sync/service/sync_service_impl.h
@@ -18,7 +18,9 @@
                            PermanentlyDeleteAccount);                          \
   FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,                           \
                            OnAccountDeleted_FailureAndRetry);                  \
-  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, JoinDeletedChain);
+  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest, JoinDeletedChain);        \
+  FRIEND_TEST_ALL_PREFIXES(BraveSyncServiceImplTest,                           \
+                           ForcedSetDecryptionPassphrase);
 
 // Forcing this include before define virtual to avoid error of
 // "duplicate 'virtual' declaration specifier" at SyncEngine's

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -303,21 +303,19 @@ TEST_F(BraveSyncServiceImplTest, ForcedSetDecryptionPassphrase) {
   EXPECT_TRUE(
       brave_sync_service_impl()->GetUserSettings()->IsPassphraseRequired());
 
-  // By default Brave enables Bookmarks datatype when sync is enabled.
-  // This caused DCHECK at DataTypeManagerImpl::DataTypeManagerImpl
-  // after OnEngineInitialized(true, false) call.
+  // During the calls below:
+  //    DataTypeManagerImpl::SetConfigurer()
+  //    SyncServiceImpl::OnEngineInitialized()
+  //    BraveSyncServiceImpl::OnEngineInitialized()
+  // SetConfigurer method requires |DataTypeManagerImpl::state_| to be in a
+  // STOPPED state.
   // Current unit test is intended to verify fix for brave/brave-browser#22898
   // and is about set encryption passphrase later setup after right after
-  // enabling sync, for example when internet connection is unstable. Related
-  // Chromium commit 3241d114b8036bb6d53931ba34b3bf819258c29d Prior to this
-  // commit DataTypeManagerImpl wasn't created for bookmarks at
-  // ForcedSetDecryptionPassphrase test.
-  // Update Dec 2023: moved this workaround closer to OnEngineInitialized,
-  // with Chromium commit 33441a0f3f9a591693157f2fd16852ce072e6f9d the logic of
-  // SyncUserSettingsImpl::GetSelectedTypes had been changed and affected this
-  // test.
-  brave_sync_service_impl()->GetUserSettings()->SetSelectedTypes(
-      false, syncer::UserSelectableTypeSet());
+  // enabling sync, for example when internet connection is unstable.
+  // So we just make DataTypeManagerImpl::SetConfigurer requirements be
+  // satisfied.
+  // Related Chromium commit 7cdf92e9470fc73a09b871f99d14ff115edef652
+  brave_sync_service_impl()->data_type_manager_->Stop(KEEP_METADATA);
 
   brave_sync_service_impl()->OnEngineInitialized(true, false);
   EXPECT_FALSE(


### PR DESCRIPTION
The call `brave_sync_service_impl()->data_type_manager_->Stop(KEEP_METADATA);` makes `DataTypeManagerImpl::SetConfigurer` see the correct state.

Related Chromium change:
https://source.chromium.org/chromium/chromium/src/+/7cdf92e9470fc73a09b871f99d14ff115edef652

```
Sync: Make DataTypeManager long-lived

Before this CL: DataTypeManager(Impl) is created when the engine finishes initializing, and is destroyed when the engine gets shut down.
After this CL: DataTypeManager is created early during browser startup, and exists until browser shutdown.

Bug: 40901755, 331136272
Change-Id: I812bbfb4963ea2e4599e17932443d9d92d3f7f33
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5396596
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

