### PR TITLE
Fix non-interactive adaptive captcha (uplift to 1.66.x)

### DIFF
--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -40,6 +40,8 @@
 
 namespace {
 
+constexpr gfx::Size kTooltipSize(434 + 15, 104 + 15);
+
 constexpr int kShadowElevation = 5;
 
 constexpr int kBorderThickness = 6;
@@ -267,17 +269,10 @@ void BraveTooltipPopup::CreatePopup() {
   SetLayoutManager(std::make_unique<views::BoxLayout>(
       views::BoxLayout::Orientation::kVertical, gfx::Insets()));
 
-  // Container
-  views::View* container_view = new views::View();
-  AddChildView(container_view);
-
   // Tooltip
   DCHECK(!tooltip_view_);
-  tooltip_view_ = container_view->AddChildView(
-      new BraveTooltipView(this, tooltip_->attributes()));
-
-  container_view->SetPosition(gfx::Point(0, 0));
-  container_view->SetSize(tooltip_view_->size());
+  tooltip_view_ =
+      AddChildView(new BraveTooltipView(this, tooltip_->attributes()));
 
   CreateWidgetView();
 }
@@ -318,6 +313,7 @@ gfx::Point BraveTooltipPopup::GetDefaultOriginForSize(const gfx::Size& size) {
 gfx::Rect BraveTooltipPopup::CalculateBounds(bool use_default_origin) {
   DCHECK(tooltip_view_);
   gfx::Size size = tooltip_view_->size();
+  size.set_height(kTooltipSize.height());
   DCHECK(!size.IsEmpty());
 
   const gfx::Point origin =

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
@@ -25,6 +25,7 @@
 #include "ui/native_theme/native_theme.h"
 #include "ui/views/background.h"
 #include "ui/views/border.h"
+#include "ui/views/controls/button/button.h"
 #include "ui/views/controls/button/label_button.h"
 #include "ui/views/controls/image_view.h"
 #include "ui/views/controls/label.h"
@@ -370,6 +371,10 @@ void BraveTooltipView::UpdateOkButtonColors() {
   const bool should_use_dark_colors = GetNativeTheme()->ShouldUseDarkColors();
   ok_button_->SetBackground(views::CreateRoundedRectBackground(
       kDefaultButtonColor, kButtonCornerRadius));
+  ok_button_->SetTextColor(views::Button::ButtonState::STATE_DISABLED,
+                           should_use_dark_colors
+                               ? kDarkModeDefaultButtonTextColor
+                               : kLightModeDefaultButtonTextColor);
   ok_button_->SetEnabledTextColors(should_use_dark_colors
                                        ? kDarkModeDefaultButtonTextColor
                                        : kLightModeDefaultButtonTextColor);
@@ -409,6 +414,10 @@ void BraveTooltipView::UpdateCancelButtonColors() {
   cancel_button_->SetBackground(views::CreateRoundedRectBackground(
       should_use_dark_colors ? kDarkModeButtonColor : kLightModeButtonColor,
       kButtonCornerRadius));
+  cancel_button_->SetTextColor(views::Button::ButtonState::STATE_DISABLED,
+                               should_use_dark_colors
+                                   ? kDarkModeButtonTextColor
+                                   : kLightModeButtonTextColor);
   cancel_button_->SetEnabledTextColors(should_use_dark_colors
                                            ? kDarkModeButtonTextColor
                                            : kLightModeButtonTextColor);


### PR DESCRIPTION
Uplift of #23201
Resolves https://github.com/brave/brave-browser/issues/37760

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.