### PR TITLE
Back button not disabled on New Tab Page without history

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -131,7 +131,7 @@ extension BrowserViewController: TabManagerDelegate {
     selected?.updatePullToRefreshVisibility()
 
     topToolbar.locationView.loading = selected?.loading ?? false
-    updateForwardStatusIfNeeded(webView: selected?.webView)
+    updateBackForwardActionStatus(for: selected?.webView)
     navigationToolbar.updateForwardStatus(selected?.canGoForward ?? false)
 
     let shouldShowPlaylistURLBarButton = selected?.url?.isPlaylistSupportedSiteURL == true

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -980,7 +980,7 @@ extension BrowserViewController: WKNavigationDelegate {
       updateUIForReaderHomeStateForTab(tab)
     }
 
-    updateForwardStatusIfNeeded(webView: webView)
+    updateBackForwardActionStatus(for: webView)
   }
 
   public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -714,7 +714,7 @@ public class BrowserViewController: UIViewController {
       let webView = tab.webView
     {
       updateURLBar()
-      updateForwardStatusIfNeeded(webView: webView)
+      updateBackForwardActionStatus(for: webView)
       topToolbar.locationView.loading = tab.loading
     }
 
@@ -2013,11 +2013,11 @@ public class BrowserViewController: UIViewController {
         tabsBar.updateSelectedTabTitle()
       }
     case .canGoBack, .canGoForward:
-      guard tab === tabManager.selectedTab, let canGoBack = change?[.newKey] as? Bool else {
+      guard tab === tabManager.selectedTab else {
         break
       }
 
-      updateForwardStatusIfNeeded(webView: webView)
+      updateBackForwardActionStatus(for: webView)
     case .hasOnlySecureContent:
       Task {
         await tab.updateSecureContentState()
@@ -2074,7 +2074,7 @@ public class BrowserViewController: UIViewController {
     DebugLogger.log(for: .secureState, text: text)
   }
 
-  func updateForwardStatusIfNeeded(webView: WKWebView?) {
+  func updateBackForwardActionStatus(for webView: WKWebView?) {
     guard let webView = webView else { return }
 
     if let forwardListItem = webView.backForwardList.forwardList.first,
@@ -2084,6 +2084,8 @@ public class BrowserViewController: UIViewController {
     } else {
       navigationToolbar.updateForwardStatus(webView.canGoForward)
     }
+
+    navigationToolbar.updateBackStatus(webView.canGoBack)
   }
 
   func updateUIForReaderHomeStateForTab(_ tab: Tab) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38670

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open new tab
2. Back button not disabled (can long-press but tapping does nothing)

## Screenshots:


https://github.com/brave/brave-core/assets/6643505/b5ac873e-4ff5-4dd9-8d40-4154951d2252

