### PR TITLE
initial filter for macos upstream unit tests

### DIFF
--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -7,10 +7,9 @@
 
 #include <string>
 
-#include "brave/browser/new_tab/new_tab_shows_options.h"
-
 #include "brave/browser/brave_shields/brave_shields_web_contents_observer.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
+#include "brave/browser/new_tab/new_tab_shows_options.h"
 #include "brave/browser/search/ntp_utils.h"
 #include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/translate/brave_translate_prefs_migration.h"
@@ -20,6 +19,7 @@
 #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h"
 #include "brave/components/brave_ads/browser/analytics/p2a/p2a.h"
 #include "brave/components/brave_ads/core/public/prefs/obsolete_pref_util.h"
+#include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
 #include "brave/components/brave_news/browser/brave_news_p3a.h"
 #include "brave/components/brave_news/browser/brave_news_pref_manager.h"
@@ -65,6 +65,7 @@
 #include "components/safe_browsing/core/common/safe_browsing_prefs.h"
 #include "components/search_engines/search_engines_pref_names.h"
 #include "components/signin/public/base/signin_pref_names.h"
+#include "components/spellcheck/browser/pref_names.h"
 #include "components/sync/base/pref_names.h"
 #include "extensions/buildflags/buildflags.h"
 #include "third_party/widevine/cdm/buildflags.h"
@@ -498,6 +499,12 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 #if defined(TOOLKIT_VIEWS)
   bookmarks::prefs::RegisterProfilePrefs(registry);
 #endif
+
+  brave_ads::RegisterProfilePrefs(registry);
+  brave_rewards::RegisterProfilePrefs(registry);
+
+  registry->SetDefaultPrefValue(prefs::kSearchSuggestEnabled,
+                                base::Value(false));
 }
 
 }  // namespace brave

--- a/browser/greaselion/greaselion_service_factory.cc
+++ b/browser/greaselion/greaselion_service_factory.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <string>
 
+#include "base/check_is_test.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
 #include "brave/browser/brave_browser_process.h"
