### PR TITLE
style(wallet): Add Network Icon to Asset Details

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.style.ts
@@ -6,7 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css'
 import Icon from '@brave/leo/react/icon'
-import { AssetIconProps, AssetIconFactory } from '../../shared/style'
+import { AssetIconProps, AssetIconFactory, Column } from '../../shared/style'
 
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
   width: '40px',
@@ -61,4 +61,17 @@ export const UpDownIcon = styled(Icon)<{
 }>`
   --leo-icon-size: 24px;
   color: inherit;
+`
+
+export const IconsWrapper = styled(Column)`
+  position: relative;
+`
+
+export const NetworkIconWrapper = styled(Column)`
+  position: absolute;
+  bottom: 0px;
+  right: 0px;
+  background-color: ${leo.color.container.background};
+  border-radius: 100%;
+  padding: 2px;
 `

--- a/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/asset-details-header.tsx
@@ -23,6 +23,7 @@ import {
 import {
   externalWalletProviderFromString //
 } from '../../../../brave_rewards/resources/shared/lib/external_wallet'
+import { checkIfTokenNeedsNetworkIcon } from '../../../utils/asset-utils'
 
 // Queries
 import {
@@ -39,6 +40,7 @@ import useExplorer from '../../../common/hooks/explorer'
 // Components
 import withPlaceholderIcon from '../../shared/create-placeholder-icon'
 import { AssetDetailsMenu } from '../wallet-menus/asset-details-menu'
+import { CreateNetworkIcon } from '../../shared/create-network-icon'
 
 // Styled Components
 import {
@@ -53,7 +55,9 @@ import {
   NetworkDescriptionText,
   PriceText,
   PercentChange,
-  UpDownIcon
+  UpDownIcon,
+  IconsWrapper,
+  NetworkIconWrapper
 } from './asset-details-header.style'
 import { Row, Column, HorizontalSpace } from '../../shared/style'
 import { Skeleton } from '../../shared/loading-skeleton/styles'
@@ -192,10 +196,24 @@ export const AssetDetailsHeader = (props: Props) => {
           gap='8px'
         >
           {selectedAsset ? (
-            <AssetIconWithPlaceholder
-              asset={selectedAsset}
-              network={selectedAssetsNetwork}
-            />
+            <IconsWrapper>
+              <AssetIconWithPlaceholder
+                asset={selectedAsset}
+                network={selectedAssetsNetwork}
+              />
+              {selectedAssetsNetwork &&
+                checkIfTokenNeedsNetworkIcon(
+                  selectedAssetsNetwork,
+                  selectedAsset.contractAddress
+                ) && (
+                  <NetworkIconWrapper>
+                    <CreateNetworkIcon
+                      network={selectedAssetsNetwork}
+                      marginRight={0}
+                    />
+                  </NetworkIconWrapper>
+                )}
+            </IconsWrapper>
           ) : (
             <Skeleton
               height={'40px'}


### PR DESCRIPTION
## Description 
Adds a `Network` icon to the `Asset Details` view.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37818>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Open the `Wallet` and select an asset
   2. The network icon should be displayed for non-native assets.

Before:

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/73908810-c5d2-4adf-bd7a-a4df0f0b3cd3)

After:

![Screenshot 5](https://github.com/brave/brave-core/assets/40611140/d334e4f4-da5f-4d8e-9f89-bcbf2aae9c52)
