### PR TITLE
[FullscreenReminder] Add "Show full screen reminder to press Esc on exit" option in settings page

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1473,6 +1473,9 @@
   <message name="IDS_SETTINGS_CLOSING_LAST_TAB_OPTION_LABEL" desc="The text for settings option">
     Close window when closing last tab
   </message>
+  <message name="IDS_SETTINGS_SHOW_FULLSCREEN_REMINDER_OPTION_LABEL" desc="The text for fullscreen reminder settings option">
+    Show full screen reminder to press Esc on exit
+  </message>
 
   <!-- Settings / Leo Assistant -->
   <message name="IDS_SETTINGS_LEO_ASSISTANT" desc="Title for an item in the 'Leo Assistant' section of Brave Settings">

--- a/browser/brave_browser_features.h
+++ b/browser/brave_browser_features.h
@@ -17,8 +17,8 @@ BASE_DECLARE_FEATURE(kBraveCleanupSessionCookiesOnSessionRestore);
 BASE_DECLARE_FEATURE(kBraveCopyCleanLinkByDefault);
 BASE_DECLARE_FEATURE(kBraveOverrideDownloadDangerLevel);
 BASE_DECLARE_FEATURE(kBraveWebViewRoundedCorners);
-
 BASE_DECLARE_FEATURE(kBraveDayZeroExperiment);
+
 extern const base::FeatureParam<std::string> kBraveDayZeroExperimentVariant;
 
 }  // namespace features

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -461,6 +461,7 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 base::Value(true));
   registry->RegisterBooleanPref(kEnableWindowClosingConfirm, true);
   registry->RegisterBooleanPref(kEnableClosingLastTab, true);
+  registry->RegisterBooleanPref(kShowFullscreenReminder, true);
 
   brave_tabs::RegisterBraveProfilePrefs(registry);
 

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -239,6 +239,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[kEnableClosingLastTab] =
       settings_api::PrefType::kBoolean;
+  (*s_brave_allowlist)[kShowFullscreenReminder] =
+      settings_api::PrefType::kBoolean;
   // Hangouts pref
   (*s_brave_allowlist)[kHangoutsEnabled] = settings_api::PrefType::kBoolean;
   // IPFS Companion pref

