### PR TITLE
[iOS] Only show download prompt if tab is selected (uplift to 1.66.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -731,7 +731,8 @@ extension BrowserViewController: WKNavigationDelegate {
       }
 
       // Open our helper and cancel this response from the webview.
-      if let downloadAlert = downloadHelper.downloadAlert(from: view, okAction: downloadAlertAction)
+      if tab === tabManager.selectedTab,
+        let downloadAlert = downloadHelper.downloadAlert(from: view, okAction: downloadAlertAction)
       {
         present(downloadAlert, animated: true, completion: nil)
       }


### PR DESCRIPTION
Uplift of #23899
Resolves https://github.com/brave/brave-browser/issues/38551

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.