### PR TITLE
Close windows when "Bring all tabs" executes

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -118,7 +118,7 @@ void BraveBrowser::OnTabClosing(content::WebContents* contents) {
 
 void BraveBrowser::TabStripEmpty() {
   if (unload_controller_.is_attempting_to_close_browser() ||
-      !is_type_normal()) {
+      !is_type_normal() || ignore_enable_closing_last_tab_pref_) {
     Browser::TabStripEmpty();
     return;
   }

--- a/browser/ui/brave_browser.h
+++ b/browser/ui/brave_browser.h
@@ -68,6 +68,10 @@ class BraveBrowser : public Browser {
 
   void set_confirmed_to_close(bool close) { confirmed_to_close_ = close; }
 
+  void set_ignore_enable_closing_last_tab_pref() {
+    ignore_enable_closing_last_tab_pref_ = true;
+  }
+
  private:
   friend class BraveTestLauncherDelegate;
   friend class WindowClosingConfirmBrowserTest;
@@ -83,6 +87,11 @@ class BraveBrowser : public Browser {
   // Set true when user allowed to close browser before starting any
   // warning or onbeforeunload handlers.
   bool confirmed_to_close_ = false;
+
+  // When "kEnableClosingLastTab" is false, browser will try to add new tab in
+  // TabStripEmpty() if there is no tab. But, in some cases, we should not add
+  // new tab, like when user tries to "Bring all tabs" to other window.
+  bool ignore_enable_closing_last_tab_pref_ = false;
 
   base::WeakPtrFactory<BraveBrowser> weak_ptr_factory_{this};
 };

--- a/browser/ui/brave_browser_browsertest.cc
+++ b/browser/ui/brave_browser_browsertest.cc
@@ -4,6 +4,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "brave/browser/ui/brave_browser.h"
+
+#include "brave/browser/ui/browser_commands.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/devtools/devtools_window_testing.h"
 #include "chrome/browser/profiles/profile.h"
@@ -119,5 +121,23 @@ IN_PROC_BROWSER_TEST_F(BraveBrowserBrowserTest,
   // Close the last tab.
   tab_strip->GetActiveWebContents()->Close();
   base::RunLoop().RunUntilIdle();
+  EXPECT_EQ(chrome::GetTotalBrowserCount(), 1u);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveBrowserBrowserTest,
+                       DoNotOpenNewTabWhenBringingAllTabs) {
+  // Given that kEnableClosingLastTab is false, which normally creates a new tab
+  // when tab strip is empty.
+  ASSERT_TRUE(embedded_test_server()->Start());
+  Browser* new_browser = OpenNewBrowser(browser()->profile());
+  ASSERT_TRUE(new_browser);
+  new_browser->profile()->GetPrefs()->SetBoolean(kEnableClosingLastTab, false);
+
+  // When "Bring all tabs to this window" commands executes
+  brave::BringAllTabs(browser());
+
+  // Then other windows should be closed
+  base::RunLoop().RunUntilIdle();
+  EXPECT_EQ(browser()->tab_strip_model()->count(), 2);
   EXPECT_EQ(chrome::GetTotalBrowserCount(), 1u);
 }

--- a/browser/ui/browser_commands.cc
+++ b/browser/ui/browser_commands.cc
@@ -19,6 +19,7 @@
 #include "brave/app/brave_command_ids.h"
 #include "brave/browser/debounce/debounce_service_factory.h"
 #include "brave/browser/ui/bookmark/brave_bookmark_prefs.h"
+#include "brave/browser/ui/brave_browser.h"
 #include "brave/browser/ui/brave_shields_data_controller.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/tabs/brave_tab_prefs.h"
@@ -701,6 +702,9 @@ void BringAllTabs(Browser* browser) {
   base::ranges::for_each(browsers, [&detached_pinned_tabs,
                                     &detached_unpinned_tabs, &browsers_to_close,
                                     shared_pinned_tab_enabled](auto* other) {
+    static_cast<BraveBrowser*>(other)
+        ->set_ignore_enable_closing_last_tab_pref();
+
     auto* tab_strip_model = other->tab_strip_model();
     const int pinned_tab_count = tab_strip_model->IndexOfFirstNonPinnedTab();
     for (int i = tab_strip_model->count() - 1; i >= 0; --i) {


### PR DESCRIPTION
WIth `kEnableClosingLastTab` pref is false, a new tab is created when tab strip is empty. But this makes the window stay open even when the "Bring all tabs" command is executed. In order to detour this, add a bit to skip adding new tab.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38779

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