--- a/browser/resources/settings/brave_overrides/system_page.ts
+++ b/browser/resources/settings/brave_overrides/system_page.ts
@@ -105,6 +105,17 @@ RegisterPolymerTemplateModifications({
     )
     // </if>
 
+    templateContent.appendChild(
+      html`
+        <settings-toggle-button
+          class="cr-row"
+          pref="{{prefs.brave.show_fullscreen_reminder}}"
+          label="${loadTimeData.getString('braveShowFullscreenReminder')}"
+        >
+        </settings-toggle-button>
+      `
+    )
+
     // <if expr="enable_brave_vpn_wireguard">
     let showVpnPage = loadTimeData.getBoolean('isBraveVPNEnabled')
     // <if expr="is_macosx">

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -400,6 +400,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       {"braveClosingLastTab", IDS_SETTINGS_CLOSING_LAST_TAB_OPTION_LABEL},
       {"braveDisableClickableMuteIndicators",
        IDS_SETTINGS_DISABLE_CLICKABLE_MUTE_INDICATORS},
+      {"braveShowFullscreenReminder",
+       IDS_SETTINGS_SHOW_FULLSCREEN_REMINDER_OPTION_LABEL},
 
       // Leo Assistant Page
       {"leoAssistant", IDS_SETTINGS_LEO_ASSISTANT},

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.cc
@@ -17,6 +17,7 @@
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
+#include "brave/components/constants/pref_names.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/views/frame/browser_view_layout.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
@@ -33,9 +34,11 @@
 #define SidePanelCoordinator BraveSidePanelCoordinator
 #define BookmarkBarView BraveBookmarkBarView
 #define ContentsLayoutManager BraveContentsLayoutManager
+#define UpdateExclusiveAccessBubble UpdateExclusiveAccessBubble_ChromiumImpl
 
 #include "src/chrome/browser/ui/views/frame/browser_view.cc"
 
+#undef UpdateExclusiveAccessBubble
 #undef ContentsLayoutManager
 #undef BookmarkBarView
 #undef SidePanelCoordinator
@@ -57,4 +60,18 @@ void BrowserView::SetNativeWindowPropertyForWidget(views::Widget* widget) {
       << "The |widget| should be child of BrowserView's widget.";
 
   widget->SetNativeWindowProperty(kBrowserViewKey, this);
+}
+
+void BrowserView::UpdateExclusiveAccessBubble(
+    const ExclusiveAccessBubbleParams& params,
+    ExclusiveAccessBubbleHideCallback first_hide_callback) {
+  // Show/Hide full screen reminder bubble based on our settings preference
+  // for tab-initiated ones.
+  if (!GetProfile()->GetPrefs()->GetBoolean(kShowFullscreenReminder) &&
+      params.type == EXCLUSIVE_ACCESS_BUBBLE_TYPE_FULLSCREEN_EXIT_INSTRUCTION) {
+    return;
+  }
+
+  UpdateExclusiveAccessBubble_ChromiumImpl(params,
+                                           std::move(first_hide_callback));
 }

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view.h
@@ -11,6 +11,7 @@
 #include "brave/browser/ui/views/frame/brave_browser_view_layout.h"
 #include "brave/browser/ui/views/side_panel/brave_side_panel.h"
 #include "build/build_config.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_context.h"
 #include "chrome/browser/ui/views/side_panel/side_panel.h"
 
 #define BrowserViewLayoutDelegateImpl \
@@ -33,6 +34,12 @@
   GetTabSearchBubbleHost_Unused(); \
   virtual TabSearchBubbleHost* GetTabSearchBubbleHost
 
+#define UpdateExclusiveAccessBubble                           \
+  UpdateExclusiveAccessBubble_ChromiumImpl(                   \
+      const ExclusiveAccessBubbleParams& params,              \
+      ExclusiveAccessBubbleHideCallback first_hide_callback); \
+  void UpdateExclusiveAccessBubble
+
 #if BUILDFLAG(IS_WIN)
 #define GetSupportsTitle virtual GetSupportsTitle
 
@@ -52,6 +59,7 @@
 #undef GetSupportsTitle
 #endif
 
+#undef UpdateExclusiveAccessBubble
 #undef GetTabSearchBubbleHost
 #undef GetTabStripVisible
 #undef UpdateDevToolsForContents

--- a/components/constants/pref_names.h
+++ b/components/constants/pref_names.h
@@ -123,6 +123,8 @@ inline constexpr char kSafetynetStatus[] = "safetynet.status";
 inline constexpr char kEnableWindowClosingConfirm[] =
     "brave.enable_window_closing_confirm";
 inline constexpr char kEnableClosingLastTab[] = "brave.enable_closing_last_tab";
+inline constexpr char kShowFullscreenReminder[] =
+    "brave.show_fullscreen_reminder";
 #endif
 
 inline constexpr char kDefaultBrowserLaunchingCount[] =


### PR DESCRIPTION
- Add an option to Show/Hide `fullscreen reminder to press Esc on exit` message when going fullscreen on videos.
- Add feature flag for the same which is disabled by default.


Note: This PR does not intend to hide the `To exit fullscreen, press F11` bubble from this preference.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38928

Outcome:
![image](https://github.com/brave/brave-core/assets/45998266/b6bcc371-f8ef-4e29-b475-09c47c48b378)


https://github.com/brave/brave-core/assets/45998266/0fad3302-4f1b-43e8-af84-cca38404fe49




<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used GitHub [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See https://github.com/brave/brave-browser/issues/38928