### PR TITLE
AI Chat search events from Conversation API

### DIFF
--- a/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
+++ b/browser/ai_chat/ai_chat_render_view_context_menu_browsertest.cc
@@ -54,7 +54,6 @@ class MockEngineConsumer : public EngineConsumer {
               GenerateAssistantResponse,
               (const bool&,
                const std::string&,
-               std::optional<std::string>,
                const ConversationHistory&,
                const std::string&,
                GenerationDataCallback,
@@ -127,7 +126,9 @@ class AIChatRenderViewContextMenuBrowserTest : public InProcessBrowserTest {
           ASSERT_TRUE(callback);
           ASSERT_TRUE(data_callback);
           for (const auto& data : received_data) {
-            data_callback.Run(data);
+            auto event = mojom::ConversationEntryEvent::NewCompletionEvent(
+                mojom::CompletionEvent::New(data));
+            data_callback.Run(std::move(event));
           }
           std::move(callback).Run(completed_result);
           run_loop.Quit();

--- a/browser/ai_chat/android/ai_chat_utils.cc
+++ b/browser/ai_chat/android/ai_chat_utils.cc
@@ -3,11 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/build/android/jni_headers/BraveLeoUtils_jni.h"
-
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
+#include "brave/build/android/jni_headers/BraveLeoUtils_jni.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
@@ -27,10 +27,10 @@ static void JNI_BraveLeoUtils_OpenLeoQuery(
   auto* chat_tab_helper = AIChatTabHelper::FromWebContents(web_contents);
   DCHECK(chat_tab_helper);
   chat_tab_helper->MaybeUnlinkPageContent();
-  mojom::ConversationTurn turn = {
+  mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
-      base::android::ConvertJavaStringToUTF8(query), std::nullopt};
+      base::android::ConvertJavaStringToUTF8(query), std::nullopt);
   chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
 #endif
 }

--- a/browser/ai_chat/android/ai_chat_utils.cc
+++ b/browser/ai_chat/android/ai_chat_utils.cc
@@ -30,7 +30,8 @@ static void JNI_BraveLeoUtils_OpenLeoQuery(
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
-      base::android::ConvertJavaStringToUTF8(query), std::nullopt);
+      base::android::ConvertJavaStringToUTF8(query), std::nullopt,
+      std::nullopt);
   chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
 #endif
 }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -133,9 +133,9 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
       << "Should not be able to submit more"
       << "than a single human conversation turn at a time.";
 
-  mojom::ConversationTurn turn = {
+  mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       CharacterType::HUMAN, mojom::ActionType::UNSPECIFIED,
-      ConversationTurnVisibility::VISIBLE, input, std::nullopt};
+      ConversationTurnVisibility::VISIBLE, input, std::nullopt);
   active_chat_tab_helper_->SubmitHumanConversationEntry(std::move(turn));
 }
 

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -135,7 +135,7 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
 
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       CharacterType::HUMAN, mojom::ActionType::UNSPECIFIED,
-      ConversationTurnVisibility::VISIBLE, input, std::nullopt);
+      ConversationTurnVisibility::VISIBLE, input, std::nullopt, std::nullopt);
   active_chat_tab_helper_->SubmitHumanConversationEntry(std::move(turn));
 }
 

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
@@ -71,11 +71,16 @@ void ChromeAutocompleteProviderClient::OpenLeo(const std::u16string& query) {
       sidebar::SidebarItem::BuiltInItemType::kChatUI);
 
   // Send the query to the AIChat's backend.
-  ai_chat::mojom::ConversationTurn turn = {
-      ai_chat::mojom::CharacterType::HUMAN, ai_chat::mojom::ActionType::QUERY,
-      ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
-      base::UTF16ToUTF8(query), std::nullopt};
+  ai_chat::mojom::ConversationTurnPtr turn =
+      ai_chat::mojom::ConversationTurn::New();
+  turn->character_type = ai_chat::mojom::CharacterType::HUMAN;
+  turn->action_type = ai_chat::mojom::ActionType::QUERY;
+  turn->visibility = ai_chat::mojom::ConversationTurnVisibility::VISIBLE;
+  turn->text = base::UTF16ToUTF8(query);
+  turn->selected_text = std::nullopt;
+
   chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
+
   ai_chat::AIChatMetrics* metrics =
       g_brave_browser_process->process_misc_metrics()->ai_chat_metrics();
   CHECK(metrics);

