### PR TITLE
Rebroadcast Solana transactions every 5 seconds on client side

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1508,6 +1508,7 @@ inline constexpr double kLiFiFeePercentage = 0.875;
 
 constexpr int64_t kBlockTrackerDefaultTimeInSeconds = 20;
 constexpr int64_t kLogTrackerDefaultTimeInSeconds = 20;
+constexpr int64_t kSolanaBlockTrackerTimeInSeconds = 5;
 
 inline constexpr char kPolygonMainnetEndpoint[] =
     "https://mainnet-polygon.brave.com/";

--- a/components/brave_wallet/browser/solana_block_tracker.cc
+++ b/components/brave_wallet/browser/solana_block_tracker.cc
@@ -20,9 +20,9 @@ namespace brave_wallet {
 namespace {
 
 constexpr base::TimeDelta kExpiredTimeDelta =
-    base::Seconds(kBlockTrackerDefaultTimeInSeconds);
+    base::Seconds(kSolanaBlockTrackerTimeInSeconds);
 
-}
+}  // namespace
 
 SolanaBlockTracker::SolanaBlockTracker(JsonRpcService* json_rpc_service)
     : json_rpc_service_(json_rpc_service), weak_ptr_factory_(this) {}

--- a/components/brave_wallet/browser/solana_block_tracker_unittest.cc
+++ b/components/brave_wallet/browser/solana_block_tracker_unittest.cc
@@ -248,11 +248,11 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashWithoutStartTracker) {
                            mojom::SolanaProviderError::kSuccess, "");
     EXPECT_TRUE(testing::Mock::VerifyAndClearExpectations(&observer));
 
