### PR TITLE
Fix metric name in iOS UptimeMonitor (uplift to 1.65.x)

### DIFF
--- a/ios/brave-ios/Sources/Growth/UptimeMonitor.swift
+++ b/ios/brave-ios/Sources/Growth/UptimeMonitor.swift
@@ -73,7 +73,7 @@ public class UptimeMonitor {
     ]
     let durationInMinutes = Int(Preferences.UptimeMonitor.uptimeSum.value / 60.0)
     UmaHistogramRecordValueToBucket(
-      "Brave.Uptime.BrowserOpenMinutes",
+      "Brave.Uptime.BrowserOpenTime",
       buckets: buckets,
       value: durationInMinutes
     )


### PR DESCRIPTION
Uplift of #23417
Resolves https://github.com/brave/brave-browser/issues/38055

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.