### PR TITLE
[iOS] - Add an upgrade card when the user accesses a premium model and fix badges in the AIChat menu

### DIFF
--- a/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
@@ -85,7 +85,6 @@ public struct AIChatView: View {
                       upsellType: model.apiError == .rateLimitReached ? .rateLimit : .premium,
                       upgradeAction: {
                         isPremiumPaywallPresented = true
-
                       },
                       dismissAction: {
                         if model.apiError == .rateLimitReached {
@@ -146,7 +145,7 @@ public struct AIChatView: View {
                       }
                     }
 
-                    apiErrorViews(for: model.apiError)
+                    apiErrorViews(for: model)
 
                     if model.shouldShowSuggestions && !model.requestInProgress
                       && model.apiError == .none
@@ -396,18 +395,13 @@ public struct AIChatView: View {
   }
 
   @ViewBuilder
-  private func apiErrorViews(for error: AiChat.APIError) -> some View {
-    switch error {
-    case .connectionIssue:
-      AIChatNetworkErrorView {
-        if !model.conversationHistory.isEmpty {
-          model.retryLastRequest()
-        }
-      }
-      .padding()
-    case .rateLimitReached:
+  private func apiErrorViews(for model: AIChatViewModel) -> some View {
+    let isPremiumAccess = model.currentModel.access == .premium
+    let isPremium = model.premiumStatus == .active || model.premiumStatus == .activeDisconnected
+
+    if isPremiumAccess && !isPremium {
       AIChatPremiumUpsellView(
-        upsellType: .rateLimit,
+        upsellType: .premium,
         upgradeAction: {
           isPremiumPaywallPresented = true
         },
@@ -425,13 +419,43 @@ public struct AIChatView: View {
         }
       )
       .padding()
-    case .contextLimitReached:
-      AIChatContextLimitErrorView()
+    } else {
+      switch model.apiError {
+      case .connectionIssue:
+        AIChatNetworkErrorView {
+          if !model.conversationHistory.isEmpty {
+            model.retryLastRequest()
+          }
+        }
         .padding()
-    case .none:
-      EmptyView()
-    @unknown default:
-      EmptyView()
+      case .rateLimitReached:
+        AIChatPremiumUpsellView(
+          upsellType: .rateLimit,
+          upgradeAction: {
+            isPremiumPaywallPresented = true
+          },
+          dismissAction: {
+            Task { @MainActor in
+              await model.refreshPremiumStatus()
+
+              if let basicModel = model.models.first(where: { $0.access == .basic }) {
+                model.changeModel(modelKey: basicModel.key)
+                model.retryLastRequest()
+              } else {
+                Logger.module.error("No basic models available")
+              }
+            }
+          }
+        )
+        .padding()
+      case .contextLimitReached:
+        AIChatContextLimitErrorView()
+          .padding()
+      case .none:
+        EmptyView()
+      @unknown default:
+        EmptyView()
+      }
     }
   }
 

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatDefaultModelView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatDefaultModelView.swift
@@ -70,9 +70,13 @@ struct AIChatDefaultModelView: View {
                           .strokeBorder(Color(braveSystemName: .blue50), lineWidth: 1.0)
                       )
                   } else if model.access == .premium {
-                    Image(braveSystemName: "leo.lock.plain")
-                      .foregroundStyle(Color(braveSystemName: .iconDefault))
-                      .padding(.horizontal, 4.0)
+                    Image(
+                      braveSystemName: aiModel.premiumStatus != .active
+                        && aiModel.premiumStatus != .activeDisconnected
+                        ? "leo.lock.plain" : "leo.lock.open"
+                    )
+                    .foregroundStyle(Color(braveSystemName: .iconDefault))
+                    .padding(.horizontal, 4.0)
                   }
                 }
               }

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
@@ -147,7 +147,7 @@ struct AIChatMenuView: View {
               subtitle: modelPurpose(for: model),
               isSelected: model.key == currentModel.key
             ) {
-              if model.access == .basicAndPremium || model.access == .premium {
+              if model.access == .basicAndPremium {
                 Text(
                   premiumStatus == .active || premiumStatus == .activeDisconnected
                     ? Strings.AIChat.unlimitedModelStatusTitle.uppercased()
@@ -161,12 +161,13 @@ struct AIChatMenuView: View {
                   RoundedRectangle(cornerRadius: 4.0, style: .continuous)
                     .strokeBorder(Color(braveSystemName: .blue50), lineWidth: 1.0)
                 )
-              } else if model.access == .premium
-                && (premiumStatus == .inactive || premiumStatus == .unknown)
-              {
-                Image(braveSystemName: "leo.lock.plain")
-                  .foregroundStyle(Color(braveSystemName: .iconDefault))
-                  .opacity(model.access == .premium ? 1.0 : 0.0)
+              } else {
+                Image(
+                  braveSystemName: premiumStatus != .active && premiumStatus != .activeDisconnected
+                    ? "leo.lock.plain" : "leo.lock.open"
+                )
+                .foregroundStyle(Color(braveSystemName: .iconDefault))
+                .opacity(model.access == .premium ? 1.0 : 0.0)
               }
             }
           }

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
@@ -59,6 +59,7 @@ private struct AIChatMenuItemView<RightAccessoryView: View>: View {
           .font(.footnote)
           .foregroundStyle(Color(braveSystemName: .textSecondary))
       }
+      .multilineTextAlignment(.leading)
       .frame(maxWidth: .infinity, alignment: .leading)
 
       rightAccessoryView
@@ -146,7 +147,7 @@ struct AIChatMenuView: View {
               subtitle: modelPurpose(for: model),
               isSelected: model.key == currentModel.key
             ) {
-              if model.access == .basicAndPremium {
+              if model.access == .basicAndPremium || model.access == .premium {
                 Text(
                   premiumStatus == .active || premiumStatus == .activeDisconnected
                     ? Strings.AIChat.unlimitedModelStatusTitle.uppercased()
@@ -160,7 +161,9 @@ struct AIChatMenuView: View {
                   RoundedRectangle(cornerRadius: 4.0, style: .continuous)
                     .strokeBorder(Color(braveSystemName: .blue50), lineWidth: 1.0)
                 )
-              } else {
+              } else if model.access == .premium
+                && (premiumStatus == .inactive || premiumStatus == .unknown)
+              {
                 Image(braveSystemName: "leo.lock.plain")
                   .foregroundStyle(Color(braveSystemName: .iconDefault))
                   .opacity(model.access == .premium ? 1.0 : 0.0)


### PR DESCRIPTION
## Summary

- Add an upgrade card when the user accesses a premium model and the user isn't premium. 
- BraveCore shows connectionIssue, but it's wrong.

Updated the logic for the menuView to show the lock icon only when you're not premium and only show blank when the model is completely free.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38385

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Regular user has lock icon:
<img width="318" alt="image" src="https://github.com/brave/brave-core/assets/1530031/409bef53-decc-43d0-b1c4-a9ecc3c996e3">
<img width="296" alt="image" src="https://github.com/brave/brave-core/assets/1530031/768f5bc8-4199-4c36-9ad5-ef307a117285">

Premium user has unlock icon just like on Desktop:
<img width="300" alt="image" src="https://github.com/brave/brave-core/assets/1530031/3e5910bf-8cb7-432e-a819-288074eaffa2">
<img width="296" alt="image" src="https://github.com/brave/brave-core/assets/1530031/7cd3d4ac-eb03-4abe-8980-e5f030e807ae">

Sonnet showing premium upsell to a regular user instead of network error:
<img width="301" alt="image" src="https://github.com/brave/brave-core/assets/1530031/193d2b11-c64d-45bb-9bb5-d205a1397f4b">
