### PR TITLE
allow overriding of buildflags for testing

### DIFF
--- a/app/brave_main_delegate.h
+++ b/app/brave_main_delegate.h
@@ -32,8 +32,6 @@ class BraveMainDelegate : public ChromeMainDelegate {
   content::ContentUtilityClient* CreateContentUtilityClient() override;
   std::optional<int> BasicStartupComplete() override;
   void PreSandboxStartup() override;
-  std::optional<int> PostEarlyInitialization(
-      ChromeMainDelegate::InvokedIn invoked_in) override;
 
  private:
   FRIEND_TEST_ALL_PREFIXES(BraveMainDelegateUnitTest,

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -4,7 +4,11 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 source_set("base") {
-  sources = [ "process/process_launcher.h" ]
+  sources = [
+    "buildflag_config.cc",
+    "buildflag_config.h",
+    "process/process_launcher.h",
+  ]
 
   if (is_posix) {
     sources += [ "process/process_launcher_posix.cc" ]

--- a/base/buildflag_config.cc
+++ b/base/buildflag_config.cc
@@ -1,0 +1,44 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/base/buildflag_config.h"
+
+#include "base/containers/flat_map.h"
+#include "build/buildflag.h"
+
+namespace brave {
+
+namespace {
+base::flat_map<std::string, std::string> g_build_flag_config_override_map;
+}  // namespace
+
+BuildflagConfig::BuildflagConfig(std::string_view name, std::string_view value)
+    : name_(name), value_(value) {}
+
+std::string BuildflagConfig::Get() const {
+  auto it = g_build_flag_config_override_map.find(name_);
+  if (it != g_build_flag_config_override_map.end()) {
+    return it->second;
+  }
+  return value_;
+}
+
+ScopedBuildflagConfigOverride::ScopedBuildflagConfigOverride(
+    std::string_view name,
+    std::string_view value)
+    : BuildflagConfig(name, value) {
+  g_build_flag_config_override_map[name_] = value;
+}
+
+ScopedBuildflagConfigOverride::~ScopedBuildflagConfigOverride() {
+  g_build_flag_config_override_map.erase(name_);
+}
+
+// always return the value that was set in the constructor
+std::string ScopedBuildflagConfigOverride::Get() const {
+  return value_;
+}
+
+}  // namespace brave

--- a/base/buildflag_config.h
+++ b/base/buildflag_config.h
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BASE_BUILDFLAG_CONFIG_H_
+#define BRAVE_BASE_BUILDFLAG_CONFIG_H_
+
+#include <string>
+#include <string_view>
+
+#include "build/buildflag.h"
+
+#define BUILDFLAG_CONFIG(flag) \
+  brave::BuildflagConfig(#flag, BUILDFLAG(flag)).Get()
+
+#define SCOPED_BUILDFLAG_CONFIG_OVERRIDE(flag, value)                        \
+  brave::ScopedBuildflagConfigOverride scoped_buildflag_config_##flag(#flag, \
+                                                                      value);
+
+namespace brave {
+
+class BuildflagConfig {
+ public:
+  BuildflagConfig(std::string_view name, std::string_view value);
+
+  virtual std::string Get() const;
+
+ protected:
+  std::string name_;
+  std::string value_;
+};
+
+class ScopedBuildflagConfigOverride : BuildflagConfig {
+ public:
+  ScopedBuildflagConfigOverride(std::string_view name, std::string_view value);
+  ~ScopedBuildflagConfigOverride();
+
+  std::string Get() const override;
+};
+
+}  // namespace brave
+
+#endif  // BRAVE_BASE_BUILDFLAG_CONFIG_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

