### PR TITLE
Ad coefficient update for last seen ad

### DIFF
--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/inline_content_ads/eligible_inline_content_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/inline_content_ads/eligible_inline_content_ads_v2_unittest.cc
@@ -41,9 +41,8 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAds) {
   // Arrange
   CreativeInlineContentAdList creative_ads;
 
-  CreativeInlineContentAdInfo creative_ad_1 =
+  const CreativeInlineContentAdInfo creative_ad_1 =
       test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
-  creative_ad_1.segment = "untargeted";
   creative_ads.push_back(creative_ad_1);
 
   CreativeInlineContentAdInfo creative_ad_2 =

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/inline_content_ads/eligible_inline_content_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/inline_content_ads/eligible_inline_content_ads_v2_unittest.cc
@@ -42,63 +42,73 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAds) {
   CreativeInlineContentAdList creative_ads;
 
   CreativeInlineContentAdInfo creative_ad_1 =
-      test::BuildCreativeInlineContentAd(/*should_generate_random_uuids=*/true);
-  creative_ad_1.segment = "foo-bar1";
+      test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
+  creative_ad_1.segment = "untargeted";
   creative_ads.push_back(creative_ad_1);
 
   CreativeInlineContentAdInfo creative_ad_2 =
-      test::BuildCreativeInlineContentAd(/*should_generate_random_uuids=*/true);
-  creative_ad_2.segment = "foo-bar3";
+      test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
+  creative_ad_2.segment = "parent";
   creative_ads.push_back(creative_ad_2);
+
+  CreativeInlineContentAdInfo creative_ad_3 =
+      test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
+  creative_ad_3.segment = "parent-child";
+  creative_ads.push_back(creative_ad_3);
 
   database::SaveCreativeInlineContentAds(creative_ads);
 
   // Act & Assert
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
-  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::SizeIs(1)));
+  EXPECT_CALL(callback, Run(CreativeInlineContentAdList{creative_ad_1}));
   eligible_ads_->GetForUserModel(
       UserModelInfo{
-          IntentUserModelInfo{SegmentList{"foo-bar1", "foo-bar2"}},
+          IntentUserModelInfo{},
           LatentInterestUserModelInfo{},
-          InterestUserModelInfo{SegmentList{"foo-bar3"}},
+          InterestUserModelInfo{SegmentList{"untargeted"}},
       },
       /*dimensions=*/"200x100", callback.Get());
 }
 
-TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAdsForNoSegments) {
+TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAdsForNoMatchingSegments) {
   // Arrange
   CreativeInlineContentAdList creative_ads;
 
   CreativeInlineContentAdInfo creative_ad_1 =
-      test::BuildCreativeInlineContentAd(/*should_generate_random_uuids=*/true);
-  creative_ad_1.segment = "foo";
+      test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
+  creative_ad_1.segment = "parent";
   creative_ads.push_back(creative_ad_1);
 
   CreativeInlineContentAdInfo creative_ad_2 =
-      test::BuildCreativeInlineContentAd(/*should_generate_random_uuids=*/true);
-  creative_ad_2.segment = "foo-bar";
+      test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
+  creative_ad_2.segment = "parent-child";
   creative_ads.push_back(creative_ad_2);
 
   database::SaveCreativeInlineContentAds(creative_ads);
 
   // Act & Assert
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
-  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::SizeIs(1)));
+  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
   eligible_ads_->GetForUserModel(/*user_model=*/{}, /*dimensions=*/"200x100",
                                  callback.Get());
 }
 
 TEST_F(BraveAdsEligibleInlineContentAdsV2Test,
        DoNotGetAdsForNonExistentDimensions) {
+  // Arrange
+  CreativeInlineContentAdList creative_ads;
+
+  const CreativeInlineContentAdInfo creative_ad =
+      test::BuildCreativeInlineContentAd(/*should_use_random_uuids=*/true);
+  creative_ads.push_back(creative_ad);
+
+  database::SaveCreativeInlineContentAds(creative_ads);
+
   // Act & Assert
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
   EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
-  eligible_ads_->GetForUserModel(
-      UserModelInfo{
-          IntentUserModelInfo{SegmentList{"intent-foo", "intent-bar"}},
-          LatentInterestUserModelInfo{},
-          InterestUserModelInfo{SegmentList{"interest-foo", "interest-bar"}}},
-      /*dimensions=*/"?x?", callback.Get());
+  eligible_ads_->GetForUserModel(UserModelInfo{},
+                                 /*dimensions=*/"?x?", callback.Get());
 }
 
 TEST_F(BraveAdsEligibleInlineContentAdsV2Test, DoNotGetAdsIfNoEligibleAds) {
@@ -107,9 +117,9 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test, DoNotGetAdsIfNoEligibleAds) {
   EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
   eligible_ads_->GetForUserModel(
       UserModelInfo{
-          IntentUserModelInfo{SegmentList{"intent-foo", "intent-bar"}},
+          IntentUserModelInfo{SegmentList{"parent-child", "parent"}},
           LatentInterestUserModelInfo{},
-          InterestUserModelInfo{SegmentList{"interest-foo", "interest-bar"}}},
+          InterestUserModelInfo{SegmentList{"parent-child", "parent"}}},
       /*dimensions=*/"200x100", callback.Get());
 }
 

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/new_tab_page_ads/eligible_new_tab_page_ads_v2_unittest.cc
@@ -40,9 +40,8 @@ TEST_F(BraveAdsEligibleNewTabPageAdsV2Test, GetAds) {
   // Arrange
   CreativeNewTabPageAdList creative_ads;
 
-  CreativeNewTabPageAdInfo creative_ad_1 =
+  const CreativeNewTabPageAdInfo creative_ad_1 =
       test::BuildCreativeNewTabPageAd(/*should_use_random_uuids=*/true);
-  creative_ad_1.segment = "untargeted";
   creative_ads.push_back(creative_ad_1);
 
   CreativeNewTabPageAdInfo creative_ad_2 =

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/notification_ads/eligible_notification_ads_v2_unittest.cc
@@ -41,13 +41,13 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test, GetAds) {
   CreativeNotificationAdList creative_ads;
 
   CreativeNotificationAdInfo creative_ad_1 =
-      test::BuildCreativeNotificationAd(/*should_generate_random_uuids=*/true);
-  creative_ad_1.segment = "foo-bar1";
+      test::BuildCreativeNotificationAd(/*should_use_random_uuids=*/true);
+  creative_ad_1.segment = "parent-child-1";
   creative_ads.push_back(creative_ad_1);
 
   CreativeNotificationAdInfo creative_ad_2 =
-      test::BuildCreativeNotificationAd(/*should_generate_random_uuids=*/true);
-  creative_ad_2.segment = "foo-bar3";
+      test::BuildCreativeNotificationAd(/*should_use_random_uuids=*/true);
+  creative_ad_2.segment = "parent-child-3";
   creative_ads.push_back(creative_ad_2);
 
   database::SaveCreativeNotificationAds(creative_ads);
@@ -56,31 +56,32 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test, GetAds) {
   base::MockCallback<EligibleAdsCallback<CreativeNotificationAdList>> callback;
   EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::SizeIs(1)));
   eligible_ads_->GetForUserModel(
-      UserModelInfo{IntentUserModelInfo{SegmentList{"foo-bar1", "foo-bar2"}},
-                    LatentInterestUserModelInfo{},
-                    InterestUserModelInfo{SegmentList{"foo-bar3"}}},
+      UserModelInfo{
+          IntentUserModelInfo{SegmentList{"parent-child-1", "parent-child-2"}},
+          LatentInterestUserModelInfo{},
+          InterestUserModelInfo{SegmentList{"parent-child-3"}}},
       callback.Get());
 }
 
-TEST_F(BraveAdsEligibleNotificationAdsV2Test, GetAdsForNoSegments) {
+TEST_F(BraveAdsEligibleNotificationAdsV2Test, GetAdsForNoMatchingSegments) {
   // Arrange
   CreativeNotificationAdList creative_ads;
 
   CreativeNotificationAdInfo creative_ad_1 =
-      test::BuildCreativeNotificationAd(/*should_generate_random_uuids=*/true);
-  creative_ad_1.segment = "foo";
+      test::BuildCreativeNotificationAd(/*should_use_random_uuids=*/true);
+  creative_ad_1.segment = "parent";
   creative_ads.push_back(creative_ad_1);
 
   CreativeNotificationAdInfo creative_ad_2 =
-      test::BuildCreativeNotificationAd(/*should_generate_random_uuids=*/true);
-  creative_ad_2.segment = "foo-bar";
+      test::BuildCreativeNotificationAd(/*should_use_random_uuids=*/true);
+  creative_ad_2.segment = "parent-child";
   creative_ads.push_back(creative_ad_2);
 
   database::SaveCreativeNotificationAds(creative_ads);
 
   // Act & Assert
   base::MockCallback<EligibleAdsCallback<CreativeNotificationAdList>> callback;
-  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::SizeIs(1)));
+  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
   eligible_ads_->GetForUserModel(/*user_model=*/{}, callback.Get());
 }
 
