### PR TITLE
[iOS] - Add network status logging (uplift to 1.66.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -56,6 +56,8 @@ public class AppState {
           Migration.postCoreDataInitMigrations()
           Migration.migrateLostTabsActiveWindow()
         }
+
+        NetworkMonitor.shared.start()
         break
       case .active:
         break

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2028,6 +2028,11 @@ public class BrowserViewController: UIViewController {
       Task {
         await tab.updateSecureContentState()
         self.logSecureContentState(tab: tab, path: .serverTrust)
+        DebugLogger.log(
+          for: .secureState,
+          text:
+            "WebView Trust: \(webView.serverTrust != nil) -- SecureContentState NewKey: \(change?[.newKey] != nil)"
+        )
         if self.tabManager.selectedTab === tab {
           self.updateToolbarSecureContentState(tab.lastKnownSecureContentState)
         }

--- a/ios/brave-ios/Sources/Brave/Networking/NetworkMonitor.swift
+++ b/ios/brave-ios/Sources/Brave/Networking/NetworkMonitor.swift
@@ -1,0 +1,98 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShared
+import Foundation
+import Network
+
+public class NetworkMonitor: NSObject {
+  private let monitor = NWPathMonitor()
+  private let queue = DispatchQueue(label: "com.brave.network-monitor")
+
+  public static let shared = NetworkMonitor()
+
+  private override init() {
+    super.init()
+  }
+
+  public func start() {
+    // Already monitoring
+    if monitor.pathUpdateHandler != nil {
+      return
+    }
+
+    monitor.pathUpdateHandler = { path in
+      switch path.status {
+      case .satisfied:
+        let interfaces = String(
+          path.availableInterfaces.map({
+            switch $0.type {
+            case .other:
+              return "Other"
+            case .wifi:
+              return "Wifi"
+            case .cellular:
+              return "Cellular"
+            case .wiredEthernet:
+              return "WiredEthernet"
+            case .loopback:
+              return "Loopback"
+            @unknown default:
+              return "Unknown: \($0.name)"
+            }
+          }).joined(by: ", ")
+        )
+
+        DebugLogger.log(
+          for: .secureState,
+          text: "Network State Changed: Satisfied - Available: \(interfaces)\n"
+        )
+      case .unsatisfied:
+        let reason = path.unsatisfiedReason
+        switch reason {
+        case .notAvailable:
+          DebugLogger.log(
+            for: .secureState,
+            text: "Network State Changed: Unsatisfied - Reason: notAvailable\n"
+          )
+        case .cellularDenied:
+          DebugLogger.log(
+            for: .secureState,
+            text: "Network State Changed: Unsatisfied - Reason: cellularDenied\n"
+          )
+        case .wifiDenied:
+          DebugLogger.log(
+            for: .secureState,
+            text: "Network State Changed: Unsatisfied - Reason: wifiDenied\n"
+          )
+        case .localNetworkDenied:
+          DebugLogger.log(
+            for: .secureState,
+            text: "Network State Changed: Unsatisfied - Reason: localNetworkDenied\n"
+          )
+        case .vpnInactive:
+          DebugLogger.log(
+            for: .secureState,
+            text: "Network State Changed: Unsatisfied - Reason: vpnInactive\n"
+          )
+        @unknown default:
+          DebugLogger.log(
+            for: .secureState,
+            text: "Network State Changed: Unsatisfied - Reason: Unknown => \(reason)\n"
+          )
+        }
+      case .requiresConnection:
+        DebugLogger.log(for: .secureState, text: "Network State Changed: RequiresConnection\n")
+      @unknown default:
+        DebugLogger.log(
+          for: .secureState,
+          text: "Network State Changed: Unknown => \(path.status)\n"
+        )
+      }
+    }
+
+    monitor.start(queue: queue)
+  }
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Uplift of #23965
Resolves https://github.com/brave/brave-browser/issues/38768

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

