### PR TITLE
Fix HostPortPair comparison

### DIFF
--- a/chromium_src/net/base/host_port_pair.cc
+++ b/chromium_src/net/base/host_port_pair.cc
@@ -33,7 +33,7 @@ HostPortPair FromStringWithAuthentication(std::string_view str) {
       HostPortPair::FromString(std::string(auth_host[1]));
 
   std::vector<std::string_view> user_pass = base::SplitStringPiece(
-      str, ":", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
+      auth_host[0], ":", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
 
   host_port_pair.set_username(std::string(user_pass[0]));
   host_port_pair.set_password(std::string(user_pass[1]));
@@ -122,14 +122,6 @@ std::optional<HostPortPair> HostPortPair::FromValue(const base::Value& value) {
   return std::nullopt;
 }
 
-const std::string& HostPortPair::username() const {
-  return username_;
-}
-
-const std::string& HostPortPair::password() const {
-  return password_;
-}
-
 void HostPortPair::set_username(const std::string& in_username) {
   username_ = in_username;
 }
@@ -138,21 +130,22 @@ void HostPortPair::set_password(const std::string& in_password) {
   password_ = in_password;
 }
 
-bool HostPortPair::operator<(const HostPortPair& other) const {
-  if (HostPortPair_ChromiumImpl::operator<(other)) {
-    return true;
-  }
-  return std::tie(username_, password_) <
-         std::tie(other.username_, other.password_);
+std::strong_ordering HostPortPair::operator<=>(
+    const HostPortPair& other) const {
+  auto tie = [](const HostPortPair& v) {
+    // note: std::pair is used because port() is r-value.
+    return std::make_pair(v.port(),
+                          std::tie(v.host(), v.username(), v.password()));
+  };
+  return tie(*this) <=> tie(other);
 }
 
 bool HostPortPair::operator==(const HostPortPair& other) const {
-  return Equals(other);
+  return (*this <=> other) == std::strong_ordering::equal;
 }
 
 bool HostPortPair::Equals(const HostPortPair& other) const {
-  return HostPortPair_ChromiumImpl::Equals(other) &&
-         username_ == other.username_ && password_ == other.password_;
+  return *this == other;
 }
 
 std::string HostPortPair::ToString() const {

--- a/chromium_src/net/base/host_port_pair.cc
+++ b/chromium_src/net/base/host_port_pair.cc
@@ -132,10 +132,13 @@ void HostPortPair::set_password(const std::string& in_password) {
 
 std::strong_ordering HostPortPair::operator<=>(
     const HostPortPair& other) const {
+  if (port() != other.port()) {
+    // note: port() is r-value, can't be used with std::tie
+    return port() <=> other.port();
+  }
+
   auto tie = [](const HostPortPair& v) {
-    // note: std::pair is used because port() is r-value.
-    return std::make_pair(v.port(),
-                          std::tie(v.host(), v.username(), v.password()));
+    return std::tie(v.host(), v.username(), v.password());
   };
   return tie(*this) <=> tie(other);
 }

--- a/chromium_src/net/base/host_port_pair.h
+++ b/chromium_src/net/base/host_port_pair.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_CHROMIUM_SRC_NET_BASE_HOST_PORT_PAIR_H_
 #define BRAVE_CHROMIUM_SRC_NET_BASE_HOST_PORT_PAIR_H_
 
+#include <compare>
 #include <string>
 #include <string_view>
 
@@ -35,13 +36,13 @@ class NET_EXPORT HostPortPair : public HostPortPair_ChromiumImpl {
   static HostPortPair FromString(std::string_view str);
   static std::optional<HostPortPair> FromValue(const base::Value& value);
 
-  const std::string& username() const;
-  const std::string& password() const;
+  const std::string& username() const { return username_; }
+  const std::string& password() const { return password_; }
 
   void set_username(const std::string& username);
   void set_password(const std::string& password);
 
-  bool operator<(const HostPortPair& other) const;
+  std::strong_ordering operator<=>(const HostPortPair& other) const;
   bool operator==(const HostPortPair& other) const;
   bool Equals(const HostPortPair& other) const;
 

--- a/net/BUILD.gn
+++ b/net/BUILD.gn
@@ -1,8 +1,13 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
 import("//brave/components/tor/buildflags/buildflags.gni")
 
 source_set("unit_tests") {
   testonly = true
   sources = [
+    "base/brave_host_port_pair_unittest.cc",
     "http/partitioned_host_state_map_unittest.cc",
     "http/transport_security_state_unittest.cc",
   ]

--- a/net/base/brave_host_port_pair_unittest.cc
+++ b/net/base/brave_host_port_pair_unittest.cc
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <optional>
+
+#include "net/base/host_port_pair.h"
+#include "net/test/gtest_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace net {
+
+namespace {
+
+std::vector<HostPortPair> GetTestCasesInAccedingOrder() {
+  std::vector<HostPortPair> v;
+  v.emplace_back("a.com", 10);
+  v.emplace_back("user1", "pass1", "a.com", 10);
+  v.emplace_back("user1", "pass2", "a.com", 10);
+  v.emplace_back("user2", "pass2", "a.com", 10);
+  v.emplace_back("user2", "pass2", "b.com", 10);
+  v.emplace_back("user2", "pass2", "a.com", 11);
+  v.emplace_back("user2", "pass3", "a.com", 11);
+  v.emplace_back("c.com", 11);
+  return v;
+}
+
+}  // namespace
+
+TEST(BraveHostPortPairTest, Parsing) {
+  HostPortPair foo("user", "pass", "foo.com", 10);
+  std::string foo_str = foo.ToString();
+  EXPECT_EQ("user:pass@foo.com:10", foo_str);
+  HostPortPair bar = HostPortPair::FromString(foo_str);
+  EXPECT_EQ(bar.host(), "foo.com");
+  EXPECT_EQ(bar.port(), 10);
+  EXPECT_EQ(bar.username(), "user");
+  EXPECT_EQ(bar.password(), "pass");
+
+  EXPECT_TRUE(foo == bar) << bar.ToString();
+}
+
+TEST(BraveHostPortPairTest, Compare) {
+  const auto v = GetTestCasesInAccedingOrder();
+  // Compare each pair using < and == operators and verify the result.
+  for (size_t i = 0; i < v.size(); i++) {
+    for (size_t j = 0; j < v.size(); j++) {
+      const auto& a = v[i];
+      const auto& b = v[j];
+      SCOPED_TRACE(testing::Message()
+                   << "case " << a.ToString() << " vs " << b.ToString());
+      if (i == j) {
+        EXPECT_TRUE(a == b);
+        EXPECT_TRUE(a.Equals(b));
+      } else {
+        EXPECT_FALSE(a == b);
+        EXPECT_FALSE(a.Equals(b));
+
+        const bool expected_less = i < j;
+        EXPECT_EQ(a < b, expected_less);
+        EXPECT_EQ(b < a, !expected_less);
+      }
+    }
+  }
+}
+
+TEST(BraveHostPortPairTest, Equals) {
+  const auto v = GetTestCasesInAccedingOrder();
+  HostPortPair second_item("user1", "pass1", "a.com", 10);
+  for (size_t i = 0; i < v.size(); i++) {
+    EXPECT_EQ(v[i] == second_item, i == 1);
+  }
+}
+
+}  // namespace net


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36535

The PR:
* fixes the crash ([the details](https://github.com/brave/brave-browser/issues/36535#issuecomment-2163761449) in the issue)
* simplify the comparison code to prevent future issues.
* fixes another issue with parsing `HostPortPair`.
* adds unit tests;

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

