### PR TITLE
[ads] Fixes sometimes Play and Pause button are not responsive on NTT fullscreen video ad

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
@@ -86,7 +86,7 @@ class NewTabPageVideoButtonsView: UIView {
     UIView.animate(
       withDuration: 0.1,
       delay: 0,
-      options: AnimationOptions.allowUserInteraction,
+      options: .allowUserInteraction,
       animations: {
         imageView.alpha = 1
       },
@@ -94,7 +94,7 @@ class NewTabPageVideoButtonsView: UIView {
         UIView.animate(
           withDuration: 0.3,
           delay: 0.5,
-          options: AnimationOptions.allowUserInteraction,
+          options: .allowUserInteraction,
           animations: {
             imageView.alpha = 0
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
@@ -85,6 +85,8 @@ class NewTabPageVideoButtonsView: UIView {
     imageView.alpha = 0
     UIView.animate(
       withDuration: 0.1,
+      delay: 0,
+      options: AnimationOptions.allowUserInteraction,
       animations: {
         imageView.alpha = 1
       },
@@ -92,6 +94,7 @@ class NewTabPageVideoButtonsView: UIView {
         UIView.animate(
           withDuration: 0.3,
           delay: 0.5,
+          options: AnimationOptions.allowUserInteraction,
           animations: {
             imageView.alpha = 0
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoPlayer.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoPlayer.swift
@@ -108,6 +108,7 @@ class NewTabPageVideoPlayer {
     if !didFinishAutoplay {
       autoplayFinished()
       player?.pause()
+      seekToStopFrame()
     } else if didStartPlayback {
       player?.pause()
       if let timeObserver = timeObserver {
@@ -219,6 +220,7 @@ class NewTabPageVideoPlayer {
       guard let self = self else { return }
       if player.timeControlStatus == .paused && !self.didFinishAutoplay {
         self.autoplayFinished()
+        self.seekToStopFrame()
       }
     }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37893
Resolves https://github.com/brave/brave-browser/issues/37889

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
* Check that the Issue from https://github.com/brave/brave-browser/issues/37893 is no longer reproducible

### Test case 2
* Check that the Issue from https://github.com/brave/brave-browser/issues/37889 is no longer reproducible

### Test case 3
1. Fresh install
2. Turn off WiFi and mobile network
3. Launch browser
4. Toggle Use Staging CRX components in Settings -> BraveCore Switches
5. Set rewards to staging
6. Close the browser
7. Turn on WiFi or mobile network
8. Launch Brave browser
9. Launch browser in Portrait orientation
10. Open New Tab Pages until a tab with New Tab Takeover video ad is opened
11. Make sure that video autoplay is started
12. Wait until autoplay is finished

EXPECTATION: Designated stop keyframe is shown

### Test case 4
1. Fresh install
2. Turn off WiFi and mobile network
3. Launch browser
4. Toggle Use Staging CRX components in Settings -> BraveCore Switches
5. Set rewards to staging
6. Close the browser
7. Turn on WiFi or mobile network
8. Launch Brave browser
9. Launch browser in Portrait orientation
10. Open New Tab Pages until a tab with New Tab Takeover video ad is opened
11. Make sure that video autoplay started
13. While video is autoplaying, rotate your iPhone to the landscape mode
14. Rotate your phone back to the portrait mode

EXPECTATION: Designated stop keyframe is shown

### Test case 5
1. Fresh install
2. Turn off WiFi and mobile network
3. Launch browser
4. Toggle Use Staging CRX components in Settings -> BraveCore Switches
5. Set rewards to staging
6. Close the browser
7. Turn on WiFi or mobile network
8. Launch Brave browser
9. Launch browser in Portrait orientation
10. Open New Tab Pages until a tab with New Tab Takeover video ad is opened
11. Make sure that video autoplay started
13. While video is autoplaying, switch to another iOS application (make any other iOS application active)
14. While video is autoplaying, switch back to Brave Browser application

EXPECTATION: Designated stop keyframe is shown

### Test case 6
1. Fresh install
2. Turn off WiFi and mobile network
3. Launch browser
4. Toggle Use Staging CRX components in Settings -> BraveCore Switches
5. Set rewards to staging
6. Close the browser
7. Turn on WiFi or mobile network
8. Launch Brave browser
9. Launch browser in Portrait orientation
10. Open New Tab Pages until a tab with New Tab Takeover video ad is opened
11. Make sure that video autoplay started
12. While video is autoplaying, switch to another Tab
13. Switch back to Tab with NTT video ad

EXPECTATION: Designated stop keyframe is shown

### Test case 7
1. Fresh install
2. Turn off WiFi and mobile network
3. Launch browser
4. Toggle Use Staging CRX components in Settings -> BraveCore Switches
5. Set rewards to staging
6. Close the browser
7. Turn on WiFi or mobile network
8. Launch Brave browser
9. Launch browser in Portrait orientation
10. Open New Tab Pages until a tab with New Tab Takeover video ad is opened
11. Wait until video autoplay is finished
12. Tap Play button
13. While fullscreen video is playing, tap the Cancel button

EXPECTATION: Designated stop keyframe is shown

### Test case 8
1. Fresh install
2. Turn off WiFi and mobile network
3. Launch browser
4. Toggle Use Staging CRX components in Settings -> BraveCore Switches
5. Set rewards to staging
6. Close the browser
7. Turn on WiFi or mobile network
8. Launch Brave browser
9. Launch browser in Portrait orientation
10. Open New Tab Pages until a tab with New Tab Takeover video ad is opened
11. Wait until video autoplay is finished
12. Tap Play button
13. While fullscreen video is playing, rotate your iPhone to the landscape mode
14. Rotate your iPhone back to the Portrait mode

EXPECTATION: Designated stop keyframe is shown