### PR TITLE
aichat: update page context toggle design

### DIFF
--- a/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
+++ b/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
@@ -22,7 +22,8 @@ function PageContextToggle() {
     context.updateShouldSendPageContents(checked)
   }
 
-  const toggleTooltipVisibility = () => {
+  const toggleTooltipVisibility = (e: any) => {
+    e.preventDefault()
     setIsTooltipVisible(state => !state)
   }
 

--- a/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
+++ b/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
@@ -48,8 +48,10 @@ function PageContextToggle() {
               </div>
             </div>
             <Button
+              fab
               kind='plain-faint'
               className={styles.tooltipButton}
+              onClick={(e: any) => e.preventDefault()}
             >
               <Icon name='info-outline' />
             </Button>

--- a/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
+++ b/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 import Toggle from '@brave/leo/react/toggle'
 import Tooltip from '@brave/leo/react/tooltip'
+import Button from '@brave/leo/react/button'
 import Icon from '@brave/leo/react/icon'
 import { getLocale } from '$web-common/locale'
 
@@ -14,21 +15,10 @@ import SiteTitle from '../site_title'
 import DataContext from '../../state/context'
 
 function PageContextToggle() {
-  const [showTooltip, setShowTooltip] = React.useState(false)
   const context = React.useContext(DataContext)
 
   const handleToggleChange = ({ checked }: { checked: boolean }) => {
     context.updateShouldSendPageContents(checked)
-  }
-
-  const handleInfoIconTouchStart = (e: React.TouchEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setShowTooltip(true)
-  }
-
-  const handleInfoIconTouchEnd = (e: React.TouchEvent<HTMLDivElement>) => {
-    e.preventDefault()
-    setShowTooltip(false)
   }
 
   return (
@@ -42,10 +32,13 @@ function PageContextToggle() {
         <span slot="on-icon" />
         <div className={styles.label}>
           <span>{getLocale('contextToggleLabel')}</span>
-          <Tooltip visible={showTooltip}>
+          <Tooltip
+            mode="default"
+            className={styles.tooltip}
+          >
             <div
               slot='content'
-              className={styles.tooltipContainer}
+              className={styles.tooltipContent}
             >
               <div className={styles.tooltipInfo}>
                 {getLocale('contextToggleTooltipInfo')}
@@ -54,16 +47,12 @@ function PageContextToggle() {
                 <SiteTitle size='small' />
               </div>
             </div>
-            <div
-              onMouseOver={() => setShowTooltip(true)}
-              onMouseOut={() => setShowTooltip(false)}
-              onTouchStart={handleInfoIconTouchStart}
-              onTouchEnd={handleInfoIconTouchEnd}
-              onFocus={() => setShowTooltip(true)}
-              onBlur={() => setShowTooltip(false)}
+            <Button
+              kind='plain-faint'
+              className={styles.tooltipButton}
             >
               <Icon name='info-outline' />
-            </div>
+            </Button>
           </Tooltip>
         </div>
       </Toggle>

--- a/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
+++ b/components/ai_chat/resources/page/components/page_context_toggle/index.tsx
@@ -16,9 +16,14 @@ import DataContext from '../../state/context'
 
 function PageContextToggle() {
   const context = React.useContext(DataContext)
+  const [isTooltipVisible, setIsTooltipVisible] = React.useState(false)
 
   const handleToggleChange = ({ checked }: { checked: boolean }) => {
     context.updateShouldSendPageContents(checked)
+  }
+
+  const toggleTooltipVisibility = () => {
+    setIsTooltipVisible(state => !state)
   }
 
   return (
@@ -33,12 +38,22 @@ function PageContextToggle() {
         <div className={styles.label}>
           <span>{getLocale('contextToggleLabel')}</span>
           <Tooltip
+            visible={isTooltipVisible}
             mode="default"
             className={styles.tooltip}
+            onVisibilityChange={(detail) => {
+              setTimeout(() => {
+                setIsTooltipVisible(detail.visible)
+              })
+            }}
           >
             <div
               slot='content'
               className={styles.tooltipContent}
+              onClick={(e: any) => {
+                // inner content click/tap shouldn't change parent's toggle
+                e.preventDefault()
+              }}
             >
               <div className={styles.tooltipInfo}>
                 {getLocale('contextToggleTooltipInfo')}
@@ -51,7 +66,7 @@ function PageContextToggle() {
               fab
               kind='plain-faint'
               className={styles.tooltipButton}
-              onClick={(e: any) => e.preventDefault()}
+              onClick={toggleTooltipVisibility}
             >
               <Icon name='info-outline' />
             </Button>

--- a/components/ai_chat/resources/page/components/page_context_toggle/style.module.scss
+++ b/components/ai_chat/resources/page/components/page_context_toggle/style.module.scss
@@ -7,7 +7,7 @@
   width: 100%;
   background: var(--leo-color-page-background);
   border-radius: var(--leo-radius-m);
-  padding: 10px 16px;
+  padding: 8px 16px;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -24,28 +24,39 @@
 
   font: var(--leo-font-small-regular);
   color: var(--leo-color-text-tertiary);
-
-  h1 {
-    margin: 0;
-    padding: 0;
-  }
 }
 
-.tooltipContainer {
+.tooltip {
+  --leo-tooltip-padding: 0;
+}
+
+.tooltipContent {
+  max-width: 280px;
   font: var(--leo-font-small-regular);
   color: var(--leo-color-text-secondary);
-  max-width: 280px;
-  padding: 0;
 }
 
 .tooltipInfo {
-  font: inherit;
   padding: var(--leo-spacing-xl);
 }
 
 .tooltipSiteTitle {
   border-top: 1px solid var(--leo-color-divider-subtle);
   padding: var(--leo-spacing-m);
+}
+
+.tooltipButton {
+  --leo-button-padding: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  leo-icon {
+    --leo-icon-size: 14px;
+    --leo-icon-color: var(--leo-color-text-tertiary);
+  }
 }
 
 .toggle {

--- a/components/ai_chat/resources/page/components/page_context_toggle/style.module.scss
+++ b/components/ai_chat/resources/page/components/page_context_toggle/style.module.scss
@@ -46,7 +46,6 @@
 }
 
 .tooltipButton {
-  --leo-button-padding: 0;
   width: 24px;
   height: 24px;
   display: flex;

--- a/components/ai_chat/resources/page/components/page_context_toggle/style.module.scss
+++ b/components/ai_chat/resources/page/components/page_context_toggle/style.module.scss
@@ -47,7 +47,6 @@
 
 .tooltipButton {
   width: 24px;
-  height: 24px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/components/ai_chat/resources/page/stories/locale.ts
+++ b/components/ai_chat/resources/page/stories/locale.ts
@@ -86,7 +86,7 @@ provideStrings({
   welcomeGuideShatCardTitle: 'Just want to chat?',
   welcomeGuideShatCardDesc: 'Ask me anything! We can talk about any topic you want. I\'m always learning and improving to provide better answers.',
   privacyTitle: 'Privacy agreement',
-  contextToggleLabel: 'Use page context for response',
+  contextToggleLabel: 'Shape answers based on the page\'s contents',
   contextToggleTooltipInfo: 'Toggle on to ask about this page. It\'s content will be sent to Brave Leo along with your messages.',
   subscriptionPolicyInfo: 'All subscriptions are auto-renewed but can be cancelled at any time before renewal.',
   summarizeLabel: 'Summarize',

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -271,7 +271,7 @@
     Chat Privately with Brave Leo
   </message>
   <message name="IDS_CHAT_UI_CONTEXT_TOGGLE_LABEL" desc="Label for toggle that enabled/disabled contextual conversations.">
-    Use page context for response
+    Shape answers based on the page's contents
   </message>
   <message name="IDS_CHAT_UI_CONTEXT_TOGGLE_TOOLTIP_INFO" desc="Info tooltip for contextual toggle">
     Toggle on to ask about this page. Its content will be sent to Brave Leo along with your messages.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38127
Resolves https://github.com/brave/brave-browser/issues/36112
Resolves https://github.com/brave/brave-browser/issues/35989

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. hover or tap should show tooltip
2. tap radius should be improved on mobile
3. tap info icon should show tooltip and tapping outside should make it dissapear
