### PR TITLE
Fixed unreadable text from prominent button (uplift to 1.68.x)

### DIFF
--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -277,8 +277,10 @@ void MdTextButton::SetLoading(bool loading) {
 void MdTextButton::UpdateTextColor() {
   MdTextButtonBase::UpdateTextColor();
 
-  // Use explicitely set color instead of our default colors.
-  if (explicitly_set_normal_color()) {
+  // Use explicitely set color instead of our default colors except for
+  // prominent style. As we have specific bg color for prominent, need to use
+  // our text color for this style.
+  if (style_ != ui::ButtonStyle::kProminent && explicitly_set_normal_color()) {
     return;
   }
 


### PR DESCRIPTION
Uplift of #24320
fix https://github.com/brave/brave-browser/issues/39072
fix https://github.com/brave/brave-browser/issues/38905

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.