### PR TITLE
fix(wallet): Close Swap Modal Routing

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -238,7 +238,7 @@ export const SendScreen = React.memo((props: Props) => {
       }
       setToAddressOrUrl('')
       if (account) {
-        history.push(makeSendRoute(asset, account))
+        history.replace(makeSendRoute(asset, account))
       }
     },
     [history]

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
@@ -613,9 +613,9 @@ export const useSwap = () => {
       fromAccount.accountId.coin !== toToken.coin ||
       toCoin !== fromToken.coin
     ) {
-      history.push(WalletRoutes.Swap)
+      history.replace(WalletRoutes.Swap)
     } else {
-      history.push(
+      history.replace(
         makeSwapRoute({
           fromToken: toToken,
           fromAccount,
@@ -649,7 +649,7 @@ export const useSwap = () => {
         return
       }
       setEditingFromOrToAmount('from')
-      history.push(
+      history.replace(
         makeSwapRoute({
           fromToken,
           fromAccount,
@@ -696,7 +696,7 @@ export const useSwap = () => {
       // and the incoming fromToken are on the same network.
       // If not we clear the toToken from params.
       if (toToken && toToken.chainId === token.chainId) {
-        history.push(
+        history.replace(
           makeSwapRoute({
             fromToken: token,
             fromAccount: account,
@@ -706,7 +706,9 @@ export const useSwap = () => {
           })
         )
       } else {
-        history.push(makeSwapRoute({ fromToken: token, fromAccount: account }))
+        history.replace(
+          makeSwapRoute({ fromToken: token, fromAccount: account })
+        )
       }
       setSelectingFromOrTo(undefined)
       setFromAmount('')


### PR DESCRIPTION
## Description 

- Fixes a bug where while on the `Swap` screen in the Wallet `Panel`, clicking the close button would route back to previous selected tokens.

- Replaces `history.push` with `history.replace` when selecting a `Swap` or `Send` asset to update the URL instead or refreshing the page.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/37943>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

   1. Open the `Panel` and navigate to the `Swap` screen
   2. Select a token to swap, then reselect a different token
   3. Click the `Close` button
   4. It should route back to the `Previous` screen

Before:

https://github.com/brave/brave-core/assets/40611140/1e4a113b-79ef-41fe-a149-4222ade2d4d2

After:

https://github.com/brave/brave-core/assets/40611140/3c690293-4067-47c0-8075-32906caf76f4
