### PR TITLE
Use locale independent link in "Help WDP" page

### DIFF
--- a/components/brave_welcome_ui/components/help-wdp/index.tsx
+++ b/components/brave_welcome_ui/components/help-wdp/index.tsx
@@ -45,7 +45,7 @@ function HelpWDP () {
       <S.BodyBox>
         {getLocale('braveWelcomeHelpWDPDescription')}
         <a
-          href='https://support.brave.com/hc/en-us/articles/4409406835469-What-is-the-Web-Discovery-Project'
+          href='https://support.brave.com/hc/articles/4409406835469-What-is-the-Web-Discovery-Project'
           target='_blank'
         >
           {getLocale('braveWelcomeHelpWDPLearnMore')}


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/37671

This change was accidentally applied to the Nightly in the https://github.com/brave/brave-core/pull/23071/files#diff-6a920f9fe8a51f932635a48274af5ef56e7fc85967663d5a0d365232d78f6c84 .