### PR TITLE
[NTP Search]: More UX tweaks

### DIFF
--- a/components/brave_new_tab_ui/components/search/EnginePicker.tsx
+++ b/components/brave_new_tab_ui/components/search/EnginePicker.tsx
@@ -3,14 +3,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import Flex from "$web-common/Flex";
+import { getLocale } from "$web-common/locale";
 import Button from '@brave/leo/react/button';
 import ButtonMenu from '@brave/leo/react/buttonMenu';
-import Icon from '@brave/leo/react/icon';
-import { color, icon, spacing } from "@brave/leo/tokens/css/variables";
+import { color, spacing } from "@brave/leo/tokens/css/variables";
 import * as React from "react";
 import styled from "styled-components";
-import Flex from '$web-common/Flex';
-import { getLocale } from "$web-common/locale";
 import { useSearchContext } from "./SearchContext";
 import { MediumSearchEngineIcon } from "./SearchEngineIcon";
 
@@ -20,24 +19,17 @@ const Option = styled.div`
     gap: ${spacing.m};
 `
 
-const OpenIcon = styled(Icon)`
-  --leo-icon-color: rgba(255, 255, 255, 0.5);
-  --leo-icon-size: ${icon.xs};
-`
-
 const CustomizeButton = styled(Button)`
   border-top: 1px solid ${color.divider.subtle};
   color: ${color.text.secondary};
 `
 
