### PR TITLE
[iOS] Update `unknown` secure status copy & color (uplift to 1.67.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/PageSecurityView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/PageSecurityView.swift
@@ -20,14 +20,43 @@ struct PageSecurityView: View {
 
   @Environment(\.pixelLength) private var pixelLength
 
-  private var warningTitle: String {
+  @ViewBuilder private var warningIcon: some View {
+    switch secureState {
+    case .secure, .localhost:
+      EmptyView()
+    case .unknown:
+      Image(braveSystemName: "leo.info.filled")
+        .foregroundColor(Color(braveSystemName: .systemfeedbackWarningIcon))
+    case .invalidCert, .missingSSL, .mixedContent:
+      Image(braveSystemName: "leo.warning.triangle-filled")
+        .foregroundColor(Color(braveSystemName: .systemfeedbackErrorIcon))
+    }
+  }
+
+  @ViewBuilder private var warningTitle: some View {
+    switch secureState {
+    case .secure, .localhost:
+      EmptyView()
+    case .unknown:
+      Text(Strings.PageSecurityView.pageUnknownStatusTitle)
+        .foregroundColor(Color(braveSystemName: .systemfeedbackWarningText))
+    case .invalidCert, .missingSSL:
+      Text(Strings.PageSecurityView.pageNotSecureTitle)
+        .foregroundColor(Color(braveSystemName: .systemfeedbackErrorText))
+    case .mixedContent:
+      Text(Strings.PageSecurityView.pageNotFullySecureTitle)
+        .foregroundColor(Color(braveSystemName: .systemfeedbackErrorText))
+    }
+  }
+
+  private var warningBody: String {
     switch secureState {
     case .secure, .localhost:
       return ""
-    case .unknown, .invalidCert, .missingSSL:
-      return Strings.PageSecurityView.pageNotSecureTitle
-    case .mixedContent:
-      return Strings.PageSecurityView.pageNotFullySecureTitle
+    case .unknown:
+      return Strings.PageSecurityView.pageUnknownStatusWarning
+    case .invalidCert, .missingSSL, .mixedContent:
+      return Strings.PageSecurityView.pageNotSecureDetailedWarning
     }
   }
 
@@ -38,12 +67,10 @@ struct PageSecurityView: View {
           .font(.headline)
           .foregroundStyle(Color(braveSystemName: .textPrimary))
         HStack(alignment: .firstTextBaseline) {
-          Image(braveSystemName: "leo.warning.triangle-filled")
-            .foregroundColor(Color(braveSystemName: .systemfeedbackErrorIcon))
+          warningIcon
           VStack(alignment: .leading, spacing: 4) {
-            Text(warningTitle)
-              .foregroundColor(Color(braveSystemName: .systemfeedbackErrorText))
-            Text(Strings.PageSecurityView.pageNotSecureDetailedWarning)
+            warningTitle
+            Text(warningBody)
               .foregroundColor(Color(braveSystemName: .textTertiary))
               .font(.footnote)
           }

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -1097,6 +1097,20 @@ extension Strings {
 // MARK: - PageSecurityView.swift
 extension Strings {
   public enum PageSecurityView {
+    public static let pageUnknownStatusTitle = NSLocalizedString(
+      "pageSecurityView.pageUnknownStatusTitle",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Site connection not verified.",
+      comment: ""
+    )
+    public static let pageUnknownStatusWarning = NSLocalizedString(
+      "pageSecurityView.pageUnknownStatusWarning",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Your connection to this site could not be fully verified. You may proceed, or try reloading the page to establish a secure connection.",
+      comment: ""
+    )
     public static let pageNotSecureTitle = NSLocalizedString(
       "pageSecurityView.pageNotSecureTitle",
       tableName: "BraveShared",


### PR DESCRIPTION
Uplift of #24187
Resolves https://github.com/brave/brave-browser/issues/38671

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.