### PR TITLE
[iOS] - Add Claude 3 Haiku and Sonnet models and Update texts

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -324,60 +324,6 @@ extension Strings {
       comment:
         "The model intro message when you first enter the chat assistant -- %@ is a place-holder for the model name"
     )
-    public static let introPopoverLlamaMessageDescription = NSLocalizedString(
-      "aichat.introPopoverLlamaMessageDescription",
-      tableName: "BraveLeo",
-      bundle: .module,
-      value:
-        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
-      comment:
-        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
-    )
-    public static let introPopoverMixtralMessageDescription = NSLocalizedString(
-      "aichat.introPopoverMixtralMessageDescription",
-      tableName: "BraveLeo",
-      bundle: .module,
-      value:
-        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
-      comment:
-        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
-    )
-    public static let introPopoverClaudeInstantMessageDescription = NSLocalizedString(
-      "aichat.introPopoverClaudeInstantMessageDescription",
-      tableName: "BraveLeo",
-      bundle: .module,
-      value:
-        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
-      comment:
-        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
-    )
-    public static let introPopoverClaudeHaikuMessageDescription = NSLocalizedString(
-      "aichat.introPopoverClaudeHaikuMessageDescription",
-      tableName: "BraveLeo",
-      bundle: .module,
-      value:
-        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
-      comment:
-        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
-    )
-    public static let introPopoverClaudeSonnetMessageDescription = NSLocalizedString(
-      "aichat.introPopoverClaudeSonnetMessageDescription",
-      tableName: "BraveLeo",
-      bundle: .module,
-      value:
-        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
-      comment:
-        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
-    )
-    public static let introGenericPopoverMessage = NSLocalizedString(
-      "aichat.introGenericPopoverMessage",
-      tableName: "BraveLeo",
-      bundle: .module,
-      value:
-        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
-      comment:
-        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
-    )
     public static let paywallViewTitle = NSLocalizedString(
       "aichat.paywallViewTitle",
       tableName: "BraveLeo",

--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -219,6 +219,62 @@ extension Strings {
       comment:
         "The model and creator for intro message - Claude Instant is the model -- Anthropic is the creator"
     )
+    public static let introMessageClaudeHaikuModelDescription = NSLocalizedString(
+      "aichat.introMessageClaudeHaikuModelDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Claude Haiku by Anthropic",
+      comment:
+        "The model and creator for intro message - Claude Haiku is the model -- Anthropic is the creator"
+    )
+    public static let introMessageClaudeSonnetModelDescription = NSLocalizedString(
+      "aichat.introMessageClaudeSonnetModelDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Claude Sonnet by Anthropic",
+      comment:
+        "The model and creator for intro message - Claude Sonnet is the model -- Anthropic is the creator"
+    )
+    public static let introMessageLlamaModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageLlamaModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "General purpose chat",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageMixtralModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageMixtralModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Advanced chat tasks",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageClaudeInstantModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageClaudeInstantModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Conversation and text generation",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageClaudeHaikuModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageClaudeHaikuModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Lightning fast chat",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageClaudeSonnetModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageClaudeSonnetModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Balanced speed and intelligence",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
     public static let introMessageLlamaMessageDescription = NSLocalizedString(
       "aichat.introMessageLlamaMessageDescription",
       tableName: "BraveLeo",
@@ -243,6 +299,22 @@ extension Strings {
         "Hi, I'm Leo. I'm proxied by Brave and powered by Claude Instant, a model created by Anthropic to power conversational and text processing tasks.",
       comment: "The model intro message when you first enter the chat assistant"
     )
+    public static let introMessageClaudeHaikuMessageDescription = NSLocalizedString(
+      "aichat.introMessageClaudeHaikuMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Hi, I'm Leo. I'm proxied by Brave and powered by Claude 3 Haiku, a model created by Anthropic to power conversational and text processing tasks.",
+      comment: "The model intro message when you first enter the chat assistant"
+    )
+    public static let introMessageClaudeSonnetMessageDescription = NSLocalizedString(
+      "aichat.introMessageClaudeSonnetMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Hi, I'm Leo. I'm proxied by Brave and powered by Claude 3 Sonnet, a model created by Anthropic to power conversational and text processing tasks.",
+      comment: "The model intro message when you first enter the chat assistant"
+    )
     public static let introMessageGenericMessageDescription = NSLocalizedString(
       "aichat.introMessageGenericMessageDescription",
       tableName: "BraveLeo",
@@ -251,6 +323,60 @@ extension Strings {
         "Hi, I'm Leo. I'm an AI assistant by Brave. I'm powered by %@. Ask me anything, and I'll do my best to answer.",
       comment:
         "The model intro message when you first enter the chat assistant -- %@ is a place-holder for the model name"
+    )
+    public static let introPopoverLlamaMessageDescription = NSLocalizedString(
+      "aichat.introPopoverLlamaMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
+      comment:
+        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
+    )
+    public static let introPopoverMixtralMessageDescription = NSLocalizedString(
+      "aichat.introPopoverMixtralMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
+      comment:
+        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
+    )
+    public static let introPopoverClaudeInstantMessageDescription = NSLocalizedString(
+      "aichat.introPopoverClaudeInstantMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
+      comment:
+        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
+    )
+    public static let introPopoverClaudeHaikuMessageDescription = NSLocalizedString(
+      "aichat.introPopoverClaudeHaikuMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
+      comment:
+        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
+    )
+    public static let introPopoverClaudeSonnetMessageDescription = NSLocalizedString(
+      "aichat.introPopoverClaudeSonnetMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
+      comment:
+        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
+    )
+    public static let introGenericPopoverMessage = NSLocalizedString(
+      "aichat.introGenericPopoverMessage",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "%@ is a model created by %@ to handle advanced tasks. This model is hosted by Brave.",
+      comment:
+        "The model intro popover message when you first enter the chat assistant popover -- %@ is a place-holder for the model name"
     )
     public static let paywallViewTitle = NSLocalizedString(
       "aichat.paywallViewTitle",

--- a/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
@@ -151,13 +151,6 @@ public struct AIChatView: View {
                     if model.shouldShowSuggestions && !model.requestInProgress
                       && model.apiError == .none
                     {
-                      if model.conversationHistory.isEmpty {
-                        AIChatProductIcon(containerShape: Circle(), padding: 6.0)
-                          .font(.callout)
-                          .frame(maxWidth: .infinity, alignment: .leading)
-                          .padding([.horizontal, .bottom])
-                      }
-
                       if model.suggestionsStatus != .isGenerating
                         && !model.suggestedQuestions.isEmpty
                       {

--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatIntroMessageView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatIntroMessageView.swift
@@ -59,53 +59,6 @@ struct AIChatIntroMessageView: View {
     }
   }
 
-  private var popoverMessage: String {
-    guard let modelKey = AIChatModelKey(rawValue: model.key) else {
-      return String(
-        format: Strings.AIChat.introGenericPopoverMessage,
-        model.displayName,
-        model.displayMaker
-      )
-    }
-
-    switch modelKey {
-    case .chatBasic:
-      return String(
-        format: Strings.AIChat.introPopoverLlamaMessageDescription,
-        model.displayName,
-        model.displayMaker
-      )
-
-    case .chatExpanded:
-      return String(
-        format: Strings.AIChat.introPopoverMixtralMessageDescription,
-        model.displayName,
-        model.displayMaker
-      )
-
-    case .chatClaudeInstant:
-      return String(
-        format: Strings.AIChat.introPopoverClaudeInstantMessageDescription,
-        model.displayName,
-        model.displayMaker
-      )
-
-    case .chatClaudeHaiku:
-      return String(
-        format: Strings.AIChat.introPopoverClaudeHaikuMessageDescription,
-        model.displayName,
-        model.displayMaker
-      )
-
-    case .chatClaudeSonnet:
-      return String(
-        format: Strings.AIChat.introPopoverClaudeSonnetMessageDescription,
-        model.displayName,
-        model.displayMaker
-      )
-    }
-  }
-
   var body: some View {
     VStack(alignment: .leading, spacing: 0.0) {
       AIChatProductIcon(containerShape: Circle(), padding: 9.0)
@@ -151,7 +104,7 @@ struct AIChatIntroMessageView: View {
             backgroundColor: UIColor(braveSystemName: .containerBackground)
           ) {
             VStack {
-              Text(popoverMessage)
+              Text(introMessage)
                 .font(.footnote)
                 .foregroundStyle(Color(braveSystemName: .textPrimary))
                 .fixedSize(horizontal: false, vertical: true)
@@ -179,13 +132,6 @@ struct AIChatIntroMessageView: View {
         }
       }
       .frame(maxWidth: .infinity, alignment: .leading)
-
-      Text(introMessage)
-        .font(.subheadline)
-        .foregroundStyle(Color(braveSystemName: .textPrimary))
-        .multilineTextAlignment(.leading)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .fixedSize(horizontal: false, vertical: true)
     }
   }
 }

--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatIntroMessageView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatIntroMessageView.swift
@@ -8,16 +8,13 @@ import DesignSystem
 import SwiftUI
 
 struct AIChatIntroMessageView: View {
+  @State
+  private var shouldShowInformationPopover = false
+
   var model: AiChat.Model
 
-  private enum ModelKey: String {
-    case chatBasic = "chat-basic"
-    case chatExpanded = "chat-leo-expanded"
-    case chatClaudeInstant = "chat-claude-instant"
-  }
-
   private var modelDescription: String {
-    guard let modelKey = ModelKey(rawValue: model.key) else {
+    guard let modelKey = AIChatModelKey(rawValue: model.key) else {
       return model.displayName
     }
 
@@ -30,11 +27,17 @@ struct AIChatIntroMessageView: View {
 
     case .chatClaudeInstant:
       return Strings.AIChat.introMessageClaudeInstantModelDescription
+
+    case .chatClaudeHaiku:
+      return Strings.AIChat.introMessageClaudeHaikuModelDescription
+
+    case .chatClaudeSonnet:
+      return Strings.AIChat.introMessageClaudeSonnetModelDescription
     }
   }
 
   private var introMessage: String {
-    guard let modelKey = ModelKey(rawValue: model.key) else {
+    guard let modelKey = AIChatModelKey(rawValue: model.key) else {
       return String(format: Strings.AIChat.introMessageGenericMessageDescription, model.displayName)
     }
 
@@ -47,6 +50,59 @@ struct AIChatIntroMessageView: View {
 
     case .chatClaudeInstant:
       return Strings.AIChat.introMessageClaudeInstantMessageDescription
+
+    case .chatClaudeHaiku:
+      return Strings.AIChat.introMessageClaudeHaikuMessageDescription
+
+    case .chatClaudeSonnet:
+      return Strings.AIChat.introMessageClaudeSonnetMessageDescription
+    }
+  }
+
+  private var popoverMessage: String {
+    guard let modelKey = AIChatModelKey(rawValue: model.key) else {
+      return String(
+        format: Strings.AIChat.introGenericPopoverMessage,
+        model.displayName,
+        model.displayMaker
+      )
+    }
+
+    switch modelKey {
+    case .chatBasic:
+      return String(
+        format: Strings.AIChat.introPopoverLlamaMessageDescription,
+        model.displayName,
+        model.displayMaker
+      )
+
+    case .chatExpanded:
+      return String(
+        format: Strings.AIChat.introPopoverMixtralMessageDescription,
+        model.displayName,
+        model.displayMaker
+      )
+
+    case .chatClaudeInstant:
+      return String(
+        format: Strings.AIChat.introPopoverClaudeInstantMessageDescription,
+        model.displayName,
+        model.displayMaker
+      )
+
+    case .chatClaudeHaiku:
+      return String(
+        format: Strings.AIChat.introPopoverClaudeHaikuMessageDescription,
+        model.displayName,
+        model.displayMaker
+      )
+
+    case .chatClaudeSonnet:
+      return String(
+        format: Strings.AIChat.introPopoverClaudeSonnetMessageDescription,
+        model.displayName,
+        model.displayMaker
+      )
     }
   }
 
@@ -64,13 +120,65 @@ struct AIChatIntroMessageView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
 
-      Text(modelDescription)
-        .font(.footnote)
-        .foregroundStyle(Color(braveSystemName: .textTertiary))
-        .multilineTextAlignment(.leading)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .fixedSize(horizontal: false, vertical: true)
-        .padding(.bottom)
+      HStack(alignment: .firstTextBaseline) {
+        Text(modelDescription)
+          .font(.footnote)
+          .foregroundStyle(Color(braveSystemName: .textTertiary))
+          .multilineTextAlignment(.leading)
+          .fixedSize(horizontal: false, vertical: true)
+          .padding(.bottom)
+
+        Button(
+          action: {
+            shouldShowInformationPopover = true
+          },
+          label: {
+            Label {
+              Text(Strings.AIChat.leoPageContextInfoDescriptionTitle)
+            } icon: {
+              Image(braveSystemName: "leo.info.outline")
+                .foregroundStyle(Color(braveSystemName: .iconDefault))
+                .font(.footnote)
+            }
+            .labelStyle(.iconOnly)
+          }
+        )
+        .bravePopover(
+          isPresented: $shouldShowInformationPopover,
+          arrowDirection: .forcedDirection(.up)
+        ) {
+          PopoverWrapperView(
+            backgroundColor: UIColor(braveSystemName: .containerBackground)
+          ) {
+            VStack {
+              Text(popoverMessage)
+                .font(.footnote)
+                .foregroundStyle(Color(braveSystemName: .textPrimary))
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+              Text(
+                LocalizedStringKey(
+                  String(
+                    format: "[%@](%@)",
+                    Strings.learnMore,
+                    URL.Brave.braveLeoModelCategorySupport.absoluteString
+                  )
+                )
+              )
+              .underline()
+              .font(.footnote)
+              .foregroundStyle(Color(braveSystemName: .textPrimary))
+              .fixedSize(horizontal: false, vertical: true)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .tint(Color(braveSystemName: .textInteractive))
+            }
+            .padding()
+            .frame(maxWidth: 260.0)
+          }
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
 
       Text(introMessage)
         .font(.subheadline)

--- a/ios/brave-ios/Sources/AIChat/Components/Popover/PopoverView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Popover/PopoverView.swift
@@ -12,6 +12,7 @@ import UIKit
 struct BravePopoverViewModifier<PopoverContent>: ViewModifier
 where PopoverContent: View & PopoverContentComponent {
   @Binding var isPresented: Bool
+  var arrowDirection: PopoverController.ArrowDirectionBehavior = .automatic
   let content: () -> PopoverContent
 
   func body(content: Content) -> some View {
@@ -19,6 +20,7 @@ where PopoverContent: View & PopoverContentComponent {
       .background(
         BravePopoverView(
           isPresented: self.$isPresented,
+          arrowDirection: arrowDirection,
           content: self.content
         )
       )
@@ -28,11 +30,13 @@ where PopoverContent: View & PopoverContentComponent {
 extension View {
   func bravePopover<Content>(
     isPresented: Binding<Bool>,
+    arrowDirection: PopoverController.ArrowDirectionBehavior = .automatic,
     @ViewBuilder content: @escaping () -> Content
   ) -> some View where Content: View & PopoverContentComponent {
     self.modifier(
       BravePopoverViewModifier(
         isPresented: isPresented,
+        arrowDirection: arrowDirection,
         content: content
       )
     )
@@ -41,10 +45,17 @@ extension View {
 
 struct BravePopoverView<Content: View & PopoverContentComponent>: UIViewControllerRepresentable {
   @Binding var isPresented: Bool
+
+  private var arrowDirection: PopoverController.ArrowDirectionBehavior
   private var content: Content
 
-  init(isPresented: Binding<Bool>, @ViewBuilder content: () -> Content) {
+  init(
+    isPresented: Binding<Bool>,
+    arrowDirection: PopoverController.ArrowDirectionBehavior,
+    @ViewBuilder content: () -> Content
+  ) {
     self._isPresented = isPresented
+    self.arrowDirection = arrowDirection
     self.content = content()
   }
 
@@ -70,6 +81,7 @@ struct BravePopoverView<Content: View & PopoverContentComponent>: UIViewControll
       if let parent = uiViewController.parent, !parent.isBeingDismissed {
         let controller = PopoverController(content: content)
         context.coordinator.presentedViewController = .init(controller)
+        controller.arrowDirectionBehavior = arrowDirection
         controller.popoverDidDismiss = { _ in
           self.isPresented = false
         }

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
@@ -143,7 +143,7 @@ struct AIChatMenuView: View {
           label: {
             AIChatMenuItemView(
               title: model.displayName,
-              subtitle: model.displayMaker,
+              subtitle: modelPurpose(for: model),
               isSelected: model.key == currentModel.key
             ) {
               if model.access == .basicAndPremium {
@@ -223,7 +223,30 @@ struct AIChatMenuView: View {
     }
   }
 
-  func menuActionItems(for menuOption: AIChatMenuOptionTypes) -> some View {
+  private func modelPurpose(for model: AiChat.Model) -> String {
+    guard let modelKey = AIChatModelKey(rawValue: model.key) else {
+      return model.displayMaker
+    }
+
+    switch modelKey {
+    case .chatBasic:
+      return Strings.AIChat.introMessageLlamaModelPurposeDescription
+
+    case .chatExpanded:
+      return Strings.AIChat.introMessageMixtralModelPurposeDescription
+
+    case .chatClaudeInstant:
+      return Strings.AIChat.introMessageClaudeInstantModelPurposeDescription
+
+    case .chatClaudeHaiku:
+      return Strings.AIChat.introMessageClaudeHaikuModelPurposeDescription
+
+    case .chatClaudeSonnet:
+      return Strings.AIChat.introMessageClaudeSonnetModelPurposeDescription
+    }
+  }
+
+  private func menuActionItems(for menuOption: AIChatMenuOptionTypes) -> some View {
     Button {
       if menuOption == .goPremium, !BraveStoreSDK.shared.isLeoProductsLoaded {
         appStoreConnectionErrorPresented = true

--- a/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
+++ b/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
@@ -10,6 +10,14 @@ import Shared
 import SwiftUI
 import WebKit
 
+public enum AIChatModelKey: String {
+  case chatBasic = "chat-basic"
+  case chatExpanded = "chat-leo-expanded"
+  case chatClaudeInstant = "chat-claude-instant"
+  case chatClaudeHaiku = "chat-claude-haiku"
+  case chatClaudeSonnet = "chat-claude-sonnet"
+}
+
 public class AIChatViewModel: NSObject, ObservableObject {
   private var api: AIChat!
   private weak var webView: WKWebView?

--- a/ios/brave-ios/Sources/BraveShared/BraveURLs.swift
+++ b/ios/brave-ios/Sources/BraveShared/BraveURLs.swift
@@ -64,6 +64,9 @@ extension URL {
     public static let braveLeoLinkReceiptDev = URL(
       string: "https://account.brave.software/?intent=link-order&product=leo"
     )!
+    public static let braveLeoModelCategorySupport = URL(
+      string: "https://support.brave.com/hc/en-us/categories/20990938292237-Brave-Leo"
+    )!
   }
   public enum Apple {
     public static let manageSubscriptions = URL(


### PR DESCRIPTION
- Add Claude 3 Haiku.
- Add Claude 3 Sonnet.
- Update descriptions for models purpose in Settings.
- Add popover for model intro with learn-more link in the chat intro message.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37989 and https://github.com/brave/brave-browser/issues/37832

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="287" alt="image" src="https://github.com/brave/brave-core/assets/1530031/c8db4751-b505-45a6-83c5-f49713872503">

![image](https://github.com/brave/brave-core/assets/1530031/a1ce92c3-943c-4d4e-932f-512a92c651b0)
![image](https://github.com/brave/brave-core/assets/1530031/30251d0d-f97e-4b6e-bacd-08264631e95f)
