### PR TITLE
[iOS] - Export AutocompleteClassifier and Fix URL handling

### DIFF
--- a/chromium_src/ios/chrome/browser/browser_state/model/browser_state_keyed_service_factories.mm
+++ b/chromium_src/ios/chrome/browser/browser_state/model/browser_state_keyed_service_factories.mm
@@ -6,6 +6,7 @@
 #include "ios/chrome/browser/browser_state/model/browser_state_keyed_service_factories.h"
 
 #include "brave/ios/browser/browser_state/brave_browser_state_keyed_service_factories.h"
+#include "ios/chrome/browser/autocomplete/model/autocomplete_classifier_factory.h"
 #include "ios/chrome/browser/autofill/model/personal_data_manager_factory.h"
 #include "ios/chrome/browser/bookmarks/model/bookmark_model_factory.h"
 #include "ios/chrome/browser/bookmarks/model/bookmark_undo_service_factory.h"
@@ -18,6 +19,7 @@
 #include "ios/chrome/browser/favicon/model/ios_chrome_large_icon_cache_factory.h"
 #include "ios/chrome/browser/favicon/model/ios_chrome_large_icon_service_factory.h"
 #include "ios/chrome/browser/history/model/history_service_factory.h"
+#include "ios/chrome/browser/history/model/top_sites_factory.h"
 #include "ios/chrome/browser/history/model/web_history_service_factory.h"
 #include "ios/chrome/browser/invalidation/model/ios_chrome_profile_invalidation_provider_factory.h"
 #include "ios/chrome/browser/passwords/model/ios_chrome_profile_password_store_factory.h"
