### PR TITLE
[iOS] - Add ability to set custom command-line switches

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -185,7 +185,10 @@ public class AppState {
     var switches: [BraveCoreSwitch] = []
     // Check prefs for additional switches
     let activeSwitches = Set(Preferences.BraveCore.activeSwitches.value)
+    let customSwitches = Set(Preferences.BraveCore.customSwitches.value)
     let switchValues = Preferences.BraveCore.switchValues.value
+
+    // Add regular known switches
     for activeSwitch in activeSwitches {
       let key = BraveCoreSwitchKey(rawValue: activeSwitch)
       if key.isValueless {
@@ -194,6 +197,19 @@ public class AppState {
         switches.append(.init(key: key, value: value))
       }
     }
+
+    // Add custom user defined switches
+    for customSwitch in customSwitches {
+      let key = BraveCoreSwitchKey(rawValue: customSwitch)
+      if let value = switchValues[customSwitch] {
+        if value.isEmpty {
+          switches.append(.init(key: key))
+        } else {
+          switches.append(.init(key: key, value: value))
+        }
+      }
+    }
+
     switches.append(.init(key: .rewardsFlags, value: BraveRewards.Configuration.current().flags))
 
     // Initialize BraveCore

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
@@ -173,6 +173,68 @@ private struct BasicPickerInputView: View {
   }
 }
 
+private struct CustomSwitchInputView: View {
+  @ObservedObject private var customSwitches = Preferences.BraveCore.customSwitches
+  @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
+  @Environment(\.presentationMode) @Binding private var presentationMode
+
+  @State var key: String = ""
+  @State private var value: String = ""
+
+  var body: some View {
+    List {
+      Section {
+        TextField("Key", text: $key)
+          .disableAutocorrection(true)
+          .autocapitalization(.none)
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      } footer: {
+        Text("Enter the key. Format: --")
+          + Text("**Key**")
+          .foregroundColor(Color(braveSystemName: .textInteractive))
+          + Text("=Value")
+      }
+
+      Section {
+        TextField("Value", text: $value)
+          .disableAutocorrection(true)
+          .autocapitalization(.none)
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      } footer: {
+        Text("Enter the value. Format: --Key=")
+          + Text("**Value**")
+          .foregroundColor(Color(braveSystemName: .textInteractive))
+      }
+    }
+    .listStyle(.insetGrouped)
+    .listBackgroundColor(Color(UIColor.braveGroupedBackground))
+    .navigationTitle("Custom Switch")
+    .onAppear {
+      // SwiftUI bug, has to wait a bit
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+        value = switchValues.value[key, default: ""]
+      }
+    }
+    .toolbar {
+      ToolbarItemGroup(placement: .confirmationAction) {
+        Button {
+          switchValues.value[key] = value
+          if !customSwitches.value.contains(key) {
+            customSwitches.value.append(key)
+          }
+          presentationMode.dismiss()
+        } label: {
+          Text("Save")
+            .foregroundColor(
+              !key.isEmpty ? Color(.braveBlurpleTint) : Color(braveSystemName: .buttonDisabled)
+            )
+        }
+        .disabled(key.isEmpty)
+      }
+    }
+  }
+}
+
 struct BraveCoreDebugSwitchesView: View {
   @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
@@ -339,6 +401,56 @@ struct BraveCoreDebugSwitchesView: View {
       } header: {
         Text("P3A")
       }
+
+      if !Preferences.BraveCore.customSwitches.value.isEmpty {
+        Section {
+          Group {
+            ForEach(Preferences.BraveCore.customSwitches.value, id: \.self) { switchKey in
+              NavigationLink {
+                CustomSwitchInputView(key: switchKey)
+              } label: {
+                VStack(alignment: .leading) {
+                  Text(String(switchKey.separatedBy("-").map({ $0.capitalized }).joined(by: " ")))
+                    .font(.headline)
+
+                  if let value = Preferences.BraveCore.switchValues.value[switchKey], !value.isEmpty
+                  {
+                    Text("--\(switchKey)=\(value)")
+                      .font(.caption)
+                      .foregroundColor(
+                        Color(.secondaryBraveLabel)
+                      )
+                      .lineLimit(1)
+                  }
+                }
+              }
+            }
+            .onDelete {
+              let keys = $0.map { Preferences.BraveCore.customSwitches.value[$0] }
+
+              withAnimation(.default) {
+                keys.forEach { key in
+                  Preferences.BraveCore.switchValues.value[key] = nil
+                  Preferences.BraveCore.customSwitches.value.removeAll(where: { $0 == key })
+                }
+              }
+            }
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        } header: {
+          Text("Custom Switches")
+        }
+      }
+
+      Section {
+        NavigationLink {
+          CustomSwitchInputView(key: "")
+        } label: {
+          Text("Add Custom Switch")
+        }
+        .listRowBackground(Color(.secondaryBraveGroupedBackground))
+      }
+
       Section {
         Button("Disable All") {
           withAnimation {

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
@@ -176,10 +176,14 @@ private struct BasicPickerInputView: View {
 private struct CustomSwitchInputView: View {
   @ObservedObject private var customSwitches = Preferences.BraveCore.customSwitches
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
-  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.dismiss) private var dismiss
 
   @State var key: String
   @State private var value: String = ""
+
+  init(key: String) {
+    _key = State(wrappedValue: key)
+  }
 
   var body: some View {
     List {
@@ -222,7 +226,7 @@ private struct CustomSwitchInputView: View {
           if !customSwitches.value.contains(key) {
             customSwitches.value.append(key)
           }
-          presentationMode.dismiss()
+          dismiss()
         } label: {
           Text("Save")
             .foregroundColor(

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
@@ -69,7 +69,7 @@ private enum SkusEnvironment: String, CaseIterable {
 private struct BasicStringInputView: View {
   @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
-  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.dismiss) private var dismiss
 
   var coreSwitch: BraveCoreSwitchKey
   var hint: String?
@@ -110,7 +110,7 @@ private struct BasicStringInputView: View {
               activeSwitches.value.append(coreSwitch.rawValue)
             }
           }
-          presentationMode.dismiss()
+          dismiss()
         } label: {
           Text("Save")
             .foregroundColor(Color(.braveBlurpleTint))
@@ -123,7 +123,7 @@ private struct BasicStringInputView: View {
 private struct BasicPickerInputView: View {
   @ObservedObject private var activeSwitches = Preferences.BraveCore.activeSwitches
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
-  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.dismiss) private var dismiss
 
   var coreSwitch: BraveCoreSwitchKey
   var options: [String]
@@ -163,7 +163,7 @@ private struct BasicPickerInputView: View {
               activeSwitches.value.append(coreSwitch.rawValue)
             }
           }
-          presentationMode.dismiss()
+          dismiss()
         } label: {
           Text("Save")
             .foregroundColor(Color(.braveBlurpleTint))
@@ -178,7 +178,7 @@ private struct CustomSwitchInputView: View {
   @ObservedObject private var switchValues = Preferences.BraveCore.switchValues
   @Environment(\.presentationMode) @Binding private var presentationMode
 
-  @State var key: String = ""
+  @State var key: String
   @State private var value: String = ""
 
   var body: some View {
@@ -429,7 +429,7 @@ struct BraveCoreDebugSwitchesView: View {
               let keys = $0.map { Preferences.BraveCore.customSwitches.value[$0] }
 
               withAnimation(.default) {
-                keys.forEach { key in
+                for key in keys {
                   Preferences.BraveCore.switchValues.value[key] = nil
                   Preferences.BraveCore.customSwitches.value.removeAll(where: { $0 == key })
                 }

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -175,6 +175,13 @@ extension Preferences {
       key: "brave-core.switches.values",
       default: [:]
     )
+    /// Custom Switches that are passed into BraveCoreMain during launch.
+    ///
+    /// This preference stores a list of `BraveCoreSwitch` raw values
+    public static let customSwitches = Option<[String]>(
+      key: "brave-core.custom-switches",
+      default: []
+    )
   }
 
   public final class AppState {


### PR DESCRIPTION
## Summary
- Add ability to set custom command-line switches/flags for Brave-Core

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39384

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable the Debug menu in Settings
2. Scroll down to Brave Core Switches
3. Scroll down to "Add Custom Switch"
4. Enter Key: "env-ai-chat.bsg" and Value: "dev"
5. Save
6. Notice new switch added at the bottom of the screen with `--env-ai-chat.bsg=dev` as the sub-text.
7. Restart the app
8. Visit: `brave://version` and verify the command-line switch was added.
9. Swipe to delete the switch you added.
10. Verify that it was deleted in the UI.
11. Visit: `brave://version` and verify the command-line switch was removed.

## Screenshots

![image](https://github.com/brave/brave-core/assets/1530031/83760cac-dbfd-4a85-b7cf-9188b11be5c6)
![image](https://github.com/brave/brave-core/assets/1530031/7d62a060-837b-41d2-9a9f-8cadfe9f9415)
![image](https://github.com/brave/brave-core/assets/1530031/8734a3b9-98d9-4624-b7f7-0c2066694318)
![image](https://github.com/brave/brave-core/assets/1530031/24826f1f-35ec-4887-ad86-cc2cc4bc92a8)
