### PR TITLE
Replace std::to_address with base::to_address

### DIFF
--- a/browser/component_updater/brave_component_updater_configurator.cc
+++ b/browser/component_updater/brave_component_updater_configurator.cc
@@ -180,7 +180,7 @@ bool BraveConfigurator::EnabledCupSigning() const {
 }
 
 PrefService* BraveConfigurator::GetPrefService() const {
-  return std::to_address(pref_service_);
+  return base::to_address(pref_service_);
 }
 
 update_client::PersistedData* BraveConfigurator::GetPersistedData() const {

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -419,7 +419,7 @@ void BraveBrowserCommandController::UpdateCommandsForPin() {
 
 void BraveBrowserCommandController::UpdateCommandForSplitView() {
   auto* split_view_browser_data =
-      SplitViewBrowserData::FromBrowser(std::to_address(browser_));
+      SplitViewBrowserData::FromBrowser(base::to_address(browser_));
   if (!split_view_browser_data) {
     // Can happen on start up.
     return;
@@ -613,7 +613,7 @@ bool BraveBrowserCommandController::ExecuteBraveCommandWithDisposition(
       chrome::SendTabToSelf(&*browser_);
       break;
     case IDC_TOGGLE_ALL_BOOKMARKS_BUTTON_VISIBILITY:
-      brave::ToggleAllBookmarksButtonVisibility(std::to_address(browser_));
+      brave::ToggleAllBookmarksButtonVisibility(base::to_address(browser_));
       break;
     case IDC_COMMANDER:
 #if BUILDFLAG(ENABLE_COMMANDER)

--- a/browser/ui/views/brave_player/brave_player_action_icon_view.cc
+++ b/browser/ui/views/brave_player/brave_player_action_icon_view.cc
@@ -67,7 +67,7 @@ BravePlayerActionIconView::~BravePlayerActionIconView() = default;
 
 void BravePlayerActionIconView::OnExecuting(ExecuteSource execute_source) {
   CHECK(player_url_.is_valid());
-  chrome::AddTabAt(std::to_address(browser_), player_url_, /*index*/ -1,
+  chrome::AddTabAt(base::to_address(browser_), player_url_, /*index*/ -1,
                    /*foreground=*/true);
 }
 

--- a/browser/ui/views/playlist/thumbnail_provider.cc
+++ b/browser/ui/views/playlist/thumbnail_provider.cc
@@ -87,7 +87,7 @@ void ThumbnailProvider::GetThumbnail(
     return;
   }
 
-  auto& in_memory_cache = GetInMemoryCache(std::to_address(service_));
+  auto& in_memory_cache = GetInMemoryCache(base::to_address(service_));
   if (auto iter = in_memory_cache.Get(item->id);
       iter != in_memory_cache.end()) {
     std::move(callback).Run(iter->second);
@@ -134,7 +134,7 @@ void ThumbnailProvider::OnGotThumbnail(
     gfx::Image thumbnail) {
   if (!thumbnail.IsEmpty()) {
     DCHECK(!id.empty());
-    auto& in_memory_cache = GetInMemoryCache(std::to_address(service_));
+    auto& in_memory_cache = GetInMemoryCache(base::to_address(service_));
     if (from_network) {
       in_memory_cache.Put({id, thumbnail});
     } else if (in_memory_cache.Peek(id) != in_memory_cache.end()) {

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -152,7 +152,7 @@ base::OnceClosure BraveCompoundTabContainer::LockLayout() {
   for (const auto& tab_container :
        {unpinned_tab_container_, pinned_tab_container_}) {
     closures.push_back(
-        static_cast<BraveTabContainer*>(std::to_address(tab_container))
+        static_cast<BraveTabContainer*>(base::to_address(tab_container))
             ->LockLayout());
   }
 
@@ -175,12 +175,12 @@ void BraveCompoundTabContainer::SetScrollEnabled(bool enabled) {
     scroll_view_->SetBackgroundThemeColorId(kColorToolbar);
     auto* contents_view =
         scroll_view_->SetContents(std::make_unique<ContentsView>(this));
-    contents_view->AddChildView(std::to_address(unpinned_tab_container_));
+    contents_view->AddChildView(base::to_address(unpinned_tab_container_));
     DeprecatedLayoutImmediately();
   } else {
     unpinned_tab_container_->parent()->RemoveChildView(
-        std::to_address(unpinned_tab_container_));
-    AddChildView(std::to_address(unpinned_tab_container_));
+        base::to_address(unpinned_tab_container_));
+    AddChildView(base::to_address(unpinned_tab_container_));
 
     RemoveChildViewT(scroll_view_.get());
     scroll_view_ = nullptr;
@@ -356,7 +356,7 @@ BraveCompoundTabContainer::GetDropIndex(const ui::DropTargetEvent& event,
       event.data(), gfx::PointF(loc_in_sub_target),
       gfx::PointF(loc_in_sub_target), event.source_operations());
 
-  if (sub_drop_target == std::to_address(pinned_tab_container_)) {
+  if (sub_drop_target == base::to_address(pinned_tab_container_)) {
     // Pinned tab container shares an index and coordinate space, so no
     // adjustments needed.
     return sub_drop_target->GetDropIndex(adjusted_event, allow_replacement);
@@ -417,7 +417,7 @@ void BraveCompoundTabContainer::PaintChildren(const views::PaintInfo& info) {
 
 void BraveCompoundTabContainer::ChildPreferredSizeChanged(views::View* child) {
   if (ShouldShowVerticalTabs() && scroll_view_ &&
-      child->Contains(std::to_address(unpinned_tab_container_))) {
+      child->Contains(base::to_address(unpinned_tab_container_))) {
     UpdateUnpinnedContainerSize();
   }
 
@@ -457,8 +457,8 @@ TabContainer* BraveCompoundTabContainer::GetTabContainerAt(
 
   auto* container =
       point_in_local_coords.y() < pinned_tab_container_->bounds().bottom()
-          ? std::to_address(pinned_tab_container_)
-          : std::to_address(unpinned_tab_container_);
+          ? base::to_address(pinned_tab_container_)
+          : base::to_address(unpinned_tab_container_);
 
   if (!container->GetWidget()) {
     // Note that this could be happen when we're detaching tabs and we're still
@@ -478,7 +478,7 @@ gfx::Rect BraveCompoundTabContainer::ConvertUnpinnedContainerIdealBoundsToLocal(
 
   if (scroll_view_) {
     return views::View::ConvertRectToTarget(
-        /*source=*/std::to_address(unpinned_tab_container_), /*target=*/this,
+        /*source=*/base::to_address(unpinned_tab_container_), /*target=*/this,
         ideal_bounds);
   }
 

--- a/browser/ui/views/tabs/brave_new_tab_button.h
+++ b/browser/ui/views/tabs/brave_new_tab_button.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_NEW_TAB_BUTTON_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_NEW_TAB_BUTTON_H_
 
-#include <memory>
-
 #include "chrome/browser/ui/views/tabs/new_tab_button.h"
 #include "third_party/skia/include/core/SkPath.h"
 #include "ui/base/metadata/metadata_header_macros.h"

--- a/browser/ui/views/tabs/brave_new_tab_button.h
+++ b/browser/ui/views/tabs/brave_new_tab_button.h
@@ -36,7 +36,7 @@ class BraveNewTabButton : public NewTabButton {
   const TabStrip* tab_strip() const { return tab_strip_; }
 
   views::InkDropContainerView* ink_drop_container() {
-    return std::to_address(ink_drop_container_);
+    return base::to_address(ink_drop_container_);
   }
 
   // Allow child classes to override PaintFill().

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -283,7 +283,7 @@ void BraveTabContainer::UpdateLayoutOrientation() {
   layout_helper_->set_use_vertical_tabs(
       tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()));
   layout_helper_->set_tab_strip(
-      static_cast<BraveTabStrip*>(std::to_address(tab_slot_controller_)));
+      static_cast<BraveTabStrip*>(base::to_address(tab_slot_controller_)));
   InvalidateLayout();
 }
 

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -304,7 +304,7 @@ void BraveTabStrip::UpdateTabContainer() {
       base::FeatureList::IsEnabled(features::kSplitTabStrip);
   const bool is_using_compound_tab_container =
       views::IsViewClass<BraveCompoundTabContainer>(
-          std::to_address(tab_container_));
+          base::to_address(tab_container_));
 
   base::ScopedClosureRunner layout_lock;
   if (should_use_compound_tab_container != is_using_compound_tab_container) {
@@ -314,7 +314,7 @@ void BraveTabStrip::UpdateTabContainer() {
 
     // Resets TabContainer to use.
     auto original_container = RemoveChildViewT(
-        static_cast<TabContainer*>(std::to_address(tab_container_)));
+        static_cast<TabContainer*>(base::to_address(tab_container_)));
 
     if (should_use_compound_tab_container) {
       // Container should be attached before TabDragContext so that dragged

--- a/components/brave_component_updater/browser/brave_component_updater_delegate.cc
+++ b/components/brave_component_updater/browser/brave_component_updater_delegate.cc
@@ -40,7 +40,7 @@ void BraveComponentUpdaterDelegate::Register(
     const std::string& component_base64_public_key,
     base::OnceClosure registered_callback,
     BraveComponent::ReadyCallback ready_callback) {
-  brave::RegisterComponent(std::to_address(component_updater_), component_name,
+  brave::RegisterComponent(base::to_address(component_updater_), component_name,
                            component_base64_public_key,
                            std::move(registered_callback),
                            std::move(ready_callback));
@@ -75,7 +75,7 @@ const std::string& BraveComponentUpdaterDelegate::locale() const {
 }
 
 PrefService* BraveComponentUpdaterDelegate::local_state() {
-  return std::to_address(local_state_);
+  return base::to_address(local_state_);
 }
 
 }  // namespace brave


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves : [brave/brave-browser#38658](https://github.com/brave/brave-browser/issues/38658) 

std::to_address is banned because it is not guaranteed to be SFINAE-compatible. Use base::to_address from base/types/to_address.h instead.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

