### PR TITLE
fix(wallet): Update iOS wallet price rounding to be more accurate for smaller values

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailHeaderView.swift
@@ -66,13 +66,13 @@ struct AssetDetailHeaderView: View {
             }
             Group {
               if let selectedCandle = selectedCandle,
-                let formattedString = assetDetailStore.currencyFormatter.string(
-                  from: NSNumber(value: selectedCandle.value)
+                let formattedString = assetDetailStore.currencyFormatter.formatAsFiat(
+                  selectedCandle.value
                 )
               {
                 Text(formattedString)
               } else {
-                Text(assetDetailStore.price)
+                Text(assetDetailStore.currencyFormatter.formatAsFiat(assetDetailStore.price) ?? "")
               }
             }
             .font(.subheadline.weight(.semibold))
@@ -105,13 +105,13 @@ struct AssetDetailHeaderView: View {
         VStack(alignment: .trailing, spacing: 8) {
           Group {
             if let selectedCandle = selectedCandle,
-              let formattedString = assetDetailStore.currencyFormatter.string(
-                from: NSNumber(value: selectedCandle.value)
+              let formattedString = assetDetailStore.currencyFormatter.formatAsFiat(
+                selectedCandle.value
               )
             {
               Text(formattedString)
             } else {
-              Text(assetDetailStore.price)
+              Text(assetDetailStore.currencyFormatter.formatAsFiat(assetDetailStore.price) ?? "")
             }
           }
           .font(.subheadline.weight(.semibold))

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Asset Details/AssetDetailView.swift
@@ -155,16 +155,12 @@ struct AssetDetailView: View {
       let grids = [GridItem(.adaptive(minimum: 160), spacing: 8, alignment: .top)]
       let info: [CoinMarketInfo] = {
         let computedMarketCap =
-          assetDetailStore.currencyFormatter.string(
-            from: NSNumber(
-              value: BraveWallet.CoinMarket.abbreviateToBillion(input: coinMarket.marketCap)
-            )
+          assetDetailStore.currencyFormatter.formatAsFiat(
+            BraveWallet.CoinMarket.abbreviateToBillion(input: coinMarket.marketCap)
           ) ?? ""
         let computedTotalVolume =
-          assetDetailStore.currencyFormatter.string(
-            from: NSNumber(
-              value: BraveWallet.CoinMarket.abbreviateToBillion(input: coinMarket.totalVolume)
-            )
+          assetDetailStore.currencyFormatter.formatAsFiat(
+            BraveWallet.CoinMarket.abbreviateToBillion(input: coinMarket.totalVolume)
           ) ?? ""
         return [
           .init(title: Strings.Wallet.coinMarketRank, value: "#\(coinMarket.marketCapRank)"),

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AccountActivityStore.swift
@@ -269,7 +269,7 @@ class AccountActivityStore: ObservableObject, WalletObserverStore {
           totalFiat += tokenFiat
         }
       }
-      self.accountTotalFiat = currencyFormatter.string(from: .init(value: totalFiat)) ?? "$0.00"
+      self.accountTotalFiat = currencyFormatter.formatAsFiat(totalFiat) ?? "$0.00"
       self.isLoadingAccountFiat = false
 
       guard !Task.isCancelled else { return }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AccountsStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/AccountsStore.swift
@@ -223,12 +223,10 @@ class AccountsStore: ObservableObject, WalletObserverStore {
           tokens: tokens
         )
         let totalBalanceFiat =
-          currencyFormatter.string(
-            from: NSNumber(
-              value: totalBalanceFiat(
-                for: account,
-                tokens: tokens
-              )
+          currencyFormatter.formatAsFiat(
+            totalBalanceFiat(
+              for: account,
+              tokens: tokens
             )
           ) ?? ""
         return AccountDetails(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/PortfolioStore.swift
@@ -143,7 +143,7 @@ public struct AssetViewModel: Identifiable, Equatable {
     case .none, .network:
       balance = totalBalance
     }
-    return currencyFormatter.string(from: NSNumber(value: (Double(price) ?? 0) * balance)) ?? ""
+    return currencyFormatter.formatAsFiat((Double(price) ?? 0) * balance) ?? ""
   }
 
   /// Sort by the fiat/value of the asset (price x balance), otherwise by balance when price is unavailable.
@@ -631,7 +631,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
           return nil
         }
         .reduce(0.0, +)
-      balance = currencyFormatter.string(from: NSNumber(value: currentBalance)) ?? "–"
+      balance = currencyFormatter.formatAsFiat(currentBalance) ?? "–"
       // Compute historical balances based on historical prices and current balances
       let assetsWithHistory = allAssets.filter { !$0.history.isEmpty }  // [[AssetTimePrice]]
       let minCount = assetsWithHistory.map(\.history.count).min() ?? 0  // Shortest array count
@@ -645,7 +645,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
         return .init(
           date: assetsWithHistory.map { $0.history[index].date }.max() ?? .init(),
           price: value,
-          formattedPrice: currencyFormatter.string(from: NSNumber(value: value)) ?? "0.00"
+          formattedPrice: currencyFormatter.formatAsFiat(value) ?? "0.00"
         )
       }
 
@@ -660,7 +660,7 @@ public class PortfolioStore: ObservableObject, WalletObserverStore {
           priceDifference: String(
             format: "%@%@",
             isBalanceUp ? "+" : "",  // include plus if balance increased
-            currencyFormatter.string(from: NSNumber(value: priceDifference)) ?? "\(priceDifference)"
+            currencyFormatter.formatAsFiat(priceDifference) ?? "\(priceDifference)"
           ),
           percentageChange: String(
             format: "%@%.2f%%",

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/SelectAccountTokenStore.swift
@@ -341,8 +341,8 @@ class SelectAccountTokenStore: ObservableObject, WalletObserverStore {
             if let tokenPrice = pricesCache[token.assetRatioId.lowercased()],
               balance > 0
             {
-              price = currencyFormatter.string(
-                from: NSNumber(value: (Double(tokenPrice) ?? 0) * balance)
+              price = currencyFormatter.formatAsFiat(
+                (Double(tokenPrice) ?? 0) * balance
               )
             }
             return AccountSection.TokenBalance(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -820,7 +820,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     let gasRatio = assetRatios[gasSymbol.lowercased(), default: 0]
     let amount = (Double(value) ?? 0.0) * ratio
     let gasAmount = (Double(gasValue) ?? 0.0) * gasRatio
-    let totalFiat = currencyFormatter.string(from: NSNumber(value: amount + gasAmount)) ?? "$0.00"
+    let totalFiat = currencyFormatter.formatAsFiat(amount + gasAmount) ?? "$0.00"
     return totalFiat
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/EditPriorityFeeView.swift
@@ -138,8 +138,8 @@ struct EditPriorityFeeView: View {
     let proposedGasValue =
       formatter.decimalString(for: gasFeeInWei.removingHexPrefix, radix: .hex, decimals: 18) ?? ""
     let proposedGasFiat =
-      confirmationStore.currencyFormatter.string(
-        from: NSNumber(value: confirmationStore.gasAssetRatio * (Double(proposedGasValue) ?? 0.0))
+      confirmationStore.currencyFormatter.formatAsFiat(
+        confirmationStore.gasAssetRatio * (Double(proposedGasValue) ?? 0.0)
       ) ?? "–"
     return "\(proposedGasFiat) (\(proposedGasValue) \(confirmationStore.gasSymbol))"
   }

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/WalletNumberFormatterExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/WalletNumberFormatterExtensions.swift
@@ -14,6 +14,32 @@ extension NumberFormatter {
     }
   }
 
+  /// Formats the given `value` for fiat display.
+  /// Values less than 1 will show up to 3 significant digits.
+  /// Values greater than 1 & less than 10 will show 3 digits after the decimal.
+  /// All other values will display with grouping and 2 digits after the decimal.
+  func formatAsFiat(_ value: Double) -> String? {
+    let currencyFormatter = NumberFormatter.usdCurrencyFormatter
+    let prevUsesSignificantDigits = currencyFormatter.usesSignificantDigits
+    let prevMaxSignificantDigits = currencyFormatter.maximumSignificantDigits
+    let prevMinFractionDigits = currencyFormatter.minimumFractionDigits
+    let prevMaxFractionDigits = currencyFormatter.maximumFractionDigits
+    let valueDecimalPlaces = value.decimalPlaces
+    if abs(value) < 1 && valueDecimalPlaces != 0 {
+      currencyFormatter.usesSignificantDigits = true
+      currencyFormatter.maximumSignificantDigits = 3
+    } else if abs(value) < 10 && valueDecimalPlaces != 0 {
+      currencyFormatter.minimumFractionDigits = 2
+      currencyFormatter.maximumFractionDigits = 3
+    }
+    let result = currencyFormatter.string(from: .init(value: value))
+    currencyFormatter.usesSignificantDigits = prevUsesSignificantDigits
+    currencyFormatter.maximumSignificantDigits = prevMaxSignificantDigits
+    currencyFormatter.minimumFractionDigits = prevMinFractionDigits
+    currencyFormatter.maximumFractionDigits = prevMaxFractionDigits
+    return result
+  }
+
   func coinMarketPriceString(from value: Double) -> String? {
     assert(numberStyle == .currency)
     var decimals: Int?

--- a/ios/brave-ios/Sources/BraveWallet/Panels/WalletPanelView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/WalletPanelView.swift
@@ -520,11 +520,9 @@ struct WalletPanelView: View {
             )
             .font(.title2.weight(.bold))
             Text(
-              currencyFormatter.string(
-                from: NSNumber(
-                  value: (Double(nativeAsset?.price ?? "") ?? 0)
-                    * (nativeAsset?.totalBalance ?? 0.0)
-                )
+              currencyFormatter.formatAsFiat(
+                (Double(nativeAsset?.price ?? "") ?? 0)
+                  * (nativeAsset?.totalBalance ?? 0.0)
               ) ?? ""
             )
             .font(.callout)

--- a/ios/brave-ios/Tests/BraveWalletTests/AccountsStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AccountsStoreTests.swift
@@ -357,12 +357,12 @@ import XCTest
 
         XCTAssertEqual(accountDetails[safe: 5]?.account, self.btcAccount1)
         XCTAssertEqual(accountDetails[safe: 5]?.tokensWithBalance, self.btcMainnetTokens)
-        XCTAssertEqual(accountDetails[safe: 5]?.totalBalanceFiat, "$0.66")
+        XCTAssertEqual(accountDetails[safe: 5]?.totalBalanceFiat, "$0.657")
 
         if bitcoinTestnetEnabled {
           XCTAssertEqual(accountDetails[safe: 6]?.account, self.btcTestnetAccount)
           XCTAssertEqual(accountDetails[safe: 6]?.tokensWithBalance, self.btcTestnetTokens)
-          XCTAssertEqual(accountDetails[safe: 6]?.totalBalanceFiat, "$6.57")
+          XCTAssertEqual(accountDetails[safe: 6]?.totalBalanceFiat, "$6.573")
         }
       }.store(in: &cancellables)
 

--- a/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -47,7 +47,6 @@ class AssetDetailStoreTests: XCTestCase {
         radix: .hex,
         decimals: Int(BraveWallet.BlockchainToken.previewToken.decimals)
       ) ?? ""
-    let formattedEthBalance = currencyFormatter.string(from: NSNumber(value: mockEthBalance)) ?? ""
     let rpcService = BraveWallet.TestJsonRpcService()
     rpcService._allNetworks = {
       $1([.mockMainnet])
@@ -154,7 +153,7 @@ class AssetDetailStoreTests: XCTestCase {
       .dropFirst()
       .sink {
         defer { assetDetailException.fulfill() }
-        XCTAssertEqual($0, "$1.00")
+        XCTAssertEqual($0, 1.00)
       }
       .store(in: &cancellables)
     store.$priceIsDown
@@ -178,7 +177,7 @@ class AssetDetailStoreTests: XCTestCase {
         XCTAssertEqual(accounts.count, 1)
         XCTAssertEqual(accounts[0].account, .mockEthAccount)
         XCTAssertEqual(accounts[0].balance, String(format: "%.4f", mockEthBalance))
-        XCTAssertEqual(accounts[0].fiatBalance, formattedEthBalance)
+        XCTAssertEqual(accounts[0].fiatBalance, "$1.00")
       }
       .store(in: &cancellables)
     store.$transactionSections
@@ -312,10 +311,6 @@ class AssetDetailStoreTests: XCTestCase {
         radix: .decimal,
         decimals: Int(BraveWallet.BlockchainToken.mockBTCToken.decimals)
       ) ?? ""
-    let formattedBthBalance =
-      currencyFormatter.string(
-        from: NSNumber(value: mockBtcBalance * mockBtcPrice)
-      ) ?? ""
     let bitcoinWalletService = BraveWallet.TestBitcoinWalletService()
     bitcoinWalletService._balance = {
       $1(
@@ -387,7 +382,7 @@ class AssetDetailStoreTests: XCTestCase {
       .dropFirst()
       .sink {
         defer { assetDetailException.fulfill() }
-        XCTAssertEqual($0, "$63,503.00")
+        XCTAssertEqual($0, 63_503.00)
       }
       .store(in: &cancellables)
     store.$priceIsDown
@@ -411,7 +406,7 @@ class AssetDetailStoreTests: XCTestCase {
         XCTAssertEqual(accounts.count, 1)
         XCTAssertEqual(accounts[0].account, .mockBtcAccount)
         XCTAssertEqual(accounts[0].balance, String(format: "%.4f", mockBtcBalance))
-        XCTAssertEqual(accounts[0].fiatBalance, formattedBthBalance)
+        XCTAssertEqual(accounts[0].fiatBalance, "$6.35")
       }
       .store(in: &cancellables)
     store.$isLoadingPrice
@@ -575,7 +570,7 @@ class AssetDetailStoreTests: XCTestCase {
       .dropFirst()
       .sink {
         defer { assetDetailBitcoinException.fulfill() }
-        XCTAssertEqual($0, "$28,324.00")
+        XCTAssertEqual($0, 28_324.00)
       }
       .store(in: &cancellables)
     store.$priceIsDown
@@ -686,7 +681,7 @@ class AssetDetailStoreTests: XCTestCase {
       .dropFirst()
       .sink {
         defer { assetDetailNonBitcoinException.fulfill() }
-        XCTAssertEqual($0, "$1,860.57")
+        XCTAssertEqual($0, 1_860.57)
       }
       .store(in: &cancellables)
     store.$priceIsDown

--- a/ios/brave-ios/Tests/BraveWalletTests/NumberFormatterTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NumberFormatterTests.swift
@@ -1,0 +1,40 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import XCTest
+
+@testable import BraveWallet
+
+class NumberFormatterTests: XCTestCase {
+
+  func testFormatAsFiat() {
+    typealias ValueExpected = (value: Double, expected: String)
+    let currencyFormatter = NumberFormatter.usdCurrencyFormatter
+    let testCases: [ValueExpected] = [
+      // minimum 2 digits after decimal
+      ValueExpected(value: 0, expected: "$0.00"),
+      ValueExpected(value: 1, expected: "$1.00"),
+      ValueExpected(value: 100, expected: "$100.00"),
+      ValueExpected(value: 100001.1, expected: "$100,001.10"),
+      ValueExpected(value: 10001.1, expected: "$10,001.10"),
+      // significant digits for values < 1
+      ValueExpected(value: 0.0000000000001, expected: "$0.0000000000001"),
+      ValueExpected(value: 0.0000123454321, expected: "$0.0000123"),
+      // trailing zeros trimmed
+      ValueExpected(value: 0.0010000, expected: "$0.001"),
+      ValueExpected(value: 0.001230000, expected: "$0.00123"),
+      ValueExpected(value: 0.0000000000001000, expected: "$0.0000000000001"),
+      // Comma separated
+      ValueExpected(value: 123456789.0, expected: "$123,456,789.00"),
+      ValueExpected(value: 12345678.90, expected: "$12,345,678.90"),
+      ValueExpected(value: 1234567.890, expected: "$1,234,567.89"),
+      ValueExpected(value: 123456.7890, expected: "$123,456.79"),
+      ValueExpected(value: 12345.67890, expected: "$12,345.68"),
+    ]
+    testCases.forEach {
+      XCTAssertEqual(currencyFormatter.formatAsFiat($0.value), $0.expected)
+    }
+  }
+}

--- a/ios/brave-ios/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -162,7 +162,7 @@ import XCTest
     let totalBalanceValue =
       totalEthBalanceValue + totalSolBalanceValue + totalUSDCBalanceValue
       + totalFilBalanceValue + totalBtcBalanceValue
-    return currencyFormatter.string(from: NSNumber(value: totalBalanceValue)) ?? ""
+    return currencyFormatter.formatAsFiat(totalBalanceValue) ?? ""
   }
 
   private func setupStore() -> PortfolioStore {

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionDetailsStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionDetailsStoreTests.swift
@@ -111,7 +111,7 @@ class TransactionDetailsStoreTests: XCTestCase {
         defer { parsedTransactionExpectation.fulfill() }
         XCTAssertNotNil(parsedTransaction)
         XCTAssertEqual(parsedTransaction?.transaction.txHash, transaction.txHash)
-        XCTAssertEqual(parsedTransaction?.gasFee, .init(fee: "0.003402", fiat: "$10.41008598"))
+        XCTAssertEqual(parsedTransaction?.gasFee, .init(fee: "0.003402", fiat: "$10.41"))
       }
       .store(in: &cancellables)
     let networkExpectation = expectation(description: "update-network")

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -138,7 +138,7 @@ class TransactionParserTests: XCTestCase {
           fromToken: network.nativeToken,
           fromValue: "0x1b667a56d488000",
           fromAmount: "0.1234",
-          fromFiat: "$0.12",
+          fromFiat: "$0.123",
           fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.000031",
@@ -240,7 +240,7 @@ class TransactionParserTests: XCTestCase {
           fromToken: .previewDaiToken,
           fromValue: "0x5ff20a91f724000",
           fromAmount: "0.4321",
-          fromFiat: "$0.86",
+          fromFiat: "$0.864",
           fromTokenMetadata: nil,
           gasFee: .init(
             fee: "0.000078",
@@ -332,7 +332,7 @@ class TransactionParserTests: XCTestCase {
           fromToken: .previewToken,
           fromValue: "0x1b6951ef585a000",
           fromAmount: "0.12345",
-          fromFiat: "$0.12",
+          fromFiat: "$0.123",
           toToken: .previewDaiToken,
           minBuyValue: "0x5c6f2d76e910358b",
           minBuyAmount: "6.660592362643797387",
@@ -431,7 +431,7 @@ class TransactionParserTests: XCTestCase {
           toToken: .previewDaiToken,
           minBuyValue: "0x1bd02ca9a7c244e",
           minBuyAmount: "0.125259433834718286",
-          minBuyAmountFiat: "$0.25",
+          minBuyAmountFiat: "$0.251",
           gasFee: .init(
             fee: "0.000466",
             fiat: "$0.000466"
@@ -1250,7 +1250,7 @@ class TransactionParserTests: XCTestCase {
           gasFeeCap: "0.000000000000101965",
           gasFee: GasFee(
             fee: "0.000000155797727645",
-            fiat: "$0.0000003116"
+            fiat: "$0.000000312"
           )
         )
       )

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -330,11 +330,11 @@ class TransactionsActivityStoreTests: XCTestCase {
         // verify gas fee fiat
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 0]?.transactions[safe: 0]?.gasFee?.fiat,
-          "$0.0000006232"
+          "$0.000000623"
         )
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 1]?.transactions[safe: 0]?.gasFee?.fiat,
-          "$0.0000006232"
+          "$0.000000623"
         )
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 1]?.transactions[safe: 1]?.gasFee?.fiat,
@@ -346,15 +346,15 @@ class TransactionsActivityStoreTests: XCTestCase {
         )
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 2]?.transactions[safe: 1]?.gasFee?.fiat,
-          "$255.03792654"
+          "$255.04"
         )
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 3]?.transactions[safe: 0]?.gasFee?.fiat,
-          "$10.41008598"
+          "$10.41"
         )
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 3]?.transactions[safe: 1]?.gasFee?.fiat,
-          "$10.19894667"
+          "$10.20"
         )
       }
       .store(in: &cancellables)


### PR DESCRIPTION
- Added a new `formatAsFiat` helper function to `NumberFormatter` for helping with more accurate fiat/price display. For quick examples, see `BraveWalletTests/NumberFormatterTests` or screenshots at bottom of PR.
- Similar to desktop, we will use significant digits for price rounding smaller values for more accurate display. 
    - If value is < 1, we show using significant digits. 
    - If value is >= 1 and < 10, we show 3 digits after decimal
    - For larger values we continue to display with 2 digits after decimal.

Resolves https://github.com/brave/brave-browser/issues/36163

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Check price/fiat display throughout wallet, ex. in Portfolio, Asset Details, Transactions (fiat value + gas fiat value), Accounts.
Fiat/price values less than 1 should display more accurately using 3 significant digits. 
Fiat/price values less than 10 (>= 1) should display with 3 digits after decimal.
For remaining larger values (>= 10) should display with 2 digits after the decimal (matches existing behaviour).

Helpful with smaller value tokens, or fiat value of tokens with small user balance. Karate token much better displayed with ~$0.00126 than $0.01 rounded for example.

![Portfolio graph](https://github.com/brave/brave-core/assets/5314553/10907b14-e348-45d3-af98-0a0d1163f066) | ![Assets Fiat Value](https://github.com/brave/brave-core/assets/5314553/a0a144c4-1396-47b3-91c3-b0c337d14855) | ![Karate token](https://github.com/brave/brave-core/assets/5314553/ff2d8b26-7b8b-48f7-8af6-6d08c0b20971)
--|--|--
![Select Token to Send](https://github.com/brave/brave-core/assets/5314553/a4c78243-28bb-446a-afa6-8d3fb890854f) | ![Transaction Confirmation](https://github.com/brave/brave-core/assets/5314553/fcf72c42-16d4-4ad0-957b-743197b4a866) | ![Transaction Details](https://github.com/brave/brave-core/assets/5314553/edfc7274-93a8-4be2-88ff-d669178f2053)
