### PR TITLE
fix(wallet): Differentiate between mainnet and testnet in default account names on iOS

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountSelectionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountSelectionView.swift
@@ -65,22 +65,7 @@ struct AccountSelectionView: View {
 struct AccountSelectionView_Previews: PreviewProvider {
   static var previews: some View {
     AccountSelectionView(
-      keyringStore: {
-        let store = KeyringStore.previewStoreWithWalletCreated
-        store.addPrimaryAccount(
-          "Account 2",
-          coin: .eth,
-          chainId: BraveWallet.MainnetChainId,
-          completion: nil
-        )
-        store.addPrimaryAccount(
-          "Account 3",
-          coin: .eth,
-          chainId: BraveWallet.MainnetChainId,
-          completion: nil
-        )
-        return store
-      }(),
+      keyringStore: .previewStoreWithWalletCreated,
       networkStore: .previewStore,
       onDismiss: {}
     )

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -198,7 +198,7 @@ struct AddAccountView: View {
         }
       }
       .buttonStyle(BraveFilledButtonStyle(size: .small))
-      .disabled(!name.isValidAccountName)
+      .disabled(!name.isValidAccountName || isCreatingAccount)
     )
     .alert(isPresented: $failedToImport) {
       Alert(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/Add/AddAccountView.swift
@@ -64,19 +64,14 @@ struct AddAccountView: View {
   }
 
   private func addAccount(for coin: BraveWallet.CoinType) {
-    let accountName =
-      name.isEmpty
-      ? defaultAccountName(
-        for: coin,
-        chainId: accountNetwork.chainId,
-        isPrimary: privateKey.isEmpty
-      )
-      : name
-    guard accountName.isValidAccountName else { return }
+    if !name.isEmpty && !name.isValidAccountName {
+      // User entered name is invalid
+      return
+    }  // else empty, KeyringStore will assign default account name
 
     if privateKey.isEmpty {
       // Add normal account
-      keyringStore.addPrimaryAccount(accountName, coin: coin, chainId: accountNetwork.chainId) {
+      keyringStore.addPrimaryAccount(name, coin: coin, chainId: accountNetwork.chainId) {
         success in
         if success {
           onCreate?()
@@ -96,14 +91,16 @@ struct AddAccountView: View {
       }
       if isJSONImported {
         keyringStore.addSecondaryAccount(
-          accountName,
+          name,
+          coin: coin,
+          chainId: accountNetwork.chainId,
           json: privateKey,
           password: originPassword,
           completion: handler
         )
       } else {
         keyringStore.addSecondaryAccount(
-          accountName,
+          name,
           coin: coin,
           chainId: accountNetwork.chainId,
           privateKey: privateKey,
@@ -399,27 +396,6 @@ struct AddAccountView: View {
         }
       }
       .listRowBackground(Color(.secondaryBraveGroupedBackground))
-    }
-  }
-
-  private func defaultAccountName(
-    for coin: BraveWallet.CoinType,
-    chainId: String,
-    isPrimary: Bool
-  ) -> String {
-    let accountsForCoin = keyringStore.allAccounts.filter { $0.coin == coin }
-    if isPrimary {
-      let numberOfPrimaryAccountsForCoin = accountsForCoin.filter(\.isPrimary).count
-      return String.localizedStringWithFormat(
-        coin.defaultAccountName,
-        numberOfPrimaryAccountsForCoin + 1
-      )
-    } else {
-      let numberOfImportedAccounts = accountsForCoin.filter(\.isImported).count
-      return String.localizedStringWithFormat(
-        coin.defaultSecondaryAccountName,
-        numberOfImportedAccounts + 1
-      )
     }
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/KeyringStore.swift
@@ -301,7 +301,14 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
     rpcServiceObserver = nil
   }
 
-  private func updateInfo() {
+  func updateInfo(completion: (() -> Void)? = nil) {
+    Task { @MainActor in
+      await updateInfo()
+      completion?()
+    }
+  }
+
+  @MainActor func updateInfo() async {
     if UIApplication.shared.applicationState != .active {
       // Changes made in the backgroud due to timers going off at launch don't
       // re-render things properly.
@@ -309,22 +316,20 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
       // This function is called again on `didBecomeActiveNotification` anyways.
       return
     }
-    Task { @MainActor in  // fetch all KeyringInfo for all coin types
-      let allAccounts = await keyringService.allAccounts()
-      self.allAccounts = allAccounts.accounts
-      if let selectedAccount = allAccounts.selectedAccount {
-        self.selectedAccount = selectedAccount
-      }
-      self.isWalletCreated = await keyringService.isWalletCreated()
-      // fallback case where user completed front-end onboarding, but has no keyring created/accounts.
-      // this can occur if we crash prior to saving, ex. brave-ios #8291
-      if !isWalletCreated && Preferences.Wallet.isOnboardingCompleted.value {
-        Preferences.Wallet.isOnboardingCompleted.reset()
-      }
-      self.isWalletLocked = await keyringService.isLocked()
-      self.isWalletBackedUp = await keyringService.isWalletBackedUp()
-      self.isLoaded = true
+    let allAccounts = await keyringService.allAccounts()
+    self.allAccounts = allAccounts.accounts
+    if let selectedAccount = allAccounts.selectedAccount {
+      self.selectedAccount = selectedAccount
     }
+    self.isWalletCreated = await keyringService.isWalletCreated()
+    // fallback case where user completed front-end onboarding, but has no keyring created/accounts.
+    // this can occur if we crash prior to saving, ex. brave-ios #8291
+    if !isWalletCreated && Preferences.Wallet.isOnboardingCompleted.value {
+      Preferences.Wallet.isOnboardingCompleted.reset()
+    }
+    self.isWalletLocked = await keyringService.isLocked()
+    self.isWalletBackedUp = await keyringService.isWalletBackedUp()
+    self.isLoaded = true
   }
 
   private func setSelectedAccount(to account: BraveWallet.AccountInfo) {
@@ -507,75 +512,74 @@ public class KeyringStore: ObservableObject, WalletObserverStore {
 
   /// `chainId` is only for .fil or .btc coin type
   /// correct `BraveWallet.KeyringId` will be returned from `keyringIdForNewAccount`
-  func addPrimaryAccount(
+  @MainActor func addPrimaryAccount(
     _ name: String,
     coin: BraveWallet.CoinType,
-    chainId: String,
-    completion: ((Bool) -> Void)? = nil
-  ) {
+    chainId: String
+  ) async -> Bool {
     var accountName = name
     if accountName.isEmpty {
       // assign default name
       accountName = defaultAccountName(for: coin, chainId: chainId)
     }
-    keyringService.addAccount(
+    let accountInfo = await keyringService.addAccount(
       coin: coin,
       keyringId: BraveWallet.KeyringId.keyringId(for: coin, on: chainId),
       accountName: accountName
-    ) { accountInfo in
-      self.updateInfo()
-      completion?(accountInfo != nil)
-    }
+    )
+    await updateInfo()
+    return accountInfo != nil
   }
 
   /// `chainId` is only for .fil or .btc coin type
-  func addSecondaryAccount(
+  @MainActor func addSecondaryAccount(
     _ name: String,
     coin: BraveWallet.CoinType,
     chainId: String,
-    privateKey: String,
-    completion: ((BraveWallet.AccountInfo?) -> Void)? = nil
-  ) {
+    privateKey: String
+  ) async -> BraveWallet.AccountInfo? {
     var accountName = name
     if accountName.isEmpty {
       // assign default name
       accountName = defaultAccountName(for: coin, chainId: chainId)
     }
+    let accountInfo: BraveWallet.AccountInfo?
     if coin == .fil {
-      keyringService.importFilecoinAccount(
+      accountInfo = await keyringService.importFilecoinAccount(
         accountName: accountName,
         privateKey: privateKey,
         network: chainId
-      ) {
-        accountInfo in
-        completion?(accountInfo)
-      }
+      )
     } else {
-      keyringService.importAccount(accountName: accountName, privateKey: privateKey, coin: coin) {
-        accountInfo in
-        self.updateInfo()
-        completion?(accountInfo)
-      }
+      accountInfo = await keyringService.importAccount(
+        accountName: accountName,
+        privateKey: privateKey,
+        coin: coin
+      )
     }
+    await updateInfo()
+    return accountInfo
   }
 
-  func addSecondaryAccount(
+  @MainActor func addSecondaryAccount(
     _ name: String,
     coin: BraveWallet.CoinType,
     chainId: String,
     json: String,
-    password: String,
-    completion: ((BraveWallet.AccountInfo?) -> Void)? = nil
-  ) {
+    password: String
+  ) async -> BraveWallet.AccountInfo? {
     var accountName = name
     if accountName.isEmpty {
       // assign default name
       accountName = defaultAccountName(for: coin, chainId: chainId)
     }
-    keyringService.importAccountFromJson(accountName: accountName, password: password, json: json) {
-      accountInfo in
-      completion?(accountInfo)
-    }
+    let accountInfo = await keyringService.importAccountFromJson(
+      accountName: accountName,
+      password: password,
+      json: json
+    )
+    await updateInfo()
+    return accountInfo
   }
 
   private func defaultAccountName(

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -280,39 +280,6 @@ extension BraveWallet.CoinType {
     }
   }
 
-  var defaultAccountName: String {
-    switch self {
-    case .eth:
-      return Strings.Wallet.defaultEthAccountName
-    case .sol:
-      return Strings.Wallet.defaultSolAccountName
-    case .fil:
-      return Strings.Wallet.defaultFilAccountName
-    case .btc:
-      return Strings.Wallet.defaultBitcoinAccountName
-    case .zec:
-      fallthrough
-    @unknown default:
-      return ""
-    }
-  }
-
-  var defaultSecondaryAccountName: String {
-    switch self {
-    case .eth:
-      return Strings.Wallet.defaultSecondaryEthAccountName
-    case .sol:
-      return Strings.Wallet.defaultSecondarySolAccountName
-    case .fil:
-      return Strings.Wallet.defaultSecondaryFilAccountName
-    case .btc, .zec:
-      // no secondary/import account for bitcoin
-      fallthrough
-    @unknown default:
-      return ""
-    }
-  }
-
   /// Sort order used when sorting by coin types
   var sortOrder: Int {
     switch self {

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/ViewExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/ViewExtensions.swift
@@ -10,11 +10,9 @@ import UIKit
 extension View {
   /// Helper for `hidden()` modifier that accepts a boolean determining if we should hide the view or not.
   @ViewBuilder public func hidden(isHidden: Bool) -> some View {
-    if isHidden {
-      self.hidden()
-    } else {
-      self
-    }
+    self  // use opacity to avoid identity resets when not required
+      .opacity(isHidden ? 0 : 1)
+      .accessibilityHidden(isHidden)
   }
 
   /// This function will use the help from `introspectViewController` to find the

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Connect/EditSiteConnectionView.swift
@@ -222,22 +222,7 @@ struct EditSiteConnectionView: View {
 struct EditSiteConnectionView_Previews: PreviewProvider {
   static var previews: some View {
     EditSiteConnectionView(
-      keyringStore: {
-        let store = KeyringStore.previewStoreWithWalletCreated
-        store.addPrimaryAccount(
-          "Account 2",
-          coin: .eth,
-          chainId: BraveWallet.MainnetChainId,
-          completion: nil
-        )
-        store.addPrimaryAccount(
-          "Account 3",
-          coin: .eth,
-          chainId: BraveWallet.MainnetChainId,
-          completion: nil
-        )
-        return store
-      }(),
+      keyringStore: .previewStoreWithWalletCreated,
       origin: .init(url: URL(string: "https://app.uniswap.org")!),
       coin: .eth,
       onDismiss: { _ in }

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Connect/NewSiteConnectionView.swift
@@ -264,22 +264,7 @@ struct NewSiteConnectionView_Previews: PreviewProvider {
       origin: .init(url: URL(string: "https://app.uniswap.org")!),
       accounts: [BraveWallet.AccountInfo.previewAccount.address],
       coin: .eth,
-      keyringStore: {
-        let store = KeyringStore.previewStoreWithWalletCreated
-        store.addPrimaryAccount(
-          "Account 2",
-          coin: .eth,
-          chainId: BraveWallet.MainnetChainId,
-          completion: nil
-        )
-        store.addPrimaryAccount(
-          "Account 3",
-          coin: .eth,
-          chainId: BraveWallet.MainnetChainId,
-          completion: nil
-        )
-        return store
-      }(),
+      keyringStore: .previewStoreWithWalletCreated,
       onConnect: { _ in },
       onDismiss: {}
     )

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -105,6 +105,7 @@ extension KeyringStore {
   static var previewStoreWithWalletCreated: KeyringStore {
     let store = KeyringStore.previewStore
     store.createWallet(password: "password")
+    store.allAccounts = [.previewAccount, .mockSolAccount]
     return store
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -276,61 +276,21 @@ extension Strings {
       comment:
         "A button title that shows a screen that allows the user to backup their recovery phrase"
     )
-    public static let defaultEthAccountName = NSLocalizedString(
-      "wallet.defaultEthAccountName",
+    public static let defaultAccountName = NSLocalizedString(
+      "wallet.defaultAccountName",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Ethereum Account %lld",
+      value: "%@ Account %lld",
       comment:
-        "The default Ethereum account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Ethereum Account 3\")"
+        "The default account name when adding an account and not entering a custom name. '%@' refers to a coin type and '%lld' refers to a number (for example \"Ethereum Account 2\")"
     )
-    public static let defaultSolAccountName = NSLocalizedString(
-      "wallet.defaultSolAccountName",
+    public static let defaultTestnetAccountName = NSLocalizedString(
+      "wallet.defaultTestnetAccountName",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Solana Account %lld",
+      value: "%@ Testnet Account %lld",
       comment:
-        "The default Solana account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Solana Account 3\")"
-    )
-    public static let defaultFilAccountName = NSLocalizedString(
-      "wallet.defaultFilAccountName",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Filecoin Account %lld",
-      comment:
-        "The default Filecoin account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Filecoin Account 3\")"
-    )
-    public static let defaultBitcoinAccountName = NSLocalizedString(
-      "wallet.defaultBitcoinAccountName",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Bitcoin Account %lld",
-      comment:
-        "The default Bitcoin account name when adding a primary account and not entering a custom name. '%lld' refers to a number (for example \"Bitcoin Account 3\")"
-    )
-    public static let defaultSecondaryEthAccountName = NSLocalizedString(
-      "wallet.defaultSecondaryEthAccountName",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Secondary Ethereum Account %lld",
-      comment:
-        "The default account name when adding a secondary account and not entering a custom name. '%lld' refers to a number (for example \"Secondary Ethereum Account 3\")"
-    )
-    public static let defaultSecondarySolAccountName = NSLocalizedString(
-      "wallet.defaultSecondarySolAccountName",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Secondary Solana Account %lld",
-      comment:
-        "The default account name when adding a secondary account and not entering a custom name. '%lld' refers to a number (for example \"Secondary Solana Account 3\")"
-    )
-    public static let defaultSecondaryFilAccountName = NSLocalizedString(
-      "wallet.defaultSecondaryFilAccountName",
-      tableName: "BraveWallet",
-      bundle: .module,
-      value: "Secondary Filecoin Account %lld",
-      comment:
-        "The default account name when adding a secondary account and not entering a custom name. '%lld' refers to a number (for example \"Secondary Filecoin Account 3\")"
+        "The default account name when adding an account and not entering a custom name. '%@' refers to a coin type and '%lld' refers to a number (for example \"Filecoin Testnet Account 2\")"
     )
     public static let addAccountWithCoinTypeTitle = NSLocalizedString(
       "wallet.addAccountWithCoinTypeTitle",


### PR DESCRIPTION
- Update default account name to be `"<coin name> Account #"` for regular accounts or `"<coin name> Testnet Account #"` for testnet accounts.
    - Default account name function was moved to `KeyringStore` so it can be used without `AddAccountView` (it will be used later during onboarding)
- Use async/await for adding accounts. Also adds a loading indicator to the `Add` button.

Resolves https://github.com/brave/brave-browser/issues/38526

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Switch to accounts tab
2. Tap `...` and tap `Add Account`
3. Select Filecoin
    - Default should have Filecoin Mainnet selected
4. Do not enter a name and tap `Add`
5. Tap `...` and tap `Add Account` again
6. Select Filecoin
7. Change network to Filecoin Testnet
8. Do not enter a name, and tap `Add`
9. Verify the Mainnet account is `Filecoin Account #` and the Testnet account is `Filecoin Testnet  Account #`
    - For Filecoin accounts you can either check address starts with `f` for Filecoin Mainnet or `t` for Filecoin Testnet, or for Bitcoin and/or Filecoin accounts you can tap the account card and check the network displayed under `Assets`


https://github.com/brave/brave-core/assets/5314553/917daf1b-46c1-49bf-8393-4dfb20341f3b