### PR TITLE
[Android] fix multiple window dialog text cutoff (uplift to 1.66.x)

### DIFF
--- a/android/java/res/layout/fragment_brave_multiwindow_dialog.xml
+++ b/android/java/res/layout/fragment_brave_multiwindow_dialog.xml
@@ -39,13 +39,15 @@
 
     <android.widget.Button
         android:id="@+id/btn_merge"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         app:layout_constraintTop_toBottomOf="@id/tv_summary"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toStartOf="@id/btn_close"
         android:background="@android:color/transparent"
+        android:maxLines="2"
+        android:ellipsize="end"
         android:textAllCaps="false"
         android:text="@string/merge_windows"
         android:textColor="@color/bookmark_import_export_dialog_button_color"
@@ -54,7 +56,7 @@
 
     <android.widget.Button
         android:id="@+id/btn_close"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="10dp"
         android:layout_marginStart="16dp"
@@ -62,6 +64,8 @@
         app:layout_constraintStart_toEndOf="@id/btn_merge"
         app:layout_constraintEnd_toEndOf="parent"
         android:background="@android:color/transparent"
+        android:maxLines="2"
+        android:ellipsize="end"
         android:textAllCaps="false"
         android:text="@string/close_windows"
         android:textColor="@color/bookmark_import_export_dialog_button_color"


### PR DESCRIPTION
Uplift of #23617
Resolves https://github.com/brave/brave-browser/issues/38269

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.