### PR TITLE
Accurately provide cr_button disabled to leo-button (uplift to 1.67.x)

### DIFF
--- a/ui/webui/resources/cr_elements/cr_button/cr_button.html
+++ b/ui/webui/resources/cr_elements/cr_button/cr_button.html
@@ -18,7 +18,7 @@
     height: 100%;
   }
  </style>
-<leo-button id="button" isDisabled="[[disabled]]" kind="outline" size="small">
+<leo-button id="button" kind="outline" size="small">
   <slot slot="icon-before" name="prefix-icon"></slot>
   <slot></slot>
   <slot slot="icon-after" name="suffix-icon"></slot>

--- a/ui/webui/resources/cr_elements/cr_button/cr_button.ts
+++ b/ui/webui/resources/cr_elements/cr_button/cr_button.ts
@@ -29,6 +29,7 @@ export class CrButtonElement extends PolymerElement {
         type: Boolean,
         value: false,
         reflectToAttribute: true,
+        observer: 'disabledChanged_'
       },
       class: {
         type: String,
@@ -66,6 +67,17 @@ export class CrButtonElement extends PolymerElement {
     }
 
     this.$.button.setAttribute('kind', kind)
+  }
+
+  disabledChanged_() {
+    // TODO(petemill): This should be a $= binding but the leo-button
+    // has a bug with treating it as a boolean attribute
+    // https://github.com/brave/leo/issues/690.
+    if (this.disabled) {
+      this.$.button.setAttribute('isDisabled', '_')
+    } else {
+      this.$.button.removeAttribute('isDisabled')
+    }
   }
 }
 


### PR DESCRIPTION
Uplift of #23835
Resolves https://github.com/brave/brave-browser/issues/38542

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.