### PR TITLE
[Brave News]: Brave News sometimes doesn't work on first load.

### DIFF
--- a/components/brave_news/browser/BUILD.gn
+++ b/components/brave_news/browser/BUILD.gn
@@ -36,6 +36,8 @@ static_library("browser") {
     "feed_v2_builder.h",
     "html_parsing.cc",
     "html_parsing.h",
+    "initialization_promise.cc",
+    "initialization_promise.h",
     "locales_helper.cc",
     "locales_helper.h",
     "network.cc",

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -822,15 +822,6 @@ void BraveNewsController::OnInitializingPrefsComplete() {
       })
           .Then(base::BindOnce(&BraveNewsController::NotifyChannelsChanged,
                                weak_ptr_factory_.GetWeakPtr())));
-
-  GetPublishers(
-      base::BindOnce([](Publishers publishers) {
-        auto event = brave_news::mojom::PublishersEvent::New();
-        event->addedOrUpdated = std::move(publishers);
-        return event;
-      })
-          .Then(base::BindOnce(&BraveNewsController::NotifyPublishersChanged,
-                               weak_ptr_factory_.GetWeakPtr())));
 }
 
 void BraveNewsController::OnNetworkChanged(

--- a/components/brave_news/browser/brave_news_controller.cc
+++ b/components/brave_news/browser/brave_news_controller.cc
@@ -105,6 +105,7 @@ BraveNewsController::BraveNewsController(
       suggestions_controller_(&publishers_controller_,
                               &api_request_helper_,
                               history_service),
+      initialization_promise_(3, pref_manager_, publishers_controller_),
       weak_ptr_factory_(this) {
   DCHECK(prefs);
   net::NetworkChangeNotifier::AddNetworkChangeObserver(this);
@@ -168,12 +169,12 @@ void BraveNewsController::GetFeed(GetFeedCallback callback) {
     std::move(callback).Run(brave_news::mojom::Feed::New());
     return;
   }
+
   // If we're only recently opted-in but we haven't yet finished adding the
   // top sources subscription (via the async functions in MaybeInitPrefs), we
   // need to wait for that to complete before we can fetch the feed.
-  if (!on_initializing_prefs_complete_.is_signaled()) {
-    on_initializing_prefs_complete_.Post(
-        FROM_HERE,
+  if (!initialization_promise_.complete()) {
+    initialization_promise_.OnceInitialized(
         base::BindOnce(&BraveNewsController::GetFeed,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
     return;
@@ -231,9 +232,8 @@ void BraveNewsController::GetFeedV2(GetFeedV2Callback callback) {
   // If we're only recently opted-in but we haven't yet finished adding the
   // top sources subscription (via the async functions in MaybeInitPrefs), we
   // need to wait for that to complete before we can fetch the feed.
-  if (!on_initializing_prefs_complete_.is_signaled()) {
-    on_initializing_prefs_complete_.Post(
-        FROM_HERE,
+  if (!initialization_promise_.complete()) {
+    initialization_promise_.OnceInitialized(
         base::BindOnce(&BraveNewsController::GetFeedV2,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
     return;
@@ -298,9 +298,8 @@ void BraveNewsController::GetChannels(GetChannelsCallback callback) {
     std::move(callback).Run({});
     return;
   }
-  if (!on_initializing_prefs_complete_.is_signaled()) {
-    on_initializing_prefs_complete_.Post(
-        FROM_HERE,
+  if (!initialization_promise_.complete()) {
+    initialization_promise_.OnceInitialized(
         base::BindOnce(&BraveNewsController::GetChannels,
                        weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
     return;
@@ -807,40 +806,14 @@ void BraveNewsController::MaybeInitPrefs() {
     return;
   }
 
-  const auto& subscriptions = pref_manager_.GetSubscriptions();
-  if (!subscriptions.channels().empty() ||
-      !subscriptions.enabled_publishers().empty() ||
-      !subscriptions.direct_feeds().empty()) {
-    OnInitializingPrefsComplete();
-    return;
-  }
-
-  publishers_controller_.GetLocale(
-      pref_manager_.GetSubscriptions(),
-      base::BindOnce(
-          [](base::WeakPtr<BraveNewsController> controller,
-             const std::string& locale) {
-            if (!controller) {
-              return;
-            }
-            // This could happen, if we're offline, or the API is down at
-            // the moment.
-            if (locale.empty()) {
-              return;
-            }
-            controller->pref_manager_.SetChannelSubscribed(
-                locale, kTopSourcesChannel, true);
-            controller->OnInitializingPrefsComplete();
-          },
-          weak_ptr_factory_.GetWeakPtr()));
+  initialization_promise_.OnceInitialized(
+      base::BindOnce(&BraveNewsController::OnInitializingPrefsComplete,
+                     weak_ptr_factory_.GetWeakPtr()));
 }
 
 void BraveNewsController::OnInitializingPrefsComplete() {
-  if (!on_initializing_prefs_complete_.is_signaled()) {
-    on_initializing_prefs_complete_.Signal();
-  }
-  // Some listeners won't have channels yet because they registered before
-  // any were fetched.
+  // Once we've finished initializing prefs, notify channel & publisher
+  // listeners.
   GetChannels(
       base::BindOnce([](Channels channels) {
         auto event = brave_news::mojom::ChannelsEvent::New();
@@ -848,6 +821,15 @@ void BraveNewsController::OnInitializingPrefsComplete() {
         return event;
       })
           .Then(base::BindOnce(&BraveNewsController::NotifyChannelsChanged,
+                               weak_ptr_factory_.GetWeakPtr())));
+
+  GetPublishers(
+      base::BindOnce([](Publishers publishers) {
+        auto event = brave_news::mojom::PublishersEvent::New();
+        event->addedOrUpdated = std::move(publishers);
+        return event;
+      })
+          .Then(base::BindOnce(&BraveNewsController::NotifyPublishersChanged,
                                weak_ptr_factory_.GetWeakPtr())));
 }
 

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -21,6 +21,7 @@
 #include "brave/components/brave_news/browser/direct_feed_controller.h"
 #include "brave/components/brave_news/browser/feed_controller.h"
 #include "brave/components/brave_news/browser/feed_v2_builder.h"
+#include "brave/components/brave_news/browser/initialization_promise.h"
 #include "brave/components/brave_news/browser/publishers_controller.h"
 #include "brave/components/brave_news/browser/suggestions_controller.h"
 #include "brave/components/brave_news/common/brave_news.mojom-forward.h"
@@ -195,7 +196,7 @@ class BraveNewsController
   // channels might only be available after this event has fired. If News is
   // already enabled and this event has already signalled, then they are already
   // available.
-  base::OneShotEvent on_initializing_prefs_complete_;
+  InitializationPromise initialization_promise_;
   base::CancelableTaskTracker task_tracker_;
 
   base::ScopedObservation<BraveNewsPrefManager,

--- a/components/brave_news/browser/initialization_promise.cc
+++ b/components/brave_news/browser/initialization_promise.cc
@@ -1,0 +1,100 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_news/browser/initialization_promise.h"
+
+#include <iterator>
+
+#include "base/functional/bind.h"
+#include "base/functional/callback_forward.h"
+#include "base/location.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
+#include "brave/components/brave_news/browser/channels_controller.h"
+#include "brave/components/brave_news/browser/publishers_controller.h"
+#include "partition_alloc/pointers/raw_ref.h"
+
+namespace brave_news {
+
+constexpr int kBackoffs[] = {1, 5, 10};
+constexpr size_t kNumBackoffs = std::size(kBackoffs);
+
+InitializationPromise::InitializationPromise(
+    size_t max_retries,
+    BraveNewsPrefManager& pref_manager,
+    PublishersController& publishers_controller)
+    : pref_manager_(pref_manager),
+      publishers_controller_(publishers_controller),
+      max_retries_(max_retries) {}
+
+InitializationPromise::~InitializationPromise() = default;
+
+void InitializationPromise::OnceInitialized(base::OnceClosure on_initialized) {
+  // This should only be called when Brave News is enabled.
+  CHECK(pref_manager_->IsEnabled());
+
+  if (state_ == State::kInitialized || state_ == State::kFailed) {
+    std::move(on_initialized).Run();
+    return;
+  }
+
+  on_initializing_prefs_complete_.Post(FROM_HERE, std::move(on_initialized));
+
+  // Only start initializing once.
+  if (state_ == State::kNone) {
+    Initialize();
+  }
+}
+
+void InitializationPromise::Initialize() {
+  state_ = State::kInitializing;
+
+  auto subscriptions = pref_manager_->GetSubscriptions();
+
+  // If things are already initialized, we're done!
+  if (!subscriptions.channels().empty() ||
+      !subscriptions.enabled_publishers().empty() ||
+      !subscriptions.disabled_publishers().empty() ||
+      !subscriptions.direct_feeds().empty()) {
+    state_ = State::kInitialized;
+    on_initializing_prefs_complete_.Signal();
+    return;
+  }
+
+  publishers_controller_->GetLocale(
+      subscriptions, base::BindOnce(&InitializationPromise::OnGotLocale,
+                                    weak_ptr_factory_.GetWeakPtr()));
+}
+
+void InitializationPromise::OnGotLocale(const std::string& locale) {
+  // Keep track of which attempt this is.
+  attempts_++;
+
+  if (!locale.empty()) {
+    pref_manager_->SetChannelSubscribed(locale, kTopSourcesChannel, true);
+    state_ = State::kInitialized;
+    on_initializing_prefs_complete_.Signal();
+    return;
+  }
+
+  // We signal even if nothing managed to initialized because otherwise we'll
+  // get stuck.
+  if (attempts_ >= max_retries_) {
+    state_ = State::kFailed;
+    on_initializing_prefs_complete_.Signal();
+    return;
+  }
+
+  // Determine how long we should wait based on the number of times we've
+  // retried.
+  int delay_index = std::min(attempts_, kNumBackoffs - 1);
+  base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&InitializationPromise::Initialize,
+                     weak_ptr_factory_.GetWeakPtr()),
+      base::Seconds(kBackoffs[delay_index]));
+}
+
+}  // namespace brave_news

--- a/components/brave_news/browser/initialization_promise.cc
+++ b/components/brave_news/browser/initialization_promise.cc
@@ -72,6 +72,8 @@ void InitializationPromise::Initialize() {
 }
 
 void InitializationPromise::OnGotLocale(const std::string& locale) {
+  CHECK_EQ(State::kInitializing, state_);
+
   // Keep track of which attempt this is.
   attempts_++;
 

--- a/components/brave_news/browser/initialization_promise.h
+++ b/components/brave_news/browser/initialization_promise.h
@@ -1,11 +1,18 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 #ifndef BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_INITIALIZATION_PROMISE_H_
 #define BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_INITIALIZATION_PROMISE_H_
 
+#include <string>
+
 #include "base/functional/callback_forward.h"
+#include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "base/one_shot_event.h"
 #include "brave/components/brave_news/browser/publishers_controller.h"
-#include "partition_alloc/pointers/raw_ref.h"
 
 namespace brave_news {
 
@@ -23,8 +30,15 @@ class InitializationPromise {
 
   void OnceInitialized(base::OnceClosure on_initialized);
 
+  State state() { return state_; }
   bool failed() { return state_ == InitializationPromise::State::kFailed; }
   bool complete() { return on_initializing_prefs_complete_.is_signaled(); }
+
+  void set_no_retry_delay_for_testing(bool no_retry_delay) {
+    no_retry_delay_for_testing_ = no_retry_delay;
+  }
+
+  size_t attempts_for_testing() { return attempts_; }
 
  private:
   void Initialize();
@@ -36,6 +50,8 @@ class InitializationPromise {
   raw_ref<PublishersController> publishers_controller_;
 
   base::OneShotEvent on_initializing_prefs_complete_;
+
+  bool no_retry_delay_for_testing_ = false;
 
   size_t max_retries_ = 0;
   size_t attempts_ = 0;

--- a/components/brave_news/browser/initialization_promise.h
+++ b/components/brave_news/browser/initialization_promise.h
@@ -1,0 +1,50 @@
+#ifndef BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_INITIALIZATION_PROMISE_H_
+#define BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_INITIALIZATION_PROMISE_H_
+
+#include "base/functional/callback_forward.h"
+#include "base/memory/weak_ptr.h"
+#include "base/one_shot_event.h"
+#include "brave/components/brave_news/browser/publishers_controller.h"
+#include "partition_alloc/pointers/raw_ref.h"
+
+namespace brave_news {
+
+class BraveNewsPrefManager;
+class PublishersController;
+
+class InitializationPromise {
+ public:
+  enum class State { kNone, kInitializing, kInitialized, kFailed };
+
+  InitializationPromise(size_t max_retries,
+                        BraveNewsPrefManager& pref_manager,
+                        PublishersController& publishers_controller);
+  ~InitializationPromise();
+
+  void OnceInitialized(base::OnceClosure on_initialized);
+
+  bool failed() { return state_ == InitializationPromise::State::kFailed; }
+  bool complete() { return on_initializing_prefs_complete_.is_signaled(); }
+
+ private:
+  void Initialize();
+  void OnGotLocale(const std::string& locale);
+
+  void Notify();
+
+  raw_ref<BraveNewsPrefManager> pref_manager_;
+  raw_ref<PublishersController> publishers_controller_;
+
+  base::OneShotEvent on_initializing_prefs_complete_;
+
+  size_t max_retries_ = 0;
+  size_t attempts_ = 0;
+
+  State state_ = InitializationPromise::State::kNone;
+
+  base::WeakPtrFactory<InitializationPromise> weak_ptr_factory_{this};
+};
+
+}  // namespace brave_news
+
+#endif  // BRAVE_COMPONENTS_BRAVE_NEWS_BROWSER_INITIALIZATION_PROMISE_H_

--- a/components/brave_news/browser/initialization_promise.h
+++ b/components/brave_news/browser/initialization_promise.h
@@ -30,15 +30,19 @@ class InitializationPromise {
 
   void OnceInitialized(base::OnceClosure on_initialized);
 
-  State state() { return state_; }
-  bool failed() { return state_ == InitializationPromise::State::kFailed; }
-  bool complete() { return on_initializing_prefs_complete_.is_signaled(); }
+  State state() const { return state_; }
+  bool failed() const {
+    return state_ == InitializationPromise::State::kFailed;
+  }
+  bool complete() const {
+    return on_initializing_prefs_complete_.is_signaled();
+  }
 
   void set_no_retry_delay_for_testing(bool no_retry_delay) {
     no_retry_delay_for_testing_ = no_retry_delay;
   }
 
-  size_t attempts_for_testing() { return attempts_; }
+  size_t attempts_for_testing() const { return attempts_; }
 
  private:
   void Initialize();
@@ -53,7 +57,7 @@ class InitializationPromise {
 
   bool no_retry_delay_for_testing_ = false;
 
-  size_t max_retries_ = 0;
+  const size_t max_retries_ = 0;
   size_t attempts_ = 0;
 
   State state_ = InitializationPromise::State::kNone;

--- a/components/brave_news/browser/initialization_promise_unittest.cc
+++ b/components/brave_news/browser/initialization_promise_unittest.cc
@@ -1,0 +1,138 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_news/browser/initialization_promise.h"
+
+#include <string>
+
+#include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
+#include "base/run_loop.h"
+#include "base/test/bind.h"
+#include "brave/components/api_request_helper/api_request_helper.h"
+#include "brave/components/brave_news/browser/brave_news_pref_manager.h"
+#include "brave/components/brave_news/browser/publishers_controller.h"
+#include "brave/components/brave_news/browser/urls.h"
+#include "brave/components/brave_news/common/brave_news.mojom.h"
+#include "chrome/test/base/testing_profile.h"
+#include "content/public/test/browser_task_environment.h"
+#include "net/http/http_status_code.h"
+#include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
+#include "services/data_decoder/public/cpp/test_support/in_process_data_decoder.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
+#include "services/network/test/test_url_loader_factory.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_news {
+
+constexpr char kPublishersResponse[] = R"([
+    {
+        "publisher_id": "111",
+        "publisher_name": "Test Publisher 1",
+        "feed_url": "https://tp1.example.com/feed",
+        "site_url": "https://tp1.example.com",
+        "category": "Tech",
+        "cover_url": "https://tp1.example.com/cover",
+        "cover_url": "https://tp1.example.com/favicon",
+        "background_color": "#FF0000",
+        "locales": [{
+          "locale": "en_NZ",
+          "channels": ["One", "Tech"]
+        }],
+        "enabled": false
+    }])";
+
+class BraveNewsInitializationPromiseTest : public testing::Test {
+ public:
+  BraveNewsInitializationPromiseTest()
+      : api_request_helper_(TRAFFIC_ANNOTATION_FOR_TESTS,
+                            test_url_loader_factory_.GetSafeWeakWrapper()),
+        pref_manager_(*profile_.GetPrefs()),
+        publishers_controller_(&api_request_helper_),
+        initialization_promise_(3, pref_manager_, publishers_controller_) {
+    // Ensure Brave News is enabled.
+    pref_manager_.SetConfig(mojom::Configuration::New(true, true, true));
+
+    // Disable backoffs, so we can test.
+    initialization_promise_.set_no_retry_delay_for_testing(true);
+  }
+  ~BraveNewsInitializationPromiseTest() override = default;
+
+ protected:
+  std::string InitializeAndGetLocale() {
+    base::RunLoop loop;
+    initialization_promise_.OnceInitialized(loop.QuitClosure());
+    loop.Run();
+
+    auto channels = pref_manager_.GetSubscriptions().channels();
+    if (channels.empty()) {
+      return "";
+    }
+    return channels.begin()->first;
+  }
+  std::string GetSourcesUrl() {
+    return "https://" + brave_news::GetHostname() + "/sources." +
+           brave_news::kRegionUrlPart + "json";
+  }
+
+  void SucceedAfter(size_t retries) {
+    test_url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+        [&, retries](const network::ResourceRequest& request) {
+          bool should_succeed =
+              initialization_promise_.attempts_for_testing() >= retries;
+          test_url_loader_factory_.AddResponse(
+              request.url.spec(), should_succeed ? kPublishersResponse : "",
+              should_succeed ? net::HTTP_OK : net::HTTP_SERVICE_UNAVAILABLE);
+        }));
+  }
+
+  content::BrowserTaskEnvironment browser_task_environment_;
+  data_decoder::test::InProcessDataDecoder data_decoder_;
+  network::TestURLLoaderFactory test_url_loader_factory_;
+  api_request_helper::APIRequestHelper api_request_helper_;
+
+  TestingProfile profile_;
+  BraveNewsPrefManager pref_manager_;
+  PublishersController publishers_controller_;
+  InitializationPromise initialization_promise_;
+};
+
+TEST_F(BraveNewsInitializationPromiseTest,
+       WaitingForInitializationChangesState) {
+  EXPECT_EQ(InitializationPromise::State::kNone,
+            initialization_promise_.state());
+  initialization_promise_.OnceInitialized(base::DoNothing());
+  EXPECT_EQ(InitializationPromise::State::kInitializing,
+            initialization_promise_.state());
+}
+
+TEST_F(BraveNewsInitializationPromiseTest, InitializedLocaleIsCorrect) {
+  SucceedAfter(0);
+  auto locale = InitializeAndGetLocale();
+  EXPECT_EQ("en_NZ", locale);
+  EXPECT_EQ(1u, initialization_promise_.attempts_for_testing());
+}
+
+TEST_F(BraveNewsInitializationPromiseTest, InitializationRetries) {
+  SucceedAfter(1);
+  auto locale = InitializeAndGetLocale();
+  EXPECT_EQ("en_NZ", locale);
+  EXPECT_TRUE(initialization_promise_.complete());
+  EXPECT_FALSE(initialization_promise_.failed());
+  EXPECT_EQ(2u, initialization_promise_.attempts_for_testing());
+}
+
+TEST_F(BraveNewsInitializationPromiseTest,
+       InitializationDoesNotRetryFourTimes) {
+  SucceedAfter(4);
+  auto locale = InitializeAndGetLocale();
+  EXPECT_EQ("", locale);
+  EXPECT_TRUE(initialization_promise_.complete());
+  EXPECT_TRUE(initialization_promise_.failed());
+  EXPECT_EQ(3u, initialization_promise_.attempts_for_testing());
+}
+
+}  // namespace brave_news

--- a/components/brave_news/browser/initialization_promise_unittest.cc
+++ b/components/brave_news/browser/initialization_promise_unittest.cc
@@ -16,6 +16,7 @@
 #include "brave/components/brave_news/browser/publishers_controller.h"
 #include "brave/components/brave_news/browser/urls.h"
 #include "brave/components/brave_news/common/brave_news.mojom.h"
+#include "brave/components/l10n/common/test/scoped_default_locale.h"
 #include "chrome/test/base/testing_profile.h"
 #include "content/public/test/browser_task_environment.h"
 #include "net/http/http_status_code.h"
@@ -99,6 +100,9 @@ class BraveNewsInitializationPromiseTest : public testing::Test {
   BraveNewsPrefManager pref_manager_;
   PublishersController publishers_controller_;
   InitializationPromise initialization_promise_;
+
+ private:
+  const brave_l10n::test::ScopedDefaultLocale locale_{"en_NZ"};
 };
 
 TEST_F(BraveNewsInitializationPromiseTest,

--- a/components/brave_news/browser/initialization_promise_unittest.cc
+++ b/components/brave_news/browser/initialization_promise_unittest.cc
@@ -73,7 +73,8 @@ class BraveNewsInitializationPromiseTest : public testing::Test {
     }
     return channels.begin()->first;
   }
-  std::string GetSourcesUrl() {
+
+  static std::string GetSourcesUrl() {
     return "https://" + brave_news::GetHostname() + "/sources." +
            brave_news::kRegionUrlPart + "json";
   }

--- a/components/brave_news/browser/publishers_controller.cc
+++ b/components/brave_news/browser/publishers_controller.cc
@@ -224,15 +224,11 @@ void PublishersController::EnsurePublishersIsUpdating(
       [](PublishersController* controller,
          const BraveNewsSubscriptions& subscriptions,
          api_request_helper::APIRequestResult api_request_result) {
-        static int calls = 0;
-        LOG(ERROR) << "Calls: " << calls++;
         VLOG(1) << "Publishers response status code: "
                 << api_request_result.response_code();
         // TODO(petemill): handle bad status or response
         std::optional<Publishers> publisher_list =
-            calls >= 3
-                ? ParseCombinedPublisherList(api_request_result.TakeBody())
-                : std::nullopt;
+            ParseCombinedPublisherList(api_request_result.TakeBody());
 
         // Update failed, we'll just reuse whatever publishers we had before.
         if (!publisher_list) {

--- a/components/brave_news/browser/publishers_controller.cc
+++ b/components/brave_news/browser/publishers_controller.cc
@@ -224,11 +224,15 @@ void PublishersController::EnsurePublishersIsUpdating(
       [](PublishersController* controller,
          const BraveNewsSubscriptions& subscriptions,
          api_request_helper::APIRequestResult api_request_result) {
+        static int calls = 0;
+        LOG(ERROR) << "Calls: " << calls++;
         VLOG(1) << "Publishers response status code: "
                 << api_request_result.response_code();
         // TODO(petemill): handle bad status or response
         std::optional<Publishers> publisher_list =
-            ParseCombinedPublisherList(api_request_result.TakeBody());
+            calls >= 3
+                ? ParseCombinedPublisherList(api_request_result.TakeBody())
+                : std::nullopt;
 
         // Update failed, we'll just reuse whatever publishers we had before.
         if (!publisher_list) {

--- a/components/brave_news/browser/resources/shared/Context.tsx
+++ b/components/brave_news/browser/resources/shared/Context.tsx
@@ -202,7 +202,7 @@ export function BraveNewsContextProvider(props: { children: React.ReactNode }) {
     reportVisit,
     reportSidebarFilterUsage,
     reportSessionStart
-  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart])
+  }), [customizePage, setFeedView, feedV2, feedV2UpdatesAvailable, channels, publishers, suggestedPublisherIds, filteredPublisherIds, updateSuggestedPublisherIds, configuration, toggleBraveNewsOnNTP, reportSidebarFilterUsage, reportViewCount, reportVisit, reportSessionStart])
 
   return <BraveNewsContext.Provider value={context}>
     {props.children}

--- a/components/brave_news/browser/test/BUILD.gn
+++ b/components/brave_news/browser/test/BUILD.gn
@@ -18,6 +18,7 @@ source_set("brave_news_unit_tests") {
     "//brave/components/brave_news/browser/feed_building_unittest.cc",
     "//brave/components/brave_news/browser/feed_sampling_unittest.cc",
     "//brave/components/brave_news/browser/html_parsing_unittest.cc",
+    "//brave/components/brave_news/browser/initialization_promise_unittest.cc",
     "//brave/components/brave_news/browser/locales_helper_unittest.cc",
     "//brave/components/brave_news/browser/publishers_controller_unittest.cc",
     "//brave/components/brave_news/browser/publishers_parsing_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37972

I think this was introduced by the promise for initializing prefs, as it wasn't firing if we failed to fetch the publishers, so nothing in Brave News was working.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See https://github.com/brave/brave-browser/issues/37738

@stephendonner can repro most easily on his Windows box