### PR TITLE
Add Jest Teamcity reporter

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,6 +18,22 @@ function getBuildOutputPathList(buildOutputRelativePath) {
   ])
 }
 
+function getReporters() {
+  if (process.env.TEAMCITY_VERSION !== undefined) {
+    return [
+      [
+        '<rootDir>/tools/jest_teamcity_reporter/jest_teamcity_reporter.js',
+        { 'suiteName': 'test-unit' }
+      ]
+    ]
+  } else {
+    return ['default']
+  }
+}
+
+/**
+ * @type {import('@jest/types').Config.InitialOptions}
+ */
 module.exports = {
   preset: 'ts-jest/presets/default',
   testEnvironment: '<rootDir>/components/test/testEnvironment.js',
@@ -29,8 +45,9 @@ module.exports = {
     }
   },
   transform: {
-    '.(jsx|js|ts|tsx)': 'ts-jest'
+    '\\.(jsx|js|ts|tsx)$': 'ts-jest'
   },
+  reporters: getReporters(),
   clearMocks: true,
   resetMocks: true,
   resetModules: true,
@@ -55,7 +72,7 @@ module.exports = {
   testPathIgnorePatterns: [
     '<rootDir>/build/commands/lib/test.js',
     '<rootDir>/build/rustup',
-    '<rootDir>/third_party',
+    '<rootDir>/third_party'
   ],
   testTimeout: 30000,
   transformIgnorePatterns: [

--- a/tools/jest_teamcity_reporter/jest_teamcity_reporter.js
+++ b/tools/jest_teamcity_reporter/jest_teamcity_reporter.js
@@ -1,0 +1,298 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+'use strict'
+
+const assert = require('assert')
+const path = require('path')
+const util = require('util')
+
+/**
+ * @typedef {import('@jest/types').Config.GlobalConfig} GlobalConfig
+ * @typedef {import('@jest/reporters').Reporter} Reporter
+ * @typedef {import('@jest/reporters').Test} Test
+ * @typedef {import('@jest/reporters').TestResult} TestResult
+ */
+
+/** @implements {Reporter} */
+class TeamcityReporter {
+  /** @type {string} */
+  #suiteName
+
+  /**
+   * @param {GlobalConfig} _globalConfig
+   * @param {Record<string, any>} reporterOptions
+   */
+  constructor(_globalConfig, reporterOptions) {
+    this.#suiteName = reporterOptions.suiteName ?? 'jest'
+  }
+
+  /**
+   * @type {Reporter["onRunStart"]}
+   */
+  onRunStart() {
+    this.tcServiceMessage('testSuiteStarted', { name: this.#suiteName })
+  }
+
+  /**
+   * @type {Reporter["onRunComplete"]}
+   */
+  onRunComplete() {
+    this.tcServiceMessage('testSuiteFinished', { name: this.#suiteName })
+  }
+
+  /**
+   * @type {Reporter["getLastError"]}
+   */
+  getLastError() {}
+
+  /**
+   * @type {Reporter["onTestFileResult"]}
+   * @param {Test} test
+   * @param {TestResult} testFileResult
+   */
+  onTestFileResult(test, testFileResult) {
+    // A flag to assert the test file result was actually reported.
+    let testFileResultWasReported = false
+
+    // Get the test file path relative to the cwd.
+    const testFilePath = path
+      .relative(test.context.config.cwd, testFileResult.testFilePath)
+      .replace(/\\/g, '/')
+
+    // Convert the test file path into a Teamcity-compatible test name prefix.
+    const tcTestPrefix = this.createTcTestPrefix(testFilePath)
+
+    // Gather console messages from the test file.
+    const consoleMessages = testFileResult.console?.map((logEntry) => {
+      return `console.${logEntry.type}\n  ${logEntry.message}\n${logEntry.origin}`
+    })
+
+    // Report each test case in the test file.
+    for (const testResult of testFileResult.testResults) {
+      // Original test name.
+      const testName = [...testResult.ancestorTitles, testResult.title].join(
+        ' > '
+      )
+
+      this.reportTest(
+        `${tcTestPrefix}.${this.createTcTestName(testName)}`,
+        testFilePath,
+        consoleMessages,
+        testResult.duration ?? 0,
+        (tcFullTestName) => {
+          // Report the unmodified test name as metadata.
+          this.tcServiceMessage('testMetadata', {
+            name: 'testName',
+            value: testName
+          })
+
+          // Report the test result.
+          switch (testResult.status) {
+            case 'passed':
+              // No special handling for 'passed' tests.
+              break
+            case 'skipped':
+            case 'pending':
+            case 'todo':
+            case 'disabled':
+              this.tcServiceMessage('testIgnored', {
+                name: tcFullTestName,
+                message: testResult.status
+              })
+              break
+            case 'failed':
+            default:
+              // Handle 'failed' and any other test status as failure to detect
+              // a possible Jest breaking change.
+              this.tcServiceMessage('testFailed', {
+                name: tcFullTestName,
+                details: [
+                  testResult.status,
+                  ...testResult.failureMessages
+                ].join('\n')
+              })
+          }
+        }
+      )
+      testFileResultWasReported = true
+    }
+
+    // Report the test file as a single test if it failed.
+    if (testFileResult.testExecError) {
+      this.reportTest(
+        `${tcTestPrefix}.All`,
+        testFilePath,
+        consoleMessages,
+        0,
+        (tcFullTestName) => {
+          this.tcServiceMessage('testFailed', {
+            name: tcFullTestName,
+            details:
+              testFileResult.failureMessage ??
+              util.format('%O', testFileResult.testExecError)
+          })
+        }
+      )
+      testFileResultWasReported = true
+    }
+
+    // Assert the test file result was reported.
+    assert(
+      testFileResultWasReported,
+      util.format(
+        'Test file result was not reported to Teamcity. It means this ' +
+          "reporter doesn't handle some edge case or is not compatible with " +
+          'the current Jest version.\nTest file result:\n%O',
+        testFileResult
+      )
+    )
+  }
+
+  /**
+   * Create a Teamcity-compatible test name prefix from a test file path.
+   * @param {string} str
+   * @returns {string}
+   */
+  createTcTestPrefix(testFilePath) {
+    // This function creates a package name and a class name string to be used
+    // as a prefix for all tests in a test file. Teamcity expects a specially
+    // formatted test name to correctly parse it into:
+    // - suite name (optional, stops at ':', can have spaces)
+    // - package name (dot-delimited)
+    // - class name (an identifier without dots)
+    // - test name (an arbitrary string with any symbols, can have spaces)
+    //
+    // See for details:
+    // https://www.jetbrains.com/help/teamcity/service-messages.html#Interpreting+Test+Names
+
+    // The reporter omits the suite name in the test prefix since it's already
+    // set via `testSuiteStarted`. Although suites can be nested, using a test
+    // file as an additional suite name would lead to numerous ungroupable
+    // suites in the Teamcity UI.
+
+    // To group tests by file, the reporter impersonates a test file as a
+    // package name.
+    const tcPackageName = testFilePath
+      .replace(/[/\\]/g, '.') // Replace slashes with dots.
+      .replace(/\.+/g, '.') // Replace multiple dots with a single dot.
+      .replace(/[^\w\-$.]/g, '_') // Replace invalid characters with underscores.
+      .replace(/(^[^a-zA-Z_])/g, '_$1') // Prepend an underscore if the first character is invalid.
+
+    // After the package name, Teamcity expects a class name. If the class name
+    // is missing, Teamcity will use a previous dot-delimited word as the class
+    // name, which in our case is a file extension. We don't want that.
+    //
+    // Jest doesn't provide a class name for tests, so we have to create one.
+    // One of the possible solutions is to use describe() values as class names,
+    // but this turned out to be problematic. These values can be nested and may
+    // contain symbols not allowed in class names, requiring replacements. This
+    // results in less readable full test names that are harder to match with
+    // the actual tests.
+    //
+    // A simpler solution is to use a fixed class name for all tests. The class
+    // name appears next to the actual test name, so 'Test' is chosen as a
+    // neutral name to not change the meaning of any test name.
+    const tcClassName = 'Test'
+
+    return `${tcPackageName}.${tcClassName}`
+  }
+
+  /**
+   * Create a Teamcity-compatible test name.
+   * @param {string} testName
+   * @returns {string}
+   */
+  createTcTestName(testName) {
+    // Replace few things to not let Teamcity split the name into test suite,
+    // package or class name.
+    return testName
+      .replace(/:/g, '_') // Replace all colons with underscores.
+      .replace(/(^[^ ]*?)\./g, '$1_') // Replace dots with underscores if there are no spaces before them.
+      .replace(/(^[^a-zA-Z_])/g, '_$1') // Prepend an underscore if the first character is invalid.
+  }
+
+  /**
+   * Report test start/finish events, test metadata, console messages and the
+   * result.
+   * @param {string} tcFullTestName
+   * @param {string} testFilePath
+   * @param {string[] | undefined} consoleMessages
+   * @param {number} duration
+   * @param {Function} reportResultClosure
+   */
+  reportTest(
+    tcFullTestName,
+    testFilePath,
+    consoleMessages,
+    duration,
+    reportResultClosure
+  ) {
+    // Report the test start.
+    this.tcServiceMessage('testStarted', { name: tcFullTestName })
+
+    // Report the test file path as metadata.
+    this.tcServiceMessage('testMetadata', {
+      name: 'testFilePath',
+      value: testFilePath
+    })
+
+    // Report console messages as test stdout.
+    if (consoleMessages && consoleMessages.length !== 0) {
+      this.tcServiceMessage('testStdOut', {
+        name: tcFullTestName,
+        out:
+          `Console messages from ${testFilePath}:\n` +
+          consoleMessages.join('\n')
+      })
+    }
+
+    // Report the test result.
+    reportResultClosure(tcFullTestName)
+
+    // Report the test finish.
+    this.tcServiceMessage('testFinished', {
+      name: tcFullTestName,
+      duration
+    })
+  }
+
+  /**
+   * Output a Teamcity Service Message.
+   * @param {string} name
+   * @param {Record<string, any>} params
+   */
+  tcServiceMessage(name, params) {
+    let paramsStr = ''
+    for (const [paramName, paramValue] of Object.entries(params)) {
+      assert(paramValue !== undefined && paramValue !== null)
+
+      const strParamValue = paramValue.toString()
+      if (strParamValue === '') {
+        continue
+      }
+
+      // https://www.jetbrains.com/help/teamcity/service-messages.html#Escaped+Values
+      const escapedParamValue = strParamValue
+        // Remove ANSI escape sequences (colors, styles, etc.).
+        .replace(/\u001B\[\d+(;\d+)*m/g, '')
+        // Replace Teamcity Service Messages special characters.
+        .replace(/[\n\r'|[\]]/g, (match) => {
+          switch (match) {
+            case '\n':
+              return '|n'
+            case '\r':
+              return '|r'
+            default:
+              return '|' + match
+          }
+        })
+      paramsStr += ` ${paramName}='${escapedParamValue}'`
+    }
+    process.stdout.write(`##teamcity[${name}${paramsStr}]\n`)
+  }
+}
+
+module.exports = TeamcityReporter

--- a/tools/jest_teamcity_reporter/jest_teamcity_reporter.test.js
+++ b/tools/jest_teamcity_reporter/jest_teamcity_reporter.test.js
@@ -1,0 +1,377 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+const TeamcityReporter = require('./jest_teamcity_reporter')
+
+describe('TeamcityReporter', () => {
+  let reporter
+  let mockStdoutWrite
+
+  beforeEach(() => {
+    mockStdoutWrite = jest.spyOn(process.stdout, 'write').mockImplementation()
+    reporter = new TeamcityReporter({}, { suiteName: 'my_suite' })
+  })
+
+  it('onRunStart should report testSuiteStarted', () => {
+    reporter.onRunStart()
+
+    expect(mockStdoutWrite).toHaveBeenCalledWith(
+      "##teamcity[testSuiteStarted name='my_suite']\n"
+    )
+  })
+
+  it('onRunComplete should report testSuiteFinished', () => {
+    reporter.onRunComplete()
+
+    expect(mockStdoutWrite).toHaveBeenCalledWith(
+      "##teamcity[testSuiteFinished name='my_suite']\n"
+    )
+  })
+
+  describe('onTestFileResult', () => {
+    it('should report each test case in the test file', () => {
+      const test = {
+        context: {
+          config: {
+            cwd: '/brave/tools/jest_teamcity_reporter'
+          }
+        }
+      }
+
+      const testFileResult = {
+        testFilePath: '/brave/tools/jest_teamcity_reporter/example.test.js',
+        testResults: [
+          {
+            ancestorTitles: ['Group 1:'],
+            title: 'Test 1',
+            duration: 100,
+            status: 'passed',
+            failureMessages: []
+          },
+          {
+            ancestorTitles: ['Group 1:', 'Group 2'],
+            title: 'Test 2',
+            duration: 200,
+            status: 'failed',
+            failureMessages: ['Assertion error']
+          }
+        ],
+        console: [{ type: 'log', message: 'Log message 1', origin: 'origin1' }]
+      }
+
+      reporter.onTestFileResult(test, testFileResult)
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='example.test.js.Test.Group 1_ > Test 1']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testMetadata name='testFilePath' value='example.test.js']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testMetadata name='testName' value='Group 1: > Test 1']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStdOut name='example.test.js.Test.Group 1_ > Test 1' out='Console messages from example.test.js:|nconsole.log|n  Log message 1|norigin1']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFinished name='example.test.js.Test.Group 1_ > Test 1' duration='100']\n"
+      )
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='example.test.js.Test.Group 1_ > Group 2 > Test 2']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testMetadata name='testFilePath' value='example.test.js']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testMetadata name='testName' value='Group 1: > Group 2 > Test 2']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStdOut name='example.test.js.Test.Group 1_ > Group 2 > Test 2' out='Console messages from example.test.js:|nconsole.log|n  Log message 1|norigin1']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFailed name='example.test.js.Test.Group 1_ > Group 2 > Test 2' details='failed|nAssertion error']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFinished name='example.test.js.Test.Group 1_ > Group 2 > Test 2' duration='200']\n"
+      )
+    })
+
+    it('should report the test file as a single test if it failed', () => {
+      const test = {
+        context: {
+          config: {
+            cwd: '/brave/tools/jest_teamcity_reporter'
+          }
+        }
+      }
+
+      const testFileResult = {
+        testFilePath: '/brave/tools/jest_teamcity_reporter/example.test.js',
+        testResults: [],
+        testExecError: new Error('Test execution error'),
+        failureMessage: 'Test failed',
+        console: [{ type: 'log', message: 'Log message 1', origin: 'origin1' }]
+      }
+
+      reporter.onTestFileResult(test, testFileResult)
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='example.test.js.Test.All']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testMetadata name='testFilePath' value='example.test.js']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStdOut name='example.test.js.Test.All' out='Console messages from example.test.js:|nconsole.log|n  Log message 1|norigin1']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFailed name='example.test.js.Test.All' details='Test failed']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFinished name='example.test.js.Test.All' duration='0']\n"
+      )
+    })
+
+    it('should assert if a test file result was not handled', () => {
+      const test = {
+        context: {
+          config: {
+            cwd: '/brave/tools/jest_teamcity_reporter'
+          }
+        }
+      }
+
+      const testFileResult = {
+        testFilePath: '/brave/tools/jest_teamcity_reporter/example.test.js',
+        testResults: [],
+        // Let's pretend Jest added another way of failing a test file which we
+        // don't handle. This member is not part of the Jest test result schema.
+        testValidationError: new Error('Test validation error')
+      }
+
+      expect(() => {
+        reporter.onTestFileResult(test, testFileResult)
+      }).toThrow(/Test file result was not reported to Teamcity/)
+    })
+
+    it('should replace dots with underscores if there were no spaces before', () => {
+      const test = {
+        context: {
+          config: {
+            cwd: '/brave/tools/jest_teamcity_reporter'
+          }
+        }
+      }
+
+      const testFileResult = {
+        testFilePath: '/brave/tools/jest_teamcity_reporter/example.test.js',
+        testResults: [
+          {
+            ancestorTitles: ['Group.1'],
+            title: 'Test.1',
+            duration: 100,
+            status: 'passed',
+            failureMessages: []
+          },
+          {
+            ancestorTitles: ['Group 2'],
+            title: '.Test B',
+            duration: 200,
+            status: 'passed',
+            failureMessages: []
+          }
+        ]
+      }
+
+      reporter.onTestFileResult(test, testFileResult)
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='example.test.js.Test.Group_1 > Test.1']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='example.test.js.Test.Group 2 > .Test B']\n"
+      )
+    })
+  })
+
+  describe('createTcTestPrefix', () => {
+    it('should generate the correct test prefix for a test file', () => {
+      const testCases = [
+        {
+          testFilePath: 'components/test/brave_new_tab_ui/state/gridSitesState_test.ts',
+          expectedPrefix: 'components.test.brave_new_tab_ui.state.gridSitesState_test.ts.Test'
+        },
+        {
+          testFilePath: 'components/test/brave_new_tab_ui/state/gridSitesState_test@#$%...ts',
+          expectedPrefix: 'components.test.brave_new_tab_ui.state.gridSitesState_test__$_.ts.Test'
+        },
+        {
+          testFilePath: '0components/test/brave_new_tab_ui/state/gridSitesState_test.ts',
+          expectedPrefix: '_0components.test.brave_new_tab_ui.state.gridSitesState_test.ts.Test'
+        },
+        {
+          testFilePath: 'components\\test\\brave_new_tab_ui\\state\\gridSitesState_test.ts',
+          expectedPrefix: 'components.test.brave_new_tab_ui.state.gridSitesState_test.ts.Test'
+        }
+      ]
+      for (const testCase of testCases) {
+        const result = reporter.createTcTestPrefix(testCase.testFilePath)
+        expect(result).toBe(testCase.expectedPrefix)
+      }
+    })
+  })
+
+  describe('createTcTestName', () => {
+    it('should replace dots with underscores if there were no spaces before', () => {
+      const testCases = [
+        {
+          testName: 'Test.1',
+          expectedName: 'Test_1'
+        },
+        {
+          testName: '.Test B',
+          expectedName: '_Test B'
+        },
+        {
+          testName: 'Test C.',
+          expectedName: 'Test C.'
+        },
+        {
+          testName: '.Test D.',
+          expectedName: '_Test D.'
+        }
+      ]
+      for (const testCase of testCases) {
+        const result = reporter.createTcTestName(testCase.testName)
+        expect(result).toBe(testCase.expectedName)
+      }
+    })
+
+    it('should prepend an underscore if the first character is invalid', () => {
+      const testCases = [
+        {
+          testName: '0Test',
+          expectedName: '_0Test'
+        },
+        {
+          testName: ' Test',
+          expectedName: '_ Test'
+        },
+        {
+          testName: 'Test',
+          expectedName: 'Test'
+        }
+      ]
+      for (const testCase of testCases) {
+        const result = reporter.createTcTestName(testCase.testName)
+        expect(result).toBe(testCase.expectedName)
+      }
+    })
+
+    it('should replace all colons with underscores', () => {
+      const testCases = [
+        {
+          testName: 'Test:1 2:3',
+          expectedName: 'Test_1 2_3'
+        },
+        {
+          testName: ':Test:2',
+          expectedName: '_Test_2'
+        }
+      ]
+      for (const testCase of testCases) {
+        const result = reporter.createTcTestName(testCase.testName)
+        expect(result).toBe(testCase.expectedName)
+      }
+    })
+  })
+
+  describe('reportTest', () => {
+    it('should write the correct test start, metadata, result, and finish messages to stdout', () => {
+      const testFilePath = 'test/file/path'
+      const tcFullTestName = 'test > case'
+      const consoleMessages = ['a', 'b']
+      const duration = 1000
+
+      reporter.reportTest(
+        tcFullTestName,
+        testFilePath,
+        consoleMessages,
+        duration,
+        (tcFullTestName) => {
+          reporter.tcServiceMessage('testFailed', {
+            name: tcFullTestName,
+            details: 'Test failed'
+          })
+        }
+      )
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='test > case']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testMetadata name='testFilePath' value='test/file/path']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStdOut name='test > case' out='Console messages from test/file/path:|na|nb']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFailed name='test > case' details='Test failed']\n"
+      )
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testFinished name='test > case' duration='1000']\n"
+      )
+    })
+  })
+
+  describe('tcServiceMessage', () => {
+    it('should write the correct service message to stdout', () => {
+      reporter.tcServiceMessage('testStarted', { name: 'test' })
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='test']\n"
+      )
+    })
+
+    it('should not write empty string', () => {
+      reporter.tcServiceMessage('testStarted', { param: '' })
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith('##teamcity[testStarted]\n')
+    })
+
+    it('should write zero number', () => {
+      reporter.tcServiceMessage('testStarted', { param: 0 })
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted param='0']\n"
+      )
+    })
+
+    it('should escape special characters in the message parameters', () => {
+      reporter.tcServiceMessage('testStarted', {
+        name: 'test\nwith\rspecial|characters'
+      })
+
+      expect(mockStdoutWrite).toHaveBeenCalledWith(
+        "##teamcity[testStarted name='test|nwith|rspecial||characters']\n"
+      )
+    })
+
+    it('should assert if a parameter value is undefined or null', () => {
+      expect(() => {
+        reporter.tcServiceMessage('testStarted', {
+          param: undefined
+        })
+      }).toThrow()
+
+      expect(() => {
+        reporter.tcServiceMessage('testStarted', {
+          param: null
+        })
+      }).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Changes in this PR:
1. Add Jest reporter to report test results via Teamcity Service Messages.
2. Enable the reporter via Jest configuration on Teamcity.
3. Fix `transform` regex to match actual source files (skip `.json` for ex.).

Related https://github.com/brave/brave-browser/issues/30125

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

