### PR TITLE
Convert dump to DCHECK in Rewards engine GetState method (uplift to 1.65.x)

### DIFF
--- a/components/brave_rewards/core/rewards_engine_impl.h
+++ b/components/brave_rewards/core/rewards_engine_impl.h
@@ -310,7 +310,9 @@ class RewardsEngineImpl : public mojom::RewardsEngine {
 
     // Occasionally during shutdown the engine can fail to read preferences from
     // the client, likely due to the complexities of sync mojo calls.
-    DUMP_WILL_BE_CHECK(ok) << "Unable to read state from Rewards engine client";
+    // TODO(https://github.com/brave/brave-browser/issues/37816): User pref
+    // access should be refactored to handle these errors gracefully.
+    DCHECK(ok) << "Unable to read state from Rewards engine client";
 
     return value;
   }


### PR DESCRIPTION
Uplift of #23259
Resolves https://github.com/brave/brave-browser/issues/36929

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.