--- a/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
+++ b/chromium_src/chrome/browser/renderer_context_menu/render_view_context_menu.cc
@@ -258,10 +258,16 @@ GetActionTypeAndP3A(int command) {
 
 void OnRewriteSuggestionDataReceived(
     base::WeakPtr<content::WebContents> web_contents,
-    std::string suggestion) {
+    ai_chat::mojom::ConversationEntryEventPtr rewrite_event) {
   if (!web_contents) {
     return;
   }
+
+  if (!rewrite_event->is_completion_event()) {
+    return;
+  }
+
+  std::string suggestion = rewrite_event->get_completion_event()->completion;
 
   base::TrimWhitespaceASCII(suggestion, base::TRIM_ALL, &suggestion);
   if (suggestion.empty()) {

--- a/components/ai_chat/core/browser/ai_chat_feedback_api.cc
+++ b/components/ai_chat/core/browser/ai_chat_feedback_api.cc
@@ -77,7 +77,7 @@ AIChatFeedbackAPI::~AIChatFeedbackAPI() = default;
 void AIChatFeedbackAPI::SendRating(
     bool is_liked,
     bool is_premium,
-    const base::span<const mojom::ConversationTurn>& history,
+    const base::span<const mojom::ConversationTurnPtr>& history,
     const std::string& model_name,
     api_request_helper::APIRequestHelper::ResultCallback on_complete_callback) {
   base::Value::Dict payload;
@@ -87,10 +87,10 @@ void AIChatFeedbackAPI::SendRating(
   for (auto& turn : history) {
     base::Value::Dict turn_dict;
     turn_dict.Set("id", id);
-    turn_dict.Set("type", turn.character_type == mojom::CharacterType::HUMAN
+    turn_dict.Set("type", turn->character_type == mojom::CharacterType::HUMAN
                               ? "human"
                               : "assistant");
-    turn_dict.Set("content", turn.text);
+    turn_dict.Set("content", turn->text);
     ++id;
 
     chat.Append(std::move(turn_dict));

--- a/components/ai_chat/core/browser/ai_chat_feedback_api.h
+++ b/components/ai_chat/core/browser/ai_chat_feedback_api.h
@@ -31,7 +31,7 @@ class AIChatFeedbackAPI {
 
   void SendRating(bool is_liked,
                   bool is_premium,
-                  const base::span<const mojom::ConversationTurn>& history,
+                  const base::span<const mojom::ConversationTurnPtr>& history,
                   const std::string& model_name,
                   api_request_helper::APIRequestHelper::ResultCallback
                       on_complete_callback);

--- a/components/ai_chat/core/browser/constants.cc
+++ b/components/ai_chat/core/browser/constants.cc
@@ -103,6 +103,8 @@ base::span<const webui::LocalizedString> GetLocalizedStrings() {
       {"gotItButtonLabel", IDS_CHAT_UI_GOT_IT_BUTTON_LABEL},
       {"pageContentTooLongWarning", IDS_CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING},
       {"errorConversationEnd", IDS_CHAT_UI_CONVERSATION_END_ERROR},
+      {"searchInProgress", IDS_CHAT_UI_SEARCH_IN_PROGRESS},
+      {"searchQueries", IDS_CHAT_UI_SEARCH_QUERIES},
       {"leoSettingsTooltipLabel", IDS_CHAT_UI_LEO_SETTINGS_TOOLTIP_LABEL},
       {"summarizePageButtonLabel", IDS_CHAT_UI_SUMMARIZE_PAGE},
       {"welcomeGuideTitle", IDS_CHAT_UI_WELCOME_GUIDE_TITLE},

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -76,15 +76,15 @@ class ConversationDriver {
   void SetDefaultModel(const std::string& model_key);
   const mojom::Model& GetCurrentModel();
   std::vector<mojom::ModelPtr> GetModels();
-  const std::vector<mojom::ConversationTurn>& GetConversationHistory();
+  const std::vector<mojom::ConversationTurnPtr>& GetConversationHistory();
   std::vector<mojom::ConversationTurnPtr> GetVisibleConversationHistory();
   // Whether the UI for this conversation is open or not. Determines
   // whether content is retrieved and queries are sent for the conversation
   // when the page changes.
   void OnConversationActiveChanged(bool is_conversation_active);
-  void AddToConversationHistory(mojom::ConversationTurn turn);
+  void AddToConversationHistory(mojom::ConversationTurnPtr turn);
   void UpdateOrCreateLastAssistantEntry(std::string text);
-  void SubmitHumanConversationEntry(mojom::ConversationTurn turn);
+  void SubmitHumanConversationEntry(mojom::ConversationTurnPtr turn);
   void RetryAPIRequest();
   bool IsRequestInProgress();
   void AddObserver(Observer* observer);
@@ -192,7 +192,6 @@ class ConversationDriver {
   void PerformAssistantGeneration(
       const std::string& input,
       std::optional<std::string> selected_text,
-      const std::vector<mojom::ConversationTurn>& history,
       int64_t current_navigation_id,
       std::string page_content = "",
       bool is_video = false,
@@ -237,8 +236,7 @@ class ConversationDriver {
 
   // TODO(nullhook): Abstract the data model
   std::string model_key_;
-  // TODO(nullhook): Change this to mojo::StructPtr
-  std::vector<mojom::ConversationTurn> chat_history_;
+  std::vector<mojom::ConversationTurnPtr> chat_history_;
   bool is_conversation_active_ = false;
 
   // Page content
@@ -267,7 +265,7 @@ class ConversationDriver {
   mojom::APIError current_error_ = mojom::APIError::None;
   mojom::PremiumStatus last_premium_status_ = mojom::PremiumStatus::Unknown;
 
-  std::unique_ptr<mojom::ConversationTurn> pending_conversation_entry_;
+  mojom::ConversationTurnPtr pending_conversation_entry_;
 
   base::WeakPtrFactory<ConversationDriver> weak_ptr_factory_{this};
 };

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -20,6 +20,7 @@
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_feedback_api.h"
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "services/data_decoder/public/cpp/data_decoder.h"
@@ -83,7 +84,6 @@ class ConversationDriver {
   // when the page changes.
   void OnConversationActiveChanged(bool is_conversation_active);
   void AddToConversationHistory(mojom::ConversationTurnPtr turn);
-  void UpdateOrCreateLastAssistantEntry(std::string text);
   void SubmitHumanConversationEntry(mojom::ConversationTurnPtr turn);
   void RetryAPIRequest();
   bool IsRequestInProgress();
@@ -183,6 +183,14 @@ class ConversationDriver {
 
  private:
   FRIEND_TEST_ALL_PREFIXES(::AIChatUIBrowserTest, PrintPreviewFallback);
+  FRIEND_TEST_ALL_PREFIXES(ConversationDriverUnitTest,
+                           UpdateOrCreateLastAssistantEntry_Delta);
+  FRIEND_TEST_ALL_PREFIXES(ConversationDriverUnitTest,
+                           UpdateOrCreateLastAssistantEntry_DeltaWithSearch);
+  FRIEND_TEST_ALL_PREFIXES(ConversationDriverUnitTest,
+                           UpdateOrCreateLastAssistantEntry_NotDelta);
+  FRIEND_TEST_ALL_PREFIXES(ConversationDriverUnitTest,
+                           UpdateOrCreateLastAssistantEntry_NotDeltaWithSearch);
 
   void InitEngine();
   void OnUserOptedIn();
@@ -191,7 +199,6 @@ class ConversationDriver {
 
   void PerformAssistantGeneration(
       const std::string& input,
-      std::optional<std::string> selected_text,
       int64_t current_navigation_id,
       std::string page_content = "",
       bool is_video = false,
@@ -206,7 +213,7 @@ class ConversationDriver {
   void OnExistingGeneratePageContentComplete(GetPageContentCallback callback);
 
   void OnEngineCompletionDataReceived(int64_t navigation_id,
-                                      std::string result);
+                                      mojom::ConversationEntryEventPtr result);
   void OnEngineCompletionComplete(int64_t navigation_id,
                                   EngineConsumer::GenerationResult result);
   void OnSuggestedQuestionsResponse(
@@ -218,7 +225,7 @@ class ConversationDriver {
       mojom::PageHandler::GetPremiumStatusCallback parent_callback,
       mojom::PremiumStatus premium_status,
       mojom::PremiumInfoPtr premium_info);
-
+  void UpdateOrCreateLastAssistantEntry(mojom::ConversationEntryEventPtr text);
   void SetAPIError(const mojom::APIError& error);
   bool IsContentAssociationPossible();
 

--- a/components/ai_chat/core/browser/engine/conversation_api_client.h
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.h
@@ -27,7 +27,8 @@ namespace ai_chat {
 class ConversationAPIClient {
  public:
   using GenerationResult = base::expected<std::string, mojom::APIError>;
-  using GenerationDataCallback = base::RepeatingCallback<void(std::string)>;
+  using GenerationDataCallback =
+      base::RepeatingCallback<void(mojom::ConversationEntryEventPtr)>;
   using GenerationCompletedCallback =
       base::OnceCallback<void(GenerationResult)>;
 

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -30,7 +30,8 @@ class EngineConsumer {
 
   using GenerationResult = base::expected<std::string, mojom::APIError>;
 
-  using GenerationDataCallback = base::RepeatingCallback<void(std::string)>;
+  using GenerationDataCallback =
+      base::RepeatingCallback<void(mojom::ConversationEntryEventPtr)>;
 
   using GenerationCompletedCallback =
       base::OnceCallback<void(GenerationResult)>;
@@ -50,7 +51,6 @@ class EngineConsumer {
   virtual void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
-      std::optional<std::string> selected_text,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
       GenerationDataCallback data_received_callback,

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -35,7 +35,7 @@ class EngineConsumer {
   using GenerationCompletedCallback =
       base::OnceCallback<void(GenerationResult)>;
 
-  using ConversationHistory = std::vector<mojom::ConversationTurn>;
+  using ConversationHistory = std::vector<mojom::ConversationTurnPtr>;
 
   EngineConsumer();
   EngineConsumer(const EngineConsumer&) = delete;

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.h
@@ -47,7 +47,6 @@ class EngineConsumerClaudeRemote : public EngineConsumer {
   void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
-      std::optional<std::string> selected_text,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
       GenerationDataCallback data_received_callback,

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
@@ -24,7 +24,6 @@
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-using ConversationHistory = std::vector<ai_chat::mojom::ConversationTurn>;
 using ::testing::_;
 
 namespace ai_chat {
@@ -62,13 +61,15 @@ class EngineConsumerClaudeUnitTest : public testing::Test {
 };
 
 TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
-  ConversationHistory history = {
-      {mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
-       mojom::ConversationTurnVisibility::VISIBLE,
-       "Which show is this catchphrase from?", "I have spoken."},
-      {mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-       std::nullopt}};
+  std::vector<mojom::ConversationTurnPtr> history;
+  history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
+      mojom::ConversationTurnVisibility::VISIBLE,
+      "Which show is this catchphrase from?", "I have spoken."));
+  history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
+      mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
+      std::nullopt));
   auto* mock_remote_completion_client = GetMockRemoteCompletionClient();
   std::string prompt_before_time_and_date =
       "\n\nHuman: Here is the text of a web page in <page> tags:\n<page>\nThis "

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
@@ -19,18 +19,21 @@
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/engine/mock_remote_completion_client.h"
 #include "brave/components/ai_chat/core/browser/models.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 using ::testing::_;
+using ::testing::Sequence;
 
 namespace ai_chat {
 
 class MockCallback {
  public:
-  MOCK_METHOD(void, OnDataReceived, (std::string));
+  MOCK_METHOD(void, OnDataReceived, (mojom::ConversationEntryEventPtr));
   MOCK_METHOD(void, OnCompleted, (EngineConsumer::GenerationResult));
 };
 
@@ -65,11 +68,11 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
-      "Which show is this catchphrase from?", "I have spoken."));
+      "Which show is this catchphrase from?", "I have spoken.", std::nullopt));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt));
+      std::nullopt, std::nullopt));
   auto* mock_remote_completion_client = GetMockRemoteCompletionClient();
   std::string prompt_before_time_and_date =
       "\n\nHuman: Here is the text of a web page in <page> tags:\n<page>\nThis "
@@ -113,9 +116,15 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
         EXPECT_TRUE(base::EndsWith(prompt, prompt_after_time_and_date));
         std::move(callback).Run("");
       });
+  {
+    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New();
+    entry->character_type = mojom::CharacterType::HUMAN;
+    entry->text = "Who?";
+    entry->selected_text = "I'm groot.";
+    history.push_back(std::move(entry));
+  }
   engine_->GenerateAssistantResponse(
-      false, "This is my page.", "I'm groot.", history, "Who?",
-      base::DoNothing(),
+      false, "This is my page.", history, "Who?", base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -141,8 +150,17 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
                   std::string::npos);
         std::move(callback).Run("");
       });
+
+  history.pop_back();
+  {
+    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New();
+    entry->character_type = mojom::CharacterType::HUMAN;
+    entry->text = "user request";
+    entry->selected_text = "12345";
+    history.push_back(std::move(entry));
+  }
   engine_->GenerateAssistantResponse(
-      false, "12345", "12345", history, "user request", base::DoNothing(),
+      false, "12345", history, "user request", base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop2](EngineConsumer::GenerationResult) {
             run_loop2.Quit();
@@ -173,9 +191,17 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
         EXPECT_TRUE(base::EndsWith(prompt, prompt_after_time_and_date));
         std::move(callback).Run("");
       });
+
+  history.pop_back();
+  {
+    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New();
+    entry->character_type = mojom::CharacterType::HUMAN;
+    entry->text = "Who?";
+    history.push_back(std::move(entry));
+  }
+
   engine_->GenerateAssistantResponse(
-      false, "This is my page.", std::nullopt, history, "Who?",
-      base::DoNothing(),
+      false, "This is my page.", history, "Who?", base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop3](EngineConsumer::GenerationResult) {
             run_loop3.Quit();
@@ -202,14 +228,27 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateRewriteSuggestion) {
             "rewritten:\n<excerpt>\nHello\n</excerpt>\n\nRewrite the excerpt "
             "in a funny tone.\nPut your rewritten version of the excerpt in "
             "<response></response> tags.\n\nAssistant: <response>");
-        data_callback.Run("Re");
-        data_callback.Run("Reply");
+        data_callback.Run(mojom::ConversationEntryEvent::NewCompletionEvent(
+            mojom::CompletionEvent::New("Re")));
+        data_callback.Run(mojom::ConversationEntryEvent::NewCompletionEvent(
+            mojom::CompletionEvent::New("Reply")));
         std::move(callback).Run("");
         run_loop.Quit();
       });
 
-  EXPECT_CALL(mock_callback, OnDataReceived("Re"));
-  EXPECT_CALL(mock_callback, OnDataReceived("Reply"));
+  Sequence seq;
+  EXPECT_CALL(mock_callback, OnDataReceived(_))
+      .InSequence(seq)
+      .WillOnce([&](mojom::ConversationEntryEventPtr event) {
+        EXPECT_TRUE(event->is_completion_event());
+        EXPECT_EQ(event->get_completion_event()->completion, "Re");
+      });
+  EXPECT_CALL(mock_callback, OnDataReceived(_))
+      .InSequence(seq)
+      .WillOnce([&](mojom::ConversationEntryEventPtr event) {
+        EXPECT_TRUE(event->is_completion_event());
+        EXPECT_EQ(event->get_completion_event()->completion, "Reply");
+      });
   EXPECT_CALL(mock_callback, OnCompleted(EngineConsumer::GenerationResult("")));
 
   engine_->GenerateRewriteSuggestion(

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -117,14 +117,15 @@ void EngineConsumerConversationAPI::GenerateAssistantResponse(
   }
   // history
   for (const auto& message : conversation_history) {
-    if (message.selected_text.has_value() && !message.selected_text->empty()) {
+    if (message->selected_text.has_value() &&
+        !message->selected_text->empty()) {
       conversation.push_back({mojom::CharacterType::HUMAN,
                               ConversationEventType::PageExcerpt,
-                              message.selected_text.value()});
+                              message->selected_text.value()});
     }
     ConversationEvent event;
-    event.role = message.character_type;
-    event.content = message.text;
+    event.role = message->character_type;
+    event.content = message->text;
     // TODO(petemill): Shouldn't the server handle the map of mojom::ActionType
     // to prompts? (e.g. SUMMARIZE_PAGE, PARAPHRASE, etc.)
     event.type = ConversationEventType::ChatMessage;

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h
@@ -46,7 +46,6 @@ class EngineConsumerConversationAPI : public EngineConsumer {
   void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
-      std::optional<std::string> selected_text,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
       GenerationDataCallback data_received_callback,

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -28,7 +28,6 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/googletest/src/googletest/include/gtest/gtest.h"
 
-using ConversationHistory = std::vector<ai_chat::mojom::ConversationTurn>;
 using ::testing::_;
 
 namespace ai_chat {
@@ -172,13 +171,15 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
        GenerateEvents_HistoryWithSelectedText) {
   // Tests events building from history with selected text and new query without
   // selected text but with page association.
-  ConversationHistory history = {
-      {mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
-       mojom::ConversationTurnVisibility::VISIBLE,
-       "Which show is this catchphrase from?", "I have spoken."},
-      {mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-       std::nullopt}};
+  EngineConsumer::ConversationHistory history;
+  history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
+      mojom::ConversationTurnVisibility::VISIBLE,
+      "Which show is this catchphrase from?", "I have spoken."));
+  history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
+      mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
+      std::nullopt));
   std::string expected_events = R"([
     {"role": "user", "type": "pageText", "content": "This is my page. I have spoken."},
     {"role": "user", "type": "pageExcerpt", "content": "I have spoken."},

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.h
@@ -46,7 +46,6 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
   void GenerateAssistantResponse(
       const bool& is_video,
       const std::string& page_content,
-      std::optional<std::string> selected_text,
       const ConversationHistory& conversation_history,
       const std::string& human_input,
       GenerationDataCallback data_received_callback,

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
@@ -19,18 +19,20 @@
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/browser/engine/mock_remote_completion_client.h"
 #include "brave/components/ai_chat/core/browser/models.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 using ::testing::_;
+using ::testing::Sequence;
 
 namespace ai_chat {
 
 class MockCallback {
  public:
-  MOCK_METHOD(void, OnDataReceived, (std::string));
+  MOCK_METHOD(void, OnDataReceived, (mojom::ConversationEntryEventPtr));
   MOCK_METHOD(void, OnCompleted, (EngineConsumer::GenerationResult));
 };
 
@@ -65,11 +67,12 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
-      "Which show is this catchphrase from?", "This is the way."));
+      "Which show is this catchphrase from?", "This is the way.",
+      std::nullopt));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt));
+      std::nullopt, std::nullopt));
   auto* mock_remote_completion_client =
       static_cast<MockRemoteCompletionClient*>(engine_->GetAPIForTesting());
   std::string prompt_before_time_and_date =
@@ -109,9 +112,15 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
         EXPECT_TRUE(base::EndsWith(prompt, prompt_after_time_and_date));
         std::move(callback).Run("");
       });
+  {
+    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New();
+    entry->character_type = mojom::CharacterType::HUMAN;
+    entry->text = "What's his name?";
+    entry->selected_text = "I'm groot.";
+    history.push_back(std::move(entry));
+  }
   engine_->GenerateAssistantResponse(
-      false, "This is a page.", "I'm groot.", history, "What's his name?",
-      base::DoNothing(),
+      false, "This is a page.", history, "What's his name?", base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
   run_loop.Run();
@@ -151,9 +160,16 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
         EXPECT_TRUE(base::EndsWith(prompt, prompt_after_time_and_date));
         std::move(callback).Run("");
       });
+  std::vector<mojom::ConversationTurnPtr> history2;
+  {
+    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New();
+    entry->character_type = mojom::CharacterType::HUMAN;
+    entry->text = "What's his name?";
+    entry->selected_text = "I'm groot.";
+    history2.push_back(std::move(entry));
+  }
   engine_->GenerateAssistantResponse(
-      false, "This is a page.", "I'm groot.", {}, "What's his name?",
-      base::DoNothing(),
+      false, "This is a page.", history2, "What's his name?", base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop2](EngineConsumer::GenerationResult) {
             run_loop2.Quit();
@@ -180,8 +196,17 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
                   std::string::npos);
         std::move(callback).Run("");
       });
