### PR TITLE
Fix crash from ai_chat::GetBrowserForWebContents (uplift to 1.66.x)

### DIFF
--- a/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
+++ b/browser/ui/views/side_panel/ai_chat/ai_chat_side_panel_utils_views.cc
@@ -12,10 +12,17 @@
 namespace ai_chat {
 
 Browser* GetBrowserForWebContents(content::WebContents* web_contents) {
+  if (!web_contents) {
+    return nullptr;
+  }
+
   auto* browser_window =
       BrowserWindow::FindBrowserWindowWithWebContents(web_contents);
   auto* browser_view = static_cast<BrowserView*>(browser_window);
-  CHECK(browser_view);
+  if (!browser_view) {
+    return nullptr;
+  }
+
   return browser_view->browser();
 }
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui.cc
@@ -126,9 +126,12 @@ void AIChatUI::BindInterface(
 
   content::WebContents* web_contents = nullptr;
 #if !BUILDFLAG(IS_ANDROID)
-  raw_ptr<Browser> browser =
+  Browser* browser =
       ai_chat::GetBrowserForWebContents(web_ui()->GetWebContents());
-  DCHECK(browser);
+  if (!browser) {
+    return;
+  }
+
   TabStripModel* tab_strip_model = browser->tab_strip_model();
   DCHECK(tab_strip_model);
   web_contents = tab_strip_model->GetActiveWebContents();


### PR DESCRIPTION
Uplift of #23333
Resolves https://github.com/brave/brave-browser/issues/37887

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.