### PR TITLE
style(wallet): Confirm ZCash Transaction Details Text

### DIFF
--- a/components/brave_wallet_ui/components/extension/transaction-box/index.tsx
+++ b/components/brave_wallet_ui/components/extension/transaction-box/index.tsx
@@ -26,7 +26,7 @@ import {
 // style
 import {
   BitcoinDetailColumn,
-  BitcoinDetailLine,
+  CodeDetailLine,
   CodeSnippet,
   CodeSnippetText,
   DetailColumn,
@@ -76,22 +76,20 @@ export const TransactionDetailBox = ({
         {btcData.inputs?.map((input, index) => {
           return (
             <div key={'input' + index}>
-              <BitcoinDetailLine>{`Input: ${index}`}</BitcoinDetailLine>
-              <BitcoinDetailLine>{`Value: ${input.value}`}</BitcoinDetailLine>
-              <BitcoinDetailLine>{`Address: ${
+              <CodeDetailLine>{`Input: ${index}`}</CodeDetailLine>
+              <CodeDetailLine>{`Value: ${input.value}`}</CodeDetailLine>
+              <CodeDetailLine>{`Address: ${
                 input.address //
-              }`}</BitcoinDetailLine>
+              }`}</CodeDetailLine>
             </div>
           )
         })}
         {btcData.outputs?.map((output, index) => {
           return (
             <div key={'output' + index}>
-              <BitcoinDetailLine>{`Output: ${index}`}</BitcoinDetailLine>
-              <BitcoinDetailLine>{`Value: ${output.value}`}</BitcoinDetailLine>
-              <BitcoinDetailLine>
-                {`Address: ${output.address}`}
-              </BitcoinDetailLine>
+              <CodeDetailLine>{`Output: ${index}`}</CodeDetailLine>
+              <CodeDetailLine>{`Value: ${output.value}`}</CodeDetailLine>
+              <CodeDetailLine>{`Address: ${output.address}`}</CodeDetailLine>
             </div>
           )
         })}
@@ -106,7 +104,9 @@ export const TransactionDetailBox = ({
         <DetailColumn>
           {zecData.inputs?.map((input, index) => {
             return (
-              <code key={index}>{`input-${input.value}-${input.address}`}</code>
+              <CodeDetailLine
+                key={index}
+              >{`input-${input.value}-${input.address}`}</CodeDetailLine>
             )
           })}
         </DetailColumn>
@@ -114,9 +114,9 @@ export const TransactionDetailBox = ({
         <DetailColumn>
           {zecData.outputs?.map((output, index) => {
             return (
-              <code
+              <CodeDetailLine
                 key={index}
-              >{`output-${output.value}-${output.address}`}</code>
+              >{`output-${output.value}-${output.address}`}</CodeDetailLine>
             )
           })}
         </DetailColumn>

--- a/components/brave_wallet_ui/components/extension/transaction-box/style.ts
+++ b/components/brave_wallet_ui/components/extension/transaction-box/style.ts
@@ -4,6 +4,7 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
 
 export const CodeSnippet = styled.pre`
   display: block;
@@ -62,9 +63,10 @@ export const BitcoinDetailColumn = styled(DetailRow)`
   gap: 8px;
 `
 
-export const BitcoinDetailLine = styled.code`
+export const CodeDetailLine = styled.code`
   overflow-wrap: anywhere;
   display: block;
+  color: ${leo.color.text.tertiary};
 `
 
 export const DetailText = styled.span`


### PR DESCRIPTION
## Description 

Fixes the `Details` dark text color when confirming a `ZCash` transaction

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/35827>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Make sure your browser is set to `dark` theme in brave://settings/appearance
2. Open the `Wallet` and navigate to the `Send` screen
3. Create a `ZEC` transaction
4. When the `Confirm Transaction` panel opens, click on the `Details` button
5. The text color should not be dark and should be readible


Before:

![Screenshot 4](https://github.com/brave/brave-core/assets/40611140/795ae984-7643-4f07-9a30-7f270c30ce98)

After:

![Screenshot 5](https://github.com/brave/brave-core/assets/40611140/11df3e05-b8f7-468c-8dc7-527c63e051f5)
