### PR TITLE
fix(wallet): Duplicate checkmarks in Portfolio Menus

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -602,19 +602,19 @@ struct FilterPickerRowView<T: Equatable & Identifiable & Hashable, Content: View
       Spacer()
       Menu(
         content: {
-          ForEach(allOptions) { option in
-            Button {
-              selection = option
-            } label: {
-              HStack {
-                Image(braveSystemName: "leo.check.normal")
-                  .resizable()
-                  .aspectRatio(contentMode: .fit)
-                  .hidden(isHidden: selection.id != option.id)
+          Picker(
+            selection: $selection,
+            content: {
+              ForEach(allOptions) { option in
                 content(option)
+                  .tag(option)
               }
+            },
+            label: {
+              // Menu label is used
+              EmptyView()
             }
-          }
+          )
         },
         label: {
           HStack(spacing: 8) {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
@@ -227,20 +227,19 @@ struct TimeframeSelector: View {
   var body: some View {
     Menu(
       content: {
-        ForEach(BraveWallet.AssetPriceTimeframe.allCases, id: \.self) { range in
-          Button {
-            selectedDateRange = range
-          } label: {
-            HStack {
-              Image(braveSystemName: "leo.check.normal")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .hidden(isHidden: selectedDateRange != range)
+        Picker(
+          selection: $selectedDateRange,
+          content: {
+            ForEach(BraveWallet.AssetPriceTimeframe.allCases, id: \.self) { range in
               Text(verbatim: range.accessibilityLabel)
+                .tag(range)
             }
-            .tag(range)
+          },
+          label: {
+            // Menu label is used
+            EmptyView()
           }
-        }
+        )
       },
       label: {
         HStack(spacing: 4) {


### PR DESCRIPTION
- Regressed in https://github.com/brave/brave-core/pull/23815/commits/366333bf724cbb3333cbf12dddcefeff6c526b23. Menu does not respect SwiftUI `opacity` modifier.

Resolves https://github.com/brave/brave-browser/issues/38616

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Tap time range in Portfolio
2. Verify only selected time range is showing checkmark
3. Open Portfolio/NFT filters
4. Tap Group By and/or Sort Assets
5. Verify only selected option is showing checkmark

![Portfolio Time Range](https://github.com/brave/brave-core/assets/5314553/39e9533a-e4fe-4080-bcc8-fb2315bac9e7) | ![Group By Filter](https://github.com/brave/brave-core/assets/5314553/fb63d8dc-1590-4456-8612-c86096d4703d) | ![Sort Assets Filter](https://github.com/brave/brave-core/assets/5314553/ab2ec517-98fe-4ab9-8a4a-0c08cec93ecc)
--|--|--
