### PR TITLE
[iOS] Fix crash when handling certain types of JS alert info actions (uplift to 1.66.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserPrompts.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserPrompts.swift
@@ -61,7 +61,7 @@ class JSPromptAlertController: UIAlertController {
 
   weak var delegate: JSPromptAlertControllerDelegate?
 
-  private var handledAction: Bool = false
+  fileprivate var handledAction: Bool = false
 
   override func viewDidDisappear(_ animated: Bool) {
     super.viewDidDisappear(animated)
@@ -102,7 +102,8 @@ struct MessageAlert: JSAlertInfo {
       showCancel: false
     )
     alertController.addAction(
-      UIAlertAction(title: Strings.OKString, style: .default) { _ in
+      UIAlertAction(title: Strings.OKString, style: .default) { [weak alertController] _ in
+        alertController?.handledAction = true
         self.completionHandler()
       }
     )
@@ -128,7 +129,8 @@ struct ConfirmPanelAlert: JSAlertInfo {
       info: self
     )
     alertController.addAction(
-      UIAlertAction(title: Strings.OKString, style: .default) { _ in
+      UIAlertAction(title: Strings.OKString, style: .default) { [weak alertController] _ in
+        alertController?.handledAction = true
         self.completionHandler(true)
       }
     )
@@ -159,7 +161,8 @@ struct TextInputAlert: JSAlertInfo {
       input.text = self.defaultText
     })
     alertController.addAction(
-      UIAlertAction(title: Strings.OKString, style: .default) { _ in
+      UIAlertAction(title: Strings.OKString, style: .default) { [weak alertController] _ in
+        alertController?.handledAction = true
         self.completionHandler(input.text)
       }
     )


### PR DESCRIPTION
Uplift of #24020
Resolves https://github.com/brave/brave-browser/issues/38849

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.