### PR TITLE
Updated bookmark icons from omnibox result and NTP search widget (uplift to 1.67.x)

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -298,6 +298,12 @@ const util = {
           config.getBraveLogoIconName()),
       path.join(config.srcDir, 'ui', 'webui', 'resources', 'images',
           'chrome_logo_dark.svg')])
+    // Replace webui bookmark svg icon.
+    fileMap.add([
+      path.join(config.braveCoreDir, 'node_modules', '@brave', 'leo', 'icons',
+          'browser-bookmark-normal.svg'),
+      path.join(config.srcDir, 'ui', 'webui', 'resources', 'images',
+          'icon_bookmark.svg')])
 
     let explicitSourceFiles = new Set()
     if (config.getTargetOS() === 'mac') {

--- a/vector_icons/leo_overrides.json
+++ b/vector_icons/leo_overrides.json
@@ -13,6 +13,7 @@
   "//chrome/app/vector_icons/sharing_hub_screenshot.icon": "leo_screenshot",
   "//chrome/app/vector_icons/zoom_minus.icon": "leo_search_zoom_out",
   "//chrome/app/vector_icons/zoom_plus.icon": "leo_search_zoom_in",
+  "//components/omnibox/browser/vector_icons/bookmark_chrome_refresh.icon": "leo_browser_bookmark_normal",
   "//components/omnibox/browser/vector_icons/bookmark.icon": "leo_browser_bookmark_normal",
   "//components/omnibox/browser/vector_icons/find_in_page.icon": "leo_window_search",
   "//components/omnibox/browser/vector_icons/http.icon": "leo_info_filled",


### PR DESCRIPTION
Uplift of #23957
fix https://github.com/brave/brave-browser/issues/38765

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.