### PR TITLE
Show 'Help WDP' in welcome ui for all countries

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -478,15 +478,6 @@
                    FEATURE_VALUE_TYPE(brave_player::features::kBravePlayer), \
                }))
 
-#define BRAVE_WELCOME_PAGE_FEATURE_ENTRIES                          \
-  EXPAND_FEATURE_ENTRIES({                                          \
-      "brave-show-help-wdp-in-welcome-page",                        \
-      "Show Help WDP in Welcome Page",                              \
-      "Show Help WDP in Welcome Page regardless of country code",   \
-      kOsWin | kOsLinux | kOsMac,                                   \
-      FEATURE_VALUE_TYPE(features::kBraveShowHelpWDPInWelcomePage), \
-  })
-
 // Keep the last item empty.
 #define LAST_BRAVE_FEATURE_ENTRIES_ITEM
 
@@ -1019,7 +1010,6 @@
   BRAVE_OMNIBOX_FEATURES                                                       \
   BRAVE_PLAYER_FEATURE_ENTRIES                                                 \
   BRAVE_MIDDLE_CLICK_AUTOSCROLL_FEATURE_ENTRY                                  \
-  BRAVE_WELCOME_PAGE_FEATURE_ENTRIES                                           \
   LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.
 namespace flags_ui {
 namespace {

--- a/browser/brave_browser_features.cc
+++ b/browser/brave_browser_features.cc
@@ -48,10 +48,4 @@ const base::FeatureParam<std::string> kBraveDayZeroExperimentVariant{
     /*name=*/"variant",
     /*default_value=*/""};
 
-// Shows "Help WDP" in brave://welcome page. If this is off,
-// the page shows up only when country code is Japan
-BASE_FEATURE(kBraveShowHelpWDPInWelcomePage,
-             "brave-show-help-wdp-in-welcome-page",
-             base::FEATURE_DISABLED_BY_DEFAULT);
-
 }  // namespace features

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -21,8 +21,6 @@ BASE_DECLARE_FEATURE(kBraveWebViewRoundedCorners);
 BASE_DECLARE_FEATURE(kBraveDayZeroExperiment);
 extern const base::FeatureParam<std::string> kBraveDayZeroExperimentVariant;
 
-BASE_DECLARE_FEATURE(kBraveShowHelpWDPInWelcomePage);
-
 }  // namespace features
 
 #endif  // BRAVE_BROWSER_BRAVE_BROWSER_FEATURES_H_

--- a/browser/ui/webui/welcome_page/brave_welcome_ui.cc
+++ b/browser/ui/webui/welcome_page/brave_welcome_ui.cc
@@ -164,11 +164,6 @@ BraveWelcomeUI::BraveWelcomeUI(content::WebUI* web_ui, const std::string& name)
       "hardwareAccelerationEnabledAtStartup",
       content::GpuDataManager::GetInstance()->HardwareAccelerationEnabled());
 
-  source->AddBoolean(
-      /*name*/ "showHelpWDP",
-      /*value*/ is_jpn || base::FeatureList::IsEnabled(
-                              features::kBraveShowHelpWDPInWelcomePage));
-
   profile->GetPrefs()->SetBoolean(prefs::kHasSeenWelcomePage, true);
 
   AddBackgroundColorToSource(source, web_ui->GetWebContents());

--- a/components/brave_welcome_ui/state/hooks.ts
+++ b/components/brave_welcome_ui/state/hooks.ts
@@ -78,8 +78,6 @@ interface ViewTypeState {
   fail?: ViewType;
 }
 
-const showHelpWDP = loadTimeData.getBoolean('showHelpWDP')
-
 export function useViewTypeTransition(currentViewType: ViewType | undefined) : ViewTypeState {
   const { browserProfiles, currentSelectedBrowserProfiles} = React.useContext(DataContext)
 
@@ -90,11 +88,11 @@ export function useViewTypeTransition(currentViewType: ViewType | undefined) : V
             ViewType.ImportSelectTheme : ViewType.ImportSelectBrowser
       },
       [ViewType.ImportSelectTheme]: {
-        forward: showHelpWDP ? ViewType.HelpWDP : ViewType.HelpImprove
+        forward: ViewType.HelpWDP
       },
       [ViewType.ImportSelectBrowser]: {
         forward: currentSelectedBrowserProfiles && currentSelectedBrowserProfiles.length > 1 ? ViewType.ImportSelectProfile : ViewType.ImportInProgress,
-        skip: showHelpWDP ? ViewType.HelpWDP : ViewType.HelpImprove,
+        skip: ViewType.HelpWDP,
       },
       [ViewType.ImportSelectProfile]: {
         forward: ViewType.ImportInProgress,
@@ -105,10 +103,10 @@ export function useViewTypeTransition(currentViewType: ViewType | undefined) : V
         fail: ViewType.ImportFailed,
       },
       [ViewType.ImportSucceeded]: {
-        forward: showHelpWDP ? ViewType.HelpWDP : ViewType.HelpImprove
+        forward: ViewType.HelpWDP
       },
       [ViewType.ImportFailed]: {
-        forward: showHelpWDP ? ViewType.HelpWDP : ViewType.HelpImprove
+        forward: ViewType.HelpWDP
       },
       [ViewType.HelpWDP]: {
         forward: ViewType.HelpImprove


### PR DESCRIPTION
Previously, we showed 'Help WDP' only for the JP. This change makes it show for all countries.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38006

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. With Already installed browser 
* Open brave://welcome page.
* "Help WDP" page should show up

2. With Newly installed browser
* Open browser
* Welcome page should show up and "Help WDP" page should be in there.
