### PR TITLE
Keep size delta for split view per tile

### DIFF
--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -24,6 +24,7 @@
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/url_sanitizer/url_sanitizer_service_factory.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -940,8 +941,8 @@ void NewSplitViewForTab(Browser* browser, std::optional<tabs::TabHandle> tab) {
 
   chrome::AddTabAt(browser, GURL("chrome://newtab"), new_tab_index,
                    /*foreground*/ true);
-  split_view_data->TileTabs(std::make_pair(
-      model->GetTabHandleAt(tab_index), model->GetTabHandleAt(new_tab_index)));
+  split_view_data->TileTabs({.first = model->GetTabHandleAt(tab_index),
+                             .second = model->GetTabHandleAt(new_tab_index)});
 }
 
 void TileTabs(Browser* browser, const std::vector<int>& indices) {
@@ -976,8 +977,8 @@ void TileTabs(Browser* browser, const std::vector<int>& indices) {
     std::swap(tab1, tab2);
   }
 
-  split_view_data->TileTabs(
-      std::make_pair(model->GetTabHandleAt(tab1), model->GetTabHandleAt(tab2)));
+  split_view_data->TileTabs({.first = model->GetTabHandleAt(tab1),
+                             .second = model->GetTabHandleAt(tab2)});
 }
 
 void BreakTiles(Browser* browser, const std::vector<int>& indices) {

--- a/browser/ui/tabs/split_view_browser_data.h
+++ b/browser/ui/tabs/split_view_browser_data.h
@@ -23,7 +23,25 @@ class SplitViewBrowserDataObserver;
 
 class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
  public:
-  using Tile = std::pair<tabs::TabHandle, tabs::TabHandle>;
+  struct Tile {
+    tabs::TabHandle first;
+    tabs::TabHandle second;
+
+    // A absolute value means that the split view for |first| and |second|
+    // should be resized by in pixel. When it's 0, the ratio between |first| and
+    // |second| would be 0.5.
+    int split_view_size_delta = 0;
+
+    bool operator<(const Tile& other) const {
+      return std::tie(first, second) < std::tie(other.first, other.second);
+    }
+    bool operator==(const Tile& other) const {
+      return std::tie(first, second) == std::tie(other.first, other.second);
+    }
+    bool operator!=(const Tile& other) const {
+      return std::tie(first, second) != std::tie(other.first, other.second);
+    }
+  };
 
   ~SplitViewBrowserData() override;
 
@@ -38,6 +56,9 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
   std::optional<Tile> GetTile(const tabs::TabHandle& tab) const;
 
   const std::vector<Tile>& tiles() const { return tiles_; }
+
+  void SetSizeDelta(const tabs::TabHandle& tab, int size_delta);
+  int GetSizeDelta(const tabs::TabHandle& tab);
 
   void AddObserver(SplitViewBrowserDataObserver* observer);
   void RemoveObserver(SplitViewBrowserDataObserver* observer);
@@ -78,7 +99,7 @@ class SplitViewBrowserData : public BrowserUserData<SplitViewBrowserData> {
 
   explicit SplitViewBrowserData(Browser* browser);
 
-  std::vector<Tile>::const_iterator FindTile(const tabs::TabHandle& tab);
+  std::vector<Tile>::iterator FindTile(const tabs::TabHandle& tab);
   std::vector<Tile>::const_iterator FindTile(const tabs::TabHandle& tab) const;
 
   void Transfer(SplitViewBrowserData* other, std::vector<Tile> tiles);

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -30,7 +30,8 @@ SplitViewTabStripModelAdapter::~SplitViewTabStripModelAdapter() = default;
 void SplitViewTabStripModelAdapter::MakeTiledTabsAdjacent(
     const SplitViewBrowserData::Tile& tile,
     bool move_right_tab) {
-  auto [tab1, tab2, _] = tile;
+  auto tab1 = tile.first;
+  auto tab2 = tile.second;
   auto index1 = model_->GetIndexOfTab(tab1);
   auto index2 = model_->GetIndexOfTab(tab2);
 
@@ -81,7 +82,8 @@ bool SplitViewTabStripModelAdapter::SynchronizeGroupedState(
 bool SplitViewTabStripModelAdapter::SynchronizePinnedState(
     const SplitViewBrowserData::Tile& tile,
     const tabs::TabHandle& source) {
-  auto [tab1, tab2, _] = tile;
+  auto tab1 = tile.first;
+  auto tab2 = tile.second;
   if (tab1 != source) {
     std::swap(tab1, tab2);
     CHECK(tab1 == source);
@@ -104,7 +106,8 @@ void SplitViewTabStripModelAdapter::TabDragEnded() {
   // the tiles.
   std::vector<SplitViewBrowserData::Tile> tiles_to_break;
   for (const auto& tile : split_view_browser_data_->tiles()) {
-    auto [tab1, tab2, _] = tile;
+    auto tab1 = tile.first;
+    auto tab2 = tile.second;
     int index1 = model_->GetIndexOfTab(tab1);
     int index2 = model_->GetIndexOfTab(tab2);
     if (index2 - index1 == 1) {
@@ -163,9 +166,9 @@ void SplitViewTabStripModelAdapter::OnTabInserted(
   }
 
   std::vector<int> indices_to_be_moved;
-  for (const auto& [tab1, tab2, _] : split_view_browser_data_->tiles()) {
-    auto lower_index = model_->GetIndexOfTab(tab1);
-    auto higher_index = model_->GetIndexOfTab(tab2);
+  for (const auto& tile : split_view_browser_data_->tiles()) {
+    auto lower_index = model_->GetIndexOfTab(tile.first);
+    auto higher_index = model_->GetIndexOfTab(tile.second);
     CHECK_LT(lower_index, higher_index);
 
     for (auto inserted_index : inserted_indices) {
@@ -234,11 +237,11 @@ void SplitViewTabStripModelAdapter::OnTabWillBeRemoved(
   // In case a tiled tab is removed, we need to remove the corresponding tile
   if (auto tab = model_->GetTabHandleAt(index);
       split_view_browser_data_->IsTabTiled(tab)) {
-    auto [tab1, tab2, _] = *split_view_browser_data_->GetTile(tab);
+    auto tile = *split_view_browser_data_->GetTile(tab);
 
     tiled_tabs_scheduled_to_be_removed_.emplace_back(
-        get_web_contents_from_tab_handle(tab1),
-        get_web_contents_from_tab_handle(tab2));
+        get_web_contents_from_tab_handle(tile.first),
+        get_web_contents_from_tab_handle(tile.second));
 
     split_view_browser_data_->BreakTile(tab);
   }

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -30,7 +30,7 @@ SplitViewTabStripModelAdapter::~SplitViewTabStripModelAdapter() = default;
 void SplitViewTabStripModelAdapter::MakeTiledTabsAdjacent(
     const SplitViewBrowserData::Tile& tile,
     bool move_right_tab) {
-  auto [tab1, tab2] = tile;
+  auto [tab1, tab2, _] = tile;
   auto index1 = model_->GetIndexOfTab(tab1);
   auto index2 = model_->GetIndexOfTab(tab2);
 
@@ -81,7 +81,7 @@ bool SplitViewTabStripModelAdapter::SynchronizeGroupedState(
 bool SplitViewTabStripModelAdapter::SynchronizePinnedState(
     const SplitViewBrowserData::Tile& tile,
     const tabs::TabHandle& source) {
-  auto [tab1, tab2] = tile;
+  auto [tab1, tab2, _] = tile;
   if (tab1 != source) {
     std::swap(tab1, tab2);
     CHECK(tab1 == source);
@@ -104,7 +104,7 @@ void SplitViewTabStripModelAdapter::TabDragEnded() {
   // the tiles.
   std::vector<SplitViewBrowserData::Tile> tiles_to_break;
   for (const auto& tile : split_view_browser_data_->tiles()) {
-    auto [tab1, tab2] = tile;
+    auto [tab1, tab2, _] = tile;
     int index1 = model_->GetIndexOfTab(tab1);
     int index2 = model_->GetIndexOfTab(tab2);
     if (index2 - index1 == 1) {
@@ -163,7 +163,7 @@ void SplitViewTabStripModelAdapter::OnTabInserted(
   }
 
   std::vector<int> indices_to_be_moved;
-  for (const auto& [tab1, tab2] : split_view_browser_data_->tiles()) {
+  for (const auto& [tab1, tab2, _] : split_view_browser_data_->tiles()) {
     auto lower_index = model_->GetIndexOfTab(tab1);
     auto higher_index = model_->GetIndexOfTab(tab2);
     CHECK_LT(lower_index, higher_index);
@@ -234,7 +234,7 @@ void SplitViewTabStripModelAdapter::OnTabWillBeRemoved(
   // In case a tiled tab is removed, we need to remove the corresponding tile
   if (auto tab = model_->GetTabHandleAt(index);
       split_view_browser_data_->IsTabTiled(tab)) {
-    auto [tab1, tab2] = *split_view_browser_data_->GetTile(tab);
+    auto [tab1, tab2, _] = *split_view_browser_data_->GetTile(tab);
 
     tiled_tabs_scheduled_to_be_removed_.emplace_back(
         get_web_contents_from_tab_handle(tab1),

--- a/browser/ui/tabs/test/split_view_browser_data_unittest.cc
+++ b/browser/ui/tabs/test/split_view_browser_data_unittest.cc
@@ -63,7 +63,7 @@ TEST_F(SplitViewBrowserDataUnitTest, TileTabs_AddsTile) {
   EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
   EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
 
-  data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_2.GetHandle()));
+  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
 
   EXPECT_TRUE(data().IsTabTiled(tab_1.GetHandle()));
   EXPECT_TRUE(data().IsTabTiled(tab_2.GetHandle()));
@@ -76,21 +76,21 @@ TEST_F(SplitViewBrowserDataUnitTest, TileTabs_WithAlreadyTiledTabIsError) {
   EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
   EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
 
-  data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_2.GetHandle()));
+  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
 
   ASSERT_TRUE(data().IsTabTiled(tab_1.GetHandle()));
   ASSERT_TRUE(data().IsTabTiled(tab_2.GetHandle()));
 
   auto tab_3 = CreateTabModel();
-  EXPECT_DEATH_IF_SUPPORTED(
-      data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_3.GetHandle())),
-      "");
+  EXPECT_DEATH_IF_SUPPORTED(data().TileTabs({.first = tab_1.GetHandle(),
+                                             .second = tab_3.GetHandle()}),
+                            "");
 }
 
 TEST_F(SplitViewBrowserDataUnitTest, BreakTile_RemovesTile) {
   auto tab_1 = CreateTabModel();
   auto tab_2 = CreateTabModel();
-  data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_2.GetHandle()));
+  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
 
   ASSERT_TRUE(data().IsTabTiled(tab_1.GetHandle()));
   ASSERT_TRUE(data().IsTabTiled(tab_2.GetHandle()));
@@ -99,7 +99,7 @@ TEST_F(SplitViewBrowserDataUnitTest, BreakTile_RemovesTile) {
   EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
   EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
 
-  data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_2.GetHandle()));
+  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
   data().BreakTile(tab_2.GetHandle());
   EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
   EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
@@ -114,11 +114,11 @@ TEST_F(SplitViewBrowserDataUnitTest, BreakTile_WithNonExistingTabIsError) {
 TEST_F(SplitViewBrowserDataUnitTest, FindTile) {
   auto tab_1 = CreateTabModel();
   auto tab_2 = CreateTabModel();
-  data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_2.GetHandle()));
+  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
 
-  EXPECT_EQ(0, std::distance(data().tiles_.cbegin(),
+  EXPECT_EQ(0, std::distance(data().tiles_.begin(),
                              data().FindTile(tab_1.GetHandle())));
-  EXPECT_EQ(0, std::distance(data().tiles_.cbegin(),
+  EXPECT_EQ(0, std::distance(data().tiles_.begin(),
                              data().FindTile(tab_2.GetHandle())));
 
   data().BreakTile(tab_2.GetHandle());
@@ -127,16 +127,16 @@ TEST_F(SplitViewBrowserDataUnitTest, FindTile) {
 
   auto tab_3 = CreateTabModel();
   auto tab_4 = CreateTabModel();
-  data().TileTabs(std::make_pair(tab_1.GetHandle(), tab_2.GetHandle()));
-  data().TileTabs(std::make_pair(tab_3.GetHandle(), tab_4.GetHandle()));
-  EXPECT_EQ(1, std::distance(data().tiles_.cbegin(),
+  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
+  data().TileTabs({.first = tab_3.GetHandle(), .second = tab_4.GetHandle()});
+  EXPECT_EQ(1, std::distance(data().tiles_.begin(),
                              data().FindTile(tab_3.GetHandle())));
-  EXPECT_EQ(1, std::distance(data().tiles_.cbegin(),
+  EXPECT_EQ(1, std::distance(data().tiles_.begin(),
                              data().FindTile(tab_4.GetHandle())));
 
   data().BreakTile(tab_1.GetHandle());
-  EXPECT_EQ(0, std::distance(data().tiles_.cbegin(),
+  EXPECT_EQ(0, std::distance(data().tiles_.begin(),
                              data().FindTile(tab_3.GetHandle())));
-  EXPECT_EQ(0, std::distance(data().tiles_.cbegin(),
+  EXPECT_EQ(0, std::distance(data().tiles_.begin(),
                              data().FindTile(tab_4.GetHandle())));
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -185,6 +185,8 @@ class BraveBrowserView : public BrowserView,
 
   tabs::TabHandle GetActiveTabHandle() const;
   bool IsActiveWebContentsTiled(const SplitViewBrowserData::Tile& tile) const;
+  void UpdateSplitViewSizeDelta(content::WebContents* old_contents,
+                                content::WebContents* new_contents);
   void UpdateContentsWebViewVisual();
   void UpdateContentsWebViewBorder();
   void UpdateSecondaryContentsWebViewVisibility();

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -36,6 +36,9 @@ class BraveContentsLayoutManager : public ContentsLayoutManager,
     split_view_browser_data_ = split_view_browser_data;
   }
 
+  int split_view_size_delta() const { return split_view_size_delta_; }
+  void set_split_view_size_delta(int delta) { split_view_size_delta_ = delta; }
+
   // When tile's second tab is the active web contents, we need to show the
   // tab after the first tab.
   void show_main_web_contents_at_tail(bool tail) {

--- a/browser/ui/views/frame/split_view_browsertest.cc
+++ b/browser/ui/views/frame/split_view_browsertest.cc
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/frame/brave_contents_layout_manager.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "content/public/test/browser_test.h"
@@ -142,4 +143,25 @@ IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest,
   EXPECT_EQ(tab_strip_model().GetWebContentsAt(
                 tab_strip_model().GetIndexOfTab(tile.first)),
             secondary_contents_view().web_contents());
+}
+
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewSizeDelta) {
+  // Given there are two tiles
+  brave::NewSplitViewForTab(browser());
+  chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
+  brave::NewSplitViewForTab(browser());
+
+  // When size delta is set
+  auto* browser_view = static_cast<BrowserView*>(browser()->window());
+  auto* contents_layout_manager = static_cast<BraveContentsLayoutManager*>(
+      browser_view->contents_container()->GetLayoutManager());
+  constexpr int kSizeDelta = 100;
+  contents_layout_manager->set_split_view_size_delta(kSizeDelta);
+
+  // Then these should be persisted during tab activation.
+  tab_strip_model().ActivateTabAt(0);
+  EXPECT_EQ(0, contents_layout_manager->split_view_size_delta());
+
+  tab_strip_model().ActivateTabAt(3);
+  EXPECT_EQ(kSizeDelta, contents_layout_manager->split_view_size_delta());
 }


### PR DESCRIPTION
This change keeps split view size delta in tile data, so that it can be restored when the a tab in a tile is activated.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38392

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

