### PR TITLE
Ignores setPictureInPictureParams IllegalStateException when pip Activity is not in an appropriate state on Android

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -233,6 +233,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/local_database/DisplayAdsTable.java",
   "../../brave/android/java/org/chromium/chrome/browser/local_database/SavedBandwidthTable.java",
   "../../brave/android/java/org/chromium/chrome/browser/local_database/TopSiteTable.java",
+  "../../brave/android/java/org/chromium/chrome/browser/media/BravePictureInPictureActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/misc_metrics/MiscAndroidMetricsConnectionErrorHandler.java",
   "../../brave/android/java/org/chromium/chrome/browser/misc_metrics/MiscAndroidMetricsFactory.java",
   "../../brave/android/java/org/chromium/chrome/browser/multiwindow/BraveMultiInstanceManagerApi31.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -366,6 +366,8 @@
 
 -keep class org.chromium.chrome.browser.app.BraveActivity
 
+-keep class org.chromium.chrome.browser.media.BravePictureInPictureActivity
+
 -keep class org.chromium.chrome.browser.suggestions.tile.SuggestionsTileView
 
 -keep class org.chromium.chrome.browser.suggestions.tile.BraveTileView

--- a/android/java/org/chromium/chrome/browser/media/BravePictureInPictureActivity.java
+++ b/android/java/org/chromium/chrome/browser/media/BravePictureInPictureActivity.java
@@ -1,0 +1,26 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.media;
+
+import android.app.PictureInPictureParams;
+
+import androidx.annotation.NonNull;
+
+import org.chromium.chrome.browser.init.AsyncInitializationActivity;
+
+public abstract class BravePictureInPictureActivity extends AsyncInitializationActivity {
+    @Override
+    public void setPictureInPictureParams(@NonNull PictureInPictureParams params) {
+        try {
+            super.setPictureInPictureParams(params);
+        } catch (IllegalStateException ignored) {
+            // TODO(sergz): It looks like the call has been made when
+            // the Java environment or the application is not in an
+            // appropriate state for the requested operation.
+            // We can just ignore it.
+        }
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -2027,85 +2027,126 @@ public class BytecodeTest {
     @Test
     @SmallTest
     public void testSuperNames() throws Exception {
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/ChromeApplicationImpl",
-                "org/chromium/chrome/browser/BraveApplicationImplBase"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/settings/MainSettings",
-                "org/chromium/chrome/browser/settings/BraveMainPreferencesBase"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/ntp/NewTabPageLayout", "android/widget/FrameLayout"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/password_manager/settings/PasswordSettings",
-                "org/chromium/chrome/browser/password_manager/settings/BravePasswordSettingsBase"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/ChromeApplicationImpl",
+                        "org/chromium/chrome/browser/BraveApplicationImplBase"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/settings/MainSettings",
+                        "org/chromium/chrome/browser/settings/BraveMainPreferencesBase"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/ntp/NewTabPageLayout",
+                        "android/widget/FrameLayout"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/password_manager/settings/PasswordSettings",
+                        "org/chromium/chrome/browser/password_manager/settings/BravePasswordSettingsBase")); // presubmit: ignore-long-line
         Assert.assertTrue(
                 checkSuperName(
                         "org/chromium/chrome/browser/search_engines/settings/SearchEngineAdapter",
-                        "org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/components/browser_ui/site_settings/SingleCategorySettings",
-                "org/chromium/components/browser_ui/site_settings/BraveSingleCategorySettings"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/ChromeTabbedActivity",
-                "org/chromium/chrome/browser/app/BraveActivity"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/tabbed_mode/TabbedAppMenuPropertiesDelegate",
-                "org/chromium/chrome/browser/app/appmenu/BraveAppMenuPropertiesDelegateImpl"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate",
-                "org/chromium/chrome/browser/app/appmenu/BraveAppMenuPropertiesDelegateImpl"));
+                        "org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter")); // presubmit: ignore-long-line
         Assert.assertTrue(
-                checkSuperName("org/chromium/chrome/browser/suggestions/tile/SuggestionsTileView",
+                checkSuperName(
+                        "org/chromium/components/browser_ui/site_settings/SingleCategorySettings",
+                        "org/chromium/components/browser_ui/site_settings/BraveSingleCategorySettings")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/ChromeTabbedActivity",
+                        "org/chromium/chrome/browser/app/BraveActivity"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/tabbed_mode/TabbedAppMenuPropertiesDelegate",
+                        "org/chromium/chrome/browser/app/appmenu/BraveAppMenuPropertiesDelegateImpl")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/customtabs/CustomTabAppMenuPropertiesDelegate",
+                        "org/chromium/chrome/browser/app/appmenu/BraveAppMenuPropertiesDelegateImpl")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/suggestions/tile/SuggestionsTileView",
                         "org/chromium/chrome/browser/suggestions/tile/BraveTileView"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/customtabs/features/toolbar/CustomTabToolbar",
