### PR TITLE
Delay initialization of UsageClock in metric uptime monitor (uplift to 1.65.x)

### DIFF
--- a/browser/brave_browser_main_extra_parts.cc
+++ b/browser/brave_browser_main_extra_parts.cc
@@ -7,6 +7,8 @@
 
 #include "base/metrics/histogram_macros.h"
 #include "brave/browser/brave_browser_process_impl.h"
+#include "brave/browser/misc_metrics/process_misc_metrics.h"
+#include "brave/browser/misc_metrics/uptime_monitor.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_p3a.h"
 #include "brave/components/p3a/buildflags.h"
 #include "brave/components/p3a/p3a_service.h"
@@ -84,4 +86,5 @@ void BraveBrowserMainExtraParts::PreMainMessageLoopRun() {
 #if !BUILDFLAG(IS_ANDROID)
   brave::BraveWindowTracker::CreateInstance(g_browser_process->local_state());
 #endif  // !BUILDFLAG(IS_ANDROID)
+  g_brave_browser_process->process_misc_metrics()->uptime_monitor()->Init();
 }

--- a/browser/misc_metrics/process_misc_metrics.cc
+++ b/browser/misc_metrics/process_misc_metrics.cc
@@ -54,14 +54,14 @@ PrivacyHubMetrics* ProcessMiscMetrics::privacy_hub_metrics() {
   return privacy_hub_metrics_.get();
 }
 
-UptimeMonitor* ProcessMiscMetrics::uptime_monitor() {
-  return uptime_monitor_.get();
-}
-
 TabMetrics* ProcessMiscMetrics::tab_metrics() {
   return tab_metrics_.get();
 }
 #endif
+
+UptimeMonitor* ProcessMiscMetrics::uptime_monitor() {
+  return uptime_monitor_.get();
+}
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 ai_chat::AIChatMetrics* ProcessMiscMetrics::ai_chat_metrics() {

--- a/browser/misc_metrics/process_misc_metrics.h
+++ b/browser/misc_metrics/process_misc_metrics.h
@@ -48,8 +48,8 @@ class ProcessMiscMetrics {
 #else
   PrivacyHubMetrics* privacy_hub_metrics();
   TabMetrics* tab_metrics();
-  UptimeMonitor* uptime_monitor();
 #endif
+  UptimeMonitor* uptime_monitor();
 #if BUILDFLAG(ENABLE_AI_CHAT)
   ai_chat::AIChatMetrics* ai_chat_metrics();
 #endif

--- a/browser/misc_metrics/uptime_monitor.h
+++ b/browser/misc_metrics/uptime_monitor.h
@@ -6,20 +6,24 @@
 #ifndef BRAVE_BROWSER_MISC_METRICS_UPTIME_MONITOR_H_
 #define BRAVE_BROWSER_MISC_METRICS_UPTIME_MONITOR_H_
 
+#include <memory>
+
 #include "base/memory/raw_ptr.h"
 #include "base/timer/timer.h"
-
-#if !BUILDFLAG(IS_ANDROID)
-#include "chrome/browser/resource_coordinator/usage_clock.h"
-#endif
 
 class PrefService;
 class PrefRegistrySimple;
 
+#if !BUILDFLAG(IS_ANDROID)
+namespace resource_coordinator {
+class UsageClock;
+}  // namespace resource_coordinator
+#endif
+
 namespace misc_metrics {
 
 inline constexpr char kBrowserOpenTimeHistogramName[] =
-    "Brave.Uptime.BrowserOpenTime";
+    "Brave.Uptime.BrowserOpenTime.2";
 
 class UptimeMonitor {
  public:
@@ -32,8 +36,11 @@ class UptimeMonitor {
   static void RegisterPrefsForMigration(PrefRegistrySimple* registry);
   static void MigrateObsoletePrefs(PrefService* local_state);
 
-  // Used on Android only.
+  void Init();
+
+#if BUILDFLAG(IS_ANDROID)
   void ReportUsageDuration(base::TimeDelta duration);
+#endif
 
  private:
   void RecordP3A();
@@ -47,7 +54,7 @@ class UptimeMonitor {
   raw_ptr<PrefService> local_state_;
 
 #if !BUILDFLAG(IS_ANDROID)
-  resource_coordinator::UsageClock usage_clock_;
+  std::unique_ptr<resource_coordinator::UsageClock> usage_clock_;
 
   base::TimeDelta current_total_usage_;
   base::RepeatingTimer timer_;

--- a/browser/misc_metrics/uptime_monitor_unittest.cc
+++ b/browser/misc_metrics/uptime_monitor_unittest.cc
@@ -27,6 +27,7 @@ class UptimeMonitorUnitTest : public testing::Test {
  protected:
   void ResetMonitor() {
     usage_monitor_ = std::make_unique<UptimeMonitor>(&local_state_);
+    usage_monitor_->Init();
   }
 
   content::BrowserTaskEnvironment task_environment_;
@@ -36,12 +37,7 @@ class UptimeMonitorUnitTest : public testing::Test {
 };
 
 #if BUILDFLAG(IS_ANDROID)
-#define MAYBE_ReportUsageDuration ReportUsageDuration
-#else
-#define MAYBE_ReportUsageDuration DISABLED_ReportUsageDuration
-#endif
-
-TEST_F(UptimeMonitorUnitTest, MAYBE_ReportUsageDuration) {
+TEST_F(UptimeMonitorUnitTest, ReportUsageDuration) {
   histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 0);
 
   usage_monitor_->ReportUsageDuration(base::Minutes(15));
@@ -78,5 +74,6 @@ TEST_F(UptimeMonitorUnitTest, MAYBE_ReportUsageDuration) {
   histogram_tester_.ExpectBucketCount(kBrowserOpenTimeHistogramName, 3, 1);
   histogram_tester_.ExpectTotalCount(kBrowserOpenTimeHistogramName, 3);
 }
+#endif
 
 }  // namespace misc_metrics

--- a/components/misc_metrics/pref_names.h
+++ b/components/misc_metrics/pref_names.h
@@ -49,7 +49,7 @@ inline constexpr char kDailyUptimesListPrefName[] =
 inline constexpr char kDailyUptimeSumPrefName[] =
     "brave.misc_metrics.uptime_sum";
 inline constexpr char kDailyUptimeFrameStartTimePrefName[] =
-    "brave.misc_metrics.uptime_frame_start_time";
+    "brave.misc_metrics.uptime_frame_start_time_v2";
 
 inline constexpr char kMiscMetricsTabSwitcherNewTabsStorage[] =
     "brave.misc_metrics.tab_switcher_new_tabs_storage";

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -267,7 +267,7 @@ inline constexpr auto kCollectedExpressHistograms =
     "Brave.Search.DefaultEngine.4",
     "Brave.Today.IsEnabled",
     "Brave.Today.UsageDaily",
-    "Brave.Uptime.BrowserOpenTime",
+    "Brave.Uptime.BrowserOpenTime.2",
     "Brave.Wallet.UsageDaily",
     "creativeInstanceId.total.count",
 });
@@ -314,6 +314,7 @@ inline constexpr auto kEphemeralHistograms =
     "Brave.Today.UsageDaily",
     "Brave.Today.UsageMonthly",
     "Brave.Today.WeeklyTotalCardClicks",
+    "Brave.Uptime.BrowserOpenTime.2",
     "Brave.VerticalTabs.GroupTabs",
     "Brave.VerticalTabs.OpenTabs",
     "Brave.VerticalTabs.PinnedTabs",


### PR DESCRIPTION
Uplift of #23448
Resolves https://github.com/brave/brave-browser/issues/38114

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.