### PR TITLE
Fix crash when opening popup with split view enabled (uplift to 1.66.x)

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -911,15 +911,16 @@ void BraveBrowserView::OnActiveTabChanged(content::WebContents* old_contents,
                                           content::WebContents* new_contents,
                                           int index,
                                           int reason) {
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView) &&
-      new_contents == secondary_contents_web_view_->web_contents()) {
+  const bool supports_split_view =
+      base::FeatureList::IsEnabled(tabs::features::kBraveSplitView) &&
+      browser()->is_type_normal();
+  if (supports_split_view) {
     secondary_contents_web_view_->SetWebContents(nullptr);
   }
 
   BrowserView::OnActiveTabChanged(old_contents, new_contents, index, reason);
 
-  if (base::FeatureList::IsEnabled(tabs::features::kBraveSplitView) &&
-      browser()->is_type_normal()) {
+  if (supports_split_view) {
     // Setting nullptr doesn't detach the previous contents.
     UpdateSecondaryContentsWebViewVisibility();
   }


### PR DESCRIPTION
Uplift of #23000
Resolves https://github.com/brave/brave-browser/issues/37447

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.