### PR TITLE
[ads] Notification ads are shown when playing media (uplift to 1.66.x)

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -228,7 +228,7 @@ void AdsTabHelper::OnMaybeNotifyTabTextContentDidChange(
 
 void AdsTabHelper::MaybeNotifyTabDidStartPlayingMedia() {
   if (ads_service_) {
-    ads_service_->NotifyTabDidStopPlayingMedia(tab_id_.id());
+    ads_service_->NotifyTabDidStartPlayingMedia(tab_id_.id());
   }
 }
 


### PR DESCRIPTION
Uplift of #23584
Resolves https://github.com/brave/brave-browser/issues/38225

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.