### PR TITLE
Show URL on inactive tab in split view

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -511,6 +511,8 @@ source_set("ui") {
       "views/side_panel/brave_side_panel_utils.cc",
       "views/side_panel/brave_side_panel_view_base.cc",
       "views/side_panel/brave_side_panel_view_base.h",
+      "views/split_view/split_view_location_bar.cc",
+      "views/split_view/split_view_location_bar.h",
       "views/split_view/split_view_menu_bubble.cc",
       "views/split_view/split_view_menu_bubble.h",
       "views/split_view/split_view_separator.cc",

--- a/browser/ui/color/brave_color_id.h
+++ b/browser/ui/color/brave_color_id.h
@@ -129,7 +129,9 @@
     E_CPONLY(kColorBraveSplitViewMenuButtonIcon)        \
     E_CPONLY(kColorBraveSplitViewMenuButtonBackground)  \
     E_CPONLY(kColorBraveSplitViewMenuButtonBorder)      \
-    E_CPONLY(kColorBraveSplitViewMenuItemIcon)
+    E_CPONLY(kColorBraveSplitViewMenuItemIcon)          \
+    E_CPONLY(kColorBraveSplitViewUrl)
+
 
 #define BRAVE_PLAYLIST_COLOR_IDS                                      \
     E_CPONLY(kColorBravePlaylistAddedIcon)                            \

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -117,6 +117,8 @@ void AddBraveTabLightThemeColorMixer(ui::ColorProvider* provider,
            leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kLight)},
           {kColorBraveSplitViewMenuItemIcon,
            leo::GetColor(leo::Color::kColorIconDefault, leo::Theme::kLight)},
+          {kColorBraveSplitViewUrl,
+           leo::GetColor(leo::Color::kColorTextTertiary, leo::Theme::kLight)},
       });
   for (const auto& [color_id, default_color] : *kDefaultColorMap) {
     mixer[color_id] =
@@ -162,6 +164,8 @@ void AddBraveTabDarkThemeColorMixer(ui::ColorProvider* provider,
            leo::GetColor(leo::Color::kColorDividerSubtle, leo::Theme::kDark)},
           {kColorBraveSplitViewMenuItemIcon,
            leo::GetColor(leo::Color::kColorIconDefault, leo::Theme::kDark)},
+          {kColorBraveSplitViewUrl,
+           leo::GetColor(leo::Color::kColorTextTertiary, leo::Theme::kDark)},
       });
   for (const auto& [color_id, default_color] : *kDefaultColorMap) {
     auto color =

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -45,6 +45,7 @@
 #include "brave/browser/ui/views/omnibox/brave_omnibox_view_views.h"
 #include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/speedreader/reader_mode_toolbar_view.h"
+#include "brave/browser/ui/views/split_view/split_view_location_bar.h"
 #include "brave/browser/ui/views/split_view/split_view_separator.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/browser/ui/views/toolbar/bookmark_button.h"
@@ -552,6 +553,7 @@ void BraveBrowserView::UpdateSecondaryContentsWebViewVisibility() {
     if (secondary_contents_web_view_->web_contents() != contents) {
       secondary_contents_web_view_->SetWebContents(nullptr);
       secondary_contents_web_view_->SetWebContents(contents);
+      secondary_location_bar_->SetWebContents(contents);
     }
 
     secondary_contents_web_view_->SetVisible(true);
@@ -563,6 +565,7 @@ void BraveBrowserView::UpdateSecondaryContentsWebViewVisibility() {
         second_tile_is_active_web_contents);
   } else {
     secondary_contents_web_view_->SetWebContents(nullptr);
+    secondary_location_bar_->SetWebContents(nullptr);
     secondary_contents_web_view_->SetVisible(false);
     secondary_devtools_web_view_->SetWebContents(nullptr);
     secondary_devtools_web_view_->SetVisible(false);
@@ -930,6 +933,11 @@ void BraveBrowserView::AddedToWidget() {
 
     GetBrowserViewLayout()->set_vertical_tab_strip_host(
         vertical_tab_strip_host_view_.get());
+  }
+
+  if (secondary_contents_web_view_) {
+    secondary_location_bar_ =
+        SplitViewLocationBar::Create(secondary_contents_web_view_);
   }
 }
 

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -936,8 +936,8 @@ void BraveBrowserView::AddedToWidget() {
   }
 
   if (secondary_contents_web_view_) {
-    secondary_location_bar_ =
-        SplitViewLocationBar::Create(secondary_contents_web_view_);
+    secondary_location_bar_ = SplitViewLocationBar::Create(
+        browser()->profile()->GetPrefs(), secondary_contents_web_view_);
   }
 }
 

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -19,8 +19,6 @@
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/ui/tabs/split_view_browser_data_observer.h"
-#include "brave/browser/ui/views/split_view/split_view_location_bar.h"
-#include "brave/browser/ui/views/split_view/split_view_separator.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
 #include "brave/components/commands/browser/accelerator_pref_manager.h"
