### PR TITLE
[iOS] Brave crashes when enabling News from NTP and scrolling down the screen immediately

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -904,6 +904,9 @@ class NewTabPageViewController: UIViewController {
     guard let section = layout.braveNewsSection, parent != nil else { return }
 
     func _completeLoading() {
+      if Preferences.BraveNews.isShowingOptIn.value {
+        Preferences.BraveNews.isShowingOptIn.value = false
+      }
       UIView.animate(
         withDuration: 0.2,
         animations: {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -786,7 +786,6 @@ class NewTabPageViewController: UIViewController {
     case .optInCardAction(.turnOnBraveNewsButtonTapped):
       preventReloadOnBraveNewsEnabledChange = true
       Preferences.BraveNews.userOptedIn.value = true
-      Preferences.BraveNews.isShowingOptIn.value = false
       Preferences.BraveNews.isEnabled.value = true
       rewards.ads.initialize { [weak self] _ in
         // Initialize ads if it hasn't already been done

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -87,8 +87,7 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
   }
 
   private var isShowingOptInCard: Bool {
-    Preferences.BraveNews.isShowingOptIn.value
-      || Preferences.BraveNews.userOptedIn.value && dataSource.state.isLoading
+    !Preferences.BraveNews.isEnabled.value && Preferences.BraveNews.isShowingOptIn.value
   }
 
   func collectionView(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -87,7 +87,7 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
   }
 
   private var isShowingOptInCard: Bool {
-    !Preferences.BraveNews.isEnabled.value && Preferences.BraveNews.isShowingOptIn.value
+    Preferences.BraveNews.isShowingOptIn.value
   }
 
   func collectionView(
@@ -326,7 +326,8 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
 
     guard let card = dataSource.state.cards?[safe: indexPath.item] else {
       assertionFailure()
-      return UICollectionViewCell()
+      return collectionView.dequeueReusableCell(for: indexPath)
+        as FeedCardCell<BraveNewsEmptyFeedView>
     }
 
     switch card {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -325,8 +325,7 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
     }
 
     guard let card = dataSource.state.cards?[safe: indexPath.item] else {
-      assertionFailure()
-      return UICollectionViewCell()
+      return collectionView.dequeueReusableCell(for: indexPath) as FeedCardCell<BraveNewsEmptyFeedView>
     }
 
     switch card {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -88,6 +88,7 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
 
   private var isShowingOptInCard: Bool {
     Preferences.BraveNews.isShowingOptIn.value
+      || Preferences.BraveNews.userOptedIn.value && dataSource.state.isLoading
   }
 
   func collectionView(
@@ -325,7 +326,8 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
     }
 
     guard let card = dataSource.state.cards?[safe: indexPath.item] else {
-      return collectionView.dequeueReusableCell(for: indexPath) as FeedCardCell<BraveNewsOptInView>
+      assertionFailure()
+      return UICollectionViewCell()
     }
 
     switch card {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Sections/BraveNewsSectionProvider.swift
@@ -325,7 +325,7 @@ class BraveNewsSectionProvider: NSObject, NTPObservableSectionProvider {
     }
 
     guard let card = dataSource.state.cards?[safe: indexPath.item] else {
-      return collectionView.dequeueReusableCell(for: indexPath) as FeedCardCell<BraveNewsEmptyFeedView>
+      return collectionView.dequeueReusableCell(for: indexPath) as FeedCardCell<BraveNewsOptInView>
     }
 
     switch card {

--- a/ios/brave-ios/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/ios/brave-ios/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -31,14 +31,6 @@ public class FeedDataSource: ObservableObject {
     /// Some sort of error has occured when attempting to load feed content
     case failure(Error)
 
-    public var isLoading: Bool {
-      switch self {
-      case .loading:
-        return true
-      default:
-        return false
-      }
-    }
     /// The list of generated feed cards, if the state is `success`
     public var cards: [FeedCard]? {
       switch self {

--- a/ios/brave-ios/Sources/BraveNews/Composer/FeedDataSource.swift
+++ b/ios/brave-ios/Sources/BraveNews/Composer/FeedDataSource.swift
@@ -31,6 +31,14 @@ public class FeedDataSource: ObservableObject {
     /// Some sort of error has occured when attempting to load feed content
     case failure(Error)
 
+    public var isLoading: Bool {
+      switch self {
+      case .loading:
+        return true
+      default:
+        return false
+      }
+    }
     /// The list of generated feed cards, if the state is `success`
     public var cards: [FeedCard]? {
       switch self {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38871

Error is 

*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'the cell returned from -collectionView:cellForItemAtIndexPath: does not have a reuseIdentifier - cells must be retrieved by calling -dequeueReusableCellWithReuseIdentifier:forIndexPath:'

Empty Cell is causing NSInternalInconsistencyException fix with reuseIdentifier for opt cell


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Fresh install and launch Brave
2. Go through onboarding and land on NTP
3. Tap the Turn on Brave News CTA button and scroll down immediately > Don't Observe the crash

Screenshot

https://github.com/brave/brave-core/assets/6643505/6547d208-161c-49ba-81de-198eedaf9fec



