### PR TITLE
Draw border for contents web view in split view mode

### DIFF
--- a/browser/ui/color/brave_color_id.h
+++ b/browser/ui/color/brave_color_id.h
@@ -120,7 +120,8 @@
     E_CPONLY(kColorBraveVerticalTabNTBShortcutTextColor)
 
 #define BRAVE_SPLIT_VIEW_COLOR_IDS \
-    E_CPONLY(kColorBraveSplitViewTileBackground)
+    E_CPONLY(kColorBraveSplitViewTileBackground)        \
+    E_CPONLY(kColorBraveSplitViewInactiveWebViewBorder) \
 
 #define BRAVE_PLAYLIST_COLOR_IDS                                      \
     E_CPONLY(kColorBravePlaylistAddedIcon)                            \

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -8,6 +8,7 @@
 #include "base/containers/fixed_flat_map.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/browser/ui/color/color_palette.h"
+#include "brave/browser/ui/color/leo/colors.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_mixer.h"
 #include "ui/color/color_provider.h"
@@ -88,6 +89,9 @@ void AddBraveTabLightThemeColorMixer(ui::ColorProvider* provider,
     mixer[color_id] =
         GetCustomColorOrDefaultColor(key.custom_theme, color_id, default_color);
   }
+
+  mixer[kColorBraveSplitViewInactiveWebViewBorder] = {
+      leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kLight)};
 }
 
 void AddBraveTabDarkThemeColorMixer(ui::ColorProvider* provider,
@@ -121,6 +125,9 @@ void AddBraveTabDarkThemeColorMixer(ui::ColorProvider* provider,
       mixer[color_id] = color;
     }
   }
+
+  mixer[kColorBraveSplitViewInactiveWebViewBorder] = {
+      leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kDark)};
 }
 
 }  // namespace tabs

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -182,8 +182,9 @@ class BraveBrowserView : public BrowserView,
 
   tabs::TabHandle GetActiveTabHandle() const;
   bool IsActiveWebContentsTiled(const SplitViewBrowserData::Tile& tile) const;
+  void UpdateContentsWebViewVisual();
+  void UpdateContentsWebViewBorder();
   void UpdateSecondaryContentsWebViewVisibility();
-
   void UpdateSecondaryDevtoolsLayoutAndVisibility(
       content::WebContents* inspected_contents);
 

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -51,7 +51,7 @@ void BraveContentsLayoutManager::LayoutImpl() {
       };
 
   gfx::Rect bounds = host_view()->GetLocalBounds();
-  bounds.set_width(bounds.width() / 2);
+  bounds.set_width((bounds.width() - kSpacingBetweenContentsWebViews) / 2);
   if (show_main_web_contents_at_tail_) {
     layout_web_contents_and_devtools(bounds, secondary_contents_view_,
                                      secondary_devtools_view_,
@@ -63,8 +63,9 @@ void BraveContentsLayoutManager::LayoutImpl() {
 
   // In case of odd width, give the remaining
   // width to the secondary contents view.
-  bounds.set_x(bounds.width());
-  bounds.set_width(host_view()->width() - bounds.width());
+  bounds.set_x(bounds.width() + kSpacingBetweenContentsWebViews);
+  bounds.set_width(host_view()->width() - bounds.width() -
+                   kSpacingBetweenContentsWebViews);
   if (show_main_web_contents_at_tail_) {
     layout_web_contents_and_devtools(bounds, contents_view_, devtools_view_,
                                      strategy_);

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -12,6 +12,9 @@ class SplitViewBrowserData;
 
 class BraveContentsLayoutManager : public ContentsLayoutManager {
  public:
+  // Spacing between |contents_web_view_| and |secondary_contents_web_view_|.
+  static constexpr auto kSpacingBetweenContentsWebViews = 4;
+
   using ContentsLayoutManager::ContentsLayoutManager;
   ~BraveContentsLayoutManager() override;
 

--- a/browser/ui/views/frame/brave_contents_layout_manager_unittest.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager_unittest.cc
@@ -86,8 +86,12 @@ TEST_F(BraveContentsLayoutManagerUnitTest, Size_SecondaryContentsViewVisible) {
 
   // Then contents_view_ should take the half and secondary_contents_view_
   // should the rest of the width.
-  EXPECT_EQ(contents_container().width() / 2, contents_view().width());
-  EXPECT_EQ(contents_container().width() - contents_view().width(),
+  EXPECT_EQ((contents_container().width() -
+             BraveContentsLayoutManager::kSpacingBetweenContentsWebViews) /
+                2,
+            contents_view().width());
+  EXPECT_EQ(contents_container().width() - contents_view().width() -
+                BraveContentsLayoutManager::kSpacingBetweenContentsWebViews,
             secondary_contents_view().width());
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37804


<img width="1059" alt="image" src="https://github.com/brave/brave-core/assets/5474642/0b761797-2116-4d14-a2ba-8662c3238445">


This should be revisited when rounded corer is applied to web views by default.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

