### PR TITLE
[ads] Fixes brave News Inline orphaned ad events are not purged - 1.67.x

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -82,7 +82,7 @@ bool AdsTabHelper::UserHasJoinedBraveRewards() const {
 }
 
 bool AdsTabHelper::IsVisible() const {
-  return is_web_contents_visible_ && is_browser_active_;
+  return is_web_contents_visible_ && is_browser_active_.value_or(false);
 }
 
 bool AdsTabHelper::IsNewNavigation(
@@ -320,21 +320,33 @@ void AdsTabHelper::WebContentsDestroyed() {
 
 #if !BUILDFLAG(IS_ANDROID)
 void AdsTabHelper::OnBrowserSetLastActive(Browser* browser) {
-  const bool last_is_browser_active = is_browser_active_;
-  is_browser_active_ = browser->tab_strip_model()->GetIndexOfWebContents(
-                           web_contents()) != TabStripModel::kNoTab;
-  if (last_is_browser_active != is_browser_active_) {
-    MaybeNotifyBrowserDidBecomeActive();
+  if (is_browser_active_ && *is_browser_active_) {
+    // Already active.
+    return;
   }
+
+  is_browser_active_ = true;
+
+  MaybeNotifyBrowserDidBecomeActive();
+
+  // Maybe notify tab change after the browser active state changes because
+  // `OnVisibilityChanged` can be called before `OnBrowserSetLastActive`.
+  MaybeNotifyTabDidChange();
 }
 
 void AdsTabHelper::OnBrowserNoLongerActive(Browser* browser) {
-  const bool last_is_browser_active = is_browser_active_;
-  is_browser_active_ = browser->tab_strip_model()->GetIndexOfWebContents(
-                           web_contents()) == TabStripModel::kNoTab;
-  if (last_is_browser_active != is_browser_active_) {
-    MaybeNotifyBrowserDidResignActive();
+  if (is_browser_active_ && !*is_browser_active_) {
+    // Already inactive.
+    return;
   }
+
+  is_browser_active_ = false;
+
+  MaybeNotifyBrowserDidResignActive();
+
+  // Maybe notify tab change after the browser active state changes because
+  // `OnVisibilityChanged` can be called before `OnBrowserNoLongerActive`.
+  MaybeNotifyTabDidChange();
 }
 #endif
 

--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -55,13 +55,9 @@ AdsTabHelper::AdsTabHelper(content::WebContents* web_contents)
 #if !BUILDFLAG(IS_ANDROID)
   // See "background_helper_android.h" for Android.
   BrowserList::AddObserver(this);
-
-  OnBrowserSetLastActive(BrowserList::GetInstance()->GetLastActive());
-#else
-  // Set `is_browser_active_` to `true` because `BrowserList` class is not
-  // available on Android.
-  is_browser_active_ = true;
 #endif  // !BUILDFLAG(IS_ANDROID)
+
+  MaybeSetBrowserIsActive();
 
   OnVisibilityChanged(web_contents->GetVisibility());
 }
@@ -83,6 +79,36 @@ bool AdsTabHelper::UserHasJoinedBraveRewards() const {
 
 bool AdsTabHelper::IsVisible() const {
   return is_web_contents_visible_ && is_browser_active_.value_or(false);
+}
+
+void AdsTabHelper::MaybeSetBrowserIsActive() {
+  if (is_browser_active_ && *is_browser_active_) {
+    // Already active.
+    return;
+  }
+
+  is_browser_active_ = true;
+
+  MaybeNotifyBrowserDidBecomeActive();
+
+  // Maybe notify tab change after the browser active state changes because
+  // `OnVisibilityChanged` can be called before `OnBrowserSetLastActive`.
+  MaybeNotifyTabDidChange();
+}
+
+void AdsTabHelper::MaybeSetBrowserIsNoLongerActive() {
+  if (is_browser_active_ && !*is_browser_active_) {
+    // Already inactive.
+    return;
+  }
+
+  is_browser_active_ = false;
+
+  MaybeNotifyBrowserDidResignActive();
+
+  // Maybe notify tab change after the browser active state changes because
+  // `OnVisibilityChanged` can be called before `OnBrowserNoLongerActive`.
+  MaybeNotifyTabDidChange();
 }
 
 bool AdsTabHelper::IsNewNavigation(
@@ -319,34 +345,12 @@ void AdsTabHelper::WebContentsDestroyed() {
 }
 
 #if !BUILDFLAG(IS_ANDROID)
-void AdsTabHelper::OnBrowserSetLastActive(Browser* browser) {
-  if (is_browser_active_ && *is_browser_active_) {
-    // Already active.
-    return;
-  }
-
-  is_browser_active_ = true;
-
-  MaybeNotifyBrowserDidBecomeActive();
-
-  // Maybe notify tab change after the browser active state changes because
-  // `OnVisibilityChanged` can be called before `OnBrowserSetLastActive`.
-  MaybeNotifyTabDidChange();
+void AdsTabHelper::OnBrowserSetLastActive(Browser* /*browser*/) {
+  MaybeSetBrowserIsActive();
 }
 
-void AdsTabHelper::OnBrowserNoLongerActive(Browser* browser) {
-  if (is_browser_active_ && !*is_browser_active_) {
-    // Already inactive.
-    return;
-  }
-
-  is_browser_active_ = false;
-
-  MaybeNotifyBrowserDidResignActive();
-
-  // Maybe notify tab change after the browser active state changes because
-  // `OnVisibilityChanged` can be called before `OnBrowserNoLongerActive`.
-  MaybeNotifyTabDidChange();
+void AdsTabHelper::OnBrowserNoLongerActive(Browser* /*browser*/) {
+  MaybeSetBrowserIsNoLongerActive();
 }
 #endif
 

--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -161,13 +161,13 @@ void AdsTabHelper::MaybeNotifyTabDidChange() {
     return;
   }
 
-  if (is_restoring_ || !is_new_navigation_) {
-    // Don't notify content changes if the tab was restored or was a previously
-    // committed navigation.
+  if (redirect_chain_.empty()) {
+    // Don't notify content changes if the tab redirect chain is empty.
     return;
   }
 
   ads_service_->NotifyTabDidChange(tab_id_.id(), redirect_chain_,
+                                   is_new_navigation_, is_restoring_,
                                    is_error_page_, IsVisible());
 }
 

--- a/browser/brave_ads/tabs/ads_tab_helper.h
+++ b/browser/brave_ads/tabs/ads_tab_helper.h
@@ -50,6 +50,9 @@ class AdsTabHelper : public content::WebContentsObserver,
 
   bool IsVisible() const;
 
+  void MaybeSetBrowserIsActive();
+  void MaybeSetBrowserIsNoLongerActive();
+
   bool IsNewNavigation(content::NavigationHandle* navigation_handle);
 
   bool IsErrorPage(content::NavigationHandle* navigation_handle);

--- a/browser/brave_ads/tabs/ads_tab_helper.h
+++ b/browser/brave_ads/tabs/ads_tab_helper.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_BROWSER_BRAVE_ADS_TABS_ADS_TAB_HELPER_H_
 #define BRAVE_BROWSER_BRAVE_ADS_TABS_ADS_TAB_HELPER_H_
 
+#include <optional>
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
@@ -110,7 +111,7 @@ class AdsTabHelper : public content::WebContentsObserver,
   std::vector<GURL> redirect_chain_;
   bool is_error_page_ = false;
 
-  bool is_browser_active_ = false;
+  std::optional<bool> is_browser_active_;
 
   base::WeakPtrFactory<AdsTabHelper> weak_factory_{this};
 

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -231,12 +231,15 @@ class AdsService : public KeyedService {
   // Invoked when a browser tab is updated with the specified `redirect_chain`
   // containing a list of redirect URLs that occurred on the way to the current
   // page. The current page is the last one in the list (so even when there's no
-  // redirect, there should be one entry in the list). `is_error_page` should be
-  // set to `true` if an error occurred otherwise should be set to `false`.
-  // `is_visible` should be set to `true` if `tab_id` refers to the currently
-  // visible tab otherwise should be set to `false`.
+  // redirect, there should be one entry in the list). `is_restoring` should be
+  // set to `true` if the page is restoring otherwise should be set to `false`.
+  // `is_error_page` should be set to `true` if an error occurred otherwise
+  // should be set to `false`. `is_visible` should be set to `true` if `tab_id`
+  // refers to the currently visible tab otherwise should be set to `false`.
   virtual void NotifyTabDidChange(int32_t tab_id,
                                   const std::vector<GURL>& redirect_chain,
+                                  bool is_new_navigation,
+                                  bool is_restoring,
                                   bool is_error_page,
                                   bool is_visible) = 0;
 

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1364,11 +1364,14 @@ void AdsServiceImpl::NotifyTabDidStopPlayingMedia(const int32_t tab_id) {
 
 void AdsServiceImpl::NotifyTabDidChange(const int32_t tab_id,
                                         const std::vector<GURL>& redirect_chain,
+                                        const bool is_new_navigation,
+                                        const bool is_restoring,
                                         const bool is_error_page,
                                         const bool is_visible) {
   if (bat_ads_client_notifier_remote_.is_bound()) {
     bat_ads_client_notifier_remote_->NotifyTabDidChange(
-        tab_id, redirect_chain, is_error_page, is_visible);
+        tab_id, redirect_chain, is_new_navigation, is_restoring, is_error_page,
+        is_visible);
   }
 }
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -278,6 +278,8 @@ class AdsServiceImpl : public AdsService,
   void NotifyTabDidStopPlayingMedia(int32_t tab_id) override;
   void NotifyTabDidChange(int32_t tab_id,
                           const std::vector<GURL>& redirect_chain,
+                          bool is_new_navigation,
+                          bool is_restoring,
                           bool is_error_page,
                           bool is_visible) override;
   void NotifyDidCloseTab(int32_t tab_id) override;

--- a/components/brave_ads/browser/ads_service_mock.h
+++ b/components/brave_ads/browser/ads_service_mock.h
@@ -124,6 +124,8 @@ class AdsServiceMock : public AdsService {
               NotifyTabDidChange,
               (int32_t tab_id,
                const std::vector<GURL>& redirect_chain,
+               bool is_new_navigation,
+               bool is_restoring,
                bool is_error_page,
                bool is_visible));
   MOCK_METHOD(void, NotifyDidCloseTab, (int32_t tab_id));

--- a/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.cc
@@ -128,11 +128,14 @@ void InlineContentAdHandler::CacheAdPlacement(const int32_t tab_id,
 
 void InlineContentAdHandler::PurgeOrphanedCachedAdPlacements(
     const int32_t tab_id) {
-  if (placement_ids_[tab_id].empty()) {
-    return;
-  }
+  BLOG(1,
+       "Purging orphaned inline content ad placements for tab id " << tab_id);
 
-  BLOG(1, "Purged orphaned inline content ad placements for tab id " << tab_id);
+  if (placement_ids_[tab_id].empty()) {
+    return BLOG(1,
+                "There are no orphaned inline content ad placements for tab id "
+                    << tab_id);
+  }
 
   PurgeOrphanedAdEvents(
       placement_ids_[tab_id],
@@ -148,7 +151,7 @@ void InlineContentAdHandler::PurgeOrphanedCachedAdPlacements(
                          << joined_placement_ids << " placement ids");
             }
 
-            BLOG(1, "Successfully purged orphaned inline content ad events for "
+            BLOG(1, "Purged orphaned inline content ad events for "
                         << joined_placement_ids << " placement ids");
           },
           placement_ids_[tab_id]));

--- a/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_test.cc
@@ -34,6 +34,7 @@ class BraveAdsInlineContentAdIntegrationTest : public UnitTestBase {
 
     NotifyTabDidChange(
         /*tab_id=*/1, /*redirect_chain=*/{GURL("brave://newtab")},
+        /*is_new_navigation=*/true, /*is_restoring=*/false,
         /*is_error_page=*/false, /*is_visible=*/true);
   }
 

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_for_mobile_test.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_for_mobile_test.cc
@@ -58,7 +58,7 @@ TEST_F(BraveAdsNotificationAdForMobileIntegrationTest,
 }
 
 TEST_F(BraveAdsNotificationAdForMobileIntegrationTest,
-       DoNotServeWhenUserBecomesActive) {
+       DoNotServeWhenUserBecomesActiveIfPermissionRulesAreDenied) {
   // Act & Assert
   EXPECT_CALL(ads_client_mock_, ShowNotificationAd).Times(0);
 

--- a/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test.cc
@@ -48,7 +48,8 @@ TEST_F(BraveAdsNotificationAdIntegrationTest, ServeAd) {
   ServeAd();
 }
 
-TEST_F(BraveAdsNotificationAdIntegrationTest, DoNotServe) {
+TEST_F(BraveAdsNotificationAdIntegrationTest,
+       DoNotServeIfPermissionRulesAreDenied) {
   // Act & Assert
   EXPECT_CALL(ads_client_mock_, RecordP2AEvents).Times(0);
 

--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -218,7 +218,7 @@ void AdsImpl::PurgeOrphanedAdEventsForType(
 
               BLOG(0, "Failed to purge orphaned ad events for " << ad_type);
             } else {
-              BLOG(1, "Successfully purged orphaned ad events for " << ad_type);
+              BLOG(1, "Purged orphaned ad events for " << ad_type);
             }
 
             std::move(callback).Run(success);

--- a/components/brave_ads/core/internal/application_state/browser_manager.h
+++ b/components/brave_ads/core/internal/application_state/browser_manager.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_APPLICATION_STATE_BROWSER_MANAGER_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_APPLICATION_STATE_BROWSER_MANAGER_H_
 
+#include <optional>
+
 #include "base/observer_list.h"
 #include "brave/components/brave_ads/core/internal/application_state/browser_manager_observer.h"
 #include "brave/components/brave_ads/core/public/client/ads_client_notifier_observer.h"
@@ -29,9 +31,9 @@ class BrowserManager final : public AdsClientNotifierObserver {
   void AddObserver(BrowserManagerObserver* observer);
   void RemoveObserver(BrowserManagerObserver* observer);
 
-  bool IsActive() const { return is_active_; }
+  bool IsActive() const { return is_active_.value_or(false); }
 
-  bool IsInForeground() const { return is_in_foreground_; }
+  bool IsInForeground() const { return is_in_foreground_.value_or(false); }
 
  private:
   void NotifyBrowserDidBecomeActive() const;
@@ -40,7 +42,8 @@ class BrowserManager final : public AdsClientNotifierObserver {
 
   void NotifyBrowserDidEnterForeground() const;
   void NotifyBrowserDidEnterBackground() const;
-  void LogBrowserForegroundState() const;
+  void InitializeBrowserBackgroundState();
+  void LogBrowserBackgroundState() const;
 
   // AdsClientNotifierObserver:
   void OnNotifyDidInitializeAds() override;
@@ -51,9 +54,9 @@ class BrowserManager final : public AdsClientNotifierObserver {
 
   base::ObserverList<BrowserManagerObserver> observers_;
 
-  bool is_active_ = false;
+  std::optional<bool> is_active_;
 
-  bool is_in_foreground_ = false;
+  std::optional<bool> is_in_foreground_;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc
+++ b/components/brave_ads/core/internal/application_state/browser_manager_unittest.cc
@@ -84,7 +84,6 @@ TEST_F(BraveAdsBrowserManagerTest,
   NotifyDidInitializeAds();
 
   // Assert
-  EXPECT_TRUE(BrowserManager::GetInstance().IsActive());
   EXPECT_TRUE(BrowserManager::GetInstance().IsInForeground());
 }
 
@@ -97,7 +96,6 @@ TEST_F(BraveAdsBrowserManagerTest,
   NotifyDidInitializeAds();
 
   // Assert
-  EXPECT_FALSE(BrowserManager::GetInstance().IsActive());
   EXPECT_FALSE(BrowserManager::GetInstance().IsInForeground());
 }
 

--- a/components/brave_ads/core/internal/client/ads_client_notifier.cc
+++ b/components/brave_ads/core/internal/client/ads_client_notifier.cc
@@ -179,18 +179,21 @@ void AdsClientNotifier::NotifyTabDidStopPlayingMedia(
 void AdsClientNotifier::NotifyTabDidChange(
     const int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
+    const bool is_new_navigation,
+    const bool is_restoring,
     const bool is_error_page,
     const bool is_visible) const {
   if (should_queue_notifications_) {
     pending_notifier_queue_->Add(base::BindOnce(
         &AdsClientNotifier::NotifyTabDidChange, weak_factory_.GetWeakPtr(),
-        tab_id, redirect_chain, is_error_page, is_visible));
+        tab_id, redirect_chain, is_new_navigation, is_restoring, is_error_page,
+        is_visible));
     return;
   }
 
   for (auto& observer : observers_) {
-    observer.OnNotifyTabDidChange(tab_id, redirect_chain, is_error_page,
-                                  is_visible);
+    observer.OnNotifyTabDidChange(tab_id, redirect_chain, is_new_navigation,
+                                  is_restoring, is_error_page, is_visible);
   }
 }
 

--- a/components/brave_ads/core/internal/client/ads_client_notifier_observer_mock.h
+++ b/components/brave_ads/core/internal/client/ads_client_notifier_observer_mock.h
@@ -53,7 +53,7 @@ class AdsClientNotifierObserverMock : public AdsClientNotifierObserver {
   MOCK_METHOD(void, OnNotifyTabDidStopPlayingMedia, (int32_t));
   MOCK_METHOD(void,
               OnNotifyTabDidChange,
-              (int32_t, const std::vector<GURL>&, bool, bool));
+              (int32_t, const std::vector<GURL>&, bool, bool, bool, bool));
   MOCK_METHOD(void, OnNotifyDidCloseTab, (int32_t));
   MOCK_METHOD(void, OnNotifyUserGestureEventTriggered, (int32_t));
   MOCK_METHOD(void, OnNotifyUserDidBecomeIdle, ());

--- a/components/brave_ads/core/internal/client/ads_client_notifier_unittest.cc
+++ b/components/brave_ads/core/internal/client/ads_client_notifier_unittest.cc
@@ -48,8 +48,9 @@ void Notify(const AdsClientNotifier& queued_notifier) {
       kTabId, {GURL(kRedirectChainUrl)}, kHtml);
   queued_notifier.NotifyTabDidStartPlayingMedia(kTabId);
   queued_notifier.NotifyTabDidStopPlayingMedia(kTabId);
-  queued_notifier.NotifyTabDidChange(kTabId, {GURL(kRedirectChainUrl)},
-                                     /*is_error_page=*/false, kIsVisible);
+  queued_notifier.NotifyTabDidChange(
+      kTabId, {GURL(kRedirectChainUrl)}, /*is_new_navigation=*/true,
+      /*is_restoring=*/false, /*is_error_page=*/false, kIsVisible);
   queued_notifier.NotifyDidCloseTab(kTabId);
   queued_notifier.NotifyUserGestureEventTriggered(kPageTransitionType);
   queued_notifier.NotifyUserDidBecomeIdle();
@@ -93,6 +94,7 @@ void ExpectNotifierCalls(AdsClientNotifierObserverMock& observer,
   EXPECT_CALL(observer,
               OnNotifyTabDidChange(
                   kTabId, ::testing::ElementsAre(GURL(kRedirectChainUrl)),
+                  /*is_new_navigation=*/true, /*is_restoring=*/false,
                   /*is_error_page=*/false, kIsVisible))
       .Times(expected_calls_count);
   EXPECT_CALL(observer, OnNotifyDidCloseTab(kTabId))

--- a/components/brave_ads/core/internal/common/unittest/unittest_base.cc
+++ b/components/brave_ads/core/internal/common/unittest/unittest_base.cc
@@ -286,6 +286,8 @@ void UnitTestBase::SetUpIntegrationTestCallback(const bool success) {
 
   NotifyDidInitializeAds();
 
+  NotifyBrowserDidBecomeActive();
+
   task_environment_.RunUntilIdle();
 }
 

--- a/components/brave_ads/core/internal/serving/inline_content_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/inline_content_ad_serving_unittest.cc
@@ -31,6 +31,7 @@ class BraveAdsInlineContentAdServingTest : public UnitTestBase {
                     MaybeServeInlineContentAdCallback callback) {
     NotifyTabDidChange(
         /*tab_id=*/1, /*redirect_chain=*/{GURL("brave://newtab")},
+        /*is_new_navigation=*/true, /*is_restoring=*/false,
         /*is_error_page=*/false, /*is_visible=*/true);
 
     SubdivisionTargeting subdivision_targeting;

--- a/components/brave_ads/core/internal/serving/notification_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/notification_ad_serving_unittest.cc
@@ -25,6 +25,7 @@ class BraveAdsNotificationAdServingTest : public UnitTestBase {
     UnitTestBase::SetUp();
 
     NotifyDidInitializeAds();
+    NotifyBrowserDidBecomeActive();
   }
 
   void MaybeServeAd() {

--- a/components/brave_ads/core/internal/serving/permission_rules/media_permission_rule_unittest.cc
+++ b/components/brave_ads/core/internal/serving/permission_rules/media_permission_rule_unittest.cc
@@ -27,6 +27,7 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -42,6 +43,7 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -59,6 +61,7 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -75,6 +78,7 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -94,6 +98,7 @@ TEST_F(
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -107,6 +112,7 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -121,6 +127,7 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);

--- a/components/brave_ads/core/internal/tabs/tab_manager.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager.cc
@@ -222,7 +222,8 @@ void TabManager::OnNotifyTabDidChange(const int32_t tab_id,
   TabInfo& tab = GetOrCreateForId(tab_id);
 
   // Check if the tab changed.
-  const bool did_change = does_exist && tab.redirect_chain != redirect_chain;
+  const bool did_change =
+      does_exist && is_new_navigation && tab.redirect_chain != redirect_chain;
 
   // Check if the tab changed focus.
   const bool did_change_focus = !does_exist || tab.is_visible != is_visible;
@@ -235,6 +236,11 @@ void TabManager::OnNotifyTabDidChange(const int32_t tab_id,
   if (is_visible) {
     // Update the visible tab id.
     visible_tab_id_ = tab_id;
+  }
+
+  if (is_restoring) {
+    return BLOG(2, "Restored " << (is_visible ? "focused" : "occluded")
+                               << " tab with id " << tab_id);
   }
 
   // Notify observers.

--- a/components/brave_ads/core/internal/tabs/tab_manager.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager.cc
@@ -211,6 +211,8 @@ void TabManager::OnNotifyTabDidStopPlayingMedia(const int32_t tab_id) {
 
 void TabManager::OnNotifyTabDidChange(const int32_t tab_id,
                                       const std::vector<GURL>& redirect_chain,
+                                      const bool is_new_navigation,
+                                      const bool is_restoring,
                                       const bool is_error_page,
                                       const bool is_visible) {
   CHECK(!redirect_chain.empty());

--- a/components/brave_ads/core/internal/tabs/tab_manager.h
+++ b/components/brave_ads/core/internal/tabs/tab_manager.h
@@ -77,6 +77,8 @@ class TabManager final : public AdsClientNotifierObserver {
   void OnNotifyTabDidStopPlayingMedia(int32_t tab_id) override;
   void OnNotifyTabDidChange(int32_t tab_id,
                             const std::vector<GURL>& redirect_chain,
+                            bool is_new_navigation,
+                            bool is_restoring,
                             bool is_error_page,
                             bool is_visible) override;
   void OnNotifyDidCloseTab(int32_t tab_id) override;

--- a/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
@@ -104,6 +104,27 @@ TEST_F(BraveAdsTabManagerTest, DoNotChangeVisibleTabIfMatchingRedirectChain) {
       /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 }
+
+TEST_F(BraveAdsTabManagerTest, DoNotNotifyForRestoredTabs) {
+  // Act & Assert
+  EXPECT_CALL(observer_mock_, OnDidOpenNewTab).Times(0);
+  EXPECT_CALL(observer_mock_, OnTabDidChange).Times(0);
+  EXPECT_CALL(observer_mock_, OnTabDidChangeFocus).Times(0);
+
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/true,
+      /*is_error_page=*/false, /*is_visible=*/true);
+}
+
+TEST_F(BraveAdsTabManagerTest,
+       DoNotNotifyTabDidChangeIfReturningToPreviouslyCommittedNavigation) {
+  // Act & Assert
+  EXPECT_CALL(observer_mock_, OnTabDidChange).Times(0);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/false, /*is_restoring=*/true,
+      /*is_error_page=*/false, /*is_visible=*/true);
 }
 
 TEST_F(BraveAdsTabManagerTest, ChangeTabFocusToOccluded) {

--- a/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
+++ b/components/brave_ads/core/internal/tabs/tab_manager_unittest.cc
@@ -35,8 +35,8 @@ TEST_F(BraveAdsTabManagerTest, IsVisible) {
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
   NotifyTabDidChange(/*tab_id=*/1,
                      /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+                     /*is_new_navigation=*/true, /*is_restoring=*/false,
+                     /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_TRUE(TabManager::GetInstance().IsVisible(/*tab_id=*/1));
@@ -48,8 +48,8 @@ TEST_F(BraveAdsTabManagerTest, IsOccluded) {
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
   NotifyTabDidChange(/*tab_id=*/1,
                      /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/false);
+                     /*is_new_navigation=*/true, /*is_restoring=*/false,
+                     /*is_error_page=*/false, /*is_visible=*/false);
 
   // Act & Assert
   EXPECT_FALSE(TabManager::GetInstance().IsVisible(/*tab_id=*/1));
@@ -67,90 +67,87 @@ TEST_F(BraveAdsTabManagerTest, OpenNewTab) {
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
-      /*is_error_page=*/false,
-      /*is_visible=*/true);
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 }
 
 TEST_F(BraveAdsTabManagerTest, DoNotChangeOccludedTabIfMatchingRedirectChain) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/false);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/false);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidChange).Times(0);
   NotifyTabDidChange(
-      /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://brave.com")},
-      /*is_error_page=*/false,
-      /*is_visible=*/false);
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/false);
 }
 
 TEST_F(BraveAdsTabManagerTest, DoNotChangeVisibleTabIfMatchingRedirectChain) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidChange).Times(0);
   NotifyTabDidChange(
-      /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://brave.com")},
-      /*is_error_page=*/false,
-      /*is_visible=*/true);
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
+}
 }
 
 TEST_F(BraveAdsTabManagerTest, ChangeTabFocusToOccluded) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus(/*tab_id=*/1));
   NotifyTabDidChange(
-      /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://brave.com")},
-      /*is_error_page=*/false,
-      /*is_visible=*/false);
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/false);
 }
 
 TEST_F(BraveAdsTabManagerTest, ChangeTabFocusToVisible) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/false);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/false);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus(/*tab_id=*/1));
   NotifyTabDidChange(
-      /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://brave.com")},
-      /*is_error_page=*/false,
-      /*is_visible=*/true);
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 }
 
 TEST_F(BraveAdsTabManagerTest, ChangeOccudedTabIfMismatchingRedirectChain) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/false);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/false);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_,
@@ -163,18 +160,18 @@ TEST_F(BraveAdsTabManagerTest, ChangeOccudedTabIfMismatchingRedirectChain) {
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-      /*is_error_page=*/false,
-      /*is_visible=*/false);
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/false);
 }
 
 TEST_F(BraveAdsTabManagerTest, ChangeVisibleTabIfMismatchingRedirectChain) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_,
@@ -187,18 +184,18 @@ TEST_F(BraveAdsTabManagerTest, ChangeVisibleTabIfMismatchingRedirectChain) {
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-      /*is_error_page=*/false,
-      /*is_visible=*/true);
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 }
 
 TEST_F(BraveAdsTabManagerTest, CloseTab) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnDidCloseTab(/*tab_id=*/1));
