### PR TITLE
Fixed wrong sync words count calculation

### DIFF
--- a/android/java/org/chromium/chrome/browser/BraveSyncWorker.java
+++ b/android/java/org/chromium/chrome/browser/BraveSyncWorker.java
@@ -159,12 +159,18 @@ public class BraveSyncWorker {
         BraveSyncWorkerJni.get().setJoinSyncChainCallback(mNativeBraveSyncWorker, callback);
     }
 
+    public int getWordsCount(String words) {
+        return BraveSyncWorkerJni.get().getWordsCount(words);
+    }
+
     @NativeMethods
     interface Natives {
         void init(BraveSyncWorker caller);
+
         void destroy(long nativeBraveSyncWorker);
 
         String getSyncCodeWords(long nativeBraveSyncWorker);
+
         void requestSync(long nativeBraveSyncWorker);
 
         String getSeedHexFromWords(String passphrase);
@@ -188,6 +194,8 @@ public class BraveSyncWorker {
         String getFormattedTimeDelta(long seconds);
 
         void saveCodeWords(long nativeBraveSyncWorker, String passphrase);
+
+        int getWordsCount(String words);
 
         void finalizeSyncSetup(long nativeBraveSyncWorker);
 

--- a/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSyncScreensPreference.java
@@ -22,7 +22,6 @@ import android.hardware.Camera;
 import android.os.Build;
 import android.os.Bundle;
 import android.text.Editable;
-import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.DisplayMetrics;
 import android.view.LayoutInflater;
@@ -633,34 +632,30 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
                         .show();
             }
         } else if (mConfirmCodeWordsButton == v) {
-            String[] words = mCodeWords.getText()
-                                     .toString()
-                                     .trim()
-                                     .replace("   ", " ")
-                                     .replace("\n", " ")
-                                     .split(" ");
-
-            String trimmedWords = TextUtils.join(" ", words);
-            String validationError = getWordsValidationString(trimmedWords);
+            String words = mCodeWords.getText().toString();
+            String validationError = getWordsValidationString(words);
             if (!validationError.isEmpty()) {
                 Log.e(TAG, "Confirm code words - wrong codephrase");
                 onSyncError(validationError);
                 return;
             }
 
-            String codephraseCandidate =
-                    getBraveSyncWorker().getPureWordsFromTimeLimited(trimmedWords);
+            String codephraseCandidate = getBraveSyncWorker().getPureWordsFromTimeLimited(words);
             assert codephraseCandidate != null && !codephraseCandidate.isEmpty();
 
-            showFinalSecurityWarning(FinalWarningFor.CODE_WORDS, () -> {
-                // We have the confirmation from user
-                // Code phrase looks valid, we can pass it down to sync system
-                mCodephrase = codephraseCandidate;
-                seedWordsReceived(mCodephrase, SyncInputType.JOIN);
-            }, () -> {});
+            showFinalSecurityWarning(
+                    FinalWarningFor.CODE_WORDS,
+                    () -> {
+                        // We have the confirmation from user
+                        // Code phrase looks valid, we can pass it down to sync system
+                        mCodephrase = codephraseCandidate;
+                        seedWordsReceived(mCodephrase, SyncInputType.JOIN);
+                    },
+                    () -> {});
         } else if (mEnterCodeWordsButton == v) {
-            getActivity().getWindow().setSoftInputMode(
-                    WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
+            getActivity()
+                    .getWindow()
+                    .setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
             if (null != mScrollViewSyncInitial) {
                 mScrollViewSyncInitial.setVisibility(View.GONE);
             }
@@ -684,31 +679,26 @@ public class BraveSyncScreensPreference extends BravePreferenceFragment
             }
             getActivity().setTitle(R.string.brave_sync_code_words_title);
             if (null != mCodeWords && null != mBraveSyncWordCountTitle) {
-                mCodeWords.addTextChangedListener(new TextWatcher() {
-                    @Override
-                    public void afterTextChanged(Editable s) {}
+                mCodeWords.addTextChangedListener(
+                        new TextWatcher() {
+                            @Override
+                            public void afterTextChanged(Editable s) {}
 
-                    @Override
-                    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
-                    }
+                            @Override
+                            public void beforeTextChanged(
+                                    CharSequence s, int start, int count, int after) {}
 
-                    @Override
-                    public void onTextChanged(CharSequence s, int start, int before, int count) {
-                        int wordCount = mCodeWords.getText().toString().length();
-                        if (0 != wordCount) {
-                            String[] words = mCodeWords.getText()
-                                                     .toString()
-                                                     .trim()
-                                                     .replace("   ", " ")
-                                                     .replace("\n", " ")
-                                                     .split(" ");
-                            wordCount = words.length;
-                        }
-                        mBraveSyncWordCountTitle.setText(
-                                getString(R.string.brave_sync_word_count_text, wordCount));
-                        mBraveSyncWordCountTitle.invalidate();
-                    }
-                });
+                            @Override
+                            public void onTextChanged(
+                                    CharSequence s, int start, int before, int count) {
+                                int wordCount =
+                                        getBraveSyncWorker()
+                                                .getWordsCount(mCodeWords.getText().toString());
+                                mBraveSyncWordCountTitle.setText(
+                                        getString(R.string.brave_sync_word_count_text, wordCount));
+                                mBraveSyncWordCountTitle.invalidate();
+                            }
+                        });
             }
         } else if (mShowCategoriesButton == v) {
             SettingsLauncher settingsLauncher = new SettingsLauncherImpl();

--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -40,6 +40,7 @@
 //    isInitialSyncFeatureSetupComplete
 
 using base::android::ConvertUTF8ToJavaString;
+using brave_sync::TimeLimitedWords;
 using content::BrowserThread;
 
 namespace {
@@ -407,11 +408,10 @@ int JNI_BraveSyncWorker_GetWordsValidationResult(
       base::android::ConvertJavaStringToUTF8(time_limited_words);
   DCHECK(!str_time_limited_words.empty());
 
-  auto pure_words_with_status =
-      brave_sync::TimeLimitedWords::Parse(str_time_limited_words);
+  auto pure_words_with_status = TimeLimitedWords::Parse(str_time_limited_words);
 
   if (pure_words_with_status.has_value()) {
-    using ValidationStatus = brave_sync::TimeLimitedWords::ValidationStatus;
+    using ValidationStatus = TimeLimitedWords::ValidationStatus;
     return static_cast<int>(ValidationStatus::kValid);
   }
   return static_cast<int>(pure_words_with_status.error());
@@ -425,8 +425,7 @@ JNI_BraveSyncWorker_GetPureWordsFromTimeLimited(
       base::android::ConvertJavaStringToUTF8(time_limited_words);
   DCHECK(!str_time_limited_words.empty());
 
-  auto pure_words_with_status =
-      brave_sync::TimeLimitedWords::Parse(str_time_limited_words);
+  auto pure_words_with_status = TimeLimitedWords::Parse(str_time_limited_words);
   DCHECK(pure_words_with_status.has_value());
 
   return base::android::ConvertUTF8ToJavaString(env,
@@ -440,8 +439,7 @@ static int64_t JNI_BraveSyncWorker_GetNotAfterFromFromTimeLimitedWords(
       base::android::ConvertJavaStringToUTF8(time_limited_words);
   DCHECK(!str_time_limited_words.empty());
 
-  auto not_after =
-      brave_sync::TimeLimitedWords::GetNotAfter(str_time_limited_words);
+  auto not_after = TimeLimitedWords::GetNotAfter(str_time_limited_words);
 
   return not_after.InMillisecondsSinceUnixEpoch() / 1000;
 }
@@ -501,8 +499,7 @@ JNI_BraveSyncWorker_GetTimeLimitedWordsFromPure(
       base::android::ConvertJavaStringToUTF8(pure_words);
   DCHECK(!str_pure_words.empty());
 
-  auto time_limited_words =
-      brave_sync::TimeLimitedWords::GenerateForNow(str_pure_words);
+  auto time_limited_words = TimeLimitedWords::GenerateForNow(str_pure_words);
 
   DCHECK(time_limited_words.has_value());
   return base::android::ConvertUTF8ToJavaString(env,
@@ -528,6 +525,14 @@ JNI_BraveSyncWorker_GetSeedHexFromQrJson(
   DCHECK(!GetWordsFromSeedHex(result).empty());
 
   return ConvertUTF8ToJavaString(env, result);
+}
+
+static int JNI_BraveSyncWorker_GetWordsCount(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jstring>& words) {
+  std::string str_words = base::android::ConvertJavaStringToUTF8(words);
+
+  return TimeLimitedWords::GetWordsCount(str_words);
 }
 
 }  // namespace android

--- a/browser/android/brave_sync_worker.cc
+++ b/browser/android/brave_sync_worker.cc
@@ -530,9 +530,8 @@ JNI_BraveSyncWorker_GetSeedHexFromQrJson(
 static int JNI_BraveSyncWorker_GetWordsCount(
     JNIEnv* env,
     const base::android::JavaParamRef<jstring>& words) {
-  std::string str_words = base::android::ConvertJavaStringToUTF8(words);
-
-  return TimeLimitedWords::GetWordsCount(str_words);
+  return TimeLimitedWords::GetWordsCount(
+      base::android::ConvertJavaStringToUTF8(words));
 }
 
 }  // namespace android

--- a/browser/resources/settings/brave_sync_page/brave_sync_browser_proxy.ts
+++ b/browser/resources/settings/brave_sync_page/brave_sync_browser_proxy.ts
@@ -53,6 +53,9 @@ export class BraveSyncBrowserProxy {
   permanentlyDeleteSyncAccount(): Promise<boolean>  {
     return sendWithPromise('SyncPermanentlyDeleteAccount');
   }
+  getWordsCount(syncCode: string): Promise<number> {
+    return sendWithPromise('SyncGetWordsCount', syncCode);
+  }
   static getInstance() {
     return instance || (instance = new BraveSyncBrowserProxy())
   }

--- a/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.ts
+++ b/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.ts
@@ -58,7 +58,7 @@ export class SettingsBraveSyncCodeDialogElement extends SettingsBraveSyncCodeDia
       },
       syncCodeWordCount_: {
         type: Number,
-        computed: 'computeSyncCodeWordCount_(syncCode)'
+        value: 0
       },
       hasCopiedSyncCode_: {
         type: Boolean,
@@ -74,6 +74,7 @@ export class SettingsBraveSyncCodeDialogElement extends SettingsBraveSyncCodeDia
   static get observers() {
     return [
       'getQRCode_(syncCode, codeType)',
+      'computeSyncCodeWordCount_(syncCode, codeType)',
     ];
   }
 
@@ -87,11 +88,17 @@ export class SettingsBraveSyncCodeDialogElement extends SettingsBraveSyncCodeDia
 
   syncBrowserProxy_: BraveSyncBrowserProxy = BraveSyncBrowserProxy.getInstance();
 
-  computeSyncCodeWordCount_() {
-    if (!this.syncCode) {
-      return 0
+  async computeSyncCodeWordCount_() {
+    if (this.codeType !== 'input') {
+      return
     }
-    return this.syncCode.trim().split(' ').length
+
+    if (!this.syncCode) {
+      return
+    }
+
+    this.syncCodeWordCount_ =
+      await this.syncBrowserProxy_.getWordsCount(this.syncCode)
   }
 
   isCodeType(askingType: string) {

--- a/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.ts
+++ b/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.ts
@@ -91,7 +91,7 @@ export class SettingsBraveSyncCodeDialogElement extends SettingsBraveSyncCodeDia
     if (!this.syncCode) {
       return 0
     }
-    return this.syncCode.trim().split(' ').length
+    return this.syncCode.trim().split(/\s+/).length
   }
 
   isCodeType(askingType: string) {

--- a/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.ts
+++ b/browser/resources/settings/brave_sync_page/brave_sync_code_dialog.ts
@@ -91,7 +91,7 @@ export class SettingsBraveSyncCodeDialogElement extends SettingsBraveSyncCodeDia
     if (!this.syncCode) {
       return 0
     }
-    return this.syncCode.trim().split(/\s+/).length
+    return this.syncCode.trim().split(' ').length
   }
 
   isCodeType(askingType: string) {

--- a/browser/ui/webui/settings/brave_sync_handler.cc
+++ b/browser/ui/webui/settings/brave_sync_handler.cc
@@ -92,10 +92,13 @@ void BraveSyncHandler::RegisterMessages() {
       "SyncDeleteDevice",
       base::BindRepeating(&BraveSyncHandler::HandleDeleteDevice,
                           base::Unretained(this)));
-
   web_ui()->RegisterMessageCallback(
       "SyncPermanentlyDeleteAccount",
       base::BindRepeating(&BraveSyncHandler::HandlePermanentlyDeleteAccount,
+                          base::Unretained(this)));
+  web_ui()->RegisterMessageCallback(
+      "SyncGetWordsCount",
+      base::BindRepeating(&BraveSyncHandler::HandleSyncGetWordsCount,
                           base::Unretained(this)));
 }
 
@@ -393,4 +396,14 @@ base::Value::List BraveSyncHandler::GetSyncDeviceList() {
   }
 
   return device_list;
+}
+
+void BraveSyncHandler::HandleSyncGetWordsCount(const base::Value::List& args) {
+  AllowJavascript();
+  CHECK_EQ(2U, args.size());
+  CHECK(args[1].is_string());
+  const std::string time_limited_sync_code = args[1].GetString();
+  ResolveJavascriptCallback(
+      args[0].Clone(),
+      base::Value(TimeLimitedWords::GetWordsCount(time_limited_sync_code)));
 }

--- a/browser/ui/webui/settings/brave_sync_handler.h
+++ b/browser/ui/webui/settings/brave_sync_handler.h
@@ -47,6 +47,7 @@ class BraveSyncHandler : public settings::SettingsPageUIHandler,
   void HandleReset(const base::Value::List& args);
   void HandleDeleteDevice(const base::Value::List& args);
   void HandlePermanentlyDeleteAccount(const base::Value::List& args);
+  void HandleSyncGetWordsCount(const base::Value::List& args);
 
   void OnResetDone(base::Value callback_id);
   void OnAccountPermanentlyDeleted(base::Value callback_id,

--- a/components/brave_sync/time_limited_words.cc
+++ b/components/brave_sync/time_limited_words.cc
@@ -30,6 +30,12 @@ static constexpr char kWordsv2Epoch[] = "Tue, 10 May 2022 00:00:00 GMT";
 
 static constexpr size_t kWordsV2Count = 25u;
 
+std::vector<std::string> SplitWords(const std::string& words_string) {
+  return base::SplitString(words_string, " \n\t",
+                           base::WhitespaceHandling::TRIM_WHITESPACE,
+                           base::SplitResult::SPLIT_WANT_NONEMPTY);
+}
+
 }  // namespace
 
 using base::Time;
@@ -142,9 +148,7 @@ TimeLimitedWords::ParseImpl(const std::string& time_limited_words,
 
   auto now = Time::Now();
 
-  std::vector<std::string> words = base::SplitString(
-      time_limited_words, " ", base::WhitespaceHandling::TRIM_WHITESPACE,
-      base::SplitResult::SPLIT_WANT_NONEMPTY);
+  std::vector<std::string> words = SplitWords(time_limited_words);
 
   size_t num_words = words.size();
 
@@ -214,9 +218,7 @@ std::string TimeLimitedWords::GenerateResultToText(
 // static
 base::Time TimeLimitedWords::GetNotAfter(
     const std::string& time_limited_words) {
-  std::vector<std::string> words = base::SplitString(
-      time_limited_words, " ", base::WhitespaceHandling::TRIM_WHITESPACE,
-      base::SplitResult::SPLIT_WANT_NONEMPTY);
+  std::vector<std::string> words = SplitWords(time_limited_words);
   size_t num_words = words.size();
   if (num_words != kWordsV2Count) {
     return base::Time();
@@ -245,6 +247,11 @@ base::Time TimeLimitedWords::GetNotAfter(
   DCHECK_EQ(GetRoundedDaysDiff(anchor_time, not_after - base::Seconds(1)), 1);
 
   return not_after;
+}
+
+// static
+int TimeLimitedWords::GetWordsCount(const std::string& time_limited_words) {
+  return SplitWords(time_limited_words).size();
 }
 
 }  // namespace brave_sync

--- a/components/brave_sync/time_limited_words.h
+++ b/components/brave_sync/time_limited_words.h
@@ -53,6 +53,8 @@ class TimeLimitedWords {
 
   static base::Time GetNotAfter(const std::string& time_limited_words);
 
+  static int GetWordsCount(const std::string& time_limited_words);
+
  private:
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, GenerateForDate);
   FRIEND_TEST_ALL_PREFIXES(TimeLimitedWordsTest, GetIndexByWord);

--- a/components/brave_sync/time_limited_words_unittest.cc
+++ b/components/brave_sync/time_limited_words_unittest.cc
@@ -261,4 +261,18 @@ TEST(TimeLimitedWordsTest, GetNotAfterForPureWords) {
   EXPECT_EQ(TimeLimitedWords::GetNotAfter(kValidSyncCode), base::Time());
 }
 
+TEST(TimeLimitedWordsTest, GetWordsCount) {
+  // Normal flow
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount(kValidSyncCode), 24);
+  // Empty case
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount(""), 0);
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount("   "), 0);
+  // STR from desktop issue
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount("d  d"), 2);
+  // Previousely failed case
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount("a\nb\tc"), 3);
+  // Additional leading and trailing whitespaces
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount(" \n \t A   B \t"), 2);
+}
+
 }  // namespace brave_sync

--- a/components/brave_sync/time_limited_words_unittest.cc
+++ b/components/brave_sync/time_limited_words_unittest.cc
@@ -266,10 +266,10 @@ TEST(TimeLimitedWordsTest, GetWordsCount) {
   EXPECT_EQ(TimeLimitedWords::GetWordsCount(kValidSyncCode), 24);
   // Empty case
   EXPECT_EQ(TimeLimitedWords::GetWordsCount(""), 0);
-  EXPECT_EQ(TimeLimitedWords::GetWordsCount("   "), 0);
+  EXPECT_EQ(TimeLimitedWords::GetWordsCount(" \n\t"), 0);
   // STR from desktop issue
   EXPECT_EQ(TimeLimitedWords::GetWordsCount("d  d"), 2);
-  // Previousely failed case
+  // Previously failed case
   EXPECT_EQ(TimeLimitedWords::GetWordsCount("a\nb\tc"), 3);
   // Additional leading and trailing whitespaces
   EXPECT_EQ(TimeLimitedWords::GetWordsCount(" \n \t A   B \t"), 2);


### PR DESCRIPTION
At this PR:
- sync words count calculation moved from UI into `TimeLimitedWords`;
- updated Desktop and Android UI to use `TimeLimitedWords::GetWordsCount`;
- fixed cases when words were counted in a wrong way - when there were 3 spaces between words or 3 new lines.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39010
Maybe resolves https://github.com/brave/brave-browser/issues/38745

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
#### Android

1. Open Sync screen
2. `Scan or enter sync code` button
3. `Enter code words`
4. Type `d<space><space><space><space><space><space>d`
Expected `Words count: 2`
5. Type:
```
d<enter>
<enter>
<enter>
d
```
Expected `Words count: 2`

#### Desktop
1. Open brave://settings/braveSync , press `Start using sync` 
2. Press `I have a Sync Code`
3. Type `d<space><space>d`
 Expected `Words count: 2`
4. Type:
```
d<enter>
d
```
Expected `Words count: 2`
5. Type `d<paste tab char from other text editor>d`
Expected `Words count: 2`
