### PR TITLE
[Omnibox]: Fix suggestions for keyword searches

### DIFF
--- a/chromium_src/components/omnibox/browser/search_provider.cc
+++ b/chromium_src/components/omnibox/browser/search_provider.cc
@@ -4,19 +4,24 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "components/omnibox/browser/search_suggestion_parser.h"
+#include "components/search_engines/search_engine_type.h"
 
 // Pass additional argument to check if it's Brave Search's rich suggestion
-#define ParseSuggestResults(root_list, input, scheme_classifier,         \
-                            default_result_relevance, is_keyword_result, \
-                            results)                                     \
-  ParseSuggestResults(                                                   \
-      root_list, input, scheme_classifier, default_result_relevance,     \
-      is_keyword_result, results,                                        \
-      /*is_brave_rich_suggestion*/ providers_.GetDefaultProviderURL() && \
-          providers_.GetDefaultProviderURL()->GetEngineType(             \
-              client()->GetTemplateURLService()->search_terms_data()) == \
-              SEARCH_ENGINE_BRAVE)
+#define ParseSuggestResults(root_list, input, scheme_classifier,            \
+                            default_result_relevance, is_keyword_result,    \
+                            results)                                        \
+  ParseSuggestResults(root_list, input, scheme_classifier,                  \
+                      default_result_relevance, is_keyword_result, results, \
+                      IsBraveRichSuggestion(is_keyword_result))
 
 #include "src/components/omnibox/browser/search_provider.cc"
 
 #undef ParseSuggestResults
+
+bool SearchProvider::IsBraveRichSuggestion(bool is_keyword) {
+  auto* url = is_keyword ? providers_.GetKeywordProviderURL()
+                         : providers_.GetDefaultProviderURL();
+  return url && url->GetEngineType(
+                    client()->GetTemplateURLService()->search_terms_data()) ==
+                    SEARCH_ENGINE_BRAVE;
+}

--- a/chromium_src/components/omnibox/browser/search_provider.h
+++ b/chromium_src/components/omnibox/browser/search_provider.h
@@ -6,10 +6,11 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_SEARCH_PROVIDER_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_OMNIBOX_BROWSER_SEARCH_PROVIDER_H_
 
-#define DoHistoryQuery                  \
-  DoHistoryQueryUnused();               \
-  friend class BraveSearchProvider;     \
-  friend class BraveSearchProviderTest; \
+#define DoHistoryQuery                         \
+  DoHistoryQueryUnused();                      \
+  friend class BraveSearchProvider;            \
+  friend class BraveSearchProviderTest;        \
+  bool IsBraveRichSuggestion(bool is_keyword); \
   virtual void DoHistoryQuery
 
 #include "src/components/omnibox/browser/search_provider.h"  // IWYU pragma: export


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38610

Thanks @MadhaviSeelam for the help debugging this one!

[Screencast from 2024-06-07 14-41-38.webm](https://github.com/brave/brave-core/assets/7678024/18da0e26-fbcd-46b3-988c-93d5528f89f7)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See issue & video (there should only be suggestions when the `Improve search suggestions` setting is on).