### PR TITLE
[ads] Fixes Brave News ads are not served for restored NTP tab (uplift to 1.67.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -665,6 +665,7 @@ extension BrowserViewController: WKNavigationDelegate {
       InternalURL(responseURL)?.isSessionRestore == true
     {
       tab.shouldNotifyAdsServiceTabDidChange = false
+      tab.shouldNotifyAdsServiceTabContentDidChange = false
     }
 
     var request: URLRequest?
@@ -981,18 +982,23 @@ extension BrowserViewController: WKNavigationDelegate {
       }
 
       navigateInTab(tab: tab, to: navigation)
-      if tab.shouldNotifyAdsServiceTabDidChange, tab.navigationType != WKNavigationType.backForward
-      {
-        rewards.reportTabUpdated(
-          tab: tab,
-          isSelected: tabManager.selectedTab == tab,
-          isPrivate: privateBrowsingManager.isPrivateBrowsing
-        )
-        tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+      if tab.navigationType != WKNavigationType.backForward {
+        if tab.shouldNotifyAdsServiceTabDidChange {
+          rewards.reportTabUpdated(
+            tab: tab,
+            isSelected: tabManager.selectedTab == tab,
+            isPrivate: privateBrowsingManager.isPrivateBrowsing
+          )
+        }
+        if tab.shouldNotifyAdsServiceTabContentDidChange {
+          tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+        }
       }
-      // Set `shouldNotifyAdsServiceTabDidChange` to `true` so that listeners
+      // Set `shouldNotifyAdsServiceTabDidChange` and
+      // `shouldNotifyAdsServiceTabContentDidChange` to `true` so that listeners
       // are notified of tab changes after the tab is restored.
       tab.shouldNotifyAdsServiceTabDidChange = true
+      tab.shouldNotifyAdsServiceTabContentDidChange = true
 
       Task {
         await tab.updateEthereumProperties()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -264,7 +264,12 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
     didEndDisplaying cell: UICollectionViewCell,
     forItemAt indexPath: IndexPath
   ) {
-    iabTrackedCellContexts[indexPath] = nil
+    // Due to an iOS bug, didEndDisplaying can be called for a cell which is
+    // still in a collection view. In this case didEndDisplaying should be
+    // ignored.
+    if collectionView.cellForItem(at: indexPath) == nil {
+      iabTrackedCellContexts[indexPath] = nil
+    }
     if indexPath.item == 0, let cell = cell as? FeedCardCell<BraveNewsOptInView> {
       cell.content.graphicAnimationView.stop()
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -302,6 +302,7 @@ class Tab: NSObject {
   var mimeType: String?
   var isEditing: Bool = false
   var shouldNotifyAdsServiceTabDidChange = true
+  var shouldNotifyAdsServiceTabContentDidChange = true
   var playlistItem: PlaylistInfo?
   var playlistItemState: PlaylistItemAddedState = .none
 
@@ -562,7 +563,7 @@ class Tab: NSObject {
       lastTitle = sessionInfo.title
       webView.interactionState = sessionInfo.interactionState
       restoring = false
-      shouldNotifyAdsServiceTabDidChange = false
+      shouldNotifyAdsServiceTabContentDidChange = false
       self.sessionData = nil
     } else if let request = lastRequest {
       webView.load(request)

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -187,8 +187,8 @@ public class BraveRewards: NSObject {
     isSelected: Bool,
     isPrivate: Bool
   ) {
-    // Don't report update for tabs that haven't finished loading.
     guard let url = tab.redirectChain.last else {
+      // Don't report update for tabs that haven't finished loading.
       return
     }
 


### PR DESCRIPTION
Uplift of #23716
Uplift of #23917
Resolves https://github.com/brave/brave-browser/issues/38378
Resolves https://github.com/brave/brave-browser/issues/38698

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.