### PR TITLE
[iOS] Fix `text/calendar` response handling from NTP/other origins (uplift to 1.67.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -618,13 +618,13 @@ extension BrowserViewController: WKNavigationDelegate {
   ///
   /// The user unfortunately has to  dismiss it manually after they have handled the file.
   /// Chrome iOS does the same
-  private func handleLinkWithSafariViewController(_ url: URL, tab: Tab?) {
+  private func handleLinkWithSafariViewController(_ url: URL, tab: Tab) {
     let vc = SFSafariViewController(url: url, configuration: .init())
     vc.modalPresentationStyle = .formSheet
     self.present(vc, animated: true)
 
     // If the website opened this URL in a separate tab, remove the empty tab
-    if let tab = tab, tab.url == nil || tab.url?.absoluteString == "about:blank" {
+    if tab.url == nil || tab.url?.absoluteString == "about:blank" {
       tabManager.removeTab(tab)
     }
   }
@@ -685,18 +685,11 @@ extension BrowserViewController: WKNavigationDelegate {
     // SFSafariViewController only supports http/https links
     if navigationResponse.isForMainFrame, let url = responseURL,
       url.isWebPage(includeDataURIs: false),
+      let tab, tab === tabManager.selectedTab,
       let mimeType = response.mimeType.flatMap({ UTType(mimeType: $0) }),
       mimeTypesThatRequireSFSafariViewControllerHandling.contains(mimeType)
     {
-
-      let isAboutHome = InternalURL(url)?.isAboutHomeURL == true
-      let isNonActiveTab = isAboutHome ? false : url.host != tabManager.selectedTab?.url?.host
-
-      // Check website is trying to open Safari Controller in non-active tab
-      if !isNonActiveTab {
-        handleLinkWithSafariViewController(url, tab: tab)
-      }
-
+      handleLinkWithSafariViewController(url, tab: tab)
       return .cancel
     }
 


### PR DESCRIPTION
Uplift of #23827
Resolves https://github.com/brave/brave-browser/issues/38548

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.