+
+  history.pop_back();
+  {
+    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New();
+    entry->character_type = mojom::CharacterType::HUMAN;
+    entry->text = "user question";
+    entry->selected_text = "12345";
+    history.push_back(std::move(entry));
+  }
   engine_->GenerateAssistantResponse(
-      false, "12345", "12345", history, "user question", base::DoNothing(),
+      false, "12345", history, "user question", base::DoNothing(),
       base::BindLambdaForTesting(
           [&run_loop3](EngineConsumer::GenerationResult) {
             run_loop3.Quit();
@@ -216,14 +241,27 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateRewriteSuggestion) {
             "in "
             "a funny tone. [/INST] Sure, here is the rewritten version of the "
             "excerpt: <response>");
-        data_callback.Run("Re");
-        data_callback.Run("Reply");
+        data_callback.Run(mojom::ConversationEntryEvent::NewCompletionEvent(
+            mojom::CompletionEvent::New("Re")));
+        data_callback.Run(mojom::ConversationEntryEvent::NewCompletionEvent(
+            mojom::CompletionEvent::New("Reply")));
         std::move(callback).Run("");
         run_loop.Quit();
       });
 
-  EXPECT_CALL(mock_callback, OnDataReceived("Re"));
-  EXPECT_CALL(mock_callback, OnDataReceived("Reply"));
+  Sequence seq;
+  EXPECT_CALL(mock_callback, OnDataReceived(_))
+      .InSequence(seq)
+      .WillOnce([&](mojom::ConversationEntryEventPtr event) {
+        EXPECT_TRUE(event->is_completion_event());
+        EXPECT_EQ(event->get_completion_event()->completion, "Re");
+      });
+  EXPECT_CALL(mock_callback, OnDataReceived(_))
+      .InSequence(seq)
+      .WillOnce([&](mojom::ConversationEntryEventPtr event) {
+        EXPECT_TRUE(event->is_completion_event());
+        EXPECT_EQ(event->get_completion_event()->completion, "Reply");
+      });
   EXPECT_CALL(mock_callback, OnCompleted(EngineConsumer::GenerationResult("")));
 
   engine_->GenerateRewriteSuggestion(

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
@@ -24,7 +24,6 @@
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-using ConversationHistory = std::vector<ai_chat::mojom::ConversationTurn>;
 using ::testing::_;
 
 namespace ai_chat {
@@ -62,13 +61,15 @@ class EngineConsumerLlamaUnitTest : public testing::Test {
 };
 
 TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
-  ConversationHistory history = {
-      {mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
-       mojom::ConversationTurnVisibility::VISIBLE,
-       "Which show is this catchphrase from?", "This is the way."},
-      {mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-       std::nullopt}};
+  EngineConsumer::ConversationHistory history;
+  history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
+      mojom::ConversationTurnVisibility::VISIBLE,
+      "Which show is this catchphrase from?", "This is the way."));
+  history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
+      mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
+      std::nullopt));
   auto* mock_remote_completion_client =
       static_cast<MockRemoteCompletionClient*>(engine_->GetAPIForTesting());
   std::string prompt_before_time_and_date =

