### PR TITLE
Check emptiness of ProxyRules and ProxyList in ProxyConfigServiceTor::SetProxyAuthorization (uplift to 1.65.x)

### DIFF
--- a/net/proxy_resolution/proxy_config_service_tor.h
+++ b/net/proxy_resolution/proxy_config_service_tor.h
@@ -12,6 +12,7 @@
 #include "net/base/net_export.h"
 #include "net/base/proxy_server.h"
 #include "net/proxy_resolution/proxy_config_service.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
 
 class GURL;
 
@@ -52,6 +53,8 @@ class NET_EXPORT ProxyConfigServiceTor : public net::ProxyConfigService {
   // This is useful when we want to test mock requests/responses in tor context
   // with embedded test server.
   static void SetBypassTorProxyConfigForTesting(bool bypass);
+
+  static NetworkTrafficAnnotationTag GetTorAnnotationTagForTesting();
 
  private:
   static bool bypass_tor_proxy_config_for_testing_;

--- a/net/proxy_resolution/proxy_config_service_tor_unittest.cc
+++ b/net/proxy_resolution/proxy_config_service_tor_unittest.cc
@@ -215,6 +215,23 @@ TEST_F(ProxyConfigServiceTorTest, SetProxyAuthorization) {
   proxy_server = info.proxy_chain().GetProxyServer(/*server_index=*/0);
   CheckProxyServer(FROM_HERE, proxy_server, circuit_anonymization_key2);
   EXPECT_NE(proxy_server.host_port_pair().password(), password);
+
+  const auto tag = ProxyConfigServiceTor::GetTorAnnotationTagForTesting();
+  // Empty config
+  const ProxyConfigWithAnnotation empty_config(ProxyConfig(), tag);
+  info = ProxyInfo();
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      empty_config, site_url, network_anonymization_key, service(), &info);
+  EXPECT_TRUE(info.is_empty());
+
+  // Empty proxy rules
+  const ProxyConfigWithAnnotation empty_proxy_rules_config(
+      ProxyConfig::CreateForTesting(ProxyList()), tag);
+  info = ProxyInfo();
+  ProxyConfigServiceTor::SetProxyAuthorization(
+      empty_proxy_rules_config, site_url, network_anonymization_key, service(),
+      &info);
+  EXPECT_TRUE(info.is_empty());
 }
 
 TEST_F(ProxyConfigServiceTorTest, SetProxyAuthorization_Subresources) {


### PR DESCRIPTION
Uplift of #23308
Resolves https://github.com/brave/brave-browser/issues/37884

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.