### PR TITLE
fix(wallet): Transaction Confirmation loading/submitting view not removed on immediate error

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -72,7 +72,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
   }
   @Published var activeTxStatus: BraveWallet.TransactionStatus = .unapproved {
     didSet {
-      if isTxSubmitting == true, oldValue == .approved, activeTxStatus != .approved {
+      if isTxSubmitting == true, activeTxStatus != .approved {
         isTxSubmitting = false
       }
     }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -197,53 +197,10 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
         // won't have any new unapproved tx being added if you on tx confirmation panel
       },
       _onUnapprovedTxUpdated: { [weak self] txInfo in
-        Task { @MainActor [self] in
-          // refresh the unapproved transaction list, as well as tx details UI
-          // first update `allTxs` with the new updated txInfo(txStatus)
-          if let index = self?.allTxs.firstIndex(where: { $0.id == txInfo.id }) {
-            self?.allTxs[index] = txInfo
-          }
-
-          // update details UI if the current active tx is updated
-          if self?.activeTransactionId == txInfo.id {
-            self?.updateTransaction(with: txInfo)
-            self?.activeTxStatus = txInfo.txStatus
-          }
-
-          // if somehow the current active transaction no longer exists
-          // set the first `.unapproved` tx as the new `activeTransactionId`
-          if let unapprovedTxs = self?.unapprovedTxs,
-            !unapprovedTxs.contains(where: { $0.id == self?.activeTransactionId })
-          {
-            self?.activeTransactionId = self?.unapprovedTxs.first?.id ?? ""
-          }
-        }
+        self?.onUnapprovedTxUpdated(txInfo)
       },
       _onTransactionStatusChanged: { [weak self] txInfo in
-        Task { @MainActor [self] in
-          // once we come here. it means user either rejects or confirms a transaction
-
-          // first update `allTxs` with the new updated txInfo(txStatus)
-          if let index = self?.allTxs.firstIndex(where: { $0.id == txInfo.id }) {
-            self?.allTxs[index] = txInfo
-          }
-
-          // only update the `activeTransactionId` if the current active transaction status
-          // becomes `.rejected`/`.dropped`
-          if self?.activeTransactionId == txInfo.id,
-            txInfo.txStatus == .rejected || txInfo.txStatus == .dropped
-          {
-            let indexOfChangedTx =
-              self?.unapprovedTxs.firstIndex(where: { $0.id == txInfo.id }) ?? 0
-            let newIndex = indexOfChangedTx > 0 ? indexOfChangedTx - 1 : 0
-            self?.activeTransactionId =
-              self?.unapprovedTxs[safe: newIndex]?.id ?? self?.unapprovedTxs.first?.id ?? ""
-          } else {
-            if self?.activeTransactionId == txInfo.id {
-              self?.activeTxStatus = txInfo.txStatus
-            }
-          }
-        }
+        self?.onTransactionStatusChanged(txInfo)
       }
     )
     self.walletServiceObserver = WalletServiceObserver(
@@ -266,24 +223,15 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     }
   }
 
