### PR TITLE
Fix app menu button upgrade alert regression

### DIFF
--- a/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
@@ -122,24 +122,3 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, NotPurchasedVPN) {
   EXPECT_TRUE(!!menu_root->GetMenuItemByID(IDC_SHOW_BRAVE_VPN_PANEL));
 }
 #endif
-
-class BraveAppMenuBrowserTestWithChromeRefresh2023
-    : public BraveAppMenuBrowserTest {
- public:
-  BraveAppMenuBrowserTestWithChromeRefresh2023() = default;
-  ~BraveAppMenuBrowserTestWithChromeRefresh2023() override = default;
-
-  void SetUp() override {
-    BraveAppMenuBrowserTest::SetUp();
-  }
-
-  base::test::ScopedFeatureList feature_list_;
-};
-
-// Test originally introduced before the chrome-refresh-2023 cleanup, to check
-// if sidebar crashes when opening.
-IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTestWithChromeRefresh2023,
-                       AppMenuOpeningTest) {
-  // Open app menu to check it doesn't make crash.
-  menu_button()->ShowMenu(views::MenuRunner::NO_FLAGS);
-}

--- a/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
@@ -7,9 +7,12 @@
 
 #include "base/test/scoped_feature_list.h"
 #include "brave/app/brave_command_ids.h"
+#include "brave/browser/themes/brave_dark_mode_utils.h"
 #include "brave/browser/ui/brave_browser_command_controller.h"
+#include "brave/browser/ui/views/toolbar/brave_browser_app_menu_button.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/skus/common/features.h"
+#include "chrome/browser/ui/toolbar/app_menu_icon_controller.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/toolbar/app_menu.h"
 #include "chrome/browser/ui/views/toolbar/browser_app_menu_button.h"
@@ -66,6 +69,36 @@ class BraveAppMenuBrowserTest : public InProcessBrowserTest {
   base::test::ScopedFeatureList scoped_feature_list_;
 #endif
 };
+
+IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, AppMenuButtonUpgradeAlertTest) {
+  // Check property for our style.
+  auto* brave_menu_button =
+      static_cast<BraveBrowserAppMenuButton*>(menu_button());
+  EXPECT_TRUE(brave_menu_button->ShouldPaintBorder());
+  EXPECT_TRUE(brave_menu_button->ShouldBlendHighlightColor());
+
+  // Check our highlight color.
+  dark_mode::SetBraveDarkModeType(
+      dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_LIGHT);
+  EXPECT_EQ(dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_LIGHT,
+            dark_mode::GetActiveBraveDarkModeType());
+  EXPECT_EQ(brave_menu_button->GetHighlightColor(), std::nullopt);
+  brave_menu_button->SetTypeAndSeverity(
+      {AppMenuIconController::IconType::UPGRADE_NOTIFICATION,
+       AppMenuIconController::Severity::LOW});
+  EXPECT_EQ(brave_menu_button->GetHighlightColor(),
+            SkColorSetRGB(0x00, 0x46, 0x07));
+  brave_menu_button->SetTypeAndSeverity(
+      {AppMenuIconController::IconType::UPGRADE_NOTIFICATION,
+       AppMenuIconController::Severity::MEDIUM});
+  EXPECT_EQ(brave_menu_button->GetHighlightColor(),
+            SkColorSetRGB(0x4A, 0x39, 0x00));
+  brave_menu_button->SetTypeAndSeverity(
+      {AppMenuIconController::IconType::UPGRADE_NOTIFICATION,
+       AppMenuIconController::Severity::HIGH});
+  EXPECT_EQ(brave_menu_button->GetHighlightColor(),
+            SkColorSetRGB(0x7D, 0x00, 0x1A));
+}
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 // Check toggle menu item has additional toggle button for purchased user.

--- a/browser/ui/views/toolbar/brave_browser_app_menu_button.cc
+++ b/browser/ui/views/toolbar/brave_browser_app_menu_button.cc
@@ -29,5 +29,13 @@ std::optional<SkColor> BraveBrowserAppMenuButton::GetHighlightColor() const {
   }
 }
 
+bool BraveBrowserAppMenuButton::ShouldPaintBorder() const {
+  return true;
+}
+
+bool BraveBrowserAppMenuButton::ShouldBlendHighlightColor() const {
+  return true;
+}
+
 BEGIN_METADATA(BraveBrowserAppMenuButton)
 END_METADATA

--- a/browser/ui/views/toolbar/brave_browser_app_menu_button.h
+++ b/browser/ui/views/toolbar/brave_browser_app_menu_button.h
@@ -8,6 +8,7 @@
 
 #include <optional>
 
+#include "base/gtest_prod_util.h"
 #include "chrome/browser/ui/views/toolbar/browser_app_menu_button.h"
 
 class BraveBrowserAppMenuButton : public BrowserAppMenuButton {
@@ -17,6 +18,12 @@ class BraveBrowserAppMenuButton : public BrowserAppMenuButton {
   using BrowserAppMenuButton::BrowserAppMenuButton;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(BraveAppMenuBrowserTest,
+                           AppMenuButtonUpgradeAlertTest);
+
+  // BrowserAppMenuButton overrides:
+  bool ShouldPaintBorder() const override;
+  bool ShouldBlendHighlightColor() const override;
   std::optional<SkColor> GetHighlightTextColor() const override;
   std::optional<SkColor> GetHighlightColor() const override;
 };


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39428

<img width="265" alt="Screenshot 2024-06-28 at 1 08 32 PM" src="https://github.com/brave/brave-core/assets/6786187/50eaf1ed-43c6-4eac-8f20-007b7c7c5cfb">


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
`BraveAppMenuBrowserTest.AppMenuButtonUpgradeAlertTest`
See the linked issue for manual test.
