### PR TITLE
Fix overriding of command line options set in BraveMainDelegate uplift to 1.68.x

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -110,7 +110,10 @@ source_set("browser_tests") {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "feature_defaults_unittest.cc" ]
+  sources = [
+    "brave_main_delegate_unittest.cc",
+    "feature_defaults_unittest.cc",
+  ]
   if (!is_android) {
     sources += [ "command_utils_unittest.cc" ]
   }
@@ -129,6 +132,7 @@ source_set("unit_tests") {
     "//components/compose/core/browser:features",
     "//components/content_settings/core/common:features",
     "//components/device_signals/core/common:features",
+    "//components/embedder_support",
     "//components/heap_profiling/in_process",
     "//components/history_clusters/core",
     "//components/language/core/common",

--- a/app/brave_main_delegate.h
+++ b/app/brave_main_delegate.h
@@ -8,7 +8,10 @@
 
 #include <optional>
 
+#include "base/gtest_prod_util.h"
 #include "chrome/app/chrome_main_delegate.h"
+
+class BraveMainDelegateUnitTest;
 
 // Chrome implementation of ContentMainDelegate.
 class BraveMainDelegate : public ChromeMainDelegate {
@@ -31,6 +34,14 @@ class BraveMainDelegate : public ChromeMainDelegate {
   void PreSandboxStartup() override;
   std::optional<int> PostEarlyInitialization(
       ChromeMainDelegate::InvokedIn invoked_in) override;
+
+ private:
+  FRIEND_TEST_ALL_PREFIXES(BraveMainDelegateUnitTest,
+                           DefaultCommandLineOverrides);
+  FRIEND_TEST_ALL_PREFIXES(BraveMainDelegateUnitTest,
+                           OverrideSwitchFromCommandLine);
+
+  static void AppendCommandLineOptions();
 };
 
 #endif  // BRAVE_APP_BRAVE_MAIN_DELEGATE_H_

--- a/app/brave_main_delegate_unittest.cc
+++ b/app/brave_main_delegate_unittest.cc
@@ -1,0 +1,79 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/app/brave_main_delegate.h"
+
+#include <string>
+
+#include "base/command_line.h"
+#include "brave/components/brave_sync/buildflags.h"
+#include "brave/components/variations/buildflags.h"
+#include "components/embedder_support/switches.h"
+#include "components/sync/base/command_line_switches.h"
+#include "components/variations/variations_switches.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+const char kBraveOriginTrialsPublicKey[] =
+    "bYUKPJoPnCxeNvu72j4EmPuK7tr1PAC7SHh8ld9Mw3E=,"
+    "fMS4mpO6buLQ/QMd+zJmxzty/VQ6B1EUZqoCU04zoRU=";
+
+TEST(BraveMainDelegateUnitTest, DefaultCommandLineOverrides) {
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+  BraveMainDelegate::AppendCommandLineOptions();
+
+  ASSERT_STREQ(
+      BUILDFLAG(BRAVE_SYNC_ENDPOINT),
+      command_line.GetSwitchValueASCII(syncer::kSyncServiceURL).c_str());
+  ASSERT_STREQ(
+      kBraveOriginTrialsPublicKey,
+      command_line.GetSwitchValueASCII(embedder_support::kOriginTrialPublicKey)
+          .c_str());
+  ASSERT_STREQ(
+      BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL),
+      command_line
+          .GetSwitchValueASCII(variations::switches::kVariationsServerURL)
+          .c_str());
+  ASSERT_STREQ(BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL),
+               command_line
+                   .GetSwitchValueASCII(
+                       variations::switches::kVariationsInsecureServerURL)
+                   .c_str());
+}
+
+TEST(BraveMainDelegateUnitTest, OverrideSwitchFromCommandLine) {
+  base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
+  const std::string override_sync_url = "https://sync.com";
+  const std::string override_origin_trials_public_key = "public_key";
+  const std::string override_variations_url = "https://variations.com";
+  const std::string override_insecure_variations_url = "https://variations.com";
+  command_line.AppendSwitchASCII(syncer::kSyncServiceURL, override_sync_url);
+  command_line.AppendSwitchASCII(embedder_support::kOriginTrialPublicKey,
+                                 override_origin_trials_public_key);
+  command_line.AppendSwitchASCII(variations::switches::kVariationsServerURL,
+                                 override_variations_url);
+  command_line.AppendSwitchASCII(
+      variations::switches::kVariationsInsecureServerURL,
+      override_insecure_variations_url);
+
+  BraveMainDelegate::AppendCommandLineOptions();
+
+  ASSERT_STREQ(
+      override_sync_url.c_str(),
+      command_line.GetSwitchValueASCII(syncer::kSyncServiceURL).c_str());
+  ASSERT_STREQ(
+      override_origin_trials_public_key.c_str(),
+      command_line.GetSwitchValueASCII(embedder_support::kOriginTrialPublicKey)
+          .c_str());
+  ASSERT_STREQ(
+      override_variations_url.c_str(),
+      command_line
+          .GetSwitchValueASCII(variations::switches::kVariationsServerURL)
+          .c_str());
+  ASSERT_STREQ(override_insecure_variations_url.c_str(),
+               command_line
+                   .GetSwitchValueASCII(
+                       variations::switches::kVariationsInsecureServerURL)
+                   .c_str());
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

Uplift of https://github.com/brave/brave-core/pull/24387
Resolves https://github.com/brave/brave-browser/issues/39400

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

