### PR TITLE
Use tab helper for registering contextual side panel entry

### DIFF
--- a/browser/brave_tab_helpers.cc
+++ b/browser/brave_tab_helpers.cc
@@ -105,21 +105,15 @@
 
 #if defined(TOOLKIT_VIEWS)
 #include "brave/browser/onboarding/onboarding_tab_helper.h"
+#include "brave/browser/ui/side_panel/brave_contextual_side_panel_tab_helper.h"
 #include "brave/browser/ui/sidebar/sidebar_tab_helper.h"
 #endif
 
 namespace brave {
 
-#if defined(TOOLKIT_VIEWS)
-// Register per-tab(contextual) side-panel registry.
-// Defined at //brave/browser/ui/views/side_panel/brave_side_panel_utils.cc as
-// the implementation is view-layer specific.
-void RegisterContextualSidePanel(content::WebContents* web_contents);
-#endif
-
 void AttachTabHelpers(content::WebContents* web_contents) {
 #if defined(TOOLKIT_VIEWS)
-  RegisterContextualSidePanel(web_contents);
+  BraveContextualSidePanelTabHelper::CreateForWebContents(web_contents);
 #endif
 #if BUILDFLAG(ENABLE_GREASELION)
   greaselion::GreaselionTabHelper::CreateForWebContents(web_contents);

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -429,6 +429,9 @@ source_set("ui") {
 
   if (toolkit_views) {
     sources += [
+      "side_panel/brave_contextual_side_panel_tab_helper.cc",
+      "side_panel/brave_contextual_side_panel_tab_helper.h",
+      "side_panel/brave_side_panel_utils.h",
       "views/bookmarks/bookmark_bar_instructions_view.cc",
       "views/bookmarks/bookmark_bar_instructions_view.h",
       "views/bookmarks/brave_bookmark_bar_view.cc",

--- a/browser/ui/side_panel/brave_contextual_side_panel_tab_helper.cc
+++ b/browser/ui/side_panel/brave_contextual_side_panel_tab_helper.cc
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/side_panel/brave_contextual_side_panel_tab_helper.h"
+
+#include "brave/browser/ui/side_panel/brave_side_panel_utils.h"
+
+BraveContextualSidePanelTabHelper::BraveContextualSidePanelTabHelper(
+    content::WebContents* contents)
+    : WebContentsUserData(*contents) {
+  brave::RegisterContextualSidePanel(contents);
+}
+
+BraveContextualSidePanelTabHelper::~BraveContextualSidePanelTabHelper() =
+    default;
+
+WEB_CONTENTS_USER_DATA_KEY_IMPL(BraveContextualSidePanelTabHelper);

--- a/browser/ui/side_panel/brave_contextual_side_panel_tab_helper.h
+++ b/browser/ui/side_panel/brave_contextual_side_panel_tab_helper.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_SIDE_PANEL_BRAVE_CONTEXTUAL_SIDE_PANEL_TAB_HELPER_H_
+#define BRAVE_BROWSER_UI_SIDE_PANEL_BRAVE_CONTEXTUAL_SIDE_PANEL_TAB_HELPER_H_
+
+#include "content/public/browser/web_contents_user_data.h"
+
+// Helper to register contextual side panel entry.
+class BraveContextualSidePanelTabHelper
+    : public content::WebContentsUserData<BraveContextualSidePanelTabHelper> {
+ public:
+  explicit BraveContextualSidePanelTabHelper(content::WebContents* contents);
+  ~BraveContextualSidePanelTabHelper() override;
+
+ private:
+  friend WebContentsUserData;
+  WEB_CONTENTS_USER_DATA_KEY_DECL();
+};
+
+#endif  // BRAVE_BROWSER_UI_SIDE_PANEL_BRAVE_CONTEXTUAL_SIDE_PANEL_TAB_HELPER_H_

--- a/browser/ui/side_panel/brave_side_panel_utils.h
+++ b/browser/ui/side_panel/brave_side_panel_utils.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_SIDE_PANEL_BRAVE_SIDE_PANEL_UTILS_H_
+#define BRAVE_BROWSER_UI_SIDE_PANEL_BRAVE_SIDE_PANEL_UTILS_H_
+
+namespace content {
+class WebContents;
+}  // namespace content
+
+namespace brave {
+
+// Register per-tab(contextual) side-panel registry.
+// Defined at //brave/browser/ui/views/side_panel/brave_side_panel_utils.cc as
+// the implementation is view-layer specific.
+void RegisterContextualSidePanel(content::WebContents* web_contents);
+
+}  // namespace brave
+
+#endif  // BRAVE_BROWSER_UI_SIDE_PANEL_BRAVE_SIDE_PANEL_UTILS_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/38886

No functional change. Use tab helper instead of calling api directly.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Check leo panel is opened properly.