### PR TITLE
fix(wallet): Fix for `TransactionConfirmationStoreTests.testPrepareBTCSend()` failure

### DIFF
--- a/ios/brave-ios/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -109,6 +109,15 @@ class SendTokenStoreTests: XCTestCase {
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
 
     let bitcoinWalletService = BraveWallet.TestBitcoinWalletService()
+    bitcoinWalletService._balance = { accountId, completion in
+      let bitcoinBalance: BraveWallet.BitcoinBalance = .init(
+        totalBalance: 100000,
+        availableBalance: 100000,
+        pendingBalance: 0,
+        balances: [:]
+      )
+      completion(bitcoinBalance, "")
+    }
 
     let mockAssetManager = TestableWalletUserAssetManager()
     mockAssetManager._getAllUserAssetsInNetworkAssetsByVisibility = { _, _ in
@@ -669,8 +678,8 @@ class SendTokenStoreTests: XCTestCase {
       userAssetManager: mockAssetManager
     )
     store.selectedSendToken = .mockBTCToken
-    let ex = expectation(description: "send-fil-transaction")
-    store.sendToken(amount: "1") { success, _ in
+    let ex = expectation(description: "send-btc-transaction")
+    store.sendToken(amount: "0.0005") { success, _ in
       defer { ex.fulfill() }
       XCTAssertTrue(success)
     }

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -150,6 +150,15 @@ class TransactionConfirmationStoreTests: XCTestCase {
     solTxManagerProxy._estimatedTxFee = { $2(0, .success, "") }
 
     let bitcoinWalletService = BraveWallet.TestBitcoinWalletService()
+    bitcoinWalletService._balance = { accountId, completion in
+      let bitcoinBalance: BraveWallet.BitcoinBalance = .init(
+        totalBalance: 100000,
+        availableBalance: 100000,
+        pendingBalance: 0,
+        balances: [:]
+      )
+      completion(bitcoinBalance, "")
+    }
 
     return TransactionConfirmationStore(
       assetRatioService: assetRatioService,


### PR DESCRIPTION
- Bitcoin feature flag overridden for unit testing in iOS, causing some failures:
- CI caught failure was due to unimplemented call to `_balance` on `TestBitcoinWalletService` in `TransactionConfirmationStoreTests.testPrepareBTCSend()`.
    - Called when validating balance on transaction. Added default implementation in `setupServices()`
- Hit the same issue with a couple tests in `SendTokenStoreTests` (`testPrefilledToken()`, `testPrefilledTokenSwitchNetwork()`, and `testMakeSendBTCTransaction()`) and applied the same default balance fetch fix there.

Resolves https://github.com/brave/brave-browser/issues/38787

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Run `TransactionConfirmationStoreTests.testPrepareBTCSend()` locally at least 10 times, confirm no failure.
2. Run `SendTokenStoreTests`, confirm no failure
    - `testPrefilledToken()`
    - `testPrefilledTokenSwitchNetwork()`
    - `testMakeSendBTCTransaction()`