### PR TITLE
[ads] Fixes crash `RefillConfirmationTokens::HandleGetSignedTokensUrlResponse` - 1.67.x

### DIFF
--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.h
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.h
@@ -65,7 +65,8 @@ class RefillConfirmationTokens final {
   void ParseAndRequireCaptcha(const base::Value::Dict& dict) const;
 
   void SuccessfullyRefilled();
-  void FailedToRefill(bool should_retry);
+  void FailedToRefillAndRetry();
+  void FailedToRefill();
 
   void Retry();
   void RetryCallback();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/23766
Resolves https://github.com/brave/brave-browser/issues/38457


- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
