### PR TITLE
Fixes a crash on Android permission dialog after cr125 update (uplift to 1.67.x)

### DIFF
--- a/chromium_src/components/permissions/request_type.cc
+++ b/chromium_src/components/permissions/request_type.cc
@@ -26,10 +26,6 @@ constexpr auto& kMicIconValue = vector_icons::kMicIcon;
 #endif
 
 // Add Brave cases into GetIconIdAndroid.
-// kWidevine is not expected to happen here as Widevine is not enabled in
-// Android, we add this case here just to avoid build error due to unhandled
-// cases in the switch.
-//
 // TODO(jocelyn): Might need to update icon when we have ethereum.enable UI
 // support in Android.
 #define IDR_ANDROID_STORAGE_ACCESS                   \
@@ -93,6 +89,11 @@ RequestType ContentSettingsTypeToRequestType(
       return RequestType::kBraveGoogleSignInPermission;
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
       return RequestType::kBraveLocalhostAccessPermission;
+    case ContentSettingsType::DEFAULT:
+      // Currently we have only one DEFAULT type that is
+      // not mapped, which is Widevine, it's used for
+      // UMA purpose only
+      return RequestType::kWidevine;
     default:
       return ContentSettingsTypeToRequestType_ChromiumImpl(
           content_settings_type);


### PR DESCRIPTION
Uplift of #23622
Resolves https://github.com/brave/brave-browser/issues/38297

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.