### PR TITLE
Don't synchronize new browser created during drag-and-drop

### DIFF
--- a/browser/ui/brave_browser_window.cc
+++ b/browser/ui/brave_browser_window.cc
@@ -41,5 +41,8 @@ void BraveBrowserWindow::CleanAndCopySelectedURL() {}
 bool BraveBrowserWindow::ShowBraveHelpBubbleView(const std::string& text) {
   return false;
 }
+#endif  // defined(TOOLKIT_VIEWS)
 
-#endif
+bool BraveBrowserWindow::IsInTabDragging() const {
+  return false;
+}

--- a/browser/ui/brave_browser_window.h
+++ b/browser/ui/brave_browser_window.h
@@ -72,6 +72,9 @@ class BraveBrowserWindow : public BrowserWindow {
 #endif
 
   virtual void ShowBraveVPNBubble() {}
+
+  // Returns true if all tabs in this window is being dragged.
+  virtual bool IsInTabDragging() const;
 };
 
 #endif  // BRAVE_BROWSER_UI_BRAVE_BROWSER_WINDOW_H_

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -723,11 +723,9 @@ void SharedPinnedTabService::SynchronizeMovedPinnedTab(int from, int to) {
 }
 
 void SharedPinnedTabService::TabDraggingEnded(Browser* browser) {
-  if (!in_tab_dragging_browsers_.count(browser)) {
+  if (!in_tab_dragging_browsers_.erase(browser)) {
     return;
   }
-
-  in_tab_dragging_browsers_.erase(browser);
 
   if (!browser->IsBrowserClosing()) {
     SynchronizeNewBrowser(browser);
@@ -950,5 +948,6 @@ SharedPinnedTabService::CreateDummyWebContents(
 }
 
 bool SharedPinnedTabService::IsBrowserInTabDragging(Browser* browser) const {
+  CHECK(browser);
   return static_cast<BraveBrowserWindow*>(browser->window())->IsInTabDragging();
 }

--- a/browser/ui/tabs/shared_pinned_tab_service.cc
+++ b/browser/ui/tabs/shared_pinned_tab_service.cc
@@ -10,6 +10,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback_forward.h"
 #include "base/notreached.h"
+#include "brave/browser/ui/brave_browser_window.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
 #include "brave/browser/ui/tabs/features.h"
 #include "brave/browser/ui/tabs/shared_pinned_tab_dummy_view.h"
@@ -721,7 +722,24 @@ void SharedPinnedTabService::SynchronizeMovedPinnedTab(int from, int to) {
   }
 }
 
+void SharedPinnedTabService::TabDraggingEnded(Browser* browser) {
+  if (!in_tab_dragging_browsers_.count(browser)) {
+    return;
+  }
+
+  in_tab_dragging_browsers_.erase(browser);
+
+  if (!browser->IsBrowserClosing()) {
+    SynchronizeNewBrowser(browser);
+  }
+}
+
 void SharedPinnedTabService::SynchronizeNewBrowser(Browser* browser) {
+  if (IsBrowserInTabDragging(browser)) {
+    in_tab_dragging_browsers_.insert(browser);
+    return;
+  }
+
   auto* model = browser->tab_strip_model();
   std::vector<PinnedTabData> new_pinned_tabs;
   for (auto i = 0; i < model->IndexOfFirstNonPinnedTab(); i++) {
@@ -793,6 +811,10 @@ void SharedPinnedTabService::MoveSharedWebContentsToBrowser(
     Browser* browser,
     int index,
     bool is_last_closing_browser) {
+  if (IsBrowserInTabDragging(browser)) {
+    return;
+  }
+
   auto* tab_strip_model = browser->tab_strip_model();
   DCHECK_LT(index, tab_strip_model->count());
 
@@ -925,4 +947,8 @@ SharedPinnedTabService::CreateDummyWebContents(
   DummyContentsData::CreateForWebContents(dummy_contents.get(),
                                           shared_contents);
   return dummy_contents;
+}
+
+bool SharedPinnedTabService::IsBrowserInTabDragging(Browser* browser) const {
+  return static_cast<BraveBrowserWindow*>(browser->window())->IsInTabDragging();
 }

--- a/browser/ui/tabs/shared_pinned_tab_service.h
+++ b/browser/ui/tabs/shared_pinned_tab_service.h
@@ -57,6 +57,8 @@ class SharedPinnedTabService : public KeyedService,
       int index,
       content::WebContents* maybe_dummy_contents);
 
+  void TabDraggingEnded(Browser* browser);
+
   // KeyedService:
   void Shutdown() override;
 
@@ -115,6 +117,8 @@ class SharedPinnedTabService : public KeyedService,
   std::unique_ptr<content::WebContents> CreateDummyWebContents(
       content::WebContents* shared_contents);
 
+  bool IsBrowserInTabDragging(Browser* browser) const;
+
   raw_ptr<Profile> profile_;
 
   base::flat_set<Browser*> browsers_;
@@ -123,6 +127,7 @@ class SharedPinnedTabService : public KeyedService,
   base::flat_set<Browser*> closing_browsers_;
   base::flat_set<std::unique_ptr<content::WebContents>>
       cached_shared_contentses_from_closing_browser_;
+  base::flat_set<Browser*> in_tab_dragging_browsers_;
 
   // This data is ordered in the actual pinned tab order.
   std::vector<PinnedTabData> pinned_tab_data_;

--- a/browser/ui/views/frame/brave_browser_frame.h
+++ b/browser/ui/views/frame/brave_browser_frame.h
@@ -30,6 +30,7 @@ class BraveBrowserFrame : public BrowserFrame {
   ui::ColorProviderKey::ThemeInitializerSupplier* GetCustomTheme()
       const override;
   views::internal::RootView* CreateRootView() override;
+  void SetTabDragKind(TabDragKind kind) override;
 
  private:
   raw_ptr<BrowserView> view_ = nullptr;

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -62,6 +62,7 @@
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/frame/window_frame_util.h"
+#include "chrome/browser/ui/views/frame/browser_frame.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/frame/contents_layout_manager.h"
 #include "chrome/browser/ui/views/frame/contents_web_view.h"
@@ -1154,8 +1155,11 @@ bool BraveBrowserView::AcceleratorPressed(const ui::Accelerator& accelerator) {
       }
     }
   }
-
   return BrowserView::AcceleratorPressed(accelerator);
+}
+
+bool BraveBrowserView::IsInTabDragging() const {
+  return frame()->tab_drag_kind() == TabDragKind::kAllTabs;
 }
 
 bool BraveBrowserView::IsSidebarVisible() const {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -105,6 +105,7 @@ class BraveBrowserView : public BrowserView,
                           int index,
                           int reason) override;
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
+  bool IsInTabDragging() const override;
 
 #if defined(USE_AURA)
   views::View* sidebar_host_view() { return sidebar_host_view_; }

--- a/chromium_src/chrome/browser/ui/views/frame/browser_frame.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_frame.h
@@ -11,7 +11,11 @@
   friend class BraveBrowserFrame; \
   void OnMenuClosed
 
+#define SetTabDragKind virtual SetTabDragKind
+
 #include "src/chrome/browser/ui/views/frame/browser_frame.h"  // IWYU pragma: export
+
+#undef SetTabDragKind
 
 #undef OnMenuClosed
 


### PR DESCRIPTION
We were synchronizing the new browser created during drag-and-drop and it caused the new browser to be dangling in some cases.

For e.g.
* Drag a non-pinned tab out of a window to create a new window
* Don't drop and drag it back to the original window
* Open tab search button and see if the dummy pinned tab is gone. => The dummy tab for new window can be dangling, even the browser looks gone.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38764

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Drag a non-pinned tab out of a window to create a new window
* Don't drop and drag it back to the original window
* Open tab search button and see if the dummy pinned tab is gone. 
  => Previously: The dummy tab for new window can be dangling, even the browser looks gone.
  => Expected: There shouldn't be no dangling web page