### PR TITLE
[iOS] - Remove Claude Instant Strings and Rename Llama 13B (#23911)

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -211,20 +211,60 @@ extension Strings {
       comment:
         "The model and creator for intro message - Mixstral is the model name -- Mistral AI is the creator"
     )
-    public static let introMessageClaudeInstantModelDescription = NSLocalizedString(
-      "aichat.introMessageClaudeInstantModelDescription",
+    public static let introMessageClaudeHaikuModelDescription = NSLocalizedString(
+      "aichat.introMessageClaudeHaikuModelDescription",
       tableName: "BraveLeo",
       bundle: .module,
-      value: "Claude Instant by Anthropic",
+      value: "Claude Haiku by Anthropic",
       comment:
-        "The model and creator for intro message - Claude Instant is the model -- Anthropic is the creator"
+        "The model and creator for intro message - Claude Haiku is the model -- Anthropic is the creator"
+    )
+    public static let introMessageClaudeSonnetModelDescription = NSLocalizedString(
+      "aichat.introMessageClaudeSonnetModelDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Claude Sonnet by Anthropic",
+      comment:
+        "The model and creator for intro message - Claude Sonnet is the model -- Anthropic is the creator"
+    )
+    public static let introMessageLlamaModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageLlamaModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "General purpose chat",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageMixtralModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageMixtralModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Advanced chat tasks",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageClaudeHaikuModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageClaudeHaikuModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Lightning fast chat",
+      comment:
+        "The model's purpose - Describes what it can do best"
+    )
+    public static let introMessageClaudeSonnetModelPurposeDescription = NSLocalizedString(
+      "aichat.introMessageClaudeSonnetModelPurposeDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Balanced speed and intelligence",
+      comment:
+        "The model's purpose - Describes what it can do best"
     )
     public static let introMessageLlamaMessageDescription = NSLocalizedString(
       "aichat.introMessageLlamaMessageDescription",
       tableName: "BraveLeo",
       bundle: .module,
       value:
-        "Hi, I'm Leo. I'm a fully hosted AI assistant by Brave. I'm powered by Llama 13B, a model created by Meta to be performant and applicable to many use cases.",
+        "Hi, I'm Leo. I'm a fully hosted AI assistant by Brave. I'm powered by Llama 3 8B, a model created by Meta to be performant and applicable to many use cases.",
       comment: "The model intro message when you first enter the chat assistant"
     )
     public static let introMessageMixtralMessageDescription = NSLocalizedString(
@@ -235,12 +275,20 @@ extension Strings {
         "Hi, I'm Leo. I'm a fully hosted AI assistant by Brave. I'm powered by Mixtral 8x7B, a model created by Mistral AI to handle advanced tasks.",
       comment: "The model intro message when you first enter the chat assistant"
     )
-    public static let introMessageClaudeInstantMessageDescription = NSLocalizedString(
-      "aichat.introMessageClaudeInstantMessageDescription",
+    public static let introMessageClaudeHaikuMessageDescription = NSLocalizedString(
+      "aichat.introMessageClaudeHaikuMessageDescription",
       tableName: "BraveLeo",
       bundle: .module,
       value:
-        "Hi, I'm Leo. I'm proxied by Brave and powered by Claude Instant, a model created by Anthropic to power conversational and text processing tasks.",
+        "Hi, I'm Leo. I'm proxied by Brave and powered by Claude 3 Haiku, a model created by Anthropic to power conversational and text processing tasks.",
+      comment: "The model intro message when you first enter the chat assistant"
+    )
+    public static let introMessageClaudeSonnetMessageDescription = NSLocalizedString(
+      "aichat.introMessageClaudeSonnetMessageDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Hi, I'm Leo. I'm proxied by Brave and powered by Claude 3 Sonnet, a model created by Anthropic to power conversational and text processing tasks.",
       comment: "The model intro message when you first enter the chat assistant"
     )
     public static let introMessageGenericMessageDescription = NSLocalizedString(

--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatIntroMessageView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatIntroMessageView.swift
@@ -13,7 +13,8 @@ struct AIChatIntroMessageView: View {
   private enum ModelKey: String {
     case chatBasic = "chat-basic"
     case chatExpanded = "chat-leo-expanded"
-    case chatClaudeInstant = "chat-claude-instant"
+    case chatClaudeHaiku = "chat-claude-haiku"
+    case chatClaudeSonnet = "chat-claude-sonnet"
   }
 
   private var modelDescription: String {
@@ -28,8 +29,11 @@ struct AIChatIntroMessageView: View {
     case .chatExpanded:
       return Strings.AIChat.introMessageMixtralModelDescription
 
-    case .chatClaudeInstant:
-      return Strings.AIChat.introMessageClaudeInstantModelDescription
+    case .chatClaudeHaiku:
+      return Strings.AIChat.introMessageClaudeHaikuModelDescription
+
+    case .chatClaudeSonnet:
+      return Strings.AIChat.introMessageClaudeSonnetModelDescription
     }
   }
 
@@ -45,8 +49,11 @@ struct AIChatIntroMessageView: View {
     case .chatExpanded:
       return Strings.AIChat.introMessageMixtralMessageDescription
 
-    case .chatClaudeInstant:
-      return Strings.AIChat.introMessageClaudeInstantMessageDescription
+    case .chatClaudeHaiku:
+      return Strings.AIChat.introMessageClaudeHaikuMessageDescription
+
+    case .chatClaudeSonnet:
+      return Strings.AIChat.introMessageClaudeSonnetMessageDescription
     }
   }
 

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatMenuView.swift
@@ -227,6 +227,26 @@ struct AIChatMenuView: View {
     }
   }
 
+  private func modelPurpose(for model: AiChat.Model) -> String {
+    guard let modelKey = AIChatModelKey(rawValue: model.key) else {
+      return model.displayMaker
+    }
+
+    switch modelKey {
+    case .chatBasic:
+      return Strings.AIChat.introMessageLlamaModelPurposeDescription
+
+    case .chatExpanded:
+      return Strings.AIChat.introMessageMixtralModelPurposeDescription
+
+    case .chatClaudeHaiku:
+      return Strings.AIChat.introMessageClaudeHaikuModelPurposeDescription
+
+    case .chatClaudeSonnet:
+      return Strings.AIChat.introMessageClaudeSonnetModelPurposeDescription
+    }
+  }
+
   func menuActionItems(for menuOption: AIChatMenuOptionTypes) -> some View {
     Button {
       if menuOption == .goPremium, !BraveStoreSDK.shared.isLeoProductsLoaded {

--- a/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
+++ b/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
@@ -10,6 +10,13 @@ import Shared
 import SwiftUI
 import WebKit
 
+public enum AIChatModelKey: String {
+  case chatBasic = "chat-basic"
+  case chatExpanded = "chat-leo-expanded"
+  case chatClaudeHaiku = "chat-claude-haiku"
+  case chatClaudeSonnet = "chat-claude-sonnet"
+}
+
 public class AIChatViewModel: NSObject, ObservableObject {
   private var api: AIChat!
   private weak var webView: WKWebView?


### PR DESCRIPTION
- Remove ClaudeInstant.
- Rename Llama 13B to Llama 3 8B.

<!-- Add brave-browser issue below that this PR will resolve -->

Uplift of https://github.com/brave/brave-core/pull/23911
Resolves https://github.com/brave/brave-browser/issues/37988
Resolves https://github.com/brave/brave-browser/issues/38071

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="281" alt="image" src="https://github.com/brave/brave-core/assets/1530031/883afdc0-50c6-456e-8de0-cdb497326210">
