### PR TITLE
Force export passwords to local storage on Android; fixes brave/brave…

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -290,6 +290,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/onboarding/v2/OnboardingV2Fragment.java",
   "../../brave/android/java/org/chromium/chrome/browser/onboarding/v2/OnboardingV2PagerAdapter.java",
   "../../brave/android/java/org/chromium/chrome/browser/partnercustomizations/CloseBraveManager.java",
+  "../../brave/android/java/org/chromium/chrome/browser/password_manager/settings/BraveExportFlow.java",
   "../../brave/android/java/org/chromium/chrome/browser/password_manager/settings/BravePasswordSettingsBase.java",
   "../../brave/android/java/org/chromium/chrome/browser/playlist/PlaylistHostActivity.java",
   "../../brave/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceFactoryAndroid.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -871,3 +871,13 @@
 -keep class org.chromium.chrome.browser.omnibox.suggestions.editurl.BraveEditUrlSuggestionProcessor {
     public <init>(...);
 }
+
+-keep class org.chromium.chrome.browser.password_manager.settings.ExportFlow {
+    public <init>(...);
+    *** runSharePasswordsIntent(...);
+    *** runCreateFileOnDiskIntent(...);
+}
+
+-keep class org.chromium.chrome.browser.password_manager.settings.BraveExportFlow {
+    public <init>(...);
+}

--- a/android/java/org/chromium/chrome/browser/password_manager/settings/BraveExportFlow.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/BraveExportFlow.java
@@ -1,0 +1,14 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.password_manager.settings;
+
+import org.chromium.base.BraveReflectionUtil;
+
+public class BraveExportFlow extends ExportFlow {
+    public void runSharePasswordsIntent() {
+        BraveReflectionUtil.InvokeMethod(ExportFlow.class, this, "runCreateFileOnDiskIntent");
+    }
+}

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -57,3 +57,7 @@
     *** shouldUseParentIds(...);
     *** getOrCreateTabGroupId(...);
 }
+
+-keep class org.chromium.chrome.browser.password_manager.settings.ExportFlow {
+    *** runCreateFileOnDiskIntent(...);
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -331,6 +331,8 @@ public class BytecodeTest {
         Assert.assertTrue(
                 classExists("org/chromium/chrome/browser/multiwindow/MultiInstanceManagerApi31"));
         Assert.assertTrue(classExists("org/chromium/chrome/browser/multiwindow/MultiWindowUtils"));
+        Assert.assertTrue(
+                classExists("org/chromium/chrome/browser/password_manager/settings/ExportFlow"));
     }
 
     @Test
@@ -810,6 +812,13 @@ public class BytecodeTest {
                         true,
                         String.class,
                         int.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/password_manager/settings/ExportFlow",
+                        "runSharePasswordsIntent",
+                        MethodModifier.REGULAR,
+                        true,
+                        void.class));
     }
 
     @Test
@@ -982,6 +991,13 @@ public class BytecodeTest {
                         float.class,
                         float.class,
                         boolean.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/password_manager/settings/ExportFlow",
+                        "runCreateFileOnDiskIntent",
+                        MethodModifier.REGULAR,
+                        true,
+                        void.class));
         // NOTE: Add new checks above. For each new check in this method add proguard exception in
         // `brave/android/java/proguard.flags` file under `Add methods for invocation below`
         // section. Both test and regular apks should have the same exceptions.
@@ -1651,6 +1667,10 @@ public class BytecodeTest {
                         Optional.class,
                         Supplier.class,
                         Supplier.class));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/chrome/browser/password_manager/settings/ExportFlow",
+                        "org/chromium/chrome/browser/password_manager/settings/BraveExportFlow"));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -44,6 +44,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveDropdownItemViewInfoListManagerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveDynamicColorsClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveEditUrlSuggestionProcessorClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveExportFlowClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveExternalNavigationHandlerClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveFeedSurfaceCoordinatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveFeedSurfaceMediatorClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -43,6 +43,7 @@ public class BraveClassAdapter {
         chain = new BraveDropdownItemViewInfoListManagerClassAdapter(chain);
         chain = new BraveDynamicColorsClassAdapter(chain);
         chain = new BraveEditUrlSuggestionProcessorClassAdapter(chain);
+        chain = new BraveExportFlowClassAdapter(chain);
         chain = new BraveExternalNavigationHandlerClassAdapter(chain);
         chain = new BraveFeedSurfaceCoordinatorClassAdapter(chain);
         chain = new BraveFeedSurfaceMediatorClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveExportFlowClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveExportFlowClassAdapter.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveExportFlowClassAdapter extends BraveClassVisitor {
+    static String sExportFlowClassName =
+            "org/chromium/chrome/browser/password_manager/settings/ExportFlow";
+    static String sBraveExportFlowClassName =
+            "org/chromium/chrome/browser/password_manager/settings/BraveExportFlow";
+
+    public BraveExportFlowClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(sExportFlowClassName, sBraveExportFlowClassName);
+
+        makePublicMethod(sExportFlowClassName, "runSharePasswordsIntent");
+        addMethodAnnotation(
+                sBraveExportFlowClassName, "runSharePasswordsIntent", "Ljava/lang/Override;");
+    }
+}


### PR DESCRIPTION
This PR forces export of bookmarks always be don to local storage.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38655

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See the issue https://github.com/brave/brave-browser/issues/38655