@@ -90,9 +91,9 @@ TEST_F(BraveAdsEligibleNotificationAdsV2Test, DoNotGetAdsIfNoEligibleAds) {
   EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
   eligible_ads_->GetForUserModel(
       UserModelInfo{
-          IntentUserModelInfo{SegmentList{"intent-foo", "intent-bar"}},
+          IntentUserModelInfo{SegmentList{"parent-child", "parent"}},
           LatentInterestUserModelInfo{},
-          InterestUserModelInfo{SegmentList{"interest-foo", "interest-bar"}}},
+          InterestUserModelInfo{SegmentList{"parent-child", "parent"}}},
       callback.Get());
 }
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_ad_model_based_predictor_util_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_ad_model_based_predictor_util_unittest.cc
@@ -81,7 +81,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorUtilTest,
       .value = false;
   expected_creative_ad_predictor_1.input_variable.interest_segment
       .parent_matches.value = true;
-  expected_creative_ad_predictor_1.score = 3.0;
+  expected_creative_ad_predictor_1.score = 2.0;
   expected_creative_ad_predictors.push_back(expected_creative_ad_predictor_1);
 
   CreativeAdModelBasedPredictorInfo<CreativeNotificationAdInfo>
@@ -101,7 +101,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorUtilTest,
       .parent_matches.value = false;
   expected_creative_ad_predictor_2.input_variable.last_seen_ad.value =
       base::Hours(3);
-  expected_creative_ad_predictor_2.score = 0.125;
+  expected_creative_ad_predictor_2.score = 0.0;
   expected_creative_ad_predictors.push_back(expected_creative_ad_predictor_2);
 
   CreativeAdModelBasedPredictorInfo<CreativeNotificationAdInfo>
@@ -119,7 +119,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorUtilTest,
       .value = true;
   expected_creative_ad_predictor_3.input_variable.interest_segment
       .parent_matches.value = true;
