### PR TITLE
Set radius for secondary web view and focus border

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -75,8 +75,10 @@
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
 #include "ui/events/event_observer.h"
+#include "ui/gfx/geometry/rounded_corners_f.h"
 #include "ui/views/border.h"
 #include "ui/views/bubble/bubble_dialog_delegate_view.h"
+#include "ui/views/controls/native/native_view_host.h"
 #include "ui/views/event_monitor.h"
 #include "ui/views/layout/fill_layout.h"
 
@@ -417,17 +419,22 @@ void BraveBrowserView::UpdateContentsWebViewBorder() {
 
   DCHECK(split_view_browser_data);
 
-  constexpr auto kFocusRingThickness = 2;
-
-  // TODO(sko) This should be revisited when
-  // features::kBraveWebViewRoundedCorners is enabled
   if (split_view_browser_data->GetTile(GetActiveTabHandle())) {
-    contents_web_view_->SetBorder(views::CreateSolidBorder(
-        kFocusRingThickness, leo::kColorPrimitivePrimary40));
+    auto create_border = [this](SkColor color) {
+      constexpr auto kFocusRingThickness = 2;
+      return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(browser_.get())
+                 ? views::CreateRoundedRectBorder(
+                       kFocusRingThickness,
+                       BraveContentsViewUtil::kBorderRadius +
+                           kFocusRingThickness / 2,
+                       color)
+                 : views::CreateSolidBorder(kFocusRingThickness, color);
+    };
+
+    contents_web_view_->SetBorder(create_border(leo::kColorPrimitivePrimary40));
 
     if (auto* cp = GetColorProvider()) {
-      secondary_contents_web_view_->SetBorder(views::CreateSolidBorder(
-          kFocusRingThickness,
+      secondary_contents_web_view_->SetBorder(create_border(
           cp->GetColor(kColorBraveSplitViewInactiveWebViewBorder)));
     }
   } else {
@@ -1064,39 +1071,57 @@ void BraveBrowserView::UpdateWebViewRoundedCorners() {
   // contents and devtools.
   contents_container_->layer()->SetRoundedCornerRadius(corners);
 
-  // In addition to giving the contents container rounded corners, we also
-  // need to round the corners of the native view holder that displays the web
-  // contents.
+  auto update_corner_radius = [](views::NativeViewHost* contents_holder,
+                                 views::NativeViewHost* devtools_holder,
+                                 DevToolsDockedPlacement devtools_placement,
+                                 gfx::RoundedCornersF corners) {
+    // In addition to giving the contents container rounded corners, we also
+    // need to round the corners of the native view holder that displays the web
+    // contents.
 
-  // Devtools lies underneath the contents webview. Round all four corners.
-  if (devtools_web_view_->holder()) {
-    devtools_web_view_->holder()->SetCornerRadii(corners);
-  }
+    // Devtools lies underneath the contents webview. Round all four corners.
+    if (devtools_holder) {
+      devtools_holder->SetCornerRadii(corners);
+    }
 
-  // In order to make the contents web view and devtools apear to be contained
-  // within a single rounded-corner view, square the contents webview corners
-  // that are adjacent to devtools.
-  switch (devtools_docked_placement()) {
-    case DevToolsDockedPlacement::kLeft:
-      corners.set_upper_left(0);
-      corners.set_lower_left(0);
-      break;
-    case DevToolsDockedPlacement::kRight:
-      corners.set_upper_right(0);
-      corners.set_lower_right(0);
-      break;
-    case DevToolsDockedPlacement::kBottom:
-      corners.set_lower_left(0);
-      corners.set_lower_right(0);
-      break;
-    case DevToolsDockedPlacement::kNone:
-      break;
-    case DevToolsDockedPlacement::kUnknown:
-      break;
-  }
+    // In order to make the contents web view and devtools apear to be contained
+    // within a single rounded-corner view, square the contents webview corners
+    // that are adjacent to devtools.
+    switch (devtools_placement) {
+      case DevToolsDockedPlacement::kLeft:
+        corners.set_upper_left(0);
+        corners.set_lower_left(0);
+        break;
+      case DevToolsDockedPlacement::kRight:
+        corners.set_upper_right(0);
+        corners.set_lower_right(0);
+        break;
+      case DevToolsDockedPlacement::kBottom:
+        corners.set_lower_left(0);
+        corners.set_lower_right(0);
+        break;
+      case DevToolsDockedPlacement::kNone:
+        break;
+      case DevToolsDockedPlacement::kUnknown:
+        break;
+    }
 
-  if (contents_web_view_->holder()) {
-    contents_web_view_->holder()->SetCornerRadii(corners);
+    if (contents_holder) {
+      contents_holder->SetCornerRadii(corners);
+    }
+  };
+
+  update_corner_radius(contents_web_view_->holder(),
+                       devtools_web_view_->holder(),
+                       devtools_docked_placement(), corners);
+
+  if (SplitViewBrowserData::FromBrowser(browser_.get())) {
+    // TODO(sko) We need to override BrowserView::GetDevToolsDockedPlacement().
+    // It depends on coordinate of it but in split view mode, the calculation
+    // is not correct.
+    update_corner_radius(secondary_contents_web_view_->holder(),
+                         secondary_devtools_web_view_->holder(),
+                         DevToolsDockedPlacement::kNone, corners);
   }
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37924

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

