### PR TITLE
style(wallet): Ellipsis Token Names in Swap and Send

### DIFF
--- a/components/brave_wallet_ui/page/screens/composer_ui/token_list_item/token_list_item.style.ts
+++ b/components/brave_wallet_ui/page/screens/composer_ui/token_list_item/token_list_item.style.ts
@@ -13,7 +13,8 @@ import {
   AssetIconFactory,
   Row,
   WalletButton,
-  Text
+  Text,
+  Column
 } from '../../../../components/shared/style'
 
 export const AssetIcon = AssetIconFactory<AssetIconProps>({
@@ -70,22 +71,35 @@ export const IconsWrapper = styled.div`
   margin-right: 16px;
 `
 
-export const IconAndName = styled(Row)`
-  width: 80%;
-  white-space: pre-line;
+export const NameAndBalanceColumn = styled(Column)`
+  overflow: hidden;
 `
 
-export const NameAndBalanceText = styled(Text)`
+export const TokenNameRow = styled(Row)`
+  overflow: hidden;
+`
+
+export const LeftSide = styled(TokenNameRow)`
+  max-width: 100%;
+`
+
+export const TokenNameText = styled(Text)`
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
   line-height: 22px;
-  color: ${leo.color.text.primary};
+  white-space: nowrap;
 `
 
-export const NetworkAndFiatText = styled(Text)`
+export const FiatBalanceText = styled(Text)`
+  line-height: 22px;
+`
+
+export const TokenBalanceText = styled(Text)`
   line-height: 20px;
-  color: ${leo.color.text.secondary};
 `
 
-export const PercentChangeText = styled(NetworkAndFiatText)<{
+export const PercentChangeText = styled(TokenBalanceText)<{
   isDown: boolean
 }>`
   color: ${(p) =>

--- a/components/brave_wallet_ui/page/screens/composer_ui/token_list_item/token_list_item.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/token_list_item/token_list_item.tsx
@@ -37,15 +37,18 @@ import {
   Button,
   IconsWrapper,
   ButtonWrapper,
-  IconAndName,
-  NameAndBalanceText,
-  NetworkAndFiatText,
   DisabledLabel,
   PercentChangeText,
   PercentChangeIcon,
   AccountsIcon,
   InfoButton,
-  InfoIcon
+  InfoIcon,
+  TokenBalanceText,
+  FiatBalanceText,
+  TokenNameText,
+  TokenNameRow,
+  LeftSide,
+  NameAndBalanceColumn
 } from './token_list_item.style'
 import {
   Column,
@@ -107,13 +110,8 @@ export const TokenListItem = React.forwardRef<HTMLDivElement, Props>(
           : ''
         return `${token.name} ${id}`
       }
-      if (disabledText) {
-        return token.name.length > 12
-          ? `${token.name.substring(0, 10)}...`
-          : token.name
-      }
       return token.name
-    }, [token, disabledText])
+    }, [token])
 
     const tokenHasBalance = balance && new Amount(balance).gt(0)
 
@@ -169,7 +167,7 @@ export const TokenListItem = React.forwardRef<HTMLDivElement, Props>(
             onClick={onClick}
             disabled={!!disabledText}
           >
-            <IconAndName justifyContent='flex-start'>
+            <LeftSide justifyContent='flex-start'>
               <IconsWrapper>
                 {token.isNft || token.isErc721 || token.isErc1155 ? (
                   <NftIconWithPlaceholder asset={token} />
@@ -183,40 +181,52 @@ export const TokenListItem = React.forwardRef<HTMLDivElement, Props>(
                   />
                 </NetworkIconWrapper>
               </IconsWrapper>
-              <Column alignItems='flex-start'>
-                <Row width='unset'>
-                  <NameAndBalanceText
+              <NameAndBalanceColumn
+                alignItems='flex-start'
+                width='100%'
+              >
+                <TokenNameRow
+                  justifyContent='flex-start'
+                  width='100%'
+                  padding='0px 8px 0px 0px'
+                >
+                  <TokenNameText
                     textSize='14px'
                     isBold={true}
                     textAlign='left'
+                    textColor='primary'
                   >
                     {tokenDisplayName}
-                  </NameAndBalanceText>
+                  </TokenNameText>
                   {disabledText && (
                     <>
                       <HorizontalSpace space='8px' />
                       <DisabledLabel>{getLocale(disabledText)}</DisabledLabel>
                     </>
                   )}
-                </Row>
-                <NetworkAndFiatText
+                </TokenNameRow>
+                <TokenBalanceText
                   textSize='12px'
                   isBold={false}
                   textAlign='left'
+                  textColor='secondary'
                 >
                   {formatTokenBalanceWithSymbol(
                     balance ?? '',
                     token.decimals,
                     token.symbol
                   )}
-                </NetworkAndFiatText>
-              </Column>
-            </IconAndName>
+                </TokenBalanceText>
+              </NameAndBalanceColumn>
+            </LeftSide>
             {!token.isNft &&
               !token.isErc721 &&
               !token.isErc1155 &&
               tokenHasBalance && (
-                <Column alignItems='flex-end'>
+                <Column
+                  alignItems='flex-end'
+                  width='25%'
+                >
                   {isLoadingSpotPrice ? (
                     <>
                       <LoadingSkeleton
@@ -233,13 +243,14 @@ export const TokenListItem = React.forwardRef<HTMLDivElement, Props>(
                     <>
                       <Row width='unset'>
                         {tokenHasMultipleAccounts && <AccountsIcon />}
-                        <NameAndBalanceText
+                        <FiatBalanceText
                           textSize='14px'
                           isBold={true}
                           textAlign='right'
+                          textColor='primary'
                         >
                           {formattedFiatBalance}
-                        </NameAndBalanceText>
+                        </FiatBalanceText>
                       </Row>
                       <Row width='unset'>
                         <PercentChangeIcon


### PR DESCRIPTION
## Description 
Will now add an `ellipsis` to token names in the Swap and Send `Select Token Modal`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/38064>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` Panel and navigate to the `Swap` screen
2. Open the `Select Token Modal`
3. Tokens with long names should have an `ellipsis` applied to them.

Before:

![Screenshot 43](https://github.com/brave/brave-core/assets/40611140/846a18f4-2498-4143-8abf-3b8ae11831bf)

After:

![Screenshot 42](https://github.com/brave/brave-core/assets/40611140/18b4af82-104b-4d49-bc90-032616713a94)