-  expected_creative_ad_predictor_3.score = 3.0;
+  expected_creative_ad_predictor_3.score = 2.0;
   expected_creative_ad_predictors.push_back(expected_creative_ad_predictor_3);
 
   EXPECT_EQ(expected_creative_ad_predictors, creative_ad_predictors);

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_inline_content_ad_model_based_predictor_feature.h
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_inline_content_ad_model_based_predictor_feature.h
@@ -48,7 +48,7 @@ inline constexpr base::FeatureParam<double>
 inline constexpr base::FeatureParam<double>
     kInlineContentAdLastSeenPredictorWeight{
         &kCreativeInlineContentAdModelBasedPredictorFeature,
-        "last_seen_ad_predictor_weight", 1.0};
+        "last_seen_ad_predictor_weight", 0.0};
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_inline_content_ad_model_based_predictor_feature_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_inline_content_ad_model_based_predictor_feature_unittest.cc
@@ -268,7 +268,7 @@ TEST(BraveAdsCreativeInlineContentAdModelBasedPredictorFeatureTest,
 TEST(BraveAdsCreativeInlineContentAdModelBasedPredictorFeatureTest,
      DefaultLastSeenAdPredictorWeight) {
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, kInlineContentAdLastSeenPredictorWeight.Get());
+  EXPECT_DOUBLE_EQ(0.0, kInlineContentAdLastSeenPredictorWeight.Get());
 }
 
 TEST(BraveAdsCreativeInlineContentAdModelBasedPredictorFeatureTest,
@@ -279,7 +279,7 @@ TEST(BraveAdsCreativeInlineContentAdModelBasedPredictorFeatureTest,
       kCreativeInlineContentAdModelBasedPredictorFeature);
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, kInlineContentAdLastSeenPredictorWeight.Get());
+  EXPECT_DOUBLE_EQ(0.0, kInlineContentAdLastSeenPredictorWeight.Get());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_new_tab_page_ad_model_based_predictor_feature.h
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_new_tab_page_ad_model_based_predictor_feature.h
@@ -48,7 +48,7 @@ inline constexpr base::FeatureParam<double>
 inline constexpr base::FeatureParam<double>
     kNewTabPageAdLastSeenPredictorWeight{
         &kCreativeNewTabPageAdModelBasedPredictorFeature,
-        "last_seen_ad_predictor_weight", 1.0};
+        "last_seen_ad_predictor_weight", 0.0};
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_new_tab_page_ad_model_based_predictor_feature_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_new_tab_page_ad_model_based_predictor_feature_unittest.cc
@@ -256,7 +256,7 @@ TEST(BraveAdsCreativeNewTabPageAdModelBasedPredictorFeatureTest,
 TEST(BraveAdsCreativeNewTabPageAdModelBasedPredictorFeatureTest,
      DefaultLastSeenAdPredictorWeight) {
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, kNewTabPageAdLastSeenPredictorWeight.Get());
+  EXPECT_DOUBLE_EQ(0.0, kNewTabPageAdLastSeenPredictorWeight.Get());
 }
 
 TEST(BraveAdsCreativeNewTabPageAdModelBasedPredictorFeatureTest,
@@ -267,7 +267,7 @@ TEST(BraveAdsCreativeNewTabPageAdModelBasedPredictorFeatureTest,
       kCreativeNewTabPageAdModelBasedPredictorFeature);
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, kNewTabPageAdLastSeenPredictorWeight.Get());
+  EXPECT_DOUBLE_EQ(0.0, kNewTabPageAdLastSeenPredictorWeight.Get());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_notification_ad_model_based_predictor_feature.h
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_notification_ad_model_based_predictor_feature.h
@@ -48,7 +48,7 @@ inline constexpr base::FeatureParam<double>
 inline constexpr base::FeatureParam<double>
     kNotificationAdLastSeenPredictorWeight{
         &kCreativeNotificationAdModelBasedPredictorFeature,
-        "last_seen_ad_predictor_weight", 1.0};
+        "last_seen_ad_predictor_weight", 0.0};
 
 }  // namespace brave_ads
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/creative_notification_ad_model_based_predictor_feature_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/creative_notification_ad_model_based_predictor_feature_unittest.cc
@@ -264,7 +264,7 @@ TEST(BraveAdsCreativeNotificationAdModelBasedPredictorFeatureTest,
 TEST(BraveAdsCreativeNotificationAdModelBasedPredictorFeatureTest,
      DefaultLastSeenAdPredictorWeight) {
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, kNotificationAdLastSeenPredictorWeight.Get());
+  EXPECT_DOUBLE_EQ(0.0, kNotificationAdLastSeenPredictorWeight.Get());
 }
 
 TEST(BraveAdsCreativeNotificationAdModelBasedPredictorFeatureTest,
@@ -275,7 +275,7 @@ TEST(BraveAdsCreativeNotificationAdModelBasedPredictorFeatureTest,
       kCreativeNotificationAdModelBasedPredictorFeature);
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, kNotificationAdLastSeenPredictorWeight.Get());
+  EXPECT_DOUBLE_EQ(0.0, kNotificationAdLastSeenPredictorWeight.Get());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/prediction/model_based/input_variable/last_seen/creative_ad_model_based_predictor_last_seen_input_variable_info.h
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/input_variable/last_seen/creative_ad_model_based_predictor_last_seen_input_variable_info.h
@@ -18,7 +18,7 @@ struct CreativeAdModelBasedPredictorLastSeenInputVariableInfo final {
 
   // The time delta since the last time the user saw an ad.
   std::optional<base::TimeDelta> value;
-  double weight = 1.0;
+  double weight = 0.0;
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/prediction/model_based/scoring/creative_ad_model_based_predictor_scoring_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/scoring/creative_ad_model_based_predictor_scoring_unittest.cc
@@ -46,7 +46,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorScoringTest,
           test::BuildCreativeAdModelBasedPredictorWeights());
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(3.2916666666666665,
+  EXPECT_DOUBLE_EQ(3.0,
                    ComputeCreativeAdModelBasedPredictorScore(input_variable));
 }
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/scoring/last_seen/creative_ad_model_based_predictor_last_seen_scoring_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/scoring/last_seen/creative_ad_model_based_predictor_last_seen_scoring_unittest.cc
@@ -21,8 +21,7 @@ TEST(BraveAdsCreativeAdModelBasedPredictorLastSeenScoringTest,
   last_seen_input_variable.value = base::Hours(7);
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(0.29166666666666669,
-                   ComputeLastSeenScore(last_seen_input_variable));
+  EXPECT_DOUBLE_EQ(0.0, ComputeLastSeenScore(last_seen_input_variable));
 }
 
 TEST(BraveAdsCreativeAdModelBasedPredictorLastSeenScoringTest,
@@ -32,7 +31,7 @@ TEST(BraveAdsCreativeAdModelBasedPredictorLastSeenScoringTest,
       last_seen_input_variable;
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, ComputeLastSeenScore(last_seen_input_variable));
+  EXPECT_DOUBLE_EQ(0.0, ComputeLastSeenScore(last_seen_input_variable));
 }
 
 TEST(BraveAdsCreativeAdModelBasedPredictorLastSeenScoringTest,
@@ -43,7 +42,7 @@ TEST(BraveAdsCreativeAdModelBasedPredictorLastSeenScoringTest,
   last_seen_input_variable.value = base::Days(1) + base::Milliseconds(1);
 
   // Act & Assert
-  EXPECT_DOUBLE_EQ(1.0, ComputeLastSeenScore(last_seen_input_variable));
+  EXPECT_DOUBLE_EQ(0.0, ComputeLastSeenScore(last_seen_input_variable));
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_ad_model_based_predictor_weights_builder_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_ad_model_based_predictor_weights_builder_unittest.cc
@@ -36,7 +36,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorWeightsBuilderTest,
   expected_weights.interest_segment.child = 0.0;
   expected_weights.interest_segment.parent = 0.0;
   expected_weights.untargeted_segment = 0.0001;
-  expected_weights.last_seen_ad = 1.0;
+  expected_weights.last_seen_ad = 0.0;
   EXPECT_EQ(expected_weights, weights);
 }
 
@@ -59,7 +59,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorWeightsBuilderTest,
   expected_weights.interest_segment.child = 0.0;
   expected_weights.interest_segment.parent = 0.0;
   expected_weights.untargeted_segment = 0.0001;
-  expected_weights.last_seen_ad = 1.0;
+  expected_weights.last_seen_ad = 0.0;
   EXPECT_EQ(expected_weights, weights);
 }
 
