### PR TITLE
[iOS] - Add ability to set custom command-line switches (uplift to 1.68.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -185,7 +185,10 @@ public class AppState {
     var switches: [BraveCoreSwitch] = []
     // Check prefs for additional switches
     let activeSwitches = Set(Preferences.BraveCore.activeSwitches.value)
+    let customSwitches = Set(Preferences.BraveCore.customSwitches.value)
     let switchValues = Preferences.BraveCore.switchValues.value
+
+    // Add regular known switches
     for activeSwitch in activeSwitches {
       let key = BraveCoreSwitchKey(rawValue: activeSwitch)
       if key.isValueless {
@@ -194,6 +197,19 @@ public class AppState {
         switches.append(.init(key: key, value: value))
       }
     }
+
+    // Add custom user defined switches
+    for customSwitch in customSwitches {
+      let key = BraveCoreSwitchKey(rawValue: customSwitch)
+      if let value = switchValues[customSwitch] {
+        if value.isEmpty {
+          switches.append(.init(key: key))
+        } else {
+          switches.append(.init(key: key, value: value))
+        }
+      }
+    }
+
     switches.append(.init(key: .rewardsFlags, value: BraveRewards.Configuration.current().flags))
 
     // Initialize BraveCore

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -175,6 +175,13 @@ extension Preferences {
       key: "brave-core.switches.values",
       default: [:]
     )
+    /// Custom Switches that are passed into BraveCoreMain during launch.
+    ///
+    /// This preference stores a list of `BraveCoreSwitch` raw values
+    public static let customSwitches = Option<[String]>(
+      key: "brave-core.custom-switches",
+      default: []
+    )
   }
 
   public final class AppState {


### PR DESCRIPTION
Uplift of #24384
Resolves https://github.com/brave/brave-browser/issues/39384

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.