### PR TITLE
Don't show SplitView flag in Release channel (uplift to 1.67.x)

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -395,7 +395,7 @@
           FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabScrollBar), \
       },                                                                  \
       {                                                                   \
-          "brave-split-view",                                             \
+          kSplitViewFeatureInternalName,                                  \
           "Enable split view",                                            \
           "Enables split view",                                           \
           kOsWin | kOsMac | kOsLinux,                                     \

--- a/browser/brave_features_internal_names.h
+++ b/browser/brave_features_internal_names.h
@@ -11,6 +11,11 @@
 
 inline constexpr char kPlaylistFeatureInternalName[] = "playlist";
 inline constexpr char kPlaylistFakeUAFeatureInternalName[] = "playlist-fake-ua";
+
+#if !BUILDFLAG(IS_ANDROID)
+inline constexpr char kSplitViewFeatureInternalName[] = "brave-split-view";
+#endif
+
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 inline constexpr char kBraveVPNFeatureInternalName[] = "brave-vpn";
 #if BUILDFLAG(IS_WIN)

--- a/chromium_src/chrome/browser/unexpire_flags.cc
+++ b/chromium_src/chrome/browser/unexpire_flags.cc
@@ -30,6 +30,17 @@ bool IsFlagExpired(const flags_ui::FlagsStorage* storage,
     return true;
   }
 #endif  // BUILDFLAG(ENABLE_PLAYLIST) && BUILDFLAG(IS_ANDROID)
+
+#if !BUILDFLAG(IS_ANDROID)
+  // Don't show the split view flag in stable channel.
+  version_info::Channel channel = chrome::GetChannel();
+  if (base::EqualsCaseInsensitiveASCII(kSplitViewFeatureInternalName,
+                                       internal_name) &&
+      channel == version_info::Channel::STABLE) {
+    return true;
+  }
+#endif
+
   if (base::EqualsCaseInsensitiveASCII(flag_descriptions::kHttpsUpgradesName,
                                        internal_name)) {
     return true;


### PR DESCRIPTION
Uplift of #23625
Resolves https://github.com/brave/brave-browser/issues/38302

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.