### PR TITLE
Configure browser UI for day-zero experiment

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -69,6 +69,16 @@
 #include "extensions/browser/extension_system.h"
 #endif
 
+#if BUILDFLAG(IS_WIN)
+#include "brave/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
+#endif
+
+BraveBrowserMainParts::BraveBrowserMainParts(bool is_integration_test,
+                                             StartupData* startup_data)
+    : ChromeBrowserMainParts(is_integration_test, startup_data) {}
+
+BraveBrowserMainParts::~BraveBrowserMainParts() = default;
+
 int BraveBrowserMainParts::PreMainMessageLoopRun() {
   brave_component_updater::BraveOnDemandUpdater::GetInstance()
       ->RegisterOnDemandUpdater(
@@ -87,6 +97,15 @@ void BraveBrowserMainParts::PreBrowserStart() {
   DCHECK(sessions::ContentSerializedNavigationDriver::GetInstance());
   speedreader::SpeedreaderExtendedInfoHandler::Register();
 #endif
+
+#if BUILDFLAG(IS_WIN)
+  // As this uses first run sentinel time, PreBrowserStart() is good place to
+  // initialize.
+  day_zero_browser_ui_expt_manager_ =
+      std::make_unique<DayZeroBrowserUIExptManager>(
+          g_browser_process->profile_manager());
+#endif
+
   ChromeBrowserMainParts::PreBrowserStart();
 }
 

--- a/browser/brave_browser_main_parts.h
+++ b/browser/brave_browser_main_parts.h
@@ -6,15 +6,21 @@
 #ifndef BRAVE_BROWSER_BRAVE_BROWSER_MAIN_PARTS_H_
 #define BRAVE_BROWSER_BRAVE_BROWSER_MAIN_PARTS_H_
 
+#include <memory>
+
 #include "chrome/browser/chrome_browser_main.h"
+
+#if BUILDFLAG(IS_WIN)
+class DayZeroBrowserUIExptManager;
+#endif
 
 class BraveBrowserMainParts : public ChromeBrowserMainParts {
  public:
-  using ChromeBrowserMainParts::ChromeBrowserMainParts;
+  BraveBrowserMainParts(bool is_integration_test, StartupData* startup_data);
 
   BraveBrowserMainParts(const BraveBrowserMainParts&) = delete;
   BraveBrowserMainParts& operator=(const BraveBrowserMainParts&) = delete;
-  ~BraveBrowserMainParts() override = default;
+  ~BraveBrowserMainParts() override;
 
   int PreMainMessageLoopRun() override;
   void PreBrowserStart() override;
@@ -25,6 +31,11 @@ class BraveBrowserMainParts : public ChromeBrowserMainParts {
 
  private:
   friend class ChromeBrowserMainExtraPartsTor;
+
+#if BUILDFLAG(IS_WIN)
+  std::unique_ptr<DayZeroBrowserUIExptManager>
+      day_zero_browser_ui_expt_manager_;
+#endif
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_BROWSER_MAIN_PARTS_H_

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -605,6 +605,8 @@ source_set("ui") {
 
     if (is_win) {
       sources += [
+        "day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc",
+        "day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h",
         "views/frame/brave_browser_frame_view_win.cc",
         "views/frame/brave_browser_frame_view_win.h",
       ]

--- a/browser/ui/day_zero_browser_ui_expt/BUILD.gn
+++ b/browser/ui/day_zero_browser_ui_expt/BUILD.gn
@@ -1,0 +1,28 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+assert(is_win)
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "day_zero_browser_ui_expt_unittest.cc" ]
+
+  deps = [
+    "//base",
+    "//brave/components/brave_news/browser",
+    "//brave/components/brave_news/common",
+    "//brave/components/brave_rewards/common",
+    "//brave/components/brave_wallet/browser:pref_names",
+    "//brave/components/ntp_background_images/browser",
+    "//brave/components/ntp_background_images/common",
+    "//chrome/browser/ui",
+    "//chrome/test:test_support",
+    "//components/prefs",
+    "//content/test:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc
+++ b/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc
@@ -1,0 +1,132 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
+
+#include "base/check_is_test.h"
+#include "base/command_line.h"
+#include "base/time/time.h"
+#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/brave_stats/first_run_util.h"
+#include "brave/components/brave_news/browser/locales_helper.h"
+#include "brave/components/brave_news/common/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/constants/pref_names.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/profiles/profile_manager.h"
+#include "components/prefs/pref_service.h"
+
+DayZeroBrowserUIExptManager::DayZeroBrowserUIExptManager(
+    ProfileManager* profile_manager)
+    : profile_manager_(*profile_manager) {
+  // This class should be instantiated after getting valid first run time;
+  if (brave_stats::GetFirstRunTime(nullptr) != base::Time()) {
+    CHECK_IS_TEST();
+  }
+
+  // If one day passed since first run or day zero expt feature is off,
+  // we don't need to touch original default pref values.
+  // Just early return and this class is no-op.
+  if (IsPassedOneDaySinceFirstRun() ||
+      !base::FeatureList::IsEnabled(features::kBraveDayZeroExperiment)) {
+    return;
+  }
+
+  for (auto* profile : profile_manager_->GetLoadedProfiles()) {
+    if (!profile->IsRegularProfile()) {
+      continue;
+    }
+
+    SetForDayZeroBrowserUI(profile);
+  }
+
+  observation_.Observe(&(*profile_manager_));
+  StartResetTimer();
+}
+
+DayZeroBrowserUIExptManager::~DayZeroBrowserUIExptManager() {
+  if (observation_.IsObserving()) {
+    observation_.Reset();
+  }
+}
+
+void DayZeroBrowserUIExptManager::OnProfileAdded(Profile* profile) {
+  SetForDayZeroBrowserUI(profile);
+}
+
+void DayZeroBrowserUIExptManager::OnProfileManagerDestroying() {
+  if (observation_.IsObserving()) {
+    observation_.Reset();
+  }
+}
+
+void DayZeroBrowserUIExptManager::SetForDayZeroBrowserUI(Profile* profile) {
+  auto* prefs = profile->GetPrefs();
+  prefs->SetDefaultPrefValue(kNewTabPageShowRewards, base::Value(false));
+  prefs->SetDefaultPrefValue(kNewTabPageShowBraveTalk, base::Value(false));
+  prefs->SetDefaultPrefValue(kShowWalletIconOnToolbar, base::Value(false));
+  prefs->SetDefaultPrefValue(ntp_background_images::prefs::
+                                 kNewTabPageShowSponsoredImagesBackgroundImage,
+                             base::Value(false));
+  prefs->SetDefaultPrefValue(brave_rewards::prefs::kShowLocationBarButton,
+                             base::Value(false));
+  prefs->SetDefaultPrefValue(brave_news::prefs::kNewTabPageShowToday,
+                             base::Value(false));
+}
+
+void DayZeroBrowserUIExptManager::ResetForDayZeroBrowserUI(Profile* profile) {
+  auto* prefs = profile->GetPrefs();
+  prefs->SetDefaultPrefValue(kNewTabPageShowRewards, base::Value(true));
+  prefs->SetDefaultPrefValue(kNewTabPageShowBraveTalk, base::Value(true));
+  prefs->SetDefaultPrefValue(kShowWalletIconOnToolbar, base::Value(true));
+  prefs->SetDefaultPrefValue(ntp_background_images::prefs::
+                                 kNewTabPageShowSponsoredImagesBackgroundImage,
+                             base::Value(true));
+  prefs->SetDefaultPrefValue(brave_rewards::prefs::kShowLocationBarButton,
+                             base::Value(true));
+  prefs->SetDefaultPrefValue(
+      brave_news::prefs::kNewTabPageShowToday,
+      base::Value(brave_news::IsUserInDefaultEnabledLocale()));
+}
+
+void DayZeroBrowserUIExptManager::ResetBrowserUIStateForAllProfiles() {
+  CHECK(observation_.IsObserving());
+  observation_.Reset();
+
+  // Reset all currently active normal profiles.
+  for (auto* profile : profile_manager_->GetLoadedProfiles()) {
+    if (!profile->IsRegularProfile()) {
+      continue;
+    }
+
+    ResetForDayZeroBrowserUI(profile);
+  }
+}
+
+bool DayZeroBrowserUIExptManager::IsPassedOneDaySinceFirstRun() const {
+  return brave_stats::GetFirstRunTime(nullptr) - base::Time::Now() >=
+         base::Days(1);
+}
+
+void DayZeroBrowserUIExptManager::StartResetTimer() {
+  auto remained_time_to_one_day_since_first_run =
+      brave_stats::GetFirstRunTime(nullptr) - base::Time::Now();
+
+  // Convenient switch only for testing purpose.
+  constexpr char kUseShortExpirationForDayZeroExpt[] =
+      "use-short-expiration-for-day-zero-expt";
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          kUseShortExpirationForDayZeroExpt)) {
+    remained_time_to_one_day_since_first_run += base::Minutes(2);
+  } else {
+    remained_time_to_one_day_since_first_run += base::Days(1);
+  }
+
+  reset_timer_.Start(
+      FROM_HERE, remained_time_to_one_day_since_first_run, this,
+      &DayZeroBrowserUIExptManager::ResetBrowserUIStateForAllProfiles);
+}

--- a/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h
+++ b/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_DAY_ZERO_BROWSER_UI_EXPT_DAY_ZERO_BROWSER_UI_EXPT_MANAGER_H_
+#define BRAVE_BROWSER_UI_DAY_ZERO_BROWSER_UI_EXPT_DAY_ZERO_BROWSER_UI_EXPT_MANAGER_H_
+
+#include "base/memory/raw_ref.h"
+#include "base/scoped_observation.h"
+#include "base/timer/timer.h"
+#include "chrome/browser/profiles/profile_manager_observer.h"
+
+class PrefService;
+class Profile;
+class ProfileManager;
+
+class DayZeroBrowserUIExptManager : public ProfileManagerObserver {
+ public:
+  explicit DayZeroBrowserUIExptManager(ProfileManager* profile_manater);
+  ~DayZeroBrowserUIExptManager() override;
+  DayZeroBrowserUIExptManager(const DayZeroBrowserUIExptManager&) = delete;
+  DayZeroBrowserUIExptManager& operator=(const DayZeroBrowserUIExptManager&) =
+      delete;
+
+  // ProfileManagerObserver overrides:
+  void OnProfileAdded(Profile* profile) override;
+  void OnProfileManagerDestroying() override;
+
+ private:
+  void SetForDayZeroBrowserUI(Profile* profile);
+  void ResetForDayZeroBrowserUI(Profile* profile);
+  void ResetBrowserUIStateForAllProfiles();
+  bool IsPassedOneDaySinceFirstRun() const;
+  void StartResetTimer();
+
+  // When fire, we'll reset browser UI to original.
+  base::OneShotTimer reset_timer_;
+  raw_ref<ProfileManager> profile_manager_;
+  base::ScopedObservation<ProfileManager, ProfileManagerObserver> observation_{
+      this};
+};
+
+#endif  // BRAVE_BROWSER_UI_DAY_ZERO_BROWSER_UI_EXPT_DAY_ZERO_BROWSER_UI_EXPT_MANAGER_H_

--- a/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_unittest.cc
+++ b/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_unittest.cc
@@ -1,0 +1,121 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/brave_browser_features.h"
+#include "brave/browser/ui/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
+#include "brave/components/brave_news/browser/locales_helper.h"
+#include "brave/components/brave_news/common/pref_names.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
+#include "brave/components/brave_wallet/browser/pref_names.h"
+#include "brave/components/constants/pref_names.h"
+#include "brave/components/ntp_background_images/browser/view_counter_service.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
+#include "chrome/browser/profiles/profile_manager_observer.h"
+#include "chrome/test/base/testing_browser_process.h"
+#include "chrome/test/base/testing_profile.h"
+#include "chrome/test/base/testing_profile_manager.h"
+#include "components/prefs/pref_service.h"
+#include "components/sync_preferences/testing_pref_service_syncable.h"
+#include "content/public/test/browser_task_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+class DayZeroBrowserUIExptTest : public testing::Test,
+                                 public ProfileManagerObserver,
+                                 public testing::WithParamInterface<bool> {
+ public:
+  DayZeroBrowserUIExptTest()
+      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME),
+        testing_profile_manager_(TestingBrowserProcess::GetGlobal()) {
+    if (IsDayZeroEnabled()) {
+      feature_list_.InitAndEnableFeature(features::kBraveDayZeroExperiment);
+    }
+  }
+
+  void SetUp() override {
+    ASSERT_TRUE(testing_profile_manager_.SetUp());
+    observation_.Observe(g_browser_process->profile_manager());
+    manager_ = std::make_unique<DayZeroBrowserUIExptManager>(
+        g_browser_process->profile_manager());
+  }
+
+  void CheckBrowserHasDayZeroUI(Profile* profile) {
+    auto* prefs = profile->GetPrefs();
+    EXPECT_FALSE(prefs->GetBoolean(kNewTabPageShowRewards));
+    EXPECT_FALSE(prefs->GetBoolean(kNewTabPageShowBraveTalk));
+    EXPECT_FALSE(prefs->GetBoolean(kShowWalletIconOnToolbar));
+    EXPECT_FALSE(
+        prefs->GetBoolean(ntp_background_images::prefs::
+                              kNewTabPageShowSponsoredImagesBackgroundImage));
+    EXPECT_FALSE(
+        prefs->GetBoolean(brave_rewards::prefs::kShowLocationBarButton));
+    EXPECT_FALSE(prefs->GetBoolean(brave_news::prefs::kNewTabPageShowToday));
+  }
+
+  void CheckBrowserHasOriginalUI(Profile* profile) {
+    auto* prefs = profile->GetPrefs();
+    EXPECT_TRUE(prefs->GetBoolean(kNewTabPageShowRewards));
+    EXPECT_TRUE(prefs->GetBoolean(kNewTabPageShowBraveTalk));
+    EXPECT_TRUE(prefs->GetBoolean(kShowWalletIconOnToolbar));
+    EXPECT_TRUE(
+        prefs->GetBoolean(ntp_background_images::prefs::
+                              kNewTabPageShowSponsoredImagesBackgroundImage));
+    EXPECT_TRUE(
+        prefs->GetBoolean(brave_rewards::prefs::kShowLocationBarButton));
+    EXPECT_EQ(prefs->GetBoolean(brave_news::prefs::kNewTabPageShowToday),
+              brave_news::IsUserInDefaultEnabledLocale());
+  }
+
+  bool IsDayZeroEnabled() { return GetParam(); }
+
+  // ProfileManagerObserver overrides:
+  void OnProfileAdded(Profile* profile) override {
+    // Need to explicitely register as it's done via its factory.
+    ntp_background_images::ViewCounterService::RegisterProfilePrefs(
+        static_cast<TestingProfile*>(profile)
+            ->GetTestingPrefService()
+            ->registry());
+  }
+
+  void OnProfileManagerDestroying() override {
+    if (observation_.IsObserving()) {
+      observation_.Reset();
+    }
+  }
+
+  content::BrowserTaskEnvironment task_environment_;
+  TestingProfileManager testing_profile_manager_;
+  base::test::ScopedFeatureList feature_list_;
+  std::unique_ptr<DayZeroBrowserUIExptManager> manager_;
+  base::ScopedObservation<ProfileManager, ProfileManagerObserver> observation_{
+      this};
+};
+
+TEST_P(DayZeroBrowserUIExptTest, PrefsTest) {
+  // Create multiple profile and check UI's prefs values are updated based on
+  // feature flag.
+  auto* profile = testing_profile_manager_.CreateTestingProfile("TestProfile");
+  auto* profile2 =
+      testing_profile_manager_.CreateTestingProfile("TestProfile2");
+
+  if (IsDayZeroEnabled()) {
+    CheckBrowserHasDayZeroUI(profile);
+    CheckBrowserHasDayZeroUI(profile2);
+  } else {
+    CheckBrowserHasOriginalUI(profile);
+    CheckBrowserHasOriginalUI(profile2);
+  }
+
+  // Advance 1-day and check prefs value are reset.
+  task_environment_.AdvanceClock(base::Days(1));
+  base::RunLoop().RunUntilIdle();
+
+  CheckBrowserHasOriginalUI(profile);
+  CheckBrowserHasOriginalUI(profile2);
+}
+
+INSTANTIATE_TEST_SUITE_P(DayZeroExpt,
+                         DayZeroBrowserUIExptTest,
+                         testing::Bool());

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -320,6 +320,10 @@ test("brave_unit_tests") {
     "//brave/components/brave_stats/browser",
   ]
 
+  if (is_win) {
+    deps += [ "//brave/browser/ui/day_zero_browser_ui_expt:unit_tests" ]
+  }
+
   if (enable_tor) {
     deps += [
       "//brave/browser/tor/test:unit_tests",


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/38874

If day zero feature is enabled,
* hide rewards/wallet button from toolbar
* hide NTP cards(rewards, talk)
* hide sponsored images
* hide brave news

Note: This feature doesn't touch the search widget and topsite tile visibility

![image](https://github.com/brave/brave-core/assets/6786187/891d23cc-aa34-4cd3-b0d7-bd4f464df430)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test brave_unit_tests -- --filter=DayZeroExpt/DayZeroBrowserUIExptTest.PrefsTest*`

#### Basic test
1. Run brave with clean profile and with this cmd args `--enable-features=BraveDayZeroExperiment`
2. Check above items are hidden by default
3. Re-launch brave w/o this feature
4. Check all items are shown by default
5. Re-launch brave with this feature
6. Enable wallet button from brave://settings/appearance
7. Re-launch brave with this feature
8. Check wallet button is shown

#### One-day timeout test - UI should be back to original since one-day passed from first run
1. Run brave with clean profile with cmd args `--enable-features=BraveDayZeroExperiment` `--use-short-expiration-for-day-zero-expt`
2. With `--use-short-expiration-for-day-zero-expt`, UI is back to original after 2 mins passed
3. W/o --use-short-expiration-for-day-zero-expt`, need to wait one-day passed
4. After expiration time passed, check browser UI is back to orignial state