### PR TITLE
fix(wallet): Editing non-eth networks will trigger eth_chainId request. 

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/NetworkStore.swift
@@ -405,7 +405,7 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
     _ network: BraveWallet.NetworkInfo
   ) async -> (accepted: Bool, errMsg: String) {
     isAddingNewNetwork = true
-    if allChains.filter({ $0.coin == .eth }).contains(where: {
+    if allChains.contains(where: {
       $0.id.lowercased() == network.id.lowercased()
     }) {
       let removeStatus = await rpcService.removeChain(chainId: network.chainId, coin: network.coin)
@@ -418,7 +418,7 @@ public class NetworkStore: ObservableObject, WalletObserverStore {
       let (_, addStatus, errMsg) = await rpcService.addChain(network)
       guard addStatus == .success else {
         // if adding is not succeeded, we have to add back the old network info
-        if let oldNetwork = allChains.filter({ $0.coin == .eth }).first(where: {
+        if let oldNetwork = allChains.first(where: {
           $0.id.lowercased() == network.id.lowercased()
         }) {
           let (_, addOldStatus, _) = await rpcService.addChain(oldNetwork)

--- a/ios/brave-ios/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Panels/Add Suggested Network/SuggestedNetworkView.swift
@@ -197,7 +197,9 @@ struct SuggestedNetworkView: View {
               .padding(.vertical, 6)
             }
             Button {
-              isPresentingNetworkDetails = .init(from: chain, mode: .view)
+              isPresentingNetworkDetails = .init(
+                mode: .view(chain)
+              )
             } label: {
               Text(Strings.Wallet.viewDetails)
                 .foregroundColor(Color(.braveBlurpleTint))

--- a/ios/brave-ios/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -666,7 +666,7 @@ struct NetworkDetailsView: View {
       )
     case .edit(let editNetwork):
       network = .init(
-        chainId: editNetwork.chainId,  // chain id is not editable in edit mode
+        chainId: editNetwork.coin == .eth ? chainIdInHex : editNetwork.chainId,
         chainName: model.networkName.input,
         blockExplorerUrls: blockExplorerUrls,
         iconUrls: iconUrls,

--- a/ios/brave-ios/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/CustomNetworkDetailsView.swift
@@ -50,16 +50,30 @@ struct NetworkTextField: View {
 class NetworkModel: ObservableObject, Identifiable {
   enum Mode {
     case add
-    case edit
-    case view
+    case edit(_ network: BraveWallet.NetworkInfo)
+    case view(_ network: BraveWallet.NetworkInfo)
 
-    var isEditMode: Bool { self == .edit }
-    var isViewMode: Bool { self == .view }
+    var isEditMode: Bool {
+      switch self {
+      case .add, .view(_):
+        return false
+      case .edit(_):
+        return true
+      }
+    }
+    var isViewMode: Bool {
+      switch self {
+      case .add, .edit(_):
+        return false
+      case .view(_):
+        return true
+      }
+    }
   }
 
-  var mode: Mode = .add
+  let mode: Mode
   var id: String {
-    "\(mode.isEditMode)"
+    "\(mode.isEditMode)\(mode.isViewMode)"
   }
 
   @Published var networkId = NetworkInputItem(input: "") {
@@ -130,10 +144,14 @@ class NetworkModel: ObservableObject, Identifiable {
           if item.input.isEmpty && item.error == nil {  // no validation on new entry
             hasNewEntry = true
           } else {
-            if URIFixup.getURL(item.input) == nil {
-              rpcUrls[index].error = Strings.Wallet.customNetworkInvalidAddressErrMsg
+            if let url = URIFixup.getURL(item.input) {
+              if url.isSecureWebPage() {
+                rpcUrls[index].error = nil
+              } else {
+                rpcUrls[index].error = Strings.Wallet.customNetworkNotSecureErrMsg
+              }
             } else {
-              rpcUrls[index].error = nil
+              rpcUrls[index].error = Strings.Wallet.customNetworkInvalidAddressErrMsg
             }
           }
         }
@@ -154,10 +172,14 @@ class NetworkModel: ObservableObject, Identifiable {
           if item.input.isEmpty && item.error == nil {  // no validation on new entry
             hasNewEntry = true
           } else {
-            if URIFixup.getURL(item.input) == nil {
-              iconUrls[index].error = Strings.Wallet.customNetworkInvalidAddressErrMsg
+            if let url = URIFixup.getURL(item.input) {
+              if url.isSecureWebPage() {
+                iconUrls[index].error = nil
+              } else {
+                iconUrls[index].error = Strings.Wallet.customNetworkNotSecureErrMsg
+              }
             } else {
-              iconUrls[index].error = nil
+              iconUrls[index].error = Strings.Wallet.customNetworkInvalidAddressErrMsg
             }
           }
         }
@@ -178,10 +200,14 @@ class NetworkModel: ObservableObject, Identifiable {
           if item.input.isEmpty && item.error == nil {  // no validation on new entry
             hasNewEntry = true
           } else {
-            if URIFixup.getURL(item.input) == nil {
-              blockUrls[index].error = Strings.Wallet.customNetworkInvalidAddressErrMsg
+            if let url = URIFixup.getURL(item.input) {
+              if url.isSecureWebPage() {
+                blockUrls[index].error = nil
+              } else {
+                blockUrls[index].error = Strings.Wallet.customNetworkNotSecureErrMsg
+              }
             } else {
-              blockUrls[index].error = nil
+              blockUrls[index].error = Strings.Wallet.customNetworkInvalidAddressErrMsg
             }
           }
         }
@@ -193,50 +219,59 @@ class NetworkModel: ObservableObject, Identifiable {
     }
   }
 
-  /// Creates model for adding a new custom network
-  init() {
-    self.mode = .add
-  }
-
   /// Creates model and populates the details based on a custom network and mode
-  init(from network: BraveWallet.NetworkInfo, mode: Mode = .edit) {
+  init(mode: Mode = .add) {
     self.mode = mode
 
-    let chainIdInDecimal: String
-    if let intValue = Int(network.chainId.removingHexPrefix, radix: 16) {
-      // BraveWallet.NetworkInfo.chainId should always in hex
-      chainIdInDecimal = "\(intValue)"
-    } else {
-      chainIdInDecimal = network.chainId
+    var network: BraveWallet.NetworkInfo?
+    switch mode {
+    case .add:
+      break
+    case .edit(let editNetwork):
+      network = editNetwork
+    case .view(let viewNetwork):
+      network = viewNetwork
     }
-    self.networkId.input = chainIdInDecimal
-    self.networkName.input = network.chainName
-    self.networkSymbolName.input = network.symbolName
-    self.networkSymbol.input = network.symbol
-    self.networkDecimals.input = String(network.decimals)
-    if !network.rpcEndpoints.isEmpty {
-      var result: [NetworkInputItem] = []
-      for (index, endpoint) in network.rpcEndpoints.enumerated() {
-        result.append(
-          NetworkInputItem(
-            input: endpoint.absoluteString,
-            isSelected: index == network.activeRpcEndpointIndex
-          )
-        )
+
+    if let network {
+      let chainIdInDecimal: String
+      if network.coin == .eth,
+        let intValue = Int(network.chainId.removingHexPrefix, radix: 16)
+      {
+        // Eth and EVM BraveWallet.NetworkInfo.chainId should always in hex
+        chainIdInDecimal = "\(intValue)"
+      } else {
+        chainIdInDecimal = network.chainId
       }
-      self.rpcUrls = result
-    } else if mode.isViewMode {
-      self.rpcUrls = []
-    }
-    if !network.iconUrls.isEmpty {
-      self.iconUrls = network.iconUrls.compactMap({ NetworkInputItem(input: $0) })
-    } else if mode.isViewMode {
-      self.iconUrls = []
-    }
-    if !network.blockExplorerUrls.isEmpty {
-      self.blockUrls = network.blockExplorerUrls.compactMap({ NetworkInputItem(input: $0) })
-    } else if mode.isViewMode {
-      self.blockUrls = []
+      self.networkId.input = chainIdInDecimal
+      self.networkName.input = network.chainName
+      self.networkSymbolName.input = network.symbolName
+      self.networkSymbol.input = network.symbol
+      self.networkDecimals.input = String(network.decimals)
+      if !network.rpcEndpoints.isEmpty {
+        var result: [NetworkInputItem] = []
+        for (index, endpoint) in network.rpcEndpoints.enumerated() {
+          result.append(
+            NetworkInputItem(
+              input: endpoint.absoluteString,
+              isSelected: index == network.activeRpcEndpointIndex
+            )
+          )
+        }
+        self.rpcUrls = result
+      } else if mode.isViewMode {
+        self.rpcUrls = []
+      }
+      if !network.iconUrls.isEmpty {
+        self.iconUrls = network.iconUrls.compactMap({ NetworkInputItem(input: $0) })
+      } else if mode.isViewMode {
+        self.iconUrls = []
+      }
+      if !network.blockExplorerUrls.isEmpty {
+        self.blockUrls = network.blockExplorerUrls.compactMap({ NetworkInputItem(input: $0) })
+      } else if mode.isViewMode {
+        self.blockUrls = []
+      }
     }
   }
 }
@@ -275,6 +310,7 @@ struct NetworkDetailsView: View {
   @Environment(\.presentationMode) @Binding private var presentationMode
 
   @State private var customNetworkError: CustomNetworkError?
+  @State private var isPresentingEditConfirmation: Bool = false
 
   init(
     networkStore: NetworkStore,
@@ -292,6 +328,17 @@ struct NetworkDetailsView: View {
     }
   }
 
+  private var isChainIdInputDisabled: Bool {
+    switch model.mode {
+    case .add:
+      return false
+    case .edit(let editNetwork):
+      return editNetwork.coin != .eth
+    case .view(_):
+      return true
+    }
+  }
+
   var body: some View {
     Form {
       Section(
@@ -299,7 +346,8 @@ struct NetworkDetailsView: View {
       ) {
         networkTextField(
           placeholder: Strings.Wallet.customNetworkChainIdPlaceholder,
-          item: $model.networkId
+          item: $model.networkId,
+          isDisabled: isChainIdInputDisabled
         )
         .keyboardType(.numberPad)
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -309,7 +357,8 @@ struct NetworkDetailsView: View {
       ) {
         networkTextField(
           placeholder: Strings.Wallet.customNetworkChainNamePlaceholder,
-          item: $model.networkName
+          item: $model.networkName,
+          isDisabled: model.mode.isViewMode
         )
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
@@ -318,7 +367,8 @@ struct NetworkDetailsView: View {
       ) {
         networkTextField(
           placeholder: Strings.Wallet.customNetworkSymbolNamePlaceholder,
-          item: $model.networkSymbolName
+          item: $model.networkSymbolName,
+          isDisabled: model.mode.isViewMode
         )
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
@@ -327,7 +377,8 @@ struct NetworkDetailsView: View {
       ) {
         networkTextField(
           placeholder: Strings.Wallet.customNetworkSymbolPlaceholder,
-          item: $model.networkSymbol
+          item: $model.networkSymbol,
+          isDisabled: model.mode.isViewMode
         )
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
       }
@@ -336,7 +387,8 @@ struct NetworkDetailsView: View {
       ) {
         networkTextField(
           placeholder: Strings.Wallet.customNetworkCurrencyDecimalPlaceholder,
-          item: $model.networkDecimals
+          item: $model.networkDecimals,
+          isDisabled: model.mode.isViewMode
         )
         .keyboardType(.numberPad)
         .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -349,7 +401,8 @@ struct NetworkDetailsView: View {
             networkTextField(
               placeholder: Strings.Wallet.customNetworkUrlsPlaceholder,
               item: $url,
-              showRadioButton: true
+              showRadioButton: true,
+              isDisabled: model.mode.isViewMode
             )
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -362,7 +415,8 @@ struct NetworkDetailsView: View {
           ForEach($model.iconUrls) { $url in
             networkTextField(
               placeholder: Strings.Wallet.customNetworkUrlsPlaceholder,
-              item: $url
+              item: $url,
+              isDisabled: model.mode.isViewMode
             )
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -377,7 +431,8 @@ struct NetworkDetailsView: View {
           ForEach($model.blockUrls) { $url in
             networkTextField(
               placeholder: Strings.Wallet.customNetworkUrlsPlaceholder,
-              item: $url
+              item: $url,
+              isDisabled: model.mode.isViewMode
             )
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
@@ -394,7 +449,11 @@ struct NetworkDetailsView: View {
             ProgressView()
           } else {
             Button {
-              addCustomNetwork()
+              if model.mode.isEditMode {
+                isPresentingEditConfirmation = true
+              } else {
+                addCustomNetwork()
+              }
             } label: {
               Text(Strings.Wallet.saveButtonTitle)
                 .foregroundColor(Color(.braveBlurpleTint))
@@ -424,12 +483,31 @@ struct NetworkDetailsView: View {
           }
         )
     )
+    .background(
+      Color.clear
+        .alert(
+          isPresented: $isPresentingEditConfirmation,
+          content: {
+            Alert(
+              title: Text(Strings.Wallet.editExistingNetworkAlertMsg),
+              primaryButton: .default(
+                Text(Strings.OKString),
+                action: {
+                  addCustomNetwork()
+                }
+              ),
+              secondaryButton: .cancel()
+            )
+          }
+        )
+    )
   }
 
   @ViewBuilder private func networkTextField(
     placeholder: String,
     item: Binding<NetworkInputItem>,
-    showRadioButton: Bool = false
+    showRadioButton: Bool = false,
+    isDisabled: Bool
   ) -> some View {
     HStack {
       if showRadioButton {
@@ -446,7 +524,7 @@ struct NetworkDetailsView: View {
           }
         )
       }
-      if model.mode.isViewMode {
+      if isDisabled {
         Text(item.wrappedValue.input)
           .contextMenu {
             Button {
@@ -486,12 +564,13 @@ struct NetworkDetailsView: View {
       }
     }
 
+    let activeRpcURL = model.rpcUrls.first(where: { $0.isSelected })
     if model.networkId.error != nil
       || model.networkName.error != nil
       || model.networkSymbolName.error != nil
       || model.networkSymbol.error != nil
       || model.networkDecimals.error != nil
-      || model.rpcUrls.filter({ !$0.input.isEmpty && $0.error == nil }).isEmpty
+      || activeRpcURL?.error != nil
     {
       return false
     }
@@ -543,20 +622,41 @@ struct NetworkDetailsView: View {
       }
     })
     let activeRpcEndpointIndex = model.rpcUrls.firstIndex(where: { $0.isSelected }) ?? 0
-    let network: BraveWallet.NetworkInfo = .init(
-      chainId: chainIdInHex,
-      chainName: model.networkName.input,
-      blockExplorerUrls: blockExplorerUrls,
-      iconUrls: iconUrls,
-      activeRpcEndpointIndex: Int32(activeRpcEndpointIndex),
-      rpcEndpoints: rpcEndpoints,
-      symbol: model.networkSymbol.input,
-      symbolName: model.networkSymbol.input,
-      decimals: Int32(model.networkDecimals.input) ?? 18,
-      coin: .eth,
-      supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:))
-    )
+    var network: BraveWallet.NetworkInfo?
+    switch model.mode {
+    case .add:
+      network = .init(
+        chainId: chainIdInHex,
+        chainName: model.networkName.input,
+        blockExplorerUrls: blockExplorerUrls,
+        iconUrls: iconUrls,
+        activeRpcEndpointIndex: Int32(activeRpcEndpointIndex),
+        rpcEndpoints: rpcEndpoints,
+        symbol: model.networkSymbol.input,
+        symbolName: model.networkSymbol.input,
+        decimals: Int32(model.networkDecimals.input) ?? 18,
+        coin: .eth,
+        supportedKeyrings: [BraveWallet.KeyringId.default.rawValue].map(NSNumber.init(value:))
+      )
+    case .edit(let editNetwork):
+      network = .init(
+        chainId: editNetwork.chainId,  // chain id is not editable in edit mode
+        chainName: model.networkName.input,
+        blockExplorerUrls: blockExplorerUrls,
+        iconUrls: iconUrls,
+        activeRpcEndpointIndex: Int32(activeRpcEndpointIndex),
+        rpcEndpoints: rpcEndpoints,
+        symbol: model.networkSymbol.input,
+        symbolName: model.networkSymbol.input,
+        decimals: Int32(model.networkDecimals.input) ?? editNetwork.decimals,
+        coin: editNetwork.coin,
+        supportedKeyrings: editNetwork.supportedKeyrings
+      )
+    case .view(_):
+      break
+    }
     Task { @MainActor in
+      guard let network else { return }
       let (accepted, errMsg) = await networkStore.addCustomNetwork(network)
       guard accepted else {
         customNetworkError = .failed(errorMessage: errMsg)

--- a/ios/brave-ios/Sources/BraveWallet/Settings/NetworkListView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Settings/NetworkListView.swift
@@ -42,7 +42,9 @@ struct NetworkListView: View {
 
   @ViewBuilder func networkRow(_ network: BraveWallet.NetworkInfo) -> some View {
     Button {
-      isPresentingNetworkDetails = .init(from: network)
+      isPresentingNetworkDetails = .init(
+        mode: .edit(network)
+      )
     } label: {
       HStack {
         VStack(alignment: .leading, spacing: 4) {
@@ -99,7 +101,9 @@ struct NetworkListView: View {
           Menu {
             VStack {
               Button {
-                isPresentingNetworkDetails = .init(from: network)
+                isPresentingNetworkDetails = .init(
+                  mode: .edit(network)
+                )
               } label: {
                 Text(Strings.Wallet.editButtonTitle)
               }

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -2436,6 +2436,14 @@ extension Strings {
       comment:
         "The error message for the input field when users input an invalid address for a custom network in Custom Network Details Screen."
     )
+    public static let customNetworkNotSecureErrMsg = NSLocalizedString(
+      "wallet.customNetworkNotSecureErrMsg",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Not secure.",
+      comment:
+        "The error message for the input field when users input an unsecure address for a custom network in Custom Network Details Screen."
+    )
     public static let customNetworkIconUrlsTitle = NSLocalizedString(
       "wallet.customNetworkIconUrlsTitle",
       tableName: "BraveWallet",
@@ -5565,6 +5573,14 @@ extension Strings {
       value: "Only %@ extended keys are supported.",
       comment:
         "The label displayed in Add Account above the private key box when adding or importing a Bitcoin account. The '%@' is the standard supported for the selected network (for example \"Only zprv extended keys are supported.\")"
+    )
+    public static let editExistingNetworkAlertMsg = NSLocalizedString(
+      "wallet.editExistingNetworkAlertMsg",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Do you want to update the existing network?",
+      comment:
+        "A pop up message that will prompt to user before user confirms to edit the existing network."
     )
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38972
Some hardcoding to eth specific values are removed.
Some UI/UX improvement for user to edit existing networks.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/38972)for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Check view network info via dapp requesting add-chain request (nothing is editable; long tap trigger opens copy option)
2. Check add new evm network is still working as expected
3. Check if chain id is disabled for editing exiting non-eth networks
4. Check if edit existing network is working as expected (we now have a popup to confirm editing the existing network)
5. Set up proxy to sniff network requests. Edit a non-eth network by change an active rpc endpoint. You should see no `eth_chainId` request made with that new rpc endpoint. 
