### PR TITLE
[NTP Search]: Use Brave News styles

### DIFF
--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -17,19 +17,9 @@ import Button from '@brave/leo/react/button';
 const SearchInput = styled(Input)`
   --leo-control-padding: 6px;
   --leo-control-color: rgba(255, 255, 255, 0.1);
-  --leo-control-radius: ${radius.m};
-
-  backdrop-filter: blur(64px);
 
   display: inline-block;
   width: 540px;
-
-  /* If we have search results, don't add a radius to the bottom of the search box */
-  &:has(+ div) {
-    --leo-control-radius: ${radius.m} ${radius.m} 0 0;
-  }
-
-  border-radius: var(--leo-control-radius);
 `
 
 const EnginePicker = styled(Dropdown)`
@@ -56,26 +46,47 @@ const CustomizeButton = styled(Button)`
   color: ${color.text.secondary};
 `
 
+const Container = styled.div`
+  --leo-control-radius: ${radius.m};
+
+  /* If we have search results, don't add a radius to the bottom of the search box */
+  &:has(+ div) {
+    --leo-control-radius: ${radius.m} ${radius.m} 0 0;
+  }
+
+  border-radius: var(--leo-control-radius);
+  position: relative;
+`
+
+const Backdrop = styled.div`
+  z-index: -1;
+  position: absolute;
+  inset: 0;
+  backdrop-filter: blur(64px);
+`
+
 export default function SearchBox() {
   const { filteredSearchEngines, searchEngine, setSearchEngine, query, setQuery, setOpen } = useSearchContext()
   const placeholderText = searchEngine?.host === braveSearchHost
     ? 'Search the web privately'
     : 'Search the web'
   const searchInput = React.useRef<HTMLElement>()
-  return <SearchInput tabIndex={0} type="text" ref={searchInput} value={query} onInput={e => setQuery(e.value)} placeholder={placeholderText}>
-    <Flex slot="left-icon">
-      <EnginePicker positionStrategy='fixed' value={searchEngine?.keyword} onChange={e => {
-        setSearchEngine(e.value!)
-      }}>
-        <EngineValueSlot slot="value">
-          <MediumIcon src={searchEngine?.faviconUrl.url} />
-        </EngineValueSlot>
-        {filteredSearchEngines.map(s => <leo-option value={s.keyword} key={s.keyword}>
-          <Option>
-            <MediumIcon src={s.faviconUrl.url} />{s.name}
-          </Option>
-        </leo-option>)}
-        <CustomizeButton kind="plain-faint" size="small" onClick={() => {
+  return <Container>
+    <Backdrop />
+    <SearchInput tabIndex={0} type="text" ref={searchInput} value={query} onInput={e => setQuery(e.value)} placeholder={placeholderText}>
+      <Flex slot="left-icon">
+        <EnginePicker positionStrategy='fixed' value={searchEngine?.keyword} onChange={e => {
+          setSearchEngine(e.value!)
+        }}>
+          <EngineValueSlot slot="value">
+            <MediumIcon src={searchEngine?.faviconUrl.url} />
+          </EngineValueSlot>
+          {filteredSearchEngines.map(s => <leo-option value={s.keyword} key={s.keyword}>
+            <Option>
+              <MediumIcon src={s.faviconUrl.url} />{s.name}
+            </Option>
+          </leo-option>)}
+          <CustomizeButton kind="plain-faint" size="small" onClick={() => {
           history.pushState(undefined, '', '?openSettings=Search')
 
           // For now, close the search box - the Settings dialog doesn't use a
@@ -85,9 +96,10 @@ export default function SearchBox() {
           Customize list
         </CustomizeButton>
       </EnginePicker>
-    </Flex>
-    <SearchIconContainer slot="right-icon">
-      <Icon name="search" />
-    </SearchIconContainer>
-  </SearchInput>
+      </Flex>
+      <SearchIconContainer slot="right-icon">
+        <Icon name="search" />
+      </SearchIconContainer>
+    </SearchInput>
+  </Container>
 }

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -16,6 +16,10 @@ import Button from '@brave/leo/react/button';
 
 const SearchInput = styled(Input)`
   --leo-control-padding: 6px;
+  --leo-control-color: rgba(255, 255, 255, 0.1);
+  --leo-control-radius: ${radius.m};
+
+  backdrop-filter: blur(64px);
 
   display: inline-block;
   width: 540px;
