### PR TITLE
Fix SharedPinnedTab functionality

### DIFF
--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -14,6 +14,8 @@
 #include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/browser_tabrestore.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/tabs/tab_enums.h"
+#include "chrome/browser/ui/tabs/tab_model.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/web_contents_user_data.h"
 
@@ -134,7 +136,7 @@ SharedPinnedTabService::GetTabRendererDataForDummyContents(
 
 void SharedPinnedTabService::CacheWebContentsIfNeeded(
     Browser* browser,
-    const std::vector<std::unique_ptr<DetachedWebContents>>& web_contents) {
+    std::vector<std::unique_ptr<tabs::TabModel>> pinned_tabs) {
   DVLOG(2) << __FUNCTION__;
   DCHECK(!profile_will_be_destroyed_);
 
@@ -149,19 +151,18 @@ void SharedPinnedTabService::CacheWebContentsIfNeeded(
     return;
   }
 
-  for (auto& detached_web_contents : web_contents) {
-    if (!detached_web_contents->tab ||
-        !detached_web_contents->tab->contents()) {
+  for (auto& pinned_tab : pinned_tabs) {
+    if (!pinned_tab->contents()) {
       // Could be already cached by another component.
       continue;
     }
 
-    if (!SharedContentsData::FromWebContents(detached_web_contents->contents)) {
+    if (!SharedContentsData::FromWebContents(pinned_tab->contents())) {
       continue;
     }
 
     cached_shared_contentses_from_closing_browser_.insert(
-        detached_web_contents->tab->ReplaceContents(nullptr));
+        tabs::TabModel::DestroyAndTakeWebContents(std::move(pinned_tab)));
   }
 }
 
@@ -252,6 +253,14 @@ void SharedPinnedTabService::OnBrowserClosing(Browser* browser) {
       }
     }
   } else {
+    // Try caching shared contents from the closing browser.
+    auto* tab_strip_model = browser->tab_strip_model();
+    std::vector<std::unique_ptr<tabs::TabModel>> pinned_tabs;
+    for (int i = tab_strip_model->IndexOfFirstNonPinnedTab() - 1; i >= 0; --i) {
+      pinned_tabs.push_back(tab_strip_model->DetachTabAtForInsertion(i));
+    }
+    CacheWebContentsIfNeeded(browser, std::move(pinned_tabs));
+
     for (auto& pinned_tab_data : pinned_tab_data_) {
       if (pinned_tab_data.contents_owner_model == browser->tab_strip_model()) {
         pinned_tab_data.contents_owner_model = nullptr;
@@ -722,6 +731,11 @@ void SharedPinnedTabService::MoveSharedWebContentsToBrowser(
         tab_strip_model->GetWebContentsAt(index));
     DCHECK(dummy_contents_data);
     dummy_contents_data->stop_propagation();
+
+    const int add_type =
+        ADD_PINNED | (is_last_closing_browser ? ADD_ACTIVE : 0);
+    tab_strip_model->InsertWebContentsAt(
+        index, std::move(unique_shared_contents), add_type);
 
     // In order to prevent browser from being closed, we should close the dummy
     // contents after we restore the tab.

--- a/browser/ui/tabs/shared_pinned_tab_service.h
+++ b/browser/ui/tabs/shared_pinned_tab_service.h
@@ -12,6 +12,7 @@
 #include "base/scoped_observation.h"
 #include "chrome/browser/profiles/profile_observer.h"
 #include "chrome/browser/ui/browser_list_observer.h"
+#include "chrome/browser/ui/tabs/tab_model.h"
 #include "chrome/browser/ui/tabs/tab_renderer_data.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
@@ -55,10 +56,6 @@ class SharedPinnedTabService : public KeyedService,
       int index,
       content::WebContents* maybe_dummy_contents);
 
-  void CacheWebContentsIfNeeded(
-      Browser* browser,
-      const std::vector<std::unique_ptr<DetachedWebContents>>& web_contents);
-
   // KeyedService:
   void Shutdown() override;
 
@@ -84,6 +81,10 @@ class SharedPinnedTabService : public KeyedService,
   void OnProfileWillBeDestroyed(Profile* profile) override;
 
  private:
+  void CacheWebContentsIfNeeded(
+      Browser* browser,
+      std::vector<std::unique_ptr<tabs::TabModel>> pinned_tabs);
+
   void OnTabAdded(TabStripModel* tab_strip_model,
                   const TabStripModelChange::Insert* insert);
   void OnTabMoved(TabStripModel* tab_strip_model,

--- a/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
+++ b/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
@@ -131,8 +131,7 @@ IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, PinAndUnpinTabs) {
       tab_strip_model_2->GetWebContentsAt(0)));
 }
 
-IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest,
-                       DISABLED_ActivatePinnedTab) {
+IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, ActivatePinnedTab) {
   // Precondition
   auto* browser_1 = browser();
   auto* tab_strip_model_1 = browser_1->tab_strip_model();
@@ -200,8 +199,7 @@ IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, NewBrowser) {
       tab_strip_model_2->GetWebContentsAt(0)));
 }
 
-IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest,
-                       DISABLED_BringAllTabs) {
+IN_PROC_BROWSER_TEST_F(SharedPinnedTabServiceBrowserTest, BringAllTabs) {
   // Given that there're multiple windows with shared pinned tabs
   auto* browser_1 = browser();
   auto* tab_strip_model_1 = browser_1->tab_strip_model();


### PR DESCRIPTION
As of cr125, SharedPinnedTab functionality is removed because upstream code was removed. This patch resurrects the functionality.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37973

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

