### PR TITLE
Add https strict mode and interstitial

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -206,6 +206,7 @@ public class AppState {
       (IPFSSchemeHandler.path, IPFSSchemeHandler()),
       (Web3DomainHandler.path, Web3DomainHandler()),
       (BlockedDomainHandler.path, BlockedDomainHandler()),
+      (HTTPBlockedHandler.path, HTTPBlockedHandler()),
     ]
 
     responders.forEach { (path, responder) in

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -469,6 +469,7 @@ var braveTarget: PackageDescription.Target = .target(
     .copy("Assets/Fonts/NewYorkMedium-Regular.otf"),
     .copy("Assets/Fonts/NewYorkMedium-RegularItalic.otf"),
     .copy("Assets/Interstitial Pages/Pages/BlockedDomain.html"),
+    .copy("Assets/Interstitial Pages/Pages/HTTPBlocked.html"),
     .copy("Assets/Interstitial Pages/Pages/CertificateError.html"),
     .copy("Assets/Interstitial Pages/Pages/GenericError.html"),
     .copy("Assets/Interstitial Pages/Pages/NetworkError.html"),

--- a/ios/brave-ios/Sources/Brave/Assets/Interstitial Pages/Pages/HTTPBlocked.html
+++ b/ios/brave-ios/Sources/Brave/Assets/Interstitial Pages/Pages/HTTPBlocked.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!-- Copyright 2024 The Brave Authors. All rights reserved.
+  -- This Source Code Form is subject to the terms of the Mozilla Public
+  -- License, v. 2.0. If a copy of the MPL was not distributed with this
+  -- file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+
+<html lang="en">
+  <head>
+      <meta name='viewport' content='initial-scale=1, maximum-scale=1, viewport-fit=cover'>
+      <meta name="referrer" content="no-referrer">
+      <title>%page_title%</title>
+      <link rel="stylesheet" href="internal://local/interstitial-style/BlockedDomain.css">
+  </head>
+
+  <body dir="&locale.dir;" class="background content">
+    <div class="container post">
+      <img src="internal://local/interstitial-icon/warning-triangle-outline.svg" alt="Icon" class="icon">
+      </img>
+      <h1>%blocked_title%</h1>
+      <p class="description">
+        %blocked_description%
+        <a href="https://support.brave.com/hc/en-us/articles/15513090104717-Strict-HTTPS-Upgrade-Mode-in-Brave-Browser" target="_blank" rel="noopener">
+          %learn_more%
+        </a>
+      </p>
+      <div class="actions">
+        <button id="proceed-action" class="main-action">%proceed_action%</button>
+        <button id="go-back-action" class="secondary-action">%go_back_action%</button>
+      </div>
+    </div>
+    
+    <script>
+      (() => {
+        const sendAction = (action) => {
+          webkit.messageHandlers["%message_handler%"].postMessage({
+            "securityToken": "%security_token%",
+            "action": action
+          })
+        }
+        
+        document.getElementById('proceed-action').onclick = () => {
+          sendAction('didProceed')
+        }
+        
+        document.getElementById('go-back-action').onclick = () => {
+          sendAction('didGoBack')
+        }
+      })()
+    </script>
+  </body>
+</html>

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -502,6 +502,7 @@ public class BrowserViewController: UIViewController {
     Preferences.Playlist.syncSharedFoldersAutomatically.observe(from: self)
     Preferences.NewTabPage.backgroundSponsoredImages.observe(from: self)
     ShieldPreferences.blockAdsAndTrackingLevelRaw.observe(from: self)
+    ShieldPreferences.httpsUpgradeLevelRaw.observe(from: self)
     Preferences.Privacy.screenTimeEnabled.observe(from: self)
 
     pageZoomListener = NotificationCenter.default.addObserver(
@@ -2658,6 +2659,7 @@ extension BrowserViewController: TabDelegate {
       ErrorPageHelper(certStore: profile.certStore),
       SessionRestoreScriptHandler(tab: tab),
       BlockedDomainScriptHandler(tab: tab),
+      HTTPBlockedScriptHandler(tab: tab, exceptionService: braveCore.httpsUpgradeExceptionsService),
       PrintScriptHandler(browserController: self, tab: tab),
       CustomSearchScriptHandler(tab: tab),
       NightModeScriptHandler(tab: tab),
@@ -3313,7 +3315,7 @@ extension BrowserViewController: PreferencesObserver {
             ?? Preferences.General.defaultPageZoomLevel.value
         $0.webView?.setValue(zoomLevel, forKey: PageZoomHandler.propertyName)
       })
-    case Preferences.Shields.httpsEverywhere.key:
+    case ShieldPreferences.httpsUpgradeLevelRaw.key:
       tabManager.reset()
       tabManager.reloadSelectedTab()
     case Preferences.Privacy.blockAllCookies.key,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/HTTPBlockedHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/HTTPBlockedHandler.swift
@@ -1,0 +1,72 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShared
+import BraveShields
+import Foundation
+import Shared
+import WebKit
+
+public class HTTPBlockedHandler: InternalSchemeResponse {
+  public static let path = InternalURL.Path.httpBlocked.rawValue
+
+  public init() {}
+
+  public func response(forRequest request: URLRequest) -> (URLResponse, Data)? {
+    guard let url = request.url, let internalURL = InternalURL(url),
+      let originalURL = internalURL.extractedUrlParam
+    else { return nil }
+    let response = InternalSchemeHandler.response(forUrl: internalURL.url)
+
+    guard let asset = Bundle.module.path(forResource: "HTTPBlocked", ofType: "html") else {
+      assert(false)
+      return nil
+    }
+
+    var html = try? String(contentsOfFile: asset)
+      .replacingOccurrences(
+        of: "%page_title%",
+        with: Strings.Shields.siteIsNotSecure
+      )
+      .replacingOccurrences(
+        of: "%blocked_title%",
+        with: String.localizedStringWithFormat(
+          Strings.Shields.theConnectionIsNotSecure,
+          "<tt>\(originalURL.domainURL.absoluteDisplayString)</tt>"
+        )
+      )
+      .replacingOccurrences(
+        of: "%blocked_description%",
+        with: Strings.Shields.httpBlockedDescription
+      )
+      .replacingOccurrences(
+        of: "%learn_more%",
+        with: Strings.learnMore
+      )
+      .replacingOccurrences(
+        of: "%proceed_action%",
+        with: Strings.Shields.domainBlockedProceedAction
+      )
+      .replacingOccurrences(of: "%go_back_action%", with: Strings.Shields.domainBlockedGoBackAction)
+      .replacingOccurrences(
+        of: "%message_handler%",
+        with: HTTPBlockedScriptHandler.messageHandlerName
+      )
+      .replacingOccurrences(of: "%security_token%", with: UserScriptManager.securityToken)
+
+    if #available(iOS 16.0, *) {
+      html = html?.replacingOccurrences(
+        of: "<html lang=\"en\">",
+        with: "<html lang=\"\(Locale.current.language.minimalIdentifier)\">"
+      )
+    }
+
+    guard let data = html?.data(using: .utf8) else {
+      return nil
+    }
+
+    return (response, data)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -3,6 +3,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShields
 import BraveWallet
 import CertificateUtilities
 import Data
@@ -463,7 +464,7 @@ class Tab: NSObject {
       configuration!.allowsInlineMediaPlayback = true
       // Enables Zoom in website by ignoring their javascript based viewport Scale limits.
       configuration!.ignoresViewportScaleLimits = true
-      configuration!.upgradeKnownHostsToHTTPS = Preferences.Shields.httpsEverywhere.value
+      configuration!.upgradeKnownHostsToHTTPS = ShieldPreferences.httpsUpgradeLevel.isEnabled
       configuration!.enablePageTopColorSampling()
 
       if configuration!.urlSchemeHandler(forURLScheme: InternalURL.scheme) == nil {

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -77,6 +77,11 @@ import os
       }
     }
   }
+  @Published var httpsUpgradeLevel: HTTPSUpgradeLevel {
+    didSet {
+      ShieldPreferences.httpsUpgradeLevel = httpsUpgradeLevel
+    }
+  }
 
   typealias ClearDataCallback = @MainActor (Bool, Bool) -> Void
   @Published var clearableSettings: [ClearableSetting]
@@ -105,6 +110,7 @@ import os
     self.isP3AEnabled = p3aUtilities.isP3AEnabled
     self.clearDataCallback = clearDataCallback
     self.adBlockAndTrackingPreventionLevel = ShieldPreferences.blockAdsAndTrackingLevel
+    self.httpsUpgradeLevel = ShieldPreferences.httpsUpgradeLevel
     self.isDeAmpEnabled = deAmpPrefs.isDeAmpEnabled
     self.isDebounceEnabled = debounceService?.isEnabled ?? false
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
@@ -38,11 +38,20 @@ struct DefaultShieldsViewView: View {
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
 
-      OptionToggleView(
-        title: Strings.HTTPSEverywhere,
-        subtitle: Strings.HTTPSEverywhereDescription,
-        option: Preferences.Shields.httpsEverywhere
-      )
+      Picker(selection: $settings.httpsUpgradeLevel) {
+        ForEach(HTTPSUpgradeLevel.allCases) { level in
+          Text(level.localizedTitle)
+            .foregroundColor(Color(.secondaryBraveLabel))
+            .tag(level)
+        }
+      } label: {
+        LabelView(
+          title: Strings.Shields.upgradeConnectionsToHTTPS,
+          subtitle: nil
+        )
+      }
+      .listRowBackground(Color(.secondaryBraveGroupedBackground))
+
       ToggleView(
         title: Strings.autoRedirectAMPPages,
         subtitle: Strings.autoRedirectAMPPagesDescription,
@@ -164,6 +173,20 @@ extension ShieldLevel: Identifiable {
   public var localizedTitle: String {
     switch self {
     case .aggressive: return Strings.Shields.trackersAndAdsBlockingAggressive
+    case .disabled: return Strings.Shields.trackersAndAdsBlockingDisabled
+    case .standard: return Strings.Shields.trackersAndAdsBlockingStandard
+    }
+  }
+}
+
+extension HTTPSUpgradeLevel: Identifiable {
+  public var id: String {
+    return rawValue
+  }
+
+  public var localizedTitle: String {
+    switch self {
+    case .strict: return Strings.Shields.httpsUpgradeLevelStrict
     case .disabled: return Strings.Shields.trackersAndAdsBlockingDisabled
     case .standard: return Strings.Shields.trackersAndAdsBlockingStandard
     }

--- a/ios/brave-ios/Sources/BraveShields/HTTPSUpgradeLevel.swift
+++ b/ios/brave-ios/Sources/BraveShields/HTTPSUpgradeLevel.swift
@@ -1,0 +1,32 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// A 3 part option for shield levels varying in strength of blocking content
+public enum HTTPSUpgradeLevel: String, CaseIterable, Hashable {
+  /// Always upgrade websites and block websites that cannot be upgraded
+  case strict
+  /// Always upgrade websites but allow http when it cannot be upgraded
+  case standard
+  /// Mode indicating this setting is disabled
+  case disabled
+
+  /// Wether this setting indicates that the shields are enabled or not
+  public var isEnabled: Bool {
+    switch self {
+    case .strict, .standard: return true
+    case .disabled: return false
+    }
+  }
+
+  /// Wether this setting indicates that the shields are aggressive or not
+  public var isStrict: Bool {
+    switch self {
+    case .strict: return true
+    case .disabled, .standard: return false
+    }
+  }
+}

--- a/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
@@ -6,8 +6,10 @@
 import Foundation
 import Preferences
 
+/// All the settings pertaining to shields and privacy
 public class ShieldPreferences {
   private static let defaultBlockAdsAndTrackingLevel: ShieldLevel = .standard
+  private static let defaultHTTPsUpgradeLevel: HTTPSUpgradeLevel = .standard
 
   /// Get the level of the adblock and tracking protection as a stored preference
   /// - Warning: You should not access this directly but  through ``blockAdsAndTrackingLevel``
@@ -16,12 +18,27 @@ public class ShieldPreferences {
     default: defaultBlockAdsAndTrackingLevel.rawValue
   )
 
+  /// Get the level of the https upgrade setting as a stored preference
+  /// - Warning: You should not access this directly but  through ``httpsUpgradeLevel``
+  public static var httpsUpgradeLevelRaw = Preferences.Option<String>(
+    key: "shields.https-upgrade-level",
+    default: defaultHTTPsUpgradeLevel.rawValue
+  )
+
   /// Get the level of the adblock and tracking protection
   public static var blockAdsAndTrackingLevel: ShieldLevel {
     get {
       ShieldLevel(rawValue: blockAdsAndTrackingLevelRaw.value) ?? defaultBlockAdsAndTrackingLevel
     }
     set { blockAdsAndTrackingLevelRaw.value = newValue.rawValue }
+  }
+
+  /// Get the level of HTTPS upgrades
+  public static var httpsUpgradeLevel: HTTPSUpgradeLevel {
+    get {
+      HTTPSUpgradeLevel(rawValue: httpsUpgradeLevelRaw.value) ?? defaultHTTPsUpgradeLevel
+    }
+    set { httpsUpgradeLevelRaw.value = newValue.rawValue }
   }
 
   /// A boolean value inidicating if GPC is enabled

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -317,3 +317,51 @@ extension Strings.Shields {
       "Text for a button in a blocked page info screen that takes you back where you came from"
   )
 }
+
+// MARK: - HTTPS Upgrades
+
+extension Strings.Shields {
+  /// The option the user can select to do aggressive ad and tracker blocking
+  public static let httpsUpgradeLevelStrict = NSLocalizedString(
+    "HttpsUpgradeLevelStrict",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Strict",
+    comment: "The option the user can select to do strict https upgrading"
+  )
+  /// The option the user can select for the type of https upgrading
+  public static let upgradeConnectionsToHTTPS = NSLocalizedString(
+    "UpgradeConnectionsToHTTPS",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Upgrade Connections to HTTPS",
+    comment: "The option the user can select for the type of https upgrading"
+  )
+
+  /// A page title for the warning page that appears when http was blocked
+  public static let siteIsNotSecure = NSLocalizedString(
+    "SiteIsNotSecure",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Site is not secure",
+    comment: "A page title for the warning page that appears when http was blocked"
+  )
+
+  /// A page title for the warning page that appears when http was blocked
+  public static let theConnectionIsNotSecure = NSLocalizedString(
+    "TheConnectionIsNotSecure",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "The connection to %@ is not secure",
+    comment: "A page title for the warning page that appears when http was blocked"
+  )
+
+  /// A tab title that appears when a page was blocked
+  public static let httpBlockedDescription = NSLocalizedString(
+    "YourConnectionIsNotPrivate",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "You are seeing this warning because this site does not support HTTPS.",
+    comment: "A description shown an a page where the http page was blocked"
+  )
+}

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -40,10 +40,8 @@ extension Preferences {
 
   public final class Shields {
     public static let allShields = [
-      httpsEverywhere, googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages,
+      googleSafeBrowsing, blockScripts, fingerprintingProtection, blockImages,
     ]
-    /// Websites will be upgraded to HTTPS if a loaded page attempts to use HTTP
-    public static let httpsEverywhere = Option<Bool>(key: "shields.https-everywhere", default: true)
     /// Enable Google Safe Browsing
     public static let googleSafeBrowsing = Option<Bool>(
       key: "shields.google-safe-browsing",

--- a/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
@@ -467,6 +467,7 @@ public struct InternalURL {
     case sessionrestore
     case readermode = "reader-mode"
     case blocked
+    case httpBlocked = "http-blocked"
 
     func matches(_ string: String) -> Bool {
       return string.range(
@@ -545,6 +546,10 @@ public struct InternalURL {
 
   public var isBlockedPage: Bool {
     return InternalURL.Path.blocked.matches(url.path)
+  }
+
+  public var isHTTPBlockedPage: Bool {
+    return InternalURL.Path.httpBlocked.matches(url.path)
   }
 
   public var isReaderModePage: Bool {

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -49,11 +49,15 @@ class URLExtensionTests: XCTestCase {
 
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .readermode)?.strippedInternalURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
     )
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .blocked)?.strippedInternalURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
+    )
+    XCTAssertEqual(
+      embeddedURL.encodeEmbeddedInternalURL(for: .httpBlocked)?.strippedInternalURL,
+      embeddedURL
     )
     XCTAssertNil(embeddedURL.strippedInternalURL)
   }
@@ -116,15 +120,19 @@ class URLExtensionTests: XCTestCase {
 
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .readermode)?.displayURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
     )
     XCTAssertEqual(
       embeddedURL.encodeEmbeddedInternalURL(for: .blocked)?.displayURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
+    )
+    XCTAssertEqual(
+      embeddedURL.encodeEmbeddedInternalURL(for: .httpBlocked)?.displayURL,
+      embeddedURL
     )
     XCTAssertEqual(
       embeddedURL.displayURL,
-      URL(string: "https://en.m.wikipedia.org/wiki/Main_Page?somequery=abc-123")
+      embeddedURL
     )
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36408

Security review: https://github.com/brave/reviews/issues/1593

Will be merged into https://github.com/brave/brave-core/pull/23029 before merging into master. Split because the other code has already been reviewed

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See issue for test plan

## Screenshots
https://github.com/brave/brave-core/assets/909331/d0df7137-d78f-408e-9d5f-0b6b4af0e01b

