### PR TITLE
feat(wallet): Balance Details Modal

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Activity/AccountActivityView.swift
@@ -326,6 +326,7 @@ private struct AssetsListDetailView: View {
   var body: some View {
     AssetsListView(
       assets: store.userAssets,
+      shouldShowContainerForBitcoin: false,
       currencyFormatter: store.currencyFormatter,
       selectedAsset: { asset in
         assetForDetails = asset

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/AssetsListView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/AssetsListView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 struct AssetsListView: View {
 
   let assets: [AssetViewModel]
+  /// If a container should be shown to around unavailable balance banner
+  /// for Bitcoin asset row (when there is a pending balance)
+  let shouldShowContainerForBitcoin: Bool
   let currencyFormatter: NumberFormatter
   let selectedAsset: (BraveWallet.BlockchainToken) -> Void
 
@@ -19,27 +22,16 @@ struct AssetsListView: View {
           emptyAssetsState
         } else {
           ForEach(assets) { asset in
-            Button {
-              selectedAsset(asset.token)
-            } label: {
-              PortfolioAssetView(
-                image: AssetIconView(
-                  token: asset.token,
-                  network: asset.network,
-                  shouldShowNetworkIcon: true
-                ),
-                title: asset.token.name,
-                symbol: asset.token.symbol,
-                networkName: asset.network.chainName,
-                amount: asset.fiatAmount(currencyFormatter: currencyFormatter),
-                quantity: asset.quantity,
-                shouldHideBalance: true
-              )
-            }
+            FungibleAssetButton(
+              asset: asset,
+              shouldShowContainerForBitcoin: shouldShowContainerForBitcoin,
+              currencyFormatter: currencyFormatter,
+              action: selectedAsset
+            )
           }
         }
       }
-      .padding()
+      .padding(.vertical)
     }
     .background(Color(braveSystemName: .containerBackground))
   }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/AssetsListView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/AssetsListView.swift
@@ -13,6 +13,7 @@ struct AssetsListView: View {
   /// for Bitcoin asset row (when there is a pending balance)
   let shouldShowContainerForBitcoin: Bool
   let currencyFormatter: NumberFormatter
+  @State private var bitcoinBalanceDetails: BitcoinBalanceDetails?
   let selectedAsset: (BraveWallet.BlockchainToken) -> Void
 
   var body: some View {
@@ -26,6 +27,7 @@ struct AssetsListView: View {
               asset: asset,
               shouldShowContainerForBitcoin: shouldShowContainerForBitcoin,
               currencyFormatter: currencyFormatter,
+              bitcoinBalanceDetails: $bitcoinBalanceDetails,
               action: selectedAsset
             )
           }
@@ -34,6 +36,23 @@ struct AssetsListView: View {
       .padding(.vertical)
     }
     .background(Color(braveSystemName: .containerBackground))
+    .sheet(
+      isPresented: Binding(
+        get: { bitcoinBalanceDetails != nil },
+        set: {
+          if !$0 {
+            bitcoinBalanceDetails = nil
+          }
+        }
+      )
+    ) {
+      if let bitcoinBalanceDetails {
+        BTCBalanceDetailsView(
+          details: bitcoinBalanceDetails,
+          currencyFormatter: .usdCurrencyFormatter
+        )
+      }
+    }
   }
 
   private var emptyAssetsState: some View {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/BTCBalanceDetailsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/BTCBalanceDetailsView.swift
@@ -1,0 +1,201 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import DesignSystem
+import SwiftUI
+
+struct UnavailableBTCBalanceView: View {
+
+  /// BTC Balances for each type
+  let btcBalances: [String: [BTCBalanceType: Double]]
+  let btcPrice: Double
+
+  private func total(for btcBalanceType: BTCBalanceType) -> Double {
+    btcBalances.compactMap { $0.value[btcBalanceType] }.reduce(0.0, +)
+  }
+
+  @State private var isShowingBalanceDetails: Bool = false
+
+  var body: some View {
+    Button(
+      action: { self.isShowingBalanceDetails = true },
+      label: {
+        HStack(spacing: 16) {
+          ProgressView()
+            .progressViewStyle(.braveCircular(size: .small, tint: .braveBlurpleTint))
+          Text(Strings.Wallet.btcPendingBalancesBannerDesc)
+            .font(.footnote)
+            .multilineTextAlignment(.leading)
+            .foregroundColor(Color(braveSystemName: .blue50))
+          Spacer(minLength: 16)
+          Text(Strings.Wallet.viewDetails)
+            .font(.footnote.weight(.medium))
+            .foregroundColor(Color(braveSystemName: .textInteractive))
+        }
+        .padding(.vertical, 8)
+        .padding(.horizontal, 16)
+        .background(Color(braveSystemName: .blue20).cornerRadius(12))
+      }
+    )
+    .sheet(isPresented: $isShowingBalanceDetails) {
+      BTCBalanceDetailsView(
+        availableBalance: total(for: .available),
+        pendingBalance: total(for: .pending),
+        totalBalance: total(for: .total),
+        btcPrice: btcPrice,
+        currencyFormatter: .usdCurrencyFormatter
+      )
+    }
+  }
+}
+
+#if DEBUG
+struct UnavailableBTCBalanceView_Previews: PreviewProvider {
+  static var previews: some View {
+    UnavailableBTCBalanceView(
+      btcBalances: [
+        "account.1": [
+          .available: 5,
+          .pending: 5,
+          .total: 10,
+        ],
+        "account.2": [
+          .available: 5,
+          .pending: 5,
+          .total: 10,
+        ],
+      ],
+      btcPrice: 62_500
+    )
+    .padding()
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif
+
+struct BTCBalanceDetailsView: View {
+
+  let availableBalance: Double
+  let pendingBalance: Double
+  let totalBalance: Double
+  let btcPrice: Double
+  let currencyFormatter: NumberFormatter
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var viewHeight: CGFloat = 0
+
+  var body: some View {
+    VStack(spacing: 16) {
+      HStack {
+        Text(Strings.Wallet.detailsButtonTitle)
+          .font(.title2.weight(.medium))
+          .foregroundColor(Color(braveSystemName: .textPrimary))
+        Spacer()
+        Button(
+          action: {
+            dismiss()
+          },
+          label: {
+            Image(braveSystemName: "leo.close")
+              .foregroundColor(Color(braveSystemName: .iconDefault))
+          }
+        )
+      }
+
+      VStack(spacing: 0) {
+        containerRow(
+          title: Strings.Wallet.btcAvailableBalanceTitle,
+          description: Strings.Wallet.btcAvailableBalanceDesc,
+          value: String(format: "%f", availableBalance),
+          price: currencyFormatter.string(from: .init(value: availableBalance * btcPrice))
+            ?? "$0.00"
+        )
+        DividerLine()
+        containerRow(
+          title: Strings.Wallet.btcPendingBalanceTitle,
+          description: Strings.Wallet.btcPendingBalanceDesc,
+          value: String(format: "%f", pendingBalance),
+          price: currencyFormatter.string(from: .init(value: pendingBalance * btcPrice)) ?? "$0.00"
+        )
+        DividerLine()
+        containerRow(
+          title: Strings.Wallet.btcTotalBalanceTitle,
+          description: Strings.Wallet.btcTotalBalanceDesc,
+          value: String(format: "%f", totalBalance),
+          price: currencyFormatter.string(from: .init(value: totalBalance * btcPrice)) ?? "$0.00"
+        )
+        .background(Color(braveSystemName: .containerHighlight))
+        .containerShape(Rectangle())
+      }
+      .frame(maxWidth: .infinity)
+      .background(Color(braveSystemName: .containerBackground))
+      .overlay {
+        ContainerRelativeShape()
+          .strokeBorder(Color(braveSystemName: .dividerSubtle))
+      }
+      .clipShape(ContainerRelativeShape())
+      .containerShape(RoundedRectangle(cornerRadius: 12))
+    }
+    .padding(16)
+    .background(Color(braveSystemName: .pageBackground))
+    .readSize { size in
+      self.viewHeight = size.height
+    }
+    .osAvailabilityModifiers({ view in
+      if #available(iOS 16, *) {
+        view
+          .presentationDetents([
+            .height(viewHeight)
+          ])
+      } else {
+        view
+      }
+    })
+  }
+
+  private func containerRow(
+    title: String,
+    description: String,
+    value: String,
+    price: String
+  ) -> some View {
+    VStack {
+      HStack {
+        Text(title)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: 16)
+        Text("\(value) BTC")
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .font(.callout.weight(.medium))
+      .foregroundColor(Color(braveSystemName: .textPrimary))
+      HStack(alignment: .top) {
+        Text(description)
+          .fixedSize(horizontal: false, vertical: true)
+        Spacer(minLength: 16)
+        Text(price)
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .font(.caption)
+      .foregroundColor(Color(braveSystemName: .textSecondary))
+    }
+    .padding(16)
+  }
+}
+
+#if DEBUG
+struct BTCBalanceDetailsView_Previews: PreviewProvider {
+  static var previews: some View {
+    BTCBalanceDetailsView(
+      availableBalance: 10,
+      pendingBalance: 5,
+      totalBalance: 15,
+      btcPrice: 62_500,
+      currencyFormatter: .usdCurrencyFormatter
+    )
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/FungibleAssetView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/FungibleAssetView.swift
@@ -14,6 +14,7 @@ struct FungibleAssetButton: View {
   /// for Bitcoin asset row (when there is a pending balance)
   let shouldShowContainerForBitcoin: Bool
   let currencyFormatter: NumberFormatter
+  @Binding var bitcoinBalanceDetails: BitcoinBalanceDetails?
   let action: (BraveWallet.BlockchainToken) -> Void
   
   var body: some View {
@@ -24,7 +25,8 @@ struct FungibleAssetButton: View {
         
         UnavailableBTCBalanceView(
           btcBalances: asset.btcBalances,
-          btcPrice: Double(asset.price) ?? 0
+          btcPrice: Double(asset.price) ?? 0,
+          bitcoinBalanceDetails: $bitcoinBalanceDetails
         )
       }
       .padding()

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/FungibleAssetView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/FungibleAssetView.swift
@@ -5,15 +5,74 @@
 
 import Preferences
 import SwiftUI
+import BraveCore
 
-struct PortfolioAssetView: View {
+// View used to display `FungibleAssetView` as a button.
+struct FungibleAssetButton: View {
+  let asset: AssetViewModel
+  /// If a container should be shown to around unavailable balance banner
+  /// for Bitcoin asset row (when there is a pending balance)
+  let shouldShowContainerForBitcoin: Bool
+  let currencyFormatter: NumberFormatter
+  let action: (BraveWallet.BlockchainToken) -> Void
+  
+  var body: some View {
+    // Avoid button inside a button for `UnavailableBTCBalanceView`
+    if asset.btcBalances.compactMap({ $0.value[.pending] }).reduce(0.0, +) > 0 {
+      VStack(spacing: 0) {
+        assetViewButton
+        
+        UnavailableBTCBalanceView(
+          btcBalances: asset.btcBalances,
+          btcPrice: Double(asset.price) ?? 0
+        )
+      }
+      .padding()
+      .overlay {
+        if shouldShowContainerForBitcoin {
+          ContainerRelativeShape()
+            .strokeBorder(Color(braveSystemName: .dividerSubtle))
+        }
+      }
+      .containerShape(RoundedRectangle(cornerRadius: 12))
+    } else {
+      assetViewButton
+        .padding(.horizontal)
+    }
+  }
+  
+  private var assetViewButton: some View {
+    Button {
+      action(asset.token)
+    } label: {
+      FungibleAssetView(
+        image: AssetIconView(
+          token: asset.token,
+          network: asset.network,
+          shouldShowNetworkIcon: true
+        ),
+        title: asset.token.name,
+        symbol: asset.token.symbol,
+        networkName: asset.network.chainName,
+        fiat: asset.fiatAmount(currencyFormatter: currencyFormatter),
+        balance: asset.quantity,
+        shouldHideBalance: true,
+        btcBalances: asset.btcBalances
+      )
+    }
+  }
+}
+
+struct FungibleAssetView: View {
   var image: AssetIconView
   var title: String
   var symbol: String
   let networkName: String
-  var amount: String
-  var quantity: String
+  var fiat: String
+  var balance: String
   let shouldHideBalance: Bool
+  /// All BTC balance types (only there is a pending balance to indicate to user)
+  let btcBalances: [String: [BTCBalanceType: Double]]?
 
   @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
 
@@ -22,17 +81,19 @@ struct PortfolioAssetView: View {
     title: String,
     symbol: String,
     networkName: String,
-    amount: String,
-    quantity: String,
-    shouldHideBalance: Bool = false
+    fiat: String,
+    balance: String,
+    shouldHideBalance: Bool = false,
+    btcBalances: [String: [BTCBalanceType: Double]]? = nil
   ) {
     self.image = image
     self.title = title
     self.symbol = symbol
     self.networkName = networkName
-    self.amount = amount
-    self.quantity = quantity
+    self.fiat = fiat
+    self.balance = balance
     self.shouldHideBalance = shouldHideBalance
+    self.btcBalances = btcBalances
   }
 
   var body: some View {
@@ -47,9 +108,9 @@ struct PortfolioAssetView: View {
             Text("****")
           } else {
             VStack(alignment: .trailing) {
-              Text(amount.isEmpty ? "0.0" : amount)
+              Text(fiat.isEmpty ? "0.0" : fiat)
                 .fontWeight(.semibold)
-              Text(verbatim: "\(quantity) \(symbol)")
+              Text(verbatim: "\(balance) \(symbol)")
             }
             .multilineTextAlignment(.trailing)
           }
@@ -58,20 +119,20 @@ struct PortfolioAssetView: View {
         .foregroundColor(Color(.braveLabel))
       }
     )
-    .accessibilityLabel("\(title), \(quantity) \(symbol), \(amount)")
+    .accessibilityLabel("\(title), \(balance) \(symbol), \(fiat)")
   }
 }
 
 #if DEBUG
-struct PortfolioAssetView_Previews: PreviewProvider {
+struct FungibleAssetView_Previews: PreviewProvider {
   static var previews: some View {
-    PortfolioAssetView(
+    FungibleAssetView(
       image: AssetIconView(token: .previewToken, network: .mockMainnet),
       title: "Basic Attention Token",
       symbol: "BAT",
       networkName: "Ethereum Mainnet Beta",
-      amount: "$10,402.22",
-      quantity: "10303"
+      fiat: "$10,402.22",
+      balance: "10303"
     )
     .previewLayout(.sizeThatFits)
     .previewColorSchemes()

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/FungibleAssetView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/FungibleAssetView.swift
@@ -17,9 +17,19 @@ struct FungibleAssetButton: View {
   @Binding var bitcoinBalanceDetails: BitcoinBalanceDetails?
   let action: (BraveWallet.BlockchainToken) -> Void
   
+  private var showUnavailableBTCBalanceBanner: Bool {
+    guard asset.token.coin == .btc else {
+      return false
+    }
+    let sumOfPendingBalances = asset.btcBalances
+      .compactMap({ $0.value[.pending] })
+      .reduce(0.0, +)
+    return sumOfPendingBalances != 0
+  }
+  
   var body: some View {
     // Avoid button inside a button for `UnavailableBTCBalanceView`
-    if asset.btcBalances.compactMap({ $0.value[.pending] }).reduce(0.0, +) > 0 {
+    if showUnavailableBTCBalanceBanner {
       VStack(spacing: 0) {
         assetViewButton
         

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
@@ -111,25 +111,15 @@ struct PortfolioAssetsView: View {
   /// Builds the list of assets without any grouping or expandable / collapse behaviour.
   @ViewBuilder private func ungroupedAssets(_ group: AssetGroupViewModel) -> some View {
     ForEach(group.assets) { asset in
-      Button {
-        selectedToken = asset.token
-      } label: {
-        PortfolioAssetView(
-          image: AssetIconView(
-            token: asset.token,
-            network: asset.network,
-            shouldShowNetworkIcon: true
-          ),
-          title: asset.token.name,
-          symbol: asset.token.symbol,
-          networkName: asset.network.chainName,
-          amount: asset.fiatAmount(currencyFormatter: portfolioStore.currencyFormatter),
-          quantity: asset.quantity,
-          shouldHideBalance: true
-        )
-      }
+      FungibleAssetButton(
+        asset: asset,
+        shouldShowContainerForBitcoin: true,
+        currencyFormatter: portfolioStore.currencyFormatter,
+        action: { token in
+          selectedToken = token
+        }
+      )
     }
-    .padding(.horizontal)
   }
 
   /// Builds the expandable/collapseable (expanded by default) section content for a given group.
@@ -145,23 +135,14 @@ struct PortfolioAssetsView: View {
       content: {
         LazyVStack(spacing: 8) {
           ForEach(group.assets) { asset in
-            Button {
-              selectedToken = asset.token
-            } label: {
-              PortfolioAssetView(
-                image: AssetIconView(
-                  token: asset.token,
-                  network: asset.network,
-                  shouldShowNetworkIcon: true
-                ),
-                title: asset.token.name,
-                symbol: asset.token.symbol,
-                networkName: asset.network.chainName,
-                amount: asset.fiatAmount(currencyFormatter: portfolioStore.currencyFormatter),
-                quantity: asset.quantity,
-                shouldHideBalance: true
-              )
-            }
+            FungibleAssetButton(
+              asset: asset,
+              shouldShowContainerForBitcoin: false,
+              currencyFormatter: portfolioStore.currencyFormatter,
+              action: { token in
+                selectedToken = token
+              }
+            )
           }
         }
       },

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioAssetsView.swift
@@ -17,6 +17,7 @@ struct PortfolioAssetsView: View {
 
   @Binding var isPresentingEditUserAssets: Bool
   @Binding var isPresentingFilters: Bool
+  @Binding var bitcoinBalanceDetails: BitcoinBalanceDetails?
   @State private var selectedToken: BraveWallet.BlockchainToken?
   @State private var groupToggleState: [AssetGroupViewModel.ID: Bool] = [:]
   @ObservedObject private var isShowingBalances = Preferences.Wallet.isShowingBalances
@@ -115,6 +116,7 @@ struct PortfolioAssetsView: View {
         asset: asset,
         shouldShowContainerForBitcoin: true,
         currencyFormatter: portfolioStore.currencyFormatter,
+        bitcoinBalanceDetails: $bitcoinBalanceDetails,
         action: { token in
           selectedToken = token
         }
@@ -139,6 +141,7 @@ struct PortfolioAssetsView: View {
               asset: asset,
               shouldShowContainerForBitcoin: false,
               currencyFormatter: portfolioStore.currencyFormatter,
+              bitcoinBalanceDetails: $bitcoinBalanceDetails,
               action: { token in
                 selectedToken = token
               }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -31,6 +31,7 @@ struct PortfolioView: View {
   @State private var isPresentingAssetsFilters: Bool = false
   @State private var isPresentingAddCustomNFT: Bool = false
   @State private var isPresentingNFTsFilters: Bool = false
+  @State private var bitcoinBalanceDetails: BitcoinBalanceDetails?
 
   var body: some View {
     ScrollView {
@@ -123,6 +124,26 @@ struct PortfolioView: View {
           })
         }
     )
+    .background(
+      Color.clear
+        .sheet(
+          isPresented: Binding(
+            get: { bitcoinBalanceDetails != nil },
+            set: {
+              if !$0 {
+                bitcoinBalanceDetails = nil
+              }
+            }
+          )
+        ) {
+          if let bitcoinBalanceDetails {
+            BTCBalanceDetailsView(
+              details: bitcoinBalanceDetails,
+              currencyFormatter: .usdCurrencyFormatter
+            )
+          }
+        }
+    )
   }
 
   private var contentDrawer: some View {
@@ -140,7 +161,8 @@ struct PortfolioView: View {
             networkStore: networkStore,
             portfolioStore: portfolioStore,
             isPresentingEditUserAssets: $isPresentingEditUserAssets,
-            isPresentingFilters: $isPresentingAssetsFilters
+            isPresentingFilters: $isPresentingAssetsFilters,
+            bitcoinBalanceDetails: $bitcoinBalanceDetails
           )
           .padding(.horizontal, 8)
         } else {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioView.swift
@@ -48,6 +48,9 @@ struct PortfolioView: View {
         contentDrawer
       }
     }
+    .onAppear {
+      portfolioStore.update()
+    }
     .background(
       VStack(spacing: 0) {
         Color(braveSystemName: .pageBackground)  // top scroll rubberband area

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -109,8 +109,10 @@ public struct AssetViewModel: Identifiable, Equatable {
   let network: BraveWallet.NetworkInfo
   let price: String
   let history: [BraveWallet.AssetTimePrice]
-  /// Balance for each account for this asset. The key is the account.cacheBalanceKey.
+  /// Balance for each account for this asset. The key is the account.id.
   let balanceForAccounts: [String: Double]
+  /// All BTC balance types for each account. Key is `account.id`.
+  let btcBalances: [String: [BTCBalanceType: Double]]
   /// The total balance for all accounts for this asset.
   var totalBalance: Double {
     balanceForAccounts.values.reduce(0, +)
@@ -242,6 +244,8 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
   @Published private(set) var historicalBalances: [BalanceTimePrice] = []
   /// Whether or not balances are still currently loading
   @Published private(set) var isLoadingBalances: Bool = false
+  /// The BTC balances for each Bitcoin account.  Key is `account.id`.
+  @Published private(set) var accountsBTCBalances: [String: [BTCBalanceType: Double]] = [:]
   /// The current default base currency code
   @Published private(set) var currencyCode: String = CurrencyCode.usd.code {
     didSet {
@@ -491,6 +495,27 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
         }
       }
 
+      if selectedAccounts.contains(where: { $0.coin == .btc }) {
+        /// We  need to know if user has pending balance to show/hide banner. Re-fetch on view load.
+        self.accountsBTCBalances = await withTaskGroup(of: [String: [BTCBalanceType: Double]].self)
+        {
+          [bitcoinWalletService] group in
+          for account in selectedAccounts where account.coin == .btc {
+            group.addTask {
+              let btcBalances = await bitcoinWalletService.fetchBTCBalances(
+                accountId: account.accountId
+              )
+              return [account.id: btcBalances]
+            }
+          }
+          var accountsBTCBalances: [String: [BTCBalanceType: Double]] = [:]
+          for await accountBTCBalances in group {
+            accountsBTCBalances.merge(with: accountBTCBalances)
+          }
+          return accountsBTCBalances
+        }
+      }
+
       // Looping through `allTokenNetworkAccounts` to get token's cached balance
       for tokenNetworkAccounts in allTokenNetworkAccounts {
         if let tokenBalances = assetManager.getBalances(
@@ -664,6 +689,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
           groupType: .none,
           assets: buildAssetViewModels(
             for: .none,
+            accounts: selectedAccounts,
             allVisibleUserAssets: allVisibleUserAssets
           )
         )
@@ -673,6 +699,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
         let groupType: AssetGroupType = .account(account)
         let assets = buildAssetViewModels(
           for: .account(account),
+          accounts: selectedAccounts,
           allVisibleUserAssets: allVisibleUserAssets
         )
         return AssetGroupViewModel(
@@ -685,6 +712,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
         let groupType: AssetGroupType = .network(network)
         let assets = buildAssetViewModels(
           for: groupType,
+          accounts: selectedAccounts,
           allVisibleUserAssets: allVisibleUserAssets
         )
         return AssetGroupViewModel(
@@ -710,6 +738,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
 
   private func buildAssetViewModels(
     for groupType: AssetGroupType,
+    accounts: [BraveWallet.AccountInfo],
     allVisibleUserAssets: [NetworkAssets]
   ) -> [AssetViewModel] {
     let selectedAccounts = self.filters.accounts.filter(\.isSelected).map(\.model)
@@ -717,7 +746,20 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
     case .none:
       return allVisibleUserAssets.flatMap { networkAssets in
         networkAssets.tokens.map { token in
-          AssetViewModel(
+          var btcBalancesForToken: [String: [BTCBalanceType: Double]] = [:]
+          if token.coin == .btc {
+            let keyringIdForToken = BraveWallet.KeyringId.keyringId(for: .btc, on: token.chainId)
+            let accountIdsForToken =
+              accounts
+              .filter({ $0.keyringId == keyringIdForToken })
+              .map(\.accountId)
+            btcBalancesForToken = accountsBTCBalances.filter({ item in
+              accountIdsForToken.contains(where: { accountId in
+                item.key == accountId.uniqueKey
+              })
+            })
+          }
+          return AssetViewModel(
             groupType: groupType,
             token: token,
             network: networkAssets.network,
@@ -728,7 +770,8 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
                 // if we previously fetched balance for an account it will remain in cache.
                 // filter out to avoid including in total balance
                 selectedAccounts.contains(where: { $0.id == key })
-              }
+              },
+            btcBalances: btcBalancesForToken
           )
         }
       }
@@ -751,6 +794,19 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
       else {
         return []
       }
+      var btcBalancesForNetwork: [String: [BTCBalanceType: Double]] = [:]
+      if network.coin == .btc {
+        let keyringIdForNetwork = BraveWallet.KeyringId.keyringId(for: .btc, on: network.chainId)
+        let accountIdsForToken =
+          accounts
+          .filter({ $0.keyringId == keyringIdForNetwork })
+          .map(\.accountId)
+        btcBalancesForNetwork = accountsBTCBalances.filter({ item in
+          accountIdsForToken.contains(where: { accountId in
+            item.key == accountId.uniqueKey
+          })
+        })
+      }
       return networkAssets.tokens
         .map { token in
           AssetViewModel(
@@ -764,7 +820,8 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
                 // if we previously fetched balance for an account it will remain in cache.
                 // filter out to avoid including in total balance
                 selectedAccounts.contains(where: { $0.id == key })
-              }
+              },
+            btcBalances: btcBalancesForNetwork
           )
         }
         .optionallyFilter(
@@ -798,7 +855,8 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
                 .filter { key, value in
                   // only provide grouped account balance
                   key == account.id
-                }
+                },
+              btcBalances: accountsBTCBalances.filter({ $0.key == account.id })
             )
           }
         }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -495,6 +495,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
         }
       }
 
+      guard !Task.isCancelled else { return }
       if selectedAccounts.contains(where: { $0.coin == .btc }) {
         /// We  need to know if user has pending balance to show/hide banner. Re-fetch on view load.
         self.accountsBTCBalances = await withTaskGroup(of: [String: [BTCBalanceType: Double]].self)
@@ -586,6 +587,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
         }
       }
 
+      guard !Task.isCancelled else { return }
       // fetch price for every token
       let allTokens = allVisibleUserAssets.flatMap(\.tokens)
       let allAssetRatioIds = allTokens.map(\.assetRatioId)

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/UserAssetsStore.swift
@@ -296,7 +296,8 @@ public class UserAssetsStore: ObservableObject, WalletObserverStore {
           network: networkAssets.network,
           price: "",
           history: [],
-          balanceForAccounts: [:]
+          balanceForAccounts: [:],
+          btcBalances: [:]
         )
       }
     }

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -5509,5 +5509,54 @@ extension Strings {
       comment:
         "The disclosure at the bottom of the deposit view for ETH address indicates ETH wallet supports Ethereum Mainnet as well as the level 2 EVM. `%@` will be replaced with current supported level 2 EVM network names."
     )
+    public static let btcPendingBalancesBannerDesc = NSLocalizedString(
+      "wallet.btcPendingBalancesBannerDesc",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Some balances may be unavailable",
+      comment: "Banner description displayed below BTC rows displaying balance when there is a pending BTC balance."
+    )
+    public static let btcAvailableBalanceTitle = NSLocalizedString(
+      "wallet.btcAvailableBalanceTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Available",
+      comment: "Title displayed in row beside users available BTC balance."
+    )
+    public static let btcAvailableBalanceDesc = NSLocalizedString(
+      "wallet.btcAvailableBalanceDesc",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Funds available for you to use.",
+      comment: "Description displayed in row beside users available balance."
+    )
+    public static let btcPendingBalanceTitle = NSLocalizedString(
+      "wallet.btcPendingBalanceTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Pending",
+      comment: "Title displayed in row beside users pending BTC balance."
+    )
+    public static let btcPendingBalanceDesc = NSLocalizedString(
+      "wallet.btcPendingBalanceDesc",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "A pending change in your wallet balance.",
+      comment: "Description displayed in row beside users pending balance."
+    )
+    public static let btcTotalBalanceTitle = NSLocalizedString(
+      "wallet.btcTotalBalanceTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Total",
+      comment: "Title displayed in row beside users total BTC balance."
+    )
+    public static let btcTotalBalanceDesc = NSLocalizedString(
+      "wallet.btcTotalBalanceDesc",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Your available funds plus any not-yet-confirmed transactions.",
+      comment: "Description displayed in row beside users total balance."
+    )
   }
 }

--- a/ios/brave-ios/Tests/BraveWalletTests/WalletArrayExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/WalletArrayExtensionTests.swift
@@ -62,7 +62,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockMainnet,
       price: "1000",
       history: [],
-      balanceForAccounts: [account1.id: 1]
+      balanceForAccounts: [account1.id: 1],
+      btcBalances: [:]
     )
     // USDC value $500
     let viewModel2: AssetViewModel = .init(
@@ -71,7 +72,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockMainnet,
       price: "500",
       history: [],
-      balanceForAccounts: [account1.id: 1]
+      balanceForAccounts: [account1.id: 1],
+      btcBalances: [:]
     )
     // SOL value $500
     let viewModel3: AssetViewModel = .init(
@@ -80,7 +82,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockSolana,
       price: "500",
       history: [],
-      balanceForAccounts: [account2.id: 1]
+      balanceForAccounts: [account2.id: 1],
+      btcBalances: [:]
     )
     // FIL value $100 on mainnet
     let viewModel4: AssetViewModel = .init(
@@ -89,7 +92,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockFilecoinMainnet,
       price: "100",
       history: [],
-      balanceForAccounts: [account3.id: 1]
+      balanceForAccounts: [account3.id: 1],
+      btcBalances: [:]
     )
     // BTC value $20000 on mainnet
     let viewModel5: AssetViewModel = .init(
@@ -98,7 +102,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockBitcoinMainnet,
       price: "20000",
       history: [],
-      balanceForAccounts: [account4.id: 1]
+      balanceForAccounts: [account4.id: 1],
+      btcBalances: [:]
     )
     // FIL value $100 on testnet
     let viewModel6: AssetViewModel = .init(
@@ -107,7 +112,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockFilecoinTestnet,
       price: "50",
       history: [],
-      balanceForAccounts: [testAccount1.id: 2]
+      balanceForAccounts: [testAccount1.id: 2],
+      btcBalances: [:]
     )
     // BTC value $40000 on testnet
     let viewModel7: AssetViewModel = .init(
@@ -116,7 +122,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockBitcoinTestnet,
       price: "20000",
       history: [],
-      balanceForAccounts: [testAccount2.id: 2]
+      balanceForAccounts: [testAccount2.id: 2],
+      btcBalances: [:]
     )
     let array: [AssetViewModel] = [
       viewModel1, viewModel2,
@@ -153,7 +160,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockMainnet,
       price: "1000",
       history: [],
-      balanceForAccounts: [account1.id: 1]
+      balanceForAccounts: [account1.id: 1],
+      btcBalances: [:]
     )
     // USDC value $500
     var viewModel2: AssetViewModel = .init(
@@ -162,7 +170,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockMainnet,
       price: "500",
       history: [],
-      balanceForAccounts: [account1.id: 1]
+      balanceForAccounts: [account1.id: 1],
+      btcBalances: [:]
     )
     // SOL value $100
     var viewModel3: AssetViewModel = .init(
@@ -171,7 +180,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockSolana,
       price: "100",
       history: [],
-      balanceForAccounts: [account2.id: 1]
+      balanceForAccounts: [account2.id: 1],
+      btcBalances: [:]
     )
     // FIL value $100 on mainnet
     var viewModel4: AssetViewModel = .init(
@@ -180,7 +190,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockFilecoinMainnet,
       price: "100",
       history: [],
-      balanceForAccounts: [account3.id: 1]
+      balanceForAccounts: [account3.id: 1],
+      btcBalances: [:]
     )
     // BTC value $20000 on mainnet
     var viewModel5: AssetViewModel = .init(
@@ -189,7 +200,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockBitcoinMainnet,
       price: "20000",
       history: [],
-      balanceForAccounts: [account4.id: 1]
+      balanceForAccounts: [account4.id: 1],
+      btcBalances: [:]
     )
     // FIL value $100 on testnet
     var viewModel6: AssetViewModel = .init(
@@ -198,7 +210,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockFilecoinTestnet,
       price: "50",
       history: [],
-      balanceForAccounts: [testAccount1.id: 2]
+      balanceForAccounts: [testAccount1.id: 2],
+      btcBalances: [:]
     )
     // BTC value $100 on testnet
     var viewModel7: AssetViewModel = .init(
@@ -207,7 +220,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockBitcoinTestnet,
       price: "20000",
       history: [],
-      balanceForAccounts: [testAccount2.id: 0.005]
+      balanceForAccounts: [testAccount2.id: 0.005],
+      btcBalances: [:]
     )
     var group1: AssetGroupViewModel = .init(
       groupType: .account(account1),
@@ -256,7 +270,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockMainnet,
       price: "1000",
       history: [],
-      balanceForAccounts: [account1.id: 1]
+      balanceForAccounts: [account1.id: 1],
+      btcBalances: [:]
     )
     // USDC value $500
     viewModel2 = .init(
@@ -265,7 +280,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockMainnet,
       price: "500",
       history: [],
-      balanceForAccounts: [account1.id: 1]
+      balanceForAccounts: [account1.id: 1],
+      btcBalances: [:]
     )
     // SOL value $100
     viewModel3 = .init(
@@ -274,7 +290,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockSolana,
       price: "100",
       history: [],
-      balanceForAccounts: [account2.id: 1]
+      balanceForAccounts: [account2.id: 1],
+      btcBalances: [:]
     )
     // FIL value $100 on mainnet
     viewModel4 = .init(
@@ -283,7 +300,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockFilecoinMainnet,
       price: "100",
       history: [],
-      balanceForAccounts: [account3.id: 1]
+      balanceForAccounts: [account3.id: 1],
+      btcBalances: [:]
     )
     // BTC value $20000 on mainnet
     viewModel5 = .init(
@@ -292,7 +310,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockBitcoinMainnet,
       price: "20000",
       history: [],
-      balanceForAccounts: [account4.id: 1]
+      balanceForAccounts: [account4.id: 1],
+      btcBalances: [:]
     )
     // FIL value $100 on testnet
     viewModel6 = .init(
@@ -301,7 +320,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockFilecoinTestnet,
       price: "50",
       history: [],
-      balanceForAccounts: [testAccount1.id: 2]
+      balanceForAccounts: [testAccount1.id: 2],
+      btcBalances: [:]
     )
     // BTC value $100 on testnet
     viewModel7 = .init(
@@ -310,7 +330,8 @@ class WalletArrayExtensionTests: XCTestCase {
       network: .mockBitcoinTestnet,
       price: "20000",
       history: [],
-      balanceForAccounts: [testAccount2.id: 0.005]
+      balanceForAccounts: [testAccount2.id: 0.005],
+      btcBalances: [:]
     )
     group1 = .init(
       groupType: .network(.mockMainnet),


### PR DESCRIPTION
Add banner when user has a pending BTC balance, tapping banner will show modal displaying `Available`, `Pending`, and `Total` balance for BTC.

Resolves https://github.com/brave/brave-browser/issues/37640

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create Bitcoin Testnet account
2. Fund one of your account from a Bitcoin Testnet Faucet, or if https://github.com/brave/brave-browser/issues/37958 has landed you can send BTC in from of your accounts to another.
3. Go the Accounts tab and view details for that account
4. You should see an Banner below BTC asset row stating that Some balances may be unavailable
5. Tap on banner / View Details, you should then see the Balance Details Modal
6. Go to the Portfolio tab
7. You should see an Banner below BTC asset row stating that Some balances may be unavailable

![Portfolio - no grouping](https://github.com/brave/brave-core/assets/5314553/df495806-dc7b-4a3f-b7b2-f44e68f1b67a) | ![Portfolio - account grouping](https://github.com/brave/brave-core/assets/5314553/db2bce1c-7dcd-4ddb-b7e4-3760bf473944) | ![Portfolio - network grouping](https://github.com/brave/brave-core/assets/5314553/df139b65-8049-4faf-897f-2ee568224102) | ![Portfolio - account grouping - btc balance details](https://github.com/brave/brave-core/assets/5314553/493a1723-ba48-4daf-871b-419ce46f887a)
--|--|--|--
![Account details](https://github.com/brave/brave-core/assets/5314553/c8a93f2b-35c5-46a8-94eb-94e7bf4f6f2b) | ![Account details - btc balance details](https://github.com/brave/brave-core/assets/5314553/1bfc14f2-4aa0-4240-b539-0e04c600baeb)