### PR TITLE
fix(wallet): Fee icon on Cow Swap confirmation screen is blank on iOS

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Blockies/Blockies.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Blockies/Blockies.swift
@@ -24,6 +24,12 @@ private struct XorshiftRandomNumberGenerator: RandomNumberGenerator {
 }
 
 class Blockies {
+  struct Colors {
+    let color: UIColor
+    let backgroundColor: UIColor
+    let spotColor: UIColor
+  }
+
   private var generator: XorshiftRandomNumberGenerator
   private let colors: [Int] = [
     0x423EEE, 0xE2E2FC, 0xFE5907, 0xFEDED6, 0x5F5CF1,
@@ -48,6 +54,10 @@ class Blockies {
     )
   }
 
+  func makeColors() -> Colors {
+    .init(color: makeColor(), backgroundColor: makeColor(), spotColor: makeColor())
+  }
+
   func makeColor() -> UIColor {
     let normalized = Double(generator.next()) / Double(Int32.max)
     return UIColor(rgb: colors[Int(floor(normalized * 100)) % colors.count])
@@ -58,9 +68,7 @@ class Blockies {
   }
 
   func image(length: Int, scale: CGFloat) -> UIImage {
-    let color = makeColor()
-    let backgroundColor = makeColor()
-    let spotColor = makeColor()
+    let colors = makeColors()
 
     func data() -> [Double] {
       let dataLength = Int(ceil(Double(length) / 2.0))
@@ -84,13 +92,13 @@ class Blockies {
     let width = sqrt(Double(data.count))
 
     let image = renderer.image { context in
-      backgroundColor.setFill()
+      colors.backgroundColor.setFill()
       context.fill(.init(origin: .zero, size: size))
-      spotColor.setFill()
+      colors.spotColor.setFill()
       for (i, value) in data.enumerated() where value > 0 {
         let row = floor(Double(i) / width)
         let col = i % Int(width)
-        let fillColor = value == 1 ? color : spotColor
+        let fillColor = value == 1 ? colors.color : colors.spotColor
         let shapeType = floor(rand() * 3)
 
         switch shapeType {
@@ -151,17 +159,17 @@ struct Blockie: View {
   }
 }
 
-struct BlockieMaterial: View {
+struct BlockieBackground: View {
+
+  let colors: Blockies.Colors
 
   init(seed: String) {
-    self.blockies = Blockies(seed: seed.lowercased())
+    self.colors = Blockies(seed: seed).makeColors()
   }
-
-  private let blockies: Blockies
 
   var body: some View {
     LinearGradient(
-      colors: [.init(blockies.makeColor()), .init(blockies.makeColor())],
+      colors: [.init(colors.backgroundColor), .init(colors.spotColor)],
       startPoint: .top,
       endPoint: .bottom
     )

--- a/ios/brave-ios/Sources/BraveWallet/Blockies/Blockies.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Blockies/Blockies.swift
@@ -153,8 +153,8 @@ struct Blockie: View {
 
 struct BlockieMaterial: View {
 
-  init(address: String) {
-    self.blockies = Blockies(seed: address.lowercased())
+  init(seed: String) {
+    self.blockies = Blockies(seed: seed.lowercased())
   }
 
   private let blockies: Blockies

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -351,7 +351,7 @@ private struct AccountCardView: View {
   }
 
   private var cardBackground: some View {
-    BlockieMaterial(seed: account.blockieSeed)
+    BlockieBackground(seed: account.blockieSeed)
       .blur(radius: 25, opaque: true)
       .opacity(0.3)
       .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -351,7 +351,7 @@ private struct AccountCardView: View {
   }
 
   private var cardBackground: some View {
-    BlockieMaterial(address: account.blockieSeed)
+    BlockieMaterial(seed: account.blockieSeed)
       .blur(radius: 25, opaque: true)
       .opacity(0.3)
       .clipShape(RoundedRectangle(cornerRadius: 8))

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -37,7 +37,7 @@ struct AssetIcon: View {
 
   @State private var monogramSize: CGSize = .zero
   private var fallbackMonogram: some View {
-    BlockieMaterial(address: token.contractAddress)
+    BlockieMaterial(seed: token.contractAddress)
       .blur(radius: 8, opaque: true)
       .clipShape(Circle())
       .readSize(onChange: { newSize in

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/AssetIconView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/AssetIconView.swift
@@ -37,24 +37,25 @@ struct AssetIcon: View {
 
   @State private var monogramSize: CGSize = .zero
   private var fallbackMonogram: some View {
-    BlockieMaterial(seed: token.contractAddress)
-      .blur(radius: 8, opaque: true)
-      .clipShape(Circle())
-      .readSize(onChange: { newSize in
-        monogramSize = newSize
-      })
-      .overlay(
-        Text(token.symbol.first?.uppercased() ?? "")
-          .font(
-            .system(
-              size: max(monogramSize.width, monogramSize.height) / 2,
-              weight: .bold,
-              design: .rounded
-            )
+    BlockieBackground(
+      seed: token.contractAddress.isEmpty ? token.name : token.contractAddress.lowercased()
+    )
+    .clipShape(Circle())
+    .readSize(onChange: { newSize in
+      monogramSize = newSize
+    })
+    .overlay(
+      Text(token.symbol.first?.uppercased() ?? "")
+        .font(
+          .system(
+            size: max(monogramSize.width, monogramSize.height) / 2,
+            weight: .bold,
+            design: .rounded
           )
-          .foregroundColor(.white)
-          .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
-      )
+        )
+        .foregroundColor(.white)
+        .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
+    )
   }
 }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Market/MarketView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Market/MarketView.swift
@@ -65,7 +65,7 @@ struct MarketView: View {
     WebImage(url: URL(string: coinMarket.image))
       .resizable()
       .placeholder {
-        BlockieMaterial(address: coinMarket.id)
+        BlockieMaterial(seed: coinMarket.id)
           .blur(radius: 8, opaque: true)
           .clipShape(Circle())
           .overlay(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Market/MarketView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Market/MarketView.swift
@@ -65,7 +65,7 @@ struct MarketView: View {
     WebImage(url: URL(string: coinMarket.image))
       .resizable()
       .placeholder {
-        BlockieMaterial(seed: coinMarket.id)
+        BlockieBackground(seed: coinMarket.id)
           .blur(radius: 8, opaque: true)
           .clipShape(Circle())
           .overlay(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/SaferSignTransactionContainerView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/SaferSignTransactionContainerView.swift
@@ -146,6 +146,7 @@ struct SaferSignTransactionContainerView: View {
           } else {
             Circle()
               .stroke(Color(.braveSeparator))
+              .background(Color(braveSystemName: .iconActive).clipShape(Circle()))
           }
         }
         .frame(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/SaferSignTransactionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/SaferSignTransactionView.swift
@@ -231,6 +231,7 @@ private struct TokenRow: View {
         Circle()
           .stroke(Color(.braveSeparator))
           .frame(width: assetIconSize, height: assetIconSize)
+          .background(Color(braveSystemName: .iconActive).clipShape(Circle()))
       }
       VStack(alignment: .leading) {
         Text(title)

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/BraveWalletExtensions.swift
@@ -147,7 +147,7 @@ extension BraveWallet.AccountId {
   }
 
   var blockieSeed: String {
-    address.isEmpty ? uniqueKey.sha256 : address
+    address.isEmpty ? uniqueKey.sha256 : address.lowercased()
   }
 }
 

--- a/ios/brave-ios/Sources/BraveWallet/NetworkIcon.swift
+++ b/ios/brave-ios/Sources/BraveWallet/NetworkIcon.swift
@@ -38,7 +38,7 @@ struct NetworkIcon: View {
   }
 
   private var networkIconMonogram: some View {
-    BlockieMaterial(seed: network.chainName)
+    BlockieBackground(seed: network.chainName)
       .clipShape(Circle())
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/NetworkIcon.swift
+++ b/ios/brave-ios/Sources/BraveWallet/NetworkIcon.swift
@@ -38,7 +38,7 @@ struct NetworkIcon: View {
   }
 
   private var networkIconMonogram: some View {
-    BlockieMaterial(address: network.chainName)
+    BlockieMaterial(seed: network.chainName)
       .clipShape(Circle())
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/NetworkIcon.swift
+++ b/ios/brave-ios/Sources/BraveWallet/NetworkIcon.swift
@@ -37,24 +37,9 @@ struct NetworkIcon: View {
     .aspectRatio(1, contentMode: .fit)
   }
 
-  @State private var monogramSize: CGSize = .zero
   private var networkIconMonogram: some View {
-    Blockie(address: network.chainName, shape: .circle)
-      .readSize(onChange: { newSize in
-        monogramSize = newSize
-      })
-      .overlay(
-        Text(network.chainName.first?.uppercased() ?? "")
-          .font(
-            .system(
-              size: max(monogramSize.width, monogramSize.height) / 2,
-              weight: .bold,
-              design: .rounded
-            )
-          )
-          .foregroundColor(.white)
-          .shadow(color: .black.opacity(0.3), radius: 2, x: 0, y: 1)
-      )
+    BlockieMaterial(address: network.chainName)
+      .clipShape(Circle())
   }
 
   private typealias NetworkImageInfo = (iconName: String, grayscale: Bool)

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Signature Request/SaferSignMessageRequestContainerView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Signature Request/SaferSignMessageRequestContainerView.swift
@@ -169,9 +169,8 @@ struct SaferSignMessageRequestContainerView: View {
             .foregroundColor(Color(.secondaryBraveLabel))
           HStack {
             Group {
-              if let image = network?.nativeTokenLogoImage {
-                Image(uiImage: image)
-                  .resizable()
+              if let network {
+                NetworkIcon(network: network)
               } else {
                 Circle()
                   .stroke(Color(.braveSeparator))

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Signature Request/SaferSignMessageRequestContainerView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Signature Request/SaferSignMessageRequestContainerView.swift
@@ -174,6 +174,7 @@ struct SaferSignMessageRequestContainerView: View {
               } else {
                 Circle()
                   .stroke(Color(.braveSeparator))
+                  .background(Color(braveSystemName: .iconActive).clipShape(Circle()))
               }
             }
             .frame(


### PR DESCRIPTION
- Aligned with WebUI to display placeholder network icon using `chainName` for network fee on CoW Swap safer sign UI.
- Fixed Blockie background implementation (renamed `BlockieMaterial` to `BlockieBackground` for clarity)
    - WebUI / desktop is using `backgroundColor` & `spotColor` (color 2 & color 3 from generator) for [Blockies.background](https://github.com/brave/blockies/blob/ae2f2eaf93064e004c3f8f19d36c4b90a461ba23/blockies.js#L156), where `bgColor` & `spotColor` are [2nd / 3rd color](https://github.com/brave/blockies/blob/ae2f2eaf93064e004c3f8f19d36c4b90a461ba23/blockies.js#L63-L65) respectively
    - iOS was using `color` & `backgroundColor` (color 1 & color 2 from generator): https://github.com/brave/brave-core/blob/d04b4adcd923593dffc4d5caa083f1b7c21e9a62/ios/brave-ios/Sources/BraveWallet/Blockies/Blockies.swift#L162-L168
- Aligned Blockie seed usage with WebUI
    - Addresses are always lowercased when used as a seed (matches existing behaviour): https://github.com/brave/brave-core/blob/02e3dc01590b93a68c9a8189f71c9c91fcbbb777/components/brave_wallet_ui/common/hooks/use-orb.ts#L39
    - Asset name (used when contract address is empty) not lowercased: https://github.com/brave/brave-core/blob/3ee579e74c08e7951c236b29457cab0fba61e85b/components/brave_wallet_ui/components/shared/create-placeholder-icon/index.tsx#L119-L121
    - Network (chain name) not lowercased: https://github.com/brave/brave-core/blob/02e3dc01590b93a68c9a8189f71c9c91fcbbb777/components/brave_wallet_ui/common/hooks/use-orb.ts#L87
    -  Sha256 (Bitcoin seed) not lowercased: https://github.com/brave/brave-core/blob/02e3dc01590b93a68c9a8189f71c9c91fcbbb777/components/brave_wallet_ui/common/hooks/use-orb.ts#L41-L43 
    - This change affects Asset Icon placeholder gradient, Network Icon placeholder gradient, and Account Card backgrounds. This aligns our colours with desktop for a uniform style across platforms.

Resolves https://github.com/brave/brave-browser/issues/36697

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Submit a swap transaction on swap.cow.fi using Gnosis network (important to use network not preloaded / network without an icon)
2. Check the panel and verify network icon is not an empty circle.

iOS | Desktop (for compare)
--|--
<img src="https://github.com/brave/brave-core/assets/5314553/682f04c3-655c-45a8-9709-2c47d7e4bf9f" width="300"> | <img src="https://github.com/brave/brave-core/assets/5314553/b59ebaf9-4c47-4785-a5c2-a22b21ba5e42" width="300">

