### PR TITLE
Remove unused `Learn more` link from WireGuard fallback

### DIFF
--- a/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
+++ b/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.cc
@@ -36,9 +36,6 @@ namespace brave_vpn {
 
 namespace {
 
-constexpr char kBraveVPNLearnMoreURL[] =
-    "https://support.brave.com/hc/en-us/articles/";
-
 constexpr int kChildSpacing = 16;
 constexpr int kPadding = 24;
 constexpr int kTopPadding = 32;
@@ -82,32 +79,13 @@ BraveVpnFallbackDialogView::BraveVpnFallbackDialogView(Browser* browser)
   const std::u16string contents_text =
       l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_TEXT);
 
-  std::u16string learn_more_link_text =
-      l10n_util::GetStringUTF16(IDS_BRAVE_VPN_FALLBACK_DIALOG_LEARN_MORE_TEXT);
-  std::u16string full_text = l10n_util::GetStringFUTF16(
-      IDS_BRAVE_VPN_FALLBACK_DIALOG_TEXT, learn_more_link_text);
-  const int main_message_length =
-      full_text.size() - learn_more_link_text.size();
-
   auto* contents_label = AddChildView(std::make_unique<views::StyledLabel>());
   contents_label->SetTextContext(views::style::CONTEXT_DIALOG_BODY_TEXT);
-  views::StyledLabel::RangeStyleInfo message_style;
-  contents_label->SetText(full_text);
-  contents_label->AddStyleRange(gfx::Range(0, main_message_length),
-                                message_style);
+  contents_label->SetText(contents_text);
   contents_label->SizeToFit(kDialogWidth);
 
   RegisterWindowClosingCallback(base::BindOnce(
       &BraveVpnFallbackDialogView::OnClosing, base::Unretained(this)));
-
-  // Add "Learn more" link.
-  views::StyledLabel::RangeStyleInfo link_style =
-      views::StyledLabel::RangeStyleInfo::CreateForLink(base::BindRepeating(
-          &BraveVpnFallbackDialogView::OnLearnMoreLinkClicked,
-          base::Unretained(this)));
-  contents_label->AddStyleRange(
-      gfx::Range(main_message_length, full_text.size()), link_style);
-  contents_label->SetHorizontalAlignment(gfx::HorizontalAlignment::ALIGN_LEFT);
 
   dont_ask_again_checkbox_ =
       AddChildView(std::make_unique<views::Checkbox>(l10n_util::GetStringUTF16(
@@ -115,12 +93,6 @@ BraveVpnFallbackDialogView::BraveVpnFallbackDialogView(Browser* browser)
 }
 
 BraveVpnFallbackDialogView::~BraveVpnFallbackDialogView() = default;
-
-void BraveVpnFallbackDialogView::OnLearnMoreLinkClicked() {
-  chrome::AddSelectedTabWithURL(browser_, GURL(kBraveVPNLearnMoreURL),
-                                ui::PAGE_TRANSITION_AUTO_TOPLEVEL);
-  CancelDialog();
-}
 
 ui::ModalType BraveVpnFallbackDialogView::GetModalType() const {
   return ui::MODAL_TYPE_WINDOW;

--- a/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h
+++ b/browser/ui/views/brave_vpn/brave_vpn_fallback_dialog_view.h
@@ -33,7 +33,6 @@ class BraveVpnFallbackDialogView : public views::DialogDelegateView {
 
   void OnAccept();
   void OnClosing();
-  void OnLearnMoreLinkClicked();
 
   // views::DialogDelegate overrides:
   ui::ModalType GetModalType() const override;

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -250,9 +250,6 @@
   <message name="IDS_BRAVE_VPN_DNS_SETTINGS_NOTIFICATION_DIALOG_LEARN_MORE_TEXT" desc="A text shown to user when he enabled Brave VPN without DoH and we override settings to visit help center">
     Learn more.
   </message>
-  <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_LEARN_MORE_TEXT" desc="A text shown to user when Brave VPN WireGuard is asking for fallback to IKEv2">
-    Learn more.
-  </message>
 
   <message name="IDS_SETTINGS_SECURE_DNS_DISABLED_BY_BRAVE_VPN" desc="A text shown to user on settings page for DNS setting when it is blocked by BraveVPN">
     The setting is locked by BraveVPN while it is connected
@@ -274,8 +271,6 @@ Need help with compatibility or configuration? Reach out to our friendly support
 You can always revert back to WireGuard on brave://settings/system.
 
 Let's get you connected!
-
-<ph name="LEARN_MORE">$1<ex>Learn more.</ex></ph>
   </message>
 
   <message name="IDS_BRAVE_VPN_FALLBACK_DIALOG_CHECKBOX_TEXT" desc="A text shown to user on dialog's checkbpox when Brave VPN WireGuard is asking for fallback to IKEv2">


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/38888
Closes https://github.com/brave/brave-browser/issues/31652

Looks like this after the change:
<kbd>
![image](https://github.com/brave/brave-browser/assets/4733304/16dd95e9-63cc-4a62-b367-ff85707b738a)
</kbd>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used GitHub [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See https://github.com/brave/brave-browser/issues/38888