### PR TITLE
[iOS] Make Brave Search default in Italy region. (uplift to 1.67.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/InitialSearchEngines.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/InitialSearchEngines.swift
@@ -84,7 +84,7 @@ class InitialSearchEngines {
   }
 
   static let braveSearchDefaultRegions = [
-    "US", "CA", "GB", "FR", "DE", "AD", "AT", "ES", "MX", "BR", "AR", "IN",
+    "US", "CA", "GB", "FR", "DE", "AD", "AT", "ES", "MX", "BR", "AR", "IN", "IT",
   ]
   static let yandexDefaultRegions = ["AM", "AZ", "BY", "KG", "KZ", "MD", "RU", "TJ", "TM", "TZ"]
   static let ecosiaEnabledRegions = [


### PR DESCRIPTION
Uplift of #23539
Resolves https://github.com/brave/brave-browser/issues/38192

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.