-                "org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/toolbar/top/ToolbarPhone",
-                "org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/toolbar/top/ToolbarTablet",
-                "org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/components/browser_ui/site_settings/SingleCategorySettings",
-                "org/chromium/components/browser_ui/site_settings/BraveSingleCategorySettings"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings",
-                "org/chromium/components/browser_ui/site_settings/BraveSingleWebsiteSettings"));
-        Assert.assertTrue(checkSuperName("org/chromium/components/browser_ui/site_settings/Website",
-                "org/chromium/components/browser_ui/site_settings/BraveWebsite"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/customtabs/features/toolbar/CustomTabToolbar",
+                        "org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/toolbar/top/ToolbarPhone",
+                        "org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/toolbar/top/ToolbarTablet",
+                        "org/chromium/chrome/browser/toolbar/top/BraveToolbarLayoutImpl"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/components/browser_ui/site_settings/SingleCategorySettings",
+                        "org/chromium/components/browser_ui/site_settings/BraveSingleCategorySettings")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/components/browser_ui/site_settings/SingleWebsiteSettings",
+                        "org/chromium/components/browser_ui/site_settings/BraveSingleWebsiteSettings")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/components/browser_ui/site_settings/Website",
+                        "org/chromium/components/browser_ui/site_settings/BraveWebsite"));
         Assert.assertTrue(
                 checkSuperName(
                         "org/chromium/components/browser_ui/site_settings/SiteSettings",
                         "org/chromium/components/browser_ui/site_settings/BraveSiteSettingsPreferencesBase"));
         Assert.assertTrue(
-                checkSuperName("org/chromium/chrome/browser/infobar/TranslateCompactInfoBar",
+                checkSuperName(
+                        "org/chromium/chrome/browser/infobar/TranslateCompactInfoBar",
                         "org/chromium/chrome/browser/infobar/BraveTranslateCompactInfoBarBase"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/download/DownloadMessageUiControllerImpl",
-                "org/chromium/chrome/browser/download/BraveDownloadMessageUiControllerImpl"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/omnibox/suggestions/AutocompleteCoordinator",
-                "org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteCoordinator"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator",
-                "org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteMediatorBase"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/omnibox/LocationBarPhone",
-                "org/chromium/chrome/browser/omnibox/BraveLocationBarLayout"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/omnibox/LocationBarTablet",
-                "org/chromium/chrome/browser/omnibox/BraveLocationBarLayout"));
-        Assert.assertTrue(checkSuperName(
-                "org/chromium/chrome/browser/searchwidget/SearchActivityLocationBarLayout",
-                "org/chromium/chrome/browser/omnibox/BraveLocationBarLayout"));
         Assert.assertTrue(
-                checkSuperName("org/chromium/chrome/browser/document/ChromeLauncherActivity",
+                checkSuperName(
+                        "org/chromium/chrome/browser/download/DownloadMessageUiControllerImpl",
+                        "org/chromium/chrome/browser/download/BraveDownloadMessageUiControllerImpl")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/omnibox/suggestions/AutocompleteCoordinator",
+                        "org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteCoordinator")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/omnibox/suggestions/AutocompleteMediator",
+                        "org/chromium/chrome/browser/omnibox/suggestions/BraveAutocompleteMediatorBase")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/omnibox/LocationBarPhone",
+                        "org/chromium/chrome/browser/omnibox/BraveLocationBarLayout"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/omnibox/LocationBarTablet",
+                        "org/chromium/chrome/browser/omnibox/BraveLocationBarLayout"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/searchwidget/SearchActivityLocationBarLayout",
+                        "org/chromium/chrome/browser/omnibox/BraveLocationBarLayout"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/document/ChromeLauncherActivity",
                         "org/chromium/chrome/browser/document/BraveLauncherActivity"));
         Assert.assertTrue(
-                checkSuperName("org/chromium/components/permissions/PermissionDialogDelegate",
+                checkSuperName(
+                        "org/chromium/components/permissions/PermissionDialogDelegate",
                         "org/chromium/components/permissions/BravePermissionDialogDelegate"));
         Assert.assertTrue(
-                checkSuperName("org/chromium/chrome/browser/tracing/settings/DeveloperSettings",
+                checkSuperName(
+                        "org/chromium/chrome/browser/tracing/settings/DeveloperSettings",
                         "org/chromium/chrome/browser/settings/BravePreferenceFragment"));
-        Assert.assertTrue(checkSuperName("org/chromium/chrome/browser/bookmarks/BookmarkModel",
-                "org/chromium/chrome/browser/bookmarks/BraveBookmarkBridge"));
         Assert.assertTrue(
-                checkSuperName("org/chromium/chrome/browser/tasks/tab_groups/TabGroupModelFilter",
+                checkSuperName(
+                        "org/chromium/chrome/browser/bookmarks/BookmarkModel",
+                        "org/chromium/chrome/browser/bookmarks/BraveBookmarkBridge"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/tasks/tab_groups/TabGroupModelFilter",
                         "org/chromium/chrome/browser/tasks/tab_groups/BraveTabGroupModelFilter"));
+        Assert.assertTrue(
+                checkSuperName(
+                        "org/chromium/chrome/browser/media/PictureInPictureActivity",
+                        "org/chromium/chrome/browser/media/BravePictureInPictureActivity"));
     }
 
     private boolean classExists(String className) {

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -78,6 +78,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePasswordSettingsBaseClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePermissionDialogDelegateClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePermissionDialogModelClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BravePictureInPictureActivityClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePreferenceFragmentClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BravePureJavaExceptionReporterClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveReaderModeManagerClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -78,6 +78,7 @@ public class BraveClassAdapter {
         chain = new BravePasswordSettingsBaseClassAdapter(chain);
         chain = new BravePermissionDialogDelegateClassAdapter(chain);
         chain = new BravePermissionDialogModelClassAdapter(chain);
+        chain = new BravePictureInPictureActivityClassAdapter(chain);
         chain = new BravePreferenceFragmentClassAdapter(chain);
         chain = new BravePureJavaExceptionReporterClassAdapter(chain);
         chain = new BraveReaderModeManagerClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BravePictureInPictureActivityClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BravePictureInPictureActivityClassAdapter.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BravePictureInPictureActivityClassAdapter extends BraveClassVisitor {
+    static String sPictureInPictureActivityClassName =
+            "org/chromium/chrome/browser/media/PictureInPictureActivity";
+    static String sBravePictureInPictureActivityClassName =
+            "org/chromium/chrome/browser/media/BravePictureInPictureActivity";
+
+    public BravePictureInPictureActivityClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        changeSuperName(
+                sPictureInPictureActivityClassName, sBravePictureInPictureActivityClassName);
+    }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38614

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

