### PR TITLE
[ads] Fixes crash `RefillConfirmationTokens::HandleGetSignedTokensUrlResponse` - 1.66.x

### DIFF
--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.cc
@@ -59,7 +59,7 @@ void RefillConfirmationTokens::MaybeRefill(const WalletInfo& wallet) {
 
   if (!HasIssuers()) {
     BLOG(0, "Failed to refill confirmation tokens due to missing issuers");
-    return FailedToRefill(/*should_retry=*/false);
+    return FailedToRefill();
   }
 
   if (!ShouldRefillConfirmationTokens()) {
@@ -99,6 +99,7 @@ bool RefillConfirmationTokens::ShouldRequestSignedTokens() const {
 }
 
 void RefillConfirmationTokens::RequestSignedTokens() {
+  CHECK(tokens_);
   CHECK(blinded_tokens_);
 
   BLOG(1, "Request signed tokens");
@@ -125,7 +126,8 @@ void RefillConfirmationTokens::RequestSignedTokensCallback(
     const auto& [failure, should_retry] = result.error();
 
     BLOG(0, failure);
-    return FailedToRefill(should_retry);
+
+    return should_retry ? FailedToRefillAndRetry() : FailedToRefill();
   }
 
   GetSignedTokens();
@@ -195,7 +197,7 @@ void RefillConfirmationTokens::GetSignedTokensCallback(
 
     BLOG(0, failure);
 
-    return FailedToRefill(should_retry);
+    return should_retry ? FailedToRefillAndRetry() : FailedToRefill();
   }
 
   SuccessfullyRefilled();
@@ -272,25 +274,21 @@ void RefillConfirmationTokens::ParseAndRequireCaptcha(
 }
 
 void RefillConfirmationTokens::SuccessfullyRefilled() {
-  StopRetrying();
-
   Reset();
-
-  is_refilling_ = false;
 
   NotifyDidRefillConfirmationTokens();
 }
 
-void RefillConfirmationTokens::FailedToRefill(const bool should_retry) {
-  is_refilling_ = false;
-
+void RefillConfirmationTokens::FailedToRefillAndRetry() {
   NotifyFailedToRefillConfirmationTokens();
 
-  if (should_retry) {
-    return Retry();
-  }
+  Retry();
+}
 
+void RefillConfirmationTokens::FailedToRefill() {
   Reset();
+
+  NotifyFailedToRefillConfirmationTokens();
 }
 
 void RefillConfirmationTokens::Retry() {
@@ -322,10 +320,14 @@ void RefillConfirmationTokens::StopRetrying() {
 }
 
 void RefillConfirmationTokens::Reset() {
+  StopRetrying();
+
   nonce_.reset();
 
   tokens_.reset();
   blinded_tokens_.reset();
+
+  is_refilling_ = false;
 }
 
 void RefillConfirmationTokens::NotifyWillRefillConfirmationTokens() const {

--- a/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.h
+++ b/components/brave_ads/core/internal/account/utility/refill_confirmation_tokens/refill_confirmation_tokens.h
@@ -65,7 +65,8 @@ class RefillConfirmationTokens final {
   void ParseAndRequireCaptcha(const base::Value::Dict& dict) const;
 
   void SuccessfullyRefilled();
-  void FailedToRefill(bool should_retry);
+  void FailedToRefillAndRetry();
+  void FailedToRefill();
 
   void Retry();
   void RetryCallback();


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/23766
Resolves https://github.com/brave/brave-browser/issues/38457


- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [ ] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
