### PR TITLE
Fix non-interactive adaptive captcha

### DIFF
--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -40,6 +40,8 @@
 
 namespace {
 
+constexpr gfx::Size kTooltipSize(434 + 15, 104 + 15);
+
 constexpr int kShadowElevation = 5;
 
 constexpr int kBorderThickness = 6;
@@ -267,17 +269,10 @@ void BraveTooltipPopup::CreatePopup() {
   SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kVertical, gfx::Insets()));
 
-  // Container
-  views::View* container_view = new views::View();
-  AddChildView(container_view);
-
   // Tooltip
   DCHECK(!tooltip_view_);
-  tooltip_view_ = container_view->AddChildView(
-      new BraveTooltipView(this, tooltip_->attributes()));
-
-  container_view->SetPosition(gfx::Point(0, 0));
-  container_view->SetSize(tooltip_view_->size());
+  tooltip_view_ =
+      AddChildView(new BraveTooltipView(this, tooltip_->attributes()));
 
   CreateWidgetView();
 }
@@ -318,6 +313,7 @@ gfx::Point BraveTooltipPopup::GetDefaultOriginForSize(const gfx::Size& size) {
 gfx::Rect BraveTooltipPopup::CalculateBounds(bool use_default_origin) {
   DCHECK(tooltip_view_);
   gfx::Size size = tooltip_view_->size();
+  size.set_height(kTooltipSize.height());
   DCHECK(!size.IsEmpty());
 
   const gfx::Point origin =

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
@@ -25,6 +25,7 @@
 #include "ui/native_theme/native_theme.h"
 #include "ui/views/background.h"
 #include "ui/views/border.h"
+#include "ui/views/controls/button/button.h"
 #include "ui/views/controls/button/label_button.h"
 #include "ui/views/controls/image_view.h"
 #include "ui/views/controls/label.h"
@@ -370,6 +371,10 @@ void BraveTooltipView::UpdateOkButtonColors() {
   const bool should_use_dark_colors = GetNativeTheme()->ShouldUseDarkColors();
   ok_button_->SetBackground(views::CreateRoundedRectBackground(
       kDefaultButtonColor, kButtonCornerRadius));
+  ok_button_->SetTextColor(views::Button::ButtonState::STATE_DISABLED,
+                           should_use_dark_colors
+                               ? kDarkModeDefaultButtonTextColor
+                               : kLightModeDefaultButtonTextColor);
   ok_button_->SetEnabledTextColors(should_use_dark_colors
                                        ? kDarkModeDefaultButtonTextColor
                                        : kLightModeDefaultButtonTextColor);
@@ -409,6 +414,10 @@ void BraveTooltipView::UpdateCancelButtonColors() {
   cancel_button_->SetBackground(views::CreateRoundedRectBackground(
       should_use_dark_colors ? kDarkModeButtonColor : kLightModeButtonColor,
       kButtonCornerRadius));
+  cancel_button_->SetTextColor(views::Button::ButtonState::STATE_DISABLED,
+                               should_use_dark_colors
+                                   ? kDarkModeButtonTextColor
+                                   : kLightModeButtonTextColor);
   cancel_button_->SetEnabledTextColors(should_use_dark_colors
                                            ? kDarkModeButtonTextColor
                                            : kLightModeButtonTextColor);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37760

Something changed to affect the layering or event-handling with widgets in CR124. Until we can establish a root cause, this PR removes an unecessary container view for the adaptive CAPTCHA tooltip which works around the problem.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

To schedule a captcha on staging, use the following command-line snippet but supply the appropriate bearer token and wallet id:

```
curl -XPUT -H "Authorization: Bearer BEARER-TOKEN" -H "Content-Type: application/json" https://reputation.rewards.bravesoftware.com/v3/captcha/challenge/WALLET-ID
```

You must run the browser with `--brave-ads-staging` when testing on staging or the scheduled captcha won't display.

In order to force the captcha to appear, you need to wait for an ad to appear and then rate the ad repeatedly via thumbs-up/thumbs-down until the tokens are exhausted and need to be refilled (this is when the captcha is shown).

For testing purposes, we want to make sure that when the captcha tooltip appears:
- It can be repositioned via the mouse
- The Solve/Later buttons are interactive and work