### PR TITLE
Updated tab search bubble's scroll thumb color (uplift to 1.67.x)

### DIFF
--- a/browser/ui/color/material_brave_color_mixer.cc
+++ b/browser/ui/color/material_brave_color_mixer.cc
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/color/material_brave_color_mixer.h"
+
+#include "chrome/browser/ui/color/chrome_color_id.h"
+#include "ui/color/color_provider.h"
+#include "ui/color/color_recipe.h"
+#include "ui/gfx/color_palette.h"
+
+void AddMaterialBraveColorMixer(ui::ColorProvider* provider,
+                                const ui::ColorProviderKey& key) {
+  CHECK(provider);
+  ui::ColorMixer& mixer = provider->AddMixer();
+  const bool is_dark = key.color_mode == ui::ColorProviderKey::ColorMode::kDark;
+
+  // Use leo color when it's ready.
+  mixer[kColorTabSearchScrollbarThumb] = {
+      is_dark ? SkColorSetRGB(0x58, 0x58, 0x58)
+              : SkColorSetRGB(0xB4, 0xB4, 0xB4)};
+}

--- a/browser/ui/color/material_brave_color_mixer.h
+++ b/browser/ui/color/material_brave_color_mixer.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_COLOR_MATERIAL_BRAVE_COLOR_MIXER_H_
+#define BRAVE_BROWSER_UI_COLOR_MATERIAL_BRAVE_COLOR_MIXER_H_
+
+#include "ui/color/color_provider_key.h"
+
+namespace ui {
+class ColorProvider;
+}  // namespace ui
+
+void AddMaterialBraveColorMixer(ui::ColorProvider* provider,
+                                const ui::ColorProviderKey& key);
+
+#endif  // BRAVE_BROWSER_UI_COLOR_MATERIAL_BRAVE_COLOR_MIXER_H_

--- a/browser/ui/color/sources.gni
+++ b/browser/ui/color/sources.gni
@@ -14,6 +14,8 @@ if (!is_android) {
     "//brave/browser/ui/color/brave_material_side_panel_color_mixer.cc",
     "//brave/browser/ui/color/brave_material_side_panel_color_mixer.h",
     "//brave/browser/ui/color/color_palette.h",
+    "//brave/browser/ui/color/material_brave_color_mixer.cc",
+    "//brave/browser/ui/color/material_brave_color_mixer.h",
     "//brave/browser/ui/color/playlist/playlist_color_mixer.cc",
     "//brave/browser/ui/color/playlist/playlist_color_mixer.h",
   ]

--- a/chromium_src/chrome/browser/ui/color/material_chrome_color_mixer.cc
+++ b/chromium_src/chrome/browser/ui/color/material_chrome_color_mixer.cc
@@ -1,0 +1,21 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/color/material_chrome_color_mixer.h"
+
+#include "brave/browser/ui/color/material_brave_color_mixer.h"
+
+#define AddMaterialChromeColorMixer AddMaterialChromeColorMixer_ChromiumImpl
+#include "src/chrome/browser/ui/color/material_chrome_color_mixer.cc"
+#undef AddMaterialChromeColorMixer
+
+void AddMaterialChromeColorMixer(ui::ColorProvider* provider,
+                                 const ui::ColorProviderKey& key) {
+  AddMaterialChromeColorMixer_ChromiumImpl(provider, key);
+
+#if !BUILDFLAG(IS_ANDROID)
+  AddMaterialBraveColorMixer(provider, key);
+#endif
+}


### PR DESCRIPTION
Uplift of #23953
fix https://github.com/brave/brave-browser/issues/38652

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.