### PR TITLE
Set size of player button explicitly

### DIFF
--- a/components/playlist/browser/resources/components/header.tsx
+++ b/components/playlist/browser/resources/components/header.tsx
@@ -93,6 +93,11 @@ const StyledButton = styled(LeoButton)`
   flex: 0 0 auto;
 `
 
+const MediumSizedButton = styled(StyledButton)`
+  width: var(--leo-icon-m);
+  height: var(--leo-icon-m);
+`
+
 const StyledSeparator = styled.div`
   width: ${elevation.xxs};
   background-color: ${color.divider.subtle};
@@ -123,8 +128,9 @@ function BackButton ({
 }) {
   return playlistEditMode === PlaylistEditMode.BULK_EDIT ? (
     <StyledButton
-      size='large'
+      size='small'
       kind='plain'
+      fab
       onClick={() => getPlaylistActions().setPlaylistEditMode(undefined)}
     >
       <ColoredIcon
@@ -293,9 +299,10 @@ function PlaylistHeader ({ playlistId }: { playlistId: string }) {
 
 function NewPlaylistButton () {
   return (
-    <StyledButton
-      size='large'
+    <MediumSizedButton
+      size='small'
       kind='plain'
+      fab
       title={getLocalizedString('bravePlaylistA11YCreatePlaylistFolder')}
       onClick={() => {
         getPlaylistAPI().showCreatePlaylistUI()
@@ -305,15 +312,16 @@ function NewPlaylistButton () {
         name='plus-add'
         color={color.icon.default}
       />
-    </StyledButton>
+    </MediumSizedButton>
   )
 }
 
 function SettingButton () {
   return (
-    <StyledButton
-      size='large'
+    <MediumSizedButton
+      size='small'
       kind='plain'
+      fab
       title={getLocalizedString('bravePlaylistA11YOpenPlaylistSettings')}
       onClick={() => getPlaylistAPI().openSettingsPage()}
     >
@@ -321,15 +329,16 @@ function SettingButton () {
         name='settings'
         color={color.icon.default}
       />
-    </StyledButton>
+    </MediumSizedButton>
   )
 }
 
 function CloseButton () {
   return (
-    <StyledButton
-      size='large'
+    <MediumSizedButton
+      size='small'
       kind='plain'
+      fab
       title={getLocalizedString('bravePlaylistA11YClosePanel')}
       onClick={() => getPlaylistAPI().closePanel()}
     >
@@ -337,7 +346,7 @@ function CloseButton () {
         name='close'
         color={color.icon.default}
       />
-    </StyledButton>
+    </MediumSizedButton>
   )
 }
 

--- a/components/playlist/browser/resources/components/playerControls.tsx
+++ b/components/playlist/browser/resources/components/playerControls.tsx
@@ -28,6 +28,7 @@ const Container = styled.div`
 
   & > div {
     display: flex;
+    align-items: center;
     gap: ${spacing.m};
   }
 `
@@ -37,6 +38,9 @@ const StyledButton = styled(Button)`
   --leo-button-padding: ${spacing.s};
   align-items: center;
   display: flex;
+  width: var(--leo-icon-xl);
+  height: var(--leo-icon-xl);
+  padding: var(--leo-spacing-s);
 `
 
 const NormalPlayerButton = styled(StyledButton)`
@@ -74,6 +78,7 @@ function Control({
       size={size}
       onClick={onClick}
       title={title}
+      fab
     >
       <Icon name={iconName}></Icon>
     </Button>


### PR DESCRIPTION
The button was oversized.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38702#event-12989553068

<img width="448" alt="image" src="https://github.com/brave/brave-core/assets/5474642/726b1158-97fc-479a-ab06-94e3cc3a8bbc">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

