### PR TITLE
[ads] Fixes db error: 1299/NOT NULL constraint failed: creative_ads.creative_instance_id

### DIFF
--- a/components/brave_ads/core/internal/catalog/catalog_url_request_json_reader.cc
+++ b/components/brave_ads/core/internal/catalog/catalog_url_request_json_reader.cc
@@ -35,6 +35,10 @@ std::optional<CatalogInfo> ReadCatalog(const std::string& json) {
   CatalogInfo catalog;
 
   catalog.id = document["catalogId"].GetString();
+  if (catalog.id.empty()) {
+    BLOG(1, "Invalid catalog id");
+    return std::nullopt;
+  }
 
   catalog.version = document["version"].GetInt();
 
@@ -49,12 +53,24 @@ std::optional<CatalogInfo> ReadCatalog(const std::string& json) {
     CatalogCampaignInfo campaign;
 
     campaign.id = campaign_node["campaignId"].GetString();
+    if (campaign.id.empty()) {
+      BLOG(1, "Invalid campaign id");
+      continue;
+    }
     campaign.priority = campaign_node["priority"].GetInt();
+
     campaign.pass_through_rate = campaign_node["ptr"].GetDouble();
+
     campaign.start_at = campaign_node["startAt"].GetString();
     campaign.end_at = campaign_node["endAt"].GetString();
+
     campaign.daily_cap = campaign_node["dailyCap"].GetInt();
+
     campaign.advertiser_id = campaign_node["advertiserId"].GetString();
+    if (campaign.advertiser_id.empty()) {
+      BLOG(1, "Invalid advertiser id");
+      continue;
+    }
 
     // Geo targets
     const auto& geo_targets_node = campaign_node["geoTargets"].GetArray();
@@ -90,9 +106,15 @@ std::optional<CatalogInfo> ReadCatalog(const std::string& json) {
       CatalogCreativeSetInfo creative_set;
 
       creative_set.id = creative_set_node["creativeSetId"].GetString();
+      if (creative_set.id.empty()) {
+        BLOG(1, "Invalid creative set id");
+        continue;
+      }
+
       creative_set.per_day = creative_set_node["perDay"].GetInt();
       creative_set.per_week = creative_set_node["perWeek"].GetInt();
       creative_set.per_month = creative_set_node["perMonth"].GetInt();
+
       creative_set.total_max = creative_set_node["totalMax"].GetInt();
 
       const char* value = creative_set_node["value"].GetString();
@@ -174,8 +196,12 @@ std::optional<CatalogInfo> ReadCatalog(const std::string& json) {
       // Creatives
       for (const auto& creative_node :
            creative_set_node["creatives"].GetArray()) {
-        const char* creative_instance_id =
+        const std::string creative_instance_id =
             creative_node["creativeInstanceId"].GetString();
+        if (creative_instance_id.empty()) {
+          BLOG(1, "Invalid creative instance id");
+          continue;
+        }
 
         // Type
         const auto& type = creative_node["type"].GetObject();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38050

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Verify that ads with an empty creative instance ID in the catalog are not saved to the database. In the case of legacy user states, the catalog is re-downloaded upon launching the browser. This problem may have arisen from a user altering ads_service/database.sqlite or due to the catalog containing an empty creative instance. This pull request adds defensive code for catalog ID, campaign ID, advertiser ID, and creative set ID.