### PR TITLE
Update short cut pin state properly on Windows

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -232,6 +232,9 @@
       <message name="IDS_SETTINGS_PIN_SHORTCUT" desc="The label for pin to taskbar button">
         Pin
       </message>
+      <message name="IDS_SETTINGS_PIN_SHORTCUT_SUBLABEL" desc="The sub label for pin to taskbar button">
+        Click Pin and confirm in the following Windows notification
+      </message>
       <message name="IDS_SETTINGS_SHORTCUT_PINNED" desc="The label for pinned state description">
         Brave is already pinned
       </message>

--- a/browser/resources/settings/pin_shortcut_page/pin_shortcut_page.html
+++ b/browser/resources/settings/pin_shortcut_page/pin_shortcut_page.html
@@ -10,6 +10,9 @@ You can obtain one at http://mozilla.org/MPL/2.0/. -->
   <div class="cr-row">
     <div class="flex cr-padded-text">
       <div>$i18n{canPinShortcut}</div>
+<if expr="is_win">
+      <div class="secondary">$i18n{pinShortcutSublabel}</div>
+</if>
     </div>
     <div class="separator"></div>
     <cr-button on-click="onPinShortcutTap_">

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -437,6 +437,9 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
 #if BUILDFLAG(ENABLE_PIN_SHORTCUT)
       {"canPinShortcut", IDS_SETTINGS_CAN_PIN_SHORTCUT},
       {"pinShortcut", IDS_SETTINGS_PIN_SHORTCUT},
+#if BUILDFLAG(IS_WIN)
+      {"pinShortcutSublabel", IDS_SETTINGS_PIN_SHORTCUT_SUBLABEL},
+#endif
       {"shortcutPinned", IDS_SETTINGS_SHORTCUT_PINNED},
 #endif
       // Rewards page

--- a/browser/ui/webui/settings/pin_shortcut_handler.cc
+++ b/browser/ui/webui/settings/pin_shortcut_handler.cc
@@ -38,20 +38,63 @@ void PinShortcutHandler::HandleCheckShortcutPinState(
     const base::Value::List& args) {
   AllowJavascript();
 
+  CheckShortcutPinState(false);
+}
+
+void PinShortcutHandler::CheckShortcutPinState(bool from_timer) {
   shell_integration::IsShortcutPinned(
       base::BindOnce(&PinShortcutHandler::OnCheckShortcutPinState,
-                     weak_factory_.GetWeakPtr()));
+                     weak_factory_.GetWeakPtr(), from_timer));
 }
+
+#if BUILDFLAG(IS_WIN)
+void PinShortcutHandler::OnPinStateCheckTimerFired() {
+  CheckShortcutPinState(true);
+}
+#endif
 
 void PinShortcutHandler::OnPinShortcut(bool pinned) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
+#if BUILDFLAG(IS_WIN)
+  // On Windows, ignore |pinned| value as Windows asks to user via another
+  // os notification to pin. |pinned| state just represents that api call is
+  // succuss. So, polling to check whether user allowed or not.
+  if (!pin_state_check_timer_) {
+    pin_state_check_timer_ = std::make_unique<base::RetainingOneShotTimer>(
+        FROM_HERE, base::Seconds(2),
+        base::BindRepeating(&PinShortcutHandler::OnPinStateCheckTimerFired,
+                            weak_factory_.GetWeakPtr()));
+  }
+  // We'll try to check 10 times after asking to pin to Windows.
+  // Maybe user will see os notification for pin right after clicking the Pin
+  // button. If user doesn't click allow in 20s, we'll not monitor anymore as we
+  // could give proper pin state after reloading.
+  pin_state_check_count_ = 10;
+  pin_state_check_timer_->Reset();
+#else
   NotifyShortcutPinStateChangeToPage(pinned);
+#endif
 }
 
-void PinShortcutHandler::OnCheckShortcutPinState(bool pinned) {
+void PinShortcutHandler::OnCheckShortcutPinState(bool from_timer, bool pinned) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
 
+#if BUILDFLAG(IS_WIN)
+  if (from_timer) {
+    pin_state_check_count_--;
+    // Clear if pinned or we did all try.
+    if (pinned || pin_state_check_count_ == 0) {
+      pin_state_check_count_ = 0;
+      pin_state_check_timer_.reset();
+    } else {
+      // Check again.
+      pin_state_check_timer_->Reset();
+    }
+  }
+#else
+  CHECK(!from_timer);
+#endif
   NotifyShortcutPinStateChangeToPage(pinned);
 }
 

--- a/browser/ui/webui/settings/pin_shortcut_handler.h
+++ b/browser/ui/webui/settings/pin_shortcut_handler.h
@@ -31,6 +31,8 @@ class PinShortcutHandler : public settings::SettingsPageUIHandler {
   void HandlePinShortcut(const base::Value::List& args);
   void NotifyShortcutPinStateChangeToPage(bool pinned);
 
+  // |from_timer| is true when it's called for polling pinned state
+  // after requesting pin. Only valid on Windows.
   void CheckShortcutPinState(bool from_timer);
   void OnPinShortcut(bool pinned);
   void OnCheckShortcutPinState(bool from_timer, bool pinned);
@@ -38,7 +40,7 @@ class PinShortcutHandler : public settings::SettingsPageUIHandler {
 #if BUILDFLAG(IS_WIN)
   void OnPinStateCheckTimerFired();
 
-  int pin_state_check_count_ = 0;
+  int pin_state_check_count_down_ = 0;
   std::unique_ptr<base::RetainingOneShotTimer> pin_state_check_timer_;
 #endif
 

--- a/browser/ui/webui/settings/pin_shortcut_handler.h
+++ b/browser/ui/webui/settings/pin_shortcut_handler.h
@@ -6,7 +6,11 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_PIN_SHORTCUT_HANDLER_H_
 #define BRAVE_BROWSER_UI_WEBUI_SETTINGS_PIN_SHORTCUT_HANDLER_H_
 
+#include <memory>
+
 #include "base/memory/weak_ptr.h"
+#include "base/timer/timer.h"
+#include "build/build_config.h"
 #include "chrome/browser/ui/webui/settings/settings_page_ui_handler.h"
 
 class PinShortcutHandler : public settings::SettingsPageUIHandler {
@@ -27,8 +31,16 @@ class PinShortcutHandler : public settings::SettingsPageUIHandler {
   void HandlePinShortcut(const base::Value::List& args);
   void NotifyShortcutPinStateChangeToPage(bool pinned);
 
+  void CheckShortcutPinState(bool from_timer);
   void OnPinShortcut(bool pinned);
-  void OnCheckShortcutPinState(bool pinned);
+  void OnCheckShortcutPinState(bool from_timer, bool pinned);
+
+#if BUILDFLAG(IS_WIN)
+  void OnPinStateCheckTimerFired();
+
+  int pin_state_check_count_ = 0;
+  std::unique_ptr<base::RetainingOneShotTimer> pin_state_check_timer_;
+#endif
 
   base::WeakPtrFactory<PinShortcutHandler> weak_factory_{this};
 };


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/26301

Polling the pinned state after asking to Windows because it's actually pinned
when user allowed via os notification.
We'll check 10 times with 2s interval after asking to Windows.
If user doesn't react or disallowed within that time, we doesn't change the state.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Launch brave and load brave://settings/getStarted
2. Click `Pin` button and click allow from os notification
3. Check Setting is changed to pinned state