### PR TITLE
[iOS] - Fix history search not filtering

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/History/HistoryView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/History/HistoryView.swift
@@ -62,122 +62,123 @@ struct HistoryView: View {
   private var timer: Timer?
 
   var body: some View {
-    if model.items.isEmpty {
-      HistoryEmptyStateView(
-        details: .init(
-          title: Preferences.Privacy.privateBrowsingOnly.value
-            ? Strings.History.historyPrivateModeOnlyStateTitle
-            : Strings.History.historyEmptyStateTitle,
-          icon: UIImage(named: "emptyHistory", in: .module, compatibleWith: nil)
-        )
-      )
-      .navigationTitle(Strings.historyScreenTitle)
-    } else {
-      List {
-        ForEach(model.items.elements, id: \.key) { section, nodes in
-          Section {
-            ForEach(nodes, id: \.self) { node in
-              Button {
-                model.handleHistoryItemSelection(.selectTab, node: node)
-              } label: {
-                HistoryItemView(title: node.title ?? "", url: node.url)
-              }
-              .contextMenu(menuItems: {
-                Button {
-                  model.handleHistoryItemSelection(.openInNewTab, node: node)
-                } label: {
-                  Text(Strings.openNewTabButtonTitle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
-                  Image(systemName: "plus.square.on.square")
-                }
-
-                if !model.isPrivateBrowsing {
-                  Button {
-                    model.handleHistoryItemSelection(.openInNewPrivateTab, node: node)
-                  } label: {
-                    Text(Strings.openNewPrivateTabButtonTitle)
-                      .frame(maxWidth: .infinity, alignment: .leading)
-                      .fixedSize(horizontal: false, vertical: true)
-                    Image(systemName: "plus.square.fill.on.square.fill")
-                  }
-                }
-
-                Divider()
-
-                Button {
-                  model.handleHistoryItemSelection(.copyLink, node: node)
-                } label: {
-                  Text(Strings.copyLinkActionTitle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
-                  Image(systemName: "doc.on.doc")
-                }
-
-                Button {
-                  model.handleHistoryItemSelection(.shareLink, node: node)
-                } label: {
-                  Text(Strings.shareLinkActionTitle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .fixedSize(horizontal: false, vertical: true)
-                  Image(systemName: "square.and.arrow.up")
-                }
-              })
-            }
-            .onDelete {
-              self.delete($0, in: section)
-            }
-          } header: {
-            Text(section.title)
-              .font(.headline)
-              .frame(maxWidth: .infinity, alignment: .leading)
-              .fixedSize(horizontal: false, vertical: true)
-              .foregroundStyle(Color(braveSystemName: .textPrimary))
-          }
-        }
-      }
-      .listStyle(.plain)
-      .searchable(
-        text: $searchText,
-        placement: .navigationBarDrawer(displayMode: .always),
-        prompt: Strings.History.historySearchBarTitle
-      )
-      .onChange(of: searchText) { searchText in
-        self.timer?.invalidate()
-        self.timer = Timer(
-          timeInterval: 0.1,
-          repeats: false,
-          block: { [weak model] timer in
-            timer.invalidate()
-            model?.refreshHistory(query: searchText)
-          }
-        )
-      }
-      .toolbar {
-        Button {
-          deleteAllAlertPresented = true
-        } label: {
-          Label {
-            Text(Strings.History.historyClearActionTitle)
-          } icon: {
-            Image(braveSystemName: "leo.trash")
-          }
-          .labelStyle(.iconOnly)
-        }
-      }
-      .alert(isPresented: $deleteAllAlertPresented) {
-        Alert(
-          title: Text(Strings.History.historyClearAlertTitle),
-          message: Text(Strings.History.historyClearAlertDescription),
-          dismissButton: .destructive(
-            Text(Strings.History.historyClearActionTitle),
-            action: {
-              model.deleteAll()
-            }
+    VStack(spacing: 0.0) {
+      if model.items.isEmpty {
+        HistoryEmptyStateView(
+          details: .init(
+            title: Preferences.Privacy.privateBrowsingOnly.value
+              ? Strings.History.historyPrivateModeOnlyStateTitle
+              : Strings.History.historyEmptyStateTitle,
+            icon: UIImage(named: "emptyHistory", in: .module, compatibleWith: nil)
           )
         )
+      } else {
+        List {
+          ForEach(model.items.elements, id: \.key) { section, nodes in
+            Section {
+              ForEach(nodes, id: \.self) { node in
+                Button {
+                  model.handleHistoryItemSelection(.selectTab, node: node)
+                } label: {
+                  HistoryItemView(title: node.title ?? "", url: node.url)
+                }
+                .contextMenu(menuItems: {
+                  Button {
+                    model.handleHistoryItemSelection(.openInNewTab, node: node)
+                  } label: {
+                    Text(Strings.openNewTabButtonTitle)
+                      .frame(maxWidth: .infinity, alignment: .leading)
+                      .fixedSize(horizontal: false, vertical: true)
+                    Image(systemName: "plus.square.on.square")
+                  }
+
+                  if !model.isPrivateBrowsing {
+                    Button {
+                      model.handleHistoryItemSelection(.openInNewPrivateTab, node: node)
+                    } label: {
+                      Text(Strings.openNewPrivateTabButtonTitle)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                      Image(systemName: "plus.square.fill.on.square.fill")
+                    }
+                  }
+
+                  Divider()
+
+                  Button {
+                    model.handleHistoryItemSelection(.copyLink, node: node)
+                  } label: {
+                    Text(Strings.copyLinkActionTitle)
+                      .frame(maxWidth: .infinity, alignment: .leading)
+                      .fixedSize(horizontal: false, vertical: true)
+                    Image(systemName: "doc.on.doc")
+                  }
+
+                  Button {
+                    model.handleHistoryItemSelection(.shareLink, node: node)
+                  } label: {
+                    Text(Strings.shareLinkActionTitle)
+                      .frame(maxWidth: .infinity, alignment: .leading)
+                      .fixedSize(horizontal: false, vertical: true)
+                    Image(systemName: "square.and.arrow.up")
+                  }
+                })
+              }
+              .onDelete {
+                self.delete($0, in: section)
+              }
+            } header: {
+              Text(section.title)
+                .font(.headline)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(Color(braveSystemName: .textPrimary))
+            }
+          }
+        }
+        .listStyle(.plain)
+        .toolbar {
+          Button {
+            deleteAllAlertPresented = true
+          } label: {
+            Label {
+              Text(Strings.History.historyClearActionTitle)
+            } icon: {
+              Image(braveSystemName: "leo.trash")
+            }
+            .labelStyle(.iconOnly)
+          }
+        }
+        .alert(isPresented: $deleteAllAlertPresented) {
+          Alert(
+            title: Text(Strings.History.historyClearAlertTitle),
+            message: Text(Strings.History.historyClearAlertDescription),
+            dismissButton: .destructive(
+              Text(Strings.History.historyClearActionTitle),
+              action: {
+                model.deleteAll()
+              }
+            )
+          )
+        }
       }
-      .navigationTitle(Strings.historyScreenTitle)
+    }
+    .navigationTitle(Strings.historyScreenTitle)
+    .searchable(
+      text: $searchText,
+      placement: .navigationBarDrawer(displayMode: .always),
+      prompt: Strings.History.historySearchBarTitle
+    )
+    .onChange(of: searchText) { searchText in
+      self.timer?.invalidate()
+      self.timer = Timer.scheduledTimer(
+        withTimeInterval: 0.1,
+        repeats: false,
+        block: { [weak model] timer in
+          timer.invalidate()
+          model?.refreshHistory(query: searchText)
+        }
+      )
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix a bug in HistorySearch when there are no results, the search bar disappears.
- Fix the timer not triggering the search at a delayed time.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39114

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:


https://github.com/brave/brave-core/assets/1530031/2c0d1785-6612-4072-80d3-fd8d948d3087

