### PR TITLE
Updated omnibox keyword button radius (uplift to 1.67.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/omnibox/omnibox_suggestion_button_row_view.cc
+++ b/chromium_src/chrome/browser/ui/views/omnibox/omnibox_suggestion_button_row_view.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/layout_constants.h"
+
+// Change button's raidus directly instead of changing TOOLBAR_CORNER_RADIUS
+// constants from our brave_layout_constants.cc because we already override
+// TOOLBAR_CORNER_RADIUS with different value.
+// Not re-defined SetCornerRadius() like below because it is declared from many
+// headers. #define SetCornerRadius(...) SetCornerRadius(8)
+#define TOOLBAR_CORNER_RADIUS TOOLBAR_CORNER_RADIUS)); (SetCornerRadius(8
+
+#include "src/chrome/browser/ui/views/omnibox/omnibox_suggestion_button_row_view.cc"
+
+#undef TOOLBAR_CORNER_RADIUS


### PR DESCRIPTION
Uplift of #23951
fix https://github.com/brave/brave-browser/issues/38731

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.