### PR TITLE
Transfer `Tile` when split view is attached into new window

### DIFF
--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -6,11 +6,13 @@
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
 
 #include "base/check_is_test.h"
+#include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
 #include "base/notreached.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/split_view_browser_data_observer.h"
 #include "brave/browser/ui/tabs/split_view_tab_strip_model_adapter.h"
+#include "chrome/browser/ui/tabs/tab_model.h"
 
 SplitViewBrowserData::SplitViewBrowserData(Browser* browser)
     : BrowserUserData(*browser) {
@@ -103,6 +105,13 @@ SplitViewBrowserData::FindTile(const tabs::TabHandle& tab) const {
   return const_cast<SplitViewBrowserData*>(this)->FindTile(tab);
 }
 
+void SplitViewBrowserData::Transfer(SplitViewBrowserData* other,
+                                    std::vector<Tile> tiles) {
+  for (const auto& tile : tiles) {
+    other->TileTabs(tile);
+  }
+}
+
 bool SplitViewBrowserData::IsTabTiled(const tabs::TabHandle& tab) const {
   return base::Contains(tile_index_for_tab_, tab);
 }
@@ -189,6 +198,32 @@ SplitViewBrowserData::TabDragStarted() {
                   }
                 },
                 weak_ptr_factory_.GetWeakPtr()));
+}
+
+void SplitViewBrowserData::TabsWillBeAttachedToNewBrowser(
+    const std::vector<tabs::TabHandle>& tabs) {
+  DCHECK(tiles_to_be_attached_to_new_window_.empty());
+
+  base::flat_set<Tile> tiles_to_be_attached_to_new_window;
+  for (const auto& tab : tabs) {
+    auto iter = FindTile(tab);
+    if (iter == tiles_.end()) {
+      continue;
+    }
+
+    tiles_to_be_attached_to_new_window.insert(*iter);
+    // The tile in the |tile_| will be removed when they actually get detached
+    // from the current tab strip model.
+  }
+
+  tiles_to_be_attached_to_new_window_ =
+      std::vector(tiles_to_be_attached_to_new_window.begin(),
+                  tiles_to_be_attached_to_new_window.end());
+}
+
+void SplitViewBrowserData::TabsAttachedToNewBrowser(Browser* browser) {
+  Transfer(SplitViewBrowserData::FromBrowser(browser),
+           std::move(tiles_to_be_attached_to_new_window_));
 }
 
 BROWSER_USER_DATA_KEY_IMPL(SplitViewBrowserData);

--- a/browser/ui/tabs/split_view_browser_data.cc
+++ b/browser/ui/tabs/split_view_browser_data.cc
@@ -204,21 +204,23 @@ void SplitViewBrowserData::TabsWillBeAttachedToNewBrowser(
     const std::vector<tabs::TabHandle>& tabs) {
   DCHECK(tiles_to_be_attached_to_new_window_.empty());
 
-  base::flat_set<Tile> tiles_to_be_attached_to_new_window;
   for (const auto& tab : tabs) {
     auto iter = FindTile(tab);
     if (iter == tiles_.end()) {
       continue;
     }
 
-    tiles_to_be_attached_to_new_window.insert(*iter);
+    tiles_to_be_attached_to_new_window_.push_back(*iter);
     // The tile in the |tile_| will be removed when they actually get detached
     // from the current tab strip model.
   }
 
-  tiles_to_be_attached_to_new_window_ =
-      std::vector(tiles_to_be_attached_to_new_window.begin(),
-                  tiles_to_be_attached_to_new_window.end());
+  if (tiles_to_be_attached_to_new_window_.size() > 1) {
+    base::ranges::sort(tiles_to_be_attached_to_new_window_);
+    tiles_to_be_attached_to_new_window_.erase(
+        base::ranges::unique(tiles_to_be_attached_to_new_window_),
+        tiles_to_be_attached_to_new_window_.end());
+  }
 }
 
 void SplitViewBrowserData::TabsAttachedToNewBrowser(Browser* browser) {

--- a/browser/ui/tabs/split_view_browser_data.h
+++ b/browser/ui/tabs/split_view_browser_data.h
@@ -62,6 +62,9 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
   };
   [[nodiscard]] OnTabDragEndedClosure TabDragStarted();
 
+  void TabsWillBeAttachedToNewBrowser(const std::vector<tabs::TabHandle>& tabs);
+  void TabsAttachedToNewBrowser(Browser* browser);
+
  private:
   friend BrowserUserData;
   friend class SplitViewBrowserDataUnitTest;
@@ -78,9 +81,12 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
   std::vector<Tile>::const_iterator FindTile(const tabs::TabHandle& tab);
   std::vector<Tile>::const_iterator FindTile(const tabs::TabHandle& tab) const;
 
+  void Transfer(SplitViewBrowserData* other, std::vector<Tile> tiles);
+
   std::unique_ptr<SplitViewTabStripModelAdapter> tab_strip_model_adapter_;
 
   std::vector<Tile> tiles_;
+  std::vector<Tile> tiles_to_be_attached_to_new_window_;
 
   // As UI is likely to read more frequently than insert or delete, we cache
   // index for faster look up.


### PR DESCRIPTION
Previously, tiled state was gone on detaching split view. We should transfer the state to the new browser window so that split view state can be restored when reattaching.


https://github.com/brave/brave-core/assets/5474642/4e01d799-5c6c-483d-9575-9152b6726a4a


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37852

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

