### PR TITLE
Fixed browser crash when attempting to change 'Maximum IPFS Cache Siz…

### DIFF
--- a/browser/resources/settings/brave_ipfs_page/brave_ipfs_browser_proxy.ts
+++ b/browser/resources/settings/brave_ipfs_page/brave_ipfs_browser_proxy.ts
@@ -11,6 +11,9 @@ export class BraveIPFSBrowserProxyImpl {
   }
 
   setIPFSStorageMax (value) {
+    if (typeof value === 'number' && !Number.isInteger(value)) {
+      value = Math.round(value)
+    }
     chrome.send('setIPFSStorageMax', [value])
   }
 


### PR DESCRIPTION
Fixed browser crashes when attempting to change 'Maximum IPFS Cache Size' to decimal.

<!-- Add brave-browser issue below that this PR will resolve -->

Resolves: https://github.com/brave/brave-browser/issues/29621

The function which triggers the crash: BraveDefaultExtensionsHandler::SetIPFSStorageMax(const base::Value::List& args);

1. It checks if the list contains exactly one item. (which is true)
2. Then, it verifies if the item is an integer. (which turns out to be false if we enter a decimal causing a check fail and crash)
3. Finally it retrieves the integer value and sets it to the pref kIpfsStorageMax: prefs->SetInteger(kIpfsStorageMax, storage_max_gb);

The value of 'IPFS Maximum IPFS cache size' must always be an Integer.


Steps to reproduce this crash:
1. go to brave://settings/web3
2. Scroll down to IPFS section
3. Change the 'Method to resolve IPFS resources' to 'Brave local IPFS node'
4. Scroll down to the option 'Maximum IPFS cache size (GB)' (bottom of IPFS section)
5. Enter any decimal value (eg. 1.5)
6. Press enter button on the keyboard
7. Observe the browser crash

Issue occurs on version: [Version 1.65.126 Chromium: 124.0.6367.118 (Official Build) (64-bit)]

![Screenshot (4)](https://github.com/brave/brave-browser/assets/93036184/fc004e4b-0f24-42a1-8ae6-b3c28712bb33)