### PR TITLE
Enables bg playback flag on Android by default (uplift to 1.68.x)

### DIFF
--- a/browser/android/preferences/features.cc
+++ b/browser/android/preferences/features.cc
@@ -13,7 +13,7 @@ namespace features {
 
 BASE_FEATURE(kBraveBackgroundVideoPlayback,
              "BraveBackgroundVideoPlayback",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 }  // namespace features
 }  // namespace preferences


### PR DESCRIPTION
Uplift of #24037
Resolves https://github.com/brave/brave-browser/issues/38869

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.