@@ -24,10 +28,12 @@ const SearchInput = styled(Input)`
   &:has(+ div) {
     --leo-control-radius: ${radius.m} ${radius.m} 0 0;
   }
+
+  border-radius: var(--leo-control-radius);
 `
 
 const EnginePicker = styled(Dropdown)`
-  --leo-control-radius: ${spacing.m};
+  --leo-control-radius: ${radius.m};
 `
 
 const EngineValueSlot = styled.div`

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -15,6 +15,7 @@ import { braveSearchHost } from './config';
 import Button from '@brave/leo/react/button';
 
 const SearchInput = styled(Input)`
+  --leo-control-focus-effect: none;
   --leo-control-padding: 6px;
   --leo-control-color: rgba(255, 255, 255, 0.1);
 

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -50,15 +50,14 @@ const Container = styled.div`
   --leo-control-radius: ${radius.m};
 
   /* If we have search results, don't add a radius to the bottom of the search box */
-  &:has(+ div) {
+  &:has(+ .search-results) {
     --leo-control-radius: ${radius.m} ${radius.m} 0 0;
   }
 
   border-radius: var(--leo-control-radius);
-  position: relative;
 `
 
-const Backdrop = styled.div`
+export const Backdrop = styled.div`
   z-index: -1;
   position: absolute;
   inset: 0;
