### PR TITLE
Wraps autofill main method to prevent a crash on Android

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -869,3 +869,11 @@
 -keep class org.chromium.chrome.browser.compositor.layouts.BraveToolbarSwipeLayout {
     public <init>(...);
 }
+
+-keep class org.chromium.components.embedder_support.view.ContentView {
+    protected <init>(...);
+}
+
+-keep class org.chromium.components.embedder_support.view.BraveContentView {
+    protected <init>(...);
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -141,8 +141,10 @@ import org.chromium.components.omnibox.action.OmniboxActionDelegate;
 import org.chromium.components.permissions.PermissionDialogController;
 import org.chromium.components.signin.base.AccountInfo;
 import org.chromium.content_public.browser.BrowserContextHandle;
+import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.ViewProvider;
 import org.chromium.ui.base.ActivityWindowAndroid;
+import org.chromium.ui.base.EventOffsetHandler;
 import org.chromium.ui.base.IntentRequestTracker;
 import org.chromium.ui.base.WindowAndroid;
 import org.chromium.ui.base.WindowDelegate;
@@ -1386,6 +1388,13 @@ public class BytecodeTest {
                         BrowserControlsStateProvider.class,
                         LayoutManager.class,
                         TopUiThemeColorProvider.class));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/components/embedder_support/view/ContentView",
+                        "org/chromium/components/embedder_support/view/BraveContentView",
+                        Context.class,
+                        EventOffsetHandler.class,
+                        WebContents.class));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -35,6 +35,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveClassVisitor.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveCommandLineInitUtilClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveContentSettingsResourcesClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveContentViewClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveCustomizationProviderDelegateImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveDefaultBrowserPromoUtilsClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveDownloadMessageUiControllerImplClassAdapter.java",

--- a/build/android/bytecode/bytecode_rewriter.gni
+++ b/build/android/bytecode/bytecode_rewriter.gni
@@ -40,6 +40,7 @@ brave_bytecode_jars = [
   "obj/chrome/browser/ui/android/toolbar/java.javac.jar",
   "obj/components/browser_ui/notifications/android/java.javac.jar",
   "obj/components/browser_ui/site_settings/android/java.javac.jar",
+  "obj/components/embedder_support/android/content_view_java.javac.jar",
   "obj/components/external_intents/android/java.javac.jar",
   "obj/components/permissions/android/java.javac.jar",
   "obj/components/sync/android/sync_java.javac.jar",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -34,6 +34,7 @@ public class BraveClassAdapter {
         chain = new BraveChromeContextMenuPopulatorAdapter(chain);
         chain = new BraveCommandLineInitUtilClassAdapter(chain);
         chain = new BraveContentSettingsResourcesClassAdapter(chain);
+        chain = new BraveContentViewClassAdapter(chain);
         chain = new BraveCustomizationProviderDelegateImplClassAdapter(chain);
         chain = new BraveDefaultBrowserPromoUtilsClassAdapter(chain);
         chain = new BraveDownloadMessageUiControllerImplClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveContentViewClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveContentViewClassAdapter.java
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveContentViewClassAdapter extends BraveClassVisitor {
+    static String sContentViewClassName =
+            "org/chromium/components/embedder_support/view/ContentView";
+    static String sBraveContentViewClassName =
+            "org/chromium/components/embedder_support/view/BraveContentView";
+
+    public BraveContentViewClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(sContentViewClassName, sBraveContentViewClassName);
+    }
+}

--- a/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/BraveContentView.java
+++ b/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/BraveContentView.java
@@ -1,0 +1,37 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.components.embedder_support.view;
+
+import android.content.Context;
+import android.view.ViewStructure;
+
+import org.chromium.base.JavaExceptionReporter;
+import org.chromium.base.task.PostTask;
+import org.chromium.base.task.TaskTraits;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.ui.base.EventOffsetHandler;
+
+/** That class extends upstream's ContentView.java to prevent a browser process crash */
+public class BraveContentView extends ContentView {
+    protected BraveContentView(
+            Context context, EventOffsetHandler eventOffsetHandler, WebContents webContents) {
+        super(context, eventOffsetHandler, webContents);
+    }
+
+    @Override
+    public void onProvideAutofillVirtualStructure(ViewStructure structure, int flags) {
+        try {
+            super.onProvideAutofillVirtualStructure(structure, flags);
+        } catch (NullPointerException exception) {
+            // We still want the stack to be reported with a hope to fix that issue
+            // one day. See https://github.com/brave/brave-browser/issues/37942 for
+            // details
+            PostTask.postTask(
+                    TaskTraits.UI_BEST_EFFORT,
+                    () -> JavaExceptionReporter.reportException(exception));
+        }
+    }
+}

--- a/components/embedder_support/android/java_sources.gni
+++ b/components/embedder_support/android/java_sources.gni
@@ -3,4 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-brave_components_embedder_support_java_sources = [ "//brave/components/embedder_support/android/java/src/org/chromium/components/embedder_support/util/BraveUrlConstants.java" ]
+brave_components_embedder_support_java_sources = [
+  "//brave/components/embedder_support/android/java/src/org/chromium/components/embedder_support/util/BraveUrlConstants.java",
+  "//brave/components/embedder_support/android/java/src/org/chromium/components/embedder_support/view/BraveContentView.java",
+]


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37942
That PR just prevents the main browser process from crashing, the root cause is still unknown and we still be reporting the stack without crashing however.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

