### PR TITLE
Check a11y tree when background pdf tab regains focus.

### DIFF
--- a/browser/ai_chat/page_content_fetcher_browsertest.cc
+++ b/browser/ai_chat/page_content_fetcher_browsertest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/ai_chat/content/browser/page_content_fetcher.h"
+
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
@@ -10,9 +12,9 @@
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/strings/string_util.h"
+#include "base/task/single_thread_task_runner.h"
 #include "base/test/bind.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
-#include "brave/components/ai_chat/content/browser/page_content_fetcher.h"
 #include "brave/components/constants/brave_paths.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
@@ -99,11 +101,14 @@ class PageContentFetcherBrowserTest : public InProcessBrowserTest {
   void FetchPageContent(const base::Location& location,
                         const std::string& expected_text,
                         bool expected_is_video,
-                        bool trim_whitespace = true) {
+                        bool trim_whitespace = true,
+                        content::WebContents* web_contents = nullptr) {
     SCOPED_TRACE(testing::Message() << location.ToString());
     base::RunLoop run_loop;
     ai_chat::FetchPageContent(
-        browser()->tab_strip_model()->GetActiveWebContents(), "",
+        web_contents ? web_contents
+                     : browser()->tab_strip_model()->GetActiveWebContents(),
+        "",
         base::BindLambdaForTesting([&run_loop, &expected_text,
                                     &expected_is_video, &trim_whitespace](
                                        std::string text, bool is_video,
@@ -170,15 +175,15 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContent) {
 }
 
 IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContentPDF) {
+  constexpr char kExpectedText[] = "This is the way\nI have spoken";
   auto* chat_tab_helper =
       ai_chat::AIChatTabHelper::FromWebContents(GetActiveWebContents());
   ASSERT_TRUE(chat_tab_helper);
   chat_tab_helper->SetUserOptedIn(true);
   auto run_loop = std::make_unique<base::RunLoop>();
   chat_tab_helper->SetOnPDFA11yInfoLoadedCallbackForTesting(
-      base::BindLambdaForTesting([this, &run_loop]() {
-        FetchPageContent(FROM_HERE, "This is the way\nI have spoken", false,
-                         false);
+      base::BindLambdaForTesting([this, &run_loop, &kExpectedText]() {
+        FetchPageContent(FROM_HERE, kExpectedText, false, false);
         run_loop->Quit();
       }));
   NavigateURL(https_server_.GetURL("a.com", "/dummy.pdf"));
@@ -191,5 +196,30 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContentPDF) {
         run_loop->Quit();
       }));
   NavigateURL(https_server_.GetURL("a.com", "/empty_pdf.pdf"));
+  run_loop->Run();
+
+  // Test pdf tab loaded in background.
+  ui_test_utils::NavigateToURLWithDisposition(
+      browser(), https_server_.GetURL("a.com", "/dummy.pdf"),
+      WindowOpenDisposition::NEW_BACKGROUND_TAB,
+      ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  ASSERT_EQ(2, browser()->tab_strip_model()->count());
+  run_loop = std::make_unique<base::RunLoop>();
+  chat_tab_helper = ai_chat::AIChatTabHelper::FromWebContents(
+      browser()->tab_strip_model()->GetWebContentsAt(1));
+  chat_tab_helper->SetOnPDFA11yInfoLoadedCallbackForTesting(
+      base::BindLambdaForTesting([this, &run_loop, &kExpectedText]() {
+        FetchPageContent(FROM_HERE, kExpectedText, false, false,
+                         browser()->tab_strip_model()->GetWebContentsAt(1));
+        run_loop->Quit();
+      }));
+  // Tab load stop doesn't mean pdf a11y info is loaded and we have to activate
+  // the tab after the info is loaded to test the pulling scenario.
+  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
+      FROM_HERE, base::BindLambdaForTesting([this]() {
+        browser()->tab_strip_model()->ActivateTabAt(1);
+        EXPECT_EQ(1, browser()->tab_strip_model()->active_index());
+      }),
+      base::Seconds(5));
   run_loop->Run();
 }

--- a/components/ai_chat/content/browser/BUILD.gn
+++ b/components/ai_chat/content/browser/BUILD.gn
@@ -16,6 +16,8 @@ static_library("browser") {
     "ai_chat_throttle.h",
     "page_content_fetcher.cc",
     "page_content_fetcher.h",
+    "pdf_utils.cc",
+    "pdf_utils.h",
   ]
 
   deps = [

--- a/components/ai_chat/content/browser/DEPS
+++ b/components/ai_chat/content/browser/DEPS
@@ -1,3 +1,5 @@
 include_rules = [
   "+brave/services/printing",
+  "+content/public/browser",
+  "+ui/accessibility",
 ]

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -106,6 +106,10 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void InnerWebContentsAttached(content::WebContents* inner_web_contents,
                                 content::RenderFrameHost* render_frame_host,
                                 bool is_full_page) override;
+  void OnWebContentsFocused(
+      content::RenderWidgetHost* render_widget_host) override;
+  void OnWebContentsLostFocus(
+      content::RenderWidgetHost* render_widget_host) override;
 
   // favicon::FaviconDriverObserver
   void OnFaviconUpdated(favicon::FaviconDriver* favicon_driver,
@@ -125,11 +129,15 @@ class AIChatTabHelper : public content::WebContentsObserver,
       mojo::PendingAssociatedReceiver<mojom::PageContentExtractorHost>
           receiver);
 
+  // Traverse through a11y tree to check existence of status node.
+  void CheckPDFA11yTree(content::RenderFrameHost*);
+
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
 
   bool is_same_document_navigation_ = false;
   int64_t pending_navigation_id_;
   bool is_pdf_a11y_info_loaded_ = false;
+  uint8_t check_pdf_a11y_tree_attempts_ = 0;
   GetPageContentCallback pending_get_page_content_callback_;
 
   std::unique_ptr<PDFA11yInfoLoadObserver> pdf_load_observer_;

--- a/components/ai_chat/content/browser/pdf_utils.cc
+++ b/components/ai_chat/content/browser/pdf_utils.cc
@@ -1,0 +1,89 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/content/browser/pdf_utils.h"
+
+#include "base/strings/strcat.h"
+#include "content/public/browser/render_process_host.h"
+#include "content/public/browser/web_contents.h"
+#include "ui/accessibility/ax_node.h"
+#include "ui/accessibility/ax_tree_manager.h"
+
+namespace ai_chat {
+
+namespace {
+
+ui::AXNode* FindPdfRoot(const ui::AXNode* start_node) {
+  if (!start_node) {
+    return nullptr;
+  }
+  for (const auto& node : start_node->GetAllChildren()) {
+    if (node->GetRole() == ax::mojom::Role::kPdfRoot) {
+      return node;
+    }
+    ui::AXNode* result = FindPdfRoot(node);
+    if (result) {
+      return result;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
+
+bool IsPdf(content::WebContents* web_contents) {
+  return web_contents->GetContentsMimeType() == "application/pdf";
+}
+
+ui::AXNode* GetPdfRoot(content::RenderFrameHost* primary_rfh) {
+  ui::AXTreeManager* ax_tree_manager = nullptr;
+  // FindPdfChildFrame
+  primary_rfh->ForEachRenderFrameHost(
+      [&ax_tree_manager](content::RenderFrameHost* rfh) {
+        if (!rfh->GetProcess()->IsPdf()) {
+          return;
+        }
+        ui::AXTreeID ax_tree_id = rfh->GetAXTreeID();
+        if (ax_tree_id.type() == ax::mojom::AXTreeIDType::kUnknown) {
+          return;
+        }
+        ax_tree_manager = ui::AXTreeManager::FromID(ax_tree_id);
+      });
+  if (!ax_tree_manager) {
+    return nullptr;
+  }
+  return FindPdfRoot(ax_tree_manager->GetRoot());
+}
+
+bool IsPdfLoaded(const ui::AXNode* pdf_root) {
+  if (!pdf_root || pdf_root->GetChildCount() < 2 ||
+      pdf_root->GetChildAtIndex(0)->GetRole() != ax::mojom::Role::kBanner ||
+      pdf_root->GetChildAtIndex(0)->IsEmptyLeaf() ||
+      pdf_root->GetChildAtIndex(0)->GetChildAtIndex(0)->GetRole() !=
+          ax::mojom::Role::kStatus) {
+    return false;
+  }
+  return true;
+}
+
+std::string ExtractPdfContent(const ui::AXNode* pdf_root) {
+  // Skip status subtree and get text from region siblings
+  if (!pdf_root || pdf_root->GetChildCount() < 2 ||
+      pdf_root->GetChildAtIndex(0)->GetRole() != ax::mojom::Role::kBanner) {
+    return std::string();
+  }
+  std::string pdf_content;
+  const auto& children = pdf_root->GetAllChildren();
+  for (auto it = children.cbegin() + 1; it != children.cend(); ++it) {
+    const ui::AXNode* node = *it;
+    if (node->GetRole() == ax::mojom::Role::kRegion) {
+      base::StrAppend(&pdf_content, {node->GetTextContentUTF8(),
+                                     it == children.cend() - 1 ? "" : "\n"});
+    }
+  }
+  return pdf_content;
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/content/browser/pdf_utils.h
+++ b/components/ai_chat/content/browser/pdf_utils.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PDF_UTILS_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PDF_UTILS_H_
+
+#include <string>
+
+namespace content {
+class RenderFrameHost;
+class WebContents;
+}  // namespace content
+
+namespace ui {
+class AXNode;
+}
+
+namespace ai_chat {
+
+bool IsPdf(content::WebContents* web_contents);
+
+ui::AXNode* GetPdfRoot(content::RenderFrameHost* primary_rfh);
+
+bool IsPdfLoaded(const ui::AXNode* pdf_root);
+
+std::string ExtractPdfContent(const ui::AXNode* pdf_root);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_PDF_UTILS_H_


### PR DESCRIPTION
When a tab is unfocused, we won't be abled to receive accessibility events which means we would wait for that event forever even when the pdf accessibility tree is fully loaded. In order to amend that, we will do a manually a11y tree scan when the tab is focused only if is_pdf_a11y_info_loaded_ is false. A11y tree might not be ready when the tab is getting focus so we will retry 3 seconds later at most 5 times for each OnWebContentsFocused.

Also move all pdf related functions into pdf_utils 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37794

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Search "dummy pdf" in Brave search
2. Open the [W3C result](https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf) in background tab (Ctrl/Cmd + Click or through context menu "Open Link in New Tab")
3. Wait for pdf to be loaded (Approximately 5s after tab title being set).
4. Active the tab and do summarization.
5. We should get the result back instead of waiting forever.
