### PR TITLE
[ads] Fixes align iOS NotifyTab[TextContent/HtmlContent]DidChange with Desktop

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -152,8 +152,8 @@ extension BrowserViewController {
 }
 
 extension Tab {
-  func reportPageLoad(to rewards: BraveRewards, redirectChain urls: [URL]) {
-    guard let url = urls.last, let webView = webView, !url.isLocal, !isPrivate
+  func reportPageLoad(to rewards: BraveRewards, redirectChain: [URL]) {
+    guard let url = redirectChain.last, let webView = webView, !url.isLocal, !isPrivate
     else {
       return
     }
@@ -162,7 +162,12 @@ extension Tab {
       adsRewardsLog.warning("No favicon found in \(self) to report to rewards panel")
     }
 
-    if isSessionStateRestored || !isNewNavigation || isErrorPage { return }
+    if rewardsReportingState.wasRestored
+      || !rewardsReportingState.isNewNavigation
+      || rewardsReportingState.isErrorPage
+    {
+      return
+    }
 
     let group = DispatchGroup()
 
@@ -193,7 +198,7 @@ extension Tab {
 
     group.notify(queue: .main) {
       rewards.reportLoadedPage(
-        redirectChain: urls,
+        redirectChain: redirectChain,
         tabId: Int(self.rewardsId),
         htmlContent: htmlContent ?? "",
         textContent: textContent

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -161,7 +161,7 @@ extension Tab {
       adsRewardsLog.warning("No favicon found in \(self) to report to rewards panel")
     }
 
-    if !shouldNotifyAdsServiceTabContentDidChange { return }
+    if isRestored || !isNewNavigation || isErrorPage { return }
 
     let group = DispatchGroup()
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -153,15 +153,16 @@ extension BrowserViewController {
 
 extension Tab {
   func reportPageLoad(to rewards: BraveRewards, redirectChain urls: [URL]) {
-    guard let webView = webView, let url = webView.url else { return }
-
-    if url.isLocal || self.isPrivate { return }
+    guard let url = urls.last, let webView = webView, !url.isLocal, !isPrivate
+    else {
+      return
+    }
 
     if self.displayFavicon == nil {
       adsRewardsLog.warning("No favicon found in \(self) to report to rewards panel")
     }
 
-    if isRestored || !isNewNavigation || isErrorPage { return }
+    if isSessionStateRestored || !isNewNavigation || isErrorPage { return }
 
     let group = DispatchGroup()
 
@@ -192,7 +193,7 @@ extension Tab {
 
     group.notify(queue: .main) {
       rewards.reportLoadedPage(
-        redirectChain: urls.isEmpty ? [url] : urls,
+        redirectChain: urls,
         tabId: Int(self.rewardsId),
         htmlContent: htmlContent ?? "",
         textContent: textContent

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -298,7 +298,7 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     let isPrivateBrowsing = privateBrowsingManager.isPrivateBrowsing
-    tab?.isNewNavigation =
+    tab?.rewardsReportingState.isNewNavigation =
       navigationAction.navigationType != WKNavigationType.backForward
       && navigationAction.navigationType != WKNavigationType.reload
     tab?.currentRequestURL = requestURL
@@ -695,21 +695,21 @@ extension BrowserViewController: WKNavigationDelegate {
     {
       let internalUrl = InternalURL(responseURL)
 
-      tab.isErrorPage = internalUrl?.isErrorPage == true
-      if !tab.isErrorPage {
-        let kClientErrorResponseCodeClass = 4
-        let kServerErrorResponseCodeClass = 5
+      tab.rewardsReportingState.isErrorPage = internalUrl?.isErrorPage == true
+      if !tab.rewardsReportingState.isErrorPage {
+        let kHttpClientErrorResponseCodeClass = 4
+        let kHttpServerErrorResponseCodeClass = 5
 
         let responseCodeClass = response.statusCode / 100
-        if responseCodeClass == kClientErrorResponseCodeClass
-          || responseCodeClass == kServerErrorResponseCodeClass
+        if responseCodeClass == kHttpClientErrorResponseCodeClass
+          || responseCodeClass == kHttpServerErrorResponseCodeClass
         {
-          tab.isErrorPage = true
+          tab.rewardsReportingState.isErrorPage = true
         }
       }
 
-      if !tab.isSessionStateRestored {
-        tab.isSessionStateRestored = internalUrl?.isSessionRestore == true
+      if !tab.rewardsReportingState.wasRestored {
+        tab.rewardsReportingState.wasRestored = internalUrl?.isSessionRestore == true
       }
     }
 
@@ -1027,12 +1027,9 @@ extension BrowserViewController: WKNavigationDelegate {
         isPrivate: privateBrowsingManager.isPrivateBrowsing
       )
       tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
-      // Reset `isSessionStateRestored`, `isNewNavigation` and `isErrorPage` tab
-      // properties so that listeners can be notified of tab changes when a new
-      // navigation happens.
-      tab.isSessionStateRestored = false
-      tab.isNewNavigation = true
-      tab.isErrorPage = false
+      // Reset `rewardsReportingState` tab property so that listeners
+      // can be notified of tab changes when a new navigation happens.
+      tab.rewardsReportingState = RewardsTabChangeReportingState()
 
       Task {
         await tab.updateEthereumProperties()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -372,6 +372,10 @@ public class BrowserViewController: UIViewController {
     }
 
     rewards.ads.captchaHandler = self
+    // Start Brave Ads if one of the following is true:
+    // - Brave Rewards is enabled
+    // - Brave News is enabled
+    // - `ShouldAlwaysRunBraveAdsService` feature is enabled
     let shouldStartAds =
       rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value
       || BraveAds.shouldAlwaysRunService()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1982,8 +1982,9 @@ public class BrowserViewController: UIViewController {
           url.host == rewardsURL.host
         {
           tab.reportPageNavigation(to: rewards)
-          // Not passing redirection chain here, in page navigation should not use them.
-          tab.reportPageLoad(to: rewards, redirectChain: [])
+          if let url = webView.url {
+            tab.reportPageLoad(to: rewards, redirectChain: [url])
+          }
         }
       }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -303,7 +303,7 @@ class Tab: NSObject {
 
   var mimeType: String?
   var isEditing = false
-  var isRestored = false
+  var isSessionStateRestored = false
   var isNewNavigation = true
   var isErrorPage = false
   var playlistItem: PlaylistInfo?
@@ -570,7 +570,7 @@ class Tab: NSObject {
       lastTitle = sessionInfo.title
       webView.interactionState = sessionInfo.interactionState
       restoring = false
-      isRestored = true
+      isSessionStateRestored = true
       self.sessionData = nil
     } else if let request = lastRequest {
       webView.load(request)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -242,9 +242,6 @@ class Tab: NSObject {
   var restoring: Bool = false
   var pendingScreenshot = false
 
-  /// The type of action triggering a navigation.
-  var navigationType: WKNavigationType?
-
   // This variable is used to keep track of current page. It is used to detect
   // and report same document navigations to Brave Rewards library.
   var rewardsXHRLoadURL: URL?
@@ -305,9 +302,10 @@ class Tab: NSObject {
   }
 
   var mimeType: String?
-  var isEditing: Bool = false
-  var shouldNotifyAdsServiceTabDidChange = true
-  var shouldNotifyAdsServiceTabContentDidChange = true
+  var isEditing = false
+  var isRestored = false
+  var isNewNavigation = true
+  var isErrorPage = false
   var playlistItem: PlaylistInfo?
   var playlistItemState: PlaylistItemAddedState = .none
 
@@ -572,7 +570,7 @@ class Tab: NSObject {
       lastTitle = sessionInfo.title
       webView.interactionState = sessionInfo.interactionState
       restoring = false
-      shouldNotifyAdsServiceTabContentDidChange = false
+      isRestored = true
       self.sessionData = nil
     } else if let request = lastRequest {
       webView.load(request)

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -187,10 +187,6 @@ public class BraveRewards: NSObject {
     isSelected: Bool,
     isPrivate: Bool
   ) {
-    if !tab.shouldNotifyAdsServiceTabDidChange {
-      return
-    }
-
     guard let url = tab.redirectChain.last else {
       // Don't report update for tabs that haven't finished loading.
       return
@@ -205,9 +201,9 @@ public class BraveRewards: NSObject {
       ads.notifyTabDidChange(
         tabId,
         redirectChain: tab.redirectChain,
-        isNewNavigation: true,
-        isRestoring: InternalURL(url)?.isSessionRestore ?? false,
-        isErrorPage: InternalURL(url)?.isErrorPage ?? false,
+        isNewNavigation: tab.isNewNavigation,
+        isRestoring: tab.isRestored,
+        isErrorPage: tab.isErrorPage,
         isSelected: isSelected
       )
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -201,9 +201,9 @@ public class BraveRewards: NSObject {
       ads.notifyTabDidChange(
         tabId,
         redirectChain: tab.redirectChain,
-        isNewNavigation: tab.isNewNavigation,
-        isRestoring: tab.isSessionStateRestored,
-        isErrorPage: tab.isErrorPage,
+        isNewNavigation: tab.rewardsReportingState.isNewNavigation,
+        isRestoring: tab.rewardsReportingState.wasRestored,
+        isErrorPage: tab.rewardsReportingState.isErrorPage,
         isSelected: isSelected
       )
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -202,7 +202,7 @@ public class BraveRewards: NSObject {
         tabId,
         redirectChain: tab.redirectChain,
         isNewNavigation: tab.isNewNavigation,
-        isRestoring: tab.isRestored,
+        isRestoring: tab.isSessionStateRestored,
         isErrorPage: tab.isErrorPage,
         isSelected: isSelected
       )


### PR DESCRIPTION
Corresponding desktop functionality:

https://github.com/brave/brave-core/blob/master/browser/brave_ads/tabs/ads_tab_helper.cc#L201
https://github.com/brave/brave-core/blob/master/browser/brave_ads/tabs/ads_tab_helper.cc#L195

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38659
Resolves https://github.com/brave/brave-browser/issues/38270
Resolves https://github.com/brave/brave-browser/issues/38278
Resolves https://github.com/brave/brave-browser/issues/38279

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Prerequisites
1. Fresh install
2. Join Brave Rewards
3. Set verbose ads logging
4. Close the browser

### Test case
1. Open the browser (there should be one tab with NTP)
EXPECTATION: 
There are log lines: 
* `[ads] Restored focused tab with id <id>`
There are NO log lines: 
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

2. Do any search query from the Omnibox (for example type Bitcoin and)
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did change`
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

3. Reload the page (tap to reload button in Omnibox)
EXPECTATION: 
There are NO log lines: 
* `[ads] Tab id <id> did change`
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

3. In SERP click the first link
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did change`
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

4. Tap Back button
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did change`
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

5. Tap Forward button
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did change`
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

5. Close the browser
6. Open the browser
EXPECTATION: 
There are log lines: 
* `[ads] Restored focused tab with id <id>`
There are NO log lines: 
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

7. Open new tab
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did become occluded`
* `[ads] Created tab with id <new id>`
* `[ads] Tab id <new id> did become focused`
* `[ads] Tab id <new id> HTML content changed`
* `[ads] Tab id <new id> text content changed`

8. Navigate to web page which return 404 error: https://httpstat.us/404
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did change`
There are NO log lines: 
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`

9. Open new tab
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did become occluded`
* `[ads] Created tab with id <new id>`
* `[ads] Tab id <new id> did become focused`
* `[ads] Tab id <new id> HTML content changed`
* `[ads] Tab id <new id> text content changed`

10. Load web page which return 500 error: https://httpstat.us/500
EXPECTATION: 
There are log lines: 
* `[ads] Tab id <id> did change`
There are NO log lines: 
* `[ads] Tab id <id> HTML content changed`
* `[ads] Tab id <id> text content changed`