@@ -56,13 +54,14 @@ class SidebarBrowserTest;
 }  // namespace sidebar
 
 class BraveBrowser;
+class BraveHelpBubbleHostView;
 class ContentsLayoutManager;
 class SidebarContainerView;
-class WalletButton;
-class ViewShadow;
-class VerticalTabStripWidgetDelegateView;
-class BraveHelpBubbleHostView;
+class SplitViewLocationBar;
 class SplitViewSeparator;
+class VerticalTabStripWidgetDelegateView;
+class ViewShadow;
+class WalletButton;
 
 class BraveBrowserView : public BrowserView,
                          public commands::AcceleratorService::Observer,

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -19,6 +19,7 @@
 #include "brave/browser/ui/tabs/brave_tab_strip_model.h"
 #include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "brave/browser/ui/tabs/split_view_browser_data_observer.h"
+#include "brave/browser/ui/views/split_view/split_view_location_bar.h"
 #include "brave/browser/ui/views/split_view/split_view_separator.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wayback_machine/buildflags/buildflags.h"
@@ -229,6 +230,7 @@ class BraveBrowserView : public BrowserView,
   raw_ptr<views::WebView> secondary_devtools_web_view_ = nullptr;
   raw_ptr<ContentsWebView> secondary_contents_web_view_ = nullptr;
   raw_ptr<SplitViewSeparator> split_view_separator_ = nullptr;
