### PR TITLE
[ads] Fixes follow up to #38191: Restoring window does not resume landed counter (uplift to 1.67.x)

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -327,12 +327,6 @@ void AdsTabHelper::MediaStoppedPlaying(
 void AdsTabHelper::OnVisibilityChanged(content::Visibility visibility) {
   const bool last_is_web_contents_visible = is_web_contents_visible_;
   is_web_contents_visible_ = visibility == content::Visibility::VISIBLE;
-
-  if (redirect_chain_.empty()) {
-    // Don't notify changes for tabs which have not finished loading.
-    return;
-  }
-
   if (last_is_web_contents_visible != is_web_contents_visible_) {
     MaybeNotifyTabDidChange();
   }

--- a/components/brave_ads/core/internal/tabs/tab_manager.h
+++ b/components/brave_ads/core/internal/tabs/tab_manager.h
@@ -38,9 +38,6 @@ class TabManager final : public AdsClientNotifierObserver {
   void AddObserver(TabManagerObserver* observer);
   void RemoveObserver(TabManagerObserver* observer);
 
-  std::optional<int32_t> MaybeGetVisibleTabId() const {
-    return visible_tab_id_;
-  }
   bool IsVisible(int32_t tab_id) const;
   std::optional<TabInfo> GetVisible() const;
 

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -152,10 +152,10 @@ void SiteVisit::StopPageLand(const int32_t tab_id) {
   page_lands_.erase(tab_id);
 }
 
-void SiteVisit::MaybeSuspendOrResumePageLandForVisibleTabId() {
-  if (const std::optional<int32_t> tab_id =
-          TabManager::GetInstance().MaybeGetVisibleTabId()) {
-    MaybeSuspendOrResumePageLand(*tab_id);
+void SiteVisit::MaybeSuspendOrResumePageLandForVisibleTab() {
+  if (const std::optional<TabInfo> tab =
+          TabManager::GetInstance().GetVisible()) {
+    MaybeSuspendOrResumePageLand(tab->id);
   }
 }
 
@@ -271,19 +271,27 @@ void SiteVisit::NotifyCanceledPageLand(const int32_t tab_id,
 }
 
 void SiteVisit::OnBrowserDidBecomeActive() {
-  MaybeSuspendOrResumePageLandForVisibleTabId();
+  // Required to suspend or resume the page land because `OnTabDidChangeFocus`
+  // is not called when the browser becomes active on mobile.
+  MaybeSuspendOrResumePageLandForVisibleTab();
 }
 
 void SiteVisit::OnBrowserDidResignActive() {
-  MaybeSuspendOrResumePageLandForVisibleTabId();
+  // Required to suspend or resume the page land because `OnTabDidChangeFocus`
+  // is not called when the browser resigns active on mobile.
+  MaybeSuspendOrResumePageLandForVisibleTab();
 }
 
 void SiteVisit::OnBrowserDidEnterForeground() {
-  MaybeSuspendOrResumePageLandForVisibleTabId();
+  // Required to suspend or resume the page land because `OnTabDidChangeFocus`
+  // is not called when the browser enters the foreground on mobile.
+  MaybeSuspendOrResumePageLandForVisibleTab();
 }
 
 void SiteVisit::OnBrowserDidEnterBackground() {
-  MaybeSuspendOrResumePageLandForVisibleTabId();
+  // Required to suspend or resume the page land because `OnTabDidChangeFocus`
+  // is not called when the browser enters the background on mobile.
+  MaybeSuspendOrResumePageLandForVisibleTab();
 }
 
 void SiteVisit::OnTabDidChangeFocus(const int32_t tab_id) {

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.h
@@ -66,7 +66,7 @@ class SiteVisit final : public BrowserManagerObserver,
   void CancelPageLand(int32_t tab_id);
   void StopPageLand(int32_t tab_id);
 
-  void MaybeSuspendOrResumePageLandForVisibleTabId();
+  void MaybeSuspendOrResumePageLandForVisibleTab();
   void MaybeSuspendOrResumePageLand(int32_t tab_id);
   base::TimeDelta CalculateRemainingTimeToLandOnPage(int32_t tab_id);
   void SuspendPageLand(const TabInfo& tab);


### PR DESCRIPTION
Uplift of #23581
Resolves https://github.com/brave/brave-browser/issues/38234

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.