### PR TITLE
prevent instantiation of EdgeRequestResponse instances

### DIFF
--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_response.cc
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_response.cc
@@ -37,10 +37,6 @@ GraphNode* EdgeRequestResponse::GetRequestingNode() const {
   return GetInNode();
 }
 
-ItemName EdgeRequestResponse::GetItemName() const {
-  return "request response";
-}
-
 void EdgeRequestResponse::AddGraphMLAttributes(xmlDocPtr doc,
                                                xmlNodePtr parent_node) const {
   EdgeRequest::AddGraphMLAttributes(doc, parent_node);

--- a/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_response.h
+++ b/third_party/blink/renderer/core/brave_page_graph/graph_item/edge/request/edge_request_response.h
@@ -35,8 +35,6 @@ class EdgeRequestResponse : public EdgeRequest {
   NodeResource* GetResourceNode() const override;
   GraphNode* GetRequestingNode() const override;
 
-  ItemName GetItemName() const override;
-
   void AddGraphMLAttributes(xmlDocPtr doc,
                             xmlNodePtr parent_node) const override;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38426

Minor code cleanup to make it impossible to instiantiate an intermediate class in the pagegraph request tracking heirachy 