### PR TITLE
[ads] Fixes Brave News ads are not served for restored NTP tab

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -687,6 +687,7 @@ extension BrowserViewController: WKNavigationDelegate {
       InternalURL(responseURL)?.isSessionRestore == true
     {
       tab.shouldNotifyAdsServiceTabDidChange = false
+      tab.shouldNotifyAdsServiceTabContentDidChange = false
     }
 
     var request: URLRequest?
@@ -1003,18 +1004,23 @@ extension BrowserViewController: WKNavigationDelegate {
       }
 
       navigateInTab(tab: tab, to: navigation)
-      if tab.shouldNotifyAdsServiceTabDidChange, tab.navigationType != WKNavigationType.backForward
-      {
-        rewards.reportTabUpdated(
-          tab: tab,
-          isSelected: tabManager.selectedTab == tab,
-          isPrivate: privateBrowsingManager.isPrivateBrowsing
-        )
-        tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+      if tab.navigationType != WKNavigationType.backForward {
+        if tab.shouldNotifyAdsServiceTabDidChange {
+          rewards.reportTabUpdated(
+            tab: tab,
+            isSelected: tabManager.selectedTab == tab,
+            isPrivate: privateBrowsingManager.isPrivateBrowsing
+          )
+        }
+        if tab.shouldNotifyAdsServiceTabContentDidChange {
+          tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+        }
       }
-      // Set `shouldNotifyAdsServiceTabDidChange` to `true` so that listeners
+      // Set `shouldNotifyAdsServiceTabDidChange` and
+      // `shouldNotifyAdsServiceTabContentDidChange` to `true` so that listeners
       // are notified of tab changes after the tab is restored.
       tab.shouldNotifyAdsServiceTabDidChange = true
+      tab.shouldNotifyAdsServiceTabContentDidChange = true
 
       Task {
         await tab.updateEthereumProperties()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -303,6 +303,7 @@ class Tab: NSObject {
   var mimeType: String?
   var isEditing: Bool = false
   var shouldNotifyAdsServiceTabDidChange = true
+  var shouldNotifyAdsServiceTabContentDidChange = true
   var playlistItem: PlaylistInfo?
   var playlistItemState: PlaylistItemAddedState = .none
 
@@ -567,7 +568,7 @@ class Tab: NSObject {
       lastTitle = sessionInfo.title
       webView.interactionState = sessionInfo.interactionState
       restoring = false
-      shouldNotifyAdsServiceTabDidChange = false
+      shouldNotifyAdsServiceTabContentDidChange = false
       self.sessionData = nil
     } else if let request = lastRequest {
       webView.load(request)

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -187,8 +187,8 @@ public class BraveRewards: NSObject {
     isSelected: Bool,
     isPrivate: Bool
   ) {
-    // Don't report update for tabs that haven't finished loading.
     guard let url = tab.redirectChain.last else {
+      // Don't report update for tabs that haven't finished loading.
       return
     }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38378

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
1. Fresh install
2. Open NTP
3. Join Brave Rewards
4. Restart the Browser
5. Join Brave News In the restored NTP tab
6. Scroll News Feed

EXPECTATION: Brave News ads cards are shown
Following logs should appear:
```
   [ads] Served inline content ad
   [ads] Viewed inline content ad impression with placement id 
```

### Test case 2
1. Fresh install
2. Open NTP
3. Join Brave Rewards
4. Join Brave News in the NTP tab (do not scroll News Feed)
5. Restart the Browser
6. Scroll News Feed in the restored NTP

EXPECTATION: Brave News ads cards are shown

### Test case 3
1. Fresh install
2. Open NTP
3. Join Brave Rewards
5. Join Brave News in the NTP tab (do not scroll News Feed)
6. Open another NTP in the second tab
7. Navigate to `brave.com`
8. Restart the Browser
9. Switch to the first tab with the NTP
10. Scroll News Feed

EXPECTATION: Brave News ads cards are shown

### Test case 4
1. Fresh install
2. Open NTP
3. Join Brave Rewards
4. Navigate to `brave.com`
5. Restart the Browser
6. Open NTP
7. Join Brave News In the restored NTP tab
8. Scroll News Feed

EXPECTATION: Brave News ads cards are shown

### Test case 5
1. Fresh install
2. Add `ShouldAlwaysRunBraveAdsService` to enabled features list
3. Restart the browser to make feature applied
4. Open NTP
5. Restart the Browser
6. Join Brave News In the restored NTP tab
7. Scroll News Feed

EXPECTATION: Brave News ads cards are shown
Following logs should appear:
```
   [ads] Served inline content ad
   [ads] Viewed inline content ad impression with placement id 
```

### Test case 6
1. Fresh install
2. Add `ShouldAlwaysRunBraveAdsService` to enabled features list
3. Restart the browser to make feature applied
4. Open NTP
5. Join Brave News in the NTP tab (do not scroll News Feed)
6. Open another NTP in the second tab
6 Navigate to `brave.com`
8. Restart the Browser
9. Switch to the first tab with the NTP
10. Scroll News Feed

EXPECTATION: Brave News ads cards are shown

### Test case 7
1. Fresh install
2. Add `ShouldAlwaysRunBraveAdsService` to enabled features list
3. Restart the browser to make feature applied
9. Navigate to `brave.com`
10. Restart the Browser
11. Open NTP
12. Join Brave News In the restored NTP tab
13. Scroll News Feed

EXPECTATION: Brave News ads cards are shown

### Test case 8
1. Fresh install
2. Join Brave Rewards
3. Restart the Browser
4. Make sure that we started serving notification ads. These logs should appear:
```
   [ads] Start serving notification ads at regular intervals
   [ads] Maybe serve notification ad in ...
```
5. Background the browser (open another iOS application). These logs should appear:
```
  [ads] Browser did resign active
  [ads] Browser did enter background
  [ads] Stop serving notification ads at regular intervals
```
6. Switch back to Brave Browser. These logs should appear:
```
  [ads] Browser did enter foreground
  [ads] Start serving notification ads at regular intervals
  [ads] Maybe serve notification ad in ...
  [ads] Browser did become active
```

### Test case 9
Check Brave Ads logs:
1. Fresh install
2. Open NTP
3. Join Brave Rewards
4. Open NTP
  EXPECTATION: Following logs appears:
```
  [ads] Tab id <previous tab id> did become occluded
  [ads] Created tab with id <new tab id>
  [ads] Tab id <new tab id> did become focused
```
5. Restart the Browser
  EXPECTATION: Following logs appears:
```
  [ads] Browser did enter foreground
  [ads] Browser did become active
  [ads] Created tab with id #
  [ads] Tab id # did become focused
```
  There should NOT be content changed logs:
```
  [ads] Tab id # HTML content changed
  [ads] Tab id # text content changed
```

7. Navigate to `brave.com`
  EXPECTATION: Following logs appears:
```
  [ads] Tab id # did change
  [ads] Tab id # HTML content changed
  [ads] Tab id # text content changed
```
8. Click link on the page
  EXPECTATION: Following logs appears:
```
  [ads] Tab id # did change
  [ads] Tab id # HTML content changed
  [ads] Tab id # text content changed
```
9. Restart the Browser
  EXPECTATION: Following logs appears:
```
  [ads] Created tab with id #
  [ads] Tab id # did become focused
```
  There should NOT be content changed logs:
```
  [ads] Tab id # HTML content changed
  [ads] Tab id # text content changed
```
