### PR TITLE
Move Sidebar menu to the top level

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -785,6 +785,18 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
         <message name="IDS_SIDEBAR_ADD_ITEM_BUBBLE_TITLE" desc="Title of sidebar add item bubble">
           Add to Sidebar
         </message>
+        <message name="IDS_APP_MENU_SIDEBAR_TITLE" desc="Tile of a group of buttons to set visibility of sidebar">
+          Sidebar
+        </message>
+        <message name="IDS_APP_MENU_SIDEBAR_ON" desc="Label for a button to always show sidebar">
+          On
+        </message>
+        <message name="IDS_APP_MENU_SIDEBAR_OFF" desc="Label for a button to hide sidebar">
+          Off
+        </message>
+        <message name="IDS_APP_MENU_SIDEBAR_HOVER" desc="Label for a button to show sidebar on hover">
+          Autohide
+        </message>
         <message name="IDS_SIDEBAR_SHOW_OPTION_TITLE" desc="Title of sidebar show option menu">
           Show Sidebar
         </message>

--- a/browser/ui/color/brave_color_id.h
+++ b/browser/ui/color/brave_color_id.h
@@ -148,6 +148,9 @@
 #define BRAVE_EXTENSION_MENU_COLOR_IDS \
     E_CPONLY(kColorBraveExtensionMenuIcon)
 
+#define BRAVE_APP_MENU_COLOR_IDS \
+    E_CPONLY(kColorBraveAppMenuAccentColor)
+
 #define BRAVE_COLOR_IDS               \
     BRAVE_COMMON_COLOR_IDS            \
     BRAVE_SEARCH_CONVERSION_COLOR_IDS \
@@ -160,7 +163,8 @@
     BRAVE_PLAYLIST_COLOR_IDS          \
     BRAVE_OMNIBOX_COLOR_IDS           \
     BRAVE_WAYBACK_MACHINE_COLOR_IDS   \
-    BRAVE_EXTENSION_MENU_COLOR_IDS
+    BRAVE_EXTENSION_MENU_COLOR_IDS    \
+    BRAVE_APP_MENU_COLOR_IDS
 
 #include "ui/color/color_id_macros.inc"
 

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -581,6 +581,8 @@ void AddBraveLightThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorBraveExtensionMenuIcon] = {
       leo::GetColor(leo::Color::kColorIconActive, leo::Theme::kLight)};
+
+  mixer[kColorBraveAppMenuAccentColor] = {SkColorSetRGB(0xDF, 0xE1, 0xFF)};
 }
 
 void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
@@ -696,6 +698,8 @@ void AddBraveDarkThemeColorMixer(ui::ColorProvider* provider,
 
   mixer[kColorBraveExtensionMenuIcon] = {
       leo::GetColor(leo::Color::kColorIconActive, leo::Theme::kDark)};
+
+  mixer[kColorBraveAppMenuAccentColor] = {SkColorSetRGB(0x37, 0x2C, 0xBF)};
 }
 
 // Handling dark or light theme on normal profile.

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -291,6 +291,17 @@ void BraveAppMenuModel::BuildBraveProductsSection() {
   }
 #endif
 
+#if defined(TOOLKIT_VIEWS)
+  if (sidebar::CanUseSidebar(browser())) {
+    sub_menus().push_back(std::make_unique<SidebarMenuModel>(browser()));
+    const int index = GetNextIndexOfBraveProductsSection();
+    InsertSubMenuWithStringIdAt(index, IDC_SIDEBAR_SHOW_OPTION_MENU,
+                                IDS_SIDEBAR_SHOW_OPTION_TITLE,
+                                sub_menus().back().get());
+    need_separator = true;
+  }
+#endif
+
   if (need_separator) {
     InsertSeparatorAt(GetNextIndexOfBraveProductsSection(),
                       ui::NORMAL_SEPARATOR);
@@ -368,17 +379,6 @@ void BraveAppMenuModel::BuildMoreToolsSubMenu() {
                                              ui::NORMAL_SEPARATOR);
     need_separator = false;
   }
-
-#if defined(TOOLKIT_VIEWS)
-  if (sidebar::CanUseSidebar(browser())) {
-    sub_menus().push_back(std::make_unique<SidebarMenuModel>(browser()));
-    more_tools_menu_model->InsertSubMenuWithStringIdAt(
-        next_target_index++, IDC_SIDEBAR_SHOW_OPTION_MENU,
-        IDS_SIDEBAR_SHOW_OPTION_TITLE, sub_menus().back().get());
-    more_tools_menu_model->InsertSeparatorAt(next_target_index++,
-                                             ui::NORMAL_SEPARATOR);
-  }
-#endif
 
   if (media_router::MediaRouterEnabled(browser()->profile())) {
     more_tools_menu_model->InsertItemWithStringIdAt(
@@ -629,13 +629,11 @@ int BraveAppMenuModel::AddIpfsImportMenuItem(int action_command_id,
 #endif
 
 size_t BraveAppMenuModel::GetNextIndexOfBraveProductsSection() const {
-  std::vector<int> commands_to_check = {IDC_APP_MENU_IPFS,
-                                        IDC_SHOW_BRAVE_VPN_PANEL,
-                                        IDC_BRAVE_VPN_MENU,
-                                        IDC_SHOW_BRAVE_WALLET,
-                                        IDC_NEW_OFFTHERECORD_WINDOW_TOR,
-                                        IDC_NEW_INCOGNITO_WINDOW,
-                                        IDC_NEW_WINDOW};
+  std::vector<int> commands_to_check = {
+      IDC_SIDEBAR_SHOW_OPTION_MENU, IDC_APP_MENU_IPFS,
+      IDC_SHOW_BRAVE_VPN_PANEL,     IDC_BRAVE_VPN_MENU,
+      IDC_SHOW_BRAVE_WALLET,        IDC_NEW_OFFTHERECORD_WINDOW_TOR,
+      IDC_NEW_INCOGNITO_WINDOW,     IDC_NEW_WINDOW};
   const auto last_index_of_second_section =
       GetProperItemIndex(commands_to_check, false).value();
   const auto last_cmd_id_of_second_section =

--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -5,6 +5,7 @@
 
 #include "brave/browser/ui/toolbar/brave_app_menu_model.h"
 
+#include <memory>
 #include <optional>
 #include <string>
 
@@ -20,10 +21,13 @@
 #include "chrome/browser/media/router/media_router_feature.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/toolbar/app_menu_model.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/grit/branded_strings.h"
 #include "chrome/grit/generated_resources.h"
 #include "components/grit/brave_components_strings.h"
+#include "ui/base/models/button_menu_item_model.h"
+#include "ui/base/models/menu_separator_types.h"
 #include "ui/base/ui_base_features.h"
 
 #if BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
@@ -42,7 +46,6 @@
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
-#include "brave/components/sidebar/browser/sidebar_service.h"
 #endif
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
@@ -73,70 +76,6 @@ class BraveHelpMenuModel : public ui::SimpleMenuModel {
                         IDS_SHOW_BRAVE_WEBCOMPAT_REPORTER);
   }
 };
-
-#if defined(TOOLKIT_VIEWS)
-using ShowSidebarOption = sidebar::SidebarService::ShowSidebarOption;
-
-class SidebarMenuModel : public ui::SimpleMenuModel,
-                         public ui::SimpleMenuModel::Delegate {
- public:
-  explicit SidebarMenuModel(Browser* browser)
-      : SimpleMenuModel(this), browser_(browser) {
-    Build(browser_);
-  }
-
-  ~SidebarMenuModel() override = default;
-  SidebarMenuModel(const SidebarMenuModel&) = delete;
-  SidebarMenuModel& operator=(const SidebarMenuModel&) = delete;
-
-  // ui::SimpleMenuModel::Delegate overrides:
-  void ExecuteCommand(int command_id, int event_flags) override {
-    auto* service =
-        sidebar::SidebarServiceFactory::GetForProfile(browser_->profile());
-    service->SetSidebarShowOption(ConvertIDCToSidebarShowOptions(command_id));
-  }
-
-  bool IsCommandIdChecked(int command_id) const override {
-    const auto* service =
-        sidebar::SidebarServiceFactory::GetForProfile(browser_->profile());
-    return ConvertIDCToSidebarShowOptions(command_id) ==
-           service->GetSidebarShowOption();
-  }
-
- private:
-  void Build(Browser* browser) {
-    // IDC_XXX is used instead of direct kShowXXX and it's translated by
-    // ConvertIDCToSidebarShowOptions() to avoid any issue with app menu.
-    // Ex, id with 0 is always disabled state in the app menu.
-    AddCheckItem(IDC_SIDEBAR_SHOW_OPTION_ALWAYS,
-                 brave_l10n::GetLocalizedResourceUTF16String(
-                     IDS_SIDEBAR_SHOW_OPTION_ALWAYS));
-    AddCheckItem(IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER,
-                 brave_l10n::GetLocalizedResourceUTF16String(
-                     IDS_SIDEBAR_SHOW_OPTION_MOUSEOVER));
-    AddCheckItem(IDC_SIDEBAR_SHOW_OPTION_NEVER,
-                 brave_l10n::GetLocalizedResourceUTF16String(
-                     IDS_SIDEBAR_SHOW_OPTION_NEVER));
-  }
-
-  ShowSidebarOption ConvertIDCToSidebarShowOptions(int id) const {
-    switch (id) {
-      case IDC_SIDEBAR_SHOW_OPTION_ALWAYS:
-        return ShowSidebarOption::kShowAlways;
-      case IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER:
-        return ShowSidebarOption::kShowOnMouseOver;
-      case IDC_SIDEBAR_SHOW_OPTION_NEVER:
-        return ShowSidebarOption::kShowNever;
-      default:
-        break;
-    }
-    NOTREACHED();
-    return ShowSidebarOption::kShowAlways;
-  }
-
-  raw_ptr<Browser> browser_ = nullptr;
-};
-#endif
 
 #if BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
 // For convenience, we show the last part of the key in the context menu item.
@@ -181,6 +120,24 @@ BraveAppMenuModel::BraveAppMenuModel(
 }
 
 BraveAppMenuModel::~BraveAppMenuModel() = default;
+
+#if defined(TOOLKIT_VIEWS)
+// static
+sidebar::SidebarService::ShowSidebarOption
+BraveAppMenuModel::ConvertIDCToSidebarShowOptions(int id) {
+  switch (id) {
+    case IDC_SIDEBAR_SHOW_OPTION_ALWAYS:
+      return sidebar::SidebarService::ShowSidebarOption::kShowAlways;
+    case IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER:
+      return sidebar::SidebarService::ShowSidebarOption::kShowOnMouseOver;
+    case IDC_SIDEBAR_SHOW_OPTION_NEVER:
+      return sidebar::SidebarService::ShowSidebarOption::kShowNever;
+    default:
+      break;
+  }
+  NOTREACHED_NORETURN();
+}
+#endif  // defined(TOOLKIT_VIEWS)
 
 void BraveAppMenuModel::Build() {
   // Customize items after build chromium items.
@@ -293,12 +250,25 @@ void BraveAppMenuModel::BuildBraveProductsSection() {
 
 #if defined(TOOLKIT_VIEWS)
   if (sidebar::CanUseSidebar(browser())) {
-    sub_menus().push_back(std::make_unique<SidebarMenuModel>(browser()));
-    const int index = GetNextIndexOfBraveProductsSection();
-    InsertSubMenuWithStringIdAt(index, IDC_SIDEBAR_SHOW_OPTION_MENU,
-                                IDS_SIDEBAR_SHOW_OPTION_TITLE,
-                                sub_menus().back().get());
-    need_separator = true;
+    sidebar_show_option_model_ = std::make_unique<ui::ButtonMenuItemModel>(
+        IDS_APP_MENU_SIDEBAR_TITLE, this);
+
+    sidebar_show_option_model_->AddGroupItemWithStringId(
+        IDC_SIDEBAR_SHOW_OPTION_ALWAYS, IDS_APP_MENU_SIDEBAR_ON);
+    sidebar_show_option_model_->AddGroupItemWithStringId(
+        IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER, IDS_APP_MENU_SIDEBAR_HOVER);
+    sidebar_show_option_model_->AddGroupItemWithStringId(
+        IDC_SIDEBAR_SHOW_OPTION_NEVER, IDS_APP_MENU_SIDEBAR_OFF);
+    const auto index = GetNextIndexOfBraveProductsSection();
+    AddButtonItemAt(IDC_SIDEBAR_SHOW_OPTION_MENU,
+                    sidebar_show_option_model_.get(),
+                    static_cast<size_t>(index));
+    // Insert separator to the top and bottom
+    InsertSeparatorAt(index, ui::LOWER_SEPARATOR);
+    InsertSeparatorAt(index + 2, ui::UPPER_SEPARATOR);
+
+    // Already added separator.
+    need_separator = false;
   }
 #endif
 
@@ -517,7 +487,19 @@ void BraveAppMenuModel::ExecuteCommand(int id, int event_flags) {
       ExecuteIPFSCommand(id, std::string());
       return;
   }
-#endif
+#endif  // BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
+
+#if defined(TOOLKIT_VIEWS)
+  if (id == IDC_SIDEBAR_SHOW_OPTION_ALWAYS ||
+      id == IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER ||
+      id == IDC_SIDEBAR_SHOW_OPTION_NEVER) {
+    auto* service =
+        sidebar::SidebarServiceFactory::GetForProfile(browser()->profile());
+    service->SetSidebarShowOption(ConvertIDCToSidebarShowOptions(id));
+    return;
+  }
+#endif  // defined(TOOLKIT_VIEWS)
+
   return AppMenuModel::ExecuteCommand(id, event_flags);
 }
 
@@ -549,6 +531,15 @@ bool BraveAppMenuModel::IsCommandIdEnabled(int id) const {
     // used.
     return true;
   }
+
+#if defined(TOOLKIT_VIEWS)
+  if (id == IDC_SIDEBAR_SHOW_OPTION_ALWAYS ||
+      id == IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER ||
+      id == IDC_SIDEBAR_SHOW_OPTION_NEVER) {
+    return sidebar::CanUseSidebar(browser());
+  }
+#endif  // defined(TOOLKIT_VIEWS)
+
   return AppMenuModel::IsCommandIdEnabled(id);
 }
 

--- a/browser/ui/toolbar/brave_app_menu_model.h
+++ b/browser/ui/toolbar/brave_app_menu_model.h
@@ -18,11 +18,19 @@
 #include "chrome/browser/ui/toolbar/app_menu_model.h"
 #include "ui/base/models/simple_menu_model.h"
 
+#if defined(TOOLKIT_VIEWS)
+#include "brave/components/sidebar/browser/sidebar_service.h"
+#endif  // defined(TOOLKIT_VIEWS)
+
 #if BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
 namespace ipfs {
 class IpnsKeysManager;
 }  // namespace ipfs
 #endif
+
+namespace ui {
+class ButtonMenuItemModel;
+}
 
 class BraveAppMenuModel : public AppMenuModel {
  public:
@@ -34,6 +42,11 @@ class BraveAppMenuModel : public AppMenuModel {
 
   BraveAppMenuModel(const BraveAppMenuModel&) = delete;
   BraveAppMenuModel& operator=(const BraveAppMenuModel&) = delete;
+
+#if defined(TOOLKIT_VIEWS)
+  static sidebar::SidebarService::ShowSidebarOption
+  ConvertIDCToSidebarShowOptions(int id);
+#endif  // defined(TOOLKIT_VIEWS)
 
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveAppMenuModelBrowserTest, BraveIpfsMenuTest);
@@ -56,15 +69,15 @@ class BraveAppMenuModel : public AppMenuModel {
   // History, bookmarks, downloads and extensions.
   void BuildBrowserSection();
 
-  // Insert profile, sidebar, sync and cast entries into existing more tools sub
-  // menu.
+  // Insert profile, sidebar, sync and cast entries into existing more tools
+  // sub menu.
   void BuildMoreToolsSubMenu();
 
   // About brave, help center and report broken site items.
   void BuildHelpSubMenu();
 
-  // We relocate some upstream items. Need to remove them before adding them to
-  // another location.
+  // We relocate some upstream items. Need to remove them before adding them
+  // to another location.
   void RemoveUpstreamMenus();
 
 #if BUILDFLAG(ENABLE_IPFS_LOCAL_NODE)
@@ -81,6 +94,10 @@ class BraveAppMenuModel : public AppMenuModel {
   std::unordered_map<int, std::unique_ptr<ui::SimpleMenuModel>>
       ipns_keys_submenu_models_;
 #endif
+
+#if defined(TOOLKIT_VIEWS)
+  std::unique_ptr<ui::ButtonMenuItemModel> sidebar_show_option_model_;
+#endif  // defined(TOOLKIT_VIEWS)
 };
 
 #endif  // BRAVE_BROWSER_UI_TOOLBAR_BRAVE_APP_MENU_MODEL_H_

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -12,6 +12,7 @@
 #include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
 #include "base/test/scoped_feature_list.h"
+#include "brave/app/brave_command_ids.h"
 #include "brave/browser/ui/brave_browser_command_controller.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
@@ -205,6 +206,9 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
       IDC_SHOW_BRAVE_VPN_PANEL,
 #endif
+#if defined(TOOLKIT_VIEWS)
+      IDC_SIDEBAR_SHOW_OPTION_MENU,
+#endif
       IDC_RECENT_TABS_MENU,
       IDC_BOOKMARKS_MENU,
       IDC_SHOW_DOWNLOADS,
@@ -236,8 +240,8 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
   CheckHelpCommandsAreInOrderInMenuModel(browser(), help_commands_in_order);
 
   std::vector<int> more_tools_in_order = {
-      IDC_ADD_NEW_PROFILE, IDC_OPEN_GUEST_PROFILE, IDC_SIDEBAR_SHOW_OPTION_MENU,
-      IDC_SHOW_BRAVE_SYNC, IDC_DEV_TOOLS,          IDC_TASK_MANAGER,
+      IDC_ADD_NEW_PROFILE, IDC_OPEN_GUEST_PROFILE, IDC_SHOW_BRAVE_SYNC,
+      IDC_DEV_TOOLS,       IDC_TASK_MANAGER,
   };
 
   if (!syncer::IsSyncAllowedByFlag()) {
@@ -259,6 +263,9 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
       IDC_NEW_OFFTHERECORD_WINDOW_TOR,
 #endif
       IDC_SHOW_BRAVE_WALLET,
+#if defined(TOOLKIT_VIEWS)
+      IDC_SIDEBAR_SHOW_OPTION_MENU,
+#endif
       IDC_BOOKMARKS_MENU,
       IDC_SHOW_DOWNLOADS,
       IDC_EXTENSIONS_SUBMENU_MANAGE_EXTENSIONS,
@@ -329,7 +336,6 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
   CheckHelpCommandsAreInOrderInMenuModel(guest_browser, help_commands_in_order);
 
   std::vector<int> more_tools_in_order_for_guest_profile = {
-      IDC_SIDEBAR_SHOW_OPTION_MENU,
       IDC_DEV_TOOLS,
       IDC_TASK_MANAGER,
   };

--- a/browser/ui/views/toolbar/brave_app_menu.h
+++ b/browser/ui/views/toolbar/brave_app_menu.h
@@ -18,6 +18,9 @@ class BraveAppMenu : public AppMenu {
   BraveAppMenu(const BraveAppMenu&) = delete;
   BraveAppMenu& operator=(const BraveAppMenu&) = delete;
 
+  Browser* browser() { return browser_; }
+  const Browser* browser() const { return browser_; }
+
   // AppMenu overrides:
   void RunMenu(views::MenuButtonController* host) override;
   void ExecuteCommand(int command_id, int mouse_event_flags) override;

--- a/chromium_src/chrome/browser/ui/views/toolbar/app_menu.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/app_menu.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/browser/ui/views/toolbar/app_menu.h"
 
+#include <memory>
+
 // Upstream uses wrong api for setting color. It comes from
 // https://chromium-review.googlesource.com/c/chromium/src/+/4395705
 #define SetTextColor SetTextColorId
@@ -12,3 +14,9 @@
 #include "src/chrome/browser/ui/views/toolbar/app_menu.cc"
 
 #undef SetTextColor
+
+std::unique_ptr<views::Background>
+AppMenu::CreateInMenuButtonBackgroundWithLeadingBorder() {
+  return std::make_unique<InMenuButtonBackground>(
+      InMenuButtonBackground::ButtonType::kLeadingBorder);
+}

--- a/chromium_src/chrome/browser/ui/views/toolbar/app_menu.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/app_menu.h
@@ -6,9 +6,13 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_APP_MENU_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_APP_MENU_H_
 
-#define RunMenu              \
-  UnusedMethod1() {}         \
-  friend class BraveAppMenu; \
+#define RunMenu                                    \
+  UnusedMethod1() {}                               \
+  friend class BraveAppMenu;                       \
+                                                   \
+  std::unique_ptr<views::Background>               \
+  CreateInMenuButtonBackgroundWithLeadingBorder(); \
+                                                   \
   virtual void RunMenu
 
 #include "src/chrome/browser/ui/views/toolbar/app_menu.h"  // IWYU pragma: export

--- a/chromium_src/ui/base/models/simple_menu_model.cc
+++ b/chromium_src/ui/base/models/simple_menu_model.cc
@@ -1,0 +1,19 @@
+
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/ui/base/models/simple_menu_model.cc"
+
+namespace ui {
+
+void SimpleMenuModel::AddButtonItemAt(int command_id,
+                                      ButtonMenuItemModel* model,
+                                      size_t index) {
+  Item item(command_id, TYPE_BUTTON_ITEM, std::u16string());
+  item.button_model = model;
+  InsertItemAtIndex(std::move(item), index);
+}
+
+}  // namespace ui

--- a/chromium_src/ui/base/models/simple_menu_model.cc
+++ b/chromium_src/ui/base/models/simple_menu_model.cc
@@ -1,4 +1,3 @@
-
 /* Copyright (c) 2024 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,

--- a/chromium_src/ui/base/models/simple_menu_model.h
+++ b/chromium_src/ui/base/models/simple_menu_model.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_SIMPLE_MENU_MODEL_H_
+#define BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_SIMPLE_MENU_MODEL_H_
+
+#define AddButtonItem                                                        \
+  AddButtonItemAt(int command_id, ButtonMenuItemModel* model, size_t index); \
+  void AddButtonItem
+
+#include "src/ui/base/models/simple_menu_model.h"  // IWYU pragma: export
+
+#undef AddButtonItem
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_BASE_MODELS_SIMPLE_MENU_MODEL_H_


### PR DESCRIPTION
<img width="288" alt="image" src="https://github.com/brave/brave-core/assets/5474642/f4e516e9-c83f-4c20-b7f3-7c4466af747b">

<img width="305" alt="image" src="https://github.com/brave/brave-core/assets/5474642/de3c5554-c7c3-4b89-a15f-a26bba58e802">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38708

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-arm64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-x64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* Open app menu, aka hamburger menu
* See if sidebar show option is at the top level of the app menu, right after vpn.
