### PR TITLE
Fix typo in android_brave_strings_es.xtb

### DIFF
--- a/browser/ui/android/strings/translations/android_brave_strings_es.xtb
+++ b/browser/ui/android/strings/translations/android_brave_strings_es.xtb
@@ -528,7 +528,7 @@ Verifica que ha sido un dispositivo tuyo el que ha generado estas palabras clave
 <translation id="1763352720905582220">Envía un informe de privacidad semanal</translation>
 <translation id="1811691435325545066">Eliminar todos los datos de informes de privacidad</translation>
 <translation id="5966003059662780423">Borrar datos al salir</translation>
-<translation id="3980704343258720102">Borra todos los datos de navegació</translation>
+<translation id="3980704343258720102">Borra todos los datos de navegación</translation>
 <translation id="8089997572759938512">Restablece tus informes de privacidad a cero</translation>
 <translation id="2718046830255553131">Se han borrado los datos de los informes de privacidad.</translation>
 <translation id="8376263745431603066">Habilitar "Modo nocturno" (experimental)</translation>


### PR DESCRIPTION
"Navegació" is missing an "n" in Spanish