### PR TITLE
[ads] Fixes brave News Inline orphaned ad events are not purged

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.h
+++ b/browser/brave_ads/tabs/ads_tab_helper.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_BROWSER_BRAVE_ADS_TABS_ADS_TAB_HELPER_H_
 #define BRAVE_BROWSER_BRAVE_ADS_TABS_ADS_TAB_HELPER_H_
 
+#include <optional>
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
@@ -110,7 +111,7 @@ class AdsTabHelper : public content::WebContentsObserver,
   std::vector<GURL> redirect_chain_;
   bool is_error_page_ = false;
 
-  bool is_browser_active_ = false;
+  std::optional<bool> is_browser_active_;
 
   base::WeakPtrFactory<AdsTabHelper> weak_factory_{this};
 

--- a/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.cc
@@ -128,11 +128,14 @@ void InlineContentAdHandler::CacheAdPlacement(const int32_t tab_id,
 
 void InlineContentAdHandler::PurgeOrphanedCachedAdPlacements(
     const int32_t tab_id) {
-  if (placement_ids_[tab_id].empty()) {
-    return;
-  }
+  BLOG(1,
+       "Purging orphaned inline content ad placements for tab id " << tab_id);
 
-  BLOG(1, "Purged orphaned inline content ad placements for tab id " << tab_id);
+  if (placement_ids_[tab_id].empty()) {
+    return BLOG(1,
+                "There are no orphaned inline content ad placements for tab id "
+                    << tab_id);
+  }
 
   PurgeOrphanedAdEvents(
       placement_ids_[tab_id],
@@ -148,7 +151,7 @@ void InlineContentAdHandler::PurgeOrphanedCachedAdPlacements(
                          << joined_placement_ids << " placement ids");
             }
 
-            BLOG(1, "Successfully purged orphaned inline content ad events for "
+            BLOG(1, "Purged orphaned inline content ad events for "
                         << joined_placement_ids << " placement ids");
           },
           placement_ids_[tab_id]));

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_for_mobile_test.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_for_mobile_test.cc
@@ -58,7 +58,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest,
 }
 
 TEST_F(BraveAdsNotificationAdForMobileIntegrationTest,
-       DoNotServeWhenUserBecomesActive) {
+       DoNotServeWhenUserBecomesActiveIfPermissionRulesAreDenied) {
   // Act & Assert
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd).Times(0);
 

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test.cc
@@ -48,7 +48,8 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, ServeAd) {
   ServeAd();
 }
 
