### PR TITLE
[Android] fix multiwindow merge page not showing in same window from settings (uplift to 1.67.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -1990,6 +1990,19 @@ public abstract class BraveActivity extends ChromeActivity
         throw new BraveActivityNotFoundException("BraveActivity Not Found");
     }
 
+    @NonNull
+    public static BraveActivity getBraveActivityFromTaskId(int taskId)
+            throws BraveActivityNotFoundException {
+
+        for (Activity ref : ApplicationStatus.getRunningActivities()) {
+            if (!BraveActivity.class.isInstance(ref) || ref.getTaskId() != taskId) continue;
+
+            return (BraveActivity) ref;
+        }
+
+        throw new BraveActivityNotFoundException("BraveActivity Not Found");
+    }
+
     @Override
     public void onNewIntent(Intent intent) {
         super.onNewIntent(intent);

--- a/android/java/org/chromium/chrome/browser/multiwindow/BraveMultiWindowUtils.java
+++ b/android/java/org/chromium/chrome/browser/multiwindow/BraveMultiWindowUtils.java
@@ -74,7 +74,8 @@ public class BraveMultiWindowUtils extends MultiWindowUtils {
     public static void mergeWindows(Activity activity) {
         try {
             MultiInstanceManager multiInstanceManager =
-                    BraveActivity.getBraveActivity().getMultiInstanceManager();
+                    BraveActivity.getBraveActivityFromTaskId(activity.getTaskId())
+                            .getMultiInstanceManager();
             if (multiInstanceManager != null) {
                 multiInstanceManager.handleMenuOrKeyboardAction(
                         org.chromium.chrome.R.id.move_to_other_window_menu_id, false);


### PR DESCRIPTION
Uplift of #23673
Resolves https://github.com/brave/brave-browser/issues/38277

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.