### PR TITLE
[ads] Fixes reset exponential backoff when refilling or redeeming payment tokens after a failure that should not retry

### DIFF
--- a/components/brave_ads/core/internal/account/issuers/issuers_url_request.cc
+++ b/components/brave_ads/core/internal/account/issuers/issuers_url_request.cc
@@ -100,9 +100,9 @@ void IssuersUrlRequest::FetchCallback(
 }
 
 void IssuersUrlRequest::SuccessfullyFetchedIssuers(const IssuersInfo& issuers) {
-  StopRetrying();
-
   BLOG(1, "Successfully fetched issuers");
+
+  StopRetrying();
 
   NotifyDidFetchIssuers(issuers);
 

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/reward/redeem_reward_confirmation.cc
@@ -117,6 +117,8 @@ void RedeemRewardConfirmation::FetchPaymentTokenAfter(
     const base::TimeDelta delay,
     RedeemRewardConfirmation redeem_confirmation,
     const ConfirmationInfo& confirmation) {
+  BLOG(1, "Fetch payment token in " << delay);
+
   base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE,
       base::BindOnce(&RedeemRewardConfirmation::FetchPaymentToken,

--- a/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/redeem_payment_tokens/redeem_payment_tokens.cc
@@ -138,6 +138,10 @@ void RedeemPaymentTokens::SuccessfullyRedeemed(
 void RedeemPaymentTokens::FailedToRedeem(const bool should_retry) {
   is_redeeming_ = false;
 
+  if (!should_retry) {
+    StopRetrying();
+  }
+
   NotifyFailedToRedeemPaymentTokens();
 
   if (should_retry) {

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -273,11 +273,11 @@ void RefillConfirmationTokens::ParseAndRequireCaptcha(
 }
 
 void RefillConfirmationTokens::SuccessfullyRefilled() {
+  is_refilling_ = false;
+
   StopRetrying();
 
   Reset();
-
-  is_refilling_ = false;
 
   NotifyDidRefillConfirmationTokens();
 }
@@ -285,13 +285,17 @@ void RefillConfirmationTokens::SuccessfullyRefilled() {
 void RefillConfirmationTokens::FailedToRefill(const bool should_retry) {
   is_refilling_ = false;
 
+  if (!should_retry) {
+    StopRetrying();
+
+    Reset();
+  }
+
   NotifyFailedToRefillConfirmationTokens();
 
   if (should_retry) {
-    return Retry();
+    Retry();
   }
-
-  Reset();
 }
 
 void RefillConfirmationTokens::Retry() {

--- a/components/brave_ads/core/internal/catalog/catalog_url_request.cc
+++ b/components/brave_ads/core/internal/catalog/catalog_url_request.cc
@@ -124,9 +124,9 @@ void CatalogUrlRequest::FetchAfterDelay() {
 }
 
 void CatalogUrlRequest::SuccessfullyFetchedCatalog(const CatalogInfo& catalog) {
-  StopRetrying();
-
   BLOG(1, "Successfully fetched catalog");
+
+  StopRetrying();
 
   NotifyDidFetchCatalog(catalog);
 

--- a/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.cc
+++ b/components/brave_ads/core/internal/common/subdivision/url_request/subdivision_url_request.cc
@@ -106,9 +106,9 @@ void SubdivisionUrlRequest::FetchAfterDelay() {
 
 void SubdivisionUrlRequest::SuccessfullyFetchedSubdivision(
     const std::string& subdivision) {
-  StopRetrying();
-
   BLOG(1, "Successfully fetched subdivision");
+
+  StopRetrying();
 
   NotifyDidFetchSubdivision(subdivision);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37957

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Confirm both confirmation and payment tokens are redeemed successfully, after a retry and after multiple retries.