### PR TITLE
Fixed location icon view bg is set in custom theme

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -784,6 +784,9 @@ void AddBraveOmniboxLightThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorBravePlayerActionViewBorder] = {
       pick_color(leo::Color::kColorDividerSubtle)};
 
+  // We don't use bg color for location icon view.
+  mixer[kColorPageInfoBackground] = {SK_ColorTRANSPARENT};
+
   if (key.custom_theme) {
     return;
   }
@@ -810,7 +813,6 @@ void AddBraveOmniboxLightThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorOmniboxResultsUrl] = {
       leo::GetColor(leo::Color::kColorTextInteractive, leo::Theme::kLight)};
   mixer[kColorOmniboxResultsUrlSelected] = {kColorOmniboxResultsUrl};
-  mixer[kColorPageInfoBackground] = {kColorLocationBarBackground};
 }
 
 void AddBraveOmniboxDarkThemeColorMixer(ui::ColorProvider* provider,
@@ -830,7 +832,7 @@ void AddBraveOmniboxDarkThemeColorMixer(ui::ColorProvider* provider,
       pick_color(leo::Color::kColorDividerSubtle)};
   mixer[kColorBravePlayerActionViewBorder] = {
       pick_color(leo::Color::kColorDividerSubtle)};
-
+  mixer[kColorPageInfoBackground] = {SK_ColorTRANSPARENT};
   if (key.custom_theme) {
     return;
   }
@@ -855,7 +857,6 @@ void AddBraveOmniboxDarkThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorOmniboxResultsUrl] = {
       leo::GetColor(leo::Color::kColorTextInteractive, leo::Theme::kDark)};
   mixer[kColorOmniboxResultsUrlSelected] = {kColorOmniboxResultsUrl};
-  mixer[kColorPageInfoBackground] = {kColorLocationBarBackground};
 }
 
 void AddBraveOmniboxPrivateThemeColorMixer(ui::ColorProvider* provider,
@@ -876,7 +877,7 @@ void AddBraveOmniboxPrivateThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorOmniboxResultsBackgroundSelected] = {
       GetOmniboxResultBackground(kColorOmniboxResultsBackgroundSelected,
                                  /*dark*/ false, /*incognito*/ true)};
-  mixer[kColorPageInfoBackground] = {kColorLocationBarBackground};
+  mixer[kColorPageInfoBackground] = {SK_ColorTRANSPARENT};
 }
 
 void AddBravifiedTabStripColorMixer(ui::ColorProvider* provider,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/38763

Set transparent for icon view as we use same color with location bar.

<img width="629" alt="Screenshot 2024-06-03 at 3 23 18 PM" src="https://github.com/brave/brave-core/assets/6786187/91053e73-6589-4675-8c29-6d5bc9400455">
<img width="423" alt="Screenshot 2024-06-03 at 3 23 29 PM" src="https://github.com/brave/brave-core/assets/6786187/c0d0bd28-fcd3-44a1-be65-85ab9fbd9886">
<img width="372" alt="Screenshot 2024-06-03 at 3 23 44 PM" src="https://github.com/brave/brave-core/assets/6786187/a8ced789-b615-439d-bd03-04017fc7b98c">
<img width="329" alt="Screenshot 2024-06-03 at 3 24 02 PM" src="https://github.com/brave/brave-core/assets/6786187/46a25f28-0a39-4a44-9294-e0f54719abbe">
<img width="429" alt="Screenshot 2024-06-03 at 3 24 36 PM" src="https://github.com/brave/brave-core/assets/6786187/13e21079-58f4-4497-b6d7-03188ff4ebf2">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue