### PR TITLE
Allows Brave to work on devices without Google Play Services on Android (uplift to 1.66.x)

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -15,6 +15,7 @@ import("//brave/browser/share/android/java_sources.gni")
 import("//brave/components/embedder_support/android/java_sources.gni")
 import("//brave/components/permissions/android/java_sources.gni")
 import("//brave/components/safetynet/java_sources.gni")
+import("//brave/components/signin/public/android/java_sources.gni")
 import("//components/feed/features.gni")
 
 brave_java_sources = [
@@ -488,6 +489,7 @@ brave_java_sources = [
 
 brave_java_sources += brave_ads_java_sources
 brave_java_sources += brave_components_embedder_support_java_sources
+brave_java_sources += brave_components_signin_java_sources
 brave_java_sources += brave_rewards_java_sources
 brave_java_sources += brave_feed_java_sources
 brave_java_sources += brave_public_tab_management_java_sources

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -836,3 +836,11 @@
     *** getApplicationLocale(...);
     *** setApplicationLocale(...);
 }
+
+-keep class org.chromium.components.signin.SystemAccountManagerDelegate {
+    public <init>(...);
+}
+
+-keep class org.chromium.components.signin.BraveSystemAccountManagerDelegate {
+    public <init>(...);
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -1315,6 +1315,10 @@ public class BytecodeTest {
                 constructorsMatch(
                         "org/chromium/components/language/LocaleManagerDelegateImpl",
                         "org/chromium/components/language/BraveLocaleManagerDelegateImpl"));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/components/signin/SystemAccountManagerDelegate",
+                        "org/chromium/components/signin/BraveSystemAccountManagerDelegate"));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -89,6 +89,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStatusMediatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveStrictPreferenceKeyCheckerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSwipeRefreshHandlerClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSystemAccountManagerDelegateAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabGroupModelFilterClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabGroupUiCoordinatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabHelpersClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -89,6 +89,7 @@ public class BraveClassAdapter {
         chain = new BraveStatusMediatorClassAdapter(chain);
         chain = new BraveStrictPreferenceKeyCheckerClassAdapter(chain);
         chain = new BraveSwipeRefreshHandlerClassAdapter(chain);
+        chain = new BraveSystemAccountManagerDelegateAdapter(chain);
         chain = new BraveTabGroupUiCoordinatorClassAdapter(chain);
         chain = new BraveTabHelpersClassAdapter(chain);
         chain = new BraveTabSwitcherModeTTCoordinatorClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveSystemAccountManagerDelegateAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveSystemAccountManagerDelegateAdapter.java
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveSystemAccountManagerDelegateAdapter extends BraveClassVisitor {
+    static String sSystemAccountManagerDelegateClassName =
+            "org/chromium/components/signin/SystemAccountManagerDelegate";
+    static String sBraveSystemAccountManagerDelegateClassName =
+            "org/chromium/components/signin/BraveSystemAccountManagerDelegate";
+
+    public BraveSystemAccountManagerDelegateAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(
+                sSystemAccountManagerDelegateClassName,
+                sBraveSystemAccountManagerDelegateClassName);
+    }
+}

--- a/components/signin/public/android/java/src/org/chromium/components/signin/BraveSystemAccountManagerDelegate.java
+++ b/components/signin/public/android/java/src/org/chromium/components/signin/BraveSystemAccountManagerDelegate.java
@@ -1,0 +1,27 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.components.signin;
+
+import android.accounts.Account;
+
+/**
+ * That class extends upstream's SystemAccountManagerDelegate.java to be able run Brave on devices
+ * without Google Play Services
+ */
+public class BraveSystemAccountManagerDelegate extends SystemAccountManagerDelegate {
+    public BraveSystemAccountManagerDelegate() {
+        super();
+    }
+
+    @Override
+    public Account[] getAccountsSynchronous() throws AccountManagerDelegateException {
+        if (!isGooglePlayServicesAvailable()) {
+            return new Account[] {};
+        }
+
+        return super.getAccountsSynchronous();
+    }
+}

--- a/components/signin/public/android/java_sources.gni
+++ b/components/signin/public/android/java_sources.gni
@@ -1,0 +1,6 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_components_signin_java_sources = [ "//brave/components/signin/public/android/java/src/org/chromium/components/signin/BraveSystemAccountManagerDelegate.java" ]


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-browser/issues/37855
Resolves https://github.com/brave/brave-core/pull/23373