--- a/components/ai_chat/core/browser/engine/remote_completion_client.cc
+++ b/components/ai_chat/core/browser/engine/remote_completion_client.cc
@@ -22,6 +22,7 @@
 #include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/brave_service_keys/brave_service_key_utils.h"
 #include "brave/components/constants/brave_services_key.h"
 #include "net/http/http_status_code.h"
@@ -215,9 +216,12 @@ void RemoteCompletionClient::OnQueryDataReceived(
     return;
   }
 
+  // This client only supports completion events
   const std::string* completion = result->GetDict().FindString("completion");
   if (completion) {
-    callback.Run(std::move(*completion));
+    auto event = mojom::ConversationEntryEvent::NewCompletionEvent(
+        mojom::CompletionEvent::New(*completion));
+    callback.Run(std::move(event));
   }
 }
 

--- a/components/ai_chat/core/browser/engine/remote_completion_client.h
+++ b/components/ai_chat/core/browser/engine/remote_completion_client.h
@@ -31,7 +31,8 @@ using api_request_helper::APIRequestResult;
 class RemoteCompletionClient {
  public:
   using GenerationResult = base::expected<std::string, mojom::APIError>;
-  using GenerationDataCallback = base::RepeatingCallback<void(std::string)>;
+  using GenerationDataCallback =
+      base::RepeatingCallback<void(mojom::ConversationEntryEventPtr)>;
   using GenerationCompletedCallback =
       base::OnceCallback<void(GenerationResult)>;
 

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -104,6 +104,25 @@ enum ActionType {
   EXPAND,
 };
 
+struct SearchQueriesEvent {
+  array<string> search_queries;
+};
+
+struct SearchStatusEvent {
+  bool is_searching = true;
+};
+
+struct CompletionEvent {
+  string completion;
+};
+
+// Events that occur during a conversation turn (only assistant for now)
+union ConversationEntryEvent {
+  CompletionEvent completion_event;
+  SearchQueriesEvent search_queries_event;
+  SearchStatusEvent search_status_event;
+};
+
 // Represents a single turn in a conversation.
 // The character type defines which party initiated the turn in the
 // conversation.
@@ -115,8 +134,18 @@ struct ConversationTurn {
   CharacterType character_type;
   ActionType action_type;
   ConversationTurnVisibility visibility;
+  // The text that is displayed to the user. This might be different than
+  // the text sent to the AI engine to represent this turn, which might be more
+  // verbose.
+  // TODO(petemill): Store the text sent to the AI engine to aid in regeneration
+  // and error retries.
   string text;
   string? selected_text;
+  // Ordered list of events that occurred during this turn
+  // TODO(petemill): ConversationTurn's |text| and |selected_text| might move
+  // to be an event - as the events become richer, the order around text could
+  // be important.
+  array<ConversationEntryEvent>? events;
 };
 
 // Represents an AI engine model choice, usually for the user to choose for a

--- a/components/ai_chat/resources/page/api/mock_page_handler.ts
+++ b/components/ai_chat/resources/page/api/mock_page_handler.ts
@@ -4,6 +4,7 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 import * as mojom from 'gen/brave/components/ai_chat/core/common/mojom/ai_chat.mojom.m.js'
+import { Url } from 'gen/url/mojom/url.mojom.m.js'
 
 // Implementing from the raw class (mojom.PageHandlerRemote) gives an error: "Types have separate declarations of a private property 'proxy'".
 // General guidance is to use the public interface only as the underlying type hides private fields: https://github.com/microsoft/TypeScript/issues/7755
@@ -110,6 +111,10 @@ export class MockPageHandlerRemote implements Public<mojom.PageHandlerRemote> {
     return Promise.resolve({ actionList: ACTIONS_LIST })
   }
 
+  openURL(url: Url) {
+    window.open(url.url, '_blank')
+  }
+
   onConnectionError() {}
   setClientPage() {}
   changeModel() {}
@@ -120,7 +125,6 @@ export class MockPageHandlerRemote implements Public<mojom.PageHandlerRemote> {
   submitSummarizationRequest() {}
   markAgreementAccepted() {}
   openBraveLeoSettings() {}
-  openURL() {}
   generateQuestions() {}
   setShouldSendPageContents() {}
   goPremium() {}

--- a/components/ai_chat/resources/page/components/assistant_response/index.tsx
+++ b/components/ai_chat/resources/page/components/assistant_response/index.tsx
@@ -1,0 +1,82 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import ProgressRing from '@brave/leo/react/progressRing'
+import Icon from '@brave/leo/react/icon'
+import { Url } from 'gen/url/mojom/url.mojom.m.js'
+import getPageHandlerInstance, * as mojom from '../../api/page_handler'
+import MarkdownRenderer from '../markdown_renderer'
+import styles from './style.module.scss'
+import formatMessage from '$web-common/formatMessage'
+import { getLocale } from '$web-common/locale'
+
+function SearchSummary (props: { searchQueries: string[] }) {
+  const handleOpenSearchQuery = React.useCallback((e: React.MouseEvent, query: string) => {
+    e.preventDefault()
+    const queryUrl = new Url()
+    queryUrl.url = `https://search.brave.com/search?q=${encodeURIComponent(query)}`
+    getPageHandlerInstance().pageHandler.openURL(queryUrl)
+  }, [])
+
+  const message = formatMessage(getLocale('searchQueries'), {
+    placeholders: {
+      $1: props.searchQueries.map((query, i, a) => (
+        <>
+          "<a className={styles.searchQueryLink} href='#' onClick={(e) => handleOpenSearchQuery(e, query)}>
+            {query}
+          </a>"{(i < a.length-1) ? ', ' : null}
+        </>
+      ))
+    }
+  })
+
+  return (
+    <div className={styles.searchSummary}>
+      <Icon name="brave-icon-search-color" />
+      <span>
+        {message}
+      </span>
+    </div>
+  )
+}
+
+export default function AssistantResponse(props: { entry: mojom.ConversationTurn, isEntryInProgress: boolean }) {
+  const searchQueriesEvent = props.entry.events?.find(event => !!event.searchQueriesEvent)?.searchQueriesEvent
+  const hasCompletionStarted = !props.isEntryInProgress || props.entry.events?.find(event => !!event.completionEvent)
+
+  return (<>
+  {
+    props.entry.events?.map((event) => {
+      if (event.completionEvent) {
+        return (
+          <MarkdownRenderer
+            shouldShowTextCursor={props.isEntryInProgress}
+            text={event.completionEvent.completion}
+          />
+        )
+      }
+      if (event.searchStatusEvent && props.isEntryInProgress && !hasCompletionStarted) {
+        return (
+          <div className={styles.searchInProgress}><ProgressRing />Improving answer with Brave Search…</div>
+        )
+      }
+      // TODO(petemill): Consider displaying in-progress queries if the API
+      // timing improves (or worsens for the completion events).
+      // if (event.searchQueriesEvent && props.isEntryInProgress) {
+      //   return (<>
+      //     {event.searchQueriesEvent.searchQueries.map(query => <div className={styles.searchQuery}>Searching for <span className={styles.searchLink}><Icon name="brave-icon-search-color" /><Link href='#'>{query}</Link></span></div>)}
+      //   </>)
+      // }
+
+      // Unknown events should be ignored
+      return null
+    })
+  }
+  { !props.isEntryInProgress && searchQueriesEvent &&
+    <SearchSummary searchQueries={searchQueriesEvent.searchQueries} />
+  }
+  </>)
+}

--- a/components/ai_chat/resources/page/components/assistant_response/style.module.scss
+++ b/components/ai_chat/resources/page/components/assistant_response/style.module.scss
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+.searchInProgress {
+  font: var(--leo-font-small-regular);
+  color: var(--leo-color-text-primary);
+  --leo-progressring-color: var(--leo-color-icon-interactive);
+  --leo-progressring-size: 15px;
+  --leo-icon-size: 20px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 6px;
+}
+
+.searchSummary {
+  --leo-icon-size: 18px;
+  margin-top: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 6px;
+  font: var(--leo-font-small-regular);
+  line-height: 1.4;
+  color: var(--leo-color-text-secondary);
+}
+
+.searchQueryLink {
+  font: var(--leo-font-small-regular);
+  text-decoration: underline;
+  color: var(--leo-color-text-primary);
+  &:hover {
+    color: var(--leo-color-text-interactive);
+  }
+}

--- a/components/ai_chat/resources/page/components/conversation_list/index.tsx
+++ b/components/ai_chat/resources/page/components/conversation_list/index.tsx
@@ -77,6 +77,7 @@ function ConversationList(props: ConversationListProps) {
   }, [conversationHistory.length, lastEntryElementRef.current?.clientHeight])
 
   const lastAssistantId = React.useMemo(() => {
+    // Get the last entry that is an assistant entry
     for (let i = conversationHistory.length - 1; i >= 0; i--) {
       if (conversationHistory[i].characterType === mojom.CharacterType.ASSISTANT) {
         return i

--- a/components/ai_chat/resources/page/components/conversation_list/index.tsx
+++ b/components/ai_chat/resources/page/components/conversation_list/index.tsx
@@ -8,8 +8,6 @@ import classnames from '$web-common/classnames'
 import Button from '@brave/leo/react/button'
 import Icon from '@brave/leo/react/icon'
 import useLongPress from '$web-common/useLongPress'
-
-import styles from './style.module.scss'
 import getPageHandlerInstance, * as mojom from '../../api/page_handler'
 import DataContext from '../../state/context'
 import ContextMenuAssistant from '../context_menu_assistant'
@@ -18,7 +16,8 @@ import SiteTitle from '../site_title'
 import Quote from '../quote'
 import ActionTypeLabel from '../action_type_label'
 import LongPageInfo from '../alerts/long_page_info'
-import MarkdownRenderer from '../markdown_renderer'
+import AssistantResponse from '../assistant_response'
+import styles from './style.module.scss'
 
 const SUGGESTION_STATUS_SHOW_BUTTON: mojom.SuggestionGenerationStatus[] = [
   mojom.SuggestionGenerationStatus.CanGenerate,
@@ -77,14 +76,23 @@ function ConversationList(props: ConversationListProps) {
     props.onLastElementHeightChange()
   }, [conversationHistory.length, lastEntryElementRef.current?.clientHeight])
 
+  const lastAssistantId = React.useMemo(() => {
+    for (let i = conversationHistory.length - 1; i >= 0; i--) {
+      if (conversationHistory[i].characterType === mojom.CharacterType.ASSISTANT) {
+        return i
+      }
+    }
+    return -1
+  }, [conversationHistory])
+
   return (
     <>
       <div>
         {conversationHistory.map((turn, id) => {
-          const isLastEntry = id === conversationHistory.length - 1
-          const shouldShowTextCursor = isLastEntry && context.isGenerating
-          const isHuman = turn.characterType === mojom.CharacterType.HUMAN
+          const isLastEntry = id === lastAssistantId
           const isAIAssistant = turn.characterType === mojom.CharacterType.ASSISTANT
+          const isEntryInProgress = isLastEntry && isAIAssistant && context.isGenerating
+          const isHuman = turn.characterType === mojom.CharacterType.HUMAN
           const showSiteTitle = id === 0 && isHuman && shouldSendPageContents
           const showLongPageContentInfo = id === 1 && isAIAssistant && context.shouldShowLongPageWarning
 
@@ -133,14 +141,15 @@ function ConversationList(props: ConversationListProps) {
                 <div
                   className={styles.message}
                 >
+                  { isAIAssistant && (
+                      <AssistantResponse
+                        entry={turn}
+                        isEntryInProgress={isEntryInProgress}
+                      />
+                    )
+                  }
                   {
-                    !turn.selectedText &&
-                      (isAIAssistant ? (
-                        <MarkdownRenderer
-                          text={turn.text}
-                          shouldShowTextCursor={shouldShowTextCursor}
-                        />
-                      ) : (turn.text))
+                    !isAIAssistant && !turn.selectedText && turn.text
                   }
                   {turn.selectedText &&
                       <ActionTypeLabel actionType={turn.actionType} />}

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -22,90 +22,142 @@ import { MockPageHandlerAPI } from '../api/mock_page_handler'
 const mockAPIHandler = new MockPageHandlerAPI()
 setPageHandlerAPIForTesting(mockAPIHandler as any)
 
+function getCompletionEvent(text: string): mojom.ConversationEntryEvent {
+  return {
+    completionEvent: { completion:  text },
+    searchQueriesEvent: undefined,
+    searchStatusEvent: undefined
+  }
+}
+
+function getSearchEvent(queries: string[]): mojom.ConversationEntryEvent {
+  return {
+    completionEvent: undefined,
+    searchQueriesEvent: { searchQueries: queries },
+    searchStatusEvent: undefined
+  }
+}
+
+function getSearchStatusEvent(): mojom.ConversationEntryEvent {
+  return {
+    completionEvent: undefined,
+    searchQueriesEvent: undefined,
+    searchStatusEvent: { isSearching: true }
+  }
+}
+
 const HISTORY: mojom.ConversationTurn[] = [
   {
     text: 'Summarize this page',
     characterType: mojom.CharacterType.HUMAN,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
     actionType: mojom.ActionType.SUMMARIZE_PAGE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: []
   },
   {
-    text: 'The ways that animals move are just about as myriad as the animal kingdom itself. They walk, run, swim, crawl, fly and slither — and within each of those categories lies a tremendous number of subtly different movement types. A seagull and a *hummingbird* both have wings, but otherwise their flight techniques and abilities are poles apart. Orcas and **piranhas** both have tails, but they accomplish very different types of swimming. Even a human walking or running is moving their body in fundamentally different ways.',
+    text: '',
     characterType: mojom.CharacterType.ASSISTANT,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
     actionType: mojom.ActionType.UNSPECIFIED,
-    selectedText: undefined
+    selectedText: undefined,
+    events: [getCompletionEvent('The ways that animals move are just about as myriad as the animal kingdom itself. They walk, run, swim, crawl, fly and slither — and within each of those categories lies a tremendous number of subtly different movement types. A seagull and a *hummingbird* both have wings, but otherwise their flight techniques and abilities are poles apart. Orcas and **piranhas** both have tails, but they accomplish very different types of swimming. Even a human walking or running is moving their body in fundamentally different ways.')]
   },
   {
     text: 'What is pointer compression?',
     characterType: mojom.CharacterType.HUMAN,
     actionType: mojom.ActionType.QUERY,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: []
   },
   {
-    text: `## How We Created an Accessible, Scalable Color Palette\n\nDuring the latter part of 2021, I reflected on the challenges we were facing at Modern Health. One recurring problem that stood out was our struggle to create new products with an unstructured color palette. This resulted in poor [communication](https://www.google.com) between designers and developers, an inconsistent product brand, and increasing accessibility problems.\n\n1. Inclusivity: our palette provides easy ways to ensure our product uses accessible contrasts.\n 2. Efficiency: our palette is diverse enough for our current and future product design, yet values are still predictable and constrained.\n 3. Reusability: our palette is on-brand but versatile. There are very few one-offs that fall outside the palette.\n\n This article shares the process I followed to apply these principles to develop a more adaptable color palette that prioritizes accessibility and is built to scale into all of our future product **design** needs.`,
+    text: '',
     characterType: mojom.CharacterType.ASSISTANT,
     actionType: mojom.ActionType.UNSPECIFIED,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: [getCompletionEvent(`## How We Created an Accessible, Scalable Color Palette\n\nDuring the latter part of 2021, I reflected on the challenges we were facing at Modern Health. One recurring problem that stood out was our struggle to create new products with an unstructured color palette. This resulted in poor [communication](https://www.google.com) between designers and developers, an inconsistent product brand, and increasing accessibility problems.\n\n1. Inclusivity: our palette provides easy ways to ensure our product uses accessible contrasts.\n 2. Efficiency: our palette is diverse enough for our current and future product design, yet values are still predictable and constrained.\n 3. Reusability: our palette is on-brand but versatile. There are very few one-offs that fall outside the palette.\n\n This article shares the process I followed to apply these principles to develop a more adaptable color palette that prioritizes accessibility and is built to scale into all of our future product **design** needs.`)]
   },
   {
     text: 'What is taylor series?',
     characterType: mojom.CharacterType.HUMAN,
     actionType: mojom.ActionType.QUERY,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: []
   },
   {
-    text: 'The partial sum formed by the first n + 1 terms of a Taylor series is a polynomial of degree n that is called the nth Taylor polynomial of the function. Taylor polynomials are approximations of a function, which become generally better as n increases.',
+    text: '',
     characterType: mojom.CharacterType.ASSISTANT,
     actionType: mojom.ActionType.UNSPECIFIED,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: [getCompletionEvent('The partial sum formed by the first n + 1 terms of a Taylor series is a polynomial of degree n that is called the nth Taylor polynomial of the function. Taylor polynomials are approximations of a function, which become generally better as n increases.')]
   },
   {
     text: 'Write a hello world program in c++',
     characterType: mojom.CharacterType.HUMAN,
     actionType: mojom.ActionType.QUERY,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: []
   },
   {
-    text: "Hello! As a helpful and respectful AI assistant, I'd be happy to assist you with your question. However, I'm a text-based AI and cannot provide code in a specific programming language like C++. Instead, I can offer a brief explanation of how to write a \"hello world\" program in C++.\n\nTo write a \"hello world\" program in C++, you can use the following code:\n\n```c++\n#include <iostream>\n\nint main() {\n    std::cout << \"Hello, world!\" << std::endl;\n    return 0;\n}\n```\nThis code will print \"Hello, world!\" and uses `iostream` std library. If you have any further questions or need more information, please don't hesitate to ask!",
+    text: '',
     characterType: mojom.CharacterType.ASSISTANT,
     actionType: mojom.ActionType.UNSPECIFIED,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: [getCompletionEvent("Hello! As a helpful and respectful AI assistant, I'd be happy to assist you with your question. However, I'm a text-based AI and cannot provide code in a specific programming language like C++. Instead, I can offer a brief explanation of how to write a \"hello world\" program in C++.\n\nTo write a \"hello world\" program in C++, you can use the following code:\n\n```c++\n#include <iostream>\n\nint main() {\n    std::cout << \"Hello, world!\" << std::endl;\n    return 0;\n}\n```\nThis code will print \"Hello, world!\" and uses `iostream` std library. If you have any further questions or need more information, please don't hesitate to ask!")]
   },
   {
     text: 'Summarize this excerpt',
     characterType: mojom.CharacterType.HUMAN,
     actionType: mojom.ActionType.SUMMARIZE_SELECTED_TEXT,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: 'Pointer compression is a memory optimization technique where pointers (memory addresses) are stored in a compressed format to save memory. The basic idea is that since most pointers will be clustered together and point to objects allocated around the same time, you can store a compressed representation of the pointer and decompress it when needed. Some common ways this is done: Store an offset from a base pointer instead of the full pointer value Store increments/decrements from the previous pointer instead of the full value Use pointer tagging to store extra information in the low bits of the pointer Encode groups of pointers together The tradeoff is some extra CPU cost to decompress the pointers, versus saving memory. This technique is most useful in memory constrained environments.'
+    selectedText: 'Pointer compression is a memory optimization technique where pointers (memory addresses) are stored in a compressed format to save memory. The basic idea is that since most pointers will be clustered together and point to objects allocated around the same time, you can store a compressed representation of the pointer and decompress it when needed. Some common ways this is done: Store an offset from a base pointer instead of the full pointer value Store increments/decrements from the previous pointer instead of the full value Use pointer tagging to store extra information in the low bits of the pointer Encode groups of pointers together The tradeoff is some extra CPU cost to decompress the pointers, versus saving memory. This technique is most useful in memory constrained environments.',
+    events: []
   },
   {
-    text: 'Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.',
+    text: '',
     characterType: mojom.CharacterType.ASSISTANT,
     actionType: mojom.ActionType.UNSPECIFIED,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: [getCompletionEvent('Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.')]
   },
   {
     text: 'Shorten this selected text',
     characterType: mojom.CharacterType.HUMAN,
     actionType: mojom.ActionType.SHORTEN,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: 'Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.'
+    selectedText: 'Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.',
+    events: []
   },
   {
-    text: 'Pointer compression is a memory optimization technique.',
+    text: '',
     characterType: mojom.CharacterType.ASSISTANT,
     actionType: mojom.ActionType.UNSPECIFIED,
     visibility: mojom.ConversationTurnVisibility.VISIBLE,
-    selectedText: undefined
+    selectedText: undefined,
+    events: [getSearchStatusEvent(), getSearchEvent(['pointer compression', 'c++ language specification']), getCompletionEvent('Pointer compression is a memory optimization technique.')]
+  },
+  {
+    text: 'Will an LTT store backpack fit in a Tesla Model Y frunk?',
+    characterType: mojom.CharacterType.HUMAN,
+    actionType: mojom.ActionType.SHORTEN,
+    visibility: mojom.ConversationTurnVisibility.VISIBLE,
+    selectedText: '',
+    events: []
+  },
+  {
+    text: '',
+    characterType: mojom.CharacterType.ASSISTANT,
+    actionType: mojom.ActionType.UNSPECIFIED,
+    visibility: mojom.ConversationTurnVisibility.VISIBLE,
+    selectedText: undefined,
+    events: [getSearchStatusEvent(), getSearchEvent(['LTT store backpack dimensions', 'Tesla Model Y frunk dimensions'])]
   }
 ]
 
@@ -218,6 +270,7 @@ export default {
         allModels: MODELS,
         conversationHistory: options.args.hasConversation ? HISTORY : [],
         isPremiumStatusFetching: false,
+        isGenerating: true,
         suggestionStatus: mojom.SuggestionGenerationStatus[options.args.suggestionStatus],
         canShowPremiumPrompt: options.args.canShowPremiumPrompt,
         isPremiumUser: options.args.isPremiumUser,

--- a/components/ai_chat/resources/page/stories/locale.ts
+++ b/components/ai_chat/resources/page/stories/locale.ts
@@ -74,6 +74,8 @@ provideStrings({
   braveLeoChatClaudeInstantSubtitle: 'Strength in creative tasks',
   pageContentTooLongWarning: 'The page is too long for Leo. Some context could be missing from the conversation. Leo was able to read $1 of the page\'s contents.',
   errorConversationEnd: 'This conversation is too long and cannot continue. There may be other models available with which Leo is capable of maintaining accuracy for longer conversations.',
+  searchInProgress: 'Improving your answer with Brave Search…',
+  searchQueries: 'Improved answer searching for $1.',
   leoSettingsTooltipLabel: 'Leo settings',
   summarizePageButtonLabel: 'Summarize this page',
   welcomeGuideTitle: 'Hi, I\'m Leo!',

--- a/components/api_request_helper/api_request_helper.cc
+++ b/components/api_request_helper/api_request_helper.cc
@@ -406,11 +406,11 @@ void APIRequestHelper::URLLoaderHandler::ParseJsonImpl(
 void APIRequestHelper::URLLoaderHandler::OnDataReceived(
     std::string_view string_piece,
     base::OnceClosure resume) {
-  DVLOG(2) << "\n[[" << __func__ << "]]"
-           << " Chunk received";
+  DVLOG(2) << "[[" << __func__ << "]]" << " Chunk received";
   if (is_sse_) {
     ParseSSE(string_piece);
   } else {
+    DVLOG(4) << "Chunk content: \n" << string_piece;
     TRACE_EVENT0("brave", "APIRequestHelper_OnDataReceivedNoSSE");
     ScopedPerfTracker tracker("Brave.APIRequestHelper.OnDataReceivedNoSSE");
     data_received_callback_.Run(base::Value(string_piece));

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -222,6 +222,12 @@
   <message name="IDS_CHAT_UI_CONVERSATION_END_ERROR" desc="An error issued when the user cannot continue chatting">
     This conversation is too long and cannot continue. There may be other models available with which Leo is capable of maintaining accuracy for longer conversations.
   </message>
+  <message name="IDS_CHAT_UI_SEARCH_IN_PROGRESS" desc="Status to indicate that AI response is being enhaced with Brave Search">
+    Improving your answer with Brave Search…
+  </message>
+  <message name="IDS_CHAT_UI_SEARCH_QUERIES" desc="AI Response status to indicate that search queries were used to enhance the response">
+    Improved answer searching for <ph name="SEARCH_TERMS">$1<ex>"my first search engine query", "my second search engine query"</ex></ph>.
+  </message>
   <message name="IDS_CHAT_UI_CHAT_BASIC_SUBTITLE" desc="A description for default chat model">
     General purpose chat
   </message>

--- a/ios/browser/api/ai_chat/ai_chat.mm
+++ b/ios/browser/api/ai_chat/ai_chat.mm
@@ -103,7 +103,7 @@
       ai_chat::mojom::CharacterType::HUMAN,
       ai_chat::mojom::ActionType::UNSPECIFIED,
       ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
-      base::SysNSStringToUTF8(text), std::nullopt));
+      base::SysNSStringToUTF8(text), std::nullopt, std::nullopt));
 }
 
 - (void)submitSummarizationRequest {

--- a/ios/browser/api/ai_chat/ai_chat.mm
+++ b/ios/browser/api/ai_chat/ai_chat.mm
@@ -99,11 +99,11 @@
 }
 
 - (void)submitHumanConversationEntry:(NSString*)text {
-  driver_->SubmitHumanConversationEntry(
-      {ai_chat::mojom::CharacterType::HUMAN,
-       ai_chat::mojom::ActionType::UNSPECIFIED,
-       ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
-       base::SysNSStringToUTF8(text), std::nullopt});
+  driver_->SubmitHumanConversationEntry(ai_chat::mojom::ConversationTurn::New(
+      ai_chat::mojom::CharacterType::HUMAN,
+      ai_chat::mojom::ActionType::UNSPECIFIED,
+      ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
+      base::SysNSStringToUTF8(text), std::nullopt));
 }
 
 - (void)submitSummarizationRequest {


### PR DESCRIPTION
This builds on https://github.com/brave/brave-core/pull/23067, which implemented the Conversation API client, by supporting some of the events it returns in the UI.

However, that needed a bit of a refactor in order to incorporate these events (now known as `ConversationEntryEvent`) in to the conversation history) - we took a detour to refactor conversation history to store ConversationTurnPtr instead of ConversationTurn and make ownership clearer and more optimized, as well as added more unit tests.

Because iOS has not yet incorporated `ConversationEntryEvent` in to its UI layer, we keep backwards compatibility via the existing `text` property.

The WebUI used by Desktop and Android will display something for the following events:
- "Search in progress" which only shows when the response has not yet started to return text completions
- "Search queries" which only shows when the response has completed generation.
- "Completions" which is the regular completion text already supported. We combine sequential completion events in the interest of simplifying rendering and object management.

This PR makes it much easier to integrate future events which can be interpreted from the designs.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38155

<img width="420" alt="image" src="https://github.com/brave/brave-core/assets/741836/bd6326e9-4706-4946-a356-399946d5a7a6">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

