### PR TITLE
[Android] fix autofill hints crash (uplift to 1.65.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/autofill/BraveAutofillBackgroundServiceImpl.java
+++ b/android/java/org/chromium/chrome/browser/autofill/BraveAutofillBackgroundServiceImpl.java
@@ -348,7 +348,7 @@ public class BraveAutofillBackgroundServiceImpl extends ChromeBackgroundServiceI
         // First try the explicit autofill hints...
 
         String[] hints = node.getAutofillHints();
-        if (hints != null && hints.length > 0) {
+        if (hints != null && hints.length > 0 && hints[0] != null && !hints[0].isEmpty()) {
             return hints[0].toLowerCase(Locale.getDefault());
         }
 


### PR DESCRIPTION
Uplift of #23384
Resolves https://github.com/brave/brave-browser/issues/37995

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.