-const Vr = styled.div`
-  width: 1px;
-  background: rgba(255,255,255,0.1);
-  height: 24px;
-`
-
 const OpenButton = styled(Button)`
   margin: -6px 0 -6px ${spacing.m};
+`
+
+const IconContainer = styled(Flex)`
+  margin-right: 16px;
 `
 
 export default function EnginePicker() {
@@ -46,11 +38,9 @@ export default function EnginePicker() {
 
   return <ButtonMenu data-theme="light" positionStrategy='fixed' isOpen={open} onClose={() => setOpen(false)}>
     <OpenButton fab kind="plain-faint" slot="anchor-content" onClick={() => setOpen(true)}>
-      <Flex gap={spacing.s} align='center'>
+      <IconContainer align="center" justify="center">
         <MediumSearchEngineIcon engine={searchEngine} />
-        <OpenIcon name={open ? "close" : "carat-down"} />
-        <Vr />
-      </Flex>
+      </IconContainer>
     </OpenButton>
     {filteredSearchEngines.map(s => <leo-menu-item onClick={() => setSearchEngine(s)} key={s.keyword}>
       <Option>

--- a/components/brave_new_tab_ui/components/search/EnginePicker.tsx
+++ b/components/brave_new_tab_ui/components/search/EnginePicker.tsx
@@ -85,7 +85,6 @@ export default function EnginePicker() {
   React.useEffect(() => {
     if (!open) return
     const handler = (e: MouseEvent) => {
-      console.log(menuRef.current)
       if (!e.composedPath().includes(menuRef.current!)) {
         setOpen(false)
       }

--- a/components/brave_new_tab_ui/components/search/EnginePicker.tsx
+++ b/components/brave_new_tab_ui/components/search/EnginePicker.tsx
@@ -7,9 +7,9 @@ import Flex from "$web-common/Flex";
 import { getLocale } from "$web-common/locale";
 import Button from '@brave/leo/react/button';
 import ButtonMenu from '@brave/leo/react/buttonMenu';
-import { color, spacing } from "@brave/leo/tokens/css/variables";
+import { color, radius, spacing } from "@brave/leo/tokens/css/variables";
 import * as React from "react";
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 import { useSearchContext } from "./SearchContext";
 import { MediumSearchEngineIcon } from "./SearchEngineIcon";
 
@@ -28,8 +28,17 @@ const OpenButton = styled(Button)`
   margin: -6px 0 -6px ${spacing.m};
 `
 
-const IconContainer = styled(Flex)`
-  margin-right: 16px;
+const IconContainer = styled(Flex) <{ open: boolean }>`
+  margin-right: 4px;
+  border-radius: ${radius.s};
+  padding: ${spacing.s};
+
+  width: 32px;
+  height: 32px;
+
+  ${p => p.open && css`
+    background: rgba(255,255,255,0.25);
+  `}
 `
 
 export default function EnginePicker() {
@@ -38,7 +47,7 @@ export default function EnginePicker() {
 
   return <ButtonMenu data-theme="light" positionStrategy='fixed' isOpen={open} onClose={() => setOpen(false)}>
     <OpenButton fab kind="plain-faint" slot="anchor-content" onClick={() => setOpen(true)}>
-      <IconContainer align="center" justify="center">
+      <IconContainer align="center" justify="center" open={open}>
         <MediumSearchEngineIcon engine={searchEngine} />
       </IconContainer>
     </OpenButton>

--- a/components/brave_new_tab_ui/components/search/EnginePicker.tsx
+++ b/components/brave_new_tab_ui/components/search/EnginePicker.tsx
@@ -32,7 +32,7 @@ const CustomizeButton = styled(Button)`
 `
 
 const OpenButton = styled(Button)`
-  margin: -6px 0 -6px ${spacing.m};
+  margin: -6px 0 -6px ${spacing.s};
 `
 
 const IconContainer = styled(Flex) <{ open: boolean }>`

--- a/components/brave_new_tab_ui/components/search/EnginePicker.tsx
+++ b/components/brave_new_tab_ui/components/search/EnginePicker.tsx
@@ -7,6 +7,7 @@ import Flex from "$web-common/Flex";
 import { getLocale } from "$web-common/locale";
 import Button from '@brave/leo/react/button';
 import ButtonMenu from '@brave/leo/react/buttonMenu';
+import Floating from '@brave/leo/react/floating';
 import { color, radius, spacing } from "@brave/leo/tokens/css/variables";
 import * as React from "react";
 import styled, { css } from "styled-components";
@@ -15,8 +16,14 @@ import { MediumSearchEngineIcon } from "./SearchEngineIcon";
 
 const Option = styled.div`
     display: flex;
-    color: ${color.black};
     gap: ${spacing.m};
+
+    padding: ${spacing.m};
+    border-radius: ${radius.s};
+
+    &:hover, &[data-selected=true] {
+      background: rgba(255,255,255,0.1);
+    }
 `
 
 const CustomizeButton = styled(Button)`
@@ -41,16 +48,65 @@ const IconContainer = styled(Flex) <{ open: boolean }>`
   `}
 `
 
+const Menu = styled.div`
+  width: 180px;
+
+  background: rgba(255,255,255,0.1);
+  backdrop-filter: blur(64px);
+
+  border-radius: ${radius.m};
+  padding: ${spacing.s};
+
+  display: flex;
+  flex-direction: column;
+  gap: ${spacing.s};
+`
+
+const findParentWithTag = (el: HTMLElement | null | undefined, tagName: string) => {
+  do {
+    el = el?.parentElement
+  } while (el && el.tagName !== tagName)
+
+  return el;
+}
+
 export default function EnginePicker() {
   const { filteredSearchEngines, searchEngine, setSearchEngine, setOpen: setBoxOpen } = useSearchContext()
   const [open, setOpen] = React.useState(false)
 
-  return <ButtonMenu data-theme="light" positionStrategy='fixed' isOpen={open} onClose={() => setOpen(false)}>
-    <OpenButton fab kind="plain-faint" slot="anchor-content" onClick={() => setOpen(true)}>
+  const ref = React.useRef<HTMLElement>();
+
+
+  return <>
+    <OpenButton ref={ref} fab kind="plain-faint" slot="anchor-content" onClick={() => setOpen(o => !o)}>
       <IconContainer align="center" justify="center" open={open}>
         <MediumSearchEngineIcon engine={searchEngine} />
       </IconContainer>
     </OpenButton>
+    {open && <Floating target={findParentWithTag(ref.current, 'LEO-INPUT')!} autoUpdate positionStrategy="fixed" placement="top-start" >
+      <Menu data-theme="dark">
+        {filteredSearchEngines.map(s => <Option onClick={() => {
+          setSearchEngine(s)
+          setOpen(false)
+        }}
+          key={s.keyword}
+          data-selected={s === searchEngine}>
+          <MediumSearchEngineIcon engine={s} />{s.name}
+        </Option>)}
+        <CustomizeButton kind="plain-faint" size="small" onClick={() => {
+          history.pushState(undefined, '', '?openSettings=Search')
+
+          // For now, close the search box - the Settings dialog doesn't use a
+          // dialog, so it gets rendered underneath.
+          setBoxOpen(false)
+        }}>
+          {getLocale('searchCustomizeList')}
+        </CustomizeButton>
+      </Menu>
+    </Floating>}
+  </>
+  return <ButtonMenu data-theme="light" positionStrategy='fixed' isOpen={open} onClose={() => setOpen(false)}>
+
     {filteredSearchEngines.map(s => <leo-menu-item onClick={() => setSearchEngine(s)} key={s.keyword}>
       <Option>
         <MediumSearchEngineIcon engine={s} />{s.name}

--- a/components/brave_new_tab_ui/components/search/EnginePicker.tsx
+++ b/components/brave_new_tab_ui/components/search/EnginePicker.tsx
@@ -7,27 +7,33 @@ import Flex from "$web-common/Flex";
 import { getLocale } from "$web-common/locale";
 import Button from '@brave/leo/react/button';
 import Floating from '@brave/leo/react/floating';
-import { color, radius, spacing } from "@brave/leo/tokens/css/variables";
+import { radius, spacing } from "@brave/leo/tokens/css/variables";
 import * as React from "react";
 import styled, { css } from "styled-components";
 import { useSearchContext } from "./SearchContext";
 import { MediumSearchEngineIcon } from "./SearchEngineIcon";
 
 const Option = styled.div`
-    display: flex;
-    gap: ${spacing.m};
+  display: flex;
+  align-items: center;
+  gap: ${spacing.m};
 
-    padding: ${spacing.m};
-    border-radius: ${radius.s};
+  padding: ${spacing.m};
+  border-radius: ${radius.s};
 
-    &:hover, &[data-selected=true] {
-      background: rgba(255,255,255,0.1);
-    }
+  &:hover, &[data-selected=true] {
+    background: rgba(255,255,255,0.1);
+  }
 `
 
-const CustomizeButton = styled(Button)`
-  border-top: 1px solid ${color.divider.subtle};
-  color: ${color.text.secondary};
+const CustomizeButton = styled(Option)`
+  border-top: 1px solid rgba(255,255,255,0.1);
+
+  justify-content: center;
+
+  &:not(:hover) {
+    border-radius: 0;
+  }
 `
 
 const OpenButton = styled(Button)`
@@ -102,6 +108,7 @@ export default function EnginePicker() {
     </OpenButton>
     {open && <Floating ref={menuRef} target={findParentWithTag(buttonRef.current, 'LEO-INPUT')!} autoUpdate positionStrategy="fixed" placement="top-start">
       <Menu data-theme="dark" onClick={e => {
+        e.preventDefault()
         e.stopPropagation()
       }}>
         {filteredSearchEngines.map(s => <Option onClick={() => {
@@ -112,7 +119,7 @@ export default function EnginePicker() {
           data-selected={s === searchEngine}>
           <MediumSearchEngineIcon engine={s} />{s.name}
         </Option>)}
-        <CustomizeButton kind="plain-faint" size="small" onClick={() => {
+        <CustomizeButton onClick={() => {
           history.pushState(undefined, '', '?openSettings=Search')
 
           // For now, close the search box - the Settings dialog doesn't use a

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -15,7 +15,7 @@ import { braveSearchHost, searchBoxRadius } from './config';
 
 const SearchInput = styled(Input)`
   --leo-control-focus-effect: none;
-  --leo-control-padding: 6px;
+  --leo-control-padding: 12px;
   --leo-control-color: rgba(255, 255, 255, 0.1);
   --leo-control-text-color: ${color.white};
   --leo-control-font: ${font.large.regular};
@@ -61,7 +61,7 @@ export default function SearchBox() {
   const searchInput = React.useRef<HTMLElement>()
   return <Container>
     <SearchInput tabIndex={0} type="text" ref={searchInput} value={query} onInput={e => setQuery(e.value)} placeholder={placeholderText}>
-      <Flex slot="left-icon">
+      <Flex slot="left-icon" align='center'>
         <EnginePicker />
       </Flex>
       <SearchIconContainer slot="right-icon">

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -13,9 +13,11 @@ import EnginePicker from './EnginePicker';
 import { useSearchContext } from './SearchContext';
 import { braveSearchHost, searchBoxRadius } from './config';
 
+const searchBoxClass = 'ntp-search-box'
+
 const SearchInput = styled(Input)`
   --leo-control-focus-effect: none;
-  --leo-control-padding: 10px;
+  --leo-control-padding: 12px 10px;
   --leo-control-color: rgba(255, 255, 255, 0.1);
   --leo-control-text-color: ${color.white};
   --leo-control-font: ${font.large.regular};
@@ -59,7 +61,7 @@ export default function SearchBox() {
     ? getLocale('searchBravePlaceholder')
     : getLocale('searchNonBravePlaceholder')
   const searchInput = React.useRef<HTMLElement>()
-  return <Container>
+  return <Container className={searchBoxClass}>
     <SearchInput tabIndex={0} type="text" ref={searchInput} value={query} onInput={e => setQuery(e.value)} placeholder={placeholderText}>
       <Flex slot="left-icon" align='center'>
         <EnginePicker />

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -15,7 +15,7 @@ import { braveSearchHost, searchBoxRadius } from './config';
 
 const SearchInput = styled(Input)`
   --leo-control-focus-effect: none;
-  --leo-control-padding: 12px;
+  --leo-control-padding: 10px;
   --leo-control-color: rgba(255, 255, 255, 0.1);
   --leo-control-text-color: ${color.white};
   --leo-control-font: ${font.large.regular};

--- a/components/brave_new_tab_ui/components/search/SearchBox.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchBox.tsx
@@ -6,12 +6,12 @@ import Flex from '$web-common/Flex';
 import { getLocale } from '$web-common/locale';
 import Icon from '@brave/leo/react/icon';
 import Input from '@brave/leo/react/input';
-import { color, font, radius, spacing } from '@brave/leo/tokens/css/variables';
+import { color, font, spacing } from '@brave/leo/tokens/css/variables';
 import * as React from 'react';
 import styled from 'styled-components';
-import { useSearchContext } from './SearchContext';
-import { braveSearchHost } from './config';
 import EnginePicker from './EnginePicker';
+import { useSearchContext } from './SearchContext';
+import { braveSearchHost, searchBoxRadius } from './config';
 
 const SearchInput = styled(Input)`
   --leo-control-focus-effect: none;
@@ -33,13 +33,13 @@ const SearchIconContainer = styled.div`
 `
 
 const Container = styled.div`
-  --leo-control-radius: ${radius.m};
+  --leo-control-radius: ${searchBoxRadius};
 
   display: flex;
 
   /* If we have search results, don't add a radius to the bottom of the search box */
   &:has(+ .search-results) {
-    --leo-control-radius: ${radius.m} ${radius.m} 0 0;
+    --leo-control-radius: ${searchBoxRadius} ${searchBoxRadius} 0 0;
   }
 
   border-radius: var(--leo-control-radius);
@@ -50,7 +50,7 @@ export const Backdrop = styled.div`
   position: absolute;
   inset: 0;
   backdrop-filter: blur(64px);
-  border-radius: ${radius.m};
+  border-radius: ${searchBoxRadius};
 `
 
 export default function SearchBox() {

--- a/components/brave_new_tab_ui/components/search/SearchContext.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchContext.tsx
@@ -84,7 +84,7 @@ export function SearchContext(props: React.PropsWithChildren<{}>) {
   const [searchEngine, setSearchEngineInternal] = React.useState<SearchEngineInfo>()
   const [query, setQuery] = React.useState('')
   const { result: searchEngines = [] } = usePromise(() => searchEnginesPromise, [])
-  const filteredSearchEngines = React.useMemo(() => searchEngines.filter(isSearchEngineEnabled), [searchEngines])
+  const filteredSearchEngines = searchEngines.filter(isSearchEngineEnabled)
 
   const setSearchEngine = React.useCallback((engine: SearchEngineInfo | string) => {
     if (typeof engine === 'string') {

--- a/components/brave_new_tab_ui/components/search/SearchDialog.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchDialog.tsx
@@ -6,7 +6,7 @@ import * as React from 'react';
 import styled, { keyframes } from 'styled-components'
 import SearchBox, { Backdrop } from './SearchBox';
 import SearchResults from './SearchResults';
-import { color, radius, spacing } from '@brave/leo/tokens/css/variables';
+import { color, radius } from '@brave/leo/tokens/css/variables';
 import { createPortal } from 'react-dom';
 
 interface Props {
@@ -58,7 +58,7 @@ const exitBackdrop = keyframes`
 `
 
 const Dialog = styled.dialog<{ offsetY: number }>`
-  --margin-top: ${spacing['9Xl']};
+  --margin-top: calc(50vh - 209px);
   --offset-y: ${p => p.offsetY}px;
 
   outline: none;
@@ -66,7 +66,7 @@ const Dialog = styled.dialog<{ offsetY: number }>`
   border-radius: ${radius.m};
   background: transparent;
   margin-top: var(--margin-top);
-  padding: 2px;
+  padding: 0px;
 
   animation: ${enterDialog} ${duration} ${easing};
 

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -43,6 +43,11 @@ function Swapper() {
   const [boxPos, setBoxPos] = React.useState(0)
   return <>
     {!open && <PlaceholderContainer onClick={e => {
+      // If we were clicking a button inside the SearchBox, don't open the box.
+      if (e.nativeEvent.composedPath().some(el => el['tagName'] === 'LEO-BUTTON')) {
+        console.log(e.nativeEvent.composedPath())
+        return
+      }
       setOpen(true)
       setBoxPos(e.currentTarget.getBoundingClientRect().y)
     }}>

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -9,14 +9,33 @@ import SearchBox, { Backdrop } from './SearchBox';
 import { SearchContext, useSearchContext } from './SearchContext';
 import SearchDialog from './SearchDialog';
 import { searchBoxRadius } from './config';
+import Button from '@brave/leo/react/button';
+import Icon from '@brave/leo/react/icon';
+
+const MenuButton = styled(Button)`
+  color: white;
+
+  position: absolute;
+  top: calc(50% - 12px);
+  right: -28px;
+
+  opacity: 0;
+
+  transition: opacity 0.2s ease-in-out;
+  transition-delay: 1s;
+`
 
 const PlaceholderContainer = styled.div`
   position: relative;
-  overflow: hidden;
-
+  
   border-radius: ${searchBoxRadius};
-
+  
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.10);
+  
+  &:hover ${MenuButton} {
+    transition-delay: 0s;
+    opacity: 1;
+  }
 `
 
 function Swapper() {
@@ -29,6 +48,9 @@ function Swapper() {
     }}>
       <Backdrop />
       <SearchBox />
+      <MenuButton fab kind='plain-faint'>
+        <Icon name='more-vertical' />
+      </MenuButton>
     </PlaceholderContainer>}
     {open && <SearchDialog offsetY={boxPos} onClose={() => setOpen(false)} />}
   </>

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -44,8 +44,8 @@ function Swapper() {
   return <>
     {!open && <PlaceholderContainer onClick={e => {
       // If we were clicking a button inside the SearchBox, don't open the box.
-      if (e.nativeEvent.composedPath().some(el => el['tagName'] === 'LEO-BUTTON')) {
-        console.log(e.nativeEvent.composedPath())
+      if (e.nativeEvent.composedPath().some(el => (el as HTMLElement).tagName === 'LEO-BUTTON')) {
+        e.preventDefault()
         return
       }
       setOpen(true)

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -11,10 +11,13 @@ import SearchDialog from './SearchDialog';
 import { searchBoxRadius } from './config';
 import Button from '@brave/leo/react/button';
 import Icon from '@brave/leo/react/icon';
+import ButtonMenu from '@brave/leo/react/buttonMenu';
+import { spacing } from '@brave/leo/tokens/css/variables';
+import { getLocale } from '$web-common/locale';
 
-const MenuButton = styled(Button)`
-  color: white;
-
+const MenuContainer = styled(ButtonMenu).attrs({
+  'data-theme': 'light'
+})`
   position: absolute;
   top: calc(50% - 12px);
   right: -28px;
@@ -23,6 +26,18 @@ const MenuButton = styled(Button)`
 
   transition: opacity 0.2s ease-in-out;
   transition-delay: 1s;
+
+  & > leo-menu-item {
+    display: flex;
+    align-items: center;
+    gap: ${spacing.m};
+
+    padding: ${spacing.m};
+  }
+`
+
+const MenuButton = styled(Button)`
+  color: white;
 `
 
 const PlaceholderContainer = styled.div`
@@ -32,7 +47,7 @@ const PlaceholderContainer = styled.div`
   
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.10);
   
-  &:hover ${MenuButton} {
+  &:hover ${MenuContainer} {
     transition-delay: 0s;
     opacity: 1;
   }
@@ -41,6 +56,7 @@ const PlaceholderContainer = styled.div`
 function Swapper() {
   const { open, setOpen } = useSearchContext()
   const [boxPos, setBoxPos] = React.useState(0)
+  const [, setShowSearchBox] = useNewTabPref('showSearchBox')
   return <>
     {!open && <PlaceholderContainer onClick={e => {
       // If we were clicking a button inside the SearchBox, don't open the box.
@@ -53,9 +69,19 @@ function Swapper() {
     }}>
       <Backdrop />
       <SearchBox />
-      <MenuButton fab kind='plain-faint'>
-        <Icon name='more-vertical' />
-      </MenuButton>
+      <div data-theme="light">
+        <MenuContainer>
+          <MenuButton fab kind='plain-faint' slot='anchor-content'>
+            <Icon name='more-vertical' />
+          </MenuButton>
+          <leo-menu-item onClick={e => {
+            e.stopPropagation()
+            setShowSearchBox(false)
+          }}>
+            <Icon name='eye-off' /> {getLocale('searchHide')}
+          </leo-menu-item>
+        </MenuContainer>
+      </div>
     </PlaceholderContainer>}
     {open && <SearchDialog offsetY={boxPos} onClose={() => setOpen(false)} />}
   </>

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -59,7 +59,6 @@ function Swapper() {
   const [, setShowSearchBox] = useNewTabPref('showSearchBox')
   return <>
     {!open && <PlaceholderContainer onClick={e => {
-      console.log("Closing", e.nativeEvent.composedPath())
       // If we were clicking a button inside the SearchBox, don't open the box.
       if (e.nativeEvent.composedPath().some(el => (el as HTMLElement).tagName === 'LEO-BUTTON')) {
         e.preventDefault()

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -59,6 +59,7 @@ function Swapper() {
   const [, setShowSearchBox] = useNewTabPref('showSearchBox')
   return <>
     {!open && <PlaceholderContainer onClick={e => {
+      console.log("Closing", e.nativeEvent.composedPath())
       // If we were clicking a button inside the SearchBox, don't open the box.
       if (e.nativeEvent.composedPath().some(el => (el as HTMLElement).tagName === 'LEO-BUTTON')) {
         e.preventDefault()

--- a/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchPlaceholder.tsx
@@ -3,18 +3,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react';
-import SearchBox, { Backdrop } from './SearchBox';
-import SearchDialog from './SearchDialog';
-import { useNewTabPref } from '../../hooks/usePref';
-import { SearchContext, useSearchContext } from './SearchContext';
 import styled from 'styled-components';
-import { radius } from '@brave/leo/tokens/css/variables';
+import { useNewTabPref } from '../../hooks/usePref';
+import SearchBox, { Backdrop } from './SearchBox';
+import { SearchContext, useSearchContext } from './SearchContext';
+import SearchDialog from './SearchDialog';
+import { searchBoxRadius } from './config';
 
 const PlaceholderContainer = styled.div`
   position: relative;
   overflow: hidden;
 
-  border-radius: ${radius.m};
+  border-radius: ${searchBoxRadius};
 
   box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.10);
 `

--- a/components/brave_new_tab_ui/components/search/SearchResult.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResult.tsx
@@ -80,7 +80,7 @@ const LeoIcon = styled(Icon)`
 `
 
 const Divider = styled.hr`
-  margin: -2px -8px;
+  margin: 2px -8px;
   opacity: 0.1;
 `
 

--- a/components/brave_new_tab_ui/components/search/SearchResult.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResult.tsx
@@ -25,7 +25,7 @@ const Container = styled.a`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: ${spacing.xl};
+  gap: ${spacing.l};
 
   text-decoration: none;
 
@@ -93,7 +93,6 @@ export default function SearchResult({ match, line, selected }: Props) {
     ? description
     : ''
 
-  const subtitle = match.destinationUrl.url || description
   const result = <Container href={match.destinationUrl.url} aria-selected={selected} onClick={e => {
     e.preventDefault()
     omniboxController.openAutocompleteMatch(line, match.destinationUrl, true, e.button, e.altKey, e.ctrlKey, e.metaKey, e.shiftKey)
@@ -105,7 +104,7 @@ export default function SearchResult({ match, line, selected }: Props) {
     </IconContainer>
     <Flex direction='column'>
       <Content>{contents}<Hint>{hint ? ` - ${hint}` : ''}</Hint></Content>
-      <Description>{subtitle}</Description>
+      {description && description !== hint && <Description>{description}</Description>}
     </Flex>
   </Container>
 

--- a/components/brave_new_tab_ui/components/search/SearchResult.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResult.tsx
@@ -19,7 +19,7 @@ interface Props {
 }
 
 const Container = styled.a`
-  padding: ${spacing.s} ${spacing.xl};
+  padding: ${spacing.s} ${spacing.m};
   border-radius: ${radius.m};
 
   display: flex;
@@ -56,11 +56,13 @@ const FavIcon = styled.span<{ url: string }>`
 
 const Content = styled.span`
   font: ${font.large.regular};
+  line-height: 24px;
   color: ${color.text.secondary};
 `
 
 const Description = styled.span`
   font: ${font.small.regular};
+  line-height: 18px;
   color: rgba(255,255,255,0.7);
 `
 

--- a/components/brave_new_tab_ui/components/search/SearchResults.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResults.tsx
@@ -21,7 +21,7 @@ const Container = styled.div`
   border-bottom-left-radius: ${radius.m};
   border-bottom-right-radius: ${radius.m};
 
-  padding: ${spacing.s};
+  padding: ${spacing.m};
   gap: ${spacing.s};
   display: flex;
   flex-direction: column;

--- a/components/brave_new_tab_ui/components/search/config.ts
+++ b/components/brave_new_tab_ui/components/search/config.ts
@@ -2,6 +2,7 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
+import { radius } from "@brave/leo/tokens/css/variables";
 import { SearchEngineInfo } from "../../api/background";
 
 // At some point we might want to store this in prefs, but
@@ -11,6 +12,7 @@ const ENABLED_SEARCH_ENGINES_KEY = 'search-engines'
 const LAST_SEARCH_ENGINE_KEY = 'last-search-engine'
 
 export const braveSearchHost = 'search.brave.com'
+export const searchBoxRadius = radius.xl;
 
 let cache: Record<string, boolean> | undefined
 

--- a/components/resources/brave_components_strings.grd
+++ b/components/resources/brave_components_strings.grd
@@ -252,6 +252,9 @@
       <message name="IDS_BRAVE_NEW_TAB_SEARCH_CUSTOMIZE_SEARCH_ENGINES">
         Customize available engines
       </message>
+      <message name="IDS_BRAVE_NEW_TAB_SEARCH_HIDE_SEARCH" desc="Message for the menu entry to hide the search box on the NTP">
+        Hide Search
+      </message>
 
       <message name="IDS_BRAVE_NEW_TAB_SEARCH_PROMOTION_POPUP_TITLE_1" desc="The text for brave search promotion from NTP">
         Want even better privacy?

--- a/components/webui/webui_resources.cc
+++ b/components/webui/webui_resources.cc
@@ -145,6 +145,7 @@ base::span<const webui::LocalizedString> GetWebUILocalizedStrings(
                {"searchCustomizeList", IDS_BRAVE_NEW_TAB_SEARCH_CUSTOMIZE_LIST},
                {"searchBravePlaceholder",
                 IDS_BRAVE_NEW_TAB_SEARCH_BRAVE_PLACEHOLDER},
+               {"searchHide", IDS_BRAVE_NEW_TAB_SEARCH_HIDE_SEARCH},
                {"searchAskLeo", IDS_OMNIBOX_ASK_LEO_DESCRIPTION},
                {"searchNonBravePlaceholder",
                 IDS_BRAVE_NEW_TAB_SEARCH_NON_BRAVE_PLACEHOLDER},


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38704

Had a call with @aguscruiz this morning to run over the changes :smile:

[Screencast from 2024-06-06 16-05-00.webm](https://github.com/brave/brave-core/assets/7678024/17dada7c-9efb-4fdf-8dcf-3c7bdd3fbbd5)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Icons in search results should line up with the search engine in the input
2. Placeholder text should be white
3. Search Engine picker menu should use the same style as the input/results (not white anymore)
4. It should be possible to hide the searchbox when it's closed via a 3 dot menu which only shows up when you hover
5. Urls should be gone from search results now

**Note:** Something seems to have happened with the search results which is stopping more suggestions coming through - I'm struggling to find the issue, but I'm pretty sure one was filed.