@@ -97,11 +98,14 @@ KeyedService* GreaselionServiceFactory::BuildServiceInstanceFor(
       extensions::ExtensionRegistry::Get(context);
   scoped_refptr<base::SequencedTaskRunner> task_runner =
       extensions::GetExtensionFileTaskRunner();
-  greaselion::GreaselionDownloadService* download_service = nullptr;
-  // Brave browser process may be null if we are being created within a unit
-  // test.
-  if (g_brave_browser_process)
-    download_service = g_brave_browser_process->greaselion_download_service();
+  auto* download_service =
+      g_brave_browser_process->greaselion_download_service();
+  // download service can be null in tests
+  if (!download_service) {
+    CHECK_IS_TEST();
+    return nullptr;
+  }
+
   std::unique_ptr<GreaselionServiceImpl> greaselion_service(
       new GreaselionServiceImpl(
           download_service, GetInstallDirectory(), extension_system,

--- a/browser/greaselion/greaselion_tab_helper.cc
+++ b/browser/greaselion/greaselion_tab_helper.cc
@@ -5,11 +5,7 @@
 
 #include "brave/browser/greaselion/greaselion_tab_helper.h"
 
-#include <string>
-#include <vector>
-
-#include "base/functional/callback_helpers.h"
-#include "base/strings/utf_string_conversions.h"
+#include "base/check_is_test.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/greaselion/greaselion_service_factory.h"
 #include "brave/components/greaselion/browser/greaselion_download_service.h"
@@ -24,11 +20,19 @@ GreaselionTabHelper::GreaselionTabHelper(content::WebContents* web_contents)
     : WebContentsObserver(web_contents),
       content::WebContentsUserData<GreaselionTabHelper>(*web_contents) {
   download_service_ = g_brave_browser_process->greaselion_download_service();
-  download_service_->AddObserver(this);
+  // download service can be null in tests
+  if (download_service_) {
+    download_service_->AddObserver(this);
+  } else {
+    CHECK_IS_TEST();
+  }
 }
 
 GreaselionTabHelper::~GreaselionTabHelper() {
-  download_service_->RemoveObserver(this);
+  // download service can be null in tests
+  if (download_service_) {
+    download_service_->RemoveObserver(this);
+  }
 }
 
 void GreaselionTabHelper::OnRulesReady(

--- a/browser/net/search_ads_header_network_delegate_helper_unittest.cc
+++ b/browser/net/search_ads_header_network_delegate_helper_unittest.cc
@@ -62,8 +62,6 @@ class SearchAdsHeaderDelegateHelperTest : public testing::Test {
     TestingProfile::Builder builder;
     auto prefs =
         std::make_unique<sync_preferences::TestingPrefServiceSyncable>();
-    brave_rewards::RegisterProfilePrefs(prefs->registry());
-    brave_ads::RegisterProfilePrefs(prefs->registry());
     RegisterUserProfilePrefs(prefs->registry());
     builder.SetPrefService(std::move(prefs));
     profile_ = builder.Build();

--- a/browser/tor/tor_profile_service_factory.cc
+++ b/browser/tor/tor_profile_service_factory.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/tor/tor_profile_service_factory.h"
 
+#include "base/check_is_test.h"
 #include "base/no_destructor.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/components/tor/brave_tor_client_updater.h"
@@ -86,8 +87,13 @@ bool TorProfileServiceFactory::IsTorDisabled(content::BrowserContext* context) {
     return true;
   }
   if (g_browser_process) {
-    return g_browser_process->local_state()->GetBoolean(
-        tor::prefs::kTorDisabled);
+    // local_state can be null in tests
+    if (g_browser_process->local_state()) {
+      return g_browser_process->local_state()->GetBoolean(
+          tor::prefs::kTorDisabled);
+    } else {
+      CHECK_IS_TEST();
+    }
   }
   return false;
 }

--- a/chromium_src/chrome/browser/profiles/pref_service_builder_utils.cc
+++ b/chromium_src/chrome/browser/profiles/pref_service_builder_utils.cc
@@ -5,9 +5,6 @@
 
 #include "chrome/browser/profiles/pref_service_builder_utils.h"
 
-#include "brave/browser/brave_profile_prefs.h"
-#include "brave/components/brave_ads/core/public/prefs/pref_registry.h"
-#include "brave/components/brave_rewards/common/pref_registry.h"
 #include "brave/components/constants/pref_names.h"
 #include "build/build_config.h"
 #include "chrome/common/pref_names.h"
@@ -25,8 +22,7 @@ void RegisterProfilePrefs(bool is_signin_profile,
                           user_prefs::PrefRegistrySyncable* registry) {
   RegisterProfilePrefs_ChromiumImpl(is_signin_profile, locale, registry);
 
-  brave_ads::RegisterProfilePrefs(registry);
-  brave_rewards::RegisterProfilePrefs(registry);
+  // Change default pref values that are registered by keyed services
 
   // Disable spell check service
   registry->SetDefaultPrefValue(

--- a/components/brave_rewards/browser/test_util.cc
+++ b/components/brave_rewards/browser/test_util.cc
@@ -29,7 +29,6 @@ std::unique_ptr<Profile> CreateBraveRewardsProfile(const base::FilePath& path) {
   std::unique_ptr<sync_preferences::PrefServiceSyncable> prefs(
       factory.CreateSyncable(registry.get()));
   RegisterUserProfilePrefs(registry.get());
-  brave_rewards::RegisterProfilePrefs(registry.get());
   TestingProfile::Builder profile_builder;
   profile_builder.SetPrefService(std::move(prefs));
   profile_builder.SetPath(path);

--- a/patches/chrome-browser-profiles-profile.cc.patch
+++ b/patches/chrome-browser-profiles-profile.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/profiles/profile.cc b/chrome/browser/profiles/profile.cc
-index a9762d47c397da91ec0c1ee4e91a8d4f75ea862b..603a91d1ab8088f4b6dfe902accd9a9ed83a3dbf 100644
+index a9762d47c397da91ec0c1ee4e91a8d4f75ea862b..8e9feab9d3f29e2434c7f6442c4a2de291bb859a 100644
 --- a/chrome/browser/profiles/profile.cc
 +++ b/chrome/browser/profiles/profile.cc
 @@ -111,6 +111,7 @@ bool Profile::OTRProfileID::AllowsBrowserWindows() const {
@@ -10,12 +10,3 @@ index a9762d47c397da91ec0c1ee4e91a8d4f75ea862b..603a91d1ab8088f4b6dfe902accd9a9e
        base::StartsWith(profile_id_, kDevToolsOTRProfileIDPrefix,
                         base::CompareCase::SENSITIVE) ||
        base::StartsWith(profile_id_, kMediaRouterOTRProfileIDPrefix,
-@@ -308,7 +309,7 @@ const char Profile::kProfileKey[] = "__PROFILE__";
- void Profile::RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
-   registry->RegisterBooleanPref(
-       prefs::kSearchSuggestEnabled,
--      true,
-+      false,
-       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
- #if BUILDFLAG(IS_ANDROID)
-   registry->RegisterStringPref(

--- a/test/base/testing_brave_browser_process.cc
+++ b/test/base/testing_brave_browser_process.cc
@@ -65,28 +65,24 @@ brave_shields::AdBlockService* TestingBraveBrowserProcess::ad_block_service() {
 #if BUILDFLAG(ENABLE_GREASELION)
 greaselion::GreaselionDownloadService*
 TestingBraveBrowserProcess::greaselion_download_service() {
-  NOTREACHED();
   return nullptr;
 }
 #endif
 
 debounce::DebounceComponentInstaller*
 TestingBraveBrowserProcess::debounce_component_installer() {
-  NOTREACHED();
   return nullptr;
 }
 
 #if BUILDFLAG(ENABLE_REQUEST_OTR)
 request_otr::RequestOTRComponentInstallerPolicy*
 TestingBraveBrowserProcess::request_otr_component_installer() {
-  NOTREACHED();
   return nullptr;
 }
 #endif
 
 brave::URLSanitizerComponentInstaller*
 TestingBraveBrowserProcess::URLSanitizerComponentInstaller() {
-  NOTREACHED();
   return nullptr;
 }
 
@@ -102,7 +98,6 @@ TestingBraveBrowserProcess::localhost_permission_component() {
 
 brave_component_updater::LocalDataFilesService*
 TestingBraveBrowserProcess::local_data_files_service() {
-  NOTREACHED();
   return nullptr;
 }
 
@@ -125,50 +120,42 @@ TestingBraveBrowserProcess::ipfs_client_updater() {
 #endif
 
 p3a::P3AService* TestingBraveBrowserProcess::p3a_service() {
-  NOTREACHED();
   return nullptr;
 }
 
 brave::BraveReferralsService*
 TestingBraveBrowserProcess::brave_referrals_service() {
-  NOTREACHED();
   return nullptr;
 }
 
 brave_stats::BraveStatsUpdater*
 TestingBraveBrowserProcess::brave_stats_updater() {
-  NOTREACHED();
   return nullptr;
 }
 
 brave_ads::BraveStatsHelper*
 TestingBraveBrowserProcess::ads_brave_stats_helper() {
-  NOTREACHED();
   return nullptr;
 }
 
 ntp_background_images::NTPBackgroundImagesService*
 TestingBraveBrowserProcess::ntp_background_images_service() {
-  NOTREACHED();
   return nullptr;
 }
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
 speedreader::SpeedreaderRewriterService*
 TestingBraveBrowserProcess::speedreader_rewriter_service() {
-  NOTREACHED();
   return nullptr;
 }
 #endif
 
 brave_ads::ResourceComponent* TestingBraveBrowserProcess::resource_component() {
-  NOTREACHED();
   return nullptr;
 }
 
 brave::BraveFarblingService*
 TestingBraveBrowserProcess::brave_farbling_service() {
-  NOTREACHED();
   return nullptr;
 }
 
@@ -185,7 +172,6 @@ void TestingBraveBrowserProcess::SetBraveVPNConnectionManagerForTesting(
 
 misc_metrics::ProcessMiscMetrics*
 TestingBraveBrowserProcess::process_misc_metrics() {
-  NOTREACHED();
   return nullptr;
 }
 

--- a/test/filters/unit_tests-linux.filter
+++ b/test/filters/unit_tests-linux.filter
@@ -5,18 +5,6 @@
 ## why the filter is required and create an associated tracking issue.
 ##
 
-# These fail because we override IdentityManager::GetAccountsInCookieJar
--SupervisedUserURLFilterTest.UrlsNotRequiringGuardianApprovalAllowed
-
-# These fail because we disable DIPS via features::kDIPS
--All/DIPSDatabasePopupsTest.*
--DIPSDatabaseBounceTableGarbageCollectionTest.*
-
-# These fail because we disable prefs::kSafeBrowsingScoutReportingEnabled.
--Impl/TrialComparisonCertVerifierControllerTest.OfficialBuildTrialEnabled/1
--Impl/TrialComparisonCertVerifierControllerTest.OfficialBuildTrialEnabledTwoClients/1
--Impl/TrialComparisonCertVerifierControllerTest.OfficialBuildTrialEnabledUmaOnly/1
-
 # These fail because OsIntegrationTestOverride::GetShortcutPath and
 # OsIntegrationTestOverride::IsRunOnOsLoginEnabled on Linux hard-codes "chrome-"
 # into the shortcut name but our shortcut starts with "brave-".
@@ -26,10 +14,6 @@
 -InstallAppLocallyCommandTest.BasicBehavior
 -WebAppPolicyForceUnregistrationTest.*
 
--ChromeBrowsingDataRemoverDelegateTest.*
 -ChromePaths.*
--Chromium/ChannelInfoTest.*
--ExtensionServiceTest.*
--MediaFileSystemRegistryTest.*
 -ShellIntegrationTest.*
 -WebAppShortcutLinuxTest.*

--- a/test/filters/unit_tests-macos.filter
+++ b/test/filters/unit_tests-macos.filter
@@ -4,3 +4,59 @@
 ## When adding a new filter to this list, please include a short description of
 ## why the filter is required and create an associated tracking issue.
 ##
+
+# MacOS overrides `DIR_USER_NATIVE_MESSAGING` to use Google dir
+-NativeMessagingTest.EchoConnect
+-NativeMessagingTest.ReconnectArgs
+-NativeMessagingTest.ReconnectArgsIfNativeConnectionDisallowed
+-NativeMessagingTest.ReconnectArgs_Disabled
+-NativeMessagingTest.UserLevel
+
+# We have a different number of items in the menu model
+-All/RecentTabsSubMenuModelTest.NoTabs/0
+-All/RecentTabsSubMenuModelTest.OtherDevices/0
+-All/RecentTabsSubMenuModelTest.OtherDevicesDynamicUpdate/0
+
+# UI specific colors and themes that we change
+-All/NewTabPageHandlerThemeTest.*
+-MaterialNewTabPageColorMixerTest.*
+-ThemeColorPickerHandlerTest.*
+-All/ThemeColorPickerHandlerSetThemeTest.*
+
+# We modify first dialog run behavior
+-FirstRunDialogControllerTest.*
+-FirstRunServiceTest.ShouldOpenFirstRun
+
+# We are incorrectly adding modifiers to accelerators somewhere - need to investigate
+-AcceleratorTableTest.CheckMacOSAccelerators
+
+# Still need investigation for failures
+-AcceleratorTableTest.CheckNoDuplicatesGlobalKeyboardShortcutsMac
+-All/TabStripRegionViewTest.NewTabButtonRightOfTabs/0
+-All/TabStripRegionViewTest.NewTabButtonRightOfTabs/1
+-MacHistorySwiperTest.MagicMouseStateResetsCorrectly
+-MacHistorySwiperTest.SwipeLeft
+-MacHistorySwiperTest.SwipeLeftSmallAmount
+-MacHistorySwiperTest.SwipeLeftThenDown
+-MacHistorySwiperTest.SwipeRight
+-MacHistorySwiperTest.SwipeRightEventOrdering
+-MacHistorySwiperTest.TouchEventAfterGestureFinishes
+-NtpCustomBackgroundServiceTest.TestUpdateCustomBackgroundColorGM3
+
+# Still need to investigate for crashes
+-All/NtpBackgroundServiceTest.CollectionRequestWithGM3Enabled/0
+-All/NtpBackgroundServiceTest.CollectionRequestWithGM3Enabled/1
+-BookmarkMenuCocoaControllerTest.TestOpenItemAfterModelLoaded
+-BookmarkMenuCocoaControllerTest.TestOpenItemWhileModelLoading
+-BrowserWindowDefaultTouchBarUnitTest.BackAccessibilityLabel
+-BrowserWindowDefaultTouchBarUnitTest.BackCommandUpdate
+-BrowserWindowDefaultTouchBarUnitTest.BookmkarStarTouchBarItem
+-BrowserWindowDefaultTouchBarUnitTest.ForwardAccessibilityLabel
+-BrowserWindowDefaultTouchBarUnitTest.ForwardCommandUpdate
+-BrowserWindowDefaultTouchBarUnitTest.HistoricTouchBarItems
+-BrowserWindowDefaultTouchBarUnitTest.HomeUpdate
+-BrowserWindowDefaultTouchBarUnitTest.ReloadOrStopTouchBarItem
+-BrowserWindowDefaultTouchBarUnitTest.TouchBarItems
+-ChromeBrowsingDataRemoverDelegateTpcdMetadataTest.ResetAllCohort_PreserveMode
+-ChromeBrowsingDataRemoverDelegateTpcdMetadataTest.ResetAllCohorts
+-FirstRunServiceTest.ShouldPopulateProfileNameFromPrimaryAccount

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -300,8 +300,8 @@
 -PermissionPromptBubbleTwoOriginsViewTest.TitleMentionsRequestingOriginAndPermission
 -SavedTabGroupBarUnitTest.*
 
-# MPArch is not supported in Brave, and therefore tests relating to it should
-# be disable.
+# Prerender is disabled
+-PrerenderManagerBasicRequirementTest.*
 -PrerendererNavigationPredictorPrefetchHoldbackDisabledTest.*
 -PrerenderGWSPrefetchHoldbackOffTest.*
 -PrerenderManagerTest.DestroyedOnNavigateAway
@@ -363,6 +363,8 @@
 -PreconnectManagerTest.*
 
 # These tests fail because we disable DIPS via features::kDIPS
+-DIPSDatabaseConfigTest.*
+-DIPSServiceUkmTest.*
 -All/DIPSDatabaseAllColumnTest.*/*
 -All/DIPSDatabaseErrorHistogramsTest.*/*
 -All/DIPSDatabaseGarbageCollectionTest.*/*
@@ -664,6 +666,14 @@
 -StorageAccessAPIServiceImplTest.PermissionDenial_NotRenewed
 -StorageAccessAPIServiceImplTest.RenewPermissionGrant
 -StorageAccessGrantPermissionContextAPIWithFedCMConnectionTest.AutoResolveWithConnection
+
+# These fail because we override IdentityManager::GetAccountsInCookieJar
+-SupervisedUserURLFilterTest.UrlsNotRequiringGuardianApprovalAllowed
+
+# These fail because we disable prefs::kSafeBrowsingScoutReportingEnabled.
+-Impl/TrialComparisonCertVerifierControllerTest.OfficialBuildTrialEnabled/1
+-Impl/TrialComparisonCertVerifierControllerTest.OfficialBuildTrialEnabledTwoClients/1
+-Impl/TrialComparisonCertVerifierControllerTest.OfficialBuildTrialEnabledUmaOnly/1
 
 # This test fails because our badge doesn't match the upstream badge
 -IconBadgingTest.VerifyFromDisk


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/38894

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

