### PR TITLE
style(wallet): Consistent Card Header Button Sizes

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
@@ -206,7 +206,6 @@ export const AccountDetailsHeader = (props: Props) => {
     >
       <Row width='unset'>
         <MenuButton
-          size={28}
           marginRight={16}
           onClick={goBack}
         >

--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
@@ -179,7 +179,6 @@ export const AssetDetailsHeader = (props: Props) => {
     >
       <Row width='unset'>
         <MenuButton
-          size={28}
           marginRight={16}
           onClick={onBack}
         >

--- a/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/nft-asset-header.tsx
@@ -55,7 +55,6 @@ export const NftAssetHeader = ({
         margin='0px 6px 0px 0px'
       >
         <MenuButton
-          size={28}
           marginRight={16}
           onClick={onBack}
         >

--- a/components/brave_wallet_ui/components/desktop/card-headers/page-title-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/page-title-header.tsx
@@ -40,7 +40,6 @@ export const PageTitleHeader = ({ title, showBackButton, onBack }: Props) => {
     >
       {showBackButton && (
         <MenuButton
-          size={28}
           marginRight={16}
           onClick={onBack}
         >

--- a/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/shared-card-headers.style.ts
@@ -6,7 +6,12 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import Icon from '@brave/leo/react/icon'
+
+// Shared Styles
 import { WalletButton } from '../../shared/style'
+import {
+  layoutSmallWidth //
+} from '../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const HeaderTitle = styled.span<{
   isPanel?: boolean
@@ -25,7 +30,6 @@ export const MenuWrapper = styled.div`
 `
 
 export const MenuButton = styled(WalletButton)<{
-  size?: number
   marginRight?: number
 }>`
   --button-border-color: ${leo.color.divider.interactive};
@@ -38,9 +42,13 @@ export const MenuButton = styled(WalletButton)<{
   background-color: ${leo.color.container.background};
   border-radius: 8px;
   border: 1px solid var(--button-border-color);
-  height: ${(p) => (p.size !== undefined ? p.size : 36)}px;
-  width: ${(p) => (p.size !== undefined ? p.size : 36)}px;
+  height: 36px;
+  width: 36px;
   margin-right: ${(p) => (p.marginRight !== undefined ? p.marginRight : 0)}px;
+  @media screen and (max-width: ${layoutSmallWidth}px) {
+    height: 28px;
+    width: 28px;
+  }
 `
 
 export const ButtonIcon = styled(Icon)<{


### PR DESCRIPTION
## Description 
Makes the `Card Header` button sizes consistent in size.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37801>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Open the `Wallet` and navigate to an `Asset Detail` or `Account Details` screen
   2. The `Back` button and `Menu` button should be the same size


Before:

![Screenshot 2](https://github.com/brave/brave-core/assets/40611140/97fcf555-4aae-4a17-89ac-1b61e2f8ef2f)

![Screenshot 3](https://github.com/brave/brave-core/assets/40611140/61d1fc02-a38f-48dc-9e1d-4d905559f8ba)

After:

![Screenshot](https://github.com/brave/brave-core/assets/40611140/77ce1c50-41c8-42ef-b31b-1ef74c641a74)

![Screenshot 1](https://github.com/brave/brave-core/assets/40611140/e9df45c5-ef81-4afe-93de-1cfb9639eb39)
