### PR TITLE
Fixes follow up of PR #23201 - Token refill is not happening in Later/Snoozing the captcha case (uplift to 1.65.x)

### DIFF
--- a/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
@@ -137,6 +137,8 @@ void RedeemPaymentTokens::SuccessfullyRedeemed(
 }
 
 void RedeemPaymentTokens::FailedToRedeem(const bool should_retry) {
+  is_redeeming_ = false;
+
   NotifyFailedToRedeemPaymentTokens();
 
   if (should_retry) {
@@ -168,8 +170,6 @@ void RedeemPaymentTokens::Retry() {
 
 void RedeemPaymentTokens::RetryCallback() {
   BLOG(1, "Retry redeeming payment tokens");
-
-  is_redeeming_ = false;
 
   NotifyDidRetryRedeemingPaymentTokens();
 

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -283,6 +283,8 @@ void RefillConfirmationTokens::SuccessfullyRefilled() {
 }
 
 void RefillConfirmationTokens::FailedToRefill(const bool should_retry) {
+  is_refilling_ = false;
+
   NotifyFailedToRefillConfirmationTokens();
 
   if (should_retry) {


### PR DESCRIPTION
Uplift of #23240
Resolves https://github.com/brave/brave-browser/issues/37790

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.