### PR TITLE
Fixed learn more link is hidden in geo permission bubble (uplift to 1.67.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc
+++ b/chromium_src/chrome/browser/ui/views/permissions/permission_prompt_bubble_base_view.cc
@@ -258,8 +258,6 @@ std::unique_ptr<views::View> CreateGeolocationDescLabel(
   contents_label->AddStyleRange(
       gfx::Range(offsets[learn_more_offset], offsets[learn_more_offset + 1]),
       learn_more_style);
-  constexpr int kFixedLabelWidth = 290;
-  contents_label->SizeToFit(kFixedLabelWidth);
   return contents_label;
 }
 


### PR DESCRIPTION
Uplift of #23782
fix https://github.com/brave/brave-browser/issues/38456

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.