### PR TITLE
fix(wallet): Filter Select Account by Mainnet or Testnet

### DIFF
--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -785,6 +785,16 @@ export const DAppSupportedPrimaryChains = [
   BraveWallet.SOLANA_MAINNET
 ]
 
+export const BitcoinMainnetKeyringIds = [
+  BraveWallet.KeyringId.kBitcoin84,
+  BraveWallet.KeyringId.kBitcoinImport
+]
+
+export const BitcoinTestnetKeyringIds = [
+  BraveWallet.KeyringId.kBitcoin84Testnet,
+  BraveWallet.KeyringId.kBitcoinImportTestnet
+]
+
 /**
  * Should match BraveWallet.CoinType defined with "as const" to allow for use
  * as a type-guard.

--- a/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
@@ -41,6 +41,9 @@ import { getAssetIdKey } from '../../../../utils/asset-utils'
 import {
   getEntitiesListFromEntityState //
 } from '../../../../utils/entities.utils'
+import {
+  getAccountsForNetwork //
+} from '../../../../utils/account-utils'
 
 // Queries
 import {
@@ -474,11 +477,8 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
       if (!pendingSelectedAsset) {
         return []
       }
-      return accounts
-        .filter(
-          (account) => account.accountId.coin === pendingSelectedAsset.coin
-        )
-        .sort(function (a, b) {
+      return getAccountsForNetwork(pendingSelectedAsset, accounts).sort(
+        function (a, b) {
           return new Amount(
             getBalance(b.accountId, pendingSelectedAsset, tokenBalancesRegistry)
           )
@@ -490,7 +490,8 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
               )
             )
             .toNumber()
-        })
+        }
+      )
     }, [accounts, pendingSelectedAsset, tokenBalancesRegistry])
 
     // Methods

--- a/components/brave_wallet_ui/utils/account-utils.ts
+++ b/components/brave_wallet_ui/utils/account-utils.ts
@@ -7,7 +7,12 @@ import { assertNotReached } from 'chrome://resources/js/assert.js'
 import { getLocale } from '../../common/locale'
 
 // types
-import { BraveWallet, WalletAccountTypeName } from '../constants/types'
+import {
+  BraveWallet,
+  WalletAccountTypeName,
+  BitcoinMainnetKeyringIds,
+  BitcoinTestnetKeyringIds
+} from '../constants/types'
 
 // constants
 import registry from '../common/constants/registry'
@@ -211,4 +216,45 @@ export const isFVMAccount = (
     (network.chainId === BraveWallet.FILECOIN_ETHEREUM_TESTNET_CHAIN_ID &&
       account.accountId.keyringId === BraveWallet.KeyringId.kFilecoinTestnet)
   )
+}
+
+export const getAccountsForNetwork = (
+  network: Pick<BraveWallet.NetworkInfo, 'chainId' | 'coin'>,
+  accounts: BraveWallet.AccountInfo[]
+) => {
+  if (network.chainId === BraveWallet.BITCOIN_MAINNET) {
+    return accounts.filter((account) =>
+      BitcoinMainnetKeyringIds.includes(account.accountId.keyringId)
+    )
+  }
+  if (network.chainId === BraveWallet.BITCOIN_TESTNET) {
+    return accounts.filter((account) =>
+      BitcoinTestnetKeyringIds.includes(account.accountId.keyringId)
+    )
+  }
+  if (network.chainId === BraveWallet.Z_CASH_MAINNET) {
+    return accounts.filter(
+      (account) =>
+        account.accountId.keyringId === BraveWallet.KeyringId.kZCashMainnet
+    )
+  }
+  if (network.chainId === BraveWallet.Z_CASH_TESTNET) {
+    return accounts.filter(
+      (account) =>
+        account.accountId.keyringId === BraveWallet.KeyringId.kZCashTestnet
+    )
+  }
+  if (network.chainId === BraveWallet.FILECOIN_MAINNET) {
+    return accounts.filter(
+      (account) =>
+        account.accountId.keyringId === BraveWallet.KeyringId.kFilecoin
+    )
+  }
+  if (network.chainId === BraveWallet.FILECOIN_TESTNET) {
+    return accounts.filter(
+      (account) =>
+        account.accountId.keyringId === BraveWallet.KeyringId.kFilecoinTestnet
+    )
+  }
+  return accounts.filter((account) => account.accountId.coin === network.coin)
 }


### PR DESCRIPTION
## Description 

Fixes a bug when selecting a `Token` to send, the `Select Account` prompt was not filtering accounts by `Testnet Accounts` vs `Mainnet Accounts` for `Bitcoin`, `ZCash` and `Filecoin`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/38927>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to the `Send` screen and select `Bitcoin`, `Zcash` or `Filecoin` to send.
2. When the `Select Account` prompt appears, it should filter accounts based on `Testnet` or `Mainnet`.

Before:

https://github.com/brave/brave-core/assets/40611140/51d8b13d-e9da-4b84-b1b3-308b113f8617

After:

https://github.com/brave/brave-core/assets/40611140/7d88e5e0-cd31-41f4-8d87-f14af7839c6d
