### PR TITLE
[ads] Fixes fullscreen NTT video ad plays extra sound when started before autoplay finished (uplift to 1.66.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoPlayer.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoPlayer.swift
@@ -75,7 +75,6 @@ class NewTabPageVideoPlayer {
       autoplayFinished()
     }
 
-    player?.isMuted = false
     player?.seek(to: CMTime.zero)
     player?.currentItem?.forwardPlaybackEndTime = CMTime()
 
@@ -90,6 +89,7 @@ class NewTabPageVideoPlayer {
         self?.checkMedia25Percentage()
       }
 
+    player?.isMuted = false
     player?.play()
     didStartPlayback = true
 


### PR DESCRIPTION
Uplift of #23480
Resolves https://github.com/brave/brave-browser/issues/38133

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.