### PR TITLE
feat(wallet): Refresh Quote Button

### DIFF
--- a/components/brave_wallet_ui/page/screens/composer_ui/to_asset/to_asset.style.ts
+++ b/components/brave_wallet_ui/page/screens/composer_ui/to_asset/to_asset.style.ts
@@ -5,9 +5,10 @@
 
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
+import Icon from '@brave/leo/react/icon'
 
 // Shared Styles
-import { Text, Row } from '../../../../components/shared/style'
+import { Text, Row, WalletButton } from '../../../../components/shared/style'
 
 export const ReceiveAndQuoteText = styled(Text)`
   line-height: 18px;
@@ -29,4 +30,33 @@ export const SelectAndInputRow = styled(Row)`
 
 export const NetworkAndFiatRow = styled(Row)`
   min-height: 22px;
+`
+
+export const RefreshIcon = styled(Icon).attrs({
+  name: 'refresh'
+})`
+  --leo-icon-size: 16px;
+  color: ${leo.color.icon.default};
+`
+
+export const RefreshButton = styled(WalletButton)<{
+  clicked: boolean
+}>`
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 0px;
+  animation: ${(p) => (p.clicked ? 'spin 1s 1' : 'none')};
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(-360deg);
+    }
+  }
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
 `

--- a/components/brave_wallet_ui/page/screens/composer_ui/to_asset/to_asset.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/to_asset/to_asset.tsx
@@ -26,6 +26,7 @@ import {
 
 // Types
 import { BraveWallet, SendPageTabHashes } from '../../../../constants/types'
+import { SwapParamsOverrides } from '../../swap/constants/types'
 
 // Components
 import { SelectButton } from '../select_button/select_button'
@@ -39,7 +40,9 @@ import {
   ReceiveAndQuoteText,
   NetworkAndFiatRow,
   ReceiveAndQuoteRow,
-  SelectAndInputRow
+  SelectAndInputRow,
+  RefreshIcon,
+  RefreshButton
 } from './to_asset.style'
 import { AmountInput, ToSectionWrapper } from '../shared_composer.style'
 import { Column, Row, Text } from '../../../../components/shared/style'
@@ -60,6 +63,7 @@ const millisecondToString = (milliseconds: number) => {
 interface Props {
   onClickSelectToken: () => void
   onInputChange: (value: string) => void
+  onRefreshQuote: (overrides: SwapParamsOverrides) => void
   inputValue: string
   inputDisabled: boolean
   buttonDisabled?: boolean
@@ -76,6 +80,7 @@ export const ToAsset = (props: Props) => {
   const {
     token,
     onClickSelectToken,
+    onRefreshQuote,
     onInputChange: onChange,
     hasInputError,
     inputDisabled,
@@ -101,6 +106,9 @@ export const ToAsset = (props: Props) => {
       querySubscriptionOptions60s
     )
 
+  // State
+  const [refreshClicked, setRefreshClicked] = React.useState<boolean>(false)
+
   // methods
   const onInputChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -108,6 +116,11 @@ export const ToAsset = (props: Props) => {
     },
     [onChange]
   )
+
+  const handleRefreshQuote = React.useCallback(() => {
+    setRefreshClicked(true)
+    onRefreshQuote({})
+  }, [onRefreshQuote])
 
   // Memos
   const fiatValue = React.useMemo(() => {
@@ -171,26 +184,39 @@ export const ToAsset = (props: Props) => {
           >
             {getLocale('braveWalletReceiveEstimate')}
           </ReceiveAndQuoteText>
-          {!isFetchingQuote && timeUntilNextQuote !== undefined && (
-            <Row
-              width='unset'
-              gap='4px'
-            >
-              <ReceiveAndQuoteText
-                textSize='12px'
-                isBold={false}
+          <Row width='unset'>
+            {!isFetchingQuote && timeUntilNextQuote !== undefined && (
+              <Row
+                width='unset'
+                gap='4px'
+                margin='0px 4px 0px 0px'
               >
-                {beforeTag}
-              </ReceiveAndQuoteText>
-              <Text
-                textSize='12px'
-                isBold={true}
-                textColor='primary'
+                <ReceiveAndQuoteText
+                  textSize='12px'
+                  isBold={false}
+                >
+                  {beforeTag}
+                </ReceiveAndQuoteText>
+                <Text
+                  textSize='12px'
+                  isBold={true}
+                  textColor='primary'
+                >
+                  {duringTag}
+                </Text>
+              </Row>
+            )}
+            {timeUntilNextQuote !== undefined && (
+              <RefreshButton
+                onClick={handleRefreshQuote}
+                clicked={refreshClicked}
+                onAnimationEnd={() => setRefreshClicked(false)}
+                disabled={refreshClicked || isFetchingQuote}
               >
-                {duringTag}
-              </Text>
-            </Row>
-          )}
+                <RefreshIcon />
+              </RefreshButton>
+            )}
+          </Row>
         </ReceiveAndQuoteRow>
         <SelectAndInputRow
           width='100%'

--- a/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
+++ b/components/brave_wallet_ui/page/screens/swap/hooks/useSwap.ts
@@ -1197,6 +1197,7 @@ export const useSwap = () => {
     setSelectingFromOrTo,
     handleOnSetFromAmount,
     handleOnSetToAmount,
+    handleQuoteRefresh,
     onClickFlipSwapTokens,
     setSwapAndSendSelected,
     handleOnSetToAnotherAddress,

--- a/components/brave_wallet_ui/page/screens/swap/swap.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/swap.tsx
@@ -64,6 +64,7 @@ export const Swap = () => {
     setSelectingFromOrTo,
     handleOnSetFromAmount,
     handleOnSetToAmount,
+    handleQuoteRefresh,
     setSelectedGasFeeOption,
     setSlippageTolerance,
     onSubmit,
@@ -158,6 +159,7 @@ export const Swap = () => {
         />
         <ToAsset
           onInputChange={handleOnSetToAmount}
+          onRefreshQuote={handleQuoteRefresh}
           inputValue={toAmount}
           onClickSelectToken={() => setSelectingFromOrTo('to')}
           token={toToken}


### PR DESCRIPTION
## Description 

Introduces a `Refresh Quote` button to the `Swap` and `Bridge` screens

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/39513>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Swap` or ` Bridge` screen.
2. Select some tokens to swap and get a quote.
3. Click the `Refresh Quote` button next to the count down.
4. It should refresh the `quote`

https://github.com/brave/brave-core/assets/40611140/be6d4a4f-c74c-4fee-8d08-9de0b3883a28


