### PR TITLE
Don't draw separator before tiled tabs

### DIFF
--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -263,22 +263,8 @@ gfx::Insets BraveVerticalTabStyle::GetContentsInsets() const {
 
 TabStyle::SeparatorBounds BraveVerticalTabStyle::GetSeparatorBounds(
     float scale) const {
-  if (ShouldShowVerticalTabs()) {
-    return {};
-  }
-
-  if (IsTabTiled(tab())) {
-    return {};
-  }
-
-  const auto is_next_tab_tiled =
-      IsTabTiled(tab()->controller()->GetAdjacentTab(tab(), 1));
   if (!HorizontalTabsUpdateEnabled()) {
-    auto bounds = BraveGM2TabStyle::GetSeparatorBounds(scale);
-    if (is_next_tab_tiled) {
-      bounds.trailing = {};
-    }
-    return bounds;
+    return BraveGM2TabStyle::GetSeparatorBounds(scale);
   }
 
   gfx::SizeF size(tab_style()->GetSeparatorSize());
@@ -298,17 +284,26 @@ TabStyle::SeparatorBounds BraveVerticalTabStyle::GetSeparatorBounds(
   gfx::PointF origin(tab()->bounds().origin());
   origin.Scale(scale);
   bounds.trailing.Offset(-origin.x(), -origin.y());
-
-  if (is_next_tab_tiled) {
-    bounds.trailing = {};
-  }
-
   return bounds;
 }
 
 float BraveVerticalTabStyle::GetSeparatorOpacity(bool for_layout,
                                                  bool leading) const {
-  if (ShouldShowVerticalTabs() || !HorizontalTabsUpdateEnabled()) {
+  if (ShouldShowVerticalTabs()) {
+    return 0;
+  }
+
+  if (IsTabTiled(tab())) {
+    return 0;
+  }
+
+  const Tab* const next_tab = tab()->controller()->GetAdjacentTab(tab(), 1);
+  const auto is_next_tab_tiled = IsTabTiled(next_tab);
+  if (is_next_tab_tiled) {
+    return 0;
+  }
+
+  if (!HorizontalTabsUpdateEnabled()) {
     return BraveGM2TabStyle::GetSeparatorOpacity(for_layout, leading);
   }
 
@@ -327,8 +322,6 @@ float BraveVerticalTabStyle::GetSeparatorOpacity(bool for_layout,
   if (has_visible_background(tab())) {
     return 0;
   }
-
-  const Tab* const next_tab = tab()->controller()->GetAdjacentTab(tab(), 1);
 
   const float visible_opacity =
       GetHoverInterpolatedSeparatorOpacity(for_layout, next_tab);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39335

## Before
<img width="676" alt="image" src="https://github.com/brave/brave-browser/assets/15734630/c8b88e51-6a7d-4abd-8b7f-b8aaf744f61b">

## After
<img width="698" alt="image" src="https://github.com/brave/brave-core/assets/5474642/2ca7bccc-a09e-4554-a8c1-69f2a2574ac3">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