-    // Cached value would expire after kBlockTrackerDefaultTimeInSeconds.
+    // Cached value would expire after kSolanaBlockTrackerTimeInSeconds.
     response_blockhash_ = "hash3";
     response_last_valid_block_height_ = 3490;
     task_environment_.FastForwardBy(
-        base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+        base::Seconds(kSolanaBlockTrackerTimeInSeconds));
     EXPECT_CALL(observer, OnLatestBlockhashUpdated(chain_id, "hash3", 3490u))
         .Times(1);
     TestGetLatestBlockhash(FROM_HERE, chain_id, true, "hash3", 3490,
@@ -278,7 +278,7 @@ TEST_F(SolanaBlockTrackerUnitTest, GetLatestBlockhashWithoutStartTracker) {
     TestGetLatestBlockhash(FROM_HERE, chain_id, true, "hash3", 3490,
                            mojom::SolanaProviderError::kSuccess, "");
     task_environment_.FastForwardBy(
-        base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+        base::Seconds(kSolanaBlockTrackerTimeInSeconds));
     TestGetLatestBlockhash(FROM_HERE, chain_id, false, "", 0,
                            mojom::SolanaProviderError::kInternalError,
                            l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR));

--- a/components/brave_wallet/browser/solana_transaction.cc
+++ b/components/brave_wallet/browser/solana_transaction.cc
@@ -188,7 +188,7 @@ SolanaTransaction::~SolanaTransaction() = default;
 
 bool SolanaTransaction::operator==(const SolanaTransaction& tx) const {
   return message_ == tx.message_ && raw_signatures_ == tx.raw_signatures_ &&
-         sign_tx_param_ == tx.sign_tx_param_ &&
+         wired_tx_ == tx.wired_tx_ && sign_tx_param_ == tx.sign_tx_param_ &&
          to_wallet_address_ == tx.to_wallet_address_ &&
          spl_token_mint_address_ == tx.spl_token_mint_address_ &&
          tx_type_ == tx.tx_type_ && lamports_ == tx.lamports_ &&
@@ -368,6 +368,8 @@ base::Value::Dict SolanaTransaction::ToValue() const {
   dict.Set("tx_type", static_cast<int>(tx_type_));
   dict.Set("lamports", base::NumberToString(lamports_));
   dict.Set("amount", base::NumberToString(amount_));
+  dict.Set("wired_tx", wired_tx_);
+
   if (send_options_) {
     dict.Set(kSendOptions, send_options_->ToValue());
   }
@@ -454,6 +456,12 @@ std::unique_ptr<SolanaTransaction> SolanaTransaction::FromValue(
     return nullptr;
   }
   tx->set_amount(amount);
+
+  const auto* wired_tx = value.FindString("wired_tx");
+  if (wired_tx) {
+    tx->set_wired_tx(*wired_tx);
+  }
+
   const base::Value::Dict* send_options_value = value.FindDict(kSendOptions);
   if (send_options_value) {
     tx->set_send_options(SendOptions::FromValue(*send_options_value));

--- a/components/brave_wallet/browser/solana_transaction.h
+++ b/components/brave_wallet/browser/solana_transaction.h
@@ -111,6 +111,7 @@ class SolanaTransaction {
   std::optional<SolanaTransaction::SendOptions> send_options() const {
     return send_options_;
   }
+  const std::string& wired_tx() const { return wired_tx_; }
 
   void set_to_wallet_address(const std::string& to_wallet_address) {
     to_wallet_address_ = to_wallet_address;
@@ -127,12 +128,19 @@ class SolanaTransaction {
   void set_sign_tx_param(mojom::SolanaSignTransactionParamPtr sign_tx_param) {
     sign_tx_param_ = std::move(sign_tx_param);
   }
+  void set_wired_tx(const std::string& wired_tx) { wired_tx_ = wired_tx; }
 
  private:
   FRIEND_TEST_ALL_PREFIXES(SolanaTransactionUnitTest, GetBase64EncodedMessage);
   SolanaMessage message_;
   // Value will be assigned when FromSignedTransactionBytes is called.
   std::vector<uint8_t> raw_signatures_;
+
+  // Base64 encoded serialized transaction to be sent to the Solana network,
+  // value will be assigned before we call
+  // JsonRPCService::SendSolanaTransaction and reused when we rebroadcast the
+  // transaction.
+  std::string wired_tx_;
 
   // Passed by dApp when calling signAndSendTransaction, signTransaction,
   // signAllTransactions provider APIs, which includes serialized message and

--- a/components/brave_wallet/browser/solana_transaction_unittest.cc
+++ b/components/brave_wallet/browser/solana_transaction_unittest.cc
@@ -627,6 +627,7 @@ TEST_F(SolanaTransactionUnitTest, FromToValue) {
         "lamports": "10000000",
         "amount": "0",
         "tx_type": 6,
+        "wired_tx": "",
         "send_options": {
           "maxRetries": "1",
           "preflightCommitment": "confirmed",

--- a/components/brave_wallet/browser/solana_tx_manager.h
+++ b/components/brave_wallet/browser/solana_tx_manager.h
@@ -101,6 +101,8 @@ class SolanaTxManager : public TxManager, public SolanaBlockTracker::Observer {
   FRIEND_TEST_ALL_PREFIXES(SolanaTxManagerUnitTest,
                            DropTxWithInvalidBlockhash_DappBlockhash);
   FRIEND_TEST_ALL_PREFIXES(SolanaTxManagerUnitTest,
+                           DropTxAfterSafeDropThreshold);
+  FRIEND_TEST_ALL_PREFIXES(SolanaTxManagerUnitTest,
                            GetTransactionMessageToSign);
   FRIEND_TEST_ALL_PREFIXES(SolanaTxManagerUnitTest,
                            ProcessSolanaHardwareSignature);

--- a/components/brave_wallet/browser/solana_tx_meta_unittest.cc
+++ b/components/brave_wallet/browser/solana_tx_meta_unittest.cc
@@ -293,6 +293,7 @@ TEST(SolanaTxMetaUnitTest, ToValue) {
         "spl_token_mint_address": "",
         "lamports": "10000000",
         "amount": "0",
+        "wired_tx": "",
         "tx_type": 6
       },
       "signature_status": {

--- a/components/brave_wallet/browser/tx_manager.cc
+++ b/components/brave_wallet/browser/tx_manager.cc
@@ -99,9 +99,11 @@ void TxManager::CheckIfBlockTrackerShouldRun(
     }
     for (const auto& chain_id : new_pending_chain_ids) {
       bool running = block_tracker_->IsRunning(chain_id);
+      auto interval = GetCoinType() == mojom::CoinType::SOL
+                          ? base::Seconds(kSolanaBlockTrackerTimeInSeconds)
+                          : base::Seconds(kBlockTrackerDefaultTimeInSeconds);
       if (!running) {
-        block_tracker_->Start(chain_id,
-                              base::Seconds(kBlockTrackerDefaultTimeInSeconds));
+        block_tracker_->Start(chain_id, interval);
       }
     }
     pending_chain_ids_ = new_pending_chain_ids;


### PR DESCRIPTION
This is done to increase the successful rate of Solana transactions, we rebroadcast on client side rather than sorely depend on remote RPC node's retry queue.
This is safe because the same exact transaction (same signature) will not be accepted by the network twice.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37310

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
A quick spot check for sending transactions.
I also manually test locally with custom log added to ensure the rebroadcast behavior is as expected.