### PR TITLE
Make sure PrintPreviewExtraction emit beforeprint and afterprint correctly 

### DIFF
--- a/browser/ui/webui/ai_chat/print_preview_extractor.cc
+++ b/browser/ui/webui/ai_chat/print_preview_extractor.cc
@@ -352,7 +352,8 @@ void PrintPreviewExtractor::DidGetDefaultPageLayout(
 void PrintPreviewExtractor::DidStartPreview(
     printing::mojom::DidStartPreviewParamsPtr params,
     int32_t request_id) {
-  DVLOG(3) << __func__ << ": id=" << request_id;
+  DVLOG(3) << __func__ << ": id=" << request_id
+           << " , page count: " << params->page_count;
 }
 
 void PrintPreviewExtractor::OnPrepareForDocumentToPdfDone(
@@ -395,6 +396,9 @@ void PrintPreviewExtractor::PreviewCleanup() {
     return;
   }
   PrintPreviewDataService::GetInstance()->RemoveEntry(*print_preview_ui_id_);
+  if (!is_pdf_) {
+    print_render_frame_->OnPrintPreviewDialogClosed();
+  }
   DisconnectPrintPrieviewUI();
 }
 

--- a/chromium_src/components/printing/renderer/print_render_frame_helper.cc
+++ b/chromium_src/components/printing/renderer/print_render_frame_helper.cc
@@ -57,8 +57,10 @@ void PrintRenderFrameHelper::InitiatePrintPreview(
     print_preview_context_.InitWithNode(plugin);
   } else {
     print_preview_context_.InitWithFrame(frame);
+    print_preview_context_.DispatchBeforePrintEvent(
+        weak_ptr_factory_.GetWeakPtr());
   }
-  print_in_progress_ = false;
+  // Print Preview resets `print_in_progress_` when the dialog closes.
 }
 
 void PrintRenderFrameHelper::SetIsPrintPreviewExtraction(bool value) {

--- a/test/data/leo/extra_long_canvas.html
+++ b/test/data/leo/extra_long_canvas.html
@@ -6,27 +6,30 @@
 <body>
     <script>
       // Here we create 21 pages to test kMaxPreviewPages which is 20.
-      for (let i = 0; i < 21; i++) {
-        const div = document.createElement('div');
-        div.style.width = '559px';
-        div.style.height = '794px';
+      // These pages will be created only after receiving the beforeprint event.
+      window.addEventListener('beforeprint', () => {
+        for (let i = 0; i < 21; i++) {
+          const div = document.createElement('div');
+          div.style.width = '559px';
+          div.style.height = '794px';
 
-        const canvas = document.createElement('canvas');
-        const context = canvas.getContext('2d');
-        canvas.width = 559
-        canvas.height = 794
-        context.font = '30px Arial';
-        if (i == 19) {
-          // This should be the last page because of the truncation.
-          context.fillText('This is the way.', 50, 100);
-        } else if (i == 20) {
-          // This will be truncated.
-          context.fillText('There is no way.', 50, 100);
+          const canvas = document.createElement('canvas');
+          const context = canvas.getContext('2d');
+          canvas.width = 559
+          canvas.height = 794
+          context.font = '30px Arial';
+          if (i == 19) {
+            // This should be the last page because of the truncation.
+            context.fillText('This is the way.', 50, 100);
+          } else if (i == 20) {
+            // This will be truncated.
+            context.fillText('There is no way.', 50, 100);
+          }
+
+          div.appendChild(canvas);
+          document.body.appendChild(div);
         }
-
-        div.appendChild(canvas);
-        document.body.appendChild(div);
-      }
+      });
     </script>
 </body>
 </html>


### PR DESCRIPTION


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/37996

Some websites might change contents when receiving `beforeprint`(ex. adding pages outside of viewport) and possibly revert it after printing. That is why we need to emit `beforeprint` and `afterprint` so we would have complete contents to extract.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### STR in the issue.

### STR in the issue without advancing to any pages.
