### PR TITLE
Fixed crash when a tab is added to saved group (uplift to 1.66.x)

### DIFF
--- a/browser/ui/views/bookmarks/saved_tab_groups/brave_saved_tab_group_button.cc
+++ b/browser/ui/views/bookmarks/saved_tab_groups/brave_saved_tab_group_button.cc
@@ -38,6 +38,17 @@ void BraveSavedTabGroupButton::Initialize() {
 }
 
 void BraveSavedTabGroupButton::UpdateButtonLayout() {
+  // This seems called after this class is removed from widget.
+  // If a tab is added to existing group and that tab is the only
+  // tab in the current window, it seems that window is closed
+  // when that group is in another window during this adding.
+  // I think SavedTabGroupBar should stop observing SavedTabGroupModel
+  // when it's removed from widget but it's upstream code and upstream
+  // doesn't have this issue.
+  if (!GetWidget()) {
+    return;
+  }
+
   auto* cp = GetColorProvider();
 
   // Note that upstream uses separate color IDs for the button background,


### PR DESCRIPTION
Uplift of #23227
fix https://github.com/brave/brave-browser/issues/37160

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.