@@ -82,7 +82,7 @@ TEST_F(BraveAdsCreativeAdModelBasedPredictorWeightsBuilderTest,
   expected_weights.interest_segment.child = 1.0;
   expected_weights.interest_segment.parent = 1.0;
   expected_weights.untargeted_segment = 0.0001;
-  expected_weights.last_seen_ad = 1.0;
+  expected_weights.last_seen_ad = 0.0;
   EXPECT_EQ(expected_weights, weights);
 }
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_inline_content_ad_model_based_predictor_weights_builder_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_inline_content_ad_model_based_predictor_weights_builder_unittest.cc
@@ -30,7 +30,7 @@ TEST_F(BraveAdsCreativeInlineContentAdModelBasedPredictorWeightsBuilderTest,
   expected_weights.interest_segment.child = 0.0;
   expected_weights.interest_segment.parent = 0.0;
   expected_weights.untargeted_segment = 0.0001;
-  expected_weights.last_seen_ad = 1.0;
+  expected_weights.last_seen_ad = 0.0;
   EXPECT_EQ(expected_weights, weights);
 }
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_new_tab_page_ad_model_based_predictor_weights_builder_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_new_tab_page_ad_model_based_predictor_weights_builder_unittest.cc
@@ -30,7 +30,7 @@ TEST_F(BraveAdsCreativeNewTabPageAdModelBasedPredictorWeightsBuilderTest,
   expected_weights.interest_segment.child = 0.0;
   expected_weights.interest_segment.parent = 0.0;
   expected_weights.untargeted_segment = 0.0001;
-  expected_weights.last_seen_ad = 1.0;
+  expected_weights.last_seen_ad = 0.0;
   EXPECT_EQ(expected_weights, weights);
 }
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_notification_ad_model_based_predictor_weights_builder_unittest.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/weight/creative_notification_ad_model_based_predictor_weights_builder_unittest.cc
@@ -30,7 +30,7 @@ TEST_F(BraveAdsCreativeNotificationAdModelBasedPredictorWeightsBuilderTest,
   expected_weights.interest_segment.child = 1.0;
   expected_weights.interest_segment.parent = 1.0;
   expected_weights.untargeted_segment = 0.0001;
-  expected_weights.last_seen_ad = 1.0;
+  expected_weights.last_seen_ad = 0.0;
   EXPECT_EQ(expected_weights, weights);
 }
 

--- a/components/brave_ads/core/internal/serving/prediction/model_based/weight/segment/creative_ad_model_based_predictor_segment_weight_unittest_util.cc
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/weight/segment/creative_ad_model_based_predictor_segment_weight_unittest_util.cc
@@ -24,7 +24,7 @@ BuildCreativeAdModelBasedPredictorWeights() {
 
   weights.untargeted_segment = 0.0001;
 
-  weights.last_seen_ad = 1.0;
+  weights.last_seen_ad = 0.0;
 
   return weights;
 }


### PR DESCRIPTION
This PR updates the default value of `last_seen_ad_predictor_weight` to 0. Recent AB testing demonstrates this updates leads to a significant increase in CTR.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves
https://github.com/brave/brave-browser/issues/39326

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

