### PR TITLE
[ads] Fixes Brave News ads are not served for restored NTP tab (uplift to 1.66.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -657,6 +657,7 @@ extension BrowserViewController: WKNavigationDelegate {
       InternalURL(responseURL)?.isSessionRestore == true
     {
       tab.shouldNotifyAdsServiceTabDidChange = false
+      tab.shouldNotifyAdsServiceTabContentDidChange = false
     }
 
     var request: URLRequest?
@@ -973,18 +974,23 @@ extension BrowserViewController: WKNavigationDelegate {
       }
 
       navigateInTab(tab: tab, to: navigation)
-      if tab.shouldNotifyAdsServiceTabDidChange, tab.navigationType != WKNavigationType.backForward
-      {
-        rewards.reportTabUpdated(
-          tab: tab,
-          isSelected: tabManager.selectedTab == tab,
-          isPrivate: privateBrowsingManager.isPrivateBrowsing
-        )
-        tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+      if tab.navigationType != WKNavigationType.backForward {
+        if tab.shouldNotifyAdsServiceTabDidChange {
+          rewards.reportTabUpdated(
+            tab: tab,
+            isSelected: tabManager.selectedTab == tab,
+            isPrivate: privateBrowsingManager.isPrivateBrowsing
+          )
+        }
+        if tab.shouldNotifyAdsServiceTabContentDidChange {
+          tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+        }
       }
-      // Set `shouldNotifyAdsServiceTabDidChange` to `true` so that listeners
+      // Set `shouldNotifyAdsServiceTabDidChange` and
+      // `shouldNotifyAdsServiceTabContentDidChange` to `true` so that listeners
       // are notified of tab changes after the tab is restored.
       tab.shouldNotifyAdsServiceTabDidChange = true
+      tab.shouldNotifyAdsServiceTabContentDidChange = true
 
       Task {
         await tab.updateEthereumProperties()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -264,7 +264,12 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
     didEndDisplaying cell: UICollectionViewCell,
     forItemAt indexPath: IndexPath
   ) {
-    iabTrackedCellContexts[indexPath] = nil
+    // Due to an iOS bug, didEndDisplaying can be called for a cell which is
+    // still in a collection view. In this case didEndDisplaying should be
+    // ignored.
+    if collectionView.cellForItem(at: indexPath) == nil {
+      iabTrackedCellContexts[indexPath] = nil
+    }
     if indexPath.item == 0, let cell = cell as? FeedCardCell<BraveNewsOptInView> {
       cell.content.graphicAnimationView.stop()
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -301,6 +301,7 @@ class Tab: NSObject {
   var mimeType: String?
   var isEditing: Bool = false
   var shouldNotifyAdsServiceTabDidChange = true
+  var shouldNotifyAdsServiceTabContentDidChange = true
   var playlistItem: PlaylistInfo?
   var playlistItemState: PlaylistItemAddedState = .none
 
@@ -561,7 +562,7 @@ class Tab: NSObject {
       lastTitle = sessionInfo.title
       webView.interactionState = sessionInfo.interactionState
       restoring = false
-      shouldNotifyAdsServiceTabDidChange = false
+      shouldNotifyAdsServiceTabContentDidChange = false
       self.sessionData = nil
     } else if let request = lastRequest {
       webView.load(request)

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -187,8 +187,8 @@ public class BraveRewards: NSObject {
     isSelected: Bool,
     isPrivate: Bool
   ) {
-    // Don't report update for tabs that haven't finished loading.
     guard let url = tab.redirectChain.last else {
+      // Don't report update for tabs that haven't finished loading.
       return
     }
 

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -147,6 +147,7 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
     adEventCache = new brave_ads::AdEventCache();
 
     adsClient = new AdsClientIOS(self);
+    adsClientNotifier = new brave_ads::AdsClientNotifier();
   }
   return self;
 }
@@ -232,7 +233,6 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
     return completion(/*success=*/false);
   }
 
-  adsClientNotifier = new brave_ads::AdsClientNotifier();
   ads = brave_ads::Ads::CreateInstance(adsClient);
 
   auto cppSysInfo =
@@ -256,7 +256,6 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
                     completion(success);
                     if (!success) {
                       [self deallocAds];
-                      [self deallocAdsClientNotifier];
                     }
                   }));
 }
@@ -269,10 +268,6 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
           // Deprecate shutdown API call.
           self->ads->Shutdown(base::BindOnce(^(bool) {
             [self deallocAds];
-            [self deallocAdsClientNotifier];
-            [self deallocAdsClient];
-
-            [self deallocAdEventCache];
 
             if (completion) {
               completion();
@@ -1823,20 +1818,20 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 }
 
 - (void)notifyDidInitializeAds {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyDidInitializeAds();
   }
 }
 
 - (void)notifyPrefDidChange:(const std::string&)path {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyPrefDidChange(path);
   }
 }
 
 - (void)notifyDidUpdateResourceComponent:(NSString*)manifest_version
                                       id:(NSString*)id {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyDidUpdateResourceComponent(
         base::SysNSStringToUTF8(manifest_version), base::SysNSStringToUTF8(id));
   }
@@ -1844,7 +1839,7 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 
 - (void)notifyRewardsWalletDidUpdate:(NSString*)paymentId
                           base64Seed:(NSString*)base64Seed {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyRewardsWalletDidUpdate(
         base::SysNSStringToUTF8(paymentId),
         base::SysNSStringToUTF8(base64Seed));
@@ -1854,7 +1849,7 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 - (void)notifyTabTextContentDidChange:(NSInteger)tabId
                         redirectChain:(NSArray<NSURL*>*)redirectChain
                                  text:(NSString*)text {
-  if (![self isServiceRunning]) {
+  if (adsClientNotifier == nil) {
     return;
   }
 
@@ -1867,7 +1862,7 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 - (void)notifyTabHtmlContentDidChange:(NSInteger)tabId
                         redirectChain:(NSArray<NSURL*>*)redirectChain
                                  html:(NSString*)html {
-  if (![self isServiceRunning]) {
+  if (adsClientNotifier == nil) {
     return;
   }
 
@@ -1878,13 +1873,13 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 }
 
 - (void)notifyTabDidStartPlayingMedia:(NSInteger)tabId {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyTabDidStartPlayingMedia((int32_t)tabId);
   }
 }
 
 - (void)notifyTabDidStopPlayingMedia:(NSInteger)tabId {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyTabDidStopPlayingMedia((int32_t)tabId);
   }
 }
@@ -1893,7 +1888,7 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
              redirectChain:(NSArray<NSURL*>*)redirectChain
                isErrorPage:(BOOL)isErrorPage
                 isSelected:(BOOL)isSelected {
-  if (![self isServiceRunning]) {
+  if (adsClientNotifier == nil) {
     return;
   }
 
@@ -1906,31 +1901,31 @@ static NSString* const kComponentUpdaterMetadataPrefKey =
 }
 
 - (void)notifyDidCloseTab:(NSInteger)tabId {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyDidCloseTab((int32_t)tabId);
   }
 }
 
 - (void)notifyBrowserDidEnterForeground {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyBrowserDidEnterForeground();
   }
 }
 
 - (void)notifyBrowserDidEnterBackground {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyBrowserDidEnterBackground();
   }
 }
 
 - (void)notifyBrowserDidBecomeActive {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyBrowserDidBecomeActive();
   }
 }
 
 - (void)notifyBrowserDidResignActive {
-  if ([self isServiceRunning]) {
+  if (adsClientNotifier != nil) {
     adsClientNotifier->NotifyBrowserDidResignActive();
   }
 }


### PR DESCRIPTION
Uplift of #23716
Uplift of #23917
Resolves https://github.com/brave/brave-browser/issues/38378
Resolves https://github.com/brave/brave-browser/issues/38698

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.