-TEST_F(BraveAdsNotificationAdIntegrationTest, DoNotServe) {
+TEST_F(BraveAdsNotificationAdIntegrationTest,
+       DoNotServeIfPermissionRulesAreDenied) {
   // Act & Assert
   EXPECT_CALL(ads_client_mock_, RecordP2AEvents).Times(0);
 

--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -218,7 +218,7 @@ void AdsImpl::PurgeOrphanedAdEventsForType(
 
               BLOG(0, "Failed to purge orphaned ad events for " << ad_type);
             } else {
-              BLOG(1, "Successfully purged orphaned ad events for " << ad_type);
+              BLOG(1, "Purged orphaned ad events for " << ad_type);
             }
 
             std::move(callback).Run(success);

--- a/components/brave_ads/core/internal/application_state/browser_manager.h
+++ b/components/brave_ads/core/internal/application_state/browser_manager.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_APPLICATION_STATE_BROWSER_MANAGER_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_APPLICATION_STATE_BROWSER_MANAGER_H_
 
+#include <optional>
+
 #include "base/observer_list.h"
 #include "brave/components/brave_ads/core/internal/application_state/browser_manager_observer.h"
 #include "brave/components/brave_ads/core/public/client/ads_client_notifier_observer.h"
@@ -29,9 +31,9 @@ class BrowserManager final : public AdsClientNotifierObserver {
   void AddObserver(BrowserManagerObserver* observer);
   void RemoveObserver(BrowserManagerObserver* observer);
 
-  bool IsActive() const { return is_active_; }
+  bool IsActive() const { return is_active_.value_or(false); }
 
-  bool IsInForeground() const { return is_in_foreground_; }
+  bool IsInForeground() const { return is_in_foreground_.value_or(false); }
 
  private:
   void NotifyBrowserDidBecomeActive() const;
@@ -40,7 +42,8 @@ class BrowserManager final : public AdsClientNotifierObserver {
 
   void NotifyBrowserDidEnterForeground() const;
   void NotifyBrowserDidEnterBackground() const;
-  void LogBrowserForegroundState() const;
+  void InitializeBrowserBackgroundState();
+  void LogBrowserBackgroundState() const;
 
   // AdsClientNotifierObserver:
   void OnNotifyDidInitializeAds() override;
@@ -51,9 +54,9 @@ class BrowserManager final : public AdsClientNotifierObserver {
 
   base::ObserverList<BrowserManagerObserver> observers_;
 
-  bool is_active_ = false;
+  std::optional<bool> is_active_;
 
-  bool is_in_foreground_ = false;
+  std::optional<bool> is_in_foreground_;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc
+++ b/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc
@@ -84,7 +84,6 @@ TEST_F(BraveAdsBrowserManagerTest,
   NotifyDidInitializeAds();
 
   // Assert
-  EXPECT_TRUE(BrowserManager::GetInstance().IsActive());
   EXPECT_TRUE(BrowserManager::GetInstance().IsInForeground());
 }
 
@@ -97,7 +96,6 @@ TEST_F(BraveAdsBrowserManagerTest,
   NotifyDidInitializeAds();
 
   // Assert
-  EXPECT_FALSE(BrowserManager::GetInstance().IsActive());
   EXPECT_FALSE(BrowserManager::GetInstance().IsInForeground());
 }
 

--- a/components/brave_ads/core/internal/common/unittest/unittest_base.cc
+++ b/components/brave_ads/core/internal/common/unittest/unittest_base.cc
@@ -286,6 +286,8 @@ void UnitTestBase::SetUpIntegrationTestCallback(const bool success) {
 
   NotifyDidInitializeAds();
 
+  NotifyBrowserDidBecomeActive();
+
   task_environment_.RunUntilIdle();
 }
 

--- a/components/brave_ads/core/internal/serving/notification_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/notification_ad_serving_unittest.cc
@@ -25,6 +25,7 @@ class BraveAdsNotificationAdServingTest : public UnitTestBase {
     UnitTestBase::SetUp();
 
     NotifyDidInitializeAds();
+    NotifyBrowserDidBecomeActive();
   }
 
   void MaybeServeAd() {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38373

`InlineContentAdServing::MaybeServeAd` was invoking `TabManager::GetVisible()`, which was returning the incorrect `tab` for the currently visible tab. The placement id was then being cached by `InlineContentAdHandler::CacheAdPlacement` under the wrong id for this `tab`.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**IMPORTANT:** Please disable "Secure Keyboard Entry" in Terminal for macOS, or the browser will not have focus when launched. When you minimize or close the browser window on macOS, the browser is still considered to be in the foreground (this may be the same for Windows and Linux). **Please also test site visit suspend/resume and the media permission rule across multiple tabs**

- Confirm `Tab id # did change` appears in the log when navigating to a new URL
- Confirm `Created tab with id #` and `Tab id # did become focused`  appear in the log when opening a new tab
- Confirm `Created tab with id #` and `Tab id # did become focused`  appear in the log when restoring a tab, i.e., after relaunching the browser
- Confirm `Tab id # did become focused` appears in the log when focusing on an existing tab
- Confirm `Tab id # did become occluded` appears in the log when a tab becomes inactive.
- Confirm `Tab id # did become occluded` and `Tab id # was closed` appear in the log when closing a tab
- Confirm `Tab id # did become occluded`, `Tab id # was closed` and `There are no tabs` appear in the log when closing the last tab
- Confirm `Created tab with id #` and `Tab id # did become focused` appear in the log when launching the browser after closing the last tab
- Confirm `Tab id # did become occluded`, `Tab id # was closed` and `There are no tabs` appear in the log when closing the browser window
- Confirm `Created tab with id #` and `Tab id # did become focused` appear in the log when launching the browser after closing the browser window
- Confirm `Purging orphaned inline content ad placements for tab id #` and `Purged orphaned inline content ad events for ... placement ids` appear in the log when closing at tab with a served inline content ad
- Confirm `Purging orphaned inline content ad placements for tab id #` and `There are no orphaned inline content ad placements for tab id #` do not appear in the log when closing a tab with a viewed inline content ad
- Confirm orphaned inline content ads are purged when launching the browser
- Confirm `Browser did enter foreground` appears in the log when the browser is foregrounded
- Confirm `Browser did enter background` appears in the log when the browser is backgrounded
- Confirm `Browser did become active` appears in the log when the browser becomes active
- Confirm `Browser did resign active` appears in the log when the browser resigns active
- Confirm `Browser did enter foreground`, `Browser did become active`, `Created tab with id #` and `Tab id # did become focused` appear in the log when the browser is launched
- Confirm `Browser did become active` and `Tab id # did become focused` appear in the log when the browser is restored
- Confirm `Browser did resign active` and `Tab id # did become occluded` appear in the log when the browser is minimized
- Sanity test with multiple browser windows

**Known issues which will not be resolved as part of this issue**

- Confirm `Browser did enter foreground` and `Browser did become active` appear in the log when opting-out of all ads at brave://rewards and then opting-in to at least one ad **[The browser will stay inactive until you open a new tab or restart it, displaying the message, `Browser window is not active` when the user becomes active]**