### PR TITLE
Updated tab search bubble's scroll thumb color

### DIFF
--- a/browser/ui/color/material_brave_color_mixer.cc
+++ b/browser/ui/color/material_brave_color_mixer.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/color/material_brave_color_mixer.h"
+
+#include "chrome/browser/ui/color/chrome_color_id.h"
+#include "ui/color/color_provider.h"
+#include "ui/color/color_recipe.h"
+#include "ui/gfx/color_palette.h"
+
+void AddMaterialBraveColorMixer(ui::ColorProvider* provider,
+                                const ui::ColorProviderKey& key) {
+  CHECK(provider);
+  ui::ColorMixer& mixer = provider->AddMixer();
+  const bool is_dark = key.color_mode == ui::ColorProviderKey::ColorMode::kDark;
+
+  // Use leo color when it's ready.
+  mixer[kColorTabSearchScrollbarThumb] = {
+      is_dark ? SkColorSetRGB(0x58, 0x58, 0x58)
+              : SkColorSetRGB(0xB4, 0xB4, 0xB4)};
+}

--- a/browser/ui/color/material_brave_color_mixer.h
+++ b/browser/ui/color/material_brave_color_mixer.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_COLOR_MATERIAL_BRAVE_COLOR_MIXER_H_
+#define BRAVE_BROWSER_UI_COLOR_MATERIAL_BRAVE_COLOR_MIXER_H_
+
+#include "ui/color/color_provider_key.h"
+
+namespace ui {
+class ColorProvider;
+}  // namespace ui
+
+void AddMaterialBraveColorMixer(ui::ColorProvider* provider,
+                                const ui::ColorProviderKey& key);
+
+#endif  // BRAVE_BROWSER_UI_COLOR_MATERIAL_BRAVE_COLOR_MIXER_H_

--- a/browser/ui/color/sources.gni
+++ b/browser/ui/color/sources.gni
@@ -14,6 +14,8 @@ if (!is_android) {
     "//brave/browser/ui/color/brave_material_side_panel_color_mixer.cc",
     "//brave/browser/ui/color/brave_material_side_panel_color_mixer.h",
     "//brave/browser/ui/color/color_palette.h",
+    "//brave/browser/ui/color/material_brave_color_mixer.cc",
+    "//brave/browser/ui/color/material_brave_color_mixer.h",
     "//brave/browser/ui/color/playlist/playlist_color_mixer.cc",
     "//brave/browser/ui/color/playlist/playlist_color_mixer.h",
   ]

--- a/chromium_src/chrome/browser/ui/color/material_chrome_color_mixer.cc
+++ b/chromium_src/chrome/browser/ui/color/material_chrome_color_mixer.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/color/material_chrome_color_mixer.h"
+
+#include "brave/browser/ui/color/material_brave_color_mixer.h"
+
+#define AddMaterialChromeColorMixer AddMaterialChromeColorMixer_ChromiumImpl
+#include "src/chrome/browser/ui/color/material_chrome_color_mixer.cc"
+#undef AddMaterialChromeColorMixer
+
+void AddMaterialChromeColorMixer(ui::ColorProvider* provider,
+                                 const ui::ColorProviderKey& key) {
+  AddMaterialChromeColorMixer_ChromiumImpl(provider, key);
+
+#if !BUILDFLAG(IS_ANDROID)
+  AddMaterialBraveColorMixer(provider, key);
+#endif
+}


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/38652

<img width="376" alt="Screenshot 2024-06-03 at 12 38 23 PM" src="https://github.com/brave/brave-core/assets/6786187/b30a8c83-a12d-48eb-b490-8213e2954d4c">
<img width="354" alt="Screenshot 2024-06-03 at 12 38 43 PM" src="https://github.com/brave/brave-core/assets/6786187/e2a3fd8a-5450-4425-892b-62142354823a">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Click tab search button and check scrollbar color is not blue