### PR TITLE
[ads] Fixes sometimes Play and Pause button are not responsive on NTT fullscreen video ad (uplift to 1.66.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoButtonsView.swift
@@ -85,6 +85,8 @@ class NewTabPageVideoButtonsView: UIView {
     imageView.alpha = 0
     UIView.animate(
       withDuration: 0.1,
+      delay: 0,
+      options: .allowUserInteraction,
       animations: {
         imageView.alpha = 1
       },
@@ -92,6 +94,7 @@ class NewTabPageVideoButtonsView: UIView {
         UIView.animate(
           withDuration: 0.3,
           delay: 0.5,
+          options: .allowUserInteraction,
           animations: {
             imageView.alpha = 0
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoPlayer.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoPlayer.swift
@@ -108,6 +108,7 @@ class NewTabPageVideoPlayer {
     if !didFinishAutoplay {
       autoplayFinished()
       player?.pause()
+      seekToStopFrame()
     } else if didStartPlayback {
       player?.pause()
       if let timeObserver = timeObserver {
@@ -219,6 +220,7 @@ class NewTabPageVideoPlayer {
       guard let self = self else { return }
       if player.timeControlStatus == .paused && !self.didFinishAutoplay {
         self.autoplayFinished()
+        self.seekToStopFrame()
       }
     }
 


### PR DESCRIPTION
Uplift of #23372
Resolves https://github.com/brave/brave-browser/issues/37893
Resolves https://github.com/brave/brave-browser/issues/37889

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.