### PR TITLE
Updated location icon view color for dangerous site (uplift to 1.68.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/location_bar/location_icon_view.cc
+++ b/chromium_src/chrome/browser/ui/views/location_bar/location_icon_view.cc
@@ -4,9 +4,24 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/components/ipfs/ipfs_constants.h"
+#include "components/strings/grit/components_strings.h"
+
+namespace {
+constexpr int kDangerousVerboseState = IDS_DANGEROUS_VERBOSE_STATE;
+}  // namespace
 
 #define BRAVE_SHOULD_SHOW_URL_IPFS_CHECK \
   url.SchemeIs(ipfs::kIPFSScheme) || url.SchemeIs(ipfs::kIPNSScheme) ||
 
+// To make |is_text_dangerous| false always.
+// It prevents to get color from LocationIconView. We want to get color
+// from its delegate.
+#undef IDS_DANGEROUS_VERBOSE_STATE
+#define IDS_DANGEROUS_VERBOSE_STATE kDangerousVerboseState) && (false
+
 #include "src/chrome/browser/ui/views/location_bar/location_icon_view.cc"
+
+#undef IDS_DANGEROUS_VERBOSE_STATE
 #undef BRAVE_SHOULD_SHOW_URL_IPFS_CHECK
+
+#define IDS_DANGEROUS_VERBOSE_STATE kDangerousVerboseState


### PR DESCRIPTION
Uplift of #24148
fix https://github.com/brave/brave-browser/issues/38830

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.