### PR TITLE
Fixed search promotion's layout regression

### DIFF
--- a/browser/ui/views/omnibox/brave_omnibox_result_view.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.cc
@@ -30,6 +30,8 @@
 #include "ui/gfx/canvas.h"
 #include "ui/gfx/scoped_canvas.h"
 #include "ui/views/controls/button/image_button.h"
+#include "ui/views/layout/fill_layout.h"
+#include "ui/views/layout/flex_layout.h"
 #include "ui/views/view_class_properties.h"
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
@@ -39,15 +41,17 @@
 BraveOmniboxResultView::~BraveOmniboxResultView() = default;
 
 void BraveOmniboxResultView::ResetChildren() {
-  // Reset children visibility. Their visibility could be configured later
-  // based on |match_| and the current input.
-  // NOTE: The first child in the result box is supposed to be the
-  // `suggestion_container_`, which used to be stored as a data member.
-  children().front()->SetVisible(true);
-  button_row_->SetVisible(true);
   if (brave_search_promotion_view_) {
     RemoveChildViewT(brave_search_promotion_view_);
     brave_search_promotion_view_ = nullptr;
+  }
+
+  // Reset children visibility. Their visibility could be configured later
+  // based on |match_| and the current input.
+  // Reset upstream's layout manager.
+  SetLayoutManager(std::make_unique<views::FillLayout>());
+  for (auto& child : children()) {
+    child->SetVisible(true);
   }
 }
 
@@ -118,10 +122,14 @@ void BraveOmniboxResultView::UpdateForBraveSearchConversion() {
   }
 
   // Hide upstream children and show our promotion view.
-  // NOTE: The first child in the result box is supposed to be the
-  // `suggestion_container_`, which used to be stored as a data member.
-  children().front()->SetVisible(false);
-  button_row_->SetVisible(false);
+  // It'll be the only visible child view.
+  for (auto& child : children()) {
+    child->SetVisible(false);
+  }
+
+  // To have proper size for promotion view.
+  SetLayoutManager(std::make_unique<views::FlexLayout>())
+      ->SetOrientation(views::LayoutOrientation::kVertical);
 
   CHECK(!brave_search_promotion_view_);
   auto* controller = popup_view_->controller()->autocomplete_controller();


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/38579

Use flex layout to OmniboxResultView when promotion view is the only visible child to have sufficient height.

[simplescreenrecorder-2024-05-28_12.12.06.webm](https://github.com/brave/brave-core/assets/6786187/3159fd58-f972-4759-8fd4-b589960d5ce6)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue