### PR TITLE
fix(wallet): Always display 'Show Zero Balances' button in Send on iOS

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/SelectAccountTokenView.swift
@@ -64,30 +64,21 @@ struct SelectAccountTokenView: View {
       ToolbarItemGroup(placement: .bottomBar) {
         networkFilterButton
         Spacer()
-        if shouldShowZeroBalanceButton {
-          Button {
-            store.isHidingZeroBalances.toggle()
-          } label: {
-            Text(
-              store.isHidingZeroBalances
-                ? Strings.Wallet.showZeroBalances : Strings.Wallet.hideZeroBalances
-            )
-            .font(.footnote.weight(.medium))
-            .foregroundColor(Color(.braveBlurpleTint))
-          }
+        Button {
+          store.isHidingZeroBalances.toggle()
+        } label: {
+          Text(
+            store.isHidingZeroBalances
+              ? Strings.Wallet.showZeroBalances : Strings.Wallet.hideZeroBalances
+          )
+          .font(.footnote.weight(.medium))
+          .foregroundColor(Color(.braveBlurpleTint))
         }
       }
     }
     .onDisappear {
       store.resetFilters()
     }
-  }
-
-  private var shouldShowZeroBalanceButton: Bool {
-    if !store.isHidingZeroBalances {
-      return true
-    }
-    return store.accountSections.isEmpty
   }
 
   private var networkFilterButton: some View {


### PR DESCRIPTION
- Always show 'Show Zero Balances' button in Select a Token to Send modal. Previously button was only displayed when no displayed tokens had a balance.
- This applies all networks, but provides extra help with Bitcoin Testnet account when throttled by Bitcoin Testnet network and 0 balance is returned causing account(s) to be hidden so user has to exist Send to copy another Bitcoin Testnet account address

Resolves https://github.com/brave/brave-browser/issues/38452

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Have a wallet with some balance on any network
1. Open Send and wait for Select a Token to Send modal to load balances
2. Verify `Show Zero Balances` button is always displayed. Previously button was only displayed when no displayed tokens had a balance.

![Show Zero Balances](https://github.com/brave/brave-core/assets/5314553/6c7df013-36e5-4726-8d47-04baf968ec36) | ![Hide Zero Balances](https://github.com/brave/brave-core/assets/5314553/14060804-f5bc-4bda-a1ac-d18af26fa405)
--|--
Previously in left screenshot, the `Show Zero Balances` button would not be displayed because other tokens are displayed with a positive balance