+  raw_ptr<SplitViewLocationBar> secondary_location_bar_ = nullptr;
 
   PrefChangeRegistrar pref_change_registrar_;
   base::ScopedObservation<commands::AcceleratorService,

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -175,8 +175,8 @@ void SplitViewLocationBar::UpdateURLAndIcon() {
     auto origin = url::Origin::Create(url);
     auto formatted_origin = url_formatter::FormatUrl(
         origin.opaque() ? url : origin.GetURL(),
-        url_formatter::kFormatUrlOmitDefaults |
-            url_formatter::kFormatUrlOmitHTTPS,
+        url_formatter::kFormatUrlOmitDefaults &
+            ~url_formatter::kFormatUrlOmitHTTP,
         base::UnescapeRule::SPACES, nullptr, nullptr, nullptr);
     url_->SetText(formatted_origin);
     UpdateIcon();
@@ -198,14 +198,10 @@ bool SplitViewLocationBar::IsContentsSafe() const {
     return true;
   }
 
-  if (SecurityStateTabHelper::FromWebContents(web_contents())
-          ->GetSecurityLevel() == security_state::SecurityLevel::SECURE) {
-    return true;
-  }
-
-  auto url = web_contents()->GetLastCommittedURL();
-  return url.is_empty() || url.SchemeIs(url::kAboutScheme) ||
-         url.SchemeIs("chrome");
+  auto security_level = SecurityStateTabHelper::FromWebContents(web_contents())
+                            ->GetSecurityLevel();
+  return security_level == security_state::SecurityLevel::SECURE ||
+         security_level == security_state::SecurityLevel::NONE;
 }
 
 SkPath SplitViewLocationBar::GetBorderPath(bool close) {

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -1,0 +1,236 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/split_view/split_view_location_bar.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+
+#include "base/strings/utf_string_conversions.h"
+#include "brave/browser/ui/color/brave_color_id.h"
+#include "brave/components/vector_icons/vector_icons.h"
+#include "cc/paint/paint_flags.h"
+#include "content/public/browser/web_contents.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/base/models/image_model.h"
+#include "ui/gfx/canvas.h"
+#include "ui/gfx/geometry/point.h"
+#include "ui/views/background.h"
+#include "ui/views/border.h"
+#include "ui/views/controls/image_view.h"
+#include "ui/views/controls/label.h"
+#include "ui/views/layout/box_layout_view.h"
+#include "ui/views/layout/fill_layout.h"
+#include "ui/views/widget/widget_delegate.h"
+#include "url/url_constants.h"
+
+SplitViewLocationBar::SplitViewLocationBar() {
+  views::Builder<SplitViewLocationBar>(this)
+      .SetBorder(
+          views::CreateEmptyBorder(gfx::Insets().set_bottom(5).set_right(5)))
+      .SetLayoutManager(std::make_unique<views::FillLayout>())
+      .AddChild(
+          views::Builder<views::BoxLayoutView>()
+              .SetBetweenChildSpacing(8)
+              .SetBorder(views::CreateEmptyBorder(
+                  gfx::Insets().set_top(1).set_bottom(4).set_left_right(12, 8)))
+              .AddChild(views::Builder<views::ImageView>()
+                            .CopyAddressTo(&safety_icon_)
+                            .SetImage(ui::ImageModel::FromVectorIcon(
+                                kLeoWarningTriangleOutlineIcon,
+                                kColorBraveSplitViewMenuItemIcon, 14)))
+              .AddChild(views::Builder<views::Label>()
+                            .CopyAddressTo(&url_)
+                            .SetEnabledColorId(kColorBraveSplitViewUrl)))
+
+      .BuildChildren();
+
+  url_->SetFontList(url_->font_list().DeriveWithSizeDelta(
+      12 - url_->font_list().GetFontSize()));
+}
+
+SplitViewLocationBar::~SplitViewLocationBar() = default;
+
+// static
+SplitViewLocationBar* SplitViewLocationBar::Create(views::View* web_view) {
+  CHECK(web_view->GetWidget());
+  auto* location_bar = new SplitViewLocationBar();
+
+  views::Widget::InitParams params;
+  params.type = views::Widget::InitParams::TYPE_CONTROL;
+  params.parent = web_view->GetWidget()->GetNativeView();
+  params.activatable = views::Widget::InitParams::Activatable::kNo;
+  params.delegate = location_bar;
+  auto* widget = new views::Widget();
+  widget->Init(std::move(params));
+
+  location_bar->view_observation_.Observe(web_view);
+  location_bar->UpdateVisibility();
+  location_bar->UpdateBounds();
+
+  widget->Show();
+
+  return location_bar;
+}
+
+void SplitViewLocationBar::SetWebContents(content::WebContents* web_contents) {
+  if (this->web_contents() == web_contents) {
+    return;
+  }
+
+  Observe(web_contents);
+  UpdateURLAndIcon();
+}
+
+void SplitViewLocationBar::OnPaintBackground(gfx::Canvas* canvas) {
+  auto* cp = GetColorProvider();
+  CHECK(cp);
+
+  auto path = GetBorderPath(/*close*/ true);
+  cc::PaintFlags flags;
+  flags.setColor(cp->GetColor(kColorToolbar));
+  flags.setAntiAlias(true);
+  canvas->DrawPath(path, flags);
+}
+
+void SplitViewLocationBar::OnPaintBorder(gfx::Canvas* canvas) {
+  auto* cp = GetColorProvider();
+  CHECK(cp);
+
+  auto path = GetBorderPath(/*close*/ false);
+  cc::PaintFlags flags;
+  flags.setColor(cp->GetColor(kColorBraveSplitViewInactiveWebViewBorder));
+  flags.setAntiAlias(true);
+  flags.setStyle(cc::PaintFlags::kStroke_Style);
+  flags.setStrokeWidth(2);
+  canvas->DrawPath(path, flags);
+}
+
+void SplitViewLocationBar::PrimaryPageChanged(content::Page& page) {
+  UpdateURLAndIcon();
+}
+
+void SplitViewLocationBar::WebContentsDestroyed() {
+  Observe(nullptr);
+  UpdateURLAndIcon();
+}
+
+void SplitViewLocationBar::OnViewVisibilityChanged(views::View* observed_view,
+                                                   views::View* starting_view) {
+  UpdateVisibility();
+}
+
+void SplitViewLocationBar::OnViewBoundsChanged(views::View* observed_view) {
+  UpdateBounds();
+}
+
+void SplitViewLocationBar::OnViewIsDeleting(views::View* observed_view) {
+  view_observation_.Reset();
+}
+
+void SplitViewLocationBar::UpdateVisibility() {
+  auto* view = view_observation_.GetSource();
+  if (view && view->GetVisible()) {
+    GetWidget()->ShowInactive();
+  } else {
+    GetWidget()->Hide();
+  }
+}
+
+void SplitViewLocationBar::UpdateBounds() {
+  auto* view = view_observation_.GetSource();
+  if (!view) {
+    return;
+  }
+
+  gfx::Point point;
+  views::View::ConvertPointToWidget(view, &point);
+
+  auto* widget = GetWidget();
+  CHECK(widget);
+  GetWidget()->SetBounds(gfx::Rect(point, GetPreferredSize()));
+}
+
+void SplitViewLocationBar::UpdateURLAndIcon() {
+  if (auto* contents = web_contents()) {
+    GURL url = contents->GetLastCommittedURL();
+    url_->SetText(base::UTF8ToUTF16(url.host()));
+    UpdateIcon(url);
+  } else {
+    url_->SetText({});
+    UpdateIcon({});
+  }
+
+  UpdateBounds();
+}
+
+void SplitViewLocationBar::UpdateIcon(const GURL& url) {
+  if (url.is_empty()) {
+    return;
+  }
+
+  // At the moment, we show only warning icon.
+  safety_icon_->SetVisible(!IsSafeURL(url));
+}
+
+bool SplitViewLocationBar::IsSafeURL(const GURL& url) {
+  return url.SchemeIs(url::kHttpsScheme) || url.SchemeIs(url::kAboutScheme) ||
+         url.SchemeIs("chrome");
+}
+
+SkPath SplitViewLocationBar::GetBorderPath(bool close) {
+  /*
+                                         //==
+                                        //  <- small arc(2)
+                                       ||   ^
+                                      /|    |
+                   Large arc  ->     //     |
+                                    //      |
+                                  //    ^   |
+                                //      |   |
+       =========================   <---- contents bounds
+     //    <- small arc(1)                  |
+   ||  <------------------------------------ bounds
+  */
+
+  constexpr auto kSmallArcRadius = 5;
+  constexpr auto kLargeArcRadius = 12;
+
+  auto bounds = GetLocalBounds();
+  auto contents_bounds = GetContentsBounds();
+  SkPath path;
+
+  // small arc(1)
+  path.moveTo(bounds.x(), bounds.bottom());
+  path.rArcTo(kSmallArcRadius, -kSmallArcRadius, 0, SkPath::kSmall_ArcSize,
+              SkPathDirection::kCW, kSmallArcRadius, -kSmallArcRadius);
+
+  // proceed to large arc
+  path.rLineTo(
+      std::max(0, contents_bounds.width() - kSmallArcRadius - kLargeArcRadius),
+      0);
+
+  // large arc
+  path.rArcTo(kLargeArcRadius, -kLargeArcRadius, 0, SkPath::kSmall_ArcSize,
+              SkPathDirection::kCCW, kLargeArcRadius, -kLargeArcRadius);
+
+  // proceed to small arc(2)
+  path.lineTo(contents_bounds.right(), std::max(0, kSmallArcRadius));
+
+  // small arc(2)
+  path.rArcTo(kSmallArcRadius, -kSmallArcRadius, 0, SkPath::kSmall_ArcSize,
+              SkPathDirection::kCW, kSmallArcRadius, -kSmallArcRadius);
+
+  if (close) {
+    path.lineTo(0, 0);
+    path.close();
+  }
+
+  return path;
+}
+
+BEGIN_METADATA(SplitViewLocationBar)
+END_METADATA

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -171,7 +171,7 @@ void SplitViewLocationBar::UpdateBounds() {
 
 void SplitViewLocationBar::UpdateURLAndIcon() {
   if (auto* contents = web_contents()) {
-    auto url = contents->GetVisibleURL();
+    auto url = contents->GetLastCommittedURL();
     auto origin = url::Origin::Create(url);
     auto formatted_origin = url_formatter::FormatUrl(
         origin.opaque() ? url : origin.GetURL(),
@@ -203,7 +203,7 @@ bool SplitViewLocationBar::IsContentsSafe() const {
     return true;
   }
 
-  auto url = web_contents()->GetVisibleURL();
+  auto url = web_contents()->GetLastCommittedURL();
   return url.is_empty() || url.SchemeIs(url::kAboutScheme) ||
          url.SchemeIs("chrome");
 }

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -9,13 +9,17 @@
 #include <memory>
 #include <utility>
 
+#include "base/functional/bind.h"
 #include "base/strings/utf_string_conversions.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "cc/paint/paint_flags.h"
 #include "chrome/browser/ssl/security_state_tab_helper.h"
+#include "components/omnibox/browser/omnibox_prefs.h"
+#include "components/prefs/pref_service.h"
 #include "components/url_formatter/url_formatter.h"
 #include "content/public/browser/web_contents.h"
+#include "net/cert/cert_status_flags.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/models/image_model.h"
 #include "ui/gfx/canvas.h"
@@ -26,17 +30,19 @@
 #include "ui/views/controls/label.h"
 #include "ui/views/layout/box_layout_view.h"
 #include "ui/views/layout/fill_layout.h"
+#include "ui/views/view_class_properties.h"
 #include "ui/views/widget/widget_delegate.h"
 #include "url/url_constants.h"
 
-SplitViewLocationBar::SplitViewLocationBar() {
+SplitViewLocationBar::SplitViewLocationBar(PrefService* prefs) : prefs_(prefs) {
+  constexpr auto kChildSpacing = 8;
   views::Builder<SplitViewLocationBar>(this)
       .SetBorder(
           views::CreateEmptyBorder(gfx::Insets().set_bottom(5).set_right(5)))
       .SetLayoutManager(std::make_unique<views::FillLayout>())
       .AddChild(
           views::Builder<views::BoxLayoutView>()
-              .SetBetweenChildSpacing(8)
+              .SetBetweenChildSpacing(kChildSpacing)
               .SetBorder(views::CreateEmptyBorder(
                   gfx::Insets().set_top(1).set_bottom(4).set_left_right(12, 8)))
               .AddChild(views::Builder<views::ImageView>()
@@ -44,22 +50,52 @@ SplitViewLocationBar::SplitViewLocationBar() {
                             .SetImage(ui::ImageModel::FromVectorIcon(
                                 kLeoWarningTriangleOutlineIcon,
                                 kColorBraveSplitViewMenuItemIcon, 14)))
+              .AddChild(
+                  views::Builder<views::Label>()
+                      .SetText(u"https")
+                      .CopyAddressTo(&https_with_strike_)
+                      .SetEnabledColorId(kColorOmniboxSecurityChipDangerous))
+              .AddChild(views::Builder<views::Label>()
+                            .SetText(u"://")
+                            .CopyAddressTo(&scheme_separator_)
+                            .SetEnabledColorId(kColorBraveSplitViewUrl))
               .AddChild(views::Builder<views::Label>()
                             .CopyAddressTo(&url_)
-                            .SetEnabledColorId(kColorBraveSplitViewUrl)))
-
+                            .SetEnabledColorId(kColorBraveSplitViewUrl)
+                            .SetElideBehavior(gfx::ElideBehavior::ELIDE_HEAD)))
       .BuildChildren();
 
-  url_->SetFontList(url_->font_list().DeriveWithSizeDelta(
-      12 - url_->font_list().GetFontSize()));
+  for (auto url_part : {https_with_strike_, scheme_separator_, url_}) {
+    // Adjust font size.
+    constexpr auto kURLSize = 12;
+    url_part->SetFontList(url_part->font_list().DeriveWithSizeDelta(
+        kURLSize - url_part->font_list().GetFontSize()));
+  }
+
+  for (auto scheme_part : {https_with_strike_, scheme_separator_}) {
+    // Remove child spacing
+    scheme_part->SetProperty(views::kMarginsKey,
+                             gfx::Insets().set_right(-kChildSpacing));
+  }
+
+  // Strike through the "https"
+  https_with_strike_->SetFontList(
+      https_with_strike_->font_list().DeriveWithStyle(
+          gfx::Font::FontStyle::STRIKE_THROUGH));
+
+  prevent_url_elision_.Init(
+      omnibox::kPreventUrlElisionsInOmnibox, prefs_,
+      base::BindRepeating(&SplitViewLocationBar::UpdateURLAndIcon,
+                          base::Unretained(this)));
 }
 
 SplitViewLocationBar::~SplitViewLocationBar() = default;
 
 // static
-SplitViewLocationBar* SplitViewLocationBar::Create(views::View* web_view) {
+SplitViewLocationBar* SplitViewLocationBar::Create(PrefService* service,
+                                                   views::View* web_view) {
   CHECK(web_view->GetWidget());
-  auto* location_bar = new SplitViewLocationBar();
+  auto* location_bar = new SplitViewLocationBar(service);
 
   views::Widget::InitParams params;
   params.type = views::Widget::InitParams::TYPE_CONTROL;
@@ -171,16 +207,28 @@ void SplitViewLocationBar::UpdateBounds() {
 
 void SplitViewLocationBar::UpdateURLAndIcon() {
   if (auto* contents = web_contents()) {
+    auto format = GetURLFormatType();
+    if (HasCertError()) {
+      // In case of cert error, we show https scheme with another view so that
+      // we can strike the scheme. So we omit HTTPS here.
+      format |= url_formatter::kFormatUrlOmitHTTPS;
+      https_with_strike_->SetVisible(true);
+      scheme_separator_->SetVisible(true);
+    } else {
+      https_with_strike_->SetVisible(false);
+      scheme_separator_->SetVisible(false);
+    }
+
     auto url = contents->GetLastCommittedURL();
     auto origin = url::Origin::Create(url);
     auto formatted_origin = url_formatter::FormatUrl(
-        origin.opaque() ? url : origin.GetURL(),
-        url_formatter::kFormatUrlOmitDefaults &
-            ~url_formatter::kFormatUrlOmitHTTP,
+        origin.opaque() ? url : origin.GetURL(), format,
         base::UnescapeRule::SPACES, nullptr, nullptr, nullptr);
     url_->SetText(formatted_origin);
     UpdateIcon();
   } else {
+    https_with_strike_->SetVisible(false);
+    scheme_separator_->SetVisible(false);
     url_->SetText({});
     UpdateIcon();
   }
@@ -202,6 +250,32 @@ bool SplitViewLocationBar::IsContentsSafe() const {
                             ->GetSecurityLevel();
   return security_level == security_state::SecurityLevel::SECURE ||
          security_level == security_state::SecurityLevel::NONE;
+}
+
+bool SplitViewLocationBar::HasCertError() const {
+  if (!web_contents()) {
+    return false;
+  }
+
+  return net::IsCertStatusError(
+      SecurityStateTabHelper::FromWebContents(web_contents())
+          ->GetVisibleSecurityState()
+          ->cert_status);
+}
+
+url_formatter::FormatUrlType SplitViewLocationBar::GetURLFormatType() const {
+  const auto full_url_format = url_formatter::kFormatUrlOmitDefaults &
+                               ~url_formatter::kFormatUrlOmitHTTP;
+  if (*prevent_url_elision_) {
+    return full_url_format;
+  }
+
+  if (IsContentsSafe()) {
+    return url_formatter::kFormatUrlOmitDefaults |
+           url_formatter::kFormatUrlOmitHTTPS;
+  }
+
+  return full_url_format;
 }
 
 SkPath SplitViewLocationBar::GetBorderPath(bool close) {

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -38,9 +38,12 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
   // views::WidgetDelegateView:
   void OnPaintBackground(gfx::Canvas* canvas) override;
   void OnPaintBorder(gfx::Canvas* canvas) override;
+  gfx::Size CalculatePreferredSize(
+      const views::SizeBounds& available_size) const override;
 
   // content::WebContentsObserver:
   void PrimaryPageChanged(content::Page& page) override;
+  void DidChangeVisibleSecurityState() override;
   void WebContentsDestroyed() override;
 
   // views::ViewObserver:
@@ -55,8 +58,8 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
   void UpdateVisibility();
   void UpdateBounds();
   void UpdateURLAndIcon();
-  void UpdateIcon(const GURL& url);
-  bool IsSafeURL(const GURL& url);
+  void UpdateIcon();
+  bool IsContentsSafe() const;
 
   SkPath GetBorderPath(bool close);
 

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -1,0 +1,77 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_LOCATION_BAR_H_
+#define BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_LOCATION_BAR_H_
+
+#include "base/scoped_observation.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/view.h"
+#include "ui/views/view_observer.h"
+#include "ui/views/widget/widget_delegate.h"
+
+namespace views {
+class Label;
+class ImageView;
+}  // namespace views
+
+// A simple version of the location bar for secondary web view.
+// This location bar only shows host of the current page.
+//  e.g. http://foo.bar.com/1234 => foo.bar.com
+// When the scheme is not https, the location bar will show an icon to indicate
+// the site might not be safe.
+class SplitViewLocationBar : public views::WidgetDelegateView,
+                             public content::WebContentsObserver,
+                             public views::ViewObserver {
+  METADATA_HEADER(SplitViewLocationBar, views::WidgetDelegateView)
+
+ public:
+  ~SplitViewLocationBar() override;
+
+  static SplitViewLocationBar* Create(views::View* web_view);
+
+  void SetWebContents(content::WebContents* web_contents);
+
+  // views::WidgetDelegateView:
+  void OnPaintBackground(gfx::Canvas* canvas) override;
+  void OnPaintBorder(gfx::Canvas* canvas) override;
+
+  // content::WebContentsObserver:
+  void PrimaryPageChanged(content::Page& page) override;
+  void WebContentsDestroyed() override;
+
+  // views::ViewObserver:
+  void OnViewVisibilityChanged(views::View* observed_view,
+                               views::View* starting_view) override;
+  void OnViewBoundsChanged(views::View* observed_view) override;
+  void OnViewIsDeleting(views::View* observed_view) override;
+
+ private:
+  SplitViewLocationBar();
+
+  void UpdateVisibility();
+  void UpdateBounds();
+  void UpdateURLAndIcon();
+  void UpdateIcon(const GURL& url);
+  bool IsSafeURL(const GURL& url);
+
+  SkPath GetBorderPath(bool close);
+
+  raw_ptr<views::ImageView> safety_icon_ = nullptr;
+  raw_ptr<views::Label> url_ = nullptr;
+
+  base::ScopedObservation<views::View, views::ViewObserver> view_observation_{
+      this};
+};
+
+BEGIN_VIEW_BUILDER(/*no export*/,
+                   SplitViewLocationBar,
+                   views::WidgetDelegateView)
+END_VIEW_BUILDER
+
+DEFINE_VIEW_BUILDER(/*no export*/, SplitViewLocationBar)
+
+#endif  // __BRAVE_BROWSER_SRC_BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_LOCATION_BAR_H_

--- a/browser/ui/views/split_view/split_view_location_bar.h
+++ b/browser/ui/views/split_view/split_view_location_bar.h
@@ -7,6 +7,8 @@
 #define BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_LOCATION_BAR_H_
 
 #include "base/scoped_observation.h"
+#include "components/prefs/pref_member.h"
+#include "components/url_formatter/url_formatter.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/views/view.h"
@@ -17,6 +19,8 @@ namespace views {
 class Label;
 class ImageView;
 }  // namespace views
+
+class PrefService;
 
 // A simple version of the location bar for secondary web view.
 // This location bar only shows host of the current page.
@@ -31,7 +35,8 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
  public:
   ~SplitViewLocationBar() override;
 
-  static SplitViewLocationBar* Create(views::View* web_view);
+  static SplitViewLocationBar* Create(PrefService* prefs,
+                                      views::View* web_view);
 
   void SetWebContents(content::WebContents* web_contents);
 
@@ -53,18 +58,26 @@ class SplitViewLocationBar : public views::WidgetDelegateView,
   void OnViewIsDeleting(views::View* observed_view) override;
 
  private:
-  SplitViewLocationBar();
+  explicit SplitViewLocationBar(PrefService* service);
 
   void UpdateVisibility();
   void UpdateBounds();
   void UpdateURLAndIcon();
   void UpdateIcon();
   bool IsContentsSafe() const;
+  bool HasCertError() const;
+  url_formatter::FormatUrlType GetURLFormatType() const;
 
   SkPath GetBorderPath(bool close);
 
+  raw_ptr<PrefService> prefs_ = nullptr;
+
   raw_ptr<views::ImageView> safety_icon_ = nullptr;
+  raw_ptr<views::Label> https_with_strike_ = nullptr;
+  raw_ptr<views::Label> scheme_separator_ = nullptr;
   raw_ptr<views::Label> url_ = nullptr;
+
+  BooleanPrefMember prevent_url_elision_;
 
   base::ScopedObservation<views::View, views::ViewObserver> view_observation_{
       this};


### PR DESCRIPTION
For security reason, we should let users know where they are.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39152

<img width="179" alt="image" src="https://github.com/brave/brave-core/assets/5474642/368bf4b1-0430-4af2-9d4c-eece2a7e0d84">

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

