### PR TITLE
Fix HostPortPair comparison (uplift to 1.67.x)

### DIFF
--- a/chromium_src/net/base/host_port_pair.h
+++ b/chromium_src/net/base/host_port_pair.h
@@ -6,6 +6,7 @@
 #ifndef BRAVE_CHROMIUM_SRC_NET_BASE_HOST_PORT_PAIR_H_
 #define BRAVE_CHROMIUM_SRC_NET_BASE_HOST_PORT_PAIR_H_
 
+#include <compare>
 #include <string>
 #include <string_view>
 
@@ -35,13 +36,13 @@ class NET_EXPORT HostPortPair : public HostPortPair_ChromiumImpl {
   static HostPortPair FromString(std::string_view str);
   static std::optional<HostPortPair> FromValue(const base::Value& value);
 
-  const std::string& username() const;
-  const std::string& password() const;
+  const std::string& username() const { return username_; }
+  const std::string& password() const { return password_; }
 
   void set_username(const std::string& username);
   void set_password(const std::string& password);
 
-  bool operator<(const HostPortPair& other) const;
+  std::strong_ordering operator<=>(const HostPortPair& other) const;
   bool operator==(const HostPortPair& other) const;
   bool Equals(const HostPortPair& other) const;
 

--- a/net/BUILD.gn
+++ b/net/BUILD.gn
@@ -1,8 +1,13 @@
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
 import("//brave/components/tor/buildflags/buildflags.gni")
 
 source_set("unit_tests") {
   testonly = true
   sources = [
+    "base/brave_host_port_pair_unittest.cc",
     "http/partitioned_host_state_map_unittest.cc",
     "http/transport_security_state_unittest.cc",
   ]

--- a/net/base/brave_host_port_pair_unittest.cc
+++ b/net/base/brave_host_port_pair_unittest.cc
@@ -1,0 +1,76 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <optional>
+
+#include "net/base/host_port_pair.h"
+#include "net/test/gtest_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace net {
+
+namespace {
+
+std::vector<HostPortPair> GetTestCasesInAccedingOrder() {
+  std::vector<HostPortPair> v;
+  v.emplace_back("a.com", 10);
+  v.emplace_back("user1", "pass1", "a.com", 10);
+  v.emplace_back("user1", "pass2", "a.com", 10);
+  v.emplace_back("user2", "pass2", "a.com", 10);
+  v.emplace_back("user2", "pass2", "b.com", 10);
+  v.emplace_back("user2", "pass2", "a.com", 11);
+  v.emplace_back("user2", "pass3", "a.com", 11);
+  v.emplace_back("c.com", 11);
+  return v;
+}
+
+}  // namespace
+
+TEST(BraveHostPortPairTest, Parsing) {
+  HostPortPair foo("user", "pass", "foo.com", 10);
+  std::string foo_str = foo.ToString();
+  EXPECT_EQ("user:pass@foo.com:10", foo_str);
+  HostPortPair bar = HostPortPair::FromString(foo_str);
+  EXPECT_EQ(bar.host(), "foo.com");
+  EXPECT_EQ(bar.port(), 10);
+  EXPECT_EQ(bar.username(), "user");
+  EXPECT_EQ(bar.password(), "pass");
+
+  EXPECT_TRUE(foo == bar) << bar.ToString();
+}
+
+TEST(BraveHostPortPairTest, Compare) {
+  const auto v = GetTestCasesInAccedingOrder();
+  // Compare each pair using < and == operators and verify the result.
+  for (size_t i = 0; i < v.size(); i++) {
+    for (size_t j = 0; j < v.size(); j++) {
+      const auto& a = v[i];
+      const auto& b = v[j];
+      SCOPED_TRACE(testing::Message()
+                   << "case " << a.ToString() << " vs " << b.ToString());
+      if (i == j) {
+        EXPECT_TRUE(a == b);
+        EXPECT_TRUE(a.Equals(b));
+      } else {
+        EXPECT_FALSE(a == b);
+        EXPECT_FALSE(a.Equals(b));
+
+        const bool expected_less = i < j;
+        EXPECT_EQ(a < b, expected_less);
+        EXPECT_EQ(b < a, !expected_less);
+      }
+    }
+  }
+}
+
+TEST(BraveHostPortPairTest, Equals) {
+  const auto v = GetTestCasesInAccedingOrder();
+  HostPortPair second_item("user1", "pass1", "a.com", 10);
+  for (size_t i = 0; i < v.size(); i++) {
+    EXPECT_EQ(v[i] == second_item, i == 1);
+  }
+}
+
+}  // namespace net


### PR DESCRIPTION
Uplift of #24167
Resolves https://github.com/brave/brave-browser/issues/36535

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.