### PR TITLE
#14278-CI-issue-fix

### DIFF
--- a/browser/net/brave_network_audit_allowed_lists.h
+++ b/browser/net/brave_network_audit_allowed_lists.h
@@ -86,6 +86,17 @@ inline constexpr const char* kAllowedUrlPatterns[] = {
     "https://mobile-data-dev.s3.brave.software/superreferrer/map-table.json",
 };
 
+inline constexpr const char* kRewardsRelatedDomains[] = {
+    "https://ledger.mercury.basicattentiontoken.org/",
+    "https://ledger-staging.mercury.basicattentiontoken.org/",
+    "https://balance.mercury.basicattentiontoken.org/",
+    "https://balance-staging.mercury.basicattentiontoken.org/",
+    "https://publishers.basicattentiontoken.org/",
+    "https://publishers-staging.basicattentiontoken.org/",
+    "https://publishers-distro.basicattentiontoken.org/",
+    "https://publishers-staging-distro.basicattentiontoken.org/"
+};
+
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_NET_BRAVE_NETWORK_AUDIT_ALLOWED_LISTS_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
### Resolves
Added CI script to check for rewards requests before rewards opt-in.
Link to the issue : https://github.com/brave/brave-browser/issues/14278
@diracdeltas  @kjozwiak  @iefremov  , please check the PR
### Methodology
- First I found out , the rewards related domains from : https://github.com/brave/brave-core/blob/9f2edc372ea22440dc382bfca758d3536dfbe022/build/commands/lib/whitelistedUrlPrefixes.js
- Modified "[brave_network_audit_browsertest.cc]" , to add a browsertest which starts the browser, navigates to twitter/github/youtube/reddit/etc. pages, and then fails if any rewards domains are found in the network log.
<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

