### PR TITLE
Add space before `Learn more` link in Help WDP page (uplift to 1.66.x)

### DIFF
--- a/components/brave_welcome_ui/components/help-wdp/index.tsx
+++ b/components/brave_welcome_ui/components/help-wdp/index.tsx
@@ -44,6 +44,7 @@ function HelpWDP () {
       </div>
       <S.BodyBox>
         {getLocale('braveWelcomeHelpWDPDescription')}
+        <span> </span>
         <a
           href='https://support.brave.com/hc/articles/4409406835469-What-is-the-Web-Discovery-Project'
           target='_blank'


### PR DESCRIPTION
Uplift of #23159
Resolves https://github.com/brave/brave-browser/issues/37663

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.