### PR TITLE
[Sync] TimeLimitedWords::GetNotAfter method for getting not_after time

### DIFF
--- a/components/brave_sync/time_limited_words.h
+++ b/components/brave_sync/time_limited_words.h
@@ -20,6 +20,7 @@ FORWARD_DECLARE_TEST(TimeLimitedWordsTest, GetIndexByWord);
 FORWARD_DECLARE_TEST(TimeLimitedWordsTest, GetRoundedDaysDiff);
 FORWARD_DECLARE_TEST(TimeLimitedWordsTest, GetWordByIndex);
 FORWARD_DECLARE_TEST(TimeLimitedWordsTest, Parse);
+FORWARD_DECLARE_TEST(TimeLimitedWordsTest, GetNotAfter);
 
 class TimeLimitedWords {
  public:
@@ -50,6 +51,8 @@ class TimeLimitedWords {
   static std::string GenerateResultToText(
       const GenerateResult& generate_result);
 
+  static base::Time GetNotAfter(const std::string& time_limited_words);
+
  private:
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, GenerateForDate);
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, GetIndexByWord);
@@ -57,6 +60,7 @@ class TimeLimitedWords {
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, GetWordByIndex);
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, Parse);
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, ParseIgnoreDate);
+  FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, GetNotAfter);
 
   enum class WrongDateBehaviour { kIgnore = 1, kDontAllow = 2 };
   static base::expected<std::string, ValidationStatus> ParseImpl(

--- a/components/brave_sync/time_limited_words_unittest.cc
+++ b/components/brave_sync/time_limited_words_unittest.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_sync/time_limited_words.h"
 
 #include <memory>
+#include <utility>
 
 #include "base/strings/strcat.h"
 #include "base/time/time_override.h"
@@ -231,6 +232,33 @@ TEST(TimeLimitedWordsTest, ParseIgnoreDate) {
     EXPECT_TRUE(pure_words_with_status.has_value());
     EXPECT_EQ(pure_words_with_status.value(), kValidSyncCode);
   }
+}
+
+TEST(TimeLimitedWordsTest, GetNotAfter) {
+  const base::Time anchorDayForWordsV2 =
+      TimeLimitedWords::GetWordsV2Epoch() + base::Days(20);
+
+  const auto& generate_result =
+      TimeLimitedWords::GenerateForDate(kValidSyncCode, anchorDayForWordsV2);
+  EXPECT_TRUE(generate_result.has_value());
+
+  base::Time not_after = TimeLimitedWords::GetNotAfter(generate_result.value());
+
+  // We must able to connect before |not_after| and we must be rejected after
+  // |not_after|
+  std::pair<int, bool> hours_to_result_data[] = {
+      {-12, true}, {-1, true}, {1, false}};
+
+  for (const auto& hours_to_result : hours_to_result_data) {
+    auto time_override =
+        OverrideWithTimeNow(not_after + base::Hours(hours_to_result.first));
+    auto parse_status = TimeLimitedWords::Parse(generate_result.value());
+    EXPECT_EQ(parse_status.has_value(), hours_to_result.second);
+  }
+}
+
+TEST(TimeLimitedWordsTest, GetNotAfterForPureWords) {
+  EXPECT_EQ(TimeLimitedWords::GetNotAfter(kValidSyncCode), base::Time());
 }
 
 }  // namespace brave_sync


### PR DESCRIPTION
This PR extracts `TimeLimitedWords::GetNotAfter` from https://github.com/brave/brave-core/pull/23051/files#diff-3c1466540e68a4bd6e339da81995420c095e6044ce7f699fb7e4311b435039c9R215 PR to unblock iOS PR https://github.com/brave/brave-core/pull/23394

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38024

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
N/A
