### PR TITLE
Add --prepare_only to build command, move midl update to hooks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -144,6 +144,12 @@ hooks = [
     'pattern': '.',
     'action': ['vpython3', 'build/util/generate_clang_format.py', '../.clang-format', '.clang-format']
   },
+  {
+    'name': 'update_midl_files',
+    'pattern': '.',
+    'condition': 'checkout_win',
+    'action': ['python3', 'build/util/update_midl_files.py']
+  },
 ]
 
 include_rules = [

--- a/build/commands/lib/build.js
+++ b/build/commands/lib/build.js
@@ -30,6 +30,11 @@ const build = async (buildConfig = config.defaultBuildConfig, options = {}) => {
 
   util.touchOverriddenFiles()
   util.updateBranding()
+  await util.buildNativeRedirectCC()
+
+  if (options.prepare_only) {
+    return
+  }
 
   if (config.xcode_gen_target) {
     util.generateXcodeWorkspace()

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -607,41 +607,6 @@ const util = {
     }
   },
 
-  // Chromium compares pre-installed midl files and generated midl files from IDL during the build to check integrity.
-  // Generated files during the build time and upstream pre-installed files are different because we use different IDL file.
-  // So, we should copy our pre-installed files to overwrite upstream pre-installed files.
-  // After checking, pre-installed files are copied to gen dir and they are used to compile.
-  // So, this copying in every build doesn't affect compile performance.
-  updateMidlFiles: () => {
-    Log.progressScope('update midl files', () => {
-      const files = fs.readdirSync(path.join(
-          config.braveCoreDir,
-          'win_build_output', 'midl'))
-      for (const file of files) {
-        const srcFile = path.join(config.braveCoreDir,
-            'win_build_output',
-            'midl', file)
-        const dstFile = path.join(config.srcDir,
-            'third_party',
-            'win_build_output', 'midl', file)
-        try {
-          const stat = fs.lstatSync(srcFile);
-          // only copy the directories here
-          // they each have a structure with x86/x64/arm64 versions of the files
-          if (stat.isDirectory()) {
-            fs.copySync(srcFile, dstFile)
-          }
-        } catch (e) {
-          throw new Error('error copying file \"' +
-              srcFile + "\"  to \"" +
-              dstFile + "\"", {
-                cause: e
-              })
-        }
-      }
-    })
-  },
-
   buildNativeRedirectCC: async () => {
     // Expected path to redirect_cc.
     const redirectCC = path.join(config.nativeRedirectCCDir, util.appendExeIfWin32('redirect_cc'))
@@ -753,9 +718,6 @@ const util = {
     await Log.progressScopeAsync('generate ninja files', async () => {
       await util.buildNativeRedirectCC()
 
-      if (config.getTargetOS() === 'win') {
-        util.updateMidlFiles()
-      }
       const extraGnGenOpts = config.extraGnGenOpts ? [config.extraGnGenOpts] : []
       util.runGnGen(config.outputDir, config.buildArgs(), extraGnGenOpts, options)
     })

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -162,6 +162,7 @@ program
   .option('--target <target>', 'Comma-separated list of targets to build, instead of the default browser target')
   .option('--build_sparkle', 'Build the Sparkle macOS update framework from source')
   .option('--no_gn_gen', 'Build without running gn gen')
+  .option('--prepare_only', 'Do not build targets, but prepare everything (build redirect_cc, update branding, etc.)')
   .arguments('[build_config]')
   .action(build)
 

--- a/build/util/update_midl_files.py
+++ b/build/util/update_midl_files.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import shutil
+import hashlib
+
+from brave_chromium_utils import wspath
+
+# Chromium compares pre-installed midl files and generated midl files from IDL
+# during the build to check integrity. Generated files during the build time and
+# upstream pre-installed files are different because we use different IDL file.
+# So, we should copy our pre-installed files to overwrite upstream pre-installed
+# files. After checking, pre-installed files are copied to gen dir and they are
+# used to compile.
+
+
+def update_midl_files():
+    midl_dir = wspath("//brave/win_build_output/midl")
+    with os.scandir(midl_dir) as entries:
+        for entry in entries:
+            if not entry.is_dir():
+                continue
+            src_dir = entry.path
+            src_dir_name = entry.name
+            dst_dir = wspath(
+                f"//third_party/win_build_output/midl/{src_dir_name}")
+            shutil.copytree(src_dir,
+                            dst_dir,
+                            dirs_exist_ok=True,
+                            copy_function=copy_only_if_modified)
+
+
+def copy_only_if_modified(src, dst):
+    """Copy file if it doesn't exist or if its hash is different."""
+
+    def file_hash(file_path):
+        with open(file_path, "rb") as f:
+            return hashlib.file_digest(f, "sha256").digest()
+
+    if not os.path.exists(dst) or file_hash(src) != file_hash(dst):
+        shutil.copy2(src, dst)
+
+
+if __name__ == "__main__":
+    update_midl_files()


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Teamcity pipeline archives workspace (excluding `src/out/*`) via `tar` after `sync/init` in parallel with `npm run build`. The issue is: `npm run build` updates some parts of the source tree as a part of branding update, which can make `tar` result non-deterministic.

This PR adds `--prepare_only` flag to `npm run build` to prepare everything, but not build the actual target. This command will build redirect_cc and update branding. Redirect_cc will also be cached in the workspace.

MIDL files update is moved to hooks to do the update as a part of sync.

Resolves https://github.com/brave/brave-browser/issues/39219

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

