### PR TITLE
[iOS] - Added Error Views for Premium Disconnected

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -17,12 +17,28 @@ extension Strings {
       comment:
         "The title shown on limit reached error view, which is suggesting user to change default model"
     )
+    public static let accountSessionExpiredDescription = NSLocalizedString(
+      "aichat.accountSessionExpiredDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Your Brave account session has expired. Please visit your account page to refresh, then come back to use premium features.",
+      comment:
+        "The description for the error message when the user's session has expired"
+    )
     public static let newChatActionTitle = NSLocalizedString(
       "aichat.newChatActionTitle",
       tableName: "BraveLeo",
       bundle: .module,
       value: "New Chat",
       comment: "The title for button that starts a new chat"
+    )
+    public static let refreshCredentialsActionTitle = NSLocalizedString(
+      "aichat.refreshCredentialsActionTitle",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Refresh",
+      comment: "The title for button that refreshes user credentials"
     )
     public static let networkErrorViewTitle = NSLocalizedString(
       "aichat.networkErrorViewTitle",
@@ -38,6 +54,14 @@ extension Strings {
       bundle: .module,
       value: "Retry",
       comment: "The title for button for re-try"
+    )
+    public static let busyErrorDescription = NSLocalizedString(
+      "aichat.busyErrorDescription",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Leo is too busy right now. Please try again in a few minutes.",
+      comment:
+        "The title for view that shows when leo is too busy (active disconnected) and the user is premium"
     )
     public static let feedbackSuccessAnswerLikedTitle = NSLocalizedString(
       "aichat.feedbackSuccessAnswerLikedTitle",

--- a/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatBusyErrorView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatBusyErrorView.swift
@@ -1,0 +1,58 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import DesignSystem
+import SwiftUI
+
+struct AIChatBusyErrorView: View {
+  var retryAction: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 0.0) {
+      Image(braveSystemName: "leo.warning.triangle-filled")
+        .foregroundStyle(Color(braveSystemName: .systemfeedbackWarningIcon))
+        .padding([.bottom, .trailing])
+
+      VStack(alignment: .leading, spacing: 0.0) {
+        Text(Strings.AIChat.busyErrorDescription)
+          .font(.callout)
+          .foregroundColor(Color(braveSystemName: .systemfeedbackWarningText))
+          .padding(.bottom)
+
+        Button(
+          action: {
+            retryAction()
+          },
+          label: {
+            Text(Strings.AIChat.retryActionTitle)
+              .font(.body.weight(.semibold))
+              .foregroundColor(Color(.white))
+              .padding()
+              .foregroundStyle(.white)
+              .background(
+                Color(braveSystemName: .buttonBackground),
+                in: Capsule()
+              )
+          }
+        )
+        .buttonStyle(.plain)
+      }
+    }
+    .padding()
+    .background(Color(braveSystemName: .systemfeedbackWarningBackground))
+    .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+  }
+}
+
+#if DEBUG
+struct AIChatBusyErrorView_Preview: PreviewProvider {
+  static var previews: some View {
+    AIChatBusyErrorView {
+      print("Retry")
+    }
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif

--- a/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatSessionExpiredErrorView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatSessionExpiredErrorView.swift
@@ -1,0 +1,58 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import DesignSystem
+import SwiftUI
+
+struct AIChatSessionExpiredErrorView: View {
+  var refreshSession: () -> Void
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 0.0) {
+      Image(braveSystemName: "leo.warning.triangle-filled")
+        .foregroundStyle(Color(braveSystemName: .systemfeedbackWarningIcon))
+        .padding([.bottom, .trailing])
+
+      VStack(alignment: .leading, spacing: 0.0) {
+        Text(Strings.AIChat.accountSessionExpiredDescription)
+          .font(.callout)
+          .foregroundColor(Color(braveSystemName: .systemfeedbackWarningText))
+          .padding(.bottom)
+
+        Button(
+          action: {
+            refreshSession()
+          },
+          label: {
+            Text(Strings.AIChat.refreshCredentialsActionTitle)
+              .font(.body.weight(.semibold))
+              .foregroundColor(Color(.white))
+              .padding()
+              .foregroundStyle(.white)
+              .background(
+                Color(braveSystemName: .buttonBackground),
+                in: Capsule()
+              )
+          }
+        )
+        .buttonStyle(.plain)
+      }
+    }
+    .padding()
+    .background(Color(braveSystemName: .systemfeedbackWarningBackground))
+    .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+  }
+}
+
+#if DEBUG
+struct AIChatSessionExpiredErrorView_Preview: PreviewProvider {
+  static var previews: some View {
+    AIChatSessionExpiredErrorView {
+      print("Refresh Credentials")
+    }
+    .previewLayout(.sizeThatFits)
+  }
+}
+#endif


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39231

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Get rated limited or session expired when either premium or premium linked

<img width="280" alt="image" src="https://github.com/brave/brave-core/assets/1530031/0d268238-d894-447e-853a-452e93609669">
<img width="443" alt="image" src="https://github.com/brave/brave-core/assets/1530031/c645b6e4-3dcc-437d-bd5f-3481dcf8378d">
