### PR TITLE
style(wallet): Make all More Menu Icons Vertical

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/default-panel-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/default-panel-header.tsx
@@ -81,7 +81,7 @@ export const DefaultPanelHeader = (props: Props) => {
         <DAppConnectionSettings />
         <MenuWrapper ref={settingsMenuRef}>
           <Button onClick={() => setShowSettingsMenu((prev) => !prev)}>
-            <ButtonIcon name='more-horizontal' />
+            <ButtonIcon name='more-vertical' />
           </Button>
           {showSettingsMenu && <WalletSettingsMenu />}
         </MenuWrapper>

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/style.ts
@@ -114,7 +114,7 @@ export const MoreButton = styled(WalletButton)`
 `
 
 export const MoreIcon = styled(Icon).attrs({
-  name: 'more-horizontal'
+  name: 'more-vertical'
 })`
   --leo-icon-size: 22px;
   color: ${leo.color.text.secondary};

--- a/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.tsx
+++ b/components/brave_wallet_ui/page/screens/shared-screen-components/tab-header/tab-header.tsx
@@ -55,7 +55,7 @@ export const TabHeader = (props: Props) => {
       {!hideHeaderMenu && (
         <SettingsWrapper ref={settingsModalRef}>
           <SettingsButton onClick={() => setShowSettings((prev) => !prev)}>
-            <SettingsIcon name='more-horizontal' />
+            <SettingsIcon name='more-vertical' />
           </SettingsButton>
           {showSettings && (
             <WalletSettingsMenu


### PR DESCRIPTION
## Description 
Unifies all `More Menu` icons to be `Vertical` in the `Wallet`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37767>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Page `More Menu` should now be vertical
   2. Panel `More Menu` should now be vertical
   3. NFT `More Menu` should now be vertical


Before:

![Screenshot 18](https://github.com/brave/brave-browser/assets/40611140/d5490fb8-6da6-47d2-bf3d-aad210a5d805)

![Screenshot 19](https://github.com/brave/brave-browser/assets/40611140/1a90cb83-78f5-4e27-be0f-e881db29fd9a)

![Screenshot 21](https://github.com/brave/brave-browser/assets/40611140/1e2be263-988f-4bb7-8fa7-1bdb5c633ea8)

After:

![Screenshot 20](https://github.com/brave/brave-browser/assets/40611140/6746c19e-7e6a-4a78-a778-b09916f24967)

![Screenshot 22](https://github.com/brave/brave-browser/assets/40611140/8848d252-9258-45d0-a1a8-54d8b0721487)

![Screenshot 23](https://github.com/brave/brave-browser/assets/40611140/de1d2c71-9733-4cf9-b082-40c5d1a68baf)