@@ -209,10 +206,10 @@ TEST_F(BraveAdsTabManagerTest, IsPlayingMedia) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -225,10 +222,10 @@ TEST_F(BraveAdsTabManagerTest, IsNotPlayingMedia) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_FALSE(TabManager::GetInstance().IsPlayingMedia(/*tab_id=*/1));
@@ -238,10 +235,10 @@ TEST_F(BraveAdsTabManagerTest, StartPlayingMedia) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
@@ -252,10 +249,10 @@ TEST_F(BraveAdsTabManagerTest, DoNotStartPlayingMediaIfAlreadyPlaying) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
   EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 
@@ -267,10 +264,10 @@ TEST_F(BraveAdsTabManagerTest, StopPlayingMedia) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   EXPECT_CALL(observer_mock_, OnTabDidStartPlayingMedia(/*tab_id=*/1));
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
@@ -284,10 +281,10 @@ TEST_F(BraveAdsTabManagerTest, GetVisibleTab) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   const TabInfo tab{/*id=*/1, /*is_visible=*/true,
@@ -306,18 +303,18 @@ TEST_F(BraveAdsTabManagerTest, GetTabForId) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
   NotifyTabDidChange(
       /*tab_id=*/2,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
-      /*is_error_page=*/false,
-      /*is_visible=*/true);
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   const TabInfo tab{
@@ -332,10 +329,10 @@ TEST_F(BraveAdsTabManagerTest, DoNotGetIfMissingTab) {
   // Arrange
   EXPECT_CALL(observer_mock_, OnDidOpenNewTab);
   EXPECT_CALL(observer_mock_, OnTabDidChangeFocus);
-  NotifyTabDidChange(/*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")},
-                     /*is_error_page=*/false,
-                     /*is_visible=*/true);
+  NotifyTabDidChange(
+      /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
+      /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
   EXPECT_FALSE(TabManager::GetInstance().MaybeGetForId(2));

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
@@ -50,6 +50,7 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheLastClickedAdIsInvalid) {
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
@@ -67,6 +68,7 @@ TEST_F(BraveAdsSiteVisitTest,
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
@@ -84,10 +86,12 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheSameTabIsAlreadyLanding) {
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com/about")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   ASSERT_EQ(1U, GetPendingTaskCount());
@@ -116,6 +120,7 @@ TEST_F(
               OnMaybeLandOnPage(ad_1, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -132,6 +137,7 @@ TEST_F(
                   /*remaining_time=*/base::Seconds(3)));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/false);
 
   ASSERT_FALSE(HasPendingTasks());
@@ -145,6 +151,7 @@ TEST_F(
               OnMaybeLandOnPage(ad_2, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/2, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -161,6 +168,7 @@ TEST_F(
                   /*remaining_time=*/base::Seconds(7)));
   NotifyTabDidChange(
       /*tab_id=*/2, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/false);
   ASSERT_FALSE(HasPendingTasks());
 
@@ -175,6 +183,7 @@ TEST_F(
                   /*remaining_time=*/base::Seconds(3)));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -199,6 +208,7 @@ TEST_F(
                   /*remaining_time=*/base::Seconds(7)));
   NotifyTabDidChange(
       /*tab_id=*/2, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -227,6 +237,7 @@ TEST_F(
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -283,6 +294,7 @@ TEST_F(
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -338,6 +350,7 @@ TEST_F(BraveAdsSiteVisitTest,
               OnMaybeLandOnPage(ad_1, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -352,6 +365,7 @@ TEST_F(BraveAdsSiteVisitTest,
                   kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/false);
   ASSERT_FALSE(HasPendingTasks());
 
@@ -364,6 +378,7 @@ TEST_F(BraveAdsSiteVisitTest,
               OnMaybeLandOnPage(ad_2, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/2, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -378,6 +393,7 @@ TEST_F(BraveAdsSiteVisitTest,
                   kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/2, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/false);
   ASSERT_FALSE(HasPendingTasks());
 
@@ -392,6 +408,7 @@ TEST_F(BraveAdsSiteVisitTest,
                   kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -416,6 +433,7 @@ TEST_F(BraveAdsSiteVisitTest,
                   kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/2, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -444,6 +462,7 @@ TEST_F(BraveAdsSiteVisitTest,
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -471,6 +490,7 @@ TEST_F(
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/true, /*is_visible=*/true);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
@@ -494,10 +514,12 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheTabIsOccluded) {
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com/new_tab")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com/new_tab")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/false);
 
   // Act & Assert
@@ -516,6 +538,7 @@ TEST_F(
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
@@ -532,6 +555,7 @@ TEST_F(BraveAdsSiteVisitTest,
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
@@ -539,6 +563,7 @@ TEST_F(BraveAdsSiteVisitTest,
   NotifyTabDidChange(
       /*tab_id=*/1,
       /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 }
 
@@ -550,6 +575,7 @@ TEST_F(BraveAdsSiteVisitTest, CancelPageLandIfTheTabIsClosed) {
 
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
@@ -17,6 +17,7 @@ TEST_F(BraveAdsSiteVisitUtilTest, DidNotLandOnClosedTab) {
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   NotifyDidCloseTab(/*tab_id=*/1);
@@ -29,6 +30,7 @@ TEST_F(BraveAdsSiteVisitUtilTest, DidNotLandOnTabIfMismatchingDomainOrHost) {
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://foo.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert
@@ -39,6 +41,7 @@ TEST_F(BraveAdsSiteVisitUtilTest, DidLandOnPage) {
   // Arrange
   NotifyTabDidChange(
       /*tab_id=*/1, /*redirect_chain=*/{GURL("https://brave.com")},
+      /*is_new_navigation=*/true, /*is_restoring=*/false,
       /*is_error_page=*/false, /*is_visible=*/true);
 
   // Act & Assert

--- a/components/brave_ads/core/public/client/ads_client_notifier.h
+++ b/components/brave_ads/core/public/client/ads_client_notifier.h
@@ -97,12 +97,15 @@ class AdsClientNotifier {
   // Invoked when a browser tab is updated with the specified `redirect_chain`
   // containing a list of redirect URLs that occurred on the way to the current
   // page. The current page is the last one in the list (so even when there's no
-  // redirect, there should be one entry in the list). `is_error_page` should be
-  // set to `true` if an error occurred otherwise should be set to `false`.
-  // `is_visible` should be set to `true` if `tab_id` refers to the currently
-  // visible tab otherwise should be set to `false`.
+  // redirect, there should be one entry in the list). `is_restoring` should be
+  // set to `true` if the page is restoring otherwise should be set to `false`.
+  // `is_error_page` should be set to `true` if an error occurred otherwise
+  // should be set to `false`. `is_visible` should be set to `true` if `tab_id`
+  // refers to the currently visible tab otherwise should be set to `false`.
   void NotifyTabDidChange(int32_t tab_id,
                           const std::vector<GURL>& redirect_chain,
+                          bool is_new_navigation,
+                          bool is_restoring,
                           bool is_error_page,
                           bool is_visible) const;
 

--- a/components/brave_ads/core/public/client/ads_client_notifier_observer.h
+++ b/components/brave_ads/core/public/client/ads_client_notifier_observer.h
@@ -87,12 +87,15 @@ class AdsClientNotifierObserver : public base::CheckedObserver {
   // Invoked when a browser tab is updated with the specified `redirect_chain`
   // containing a list of redirect URLs that occurred on the way to the current
   // page. The current page is the last one in the list (so even when there's no
-  // redirect, there should be one entry in the list). `is_error_page` should be
-  // set to `true` if an error occurred otherwise should be set to `false`.
-  // `is_visible` should be set to `true` if `tab_id` refers to the currently
-  // visible tab otherwise should be set to `false`.
+  // redirect, there should be one entry in the list). `is_restoring` should be
+  // set to `true` if the page is restoring otherwise should be set to `false`.
+  // `is_error_page` should be set to `true` if an error occurred otherwise
+  // should be set to `false`. `is_visible` should be set to `true` if `tab_id`
+  // refers to the currently visible tab otherwise should be set to `false`.
   virtual void OnNotifyTabDidChange(int32_t tab_id,
                                     const std::vector<GURL>& redirect_chain,
+                                    const bool is_new_navigation,
+                                    bool is_restoring,
                                     bool is_error_page,
                                     bool is_visible) {}
 

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.cc
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.cc
@@ -89,10 +89,12 @@ void BatAdsClientNotifierImpl::NotifyTabDidStopPlayingMedia(
 void BatAdsClientNotifierImpl::NotifyTabDidChange(
     const int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
+    const bool is_new_navigation,
+    const bool is_restoring,
     const bool is_error_page,
     const bool is_visible) {
-  notifier_.NotifyTabDidChange(tab_id, redirect_chain, is_error_page,
-                               is_visible);
+  notifier_.NotifyTabDidChange(tab_id, redirect_chain, is_new_navigation,
+                               is_restoring, is_error_page, is_visible);
 }
 
 void BatAdsClientNotifierImpl::NotifyDidCloseTab(const int32_t tab_id) {

--- a/components/services/bat_ads/bat_ads_client_notifier_impl.h
+++ b/components/services/bat_ads/bat_ads_client_notifier_impl.h
@@ -89,11 +89,15 @@ class BatAdsClientNotifierImpl : public bat_ads::mojom::BatAdsClientNotifier {
   // Invoked when a browser tab is updated with the specified `redirect_chain`
   // containing a list of redirect URLs that occurred on the way to the current
   // page. The current page is the last one in the list (so even when there's no
-  // redirect, there should be one entry in the list). `is_visible` should be
-  // set to `true` if `tab_id` refers to the currently visible tab otherwise
-  // should be set to `false`.
+  // redirect, there should be one entry in the list). `is_restoring` should be
+  // set to `true` if the page is restoring otherwise should be set to `false`.
+  // `is_error_page` should be set to `true` if an error occurred otherwise
+  // should be set to `false`. `is_visible` should be set to `true` if `tab_id`
+  // refers to the currently visible tab otherwise should be set to `false`.
   void NotifyTabDidChange(int32_t tab_id,
                           const std::vector<GURL>& redirect_chain,
+                          bool is_new_navigation,
+                          bool is_restoring,
                           bool is_error_page,
                           bool is_visible) override;
 

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -43,6 +43,8 @@ interface BatAdsClientNotifier {
   NotifyTabDidStopPlayingMedia(int32 tab_id);
   NotifyTabDidChange(int32 tab_id,
                      array<url.mojom.Url> redirect_chain,
+                     bool is_new_navigation,
+                     bool is_restoring,
                      bool is_error_page,
                      bool is_visible);
   NotifyDidCloseTab(int32 tab_id);

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -201,6 +201,8 @@ public class BraveRewards: NSObject {
       ads.notifyTabDidChange(
         tabId,
         redirectChain: tab.redirectChain,
+        isNewNavigation: true,
+        isRestoring: InternalURL(url)?.isSessionRestore ?? false,
         isErrorPage: InternalURL(url)?.isErrorPage ?? false,
         isSelected: isSelected
       )

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -158,6 +158,8 @@ OBJC_EXPORT
 
 - (void)notifyTabDidChange:(NSInteger)tabId
              redirectChain:(NSArray<NSURL*>*)redirectChain
+           isNewNavigation:(BOOL)isNewNavigation
+               isRestoring:(BOOL)isRestoring
                isErrorPage:(BOOL)isErrorPage
                 isSelected:(BOOL)isSelected;
 

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -1885,6 +1885,8 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 
 - (void)notifyTabDidChange:(NSInteger)tabId
              redirectChain:(NSArray<NSURL*>*)redirectChain
+           isNewNavigation:(BOOL)isNewNavigation
+               isRestoring:(BOOL)isRestoring
                isErrorPage:(BOOL)isErrorPage
                 isSelected:(BOOL)isSelected {
   if (![self isServiceRunning]) {
@@ -1895,8 +1897,8 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 
   const bool isVisible = isSelected && [self isBrowserActive];
 
-  adsClientNotifier->NotifyTabDidChange((int32_t)tabId, urls, isErrorPage,
-                                        isVisible);
+  adsClientNotifier->NotifyTabDidChange((int32_t)tabId, urls, isNewNavigation,
+                                        isRestoring, isErrorPage, isVisible);
 }
 
 - (void)notifyDidCloseTab:(NSInteger)tabId {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/23720
Uplift of https://github.com/brave/brave-core/pull/23749
Uplift of https://github.com/brave/brave-core/pull/23771
Resolves https://github.com/brave/brave-browser/issues/38373
Resolves https://github.com/brave/brave-browser/issues/38420
Resolves https://github.com/brave/brave-browser/issues/38463

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
