### PR TITLE
[NTP Search]: Add rich result images

### DIFF
--- a/components/brave_new_tab_ui/components/search/SearchResult.tsx
+++ b/components/brave_new_tab_ui/components/search/SearchResult.tsx
@@ -2,15 +2,16 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
+import Flex from '$web-common/Flex';
+import { getLocale } from '$web-common/locale';
+import Icon from '@brave/leo/react/icon';
 import { color, font, gradient, icon, radius, spacing } from '@brave/leo/tokens/css/variables';
 import { mojoString16ToString } from 'chrome://resources/js/mojo_type_util.js';
+import { useUnpaddedImageUrl } from '../../../brave_news/browser/resources/shared/useUnpaddedImageUrl';
 import { AutocompleteMatch } from 'gen/ui/webui/resources/cr_components/searchbox/searchbox.mojom.m';
 import * as React from 'react';
 import styled from 'styled-components';
-import Flex from '$web-common/Flex';
 import { omniboxController } from './SearchContext';
-import { getLocale } from '$web-common/locale';
-import Icon from '@brave/leo/react/icon';
 
 interface Props {
   match: AutocompleteMatch
@@ -44,11 +45,14 @@ const IconContainer = styled.div`
   justify-content: center;
 
   flex-shrink: 0;
+
+  > span, > img {
+    width: 20px;
+    height: 20px;
+  }
 `
 
 const FavIcon = styled.span<{ url: string }>`
-  width: 20px;
-  height: 20px;
   background: rgba(255, 255, 255, 0.5);
   mask-image: url(${p => p.url});
   mask-size: contain;
@@ -84,6 +88,22 @@ const Divider = styled.hr`
   opacity: 0.1;
 `
 
+const hide = { opacity: 0 }
+const show = { opacity: 1 }
+function RichImage({ url }: { url: string }) {
+  const [loaded, setLoaded] = React.useState(false)
+  const iconUrl = useUnpaddedImageUrl(url, () => setLoaded(true))
+  return <img src={iconUrl} style={loaded ? show : hide} />
+}
+function Image({ match, isAskLeo }: { match: AutocompleteMatch, isAskLeo: boolean }) {
+  if (isAskLeo) return <LeoIcon name='product-brave-leo' />
+
+  const isGeneric = !match.imageUrl
+  return isGeneric
+    ? <FavIcon url={match.iconUrl} />
+    : <RichImage url={match.imageUrl} />
+}
+
 export default function SearchResult({ match, line, selected }: Props) {
   const contents = mojoString16ToString(match.swapContentsAndDescription ? match.description : match.contents)
   const description = mojoString16ToString(match.swapContentsAndDescription ? match.contents : match.description)
@@ -98,9 +118,7 @@ export default function SearchResult({ match, line, selected }: Props) {
     omniboxController.openAutocompleteMatch(line, match.destinationUrl, true, e.button, e.altKey, e.ctrlKey, e.metaKey, e.shiftKey)
   }}>
     <IconContainer>
-      {isAskLeo
-        ? <LeoIcon name="product-brave-leo" />
-        : <FavIcon url={match.iconUrl} />}
+      <Image key={match.imageUrl ?? match.iconUrl} match={match} isAskLeo={isAskLeo} />
     </IconContainer>
     <Flex direction='column'>
       <Content>{contents}<Hint>{hint ? ` - ${hint}` : ''}</Hint></Content>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38909

Before:
![image](https://github.com/brave/brave-core/assets/7678024/7650df17-bc5d-4082-8527-7f53cab1e46f)

After:
![image](https://github.com/brave/brave-core/assets/7678024/5c200901-4173-457c-ae76-804f738601d6)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Do a search on the NTP search box with Brave as the default engine for `Hello`
2. There should be rich result images (i.e. not everything is a search icon)
![image](https://github.com/brave/brave-core/assets/7678024/a7a65260-fce3-4990-aab9-530b72fa7bef)