@@ -72,7 +71,6 @@ export default function SearchBox() {
     : 'Search the web'
   const searchInput = React.useRef<HTMLElement>()
   return <Container>
-    <Backdrop />
     <SearchInput tabIndex={0} type="text" ref={searchInput} value={query} onInput={e => setQuery(e.value)} placeholder={placeholderText}>
       <Flex slot="left-icon">
         <EnginePicker positionStrategy='fixed' value={searchEngine?.keyword} onChange={e => {

--- a/components/brave_new_tab_ui/components/search/SearchDialog.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchDialog.tsx
@@ -4,9 +4,9 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react';
 import styled, { keyframes } from 'styled-components'
-import SearchBox from './SearchBox';
+import SearchBox, { Backdrop } from './SearchBox';
 import SearchResults from './SearchResults';
-import { color, spacing } from '@brave/leo/tokens/css';
+import { color, radius, spacing } from '@brave/leo/tokens/css';
 import { createPortal } from 'react-dom';
 
 interface Props {
@@ -63,6 +63,7 @@ const Dialog = styled.dialog<{ offsetY: number }>`
 
   outline: none;
   border: none;
+  border-radius: ${radius.m};
   background: transparent;
   margin-top: var(--margin-top);
   padding: 2px;
@@ -137,6 +138,7 @@ export default function Component(props: Props) {
       doClose()
     }
   }}>
+    <Backdrop />
     <SearchBox />
     <SearchResults />
   </Dialog>, document.body)

--- a/components/brave_new_tab_ui/components/search/SearchDialog.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchDialog.tsx
@@ -14,7 +14,8 @@ interface Props {
   offsetY: number
 }
 
-const duration = '0.12s'
+const duration = '0.4s'
+const easing = 'cubic-bezier(0.7, -0.4, 0.4, 1.4)'
 
 const enterDialog = keyframes`
   from {
@@ -66,20 +67,20 @@ const Dialog = styled.dialog<{ offsetY: number }>`
   margin-top: var(--margin-top);
   padding: 2px;
 
-  animation: ${enterDialog} ${duration} ease-in-out;
+  animation: ${enterDialog} ${duration} ${easing};
 
   &::backdrop {
     opacity: 1;
     background: ${color.dialogs.scrimBackground};
     backdrop-filter: blur(4px);
-    animation: ${enterBackdrop} ${duration} ease-in-out;
+    animation: ${enterBackdrop} ${duration} ${easing};
   }
 
   &.closing {
-    animation: ${exitDialog} ${duration} ease-in-out;
+    animation: ${exitDialog} ${duration} ${easing};
 
     &::backdrop {
-      animation: ${exitBackdrop} ${duration} ease-in-out;
+      animation: ${exitBackdrop} ${duration} ${easing};
     }
   }
 `

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -8,10 +8,13 @@ import SearchDialog from './SearchDialog';
 import { useNewTabPref } from '../../hooks/usePref';
 import { SearchContext, useSearchContext } from './SearchContext';
 import styled from 'styled-components';
+import { radius } from '@brave/leo/tokens/css';
 
 const PlaceholderContainer = styled.div`
   position: relative;
   overflow: hidden;
+
+  border-radius: ${radius.xs};
 `
 
 function Swapper() {

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -3,21 +3,28 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react';
-import SearchBox from './SearchBox';
+import SearchBox, { Backdrop } from './SearchBox';
 import SearchDialog from './SearchDialog';
 import { useNewTabPref } from '../../hooks/usePref';
 import { SearchContext, useSearchContext } from './SearchContext';
+import styled from 'styled-components';
+
+const PlaceholderContainer = styled.div`
+  position: relative;
+  overflow: hidden;
+`
 
 function Swapper() {
   const { open, setOpen } = useSearchContext()
   const [boxPos, setBoxPos] = React.useState(0)
   return <>
-    {!open && <div onClick={e => {
+    {!open && <PlaceholderContainer onClick={e => {
       setOpen(true)
       setBoxPos(e.currentTarget.getBoundingClientRect().y)
     }}>
+      <Backdrop />
       <SearchBox />
-    </div>}
+    </PlaceholderContainer>}
     {open && <SearchDialog offsetY={boxPos} onClose={() => setOpen(false)} />}
   </>
 }

--- a/components/brave_new_tab_ui/components/search/SearchResult.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResult.tsx
@@ -27,11 +27,11 @@ const Container = styled.a`
   text-decoration: none;
 
   &[aria-selected=true] {
-    background: ${color.container.interactive};
+    background: color-mix(in srgb, ${color.container.interactive}, transparent 80%);
   }
 
   &:hover {
-    background: ${color.container.highlight};
+    backdrop-filter: blur(64px);
   }
 `
 

--- a/components/brave_new_tab_ui/components/search/SearchResult.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResult.tsx
@@ -40,7 +40,7 @@ const IconContainer = styled.div`
   width: 32px;
   height: 32px;
 
-  background: ${color.container.highlight};
+  background: rgba(255,255,255,0.25);
 
   display: flex;
   align-items: center;

--- a/components/brave_new_tab_ui/components/search/SearchResults.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResults.tsx
@@ -12,6 +12,8 @@ import { omniboxController, search, useSearchContext } from './SearchContext'
 import { braveSearchHost } from './config'
 
 const Container = styled.div`
+  border-top: 1px solid ${color.divider.subtle};
+
   background: rgba(255,255,255,0.1);
 
   color: ${color.white};

--- a/components/brave_new_tab_ui/components/search/SearchResults.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResults.tsx
@@ -12,9 +12,12 @@ import { omniboxController, search, useSearchContext } from './SearchContext'
 import { braveSearchHost } from './config'
 
 const Container = styled.div`
-  background: ${color.container.background};
+  backdrop-filter: blur(64px);
+  background: rgba(255,255,255,0.1);
 
-  border: 1px solid ${color.divider.subtle};
+  color: ${color.white};
+
+  // border: 1px solid ${color.divider.subtle};
   border-bottom-left-radius: ${radius.m};
   border-bottom-right-radius: ${radius.m};
 
@@ -118,7 +121,7 @@ export default function SearchResults() {
       document.removeEventListener('keydown', handler)
     }
   }, [result, selectedMatch, query, searchEngine])
-  return result && result?.matches.length ? <Container>
+  return result && result?.matches.length ? <Container data-theme="dark">
     {result?.matches.map((r, i) => <SearchResult key={i} selected={i === selectedMatch} line={i} match={r} />)}
   </Container> : null
 }

--- a/components/brave_new_tab_ui/components/search/SearchResults.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResults.tsx
@@ -12,7 +12,6 @@ import { omniboxController, search, useSearchContext } from './SearchContext'
 import { braveSearchHost } from './config'
 
 const Container = styled.div`
-  backdrop-filter: blur(64px);
   background: rgba(255,255,255,0.1);
 
   color: ${color.white};
@@ -121,7 +120,7 @@ export default function SearchResults() {
       document.removeEventListener('keydown', handler)
     }
   }, [result, selectedMatch, query, searchEngine])
-  return result && result?.matches.length ? <Container data-theme="dark">
+  return result && result?.matches.length ? <Container data-theme="dark" className='search-results'>
     {result?.matches.map((r, i) => <SearchResult key={i} selected={i === selectedMatch} line={i} match={r} />)}
   </Container> : null
 }

--- a/components/brave_new_tab_ui/components/search/SearchResults.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResults.tsx
@@ -18,7 +18,6 @@ const Container = styled.div`
 
   color: ${color.white};
 
-  // border: 1px solid ${color.divider.subtle};
   border-bottom-left-radius: ${radius.m};
   border-bottom-right-radius: ${radius.m};
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37107

## Leftovers
There are quite a few leftovers in this PR - the new design has added hard borders to the Brave News elements, which we don't yet support. Additionally, the text in the input is black, not white, as we can't customize this in Nala (yet).

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open the NTP search box
2. It should have similar styling to Brave News
