### PR TITLE
Layout split view menu button when parent view bounds is changed

### DIFF
--- a/browser/ui/views/split_view/split_view_separator.cc
+++ b/browser/ui/views/split_view/split_view_separator.cc
@@ -113,6 +113,17 @@ void SplitViewSeparator::Layout(PassKey) {
   LayoutMenuButton();
 }
 
+void SplitViewSeparator::ViewHierarchyChanged(
+    const views::ViewHierarchyChangedDetails& details) {
+  ResizeArea::ViewHierarchyChanged(details);
+
+  if (details.is_add && details.child == this) {
+    CHECK(!parent_view_observation_.IsObserving())
+        << "This is supposed to be called only once.";
+    parent_view_observation_.Observe(parent());
+  }
+}
+
 void SplitViewSeparator::OnResize(int resize_amount, bool done_resizing) {
   // When mouse goes toward web contents area, the cursor could have been
   // changed to the normal cursor. Reset it resize cursor.
@@ -135,6 +146,10 @@ void SplitViewSeparator::OnResize(int resize_amount, bool done_resizing) {
 
 void SplitViewSeparator::OnWidgetBoundsChanged(views::Widget* widget,
                                                const gfx::Rect& new_bounds) {
+  LayoutMenuButton();
+}
+
+void SplitViewSeparator::OnViewBoundsChanged(views::View* observed_view) {
   LayoutMenuButton();
 }
 

--- a/browser/ui/views/split_view/split_view_separator.h
+++ b/browser/ui/views/split_view/split_view_separator.h
@@ -11,6 +11,7 @@
 #include "brave/browser/ui/views/split_view/split_view_separator_delegate.h"
 #include "ui/views/controls/resize_area.h"
 #include "ui/views/controls/resize_area_delegate.h"
+#include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
 #include "ui/views/widget/widget_observer.h"
 
@@ -20,7 +21,8 @@ class Browser;
 // This separator is used to resize the contents web views.
 class SplitViewSeparator : public views::ResizeArea,
                            public views::ResizeAreaDelegate,
-                           public views::WidgetObserver {
+                           public views::WidgetObserver,
+                           public views::ViewObserver {
   METADATA_HEADER(SplitViewSeparator, views::ResizeArea)
  public:
   explicit SplitViewSeparator(Browser* browser);
@@ -35,6 +37,8 @@ class SplitViewSeparator : public views::ResizeArea,
   void VisibilityChanged(views::View* starting_from, bool is_visible) override;
   bool OnMousePressed(const ui::MouseEvent& event) override;
   void Layout(PassKey) override;
+  void ViewHierarchyChanged(
+      const views::ViewHierarchyChangedDetails& details) override;
 
   // views::ResizeAreaDelegate:
   void OnResize(int resize_amount, bool done_resizing) override;
@@ -42,6 +46,9 @@ class SplitViewSeparator : public views::ResizeArea,
   // views::WidgetObserver:
   void OnWidgetBoundsChanged(views::Widget* widget,
                              const gfx::Rect& new_bounds) override;
+
+  // views::ViewObserver:
+  void OnViewBoundsChanged(views::View* observed_view) override;
 
  private:
   void CreateMenuButton();
@@ -55,6 +62,9 @@ class SplitViewSeparator : public views::ResizeArea,
 
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       parent_widget_observation_{this};
+
+  base::ScopedObservation<views::View, views::ViewObserver>
+      parent_view_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_SEPARATOR_H_


### PR DESCRIPTION
When the parent view's bounds changes while separator's bounds is same, Layout won't be called. In this case we should lay out menu button too.

This happens when vertical tab strip is minimized or expanded.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38734

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

