### PR TITLE
[iOS] Tab Tray Icon Long Press Enhancements

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -311,7 +311,7 @@ extension BrowserViewController: TabManagerDelegate {
       bookmarkMenuChildren.append(bookmarkActiveTab)
     }
 
-    if tabManager.tabsForCurrentMode.count > 1 {
+    if tabManager.tabsForCurrentMode.count > 1, containsWebPage {
       let bookmarkAllTabs = UIAction(
         title: String.localizedStringWithFormat(
           Strings.bookmarkAllTabsTitle,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -433,47 +433,76 @@ extension BrowserViewController: TabManagerDelegate {
 
     closeTabMenuChildren.append(closeActiveTab)
 
+    var closeAllTabMenuChildren: [UIAction] = []
+
     if tabManager.tabsForCurrentMode.count > 1 {
+
+      func showCloseTabWarning(isActiveTabIncluded: Bool, _ completion: @escaping () -> Void) {
+        let alert = UIAlertController(
+          title: nil,
+          message: isActiveTabIncluded
+            ? Strings.closeAllTabsPrompt : Strings.closeAllOtherTabsPrompt,
+          preferredStyle: .actionSheet
+        )
+        let cancelAction = UIAlertAction(title: Strings.CancelString, style: .cancel)
+        let closedTabsTitle =
+          isActiveTabIncluded
+          ? String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count)
+          : Strings.closeAllOtherTabsTitle
+        let closeAllAction = UIAlertAction(title: closedTabsTitle, style: .destructive) { _ in
+          completion()
+        }
+        alert.addAction(closeAllAction)
+        alert.addAction(cancelAction)
+
+        if let popoverPresentation = alert.popoverPresentationController {
+          let tabsButton = toolbar?.tabsButton ?? topToolbar.tabsButton
+          popoverPresentation.sourceView = tabsButton
+          popoverPresentation.sourceRect =
+            .init(x: tabsButton.frame.width / 2, y: tabsButton.frame.height, width: 1, height: 1)
+        }
+
+        present(alert, animated: true)
+      }
+
+      let closeAllOtherTabs = UIAction(
+        title: Strings.closeAllOtherTabsTitle,
+        image: UIImage(systemName: "xmark"),
+        attributes: .destructive,
+        handler: UIAction.deferredActionHandler { [weak self] _ in
+          guard let self = self else { return }
+
+          showCloseTabWarning(isActiveTabIncluded: false) {
+            if !self.privateBrowsingManager.isPrivateBrowsing {
+              // Add the tab information to recently closed before removing
+              self.tabManager.addAllTabsToRecentlyClosed(isActiveTabIncluded: false)
+            }
+
+            self.tabManager.removeAllForCurrentMode(isActiveTabIncluded: false)
+          }
+        }
+      )
+
       let closeAllTabs = UIAction(
         title: String(format: Strings.closeAllTabsTitle, tabManager.tabsForCurrentMode.count),
         image: UIImage(systemName: "xmark"),
         attributes: .destructive,
-        handler: UIAction.deferredActionHandler { [unowned self] _ in
+        handler: UIAction.deferredActionHandler { [weak self] _ in
+          guard let self = self else { return }
 
-          let alert = UIAlertController(
-            title: nil,
-            message: Strings.closeAllTabsPrompt,
-            preferredStyle: .actionSheet
-          )
-          let cancelAction = UIAlertAction(title: Strings.CancelString, style: .cancel)
-          let closedTabsTitle = String(
-            format: Strings.closeAllTabsTitle,
-            tabManager.tabsForCurrentMode.count
-          )
-          let closeAllAction = UIAlertAction(title: closedTabsTitle, style: .destructive) {
-            [unowned self] _ in
-            if !privateBrowsingManager.isPrivateBrowsing {
+          showCloseTabWarning(isActiveTabIncluded: true) {
+            if !self.privateBrowsingManager.isPrivateBrowsing {
               // Add the tab information to recently closed before removing
-              tabManager.addAllTabsToRecentlyClosed()
+              self.tabManager.addAllTabsToRecentlyClosed(isActiveTabIncluded: true)
             }
 
-            tabManager.removeAllForCurrentMode()
+            self.tabManager.removeAllForCurrentMode()
           }
-          alert.addAction(closeAllAction)
-          alert.addAction(cancelAction)
-
-          if let popoverPresentation = alert.popoverPresentationController {
-            let tabsButton = toolbar?.tabsButton ?? topToolbar.tabsButton
-            popoverPresentation.sourceView = tabsButton
-            popoverPresentation.sourceRect =
-              .init(x: tabsButton.frame.width / 2, y: tabsButton.frame.height, width: 1, height: 1)
-          }
-
-          self.present(alert, animated: true)
         }
       )
 
-      closeTabMenuChildren.append(closeAllTabs)
+      closeAllTabMenuChildren.append(closeAllOtherTabs)
+      closeAllTabMenuChildren.append(closeAllTabs)
     }
 
     let newTabMenu = UIMenu(title: "", options: .displayInline, children: newTabMenuChildren)
@@ -489,10 +518,15 @@ extension BrowserViewController: TabManagerDelegate {
       options: .displayInline,
       children: recentlyClosedMenuChildren
     )
+    let closeAllTabMenu = UIMenu(
+      title: "",
+      options: .displayInline,
+      children: closeAllTabMenuChildren
+    )
     let closeTabMenu = UIMenu(title: "", options: .displayInline, children: closeTabMenuChildren)
 
     let tabButtonMenuActionList = [
-      closeTabMenu, recentlyClosedMenu, duplicateTabMenu, bookmarkMenu, newTabMenu,
+      closeTabMenu, closeAllTabMenu, recentlyClosedMenu, duplicateTabMenu, bookmarkMenu, newTabMenu,
     ]
     let addTabMenuActionList = [addTabMenu]
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -946,10 +946,22 @@ class TabManager: NSObject {
     delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: nil) }
   }
 
-  @MainActor func removeAllForCurrentMode() {
+  @MainActor func removeAllForCurrentMode(isActiveTabIncluded: Bool = true) {
     isBulkDeleting = true
-    removeTabs(tabsForCurrentMode)
+
+    if isActiveTabIncluded {
+      removeTabs(tabsForCurrentMode)
+    } else {
+      let tabsToDelete = tabsForCurrentMode.filter {
+        guard let currentTab = selectedTab else { return false }
+        return currentTab.id != $0.id
+      }
+      removeTabs(tabsToDelete)
+    }
+
     isBulkDeleting = false
+    // No change needed here regarding to isActiveTabIncluded
+    // Toast value is nil and TabsBarViewController is updating the from current tabs
     delegates.forEach { $0.get()?.tabManagerDidRemoveAllTabs(self, toast: nil) }
   }
 
@@ -1215,11 +1227,16 @@ class TabManager: NSObject {
   }
 
   /// Function to add all the tabs to recently closed before the list is removef entirely by Close All Tabs
-  func addAllTabsToRecentlyClosed() {
+  func addAllTabsToRecentlyClosed(isActiveTabIncluded: Bool) {
     var allRecentlyClosed: [SavedRecentlyClosed] = []
 
-    tabs(withType: .regular).forEach {
-      if let savedItem = createRecentlyClosedFromActiveTab($0) {
+    for tab in tabs(withType: .regular) {
+      // Do not include the active tab for case isActiveTabIncluded is false
+      if !isActiveTabIncluded, let currentTab = selectedTab, currentTab.id == tab.id {
+        continue
+      }
+
+      if let savedItem = createRecentlyClosedFromActiveTab(tab) {
         allRecentlyClosed.append(savedItem)
       }
     }

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -3232,13 +3232,6 @@ extension Strings {
     value: "Show History",
     comment: "Button to show the history list"
   )
-  public static let addBookmark = NSLocalizedString(
-    "AddBookmark",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "Add Bookmark",
-    comment: "Button to add a bookmark"
-  )
   public static let editBookmark = NSLocalizedString(
     "EditBookmark",
     tableName: "BraveShared",

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -489,6 +489,13 @@ extension Strings {
     value: "Close All %i Tabs",
     comment: ""
   )
+  public static let closeAllOtherTabsTitle = NSLocalizedString(
+    "closeAllOtherTabsTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Close All Other Tabs",
+    comment: "Title for asking user to close all tabs except the active tab."
+  )
   public static let closeAllTabsPrompt =
     NSLocalizedString(
       "closeAllTabsPrompt",
@@ -496,6 +503,14 @@ extension Strings {
       bundle: .module,
       value: "Are you sure you want to close all open tabs?",
       comment: "We ask users this prompt before attempting to close multiple tabs via context menu"
+    )
+  public static let closeAllOtherTabsPrompt =
+    NSLocalizedString(
+      "closeAllOtherTabsPrompt",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Are you sure you want to close all other open tabs?",
+      comment: "We ask users this prompt before attempting to close all tabs except active one via context menu"
     )
   public static let savedTabsFolderTitle = NSLocalizedString(
     "SavedTabsFolderTitle",

--- a/ios/brave-ios/Tests/ClientTests/TabManagerTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/TabManagerTests.swift
@@ -667,6 +667,20 @@ open class MockTabManagerDelegate: TabManagerDelegate {
     XCTAssertFalse(manager.allTabs.first!.isPrivate, "The new tab should be a regular tab")
   }
 
+  func testRemoveAllOtherTabs() {
+    (0..<10).forEach { index in manager.addTab(isPrivate: false) }
+    manager.removeAllForCurrentMode(isActiveTabIncluded: false)
+
+    XCTAssertFalse(
+      manager.allTabs.count == 1,
+      "The active tab should not be removed and no new tab should be created"
+    )
+    XCTAssertFalse(
+      manager.allTabs.first!.isPrivate,
+      "The last remaining tab should be a regular tab"
+    )
+  }
+
   func testMoveTabToEnd() {
     let firstTab = manager.addTabAndSelect(isPrivate: false)
     let secondTab = manager.addTab(isPrivate: false)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38340
Resolves https://github.com/brave/brave-browser/issues/37069

This PR is resolving a minor issue related with Bookmarks All Tabs when NTP is open and adding functionality for Close All Other Tabs option.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

[#38340](https://github.com/brave/brave-browser/issues/38340) Add bookmarks button shows wrong count when landing pages are open

The Add Bookmark for %lld Tabs option should not be visible when the Tab in on NTP

- Open multiple Tabs
- Open NTP
- Navigate to New Tab Page
- Long Press Tab Tray
- Check Bookmark action is not listed

[#37069](https://github.com/brave/brave-browser/issues/37069)

Add 'Close other tabs' option

- Clear Recently Closed before testing both

1:
- Open Multiple Tabs
- Use Close All %lld Tabs option
- Check all tabs are closed and also added to recently closed

2: 
- Open Multiple Tabs
- Use Close All Other Tabs
- Check all tabs are closed except the active one and check tabs added to recently closed

## Screenshots:

![4132teat33](https://github.com/brave/brave-core/assets/6643505/143e59f9-e532-48ec-a81d-0a463cb7e59a)


https://github.com/brave/brave-core/assets/6643505/9587b401-a524-4564-958d-c3f28ab2e8ec

