### PR TITLE
[iOS] Call WebKit handlers when alerts are dismissed without user input (uplift to 1.67.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -592,6 +592,8 @@ extension BrowserViewController: WKNavigationDelegate {
         {
 
           return await withCheckedContinuation { continuation in
+            // This alert does not need to be a BrowserAlertController because we return a policy
+            // without waiting for user action
             let alert = UIAlertController(
               title: Strings.unableToOpenURLErrorTitle,
               message: Strings.unableToOpenURLError,
@@ -1310,7 +1312,7 @@ extension BrowserViewController: WKUIDelegate {
       }
     }()
     let title = String.localizedStringWithFormat(titleFormat, origin.host)
-    let alertController = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+    let alertController = BrowserAlertController(title: title, message: nil, preferredStyle: .alert)
     alertController.addAction(
       .init(
         title: Strings.requestCaptureDevicePermissionAllowButtonTitle,
@@ -1329,6 +1331,9 @@ extension BrowserViewController: WKUIDelegate {
         }
       )
     )
+    alertController.dismissedWithoutAction = {
+      decisionHandler(.prompt)
+    }
     if #available(iOS 16.0, *) {
       if webView.fullscreenState == .inFullscreen || webView.fullscreenState == .enteringFullscreen
       {
@@ -1424,8 +1429,7 @@ extension BrowserViewController: WKUIDelegate {
       return
     }
     promptingTab.alertShownCount += 1
-    let suppressBlock: JSAlertInfo.SuppressHandler = { [weak self, weak webView] suppress in
-      guard let self, let webView else { return }
+    let suppressBlock: JSAlertInfo.SuppressHandler = { [unowned self] suppress in
       if suppress {
         func suppressDialogues(_: UIAlertAction) {
           self.suppressJSAlerts(webView: webView)
@@ -1494,18 +1498,14 @@ extension BrowserViewController: WKUIDelegate {
     return false
   }
 
-  public func webView(
+  @MainActor public func webView(
     _ webView: WKWebView,
-    contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
-    completionHandler: @escaping (UIContextMenuConfiguration?) -> Void
-  ) {
-
+    contextMenuConfigurationFor elementInfo: WKContextMenuElementInfo
+  ) async -> UIContextMenuConfiguration? {
     // Only show context menu for valid links such as `http`, `https`, `data`. Safari does not show it for anything else.
     // This is because you cannot open `javascript:something` URLs in a new page, or share it, or anything else.
     guard let url = elementInfo.linkURL, url.isWebPage() else {
-      return completionHandler(
-        UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)
-      )
+      return UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: nil)
     }
 
     let actionProvider: UIContextMenuActionProvider = { _ -> UIMenu? in
@@ -1655,13 +1655,11 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     let linkPreviewProvider = Preferences.General.enableLinkPreview.value ? linkPreview : nil
-    let config = UIContextMenuConfiguration(
+    return UIContextMenuConfiguration(
       identifier: nil,
       previewProvider: linkPreviewProvider,
       actionProvider: actionProvider
     )
-
-    completionHandler(config)
   }
 
   public func webView(


### PR DESCRIPTION
Uplift of #23915
Resolves https://github.com/brave/brave-browser/issues/38651

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.