### PR TITLE
feat(wallet): Add Animation to Wallet Bottom Sheet

### DIFF
--- a/components/brave_wallet_ui/components/shared/bottom_sheet/bottom_sheet.style.ts
+++ b/components/brave_wallet_ui/components/shared/bottom_sheet/bottom_sheet.style.ts
@@ -10,20 +10,21 @@ import Icon from '@brave/leo/react/icon'
 // Shared Styles
 import { Column, WalletButton } from '../style'
 
-export const BottomCardWrapper = styled(Column)`
+export const Background = styled(Column)<{ isOpen: boolean }>`
   left: 0;
   right: 0;
   top: 0;
   bottom: 0;
   position: fixed;
-  z-index: 31;
+  z-index: ${(p) => (p.isOpen ? 31 : -1)};
   background: rgba(0, 0, 0, 0.2);
 `
 
-export const BottomCard = styled(Column)`
-  position: absolute;
-  bottom: 0px;
-  border-radius: 12px 12px 0px 0px;
+export const BottomCard = styled(Column)<{ isOpen: boolean }>`
+  position: fixed;
+  bottom: ${(p) => (p.isOpen ? 0 : -500)}px;
+  transition: all 0.3s ease-in-out;
+  border-radius: 16px 16px 0px 0px;
   background-color: ${leo.color.container.background};
   z-index: 32;
 `

--- a/components/brave_wallet_ui/components/shared/bottom_sheet/bottom_sheet.tsx
+++ b/components/brave_wallet_ui/components/shared/bottom_sheet/bottom_sheet.tsx
@@ -6,7 +6,7 @@ import * as React from 'react'
 
 // Styled Components
 import {
-  BottomCardWrapper,
+  Background,
   BottomCard,
   CloseButton,
   CloseIcon
@@ -15,15 +15,20 @@ import { Row } from '../style'
 
 interface Props {
   onClose: () => void
+  isOpen: boolean
   children?: React.ReactNode
 }
 
 export const BottomSheet = (props: Props) => {
-  const { onClose, children } = props
+  const { onClose, isOpen, children } = props
 
   return (
-    <BottomCardWrapper>
-      <BottomCard fullWidth={true}>
+    <>
+      <Background isOpen={isOpen} />
+      <BottomCard
+        fullWidth={true}
+        isOpen={isOpen}
+      >
         <Row
           padding='16px 16px 0px 16px'
           justifyContent='flex-end'
@@ -34,6 +39,6 @@ export const BottomSheet = (props: Props) => {
         </Row>
         {children}
       </BottomCard>
-    </BottomCardWrapper>
+    </>
   )
 }

--- a/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
@@ -809,27 +809,35 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
             {tokenList}
           </ScrollContainer>
         </PopupModal>
-        {isPanel && pendingSelectedAsset && (
-          <BottomSheet onClose={() => setPendingSelectedAsset(undefined)}>
-            <SelectAccount
-              token={pendingSelectedAsset}
-              accounts={accountsForPendingSelectedAsset}
-              tokenBalancesRegistry={tokenBalancesRegistry}
-              spotPrice={
-                spotPriceRegistry
-                  ? getTokenPriceFromRegistry(
-                      spotPriceRegistry,
-                      pendingSelectedAsset
-                    )
-                  : undefined
-              }
-              onSelectAccount={handleSelectAccount}
-            />
+        {isPanel && (
+          <BottomSheet
+            onClose={() => setPendingSelectedAsset(undefined)}
+            isOpen={pendingSelectedAsset !== undefined}
+          >
+            {pendingSelectedAsset && (
+              <SelectAccount
+                token={pendingSelectedAsset}
+                accounts={accountsForPendingSelectedAsset}
+                tokenBalancesRegistry={tokenBalancesRegistry}
+                spotPrice={
+                  spotPriceRegistry
+                    ? getTokenPriceFromRegistry(
+                        spotPriceRegistry,
+                        pendingSelectedAsset
+                      )
+                    : undefined
+                }
+                onSelectAccount={handleSelectAccount}
+              />
+            )}
           </BottomSheet>
         )}
-        {isPanel && tokenDetails && (
-          <BottomSheet onClose={() => setTokenDetails(undefined)}>
-            <TokenDetails token={tokenDetails} />
+        {isPanel && (
+          <BottomSheet
+            onClose={() => setTokenDetails(undefined)}
+            isOpen={tokenDetails !== undefined}
+          >
+            {tokenDetails && <TokenDetails token={tokenDetails} />}
           </BottomSheet>
         )}
       </>

--- a/components/brave_wallet_ui/page/screens/swap/components/swap/quote-info/quote-info.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/components/swap/quote-info/quote-info.tsx
@@ -600,22 +600,25 @@ export const QuoteInfo = (props: Props) => {
           </Row>
         </Section>
       )}
+      {isPanel && (
+        <BottomSheet
+          onClose={() => setShowAccountSelector(false)}
+          isOpen={showAccountSelector}
+        >
+          {AccountSelector}
+        </BottomSheet>
+      )}
 
-      {showAccountSelector &&
-        (isPanel ? (
-          <BottomSheet onClose={() => setShowAccountSelector(false)}>
-            {AccountSelector}
-          </BottomSheet>
-        ) : (
-          <PopupModal
-            title=''
-            onClose={() => setShowAccountSelector(false)}
-            width='560px'
-            showDivider={false}
-          >
-            {AccountSelector}
-          </PopupModal>
-        ))}
+      {!isPanel && showAccountSelector && (
+        <PopupModal
+          title=''
+          onClose={() => setShowAccountSelector(false)}
+          width='560px'
+          showDivider={false}
+        >
+          {AccountSelector}
+        </PopupModal>
+      )}
     </Column>
   )
 }


### PR DESCRIPTION
## Description 

Adds a `Slide Up` animation to the Wallet `Bottom Sheet` component.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/39409>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Bridge` screen
2. Select a token to `Bridge`, after clicking on a token, you will see that there is a slight `Slide Up` animation for the `Account Selector` when it appears.

https://github.com/brave/brave-core/assets/40611140/dd79b5f6-ac0f-42c5-b2fb-56448297a814