@@ -45,6 +47,8 @@ void EnsureBrowserStateKeyedServiceFactoriesBuilt() {
   ios::BookmarkUndoServiceFactory::GetInstance();
   ios::FaviconServiceFactory::GetInstance();
   ios::HistoryServiceFactory::GetInstance();
+  ios::TopSitesFactory::GetInstance();
+  ios::AutocompleteClassifierFactory::GetInstance();
   ios::HostContentSettingsMapFactory::GetInstance();
   ios::TemplateURLServiceFactory::GetInstance();
   ios::WebDataServiceFactory::GetInstance();

--- a/chromium_src/ios/chrome/browser/shared/model/prefs/DEPS
+++ b/chromium_src/ios/chrome/browser/shared/model/prefs/DEPS
@@ -10,6 +10,7 @@ include_rules = [
   "+brave/components/ipfs",
   "+brave/components/l10n/common",
   "+brave/components/ntp_background_images/browser",
+  "+brave/components/omnibox/browser",
   "+brave/components/brave_shields/core/common",
   "+brave/components/p3a",
   "+brave/components/skus/browser",

--- a/chromium_src/ios/chrome/browser/shared/model/prefs/browser_prefs.mm
+++ b/chromium_src/ios/chrome/browser/shared/model/prefs/browser_prefs.mm
@@ -18,6 +18,7 @@
 #include "brave/components/decentralized_dns/core/utils.h"
 #include "brave/components/l10n/common/prefs.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
+#include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
 #include "brave/components/p3a/buildflags.h"
 #include "brave/components/p3a/p3a_service.h"
 #include "brave/components/p3a/star_randomness_meta.h"
@@ -37,6 +38,7 @@ void BraveRegisterBrowserStatePrefs(
   debounce::DebounceService::RegisterProfilePrefs(registry);
   ai_chat::prefs::RegisterProfilePrefs(registry);
   ai_chat::ModelService::RegisterProfilePrefs(registry);
+  omnibox::RegisterBraveProfilePrefs(registry);
   brave_news::prefs::RegisterProfilePrefs(registry);
 }
 

--- a/components/omnibox/browser/BUILD.gn
+++ b/components/omnibox/browser/BUILD.gn
@@ -31,8 +31,6 @@ source_set("unit_tests") {
     "//brave/components/constants",
     "//brave/components/l10n/common:test_support",
     "//brave/components/search_engines",
-    "//chrome/browser/search_engines",
-    "//chrome/test:test_support",
     "//components/bookmarks/browser",
     "//components/bookmarks/test",
     "//components/omnibox/browser",
@@ -42,11 +40,18 @@ source_set("unit_tests") {
     "//components/search_engines",
     "//components/sync_preferences:test_support",
     "//components/variations:test_support",
-    "//content/test:test_support",
     "//services/network:test_support",
     "//testing/gmock",
     "//testing/gtest",
   ]
+
+  if (!is_ios) {
+    deps += [
+      "//chrome/browser/search_engines",
+      "//chrome/test:test_support",
+      "//content/test:test_support",
+    ]
+  }
 
   if (enable_commander) {
     sources +=

--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -24,6 +24,7 @@ import("//brave/ios/browser/api/features/headers.gni")
 import("//brave/ios/browser/api/https_upgrade_exceptions/headers.gni")
 import("//brave/ios/browser/api/ipfs/headers.gni")
 import("//brave/ios/browser/api/ntp_background_images/headers.gni")
+import("//brave/ios/browser/api/omnibox/headers.gni")
 import("//brave/ios/browser/api/opentabs/headers.gni")
 import("//brave/ios/browser/api/p3a/headers.gni")
 import("//brave/ios/browser/api/qr_code/headers.gni")
@@ -102,6 +103,7 @@ brave_core_public_headers += brave_wallet_public_headers
 brave_core_public_headers += browser_api_certificate_public_headers
 brave_core_public_headers += browser_api_favicon_public_headers
 brave_core_public_headers += rewards_public_headers
+brave_core_public_headers += browser_api_omnibox_public_headers
 brave_core_public_headers += browser_api_opentabs_public_headers
 brave_core_public_headers += browser_api_qr_code_public_headers
 brave_core_public_headers += browser_api_session_restore_public_headers

--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -269,6 +269,8 @@ const BraveCoreLogSeverity BraveCoreLogSeverityVerbose =
 }
 
 - (void)dealloc {
+  _backgroundImagesService = nil;
+  _adblockService = nil;
   _bookmarksAPI = nil;
   _historyAPI = nil;
   _openTabsAPI = nil;

--- a/ios/brave-ios/App/Client.xcodeproj/Brave.xctestplan
+++ b/ios/brave-ios/App/Client.xcodeproj/Brave.xctestplan
@@ -40,6 +40,9 @@
       }
     },
     {
+      "skippedTests" : [
+        "DecentralizedDNSHelperTests"
+      ],
       "target" : {
         "containerPath" : "container:..",
         "identifier" : "BraveWalletTests",
@@ -52,7 +55,8 @@
         "PlaylistTests\/testVideoPlayerTrackBarTimeManualFormatter()",
         "SyncTests",
         "TabSessionTests",
-        "TestFavicons"
+        "TestFavicons",
+        "URLFormatTests"
       ],
       "target" : {
         "containerPath" : "container:..",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -255,7 +255,7 @@ extension BrowserViewController: TopToolbarDelegate {
     isUserDefinedURLNavigation: Bool
   ) async -> Bool {
 
-    if let url = URL(string: text), url.scheme == "brave" {
+    if let url = URL(string: text), url.scheme == "brave" || url.scheme == "chrome" {
       topToolbar.leaveOverlayMode()
       return handleChromiumWebUIURL(url)
     }
@@ -263,35 +263,37 @@ extension BrowserViewController: TopToolbarDelegate {
     guard let fixupURL = URIFixup.getURL(text) else {
       return false
     }
-    // Do not allow users to enter URLs with the following schemes.
-    // Instead, submit them to the search engine like Chrome-iOS does.
-    if !["file"].contains(fixupURL.scheme) {
-      // check text is decentralized DNS supported domain
-      if let decentralizedDNSHelper = self.decentralizedDNSHelperFor(url: fixupURL) {
-        topToolbar.leaveOverlayMode()
-        updateToolbarCurrentURL(fixupURL)
-        topToolbar.locationView.loading = true
-        let result = await decentralizedDNSHelper.lookup(
-          domain: fixupURL.schemelessAbsoluteDisplayString
-        )
-        topToolbar.locationView.loading = tabManager.selectedTab?.loading ?? false
-        guard !Task.isCancelled else { return true }  // user pressed stop, or typed new url
-        switch result {
-        case .loadInterstitial(let service):
-          showWeb3ServiceInterstitialPage(service: service, originalURL: fixupURL)
-          return true
-        case .load(let resolvedURL):
-          if resolvedURL.isIPFSScheme,
-            let resolvedIPFSURL = braveCore.ipfsAPI.resolveGatewayUrl(for: resolvedURL)
-          {
-            finishEditingAndSubmit(resolvedIPFSURL)
-          } else {
-            finishEditingAndSubmit(resolvedURL)
-          }
-          return true
-        case .none:
-          break
+
+    if fixupURL.scheme == "brave" || fixupURL.scheme == "chrome" {
+      topToolbar.leaveOverlayMode()
+      return handleChromiumWebUIURL(fixupURL)
+    }
+
+    // check text is decentralized DNS supported domain
+    if let decentralizedDNSHelper = self.decentralizedDNSHelperFor(url: fixupURL) {
+      topToolbar.leaveOverlayMode()
+      updateToolbarCurrentURL(fixupURL)
+      topToolbar.locationView.loading = true
+      let result = await decentralizedDNSHelper.lookup(
+        domain: fixupURL.schemelessAbsoluteDisplayString
+      )
+      topToolbar.locationView.loading = tabManager.selectedTab?.loading ?? false
+      guard !Task.isCancelled else { return true }  // user pressed stop, or typed new url
+      switch result {
+      case .loadInterstitial(let service):
+        showWeb3ServiceInterstitialPage(service: service, originalURL: fixupURL)
+        return true
+      case .load(let resolvedURL):
+        if resolvedURL.isIPFSScheme,
+          let resolvedIPFSURL = braveCore.ipfsAPI.resolveGatewayUrl(for: resolvedURL)
+        {
+          finishEditingAndSubmit(resolvedIPFSURL)
+        } else {
+          finishEditingAndSubmit(resolvedURL)
         }
+        return true
+      case .none:
+        break
       }
     }
 
@@ -316,7 +318,7 @@ extension BrowserViewController: TopToolbarDelegate {
     }
     let controller = ChromeWebViewController(privateBrowsing: false)
     controller.loadURL(url.absoluteString)
-    controller.title = url.host
+    controller.title = url.host?.capitalizeFirstLetter
     let webView = controller.webView
     webView.isFindInteractionEnabled = true
     controller.navigationItem.rightBarButtonItem = UIBarButtonItem(

--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -31,6 +31,7 @@ source_set("browser") {
     "api/ipfs",
     "api/net",
     "api/ntp_background_images",
+    "api/omnibox",
     "api/opentabs",
     "api/p3a",
     "api/password",

--- a/ios/browser/api/omnibox/BUILD.gn
+++ b/ios/browser/api/omnibox/BUILD.gn
@@ -1,0 +1,25 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("omnibox") {
+  sources = [
+    "autocomplete_classifier.h",
+    "autocomplete_classifier.mm",
+  ]
+
+  deps = [
+    "//base",
+    "//components/omnibox/browser",
+    "//components/prefs",
+    "//ios/chrome/browser/autocomplete/model",
+    "//ios/chrome/browser/shared/model/application_context",
+    "//ios/chrome/browser/shared/model/browser_state",
+    "//ios/chrome/browser/shared/model/prefs:pref_names",
+    "//net",
+    "//url",
+  ]
+
+  frameworks = [ "Foundation.framework" ]
+}

--- a/ios/browser/api/omnibox/autocomplete_classifier.h
+++ b/ios/browser/api/omnibox/autocomplete_classifier.h
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <Foundation/Foundation.h>
+
+#ifndef BRAVE_IOS_BROWSER_API_OMNIBOX_AUTOCOMPLETE_CLASSIFIER_H_
+#define BRAVE_IOS_BROWSER_API_OMNIBOX_AUTOCOMPLETE_CLASSIFIER_H_
+
+NS_ASSUME_NONNULL_BEGIN
+
+// From:
+// https://source.chromium.org/chromium/chromium/src/+/main:components/omnibox/browser/autocomplete_match_type.h
+NS_SWIFT_NAME(AutocompleteMatch.Type)
+typedef NS_ENUM(NSUInteger, BraveIOSAutocompleteMatchType) {
+  BraveIOSAutocompleteMatchTypeUrlWhatYouTyped = 0,  // The input as a URL.
+  BraveIOSAutocompleteMatchTypeHistoryUrl =
+      1,  // A past page whose URL contains the input.
+  BraveIOSAutocompleteMatchTypeHistoryKeyword =
+      4,  // A past page whose keyword contains the input.
+  BraveIOSAutocompleteMatchTypeNavSuggest = 5,  // A suggested URL.
+  BraveIOSAutocompleteMatchTypeSearchWhatYouTyped =
+      6,  // The input as a search query (with the default engine).
+  BraveIOSAutocompleteMatchTypeSearchHistory =
+      7,  // A past search (with the default engine) containing the input.
+  BraveIOSAutocompleteMatchTypeSearchOtherEngine =
+      13,  // A search with a non-default engine.
+  BraveIOSAutocompleteMatchTypeBookmarkTitle =
+      16,  // A bookmark whose title contains the input.
+  BraveIOSAutocompleteMatchTypeClipboardUrl =
+      19,  // A URL based on the clipboard.
+  BraveIOSAutocompleteMatchTypeClipboardText =
+      26,  // Text based on the clipboard.
+  BraveIOSAutocompleteMatchTypeOpenTab =
+      30,  // A URL match amongst the currently open tabs.
+};
+
+OBJC_EXPORT
+NS_SWIFT_NAME(AutocompleteMatch)
+@interface BraveIOSAutocompleteMatch : NSObject
+@property(nonatomic, readonly)
+    NSString* text;  // The text passed into the classifier
+@property(nonatomic, readonly)
+    BraveIOSAutocompleteMatchType type;  // The type of match
+@property(nonatomic, readonly)
+    NSURL* destinationURL;  // The suggested search URL
+@end
+
+OBJC_EXPORT
+NS_SWIFT_NAME(AutocompleteClassifier)
+@interface BraveIOSAutocompleteClassifier : NSObject
++ (nullable BraveIOSAutocompleteMatch*)classify:(NSString*)text;
++ (bool)isSearchType:(BraveIOSAutocompleteMatchType)type;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_OMNIBOX_AUTOCOMPLETE_CLASSIFIER_H_

--- a/ios/browser/api/omnibox/autocomplete_classifier.mm
+++ b/ios/browser/api/omnibox/autocomplete_classifier.mm
@@ -1,0 +1,125 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/ios/browser/api/omnibox/autocomplete_classifier.h"
+
+#include "base/strings/sys_string_conversions.h"
+#include "base/strings/utf_string_conversions.h"
+#include "components/omnibox/browser/autocomplete_classifier.h"
+#include "components/omnibox/browser/autocomplete_match.h"
+#include "components/prefs/pref_service.h"
+#include "ios/chrome/browser/autocomplete/model/autocomplete_classifier_factory.h"
+#include "ios/chrome/browser/shared/model/application_context/application_context.h"
+#include "ios/chrome/browser/shared/model/browser_state/chrome_browser_state.h"
+#include "ios/chrome/browser/shared/model/browser_state/chrome_browser_state_manager.h"
+#include "ios/chrome/browser/shared/model/prefs/pref_names.h"
+#include "net/base/apple/url_conversions.h"
+
+namespace brave {
+AutocompleteMatch::Type MatchTypeFromBraveType(
+    BraveIOSAutocompleteMatchType type) {
+  switch (type) {
+    case BraveIOSAutocompleteMatchTypeUrlWhatYouTyped:
+      return AutocompleteMatch::Type::URL_WHAT_YOU_TYPED;
+    case BraveIOSAutocompleteMatchTypeHistoryUrl:
+      return AutocompleteMatch::Type::HISTORY_URL;
+    case BraveIOSAutocompleteMatchTypeHistoryKeyword:
+      return AutocompleteMatch::Type::HISTORY_KEYWORD;
+    case BraveIOSAutocompleteMatchTypeNavSuggest:
+      return AutocompleteMatch::Type::NAVSUGGEST;
+    case BraveIOSAutocompleteMatchTypeSearchWhatYouTyped:
+      return AutocompleteMatch::Type::SEARCH_WHAT_YOU_TYPED;
+    case BraveIOSAutocompleteMatchTypeSearchHistory:
+      return AutocompleteMatch::Type::SEARCH_HISTORY;
+    case BraveIOSAutocompleteMatchTypeSearchOtherEngine:
+      return AutocompleteMatch::Type::SEARCH_OTHER_ENGINE;
+    case BraveIOSAutocompleteMatchTypeBookmarkTitle:
+      return AutocompleteMatch::Type::BOOKMARK_TITLE;
+    case BraveIOSAutocompleteMatchTypeClipboardUrl:
+      return AutocompleteMatch::Type::CLIPBOARD_URL;
+    case BraveIOSAutocompleteMatchTypeClipboardText:
+      return AutocompleteMatch::Type::CLIPBOARD_TEXT;
+    case BraveIOSAutocompleteMatchTypeOpenTab:
+      return AutocompleteMatch::Type::OPEN_TAB;
+    default:
+      NOTREACHED_NORETURN();
+  }
+}
+
+BraveIOSAutocompleteMatchType BraveTypeFromMatchType(
+    AutocompleteMatch::Type type) {
+  switch (type) {
+    case AutocompleteMatch::Type::URL_WHAT_YOU_TYPED:
+      return BraveIOSAutocompleteMatchTypeUrlWhatYouTyped;
+    case AutocompleteMatch::Type::HISTORY_URL:
+      return BraveIOSAutocompleteMatchTypeHistoryUrl;
+    case AutocompleteMatch::Type::HISTORY_KEYWORD:
+      return BraveIOSAutocompleteMatchTypeHistoryKeyword;
+    case AutocompleteMatch::Type::NAVSUGGEST:
+      return BraveIOSAutocompleteMatchTypeNavSuggest;
+    case AutocompleteMatch::Type::SEARCH_WHAT_YOU_TYPED:
+      return BraveIOSAutocompleteMatchTypeSearchWhatYouTyped;
+    case AutocompleteMatch::Type::SEARCH_HISTORY:
+      return BraveIOSAutocompleteMatchTypeSearchHistory;
+    case AutocompleteMatch::Type::SEARCH_OTHER_ENGINE:
+      return BraveIOSAutocompleteMatchTypeSearchOtherEngine;
+    case AutocompleteMatch::Type::BOOKMARK_TITLE:
+      return BraveIOSAutocompleteMatchTypeBookmarkTitle;
+    case AutocompleteMatch::Type::CLIPBOARD_URL:
+      return BraveIOSAutocompleteMatchTypeClipboardUrl;
+    case AutocompleteMatch::Type::CLIPBOARD_TEXT:
+      return BraveIOSAutocompleteMatchTypeClipboardText;
+    case AutocompleteMatch::Type::OPEN_TAB:
+      return BraveIOSAutocompleteMatchTypeOpenTab;
+    default:
+      NOTREACHED_NORETURN();
+  }
+}
+}  // namespace brave
+
+@implementation BraveIOSAutocompleteMatch
+- (instancetype)initWithText:(NSString*)text
+                        type:(BraveIOSAutocompleteMatchType)type
+              destinationURL:(NSURL*)destinationURL {
+  if ((self = [super init])) {
+    _text = text;
+    _type = type;
+    _destinationURL = destinationURL;
+  }
+  return self;
+}
+@end
+
+@implementation BraveIOSAutocompleteClassifier
+
++ (BraveIOSAutocompleteMatch*)classify:(NSString*)text {
+  AutocompleteClassifier* classifier =
+      ios::AutocompleteClassifierFactory::GetForBrowserState(
+          GetApplicationContext()
+              ->GetChromeBrowserStateManager()
+              ->GetLastUsedBrowserStateDeprecatedDoNotUse());
+  if (classifier) {
+    AutocompleteMatch match;
+    classifier->Classify(base::SysNSStringToUTF16(text), false, false,
+                         metrics::OmniboxEventProto::INVALID_SPEC, &match,
+                         nullptr);
+
+    if (!match.destination_url.is_valid()) {
+      return nil;
+    }
+
+    return [[BraveIOSAutocompleteMatch alloc]
+          initWithText:text
+                  type:brave::BraveTypeFromMatchType(match.type)
+        destinationURL:net::NSURLWithGURL(match.destination_url)];
+  }
+  return nil;
+}
+
++ (bool)isSearchType:(BraveIOSAutocompleteMatchType)type {
+  return AutocompleteMatch::IsSearchType(brave::MatchTypeFromBraveType(type));
+}
+
+@end

--- a/ios/browser/api/omnibox/headers.gni
+++ b/ios/browser/api/omnibox/headers.gni
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+browser_api_omnibox_public_headers =
+    [ "//brave/ios/browser/api/omnibox/autocomplete_classifier.h" ]

--- a/ios/browser/brave_web_client.h
+++ b/ios/browser/brave_web_client.h
@@ -25,6 +25,10 @@ class BraveWebClient : public ChromeWebClient {
   std::unique_ptr<web::WebMainParts> CreateWebMainParts() override;
   std::string GetUserAgent(web::UserAgentType type) const override;
 
+  void AddAdditionalSchemes(Schemes* schemes) const override;
+
+  bool IsAppSpecificURL(const GURL& url) const override;
+
   void PostBrowserURLRewriterCreation(
       web::BrowserURLRewriter* rewriter) override;
 

--- a/ios/browser/brave_web_client.mm
+++ b/ios/browser/brave_web_client.mm
@@ -33,7 +33,21 @@ void BraveWebClient::SetUserAgent(const std::string& user_agent) {
 }
 
 std::string BraveWebClient::GetUserAgent(web::UserAgentType type) const {
+  if (user_agent_.empty()) {
+    return ChromeWebClient::GetUserAgent(type);
+  }
   return user_agent_;
+}
+
+void BraveWebClient::AddAdditionalSchemes(Schemes* schemes) const {
+  ChromeWebClient::AddAdditionalSchemes(schemes);
+
+  schemes->standard_schemes.push_back(kBraveUIScheme);
+  schemes->secure_schemes.push_back(kBraveUIScheme);
+}
+
+bool BraveWebClient::IsAppSpecificURL(const GURL& url) const {
+  return ChromeWebClient::IsAppSpecificURL(url) || url.SchemeIs(kBraveUIScheme);
 }
 
 bool WillHandleBraveURLRedirect(GURL* url, web::BrowserState* browser_state) {


### PR DESCRIPTION
## Summary

- Export Auto-Complete Classifier
- Fix URIFixup to use the AutocompleteClassifier
- Add extra checks for IP address handling using Brave-Core

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38620

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Visit `google..com` and it should submit to the search engine instead of trying to resolve the website.