### PR TITLE
[iOS] - Add network status logging

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -56,6 +56,10 @@ public class AppState {
           Migration.postCoreDataInitMigrations()
           Migration.migrateLostTabsActiveWindow()
         }
+
+        if !AppConstants.isOfficialBuild || Preferences.Debug.developerOptionsEnabled.value {
+          NetworkMonitor.shared.start()
+        }
         break
       case .active:
         break

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1997,7 +1997,7 @@ public class BrowserViewController: UIViewController {
 
       Task {
         await tab.updateSecureContentState()
-        self.logSecureContentState(tab: tab, path: .url)
+        self.logSecureContentState(tab: tab, path: .url, change: change)
         if self.tabManager.selectedTab === tab {
           self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
         }
@@ -2021,7 +2021,7 @@ public class BrowserViewController: UIViewController {
     case .hasOnlySecureContent:
       Task {
         await tab.updateSecureContentState()
-        self.logSecureContentState(tab: tab, path: .hasOnlySecureContent)
+        self.logSecureContentState(tab: tab, path: .hasOnlySecureContent, change: change)
         if tabManager.selectedTab === tab {
           self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
         }
@@ -2065,38 +2065,10 @@ public class BrowserViewController: UIViewController {
       )
     }
 
-    if change != nil {
-      if let change = change?[.oldKey] {
-        if let value = change as? Bool {
-          text.append("\n Changed From Value: \(value)")
-        } else if let value = change as? URL {
-          text.append("\n Changed From Value: \(value)")
-        } else if let value = change as? SecTrust? {
-          text.append("\n Changed From Value: \(value != nil ? "present" : "nil")")
-        } else if CFGetTypeID(change as CFTypeRef) == SecTrustGetTypeID() {
-          text.append("\n Changed From Value: present")
-        } else {
-          text.append("\n Changed From Value: \(change)")
-        }
-      } else {
-        text.append("\n Changed From Value: nil")
-      }
-
-      if let change = change?[.newKey] {
-        if let value = change as? Bool {
-          text.append("\n Changed To Value: \(value)")
-        } else if let value = change as? URL {
-          text.append("\n Changed To Value: \(value)")
-        } else if let value = change as? SecTrust? {
-          text.append("\n Changed To Value: \(value != nil ? "present" : "nil")")
-        } else if CFGetTypeID(change as CFTypeRef) == SecTrustGetTypeID() {
-          text.append("\n Changed To Value: present")
-        } else {
-          text.append("\n Changed To Value: \(change)")
-        }
-      } else {
-        text.append("\n Changed To Value: nil")
-      }
+    if let change, path == .serverTrust, let newServerTrust = change[.newKey] {
+      text.append("\n Change: \(newServerTrust != nil ? "present" : "nil")")
+    } else if let change, let value = change[.newKey] {
+      text.append("\n Change: \(String(describing: value))")
     }
 
     DebugLogger.log(for: .secureState, text: text)

--- a/ios/brave-ios/Sources/Brave/Networking/NetworkMonitor.swift
+++ b/ios/brave-ios/Sources/Brave/Networking/NetworkMonitor.swift
@@ -1,0 +1,43 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShared
+import Foundation
+import Network
+
+public class NetworkMonitor: NSObject {
+  private let monitor = NWPathMonitor()
+  private let queue = DispatchQueue(label: "com.brave.network-monitor")
+
+  public static let shared = NetworkMonitor()
+
+  private override init() {
+    super.init()
+  }
+
+  public func start() {
+    // Already monitoring
+    if monitor.pathUpdateHandler != nil {
+      return
+    }
+
+    monitor.pathUpdateHandler = { path in
+      let interfaces = path.availableInterfaces.map({ String(describing: $0.type) }).joined(
+        separator: ", "
+      )
+      DebugLogger.log(
+        for: .secureState,
+        text:
+          """
+          Network State Changed: \(String(describing: path.status))
+          - Reason: \(path.status == .unsatisfied ? String(describing: path.unsatisfiedReason) : "None")
+          - Available: \(String(interfaces))
+          """
+      )
+    }
+
+    monitor.start(queue: queue)
+  }
+}


### PR DESCRIPTION
## Summary
- Adds ability to log network status when using the hidden debug menu. Everything is on-device only and only in-memory.
- Log server trust key-path value

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38768

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

