### PR TITLE
refactor(wallet): Refactor MockJsonRpcService for use in tests, remove mock Goerli usage

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/FiltersDisplaySettingsView.swift
@@ -493,7 +493,7 @@ struct FiltersDisplaySettingsView_Previews: PreviewProvider {
           .init(isSelected: true, model: .mockSolana),
           .init(isSelected: true, model: .mockPolygon),
           .init(isSelected: false, model: .mockSolanaTestnet),
-          .init(isSelected: false, model: .mockGoerli),
+          .init(isSelected: false, model: .mockSepolia),
         ]
       ),
       isNFTFilters: false,

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkFilterView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkFilterView.swift
@@ -110,7 +110,7 @@ struct NetworkFilterView_Previews: PreviewProvider {
           .init(isSelected: true, model: .mockMainnet),
           .init(isSelected: true, model: .mockSolana),
           .init(isSelected: true, model: .mockPolygon),
-          .init(isSelected: true, model: .mockGoerli),
+          .init(isSelected: true, model: .mockSepolia),
           .init(isSelected: true, model: .mockSolanaTestnet),
         ],
         networkStore: .previewStore,

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
@@ -129,7 +129,7 @@ struct NetworkSelectionRootView_Previews: PreviewProvider {
         selectedNetworks: [.mockMainnet, .mockSolana, .mockPolygon],
         allNetworks: [
           .mockMainnet, .mockSolana,
-          .mockPolygon, .mockCelo,
+          .mockPolygon,
           .mockGoerli, .mockSolanaTestnet,
         ],
         selectNetwork: { _ in

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionRootView.swift
@@ -130,7 +130,7 @@ struct NetworkSelectionRootView_Previews: PreviewProvider {
         allNetworks: [
           .mockMainnet, .mockSolana,
           .mockPolygon,
-          .mockGoerli, .mockSolanaTestnet,
+          .mockSepolia, .mockSolanaTestnet,
         ],
         selectNetwork: { _ in
 

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -369,7 +369,7 @@ struct SuggestedNetworkView_Previews: PreviewProvider {
         mode: .addNetwork(
           .init(
             originInfo: .init(originSpec: "https://app.uniswap.org", eTldPlusOne: "uniswap.org"),
-            networkInfo: .mockGoerli
+            networkInfo: .mockSepolia
           )
         ),
         cryptoStore: .previewStore,

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -8,412 +8,151 @@ import Foundation
 
 #if DEBUG
 
-/// A test eth json controller which can be passed to a ``NetworkStore`` that implements some basic
-/// functionality for the use of SwiftUI Previews.
-///
-/// - note: Do not use this directly, use ``NetworkStore.previewStore``
-class MockJsonRpcService: BraveWalletJsonRpcService {
-  private var chainId: String = BraveWallet.MainnetChainId
-  private var networks: [BraveWallet.NetworkInfo] = [
-    .mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon, .mockCelo,
+/// JsonRpcService implementation used for previews and unit tests.
+/// Implements default responses for commonly used functions to avoid unimplemented crashes.
+/// Override `_*` functions to implement unit test specific responses as needed.
+class MockJsonRpcService: BraveWallet.TestJsonRpcService {
+  static let allKnownNetworks: [BraveWallet.NetworkInfo] = [
+    .mockMainnet, .mockPolygon, .mockSepolia, .mockGoerli,
+    .mockSolana, .mockSolanaTestnet,
+    .mockFilecoinMainnet, .mockFilecoinTestnet,
+    .mockBitcoinMainnet, .mockBitcoinTestnet,
   ]
-  private var networkURL: URL?
-  private var observers: NSHashTable<BraveWalletJsonRpcServiceObserver> = .weakObjects()
 
-  func chainIdForOrigin(
-    coin: BraveWallet.CoinType,
-    origin: URLOrigin,
-    completion: @escaping (String) -> Void
-  ) {
-    completion(chainId)
-  }
+  var selectedNetworkForCoin: [BraveWallet.CoinType: BraveWallet.NetworkInfo] = [
+    .eth: .mockMainnet,
+    .sol: .mockSolana,
+    .fil: .mockFilecoinMainnet,
+    .btc: .mockBitcoinMainnet,
+  ]
 
-  func blockTrackerUrl(_ completion: @escaping (String) -> Void) {
-    completion(networks.first(where: { $0.chainId == self.chainId })?.blockExplorerUrls.first ?? "")
-  }
+  var allCustomNetworks: [BraveWallet.NetworkInfo] = []
+  var hiddenNetworks: [BraveWallet.NetworkInfo] = [
+    .mockSepolia, .mockGoerli,
+    .mockSolanaTestnet,
+    .mockFilecoinTestnet,
+    .mockBitcoinTestnet,
+  ]
 
-  func networkUrl(_ coin: BraveWallet.CoinType, completion: @escaping (String) -> Void) {
-    completion(networkURL?.absoluteString ?? "")
-  }
-
-  func network(
-    coin: BraveWallet.CoinType,
-    origin: URLOrigin?,
-    completion: @escaping (BraveWallet.NetworkInfo) -> Void
-  ) {
-    completion(networks.first(where: { $0.chainId == self.chainId }) ?? .init())
-  }
-
-  func balance(
-    address: String,
-    coin: BraveWallet.CoinType,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    // return fake sufficient ETH balance `0x13e25e19dc20ba7` is about 0.0896 ETH
-    completion("0x13e25e19dc20ba7", .success, "")
-  }
-
-  func erc20TokenBalance(
-    contract: String,
-    address: String,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("10", .success, "")
-  }
-
-  func erc20TokenBalances(
-    contracts: [String],
-    address: String,
-    chainId: String,
-    completion: @escaping ([BraveWallet.ERC20BalanceResult], BraveWallet.ProviderError, String) ->
-      Void
-  ) {
-    completion([.init(contractAddress: "", balance: "10")], .success, "")
-  }
-
-  func request(
-    chainId: String,
-    jsonPayload: String,
-    autoRetryOnNetworkChange: Bool,
-    id: MojoBase.Value,
-    coin: BraveWallet.CoinType,
-    completion: @escaping (MojoBase.Value, MojoBase.Value, Bool, String, Bool) -> Void
-  ) {
-    completion(.init(), .init(), true, "", false)
-  }
-
-  func addObserver(_ observer: BraveWalletJsonRpcServiceObserver) {
-    observers.add(observer)
-  }
-
-  func pendingAddChainRequests(completion: @escaping ([BraveWallet.AddChainRequest]) -> Void) {
-    completion([])
-  }
-
-  func pendingChainRequests(_ completion: @escaping ([BraveWallet.NetworkInfo]) -> Void) {
-    completion([])
-  }
-
-  func allNetworks(
-    completion: @escaping ([BraveWallet.NetworkInfo]) -> Void
-  ) {
-    completion(networks)
-  }
-
-  func setNetwork(
-    chainId: String,
-    coin: BraveWallet.CoinType,
-    origin: URLOrigin?,
-    completion: @escaping (Bool) -> Void
-  ) {
-    self.chainId = chainId
-    completion(true)
-  }
-
-  func erc20TokenAllowance(
-    contract: String,
-    ownerAddress: String,
-    spenderAddress: String,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .disconnected, "Error Message")
-  }
-
-  func enableEnsOffchainLookup() {
-  }
-
-  func ensGetEthAddr(
-    domain: String,
-    completion: @escaping (String, Bool, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", false, .internalError, "")
-  }
-
-  func unstoppableDomainsGetWalletAddr(
-    domain: String,
-    token: BraveWallet.BlockchainToken?,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .unknown, "Error Message")
-  }
-
-  func unstoppableDomainsResolveDns(
-    domain: String,
-    completion: @escaping (URL?, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion(nil, .internalError, "Error message")
-  }
-
-  func erc721OwnerOf(
-    contract: String,
-    tokenId: String,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .unknownChain, "Error Message")
-  }
-
-  func erc721TokenBalance(
-    contractAddress: String,
-    tokenId: String,
-    accountAddress: String,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .disconnected, "Error Message")
-  }
-
-  func pendingSwitchChainRequests(
-    completion: @escaping ([BraveWallet.SwitchChainRequest]) -> Void
-  ) {
-    completion([])
-  }
-
-  func removeChain(
-    chainId: String,
-    coin: BraveWallet.CoinType,
-    completion: @escaping (Bool) -> Void
-  ) {
-    if let historyIndex = networks.firstIndex(where: { $0.chainId == chainId }) {
-      networks.remove(at: historyIndex)
+  override init() {
+    super.init()
+    self._addObserver = { _ in }
+    self._allNetworks = { [weak self] completion in
+      guard let self else {
+        completion(Self.allKnownNetworks)
+        return
+      }
+      completion(Self.allKnownNetworks + self.allCustomNetworks)
+    }
+    self._hiddenNetworks = { [weak self] _, completion in
+      guard let self else {
+        completion([])
+        return
+      }
+      completion(self.hiddenNetworks.map(\.chainId))
+    }
+    self._addHiddenNetwork = { _, _, completion in
       completion(true)
-    } else {
-      completion(false)
     }
-  }
-
-  func addChain(
-    _ chain: BraveWallet.NetworkInfo,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    networks.append(chain)
-    completion("", .success, "")
-  }
-
-  func addHiddenNetwork(
-    coin: BraveWallet.CoinType,
-    chainId: String,
-    completion: @escaping (Bool) -> Void
-  ) {
-    completion(false)
-  }
-
-  func removeHiddenNetwork(
-    coin: BraveWallet.CoinType,
-    chainId: String,
-    completion: @escaping (Bool) -> Void
-  ) {
-    completion(false)
-  }
-
-  func addEthereumChain(
-    forOrigin chain: BraveWallet.NetworkInfo,
-    origin: URLOrigin,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .chainDisconnected, "Error Message")
-  }
-
-  func addEthereumChainRequestCompleted(chainId: String, approved: Bool) {
-  }
-
-  func notifySwitchChainRequestProcessed(requestId: String, approved: Bool) {
-  }
-
-  func setCustomNetworkForTesting(_ chainId: String, coin: BraveWallet.CoinType, providerUrl: URL) {
-  }
-
-  func solanaBalance(
-    pubkey: String,
-    chainId: String,
-    completion: @escaping (UInt64, BraveWallet.SolanaProviderError, String) -> Void
-  ) {
-    completion(0, .internalError, "Error Message")
-  }
-
-  func splTokenAccountBalance(
-    walletAddress: String,
-    tokenMintAddress: String,
-    chainId: String,
-    completion: @escaping (String, UInt8, String, BraveWallet.SolanaProviderError, String) -> Void
-  ) {
-    completion("", 0, "", .internalError, "Error Message")
-  }
-
-  func splTokenBalances(
-    pubkey: String,
-    chainId: String,
-    completion: @escaping ([BraveWallet.SPLTokenAmount], BraveWallet.SolanaProviderError, String) ->
-      Void
-  ) {
-    completion([], .internalError, "Error Message")
-  }
-
-  func erc1155TokenBalance(
-    contractAddress: String,
-    tokenId: String,
-    accountAddress: String,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .internalError, "")
-  }
-
-  func erc721Metadata(
-    _ contract: String,
-    tokenId: String,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .internalError, "")
-  }
-
-  func solTokenMetadata(
-    chainId: String,
-    tokenMintAddress: String,
-    completion: @escaping (String, String, BraveWallet.SolanaProviderError, String) -> Void
-  ) {
-    completion("", "", .internalError, "")
-  }
-
-  func erc721Metadata(
-    contract: String,
-    tokenId: String,
-    chainId: String,
-    completion: @escaping (String, String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", "", .internalError, "")
-  }
-
-  func erc1155Metadata(
-    contract: String,
-    tokenId: String,
-    chainId: String,
-    completion: @escaping (String, String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", "", .internalError, "")
-  }
-
-  func hiddenNetworks(coin: BraveWallet.CoinType, completion: @escaping ([String]) -> Void) {
-    completion([])
-  }
-
-  func customNetworks(coin: BraveWallet.CoinType, completion: @escaping ([String]) -> Void) {
-    completion([])
-  }
-
-  func knownNetworks(coin: BraveWallet.CoinType, completion: @escaping ([String]) -> Void) {
-    completion([])
-  }
-
-  func snsGetSolAddr(
-    domain: String,
-    completion: @escaping (String, BraveWallet.SolanaProviderError, String) -> Void
-  ) {
-    completion("", .internalError, "Error Message")
-  }
-
-  func snsResolveHost(
-    domain: String,
-    completion: @escaping (URL?, BraveWallet.SolanaProviderError, String) -> Void
-  ) {
-    completion(nil, .internalError, "Error Message")
-  }
-
-  func unstoppableDomainsResolveMethod(completion: @escaping (BraveWallet.ResolveMethod) -> Void) {
-    completion(.ask)
-  }
-
-  func ensResolveMethod(completion: @escaping (BraveWallet.ResolveMethod) -> Void) {
-    completion(.ask)
-  }
-
-  func ensOffchainLookupResolveMethod(completion: @escaping (BraveWallet.ResolveMethod) -> Void) {
-    completion(.ask)
-  }
-
-  func snsResolveMethod(completion: @escaping (BraveWallet.ResolveMethod) -> Void) {
-    completion(.ask)
-  }
-
-  func setUnstoppableDomainsResolveMethod(_ method: BraveWallet.ResolveMethod) {
-  }
-
-  func setEnsResolveMethod(_ method: BraveWallet.ResolveMethod) {
-  }
-
-  func setEnsOffchainLookupResolveMethod(_ method: BraveWallet.ResolveMethod) {
-  }
-
-  func setSnsResolveMethod(_ method: BraveWallet.ResolveMethod) {
-  }
-
-  func code(
-    address: String,
-    coin: BraveWallet.CoinType,
-    chainId: String,
-    completion: @escaping (String, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion("", .internalError, "Error Message")
-  }
-
-  func ensGetContentHash(
-    domain: String,
-    completion: @escaping ([NSNumber], Bool, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion([], false, .internalError, "Error Message")
-  }
-
-  func defaultChainId(coin: BraveWallet.CoinType, completion: @escaping (String) -> Void) {
-    switch coin {
-    case .eth:
-      completion(BraveWallet.MainnetChainId)
-    case .sol:
-      completion(BraveWallet.SolanaMainnet)
-    case .fil:
-      completion(BraveWallet.FilecoinMainnet)
-    case .btc:
-      fallthrough
-    default:
-      completion("")
+    self._removeHiddenNetwork = { _, _, completion in
+      completion(true)
     }
-  }
-
-  func networkUrl(
-    coin: BraveWallet.CoinType,
-    origin: URLOrigin?,
-    completion: @escaping (String) -> Void
-  ) {
-    completion("")
-  }
-
-  func isSolanaBlockhashValid(
-    chainId: String,
-    blockhash: String,
-    commitment: String?,
-    completion: @escaping (Bool, BraveWallet.SolanaProviderError, String) -> Void
-  ) {
-    completion(true, .success, "")
-  }
-
-  func ethTokenInfo(
-    contractAddress: String,
-    chainId: String,
-    completion: @escaping (BraveWallet.BlockchainToken?, BraveWallet.ProviderError, String) -> Void
-  ) {
-    completion(nil, .internalError, "Error Message")
-  }
-
-  func ankrGetAccountBalances(
-    accountAddress: String,
-    chainIds: [String],
-    completion: @escaping ([BraveWallet.AnkrAssetBalance], BraveWallet.ProviderError, String) ->
-      Void
-  ) {
-    completion([], .internalError, "Error Message")
+    self._knownNetworks = { coin, completion in
+      completion(Self.allKnownNetworks.filter({ $0.coin == coin }).map(\.chainId))
+    }
+    self._customNetworks = { [weak self] _, completion in
+      guard let self else {
+        completion([])
+        return
+      }
+      completion(self.allCustomNetworks.map(\.chainId))
+    }
+    self._addChain = { [weak self] network, completion in
+      guard let self else {
+        completion("", .internalError, "Internal error")
+        return
+      }
+      self.allCustomNetworks.append(network)
+      completion(network.chainId, .success, "")
+    }
+    self._network = { [weak self] coin, _, completion in
+      guard let self, let network = self.selectedNetworkForCoin[coin] else {
+        assertionFailure("Selected network for \(coin.localizedTitle) not available.")
+        return
+      }
+      completion(network)
+    }
+    self._chainIdForOrigin = { [weak self] coin, _, completion in
+      guard let self, let network = self.selectedNetworkForCoin[coin] else {
+        assertionFailure("Selected network for \(coin.localizedTitle) not available.")
+        return
+      }
+      completion(network.chainId)
+    }
+    self._setNetwork = { [weak self] chainId, coin, _, completion in
+      guard let self,
+        let network = (Self.allKnownNetworks + self.allCustomNetworks).first(where: {
+          $0.chainId == chainId
+        })
+      else {
+        assertionFailure(
+          "Set network for \(coin.localizedTitle) unavailable. Use addChain or add network to `allKnownNetworks`."
+        )
+        return
+      }
+      self.selectedNetworkForCoin[coin] = network
+      completion(true)
+    }
+    self._balance = { _, coin, chainId, completion in
+      completion("0", .success, "")
+    }
+    self._erc20TokenBalance = { _, _, _, completion in
+      completion("0", .success, "")
+    }
+    self._erc20TokenBalances = { contractAddresses, _, _, completion in
+      let erc20BalanceResults = contractAddresses.map { contractAddress in
+        BraveWallet.ERC20BalanceResult(contractAddress: contractAddress, balance: "0")
+      }
+      completion(erc20BalanceResults, .success, "")
+    }
+    self._erc20TokenAllowance = { _, _, _, _, completion in
+      completion("0", .success, "")
+    }
+    self._erc721TokenBalance = { _, _, _, _, completion in
+      completion("0", .success, "")
+    }
+    self._solanaBalance = { accountAddress, chainId, completion in
+      completion(0, .success, "")
+    }
+    self._splTokenAccountBalance = { _, tokenMintAddress, _, completion in
+      completion("0", 0, "", .success, "")
+    }
+    self._splTokenBalances = { _, _, completion in
+      completion([], .success, "")
+    }
+    self._erc721Metadata = { _, _, _, completion in
+      let metadata = """
+        {
+          "image": "mock.image.url",
+          "name": "mock nft name",
+          "description": "mock nft description"
+        }
+        """
+      completion("", metadata, .success, "")
+    }
+    self._solTokenMetadata = { _, _, completion in
+      let metaData = """
+        {
+          "image": "sol.mock.image.url",
+          "name": "sol mock nft name",
+          "description": "sol mock nft description"
+        }
+        """
+      completion("", metaData, .success, "")
+    }
+    self._ethTokenInfo = { _, _, completion in
+      completion(nil, .resourceNotFound, "Token not found.")
+    }
   }
 }
 
@@ -466,19 +205,6 @@ extension BraveWallet.NetworkInfo {
     rpcEndpoints: [URL(string: "https://rpc.mockchain.com")!],
     symbol: "MATIC",
     symbolName: "MATIC",
-    decimals: 18,
-    coin: .eth,
-    supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:))
-  )
-  static let mockCelo: BraveWallet.NetworkInfo = .init(
-    chainId: BraveWallet.CeloMainnetChainId,
-    chainName: "Celo Mainnet",
-    blockExplorerUrls: [""],
-    iconUrls: [],
-    activeRpcEndpointIndex: 0,
-    rpcEndpoints: [URL(string: "https://rpc.mockchain.com")!],
-    symbol: "CELO",
-    symbolName: "CELO",
     decimals: 18,
     coin: .eth,
     supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:))

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockJsonRpcService.swift
@@ -13,7 +13,7 @@ import Foundation
 /// Override `_*` functions to implement unit test specific responses as needed.
 class MockJsonRpcService: BraveWallet.TestJsonRpcService {
   static let allKnownNetworks: [BraveWallet.NetworkInfo] = [
-    .mockMainnet, .mockPolygon, .mockSepolia, .mockGoerli,
+    .mockMainnet, .mockPolygon, .mockSepolia,
     .mockSolana, .mockSolanaTestnet,
     .mockFilecoinMainnet, .mockFilecoinTestnet,
     .mockBitcoinMainnet, .mockBitcoinTestnet,
@@ -28,7 +28,7 @@ class MockJsonRpcService: BraveWallet.TestJsonRpcService {
 
   var allCustomNetworks: [BraveWallet.NetworkInfo] = []
   var hiddenNetworks: [BraveWallet.NetworkInfo] = [
-    .mockSepolia, .mockGoerli,
+    .mockSepolia,
     .mockSolanaTestnet,
     .mockFilecoinTestnet,
     .mockBitcoinTestnet,
@@ -161,19 +161,6 @@ extension BraveWallet.NetworkInfo {
     chainId: BraveWallet.MainnetChainId,
     chainName: "Mainnet",
     blockExplorerUrls: ["https://etherscan.io"],
-    iconUrls: [],
-    activeRpcEndpointIndex: 0,
-    rpcEndpoints: [URL(string: "https://rpc.mockchain.com")!],
-    symbol: "ETH",
-    symbolName: "Ethereum",
-    decimals: 18,
-    coin: .eth,
-    supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:))
-  )
-  static let mockGoerli: BraveWallet.NetworkInfo = .init(
-    chainId: BraveWallet.GoerliChainId,
-    chainName: "Goerli",
-    blockExplorerUrls: ["https://goerli.etherscan.io"],
     iconUrls: [],
     activeRpcEndpointIndex: 0,
     rpcEndpoints: [URL(string: "https://rpc.mockchain.com")!],

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -284,7 +284,7 @@ extension DepositTokenStore {
   static var previewStore: DepositTokenStore {
     .init(
       keyringService: BraveWallet.TestKeyringService(),
-      rpcService: BraveWallet.TestJsonRpcService(),
+      rpcService: MockJsonRpcService(),
       walletService: BraveWallet.TestBraveWalletService(),
       blockchainRegistry: BraveWallet.TestBlockchainRegistry.previewBlockchainRegistry,
       prefilledToken: nil,

--- a/ios/brave-ios/Sources/BraveWallet/WalletUserAssetManager.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletUserAssetManager.swift
@@ -624,7 +624,15 @@ public class TestableWalletUserAssetManager: WalletUserAssetManagerType {
   ) -> [NetworkAssets] {
     let defaultAssets: [NetworkAssets] = [
       NetworkAssets(network: .mockMainnet, tokens: [.previewToken], sortOrder: 0),
-      NetworkAssets(network: .mockGoerli, tokens: [.previewToken], sortOrder: 1),
+      NetworkAssets(
+        network: .mockSepolia,
+        tokens: [
+          (BraveWallet.BlockchainToken.previewToken.copy() as! BraveWallet.BlockchainToken).then {
+            $0.chainId = BraveWallet.SepoliaChainId
+          }
+        ],
+        sortOrder: 1
+      ),
     ]
     let chainIds = networks.map { $0.chainId }
     return _getAllUserAssetsInNetworkAssets?(networks, includingUserDeleted)

--- a/ios/brave-ios/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -186,9 +186,9 @@ class AccountActivityStoreTests: XCTestCase {
     // default in mainnet
     let ethSendTxCopy =
       BraveWallet.TransactionInfo.previewConfirmedSend.copy() as! BraveWallet.TransactionInfo
-    let goerliSwapTxCopy =
+    let sepoliaSwapTxCopy =
       BraveWallet.TransactionInfo.previewConfirmedSwap.copy() as! BraveWallet.TransactionInfo
-    goerliSwapTxCopy.chainId = BraveWallet.GoerliChainId
+    sepoliaSwapTxCopy.chainId = BraveWallet.SepoliaChainId
 
     let (
       keyringService, rpcService, walletService, blockchainRegistry, assetRatioService,
@@ -197,7 +197,7 @@ class AccountActivityStoreTests: XCTestCase {
       mockEthBalanceWei: mockEthBalanceWei,
       mockERC20BalanceWei: mockERC20BalanceWei,
       mockERC721BalanceWei: mockERC721BalanceWei,
-      transactions: [goerliSwapTxCopy, ethSendTxCopy].enumerated().map { (index, tx) in
+      transactions: [sepoliaSwapTxCopy, ethSendTxCopy].enumerated().map { (index, tx) in
         // transactions sorted by created time, make sure they are in-order
         tx.createdTime = firstTransactionDate.addingTimeInterval(TimeInterval(index) * 1.days)
         return tx
@@ -219,8 +219,8 @@ class AccountActivityStoreTests: XCTestCase {
           sortOrder: 0
         ),
         NetworkAssets(
-          network: .mockGoerli,
-          tokens: [BraveWallet.NetworkInfo.mockGoerli.nativeToken.copy(asVisibleAsset: true)],
+          network: .mockSepolia,
+          tokens: [BraveWallet.NetworkInfo.mockSepolia.nativeToken.copy(asVisibleAsset: true)],
           sortOrder: 1
         ),
       ]
@@ -332,8 +332,8 @@ class AccountActivityStoreTests: XCTestCase {
         XCTAssertEqual(firstSectionTxs[safe: 0]?.transaction, ethSendTxCopy)
         XCTAssertEqual(firstSectionTxs[safe: 0]?.transaction.chainId, ethSendTxCopy.chainId)
         let secondSectionTxs = transactionSections[safe: 1]?.transactions ?? []
-        XCTAssertEqual(secondSectionTxs[safe: 0]?.transaction, goerliSwapTxCopy)
-        XCTAssertEqual(secondSectionTxs[safe: 0]?.transaction.chainId, goerliSwapTxCopy.chainId)
+        XCTAssertEqual(secondSectionTxs[safe: 0]?.transaction, sepoliaSwapTxCopy)
+        XCTAssertEqual(secondSectionTxs[safe: 0]?.transaction.chainId, sepoliaSwapTxCopy.chainId)
       }.store(in: &cancellables)
 
     accountActivityStore.update()

--- a/ios/brave-ios/Tests/BraveWalletTests/AccountActivityStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AccountActivityStoreTests.swift
@@ -14,11 +14,6 @@ class AccountActivityStoreTests: XCTestCase {
 
   private var cancellables: Set<AnyCancellable> = .init()
 
-  let networks: [BraveWallet.NetworkInfo] = [
-    .mockMainnet, .mockGoerli,
-    .mockSolana, .mockSolanaTestnet,
-    .mockFilecoinMainnet, .mockFilecoinTestnet,
-  ]
   let tokenRegistry: [BraveWallet.CoinType: [BraveWallet.BlockchainToken]] = [:]
   let mockAssetPrices: [BraveWallet.AssetPrice] = [
     .init(fromAsset: "eth", toAsset: "usd", price: "3059.99", assetTimeframeChange: "-57.23"),
@@ -68,11 +63,8 @@ class AccountActivityStoreTests: XCTestCase {
       $0(.mock)
     }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
-    rpcService._allNetworks = {
-      $0(self.networks)
-    }
+    let rpcService = MockJsonRpcService()
+    rpcService.hiddenNetworks.removeAll()
     rpcService._balance = { _, coin, chainId, completion in
       switch chainId {
       case BraveWallet.MainnetChainId:
@@ -107,29 +99,6 @@ class AccountActivityStoreTests: XCTestCase {
         .success,
         ""
       )
-    }
-    rpcService._erc721Metadata = { _, _, _, completion in
-      let metadata = """
-        {
-          "image": "mock.image.url",
-          "name": "mock nft name",
-          "description": "mock nft description"
-        }
-        """
-      completion("", metadata, .success, "")
-    }
-    rpcService._solTokenMetadata = { _, _, completion in
-      let metaData = """
-        {
-          "image": "sol.mock.image.url",
-          "name": "sol mock nft name",
-          "description": "sol mock nft description"
-        }
-        """
-      completion("", metaData, .success, "")
-    }
-    rpcService._hiddenNetworks = {
-      $1([])
     }
 
     let walletService = BraveWallet.TestBraveWalletService()

--- a/ios/brave-ios/Tests/BraveWalletTests/AccountsStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AccountsStoreTests.swift
@@ -163,24 +163,8 @@ import XCTest
         )
       )
     }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
-    rpcService._allNetworks = {
-      $0(
-        [
-          .mockMainnet,
-          .mockSolana,
-          .mockFilecoinMainnet,
-          .mockFilecoinTestnet,
-          .mockBitcoinMainnet,
-          .mockBitcoinTestnet,
-        ]
-      )
-    }
-    rpcService._hiddenNetworks = {
-      $1([])
-    }
-
+    let rpcService = MockJsonRpcService()
+    rpcService.hiddenNetworks.removeAll()
     rpcService._balance = { accountAddress, coin, chainId, completion in
       if coin == .eth,
         chainId == BraveWallet.MainnetChainId,
@@ -216,9 +200,6 @@ import XCTest
       } else if accountAddress == self.ethAccount2.address {
         completion(usdcAccount2BalanceWei, .success, "")
       }
-    }
-    rpcService._erc721TokenBalance = { _, _, _, _, completion in
-      completion("", .internalError, "")
     }
     rpcService._solanaBalance = { accountAddress, chainId, completion in
       if accountAddress == self.solAccount1.address {

--- a/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/AssetDetailStoreTests.swift
@@ -47,16 +47,7 @@ class AssetDetailStoreTests: XCTestCase {
         radix: .hex,
         decimals: Int(BraveWallet.BlockchainToken.previewToken.decimals)
       ) ?? ""
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._allNetworks = {
-      $0([.mockMainnet])
-    }
-    rpcService._network = {
-      $2(.mockMainnet)
-    }
-    rpcService._hiddenNetworks = {
-      $1([])
-    }
+    let rpcService = MockJsonRpcService()
     rpcService._balance = { _, _, _, completion in
       completion(ethBalanceWei, .success, "")
     }
@@ -275,16 +266,7 @@ class AssetDetailStoreTests: XCTestCase {
     }
     keyringService._addObserver = { _ in }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._allNetworks = {
-      $0([.mockBitcoinMainnet])
-    }
-    rpcService._network = {
-      $2(.mockBitcoinMainnet)
-    }
-    rpcService._hiddenNetworks = {
-      $1([])
-    }
+    let rpcService = MockJsonRpcService()
 
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._defaultBaseCurrency = {
@@ -495,16 +477,7 @@ class AssetDetailStoreTests: XCTestCase {
         radix: .hex,
         decimals: Int(BraveWallet.BlockchainToken.previewToken.decimals)
       ) ?? ""
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._network = {
-      $2(.mockMainnet)
-    }
-    rpcService._allNetworks = {
-      $0([.mockMainnet])
-    }
-    rpcService._hiddenNetworks = {
-      $1([])
-    }
+    let rpcService = MockJsonRpcService()
     rpcService._balance = { _, _, _, completion in
       completion(ethBalanceWei, .success, "")
     }

--- a/ios/brave-ios/Tests/BraveWalletTests/BuyTokenStoreTest.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/BuyTokenStoreTest.swift
@@ -154,10 +154,8 @@ class BuyTokenStoreTests: XCTestCase {
       )
     }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._network = { $2(selectedNetwork) }
-    rpcService._allNetworks = { $0([selectedNetwork]) }
-    rpcService._addObserver = { _ in }
 
     let walletService = BraveWallet.TestBraveWalletService()
 
@@ -220,9 +218,6 @@ class BuyTokenStoreTests: XCTestCase {
     ) = setupServices()
     rpcService._network = { coin, origin, completion in
       completion(selectedNetwork)
-    }
-    rpcService._allNetworks = {
-      $0([.mockMainnet, .mockSolana])
     }
     // simulate network switch when `setNetwork` is called
     rpcService._setNetwork = { chainId, coin, origin, completion in

--- a/ios/brave-ios/Tests/BraveWalletTests/BuyTokenStoreTest.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/BuyTokenStoreTest.swift
@@ -248,7 +248,7 @@ class BuyTokenStoreTests: XCTestCase {
       blockchainRegistry, keyringService,
       rpcService, walletService,
       assetRatioService, bitcoinWalletService
-    ) = setupServices(selectedNetwork: .mockGoerli)
+    ) = setupServices(selectedNetwork: .mockSepolia)
     let store = BuyTokenStore(
       blockchainRegistry: blockchainRegistry,
       keyringService: keyringService,

--- a/ios/brave-ios/Tests/BraveWalletTests/DecentralizedDNSHelperTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/DecentralizedDNSHelperTests.swift
@@ -30,7 +30,7 @@ import XCTest
   func testLookupWithENSDomainAsk() async {
     let domain = "braveexample.eth"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.ask) }
     rpcService._ensGetContentHash = { _, completion in
       completion([], false, .success, "")
@@ -60,7 +60,7 @@ import XCTest
     let domain = "braveexample.eth"
     let resolvedURL = URL(string: "ipfs://braveexampleeth")!
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.enabled) }
     rpcService._ensGetContentHash = { _, completion in
       let contentHash = (0..<10).map { NSNumber(value: $0) }
@@ -95,7 +95,7 @@ import XCTest
   func testLookupWithENSDomainDisabled() async {
     let domain = "braveexample.eth"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.disabled) }
     rpcService._ensGetContentHash = { _, completion in
       completion([], false, .success, "")
@@ -120,7 +120,7 @@ import XCTest
   func testLookupWithENSOffchainDomainAsk() async {
     let domain = "braveoffchainexample.eth"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.enabled) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.ask) }
     rpcService._ensGetContentHash = { _, completion in
@@ -152,7 +152,7 @@ import XCTest
     let domain = "braveoffchainexample.eth"
     let resolvedURL = URL(string: "ipfs://braveoffchainexampleeth")!
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.enabled) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.enabled) }
     rpcService._ensGetContentHash = { _, completion in
@@ -188,7 +188,7 @@ import XCTest
   func testLookupWithENSOffchainDomainDisabled() async {
     let domain = "braveoffchainexample.eth"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.enabled) }
     rpcService._ensOffchainLookupResolveMethod = { $0(.disabled) }
     rpcService._ensGetContentHash = { _, completion in
@@ -214,7 +214,7 @@ import XCTest
   func testLookupWithSNSDomainAsk() async {
     let domain = "braveexample.sol"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._snsResolveMethod = { $0(.ask) }
     rpcService._snsResolveHost = { _, completion in
       completion(nil, .internalError, "")
@@ -244,7 +244,7 @@ import XCTest
     let domain = "braveexample.sol"
     let resolvedURL = URL(string: "https://brave.com")!
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._snsResolveMethod = { $0(.enabled) }
     rpcService._snsResolveHost = { _, completion in
       completion(resolvedURL, .success, "")
@@ -273,7 +273,7 @@ import XCTest
   func testLookupWithSNSDomainDisabled() async {
     let domain = "braveexample.sol"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._snsResolveMethod = { $0(.disabled) }
     rpcService._snsResolveHost = { _, completion in
       completion(nil, .internalError, "")
@@ -298,7 +298,7 @@ import XCTest
   func testLookupWithUnstoppableDomainsDomainAsk() async {
     let domain = "braveexample.crypto"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._unstoppableDomainsResolveMethod = { $0(.ask) }
     rpcService._unstoppableDomainsResolveDns = { _, completion in
       completion(nil, .internalError, "")
@@ -328,7 +328,7 @@ import XCTest
     let domain = "braveexample.crypto"
     let resolvedURL = URL(string: "https://brave.com")!
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._unstoppableDomainsResolveMethod = { $0(.enabled) }
     rpcService._unstoppableDomainsResolveDns = { _, completion in
       completion(resolvedURL, .success, "")
@@ -357,7 +357,7 @@ import XCTest
   func testLookupWithUnstoppableDomainsDomainDisabled() async {
     let domain = "braveexample.crypto"
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._unstoppableDomainsResolveMethod = { $0(.disabled) }
     rpcService._unstoppableDomainsResolveDns = { _, completion in
       completion(nil, .internalError, "")

--- a/ios/brave-ios/Tests/BraveWalletTests/KeyringStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/KeyringStoreTests.swift
@@ -38,14 +38,9 @@ class KeyringStoreTests: XCTestCase {
     keyringService._isWalletBackedUp = { $0(true) }
     keyringService._isWalletCreated = { $0(true) }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
+    let rpcService = MockJsonRpcService()
     rpcService._chainIdForOrigin = { $2(currentChainId) }
     rpcService._network = { $2(currentNetwork) }
-
-    rpcService._setNetwork = { _, _, _, completion in
-      completion(true)
-    }
 
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }

--- a/ios/brave-ios/Tests/BraveWalletTests/MarketStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/MarketStoreTests.swift
@@ -85,8 +85,7 @@ class MarketStoreTests: XCTestCase {
     blockchainRegistry._allTokens = { _, _, completion in
       completion([])
     }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._allNetworks = { $0([.mockMainnet]) }
+    let rpcService = MockJsonRpcService()
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._userAssets = { _, _, completion in
       completion([.previewToken])

--- a/ios/brave-ios/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -71,10 +71,10 @@ import XCTest
     await networkStore.setup()
 
     let store = NetworkSelectionStore(networkStore: networkStore)
-    let success = await store.selectNetwork(.mockGoerli)
+    let success = await store.selectNetwork(.mockSepolia)
     XCTAssertTrue(
       success,
-      "Expected success for selecting Goerli because we have ethereum accounts."
+      "Expected success for selecting Sepolia because we have ethereum accounts."
     )
   }
 
@@ -101,10 +101,10 @@ import XCTest
       mode: .select(isForOrigin: true),
       networkStore: networkStore
     )
-    let success = await store.selectNetwork(.mockGoerli)
+    let success = await store.selectNetwork(.mockSepolia)
     XCTAssertTrue(
       success,
-      "Expected success for selecting Goerli because we have ethereum accounts."
+      "Expected success for selecting Sepolia because we have ethereum accounts."
     )
   }
 
@@ -145,9 +145,9 @@ import XCTest
     await networkStore.setup()
 
     let store = NetworkSelectionStore(mode: .formSelection, networkStore: networkStore)
-    let success = await store.selectNetwork(.mockGoerli)
-    XCTAssertTrue(success, "Expected success for selecting Goerli")
-    XCTAssertEqual(store.networkSelectionInForm, .mockGoerli)
+    let success = await store.selectNetwork(.mockSepolia)
+    XCTAssertTrue(success, "Expected success for selecting Sepolia")
+    XCTAssertEqual(store.networkSelectionInForm, .mockSepolia)
   }
 
   func testAlertResponseCreateAccount() async {

--- a/ios/brave-ios/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NetworkSelectionStoreTests.swift
@@ -14,12 +14,6 @@ import XCTest
 
   private var cancellables: Set<AnyCancellable> = .init()
 
-  private let allNetworks: [BraveWallet.NetworkInfo] = [
-    .mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon,
-    .mockSolana, .mockSolanaTestnet,
-    .mockFilecoinTestnet,
-  ]
-
   private func setupServices() -> (
     BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService,
     BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService
@@ -41,13 +35,9 @@ import XCTest
       )
     }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
+    let rpcService = MockJsonRpcService()
     rpcService._chainIdForOrigin = { $2(currentChainId) }
     rpcService._network = { $2(currentNetwork) }
-    rpcService._allNetworks = { [weak self] completion in
-      completion(self?.allNetworks ?? [])
-    }
     rpcService._setNetwork = { chainId, coin, origin, completion in
       completion(true)
     }

--- a/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -156,7 +156,6 @@ import XCTest
       if coin == .eth {
         completion(
           [
-            BraveWallet.NetworkInfo.mockGoerli.chainId,
             BraveWallet.NetworkInfo.mockSepolia.chainId,
             BraveWallet.NetworkInfo.mockPolygon.chainId,
           ]
@@ -194,7 +193,6 @@ import XCTest
       .mockSolana,
       .mockSolanaTestnet,
       .mockMainnet,
-      .mockGoerli,
       .mockSepolia,
       .mockPolygon,
       .mockCustomNetwork,
@@ -208,7 +206,6 @@ import XCTest
     ]
 
     let expectedHiddenChains: [BraveWallet.NetworkInfo] = [
-      .mockGoerli,
       .mockSepolia,
       .mockPolygon,
     ]

--- a/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/NetworkStoreTests.swift
@@ -18,15 +18,6 @@ import XCTest
     BraveWallet.TestKeyringService, BraveWallet.TestJsonRpcService,
     BraveWallet.TestBraveWalletService, BraveWallet.TestSwapService
   ) {
-    let currentNetwork: BraveWallet.NetworkInfo = .mockMainnet
-    let currentChainId = currentNetwork.chainId
-    let allNetworks: [BraveWallet.NetworkInfo] = [
-      .mockMainnet, .mockGoerli, .mockSepolia, .mockPolygon, .mockCustomNetwork,
-      .mockSolana, .mockSolanaTestnet,
-      .mockFilecoinMainnet, .mockFilecoinTestnet,
-      .mockBitcoinMainnet,
-    ]
-
     let keyringService = BraveWallet.TestKeyringService()
     keyringService._addObserver = { _ in }
     keyringService._isLocked = { $0(false) }
@@ -41,20 +32,8 @@ import XCTest
       )
     }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
-    rpcService._chainIdForOrigin = { $2(currentChainId) }
-    rpcService._network = { $2(currentNetwork) }
-    rpcService._allNetworks = {
-      $0(allNetworks)
-    }
-    rpcService._setNetwork = { chainId, coin, origin, completion in
-      completion(true)
-    }
-    rpcService._customNetworks = { $1([BraveWallet.NetworkInfo.mockCustomNetwork.chainId]) }
-    rpcService._hiddenNetworks = { $1([]) }
-    rpcService._addHiddenNetwork = { $2(true) }
-    rpcService._removeHiddenNetwork = { $2(true) }
+    let rpcService = MockJsonRpcService()
+    rpcService.allCustomNetworks.append(.mockCustomNetwork)
 
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._addObserver = { _ in }
@@ -80,10 +59,10 @@ import XCTest
     )
     await store.setup()
 
-    XCTAssertNotEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockGoerli.chainId)
-    let error = await store.setSelectedChain(.mockGoerli, isForOrigin: false)
+    XCTAssertNotEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockSepolia.chainId)
+    let error = await store.setSelectedChain(.mockSepolia, isForOrigin: false)
     XCTAssertNil(error, "Expected success, accounts exist for ethereum")
-    XCTAssertEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockGoerli.chainId)
+    XCTAssertEqual(store.defaultSelectedChainId, BraveWallet.NetworkInfo.mockSepolia.chainId)
   }
 
   func testSetSelectedNetworkSameNetwork() async {
@@ -123,10 +102,10 @@ import XCTest
     )
     await store.setup()
 
-    XCTAssertNotEqual(store.selectedChainIdForOrigin, BraveWallet.NetworkInfo.mockGoerli.chainId)
-    let error = await store.setSelectedChain(.mockGoerli, isForOrigin: true)
+    XCTAssertNotEqual(store.selectedChainIdForOrigin, BraveWallet.NetworkInfo.mockSepolia.chainId)
+    let error = await store.setSelectedChain(.mockSepolia, isForOrigin: true)
     XCTAssertNil(error, "Expected success")
-    XCTAssertEqual(store.selectedChainIdForOrigin, BraveWallet.NetworkInfo.mockGoerli.chainId)
+    XCTAssertEqual(store.selectedChainIdForOrigin, BraveWallet.NetworkInfo.mockSepolia.chainId)
   }
 
   func testSetSelectedNetworkNoAccounts() async {

--- a/ios/brave-ios/Tests/BraveWalletTests/PortfolioStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/PortfolioStoreTests.swift
@@ -212,8 +212,8 @@ import XCTest
         decimals: Int(BraveWallet.BlockchainToken.mockUSDCToken.decimals)
       ) ?? ""
 
-    let mockEthGoerliUserAssets: [BraveWallet.BlockchainToken] = [
-      BraveWallet.NetworkInfo.mockGoerli.nativeToken.copy(asVisibleAsset: true)
+    let mockEthSepoliaUserAssets: [BraveWallet.BlockchainToken] = [
+      BraveWallet.NetworkInfo.mockSepolia.nativeToken.copy(asVisibleAsset: true)
     ]
 
     // config bitcoin on mainnet
@@ -250,7 +250,7 @@ import XCTest
       )
     }
     let rpcService = MockJsonRpcService()
-    rpcService.hiddenNetworks = [.mockPolygon, .mockSepolia, .mockSolanaTestnet]
+    rpcService.hiddenNetworks = [.mockPolygon, .mockSolanaTestnet]
     rpcService._balance = { accountAddress, coin, chainId, completion in
       // eth balance
       if coin == .eth {
@@ -338,8 +338,8 @@ import XCTest
           sortOrder: 1
         ),
         NetworkAssets(
-          network: .mockGoerli,
-          tokens: mockEthGoerliUserAssets.filter(\.visible),
+          network: .mockSepolia,
+          tokens: mockEthSepoliaUserAssets.filter(\.visible),
           sortOrder: 2
         ),
         NetworkAssets(
@@ -460,7 +460,7 @@ import XCTest
           return
         }
 
-        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Goerli, FIL on Filecoin mainnet, FIL on Filecoin testnet, BTC on Bitcoin mainnet. No BTC on Bitcoin testnet
+        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Sepolia, FIL on Filecoin mainnet, FIL on Filecoin testnet, BTC on Bitcoin mainnet. No BTC on Bitcoin testnet
         XCTAssertEqual(group.assets.count, 5)
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(
@@ -574,7 +574,7 @@ import XCTest
           ]
         )
 
-        // ETH Goerli (value = 0), hidden because test networks not selected by default
+        // ETH Sepolia (value = 0), hidden because test networks not selected by default
         // FIL Testnet (value = $400.00), hidden because test networks not selected by default
         // BIT Testnet (value = 0.00), hidden because Bitcoin testnet is disabled by default
         XCTAssertNil(group.assets[safe: 5])
@@ -656,7 +656,7 @@ import XCTest
         accounts: store.filters.accounts,
         networks: MockJsonRpcService.allKnownNetworks.map {
           // de-select all networks with balance
-          .init(isSelected: $0.chainId == BraveWallet.GoerliChainId, model: $0)
+          .init(isSelected: $0.chainId == BraveWallet.SepoliaChainId, model: $0)
         }
       )
     )
@@ -689,7 +689,7 @@ import XCTest
         // USDC on Ethereum mainnet, SOL on Solana mainnet, ETH on Ethereum mainnet, FIL on Filecoin mainnet, FIL on Filecoin testnet, BTC on Bitcoin mainnet. No BTC on Bitcoin testnet since Bitcoin tesnet is disabled by default
         let assetGroupNumber = bitcoinTestnetEnabled ? 8 : 7
         XCTAssertEqual(group.assets.count, assetGroupNumber)
-        // ETH Goerli (value = $0)
+        // ETH Sepolia (value = $0)
         XCTAssertEqual(
           group.assets[safe: 0]?.token.symbol,
           BraveWallet.BlockchainToken.previewToken.symbol
@@ -815,7 +815,7 @@ import XCTest
           return
         }
         // ETH on Ethereum mainnet, SOL on Solana mainnet, FIL on Filecoin mainnet and testnet
-        XCTAssertEqual(group.assets.count, 4)  // USDC, ETH Goerli hidden for small balance
+        XCTAssertEqual(group.assets.count, 4)  // USDC, ETH Sepolia hidden for small balance
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(
           group.assets[safe: 0]?.token.symbol,
@@ -900,7 +900,7 @@ import XCTest
           XCTFail("Unexpected test result")
           return
         }
-        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Goerli, FIL on mainnet and testnet, BTC on mainnet and testnet
+        // ETH on Ethereum mainnet, SOL on Solana mainnet, USDC on Ethereum mainnet, ETH on Sepolia, FIL on mainnet and testnet, BTC on mainnet and testnet
         let assetGroupNumber: Int = bitcoinTestnetEnabled ? 8 : 7
         XCTAssertEqual(group.assets.count, assetGroupNumber)
         // ETH Mainnet (value ~= $2741.7510399999996)
@@ -972,10 +972,10 @@ import XCTest
           String(format: "%.04f", self.mockBTCBalanceAccount1)
         )
         offset += 1
-        // ETH Goerli (value = $0)
+        // ETH Sepolia (value = $0)
         XCTAssertEqual(
           group.assets[safe: offset]?.token.symbol,
-          BraveWallet.NetworkInfo.mockGoerli.nativeToken.symbol
+          BraveWallet.NetworkInfo.mockSepolia.nativeToken.symbol
         )
         XCTAssertEqual(group.assets[safe: offset]?.quantity, String(format: "%.04f", 0))
       }.store(in: &cancellables)
@@ -1029,7 +1029,7 @@ import XCTest
           XCTFail("Unexpected test result")
           return
         }
-        // ETH on Ethereum mainnet, USDC on Ethereum mainnet, ETH on Goerli, FIL on mainnet and testnet BTC on mainnet and testnet
+        // ETH on Ethereum mainnet, USDC on Ethereum mainnet, ETH on Sepolia, FIL on mainnet and testnet BTC on mainnet and testnet
         XCTAssertEqual(group.assets.count, 5)
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(
@@ -1067,10 +1067,10 @@ import XCTest
           group.assets[safe: 3]?.quantity,
           String(format: "%.04f", self.mockUSDCBalanceAccount1 + self.mockUSDCBalanceAccount2)
         )
-        // ETH Goerli (value = $0)
+        // ETH Sepolia (value = $0)
         XCTAssertEqual(
           group.assets[safe: 4]?.token.symbol,
-          BraveWallet.NetworkInfo.mockGoerli.nativeToken.symbol
+          BraveWallet.NetworkInfo.mockSepolia.nativeToken.symbol
         )
         XCTAssertEqual(group.assets[safe: 4]?.quantity, String(format: "%.04f", 0))
         // SOL (value = $0, SOL networks hidden)
@@ -1187,7 +1187,7 @@ import XCTest
         }
 
         XCTAssertEqual(ethAccount1Group.groupType, .account(self.ethAccount1))
-        XCTAssertEqual(ethAccount1Group.assets.count, 3)  // ETH Mainnet, USDC, ETH Goerli
+        XCTAssertEqual(ethAccount1Group.assets.count, 3)  // ETH Mainnet, USDC, ETH Sepolia
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(
           ethAccount1Group.assets[safe: 0]?.token.symbol,
@@ -1206,10 +1206,10 @@ import XCTest
           ethAccount1Group.assets[safe: 1]?.quantity,
           String(format: "%.04f", self.mockUSDCBalanceAccount1)
         )
-        // ETH Goerli (value = $0)
+        // ETH Sepolia (value = $0)
         XCTAssertEqual(
           ethAccount1Group.assets[safe: 2]?.token.symbol,
-          BraveWallet.NetworkInfo.mockGoerli.nativeToken.symbol
+          BraveWallet.NetworkInfo.mockSepolia.nativeToken.symbol
         )
         XCTAssertEqual(ethAccount1Group.assets[safe: 2]?.quantity, String(format: "%.04f", 0))
 
@@ -1250,7 +1250,7 @@ import XCTest
         )
 
         XCTAssertEqual(ethAccount2Group.groupType, .account(self.ethAccount2))
-        XCTAssertEqual(ethAccount2Group.assets.count, 3)  // ETH Mainnet, USDC, ETH Goerli
+        XCTAssertEqual(ethAccount2Group.assets.count, 3)  // ETH Mainnet, USDC, ETH Sepolia
         // USDC (value $0.01)
         XCTAssertEqual(
           ethAccount2Group.assets[safe: 0]?.token.symbol,
@@ -1266,10 +1266,10 @@ import XCTest
           BraveWallet.BlockchainToken.previewToken.symbol
         )
         XCTAssertEqual(ethAccount2Group.assets[safe: 1]?.quantity, String(format: "%.04f", 0))
-        // ETH Goerli (value = $0)
+        // ETH Sepolia (value = $0)
         XCTAssertEqual(
           ethAccount2Group.assets[safe: 2]?.token.symbol,
-          BraveWallet.NetworkInfo.mockGoerli.nativeToken.symbol
+          BraveWallet.NetworkInfo.mockSepolia.nativeToken.symbol
         )
         XCTAssertEqual(ethAccount2Group.assets[safe: 2]?.quantity, String(format: "%.04f", 0))
 
@@ -1362,7 +1362,7 @@ import XCTest
           return
         }
         XCTAssertEqual(ethAccount1Group.groupType, .account(self.ethAccount1))
-        // ETH Mainnet (USDC, ETH Goerli hidden for small balance)
+        // ETH Mainnet (USDC, ETH Sepolia hidden for small balance)
         XCTAssertEqual(ethAccount1Group.assets.count, 1)
         // ETH Mainnet (value ~= $2741.7510399999996)
         XCTAssertEqual(
@@ -1499,11 +1499,8 @@ import XCTest
         let assetGroupNumber = bitcoinTestnetEnabled ? 7 : 6
         XCTAssertEqual(lastUpdatedAssetGroups.count, assetGroupNumber)
 
-        var btcMainnetIndex = 4
-        var goerliIndex = 5
+        let offset = bitcoinTestnetEnabled ? 1 : 0
         if bitcoinTestnetEnabled {
-          btcMainnetIndex = 5
-          goerliIndex = 6
 
           guard let btcTestnetGroup = lastUpdatedAssetGroups[safe: 4]
           else {
@@ -1524,8 +1521,8 @@ import XCTest
           let solMainnetGroup = lastUpdatedAssetGroups[safe: 1],
           let filTestnetGroup = lastUpdatedAssetGroups[safe: 2],
           let filMainnetGroup = lastUpdatedAssetGroups[safe: 3],
-          let btcMainnetGroup = lastUpdatedAssetGroups[safe: btcMainnetIndex],
-          let ethGoerliGroup = lastUpdatedAssetGroups[safe: goerliIndex]
+          let btcMainnetGroup = lastUpdatedAssetGroups[safe: 4 + offset],
+          let ethSepoliaGroup = lastUpdatedAssetGroups[safe: 5 + offset]
         else {
           XCTFail("Unexpected test result")
           return
@@ -1597,14 +1594,14 @@ import XCTest
         )
         XCTAssertEqual(btcMainnetGroup.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
 
-        XCTAssertEqual(ethGoerliGroup.groupType, .network(.mockGoerli))
-        XCTAssertEqual(ethGoerliGroup.assets.count, 1)  // ETH Goerli
-        // ETH Goerli (value = $0)
+        XCTAssertEqual(ethSepoliaGroup.groupType, .network(.mockSepolia))
+        XCTAssertEqual(ethSepoliaGroup.assets.count, 1)  // ETH Sepolia
+        // ETH Sepolia (value = $0)
         XCTAssertEqual(
-          ethGoerliGroup.assets[safe: 0]?.token.symbol,
+          ethSepoliaGroup.assets[safe: 0]?.token.symbol,
           BraveWallet.BlockchainToken.previewToken.symbol
         )
-        XCTAssertEqual(ethGoerliGroup.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
+        XCTAssertEqual(ethSepoliaGroup.assets[safe: 0]?.quantity, String(format: "%.04f", 0))
 
         // Verify NFTs not used in Portfolio #7945
         let noAssetsAreNFTs = lastUpdatedAssetGroups.flatMap(\.assets).allSatisfy({
@@ -1712,7 +1709,7 @@ import XCTest
           String(format: "%.04f", self.mockFILBalanceAccount1)
         )
         // eth mainnet group hidden as network de-selected
-        // goerli network group hidden for small balance
+        // sepolia network group hidden for small balance
         // Bitcoin network group hidden for small balance
         let lastIndex = bitcoinTestnetEnabled ? 4 : 3
         XCTAssertNil(lastUpdatedAssetGroups[safe: lastIndex])

--- a/ios/brave-ios/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -16,7 +16,7 @@ class SelectAccountTokenStoreTests: XCTestCase {
 
   private let allUserAssets: [BraveWallet.BlockchainToken] = [
     .previewToken.copy(asVisibleAsset: true),
-    .mockUSDCToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.GoerliChainId },
+    .mockUSDCToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.SepoliaChainId },
     .mockSolToken.copy(asVisibleAsset: true),
     .mockSpdToken.copy(asVisibleAsset: false),  // not visible
     .mockSolanaNFTToken.copy(asVisibleAsset: true).then { $0.chainId = BraveWallet.SolanaTestnet },
@@ -31,7 +31,7 @@ class SelectAccountTokenStoreTests: XCTestCase {
         sortOrder: 0
       ),
       NetworkAssets(
-        network: .mockGoerli,
+        network: .mockSepolia,
         tokens: [allUserAssets[1]],
         sortOrder: 1
       ),
@@ -283,7 +283,7 @@ class SelectAccountTokenStoreTests: XCTestCase {
         )  // USDC
         XCTAssertEqual(
           accountSections[safe: 1]?.tokenBalances[safe: 1]?.network.chainId,
-          BraveWallet.GoerliChainId
+          BraveWallet.SepoliaChainId
         )
         XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 1]?.balance, mockUSDCBalance)
         XCTAssertEqual(accountSections[safe: 1]?.tokenBalances[safe: 1]?.price, "$4.00")
@@ -377,7 +377,7 @@ class SelectAccountTokenStoreTests: XCTestCase {
         XCTAssertEqual(
           accountSections[safe: 1]?.tokenBalances[safe: 1]?.token,
           self.allUserAssets[1]
-        )  // USDC (Goerli)
+        )  // USDC (Sepolia)
 
         // Solana Account 1
         XCTAssertEqual(accountSections[safe: 2]?.account, .mockSolAccount)
@@ -435,7 +435,7 @@ class SelectAccountTokenStoreTests: XCTestCase {
     // Test with network filters applied (only Filecoin Mainnet, Filecoin Testnet selected)
     store.networkFilters = [
       .init(isSelected: false, model: .mockMainnet),
-      .init(isSelected: false, model: .mockGoerli),
+      .init(isSelected: false, model: .mockSepolia),
       .init(isSelected: false, model: .mockSolana),
       .init(isSelected: false, model: .mockSolanaTestnet),
       .init(isSelected: true, model: .mockFilecoinMainnet),

--- a/ios/brave-ios/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SelectAccountTokenStoreTests.swift
@@ -58,15 +58,6 @@ class SelectAccountTokenStoreTests: XCTestCase {
     ]
   }
 
-  private let allNetworks: [BraveWallet.NetworkInfo] = [
-    .mockMainnet,
-    .mockGoerli,
-    .mockSolana,
-    .mockSolanaTestnet,
-    .mockFilecoinMainnet,
-    .mockFilecoinTestnet,
-  ]
-
   private let mockEthAccount2: BraveWallet.AccountInfo = .init(
     accountId: .init(
       coin: .eth,
@@ -164,11 +155,8 @@ class SelectAccountTokenStoreTests: XCTestCase {
         )
       )
     }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._allNetworks = {
-      $0(self.allNetworks)
-    }
-    rpcService._hiddenNetworks = { $1([]) }
+    let rpcService = MockJsonRpcService()
+    rpcService.hiddenNetworks.removeAll()
     rpcService._balance = { accountAddress, coin, _, completion in
       if coin == .eth {
         completion(ethBalanceWei, .success, "")  // eth balance for both eth accounts

--- a/ios/brave-ios/Tests/BraveWalletTests/SendTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SendTokenStoreTests.swift
@@ -265,7 +265,7 @@ class SendTokenStoreTests: XCTestCase {
         }
         XCTAssertEqual(
           selectedSendToken.symbol,
-          BraveWallet.NetworkInfo.mockGoerli.nativeToken.symbol
+          BraveWallet.NetworkInfo.mockSepolia.nativeToken.symbol
         )
       }.store(in: &cancellables)
     let sendTokenBalanceExpectation = expectation(description: "update-sendTokenBalance")
@@ -474,8 +474,8 @@ class SendTokenStoreTests: XCTestCase {
     let mockBalance = "47.156499657504857477"
     let mockBalanceWei = formatter.weiString(from: mockBalance, radix: .hex, decimals: 18) ?? ""
 
-    rpcService._chainIdForOrigin = { $2(BraveWallet.NetworkInfo.mockGoerli.chainId) }
-    rpcService._network = { $2(BraveWallet.NetworkInfo.mockGoerli) }
+    rpcService._chainIdForOrigin = { $2(BraveWallet.NetworkInfo.mockSepolia.chainId) }
+    rpcService._network = { $2(BraveWallet.NetworkInfo.mockSepolia) }
     rpcService._balance = { _, _, _, completion in
       completion(mockBalanceWei, .success, "")
     }
@@ -1528,12 +1528,12 @@ class SendTokenStoreTests: XCTestCase {
   }
 
   private let account: BraveWallet.AccountInfo = .previewAccount
-  private let ethGoerli: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockGoerli
+  private let ethSepolia: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockSepolia
     .nativeToken
     .copy(asVisibleAsset: true)
-  private let usdcGoerli: BraveWallet.BlockchainToken = .mockUSDCToken
+  private let usdcSepolia: BraveWallet.BlockchainToken = .mockUSDCToken
     .copy(asVisibleAsset: true).then {
-      $0.chainId = BraveWallet.GoerliChainId
+      $0.chainId = BraveWallet.SepoliaChainId
     }
   private let account2: BraveWallet.AccountInfo = .init(
     accountId: .init(
@@ -1556,7 +1556,7 @@ class SendTokenStoreTests: XCTestCase {
       bitcoinWalletService, mockAssetManager
     ) = setupServices(
       selectedAccount: account,
-      userAssets: [.mockGoerli: [ethGoerli, usdcGoerli]],
+      userAssets: [.mockSepolia: [ethSepolia, usdcSepolia]],
       selectedCoin: .eth
     )
     let store = SendTokenStore(
@@ -1569,7 +1569,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       bitcoinWalletService: bitcoinWalletService,
-      prefilledToken: ethGoerli,
+      prefilledToken: ethSepolia,
       ipfsApi: TestIpfsAPI(),
       userAssetManager: mockAssetManager
     )
@@ -1578,7 +1578,7 @@ class SendTokenStoreTests: XCTestCase {
       .dropFirst()
       .sink { selectedSendToken in
         defer { sendTokenExpectation.fulfill() }
-        XCTAssertEqual(selectedSendToken, self.ethGoerli)
+        XCTAssertEqual(selectedSendToken, self.ethSepolia)
       }
       .store(in: &cancellables)
     store.update()
@@ -1591,24 +1591,24 @@ class SendTokenStoreTests: XCTestCase {
       .dropFirst()
       .sink { selectedSendToken in
         defer { didSelectSendTokenExpectation.fulfill() }
-        XCTAssertEqual(selectedSendToken, self.usdcGoerli)
+        XCTAssertEqual(selectedSendToken, self.usdcSepolia)
       }
       .store(in: &cancellables)
-    store.didSelect(account: account, token: usdcGoerli)
+    store.didSelect(account: account, token: usdcSepolia)
     await fulfillment(of: [didSelectSendTokenExpectation], timeout: 1)
   }
 
   /// Test `didSelect(account:token:)` with a new token that is not on the currently selected account but is on the currently selected network.
   @MainActor func testDidSelectNewAccountSameNetwork() async {
     let account: BraveWallet.AccountInfo = .previewAccount
-    let ethGoerli: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockGoerli.nativeToken
+    let ethSepolia: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockSepolia.nativeToken
       .copy(asVisibleAsset: true)
     let (
       keyringService, rpcService, walletService, ethTxManagerProxy, solTxManagerProxy,
       bitcoinWalletService, mockAssetManager
     ) = setupServices(
       selectedAccount: account,
-      userAssets: [.mockGoerli: [ethGoerli]],
+      userAssets: [.mockSepolia: [ethSepolia]],
       selectedCoin: .eth
     )
     let setSelectedAccountExpectation = expectation(description: "setSelectedAccountExpectation")
@@ -1627,7 +1627,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       bitcoinWalletService: bitcoinWalletService,
-      prefilledToken: ethGoerli,
+      prefilledToken: ethSepolia,
       ipfsApi: TestIpfsAPI(),
       userAssetManager: mockAssetManager
     )
@@ -1636,7 +1636,7 @@ class SendTokenStoreTests: XCTestCase {
       .dropFirst()
       .sink { selectedSendToken in
         defer { sendTokenExpectation.fulfill() }
-        XCTAssertEqual(selectedSendToken, ethGoerli)
+        XCTAssertEqual(selectedSendToken, ethSepolia)
       }
       .store(in: &cancellables)
     store.update()
@@ -1644,7 +1644,7 @@ class SendTokenStoreTests: XCTestCase {
     await fulfillment(of: [sendTokenExpectation], timeout: 1)
     cancellables.removeAll()
 
-    store.didSelect(account: account2, token: ethGoerli)
+    store.didSelect(account: account2, token: ethSepolia)
     await fulfillment(of: [setSelectedAccountExpectation], timeout: 1)
   }
 
@@ -1658,7 +1658,7 @@ class SendTokenStoreTests: XCTestCase {
       bitcoinWalletService, mockAssetManager
     ) = setupServices(
       selectedAccount: account,
-      userAssets: [.mockMainnet: [ethMainnet], .mockGoerli: [usdcGoerli]],
+      userAssets: [.mockMainnet: [ethMainnet], .mockSepolia: [usdcSepolia]],
       selectedCoin: .eth
     )
     let setSelectedAccountExpectation = expectation(description: "setSelectedAccountExpectation")
@@ -1670,7 +1670,7 @@ class SendTokenStoreTests: XCTestCase {
     let setNetworkExpectation = expectation(description: "setNetworkExpectation")
     rpcService._setNetwork = { chainId, coin, origin, completion in
       defer { setNetworkExpectation.fulfill() }
-      XCTAssertEqual(chainId, self.usdcGoerli.chainId)
+      XCTAssertEqual(chainId, self.usdcSepolia.chainId)
       selectedNetwork =
         MockJsonRpcService.allKnownNetworks.first(where: { $0.chainId == chainId })
         ?? selectedNetwork
@@ -1711,10 +1711,10 @@ class SendTokenStoreTests: XCTestCase {
       .dropFirst()
       .sink { selectedSendToken in
         defer { didSelectSendTokenExpectation.fulfill() }
-        XCTAssertEqual(selectedSendToken, self.usdcGoerli)
+        XCTAssertEqual(selectedSendToken, self.usdcSepolia)
       }
       .store(in: &cancellables)
-    store.didSelect(account: account2, token: usdcGoerli)
+    store.didSelect(account: account2, token: usdcSepolia)
     await fulfillment(
       of: [didSelectSendTokenExpectation, setSelectedAccountExpectation, setNetworkExpectation],
       timeout: 1
@@ -1726,7 +1726,7 @@ class SendTokenStoreTests: XCTestCase {
     let solMainnet: BraveWallet.BlockchainToken = BraveWallet.NetworkInfo.mockSolana.nativeToken
       .copy(asVisibleAsset: true)
     let filTokenMainnet: BraveWallet.BlockchainToken = .mockFilToken.copy(asVisibleAsset: true)
-    var selectedNetwork: BraveWallet.NetworkInfo = .mockGoerli
+    var selectedNetwork: BraveWallet.NetworkInfo = .mockSepolia
     var selectedNetworkToBe: BraveWallet.NetworkInfo = .mockSolana
     var selectedAccount: BraveWallet.AccountInfo = account
     let (
@@ -1735,7 +1735,7 @@ class SendTokenStoreTests: XCTestCase {
     ) = setupServices(
       selectedAccount: selectedAccount,
       userAssets: [
-        .mockGoerli: [usdcGoerli], .mockSolana: [solMainnet],
+        .mockSepolia: [usdcSepolia], .mockSolana: [solMainnet],
         .mockFilecoinMainnet: [filTokenMainnet],
       ],
       selectedCoin: .eth
@@ -1791,7 +1791,7 @@ class SendTokenStoreTests: XCTestCase {
       ethTxManagerProxy: ethTxManagerProxy,
       solTxManagerProxy: solTxManagerProxy,
       bitcoinWalletService: bitcoinWalletService,
-      prefilledToken: usdcGoerli,
+      prefilledToken: usdcSepolia,
       ipfsApi: TestIpfsAPI(),
       userAssetManager: mockAssetManager
     )
@@ -1800,7 +1800,7 @@ class SendTokenStoreTests: XCTestCase {
       .dropFirst()
       .sink { selectedSendToken in
         defer { sendTokenExpectation.fulfill() }
-        XCTAssertEqual(selectedSendToken, self.usdcGoerli)
+        XCTAssertEqual(selectedSendToken, self.usdcSepolia)
       }
       .store(in: &cancellables)
     store.update()

--- a/ios/brave-ios/Tests/BraveWalletTests/SettingsStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SettingsStoreTests.swift
@@ -37,7 +37,7 @@ class SettingsStoreTests: XCTestCase {
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }  // default is USD
     walletService._nftDiscoveryEnabled = { _ in }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._ensResolveMethod = { $0(.ask) }
     rpcService._setEnsResolveMethod = { _ in }
     rpcService._ensOffchainLookupResolveMethod = { $0(.ask) }

--- a/ios/brave-ios/Tests/BraveWalletTests/SwapTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SwapTokenStoreTests.swift
@@ -30,7 +30,7 @@ class SwapStoreTests: XCTestCase {
     let ex = expectation(description: "default-sell-buy-token-on-main")
     XCTAssertNil(store.selectedFromToken)
     XCTAssertNil(store.selectedToToken)
-    let testAccountInfo: BraveWallet.AccountInfo = .init()
+    let testAccountInfo: BraveWallet.AccountInfo = .previewAccount
     store.prepare(with: testAccountInfo) {
       defer { ex.fulfill() }
       XCTAssertEqual(store.selectedFromToken?.symbol.lowercased(), "eth")
@@ -86,7 +86,7 @@ class SwapStoreTests: XCTestCase {
     // `prefilledToken` not set until validated in `prepare()`
     XCTAssertNil(store.selectedFromToken)
     XCTAssertNil(store.selectedToToken)
-    let testAccountInfo: BraveWallet.AccountInfo = .init()
+    let testAccountInfo: BraveWallet.AccountInfo = .previewAccount
     store.prepare(with: testAccountInfo) {
       defer { ex.fulfill() }
       XCTAssertEqual(store.selectedFromToken?.symbol.lowercased(), batToken.symbol.lowercased())
@@ -111,15 +111,6 @@ class SwapStoreTests: XCTestCase {
 
     rpcService._network = { coin, _, completion in
       completion(selectedNetwork)
-    }
-    rpcService._solanaBalance = { _, _, completion in
-      completion(0, .success, "")
-    }
-    rpcService._splTokenAccountBalance = { _, _, _, completion in
-      completion("", 0, "", .success, "")
-    }
-    rpcService._allNetworks = {
-      $0([.mockMainnet, .mockSolana])
     }
     // simulate network switch when `setNetwork` is called
     rpcService._setNetwork = { chainId, coin, origin, completion in
@@ -155,7 +146,7 @@ class SwapStoreTests: XCTestCase {
     // `prefilledToken` not set until validated in `prepare()`
     XCTAssertNil(store.selectedFromToken)
     XCTAssertNil(store.selectedToToken)
-    let testAccountInfo: BraveWallet.AccountInfo = .init()
+    let testAccountInfo: BraveWallet.AccountInfo = .previewAccount
     store.prepare(with: testAccountInfo) {
       defer { ex.fulfill() }
       XCTAssertEqual(
@@ -195,7 +186,7 @@ class SwapStoreTests: XCTestCase {
     rpcService.setNetwork(chainId: BraveWallet.PolygonMainnetChainId, coin: .eth, origin: nil) {
       success in
       XCTAssertTrue(success)
-      let testAccountInfo: BraveWallet.AccountInfo = .init()
+      let testAccountInfo: BraveWallet.AccountInfo = .previewAccount
       store.prepare(with: testAccountInfo) {
         defer { ex.fulfill() }
         XCTAssertEqual(store.selectedFromToken?.symbol.lowercased(), "matic")
@@ -244,8 +235,7 @@ class SwapStoreTests: XCTestCase {
       chainId: BraveWallet.PolygonMainnetChainId,
       coin: .eth
     )
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
+    let rpcService = MockJsonRpcService()
     rpcService._network = { $2(.mockPolygon) }
     rpcService._erc20TokenBalance = { $3("10", .success, "") }
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
@@ -275,7 +265,7 @@ class SwapStoreTests: XCTestCase {
       .store(in: &cancellables)
 
     let ex = expectation(description: "default-sell-buy-token-on-evm")
-    let testAccountInfo: BraveWallet.AccountInfo = .init()
+    let testAccountInfo: BraveWallet.AccountInfo = .previewAccount
     store.prepare(with: testAccountInfo) {
       defer { ex.fulfill() }
       XCTAssertEqual(store.selectedFromToken?.symbol.lowercased(), daiToken.symbol.lowercased())
@@ -300,8 +290,8 @@ class SwapStoreTests: XCTestCase {
     keyringService._addObserver = { _ in }
     let blockchainRegistry = BraveWallet.TestBlockchainRegistry()
     blockchainRegistry._allTokens = { $2([.previewToken, .previewDaiToken]) }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._addObserver = { _ in }
+    let rpcService = MockJsonRpcService()
+    rpcService.hiddenNetworks.removeAll()
     rpcService._network = { $2(network) }
     rpcService._balance = { _, _, _, completion in
       // return fake sufficient ETH balance `0x13e25e19dc20ba7` is about 0.0896 ETH
@@ -310,12 +300,6 @@ class SwapStoreTests: XCTestCase {
     rpcService._erc20TokenBalance = { _, _, _, completion in
       // return fake sufficient ETH balance `0x13e25e19dc20ba7` is about 0.0896 ETH
       completion("0x13e25e19dc20ba7", .success, "")
-    }
-    rpcService._solanaBalance = { _, _, completion in
-      completion(0, .internalError, "")
-    }
-    rpcService._splTokenAccountBalance = { _, _, _, completion in
-      completion("", 0, "", .internalError, "")
     }
     let swapService = BraveWallet.TestSwapService()
     swapService._quote = { _, completion in
@@ -945,13 +929,12 @@ class SwapStoreTests: XCTestCase {
     let mockBalance = "47.156499657504857477"
     let mockBalanceWei = formatter.weiString(from: mockBalance, radix: .hex, decimals: 18) ?? ""
 
-    let rpcService = BraveWallet.TestJsonRpcService()
+    let rpcService = MockJsonRpcService()
     rpcService._chainIdForOrigin = { $2(BraveWallet.NetworkInfo.mockGoerli.chainId) }
     rpcService._network = { $2(BraveWallet.NetworkInfo.mockGoerli) }
     rpcService._balance = { _, _, _, completion in
       completion(mockBalanceWei, .success, "")
     }
-    rpcService._addObserver = { _ in }
     let solTxManagerProxy = BraveWallet.TestSolanaTxManagerProxy()
 
     let store = SwapTokenStore(

--- a/ios/brave-ios/Tests/BraveWalletTests/SwapTokenStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/SwapTokenStoreTests.swift
@@ -930,8 +930,8 @@ class SwapStoreTests: XCTestCase {
     let mockBalanceWei = formatter.weiString(from: mockBalance, radix: .hex, decimals: 18) ?? ""
 
     let rpcService = MockJsonRpcService()
-    rpcService._chainIdForOrigin = { $2(BraveWallet.NetworkInfo.mockGoerli.chainId) }
-    rpcService._network = { $2(BraveWallet.NetworkInfo.mockGoerli) }
+    rpcService._chainIdForOrigin = { $2(BraveWallet.NetworkInfo.mockSepolia.chainId) }
+    rpcService._network = { $2(BraveWallet.NetworkInfo.mockSepolia) }
     rpcService._balance = { _, _, _, completion in
       completion(mockBalanceWei, .success, "")
     }

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -339,7 +339,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
     let firstTransactionDate = Date(timeIntervalSince1970: 1_636_399_671)
     let sendCopy =
       BraveWallet.TransactionInfo.previewConfirmedSend.copy() as! BraveWallet.TransactionInfo
-    sendCopy.chainId = BraveWallet.GoerliChainId
+    sendCopy.chainId = BraveWallet.SepoliaChainId
     sendCopy.txStatus = .unapproved
     let swapCopy =
       BraveWallet.TransactionInfo.previewConfirmedSwap.copy() as! BraveWallet.TransactionInfo
@@ -384,7 +384,7 @@ class TransactionConfirmationStoreTests: XCTestCase {
       }
       .store(in: &cancellables)
 
-    await store.prepare()  // `sendCopy` on Goerli Testnet
+    await store.prepare()  // `sendCopy` on Sepolia Testnet
     store.nextTransaction()  // `swapCopy` on Ethereum Mainnet
     store.nextTransaction()  // `solanaSendCopy` on Solana Mainnet
     store.nextTransaction()  // `solanaSPLSendCopy` on Solana Testnet

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionConfirmationStoreTests.swift
@@ -15,18 +15,6 @@ class TransactionConfirmationStoreTests: XCTestCase {
   private var cancellables: Set<AnyCancellable> = .init()
 
   private func setupStore(
-    selectedNetworkForCoinType: [BraveWallet.CoinType: BraveWallet.NetworkInfo] = [
-      .eth: BraveWallet.NetworkInfo.mockMainnet,
-      .sol: BraveWallet.NetworkInfo.mockSolana,
-      .fil: BraveWallet.NetworkInfo.mockFilecoinMainnet,
-      .btc: BraveWallet.NetworkInfo.mockBitcoinMainnet,
-    ],
-    allNetworks: [BraveWallet.NetworkInfo] = [
-      .mockMainnet, .mockGoerli,
-      .mockSolana, .mockSolanaTestnet,
-      .mockFilecoinMainnet, .mockFilecoinTestnet,
-      .mockBitcoinMainnet, .mockBitcoinTestnet,
-    ],
     accountInfos: [BraveWallet.AccountInfo] = [
       .mockEthAccount, .mockSolAccount, .mockFilAccount, .mockBtcAccount,
     ],
@@ -71,17 +59,8 @@ class TransactionConfirmationStoreTests: XCTestCase {
         [mockEthAssetPrice, mockSolAssetPrice, mockFilAssetPrice, mockBtcAssetPrice]
       )
     }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._chainIdForOrigin = { coin, origin, completion in
-      completion(selectedNetworkForCoinType[coin]?.chainId ?? BraveWallet.MainnetChainId)
-    }
-    rpcService._network = { coin, origin, completion in
-      completion(selectedNetworkForCoinType[coin] ?? .mockMainnet)
-    }
-    rpcService._allNetworks = {
-      $0(allNetworks)
-    }
-    rpcService._hiddenNetworks = { $1([]) }
+    let rpcService = MockJsonRpcService()
+    rpcService.hiddenNetworks.removeAll()
     rpcService._balance = { _, coin, _, completion in
       if coin == .eth {
         completion(mockBalanceWei, .success, "")
@@ -91,12 +70,6 @@ class TransactionConfirmationStoreTests: XCTestCase {
     }
     rpcService._erc20TokenAllowance = { _, _, _, _, completion in
       completion("16345785d8a0000", .success, "")  // 0.1000
-    }
-    rpcService._solanaBalance = { accountAddress, chainId, completion in
-      completion(0, .success, "")
-    }
-    rpcService._splTokenAccountBalance = { _, tokenMintAddress, _, completion in
-      completion("", UInt8(0), "", .success, "")
     }
     let txService = BraveWallet.TestTxService()
     txService._addObserver = { _ in }

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionDetailsStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionDetailsStoreTests.swift
@@ -37,8 +37,7 @@ class TransactionDetailsStoreTests: XCTestCase {
     }
     let walletService = BraveWallet.TestBraveWalletService()
     walletService._defaultBaseCurrency = { $0(CurrencyCode.usd.code) }
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._allNetworks = { $0([.mockSepolia]) }
+    let rpcService = MockJsonRpcService()
     let assetRatioService = BraveWallet.TestAssetRatioService()
     assetRatioService._price = { _, _, _, completion in
       let mockAssetPrices: [BraveWallet.AssetPrice] = [

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -56,14 +56,8 @@ class TransactionsActivityStoreTests: XCTestCase {
       $0(.mock)
     }
 
-    let rpcService = BraveWallet.TestJsonRpcService()
-    rpcService._allNetworks = {
-      $0([
-        .mockMainnet, .mockGoerli, .mockSolana, .mockSolanaTestnet, .mockFilecoinMainnet,
-        .mockFilecoinTestnet,
-      ])
-    }
-    rpcService._hiddenNetworks = { $1([]) }
+    let rpcService = MockJsonRpcService()
+    rpcService.hiddenNetworks.removeAll()
     rpcService._erc721Metadata = { _, _, _, completion in
       let metadata = """
         {

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionsActivityStoreTests.swift
@@ -91,9 +91,9 @@ class TransactionsActivityStoreTests: XCTestCase {
     // default in mainnet
     let ethSendTxCopy =
       BraveWallet.TransactionInfo.previewConfirmedSend.copy() as! BraveWallet.TransactionInfo
-    let goerliSwapTxCopy =
+    let sepoliaSwapTxCopy =
       BraveWallet.TransactionInfo.previewConfirmedSwap.copy() as! BraveWallet.TransactionInfo
-    goerliSwapTxCopy.chainId = BraveWallet.GoerliChainId
+    sepoliaSwapTxCopy.chainId = BraveWallet.SepoliaChainId
     let solSendTxCopy =
       BraveWallet.TransactionInfo.previewConfirmedSolSystemTransfer.copy()
       as! BraveWallet.TransactionInfo  // default in mainnet
@@ -107,7 +107,7 @@ class TransactionsActivityStoreTests: XCTestCase {
       BraveWallet.TransactionInfo.mockFilUnapprovedSend.copy() as! BraveWallet.TransactionInfo
     filTestnetSendTxCopy.chainId = BraveWallet.FilecoinTestnet
     let txs: [BraveWallet.TransactionInfo] = [
-      ethNFTSendTxCopy, ethSendTxCopy, goerliSwapTxCopy,
+      ethNFTSendTxCopy, ethSendTxCopy, sepoliaSwapTxCopy,
       solSendTxCopy, solTestnetSendTxCopy,
       filSendTxCopy, filTestnetSendTxCopy,
     ]
@@ -270,15 +270,15 @@ class TransactionsActivityStoreTests: XCTestCase {
         // Day 3 Transaction 2
         XCTAssertEqual(
           transactionSectionsWithoutPrices[safe: 2]?.transactions[safe: 1]?.transaction,
-          goerliSwapTxCopy
+          sepoliaSwapTxCopy
         )
         XCTAssertEqual(
           transactionSectionsWithoutPrices[safe: 2]?.transactions[safe: 1]?.transaction.chainId,
-          goerliSwapTxCopy.chainId
+          sepoliaSwapTxCopy.chainId
         )
         XCTAssertEqual(
           transactionSectionsWithPrices[safe: 2]?.transactions[safe: 1]?.transaction,
-          goerliSwapTxCopy
+          sepoliaSwapTxCopy
         )
         // Day 4 Transaction 1
         XCTAssertEqual(


### PR DESCRIPTION
- Replaced `MockJsonRpcService` with enw implementation using `TestJsonRpcService` for re-use in previews and unit tests. 
- Each new function added to `JsonRpcService` in core/mojom will not need added to `MockJsonRpcService` until it's used in iOS code.
- `GetAllNetworks` in all wallet unit tests will use a single defined list of all (mock) networks, instead of a different list in each unit test
        - Many unit tests were using a hardcoded specific list of 'all networks'. This all networks list should be the same in every test, it is all networks after all.
- Implemented commonly used function defaults to avoid crashes in SwiftUI previews & unit tests while still allowing override of functions for unit test specific control.
- Replaced usage of Goerli network with Sepolia in unit tests, removed `mockGoerli` helper. This is pre-emptive to help alleviate swift updates if `GoerliChainId` is removed with https://github.com/brave/brave-browser/issues/37369.

Resolves https://github.com/brave/brave-browser/issues/38892

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Run unit tests more than once (note known flakey failures in https://github.com/brave/brave-core/blob/master/ios/brave-ios/fastlane/Fastfile#L190-L200). 
Verify tests pass.

note: Unit tests were run 100 times each locally to ensure no flakiness (excluding known flakey tests above):
<img width="641" alt="unit tests success" src="https://github.com/brave/brave-core/assets/5314553/a38f85cf-3a7c-4352-9fca-06f1f597b15d">
