### PR TITLE
Fix race condition in Rewards contribution browser tests (uplift to 1.67.x)

### DIFF
--- a/components/brave_rewards/browser/test/common/rewards_browsertest_context_helper.cc
+++ b/components/brave_rewards/browser/test/common/rewards_browsertest_context_helper.cc
@@ -70,7 +70,9 @@ RewardsBrowserTestContextHelper::OpenSiteBanner() {
 
   // Click button to initiate sending a tip.
   test_util::WaitForElementThenClick(popup_contents.get(),
-                                     "[data-test-id=tip-button]");
+                                     "[data-test-id=tip-button]:enabled");
+
+  LOG(INFO) << "Waiting for tip panel to open";
 
   // Wait for the site banner to load and retrieve the notification source
   base::WeakPtr<content::WebContents> banner =


### PR DESCRIPTION
Uplift of #24298
Resolves https://github.com/brave/brave-browser/issues/39173
Resolves https://github.com/brave/brave-browser/issues/37527

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.