-  func rejectAllTransactions(completion: @escaping (Bool) -> Void) {
-    let dispatchGroup = DispatchGroup()
+  @MainActor func rejectAllTransactions() async -> Bool {
     var allRejectsSucceeded = true
     for transaction in unapprovedTxs {
-      dispatchGroup.enter()
-      reject(
-        transaction: transaction,
-        completion: { success in
-          defer { dispatchGroup.leave() }
-          if !success {
-            allRejectsSucceeded = false
-          }
-        }
-      )
+      let success = await reject(transaction: transaction)
+      if !success {
+        allRejectsSucceeded = false
+      }
     }
-    dispatchGroup.notify(queue: .main) {
-      completion(allRejectsSucceeded)
-    }
+    return allRejectsSucceeded
   }
 
   @MainActor func prepare() async {
@@ -838,41 +786,35 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     .sorted(by: { $0.createdTime > $1.createdTime })
   }
 
-  func confirm(
-    transaction: BraveWallet.TransactionInfo,
-    completion: @escaping (_ error: String?) -> Void
-  ) {
-    txService.approveTransaction(
+  @MainActor func confirm(
+    transaction: BraveWallet.TransactionInfo
+  ) async -> String? {
+    isTxSubmitting = true
+    let (success, error, message) = await txService.approveTransaction(
       coinType: transaction.coin,
       chainId: transaction.chainId,
       txMetaId: transaction.id
-    ) { [weak self] success, error, message in
-      // As desktop, we only care about eth provider error or solana
-      // provider error (plus we haven't start supporting filecoin)
-      if error.tag == .providerError {
-        self?.transactionProviderErrorRegistry[transaction.id] = TransactionProviderError(
-          code: error.providerError.rawValue,
-          message: message
-        )
-      } else if error.tag == .solanaProviderError {
-        self?.transactionProviderErrorRegistry[transaction.id] = TransactionProviderError(
-          code: error.solanaProviderError.rawValue,
-          message: message
-        )
-      }
-
-      completion(success ? nil : message)
+    )
+    if error.tag == .providerError {
+      transactionProviderErrorRegistry[transaction.id] = TransactionProviderError(
+        code: error.providerError.rawValue,
+        message: message
+      )
+    } else if error.tag == .solanaProviderError {
+      transactionProviderErrorRegistry[transaction.id] = TransactionProviderError(
+        code: error.solanaProviderError.rawValue,
+        message: message
+      )
     }
+    return success ? nil : message
   }
 
-  func reject(transaction: BraveWallet.TransactionInfo, completion: @escaping (Bool) -> Void) {
-    txService.rejectTransaction(
+  @MainActor func reject(transaction: BraveWallet.TransactionInfo) async -> Bool {
+    await txService.rejectTransaction(
       coinType: transaction.coin,
       chainId: transaction.chainId,
       txMetaId: transaction.id
-    ) { success in
-      completion(success)
-    }
+    )
   }
 
   func updateGasFeeAndLimits(
@@ -964,6 +906,48 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     let indexOfChangedTx = unapprovedTxs.firstIndex(where: { $0.id == activeTransactionId }) ?? 0
     let newIndex = indexOfChangedTx > 0 ? indexOfChangedTx - 1 : 0
     activeTransactionId = unapprovedTxs[safe: newIndex]?.id ?? unapprovedTxs.first?.id ?? ""
+  }
+
+  func onUnapprovedTxUpdated(_ txInfo: BraveWallet.TransactionInfo) {
+    // refresh the unapproved transaction list, as well as tx details UI
+    // first update `allTxs` with the new updated txInfo(txStatus)
+    if let index = allTxs.firstIndex(where: { $0.id == txInfo.id }) {
+      allTxs[index] = txInfo
+    }
+
+    // update details UI if the current active tx is updated
+    if activeTransactionId == txInfo.id {
+      updateTransaction(with: txInfo)
+      activeTxStatus = txInfo.txStatus
+    }
+
+    // if somehow the current active transaction no longer exists
+    // set the first `.unapproved` tx as the new `activeTransactionId`
+    if !unapprovedTxs.contains(where: { $0.id == activeTransactionId }) {
+      activeTransactionId = unapprovedTxs.first?.id ?? ""
+    }
+  }
+
+  func onTransactionStatusChanged(_ txInfo: BraveWallet.TransactionInfo) {
+    // first update `allTxs` with the new updated txInfo(txStatus)
+    if let index = allTxs.firstIndex(where: { $0.id == txInfo.id }) {
+      allTxs[index] = txInfo
+    }
+
+    // only update the `activeTransactionId` if the current active transaction status
+    // becomes `.rejected`/`.dropped`
+    if activeTransactionId == txInfo.id,
+      txInfo.txStatus == .rejected || txInfo.txStatus == .dropped
+    {
+      let indexOfChangedTx = unapprovedTxs.firstIndex(where: { $0.id == txInfo.id }) ?? 0
+      let newIndex = indexOfChangedTx > 0 ? indexOfChangedTx - 1 : 0
+      activeTransactionId =
+        unapprovedTxs[safe: newIndex]?.id ?? unapprovedTxs.first?.id ?? ""
+    } else {
+      if activeTransactionId == txInfo.id {
+        activeTxStatus = txInfo.txStatus
+      }
+    }
   }
 }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
@@ -451,17 +451,21 @@ struct PendingTransactionView: View {
 
   @ViewBuilder private var rejectConfirmButtons: some View {
     Button {
-      confirmationStore.reject(transaction: confirmationStore.activeParsedTransaction.transaction) {
-        _ in
+      Task {
+        await confirmationStore.reject(
+          transaction: confirmationStore.activeParsedTransaction.transaction
+        )
       }
     } label: {
       Label(Strings.Wallet.rejectTransactionButtonTitle, systemImage: "xmark")
     }
     .buttonStyle(BraveOutlineButtonStyle(size: .large))
     Button {
-      confirmationStore.isTxSubmitting = true
-      confirmationStore.confirm(transaction: confirmationStore.activeParsedTransaction.transaction)
-      { _ in }
+      Task {
+        await confirmationStore.confirm(
+          transaction: confirmationStore.activeParsedTransaction.transaction
+        )
+      }
     } label: {
       Label(Strings.Wallet.confirm, systemImage: "checkmark.circle.fill")
     }
@@ -508,7 +512,8 @@ struct PendingTransactionView: View {
         // Cancel / Confirm buttons
         if confirmationStore.unapprovedTxs.count > 1 {
           Button {
-            confirmationStore.rejectAllTransactions { success in
+            Task {
+              let success = await confirmationStore.rejectAllTransactions()
               if success {
                 onDismiss()
               }


### PR DESCRIPTION
- Fixes transaction loading spinner does not change to error state when receiving error during some transactions, for example no internet connection.
    - In specific case of internet disabled/unavailable after loading tx confirmation but before approving a transaction, the transaction status moves from `unapproved` directly to `error` so the check for `oldValue == .approved` was causing `isTxSubmitting` to not update to false.
- Update confirm/reject functions to use async/await

Resolves https://github.com/brave/brave-browser/issues/38375

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a transaction on any network. Used ethereum for testing but should work for any transaction.
2. In Transaction Confirmation panel, wait for data to load
3. Once data has loaded, disable network connection
4. Tap approve
5. Verify loading spinner is removed and error status is shown


https://github.com/brave/brave-core/assets/5314553/64d8a1f8-8a9f-4cdb-becd-627da19da8d4