### PR TITLE
[iOS] Update Swift-BigInt to latest v2.3.0

### DIFF
--- a/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -93,8 +93,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mkrd/Swift-BigInt",
       "state" : {
-        "revision" : "b5f483488bca316cbb078ae16f865fa0c21f874a",
-        "version" : "2.2.0"
+        "revision" : "b07e961f4c999671cf8c2dc80e740899e8946013",
+        "version" : "2.3.0"
       }
     },
     {

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -65,7 +65,7 @@ var package = Package(
     .package(url: "https://github.com/siteline/SwiftUI-Introspect", from: "0.1.3"),
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
-    .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.0.0"),
+    .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.3.0"),
     .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.9.1"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(

--- a/ios/brave-ios/Tests/BraveWalletTests/BigIntTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/BigIntTests.swift
@@ -1,0 +1,19 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BigNumber
+import XCTest
+
+@testable import BraveWallet
+
+class BigIntTests: XCTestCase {
+  /// Test fix for BDouble initialization from Double in scientific notation.
+  /// Fixed in v2.2.1+ https://github.com/mkrd/Swift-BigInt/pull/66
+  func testBDoubleInitFromScientificNotation() {
+    let doubleValue: Double = 5.779e-05  // 0.00005779
+    let bdoubleValue = BDouble(doubleValue)
+    XCTAssertEqual(bdoubleValue.decimalExpansion(precisionAfterDecimalPoint: 10), "0.0000577900")
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/39002

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Checkout `ios/Swift-BigInt-bug` branch using our current v2.2.0 of `Swift-BigInt` dependency.
2. Run `BigIntTests` unit test, verify failure.
3. Checkout this branch (`ios/update-Swift-BigInt`) using our current v2.3.0 of `Swift-BigInt` dependency.
4. Run `BigIntTests` unit test, verify pass.


