### PR TITLE
record attributes created by the parser

### DIFF
--- a/third_party/blink/renderer/core/brave_page_graph/changelog.md
+++ b/third_party/blink/renderer/core/brave_page_graph/changelog.md
@@ -3,6 +3,13 @@
 This document shows all the changes and improvements made in each version of
 [Page Graph](https://github.com/brave/brave-browser/wiki/PageGraph).
 
+## Version 0.7.1
+
+Add `EdgeAttributeSet` instances to capture attributes that were created
+by the parser as well.
+
+Minor type tightening in method signatures.
+
 ## Version 0.7.0
 
 Add new `EdgeDocument` type, for recording the final state of the elements
@@ -12,7 +19,7 @@ graph (e.g., tying a parser to a dom root.)
 
 Change how `EdgeCrossDOM` instances are structured. Previously they were
 tied from an iframe-like-element (i.e., `NodeFrameOwner`) to the parser
-for the execution context, whi ch is confusing and was implemented
+for the execution context, which is confusing and was implemented
 incorrectly anyway. Now we use `EdgeCrossDOM` edges tie each `NodeDOMRoot`
 node directly to its "containing" node (i.e.,
 `NodeFrameOwner` -> `EdgeCrossDOM` -> `NodeDOMRoot`).

--- a/third_party/blink/renderer/core/brave_page_graph/page_graph.h
+++ b/third_party/blink/renderer/core/brave_page_graph/page_graph.h
@@ -303,14 +303,14 @@ class CORE_EXPORT PageGraph : public GarbageCollected<PageGraph>,
   void RegisterDocumentNodeCreated(blink::Document* node);
   void RegisterHTMLTextNodeCreated(blink::CharacterData* node);
   void RegisterHTMLElementNodeCreated(blink::Node* node);
-  void RegisterHTMLTextNodeInserted(blink::Node* node,
+  void RegisterHTMLTextNodeInserted(blink::CharacterData* node,
                                     blink::Node* parent_node,
                                     const blink::DOMNodeId before_sibling_id);
   void RegisterHTMLElementNodeInserted(
       blink::Node* node,
       blink::Node* parent_node,
       const blink::DOMNodeId before_sibling_id);
-  void RegisterHTMLTextNodeRemoved(blink::Node* node);
+  void RegisterHTMLTextNodeRemoved(blink::CharacterData* node);
   void RegisterHTMLElementNodeRemoved(blink::Node* node);
 
   void RegisterEventListenerAdd(blink::Node* node,
@@ -322,16 +322,19 @@ class CORE_EXPORT PageGraph : public GarbageCollected<PageGraph>,
                                    const EventListenerId listener_id,
                                    ScriptId listener_script_id);
 
-  void RegisterInlineStyleSet(blink::Node* node,
+  void RegisterInlineStyleSet(blink::Element* element,
                               const String& attr_name,
                               const String& attr_value);
-  void RegisterInlineStyleDelete(blink::Node* node, const String& attr_name);
-  void RegisterAttributeSet(blink::Node* node,
+  void RegisterInlineStyleDelete(blink::Element* element,
+                                 const String& attr_name);
+  void RegisterAttributeSet(blink::Element* element,
                             const String& attr_name,
                             const String& attr_value);
-  void RegisterAttributeDelete(blink::Node* node, const String& attr_name);
+  void RegisterAttributeDelete(blink::Element* element,
+                               const String& attr_name);
 
-  void RegisterTextNodeChange(blink::Node* node, const String& new_text);
+  void RegisterTextNodeChange(blink::CharacterData* node,
+                              const String& new_text);
 
   void DoRegisterRequestStart(const InspectorId request_id,
                               GraphNode* requesting_node,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#38938

```
## Version 0.7.1

Add `EdgeAttributeSet` instances to capture attributes that were created
by the parser as well.

Minor type tightening in method signatures.
```