### PR TITLE
[ads] Implement iOS aggressive mode support for search ad attribution

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -433,10 +433,17 @@ extension BrowserViewController: WKNavigationDelegate {
           return (.cancel, preferences)
         }
 
+        let domain = Domain.getOrCreate(forUrl: requestURL, persistent: !isPrivateBrowsing)
+        let adsBlockingShieldUp = domain.isShieldExpected(
+          .adblockAndTp,
+          considerAllShieldsOption: true
+        )
         tab?.braveSearchResultAdManager = BraveSearchResultAdManager(
           url: requestURL,
           rewards: rewards,
-          isPrivateBrowsing: isPrivateBrowsing
+          isPrivateBrowsing: isPrivateBrowsing,
+          isAggressiveAdsBlocking: domain.blockAdsAndTrackingLevel.isAggressive
+            && adsBlockingShieldUp
         )
       }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
@@ -15,9 +15,9 @@ class BraveSearchResultAdManager: NSObject {
 
   private var searchResultAds = [String: BraveAds.SearchResultAdInfo]()
 
-  init?(url: URL, rewards: BraveRewards, isPrivateBrowsing: Bool) {
-    if !BraveAds.shouldSupportSearchResultAds() || !BraveSearchManager.isValidURL(url)
-      || isPrivateBrowsing
+  init?(url: URL, rewards: BraveRewards, isPrivateBrowsing: Bool, isAggressiveAdsBlocking: Bool) {
+    if isPrivateBrowsing || isAggressiveAdsBlocking || !BraveSearchManager.isValidURL(url)
+      || !BraveAds.shouldSupportSearchResultAds()
     {
       return nil
     }


### PR DESCRIPTION
Do not trigger ad events if `Trackers and Ads Blocking` is set to `Aggressive` and shields for `search.brave.com` is up.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36969

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Fresh install
* Enable features `ShouldAlwaysRunBraveAdsService` and `ShouldAlwaysTriggerBraveSearchResultAdEvents`
* Trigger brave search ad
EXPECTATION: Brave ad viewed event is triggered. There should be log entry:
`[ads] Viewed search result ad impression with placement id # and creative instance id #`

* Open `Settings -> Shields & Privacy` and change `Trackers & Ads Blocking` value to Aggressive
* Trigger brave search ad
EXPECTATION: Brave ad viewed event is not triggered. There should NOT be log entry:
`[ads] Viewed search result ad impression with placement id # and creative instance id #`

* Open Brave Shields panel for search.brave.com by tapping Brave icon
* Disable `Brave Shields` for search.brave.com with Brave Shields toggle
* Trigger brave search ad
EXPECTATION: Brave ad viewed event is triggered. There should be log entry:
`[ads] Viewed search result ad impression with placement id # and creative instance id #`

* Open Brave Shields panel for search.brave.com by tapping Brave icon
* Re-enabled `Brave Shields` for search.brave.com with `Brave Shields` toggle
* Disable `Trackers & Ads Blocking` for search.brave.com with `Trackers & Ads Blocking` toggle
* Trigger brave search ad
EXPECTATION: Brave ad viewed event is triggered. There should be log entry:
`[ads] Viewed search result ad impression with placement id # and creative instance id #`
