### PR TITLE
[ads] Remove segment from search result ad confirmation token redemption payload

### DIFF
--- a/components/brave_ads/core/internal/account/account_unittest.cc
+++ b/components/brave_ads/core/internal/account/account_unittest.cc
@@ -376,45 +376,45 @@ TEST_F(BraveAdsAccountTest, GetStatement) {
   AdvanceClockTo(TimeFromString("31 October 2020"));
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("18 November 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   const TransactionInfo transaction_6 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_6);
 
   const TransactionInfo transaction_7 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_7);
 
   test::SaveTransactions(transactions);

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_unittest.cc
@@ -42,8 +42,8 @@ TEST_F(BraveAdsConfirmationsTest, ConfirmForRewardsUser) {
   test::RefillConfirmationTokens(/*count=*/1);
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act
   confirmations_->Confirm(transaction, /*user_data=*/{});
@@ -60,8 +60,8 @@ TEST_F(BraveAdsConfirmationsTest, ConfirmForNonRewardsUser) {
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act
   confirmations_->Confirm(transaction, /*user_data=*/{});

--- a/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_unittest_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_unittest_util.cc
@@ -18,8 +18,8 @@ std::optional<ConfirmationInfo> BuildNonRewardConfirmation(
   CHECK(!UserHasJoinedBraveRewards());
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      should_use_random_uuids);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, should_use_random_uuids);
   return BuildNonRewardConfirmation(transaction, /*user_data=*/{});
 }
 

--- a/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/non_reward/non_reward_confirmation_util_unittest.cc
@@ -36,8 +36,8 @@ TEST_F(BraveAdsNonRewardConfirmationUtilTest, BuildNonRewardConfirmation) {
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   ConfirmationInfo expected_confirmation;
@@ -68,8 +68,8 @@ TEST_F(BraveAdsNonRewardConfirmationUtilTest,
        DISABLED_DoNotBuildNonRewardConfirmationForRewardsUser) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_DEATH_IF_SUPPORTED(

--- a/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_unittest_util.cc
+++ b/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_unittest_util.cc
@@ -25,8 +25,8 @@ std::optional<ConfirmationInfo> BuildRewardConfirmation(
   CHECK(UserHasJoinedBraveRewards());
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      should_use_random_uuids);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, should_use_random_uuids);
   return BuildRewardConfirmation(token_generator, transaction,
                                  /*user_data=*/{});
 }

--- a/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_util_unittest.cc
@@ -64,8 +64,8 @@ TEST_F(BraveAdsRewardConfirmationUtilTest, BuildRewardConfirmation) {
   test::RefillConfirmationTokens(/*count=*/1);
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   const std::optional<ConfirmationInfo> confirmation = BuildRewardConfirmation(
@@ -117,8 +117,8 @@ TEST_F(BraveAdsRewardConfirmationUtilTest,
   test::MockTokenGenerator(token_generator_mock_, /*count=*/1);
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_FALSE(BuildRewardConfirmation(&token_generator_mock_, transaction,
@@ -129,8 +129,8 @@ TEST_F(BraveAdsRewardConfirmationUtilTest,
        DISABLED_DoNotBuildRewardConfirmationWithInvalidTokenGenerator) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_DEATH_IF_SUPPORTED(
@@ -157,8 +157,8 @@ TEST_F(BraveAdsRewardConfirmationUtilTest,
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_DEATH_IF_SUPPORTED(

--- a/components/brave_ads/core/internal/account/confirmations/user_data_builder/confirmation_user_data_builder_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/user_data_builder/confirmation_user_data_builder_unittest.cc
@@ -39,8 +39,8 @@ TEST_F(BraveAdsConfirmationUserDataBuilderTest,
        BuildConfirmationUserDataForRewardsUser) {
   // Arrange
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/false);
 
   // Act & Assert
@@ -83,8 +83,8 @@ TEST_F(BraveAdsConfirmationUserDataBuilderTest,
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/false);
 
   UserDataInfo expected_user_data;

--- a/components/brave_ads/core/internal/account/confirmations/user_data_builder/fixed/confirmation_fixed_user_data_builder_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/user_data_builder/fixed/confirmation_fixed_user_data_builder_unittest.cc
@@ -33,8 +33,8 @@ class BraveAdsFixedUserDataBuilderTest : public UnitTestBase {
 TEST_F(BraveAdsFixedUserDataBuilderTest, BuildFixedUserDataForRewardsUser) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   const base::Value::Dict expected_user_data = base::test::ParseJsonDict(
@@ -63,8 +63,8 @@ TEST_F(BraveAdsFixedUserDataBuilderTest, BuildFixedUserDataForNonRewardsUser) {
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act
   const base::Value::Dict user_data = BuildFixedUserData(transaction);

--- a/components/brave_ads/core/internal/account/statement/ads_received_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/ads_received_util_unittest.cc
@@ -23,20 +23,20 @@ TEST_F(BraveAdsAdsReceivedUtilTest, GetAdsReceivedForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const base::Time from_time = Now();
@@ -44,19 +44,19 @@ TEST_F(BraveAdsAdsReceivedUtilTest, GetAdsReceivedForDateRange) {
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transaction_5.ad_type = AdType::kNewTabPageAd;
   transactions.push_back(transaction_5);
 
   TransactionInfo transaction_6 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transaction_6.ad_type = AdType::kInlineContentAd;
   transactions.push_back(transaction_6);
 
@@ -72,12 +72,12 @@ TEST_F(BraveAdsAdsReceivedUtilTest, DoNotGetAdsSummaryForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 

--- a/components/brave_ads/core/internal/account/statement/ads_summary_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/ads_summary_util_unittest.cc
@@ -24,20 +24,20 @@ TEST_F(BraveAdsAdsSummaryUtilTest, GetAdsSummaryForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const base::Time from_time = Now();
@@ -45,19 +45,19 @@ TEST_F(BraveAdsAdsSummaryUtilTest, GetAdsSummaryForDateRange) {
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transaction_5.ad_type = AdType::kNewTabPageAd;
   transactions.push_back(transaction_5);
 
   TransactionInfo transaction_6 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transaction_6.ad_type = AdType::kInlineContentAd;
   transactions.push_back(transaction_6);
 
@@ -76,12 +76,12 @@ TEST_F(BraveAdsAdsSummaryUtilTest, DoNotGetAdsSummaryForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 

--- a/components/brave_ads/core/internal/account/statement/earnings_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/earnings_util_unittest.cc
@@ -23,34 +23,34 @@ TEST_F(BraveAdsEarningsUtilTest, GetUnreconciledEarnings) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.04, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.04, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   // Act & Assert
@@ -72,45 +72,45 @@ TEST_F(BraveAdsEarningsUtilTest, GetReconciledEarningsForThisMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.04, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.04, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   const TransactionInfo transaction_6 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_6);
 
   const TransactionInfo transaction_7 = test::BuildTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_7);
 
@@ -126,34 +126,34 @@ TEST_F(BraveAdsEarningsUtilTest,
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.04, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.04, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   // Act & Assert
@@ -167,51 +167,51 @@ TEST_F(BraveAdsEarningsUtilTest, GetReconciledEarningsForLastMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.04, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.04, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   const TransactionInfo transaction_5 = test::BuildTransaction(
-      /*value=*/0.07, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.07, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_6 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_6);
 
   const TransactionInfo transaction_7 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_7);
 
   const TransactionInfo transaction_8 = test::BuildTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_8);
 
@@ -227,39 +227,39 @@ TEST_F(BraveAdsEarningsUtilTest,
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.04, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.04, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   const TransactionInfo transaction_5 = test::BuildTransaction(
-      /*value=*/0.05, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.05, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   const TransactionInfo transaction_6 = test::BuildTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_6);
 

--- a/components/brave_ads/core/internal/account/statement/next_payment_date_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/next_payment_date_util_unittest.cc
@@ -35,8 +35,8 @@ TEST_F(BraveAdsNextPaymentDateUtilTest,
 
   TransactionList transactions;
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 
@@ -76,8 +76,8 @@ TEST_F(BraveAdsNextPaymentDateUtilTest,
 
   TransactionList transactions;
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 

--- a/components/brave_ads/core/internal/account/statement/statement_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/statement_unittest.cc
@@ -26,14 +26,14 @@ TEST_F(BraveAdsStatementTest, GetForTransactionsThisMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   test::SaveTransactions(transactions);
@@ -63,50 +63,50 @@ TEST_F(BraveAdsStatementTest,
   AdvanceClockTo(TimeFromString("31 October 2020"));
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("18 November 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   const TransactionInfo transaction_6 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_6);
 
   const TransactionInfo transaction_7 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_7);
 
   const TransactionInfo transaction_8 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_8);
 
   test::SaveTransactions(transactions);
@@ -136,37 +136,37 @@ TEST_F(BraveAdsStatementTest, GetForTransactionsSplitOverTwoYears) {
   AdvanceClockTo(TimeFromString("31 December 2020"));
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("1 January 2021"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   const TransactionInfo transaction_6 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_6);
 
   test::SaveTransactions(transactions);
@@ -215,14 +215,14 @@ TEST_F(BraveAdsStatementTest, GetWithFilteredTransactions) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transaction_2.ad_type = AdType::kNewTabPageAd;
   transactions.push_back(transaction_2);
@@ -230,14 +230,14 @@ TEST_F(BraveAdsStatementTest, GetWithFilteredTransactions) {
   AdvanceClockTo(TimeFromString("18 November 2020"));
 
   const TransactionInfo transaction_3 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transaction_4.ad_type = AdType::kNewTabPageAd;
   transactions.push_back(transaction_4);
 

--- a/components/brave_ads/core/internal/account/statement/statement_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/statement_util_unittest.cc
@@ -42,36 +42,36 @@ TEST_F(BraveAdsStatementUtilTest, GetEstimatedEarningsForThisMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   const TransactionInfo transaction_5 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
   TransactionInfo transaction_6 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transaction_6.ad_type = AdType::kNewTabPageAd;
   transactions.push_back(transaction_6);
 
@@ -90,33 +90,33 @@ TEST_F(BraveAdsStatementUtilTest, GetEstimatedEarningsForLastMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   TransactionInfo transaction_2 = test::BuildTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transaction_2.ad_type = AdType::kNewTabPageAd;
   transactions.push_back(transaction_2);
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   const TransactionInfo transaction_5 = test::BuildTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_5);
 
@@ -135,25 +135,25 @@ TEST_F(BraveAdsStatementUtilTest, GetAdsReceivedThisMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   // Act & Assert
@@ -167,25 +167,25 @@ TEST_F(BraveAdsStatementUtilTest, GetAdsSummaryThisMonth) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.03, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
   const TransactionInfo transaction_4 = test::BuildUnreconciledTransaction(
-      /*value=*/0.02, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.02, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_4);
 
   // Act & Assert

--- a/components/brave_ads/core/internal/account/transactions/reconciled_transactions_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/transactions/reconciled_transactions_util_unittest.cc
@@ -23,8 +23,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest,
 
   TransactionList transactions;
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 
@@ -39,8 +39,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest,
 
   TransactionList transactions;
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
@@ -56,8 +56,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest,
 
   TransactionList transactions;
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 
@@ -74,8 +74,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest,
 
   TransactionList transactions;
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 
   // Act & Assert
@@ -87,8 +87,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest, DidReconcileTransaction) {
   AdvanceClockTo(TimeFromString("5 November 2020"));
 
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
 
   // Act & Assert
@@ -100,8 +100,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest, WasTransactionNotReconciled) {
   AdvanceClockTo(TimeFromString("5 November 2020"));
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
 
   // Act & Assert
   EXPECT_FALSE(DidReconcileTransaction(transaction));
@@ -113,8 +113,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest,
   AdvanceClockTo(TimeFromString("5 November 2020"));
 
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
 
   // Act & Assert
@@ -128,8 +128,8 @@ TEST_F(BraveAdsReconciledTransactionsUtilTest,
   AdvanceClockTo(TimeFromString("Sat, 20 Aug 2016 02:52"));  // Hello Elica!!!
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
 
   // Act & Assert
   EXPECT_FALSE(DidReconcileTransactionWithinDateRange(

--- a/components/brave_ads/core/internal/account/transactions/transactions_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_database_table_unittest.cc
@@ -35,14 +35,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, SaveTransactions) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression, DistantFuture(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/DistantFuture(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockBy(base::Days(5));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kClicked,
+      /*value=*/0.03, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
@@ -62,8 +63,8 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, DoNotSaveDuplicateTransactions) {
   TransactionList transactions;
 
   const TransactionInfo transaction = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*reconciled_at=*/Now(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/Now(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction);
 
@@ -84,14 +85,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, GetTransactionsForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression, DistantFuture(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/DistantFuture(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockBy(base::Days(5));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kClicked,
+      /*value=*/0.03, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
@@ -110,12 +112,13 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, ReconcileTransactions) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression, DistantFuture(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/DistantFuture(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kClicked,
+      /*value=*/0.03, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
@@ -150,12 +153,13 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, DeleteTransactions) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression, DistantFuture(),
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*reconciled_at=*/DistantFuture(),
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kClicked,
+      /*value=*/0.03, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 

--- a/components/brave_ads/core/internal/account/transactions/transactions_unittest.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_unittest.cc
@@ -45,20 +45,20 @@ TEST_F(BraveAdsTransactionsTest, GetForDateRange) {
   AdvanceClockTo(TimeFromString("31 August 2019"));  //
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockTo(
       TimeFromUTCString("11 September 2019"));  // A legendary moment.
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kDismissed,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kDismissed,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
   const TransactionInfo transaction_3 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kClicked,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_3);
 
@@ -76,12 +76,12 @@ TEST_F(BraveAdsTransactionsTest, RemoveAll) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.0, ConfirmationType::kDismissed,
+      /*value=*/0.0, AdType::kNotificationAd, ConfirmationType::kDismissed,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 

--- a/components/brave_ads/core/internal/account/transactions/transactions_unittest_util.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_unittest_util.cc
@@ -24,6 +24,7 @@ void SaveTransactions(const TransactionList& transactions) {
 }
 
 TransactionInfo BuildTransaction(const double value,
+                                 const AdType ad_type,
                                  const ConfirmationType confirmation_type,
                                  const base::Time reconciled_at,
                                  const bool should_use_random_uuids) {
@@ -33,9 +34,9 @@ TransactionInfo BuildTransaction(const double value,
   transaction.created_at = Now();
   transaction.creative_instance_id =
       GetConstantId(should_use_random_uuids, kCreativeInstanceId);
-  transaction.value = value;
   transaction.segment = kSegment;
-  transaction.ad_type = AdType::kNotificationAd;
+  transaction.value = value;
+  transaction.ad_type = ad_type;
   transaction.confirmation_type = confirmation_type;
   if (!reconciled_at.is_null()) {
     transaction.reconciled_at = reconciled_at;
@@ -46,10 +47,11 @@ TransactionInfo BuildTransaction(const double value,
 
 TransactionInfo BuildUnreconciledTransaction(
     const double value,
+    const AdType ad_type,
     const ConfirmationType confirmation_type,
     const bool should_use_random_uuids) {
-  return BuildTransaction(value, confirmation_type, /*reconciled_at=*/{},
-                          should_use_random_uuids);
+  return BuildTransaction(value, ad_type, confirmation_type,
+                          /*reconciled_at=*/{}, should_use_random_uuids);
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/account/transactions/transactions_unittest_util.h
+++ b/components/brave_ads/core/internal/account/transactions/transactions_unittest_util.h
@@ -18,10 +18,12 @@ namespace brave_ads::test {
 void SaveTransactions(const TransactionList& transactions);
 
 TransactionInfo BuildTransaction(double value,
+                                 AdType ad_type,
                                  ConfirmationType confirmation_type,
                                  base::Time reconciled_at,
                                  bool should_use_random_uuids);
 TransactionInfo BuildUnreconciledTransaction(double value,
+                                             AdType ad_type,
                                              ConfirmationType confirmation_type,
                                              bool should_use_random_uuids);
 

--- a/components/brave_ads/core/internal/account/transactions/transactions_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_util_unittest.cc
@@ -23,14 +23,14 @@ TEST_F(BraveAdsTransactionsUtilTest, GetTransactionsForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   AdvanceClockTo(TimeFromString("25 December 2020"));
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kClicked,
+      /*value=*/0.03, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 
@@ -49,12 +49,12 @@ TEST_F(BraveAdsTransactionsUtilTest, DoNotGetTransactionsForDateRange) {
   TransactionList transactions;
 
   const TransactionInfo transaction_1 = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_1);
 
   const TransactionInfo transaction_2 = test::BuildUnreconciledTransaction(
-      /*value=*/0.03, ConfirmationType::kClicked,
+      /*value=*/0.03, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/true);
   transactions.push_back(transaction_2);
 

--- a/components/brave_ads/core/internal/account/user_data/fixed/created_at_timestamp_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/created_at_timestamp_user_data_unittest.cc
@@ -29,8 +29,8 @@ TEST_F(BraveAdsCreatedAtTimestampUserDataTest,
        BuildCreatedAtTimestampUserDataForRewardsUser) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
 
   // Act & Assert
   EXPECT_EQ(base::test::ParseJsonDict(
@@ -47,8 +47,8 @@ TEST_F(BraveAdsCreatedAtTimestampUserDataTest,
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/true);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/true);
 
   // Act & Assert
   EXPECT_TRUE(BuildCreatedAtTimestampUserData(transaction).empty());

--- a/components/brave_ads/core/internal/account/user_data/fixed/rotating_hash_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/rotating_hash_user_data_unittest.cc
@@ -32,8 +32,8 @@ TEST_F(BraveAdsRotatingHashUserDataTest,
   MockDeviceId();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_EQ(base::test::ParseJsonDict(
@@ -52,8 +52,8 @@ TEST_F(BraveAdsRotatingHashUserDataTest,
   MockDeviceId();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_TRUE(BuildRotatingHashUserData(transaction).empty());
@@ -63,8 +63,8 @@ TEST_F(BraveAdsRotatingHashUserDataTest,
        DoNotBuildRotatingHashUserDataIfMissingDeviceId) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_EQ(base::Value::Dict(), BuildRotatingHashUserData(transaction));

--- a/components/brave_ads/core/internal/account/user_data/fixed/rotating_hash_user_data_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/rotating_hash_user_data_util_unittest.cc
@@ -23,8 +23,8 @@ TEST_F(BraveAdsRotatingHashUserDataUtilTest,
   AdvanceClockTo(TimeFromUTCString("2 June 2022 11:00"));
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_FALSE(BuildRotatingHash(transaction));
@@ -37,8 +37,8 @@ TEST_F(BraveAdsRotatingHashUserDataUtilTest, BuildRotatingHash) {
   AdvanceClockTo(TimeFromUTCString("2 June 2022 11:00"));
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_EQ("j9D7eKSoPLYNfxkG2Mx+SbgKJ9hcKg1QwDB8B5qxlpk=",
@@ -51,8 +51,8 @@ TEST_F(BraveAdsRotatingHashUserDataUtilTest,
   MockDeviceId();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   AdvanceClockTo(TimeFromUTCString("2 June 2022 11:00"));
 
@@ -72,8 +72,8 @@ TEST_F(BraveAdsRotatingHashUserDataUtilTest,
   MockDeviceId();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   AdvanceClockTo(TimeFromUTCString("2 June 2022 11:00"));
 
@@ -93,8 +93,8 @@ TEST_F(BraveAdsRotatingHashUserDataUtilTest,
   MockDeviceId();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   const std::optional<std::string> rotating_hash_before =
       BuildRotatingHash(transaction);

--- a/components/brave_ads/core/internal/account/user_data/fixed/segment_user_data.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/segment_user_data.cc
@@ -21,7 +21,8 @@ base::Value::Dict BuildSegmentUserData(const TransactionInfo& transaction) {
     return user_data;
   }
 
-  if (!transaction.segment.empty()) {
+  if (transaction.ad_type != AdType::kSearchResultAd &&
+      !transaction.segment.empty()) {
     user_data.Set(kSegmentKey, transaction.segment);
   }
 

--- a/components/brave_ads/core/internal/account/user_data/fixed/segment_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/segment_user_data_unittest.cc
@@ -33,6 +33,20 @@ TEST_F(BraveAdsSegmentUserDataTest, BuildSegmentUserDataForRewardsUser) {
 }
 
 TEST_F(BraveAdsSegmentUserDataTest,
+       DoNotBuildSearchResultAdSegmentUserDataForRewardsUser) {
+  // Arrange
+  const TransactionInfo transaction = test::BuildUnreconciledTransaction(
+      /*value=*/0.01, AdType::kSearchResultAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
+
+  // Act
+  const base::Value::Dict segment_user_data = BuildSegmentUserData(transaction);
+
+  // Assert
+  EXPECT_TRUE(segment_user_data.empty());
+}
+
+TEST_F(BraveAdsSegmentUserDataTest,
        DoNotBuildSegmentUserDataForNonRewardsUser) {
   // Arrange
   test::DisableBraveRewards();
@@ -41,16 +55,22 @@ TEST_F(BraveAdsSegmentUserDataTest,
       /*value=*/0.01, ConfirmationType::kViewedImpression,
       /*should_use_random_uuids=*/false);
 
-  // Act & Assert
-  EXPECT_TRUE(BuildSegmentUserData(transaction).empty());
+  // Act
+  const base::Value::Dict segment_user_data = BuildSegmentUserData(transaction);
+
+  // Assert
+  EXPECT_TRUE(segment_user_data.empty());
 }
 
 TEST_F(BraveAdsSegmentUserDataTest, DoNotBuildSegmentUserDataIfNoTargeting) {
   // Arrange
   const TransactionInfo transaction;
 
+  // Act
+  const base::Value::Dict segment_user_data = BuildSegmentUserData(transaction);
+
   // Act & Assert
-  EXPECT_TRUE(BuildSegmentUserData(transaction).empty());
+  EXPECT_TRUE(segment_user_data.empty());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/user_data/fixed/segment_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/segment_user_data_unittest.cc
@@ -20,8 +20,8 @@ class BraveAdsSegmentUserDataTest : public UnitTestBase {};
 TEST_F(BraveAdsSegmentUserDataTest, BuildSegmentUserDataForRewardsUser) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_EQ(base::test::ParseJsonDict(
@@ -52,8 +52,8 @@ TEST_F(BraveAdsSegmentUserDataTest,
   test::DisableBraveRewards();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act
   const base::Value::Dict segment_user_data = BuildSegmentUserData(transaction);

--- a/components/brave_ads/core/internal/account/user_data/fixed/top_segment_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/top_segment_user_data_unittest.cc
@@ -43,8 +43,8 @@ TEST_F(BraveAdsTopSegmentUserDataTest, BuildTopSegmentUserDataForRewardsUser) {
   task_environment_.RunUntilIdle();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_EQ(base::test::ParseJsonDict(
@@ -68,8 +68,8 @@ TEST_F(BraveAdsTopSegmentUserDataTest,
   task_environment_.RunUntilIdle();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_TRUE(BuildTopSegmentUserData(transaction).empty());
@@ -82,7 +82,7 @@ TEST_F(BraveAdsTopSegmentUserDataTest,
   task_environment_.RunUntilIdle();
 
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kClicked,
+      /*value=*/0.01, AdType::kNotificationAd, ConfirmationType::kClicked,
       /*should_use_random_uuids=*/false);
 
   // Act & Assert
@@ -93,8 +93,8 @@ TEST_F(BraveAdsTopSegmentUserDataTest,
        DoNotBuildTopSegmentUserDataIfNoTargeting) {
   // Arrange
   const TransactionInfo transaction = test::BuildUnreconciledTransaction(
-      /*value=*/0.01, ConfirmationType::kViewedImpression,
-      /*should_use_random_uuids=*/false);
+      /*value=*/0.01, AdType::kNotificationAd,
+      ConfirmationType::kViewedImpression, /*should_use_random_uuids=*/false);
 
   // Act & Assert
   EXPECT_EQ(base::test::ParseJsonDict(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38393

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Confirm `segment` is not sent as part of the payload for non-Rewards users
- Confirm `segment` is not sent when redeeming search result ad confirmation tokens for Brave Rewards users
- Confirm `segment` is sent when redeeming inline content ad confirmation tokens for Brave Rewards users
- Confirm `segment` is sent when redeeming push notification ad confirmation tokens for Brave Rewards users
- Confirm `segment` is sent when redeeming new tab takeover ad confirmation tokens for Brave Rewards users
