### PR TITLE
Fixed app menu button and bubble's highlight color

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -544,6 +544,8 @@ source_set("ui") {
       "views/toolbar/bookmark_button.h",
       "views/toolbar/brave_app_menu.cc",
       "views/toolbar/brave_app_menu.h",
+      "views/toolbar/brave_browser_app_menu_button.cc",
+      "views/toolbar/brave_browser_app_menu_button.h",
       "views/view_shadow.cc",
       "views/view_shadow.h",
       "views/window_closing_confirm_dialog_view.cc",

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -16,6 +16,7 @@
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/color/chrome_color_provider_utils.h"
 #include "chrome/browser/ui/color/material_chrome_color_mixer.h"
 #include "chrome/browser/ui/color/material_side_panel_color_mixer.h"
 #include "ui/base/ui_base_features.h"
@@ -392,6 +393,18 @@ void AddBravifiedChromeThemeColorMixer(ui::ColorProvider* provider,
     AddMaterialChromeColorMixer(provider, key);
     AddMaterialSidePanelColorMixer(provider, key);
   }
+
+  // Upstream started to use same colors for all severity. But, we want to use
+  // upstream's previous non-material color to app menu highlight. These colors
+  // are copied from AddChromeColorMixer() because it's overwritten by
+  // AddMaterialChromeColorMixer().
+  ui::ColorMixer& mixer = provider->AddMixer();
+  mixer[kColorAppMenuHighlightSeverityLow] = AdjustHighlightColorForContrast(
+      ui::kColorAlertLowSeverity, kColorToolbar);
+  mixer[kColorAppMenuHighlightSeverityHigh] = {
+      kColorAvatarButtonHighlightSyncError};
+  mixer[kColorAppMenuHighlightSeverityMedium] = AdjustHighlightColorForContrast(
+      ui::kColorAlertMediumSeverityIcon, kColorToolbar);
 
   if (key.custom_theme) {
     return;

--- a/browser/ui/views/toolbar/brave_browser_app_menu_button.cc
+++ b/browser/ui/views/toolbar/brave_browser_app_menu_button.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/toolbar/brave_browser_app_menu_button.h"
+
+#include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/toolbar/app_menu_icon_controller.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/color/color_provider.h"
+
+std::optional<SkColor> BraveBrowserAppMenuButton::GetHighlightTextColor()
+    const {
+  return std::nullopt;
+}
+
+std::optional<SkColor> BraveBrowserAppMenuButton::GetHighlightColor() const {
+  const auto* const color_provider = GetColorProvider();
+  switch (type_and_severity_.severity) {
+    case AppMenuIconController::Severity::NONE:
+      return std::nullopt;
+    case AppMenuIconController::Severity::LOW:
+      return color_provider->GetColor(kColorAppMenuHighlightSeverityLow);
+    case AppMenuIconController::Severity::MEDIUM:
+      return color_provider->GetColor(kColorAppMenuHighlightSeverityMedium);
+    case AppMenuIconController::Severity::HIGH:
+      return color_provider->GetColor(kColorAppMenuHighlightSeverityHigh);
+  }
+}
+
+BEGIN_METADATA(BraveBrowserAppMenuButton)
+END_METADATA

--- a/browser/ui/views/toolbar/brave_browser_app_menu_button.h
+++ b/browser/ui/views/toolbar/brave_browser_app_menu_button.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_BROWSER_APP_MENU_BUTTON_H_
+#define BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_BROWSER_APP_MENU_BUTTON_H_
+
+#include <optional>
+
+#include "chrome/browser/ui/views/toolbar/browser_app_menu_button.h"
+
+class BraveBrowserAppMenuButton : public BrowserAppMenuButton {
+  METADATA_HEADER(BraveBrowserAppMenuButton, BrowserAppMenuButton)
+
+ public:
+  using BrowserAppMenuButton::BrowserAppMenuButton;
+
+ private:
+  std::optional<SkColor> GetHighlightTextColor() const override;
+  std::optional<SkColor> GetHighlightColor() const override;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_TOOLBAR_BRAVE_BROWSER_APP_MENU_BUTTON_H_

--- a/chromium_src/chrome/browser/ui/toolbar/app_menu_model.cc
+++ b/chromium_src/chrome/browser/ui/toolbar/app_menu_model.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/toolbar/brave_bookmark_sub_menu_model.h"
 #include "brave/browser/ui/toolbar/brave_recent_tabs_sub_menu_model.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/ui/toolbar/bookmark_sub_menu_model.h"
 #include "chrome/grit/generated_resources.h"
 
@@ -15,7 +16,9 @@
 
 #define RecentTabsSubMenuModel BraveRecentTabsSubMenuModel
 #define BookmarkSubMenuModel BraveBookmarkSubMenuModel
+#define kBrowserToolsUpdateChromeRefreshIcon kBrowserToolsUpdateIcon
 #include "src/chrome/browser/ui/toolbar/app_menu_model.cc"
+#undef kBrowserToolsUpdateChromeRefreshIcon
 #undef BookmarkSubMenuModel
 #undef RecentTabsSubMenuModel
 

--- a/chromium_src/chrome/browser/ui/views/toolbar/browser_app_menu_button.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/browser_app_menu_button.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_BROWSER_APP_MENU_BUTTON_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_BROWSER_APP_MENU_BUTTON_H_
+
+#define GetHighlightColor virtual GetHighlightColor
+#define UpdateLayoutInsets                \
+  UpdateLayoutInsets_UnUsed() {}          \
+  friend class BraveBrowserAppMenuButton; \
+  void UpdateLayoutInsets
+
+#include "src/chrome/browser/ui/views/toolbar/browser_app_menu_button.h"  // IWYU pragma: export
+
+#undef UpdateLayoutInsets
+#undef GetHighlightColor
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_BROWSER_APP_MENU_BUTTON_H_

--- a/chromium_src/chrome/browser/ui/views/toolbar/toolbar_view.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/toolbar_view.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/views/profiles/brave_avatar_toolbar_button.h"
+#include "brave/browser/ui/views/toolbar/brave_browser_app_menu_button.h"
 #include "extensions/buildflags/buildflags.h"
 
 #if BUILDFLAG(ENABLE_EXTENSIONS)
@@ -13,6 +14,7 @@
 #define LocationBarView BraveLocationBarView
 #endif
 
+#define BrowserAppMenuButton BraveBrowserAppMenuButton
 #define BRAVE_TOOLBAR_VIEW_INIT                                   \
   avatar_ = container_view_->AddChildView(                        \
       std::make_unique<BraveAvatarToolbarButton>(browser_view_)); \
@@ -20,6 +22,7 @@
 
 #include "src/chrome/browser/ui/views/toolbar/toolbar_view.cc"
 #undef BRAVE_TOOLBAR_VIEW_INIT
+#undef BrowserAppMenuButton
 #if BUILDFLAG(ENABLE_EXTENSIONS)
 #undef LocationBarView
 #endif

--- a/chromium_src/ui/color/material_ui_color_mixer.cc
+++ b/chromium_src/ui/color/material_ui_color_mixer.cc
@@ -65,6 +65,9 @@ void AddMaterialUiColorMixer(ColorProvider* provider,
   mixer[ui::kColorToggleButtonTrackOn] = {ui::kColorSysPrimary};
   mixer[ui::kColorToggleButtonTrackOnDisabled] = {
       ui::kColorSysStateDisabledContainer};
+
+  mixer[kColorAppMenuRowBackgroundHovered] = {kColorSysStateHoverOnSubtle};
+  mixer[kColorAppMenuUpgradeRowBackground] = {kColorSysTonalContainer};
 }
 
 }  // namespace ui


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/38645
![image](https://github.com/brave/brave-core/assets/6786187/ae604c17-4519-45b9-a421-e4804d67d024)
![Screenshot 2024-05-31 161808](https://github.com/brave/brave-core/assets/6786187/f4ab1236-dd97-4b71-91cd-45e0b7169e0b)


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue