### PR TITLE
fix(wallet): Display "Transaction Fee" and "Amount + Fee" for Bitcoin transactions

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
@@ -331,6 +331,7 @@ struct PendingTransactionView: View {
                 VStack(alignment: .leading) {
                   Text(
                     confirmationStore.activeParsedTransaction.coin == .sol
+                      || confirmationStore.activeParsedTransaction.coin == .btc
                       ? Strings.Wallet.transactionFee : Strings.Wallet.gasFee
                   )
                   .foregroundColor(Color(.bravePrimary))
@@ -384,6 +385,7 @@ struct PendingTransactionView: View {
                   VStack(alignment: .trailing) {
                     Text(
                       confirmationStore.activeParsedTransaction.coin == .sol
+                        || confirmationStore.activeParsedTransaction.coin == .btc
                         ? Strings.Wallet.amountAndFee : Strings.Wallet.amountAndGas
                     )
                     .font(.footnote)


### PR DESCRIPTION
Updates the labels in transaction confirmation for bitcoin transactions to display "Transaction Fee" / "Amount + Fee" for Bitcoin transactions, instead of "Gas Fee".

Resolves https://github.com/brave/brave-browser/issues/38967

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a Bitcoin send transactions
2. Verify the labels in Transaction Confirmation panel display "Transaction Fee" / "Amount + Fee" instead of "Gas Fee" / "Amount + Gas"

<img src="https://github.com/brave/brave-core/assets/5314553/d3539dd4-1814-4f99-8ac2-8e5d39f97f39" width="300">