### PR TITLE
fix(wallet): show connected-sites setting when EVM network is selected (uplift to 1.67.x)

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wallet_settings_menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wallet_settings_menu.tsx
@@ -199,15 +199,15 @@ export const WalletSettingsMenu = (props: Props) => {
           </PopupButtonText>
         </PopupButton>
 
-        {selectedNetwork?.coin === BraveWallet.CoinType.ETH ||
-          (selectedNetwork?.coin === BraveWallet.CoinType.SOL && (
-            <PopupButton onClick={onClickConnectedSites}>
-              <ButtonIcon name='link-normal' />
-              <PopupButtonText>
-                {getLocale('braveWalletWalletPopupConnectedSites')}
-              </PopupButtonText>
-            </PopupButton>
-          ))}
+        {(selectedNetwork?.coin === BraveWallet.CoinType.ETH ||
+          selectedNetwork?.coin === BraveWallet.CoinType.SOL) && (
+          <PopupButton onClick={onClickConnectedSites}>
+            <ButtonIcon name='link-normal' />
+            <PopupButtonText>
+              {getLocale('braveWalletWalletPopupConnectedSites')}
+            </PopupButtonText>
+          </PopupButton>
+        )}
 
         <PopupButton onClick={onClickSettings}>
           <ButtonIcon name='settings' />


### PR DESCRIPTION
Uplift of #24036
Resolves https://github.com/brave/brave-browser/issues/38868

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.