### PR TITLE
[iOS] - Reduce Playlist Throttle

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/PlaylistScript.js
@@ -66,7 +66,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
   }
 
   let sendMessage = $(function(name, node, target, type, detected) {
-    let post = $(function() {
+    $(function() {
       var location = "";
       var pageTitle = "";
 
@@ -90,16 +90,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
         "tagId": target.$<tagUUID>,
         "invisible": !target.parentNode
       });
-    });
-    
-    if (node.$<sendMessageTimeout>) {
-      clearTimeout(node.$<sendMessageTimeout>);
-    }
-    
-    node.$<sendMessageTimeout> = setTimeout(function(){
-      node.$<sendMessageTimeout> = null;
-      post();
-    }, 2000);
+    })();
   });
 
   function isVideoNode(node) {
@@ -237,14 +228,9 @@ window.__firefox__.includeOnce("Playlist", function($) {
   // MARK: ---------------------------------------
 
   function setupDetector() {
-    var readyTimeout = null;
     function onReady(fn) {
       if (document.readyState === "complete" || document.readyState === "ready") {
-        if (readyTimeout) {
-          clearTimeout(readyTimeout);
-        }
-        
-        readyTimeout = setTimeout(fn, 2000);
+        fn();
       } else {
         document.addEventListener("DOMContentLoaded", fn);
       }
@@ -331,6 +317,12 @@ window.__firefox__.includeOnce("Playlist", function($) {
           setAudioAttribute.call(this, key, value);
           if (key.toLowerCase() == 'src') {
             notifyNode(this, 'audio', true, false);
+            
+            // Instead of using an interval and polling,
+            // we can check the page after a short period when an audio source has been setup.
+            setTimeout(function() {
+              checkPageForVideos(false);
+            }, 100);
           }
         });
       }
@@ -386,9 +378,12 @@ window.__firefox__.includeOnce("Playlist", function($) {
             });
           })();
         });
-
+        
+        fetchMedia();
+        
+        // Do one last check (if the page took too long to load - DailyMotion)
         setTimeout(function() {
-          fetchMedia();
+          checkPageForVideos(false);
         }, 5000);
       }
 
@@ -419,9 +414,7 @@ window.__firefox__.includeOnce("Playlist", function($) {
         });
       }
 
-      setTimeout(function() {
-        checkPageForVideos(false);
-      }, 2000);
+      checkPageForVideos(false);
     }
 
     observePage();


### PR DESCRIPTION
## Summary
- There was no need to throttle playlist since the slow down in 1.66.x was from Adblock.
- Reduce the throttling and return playlist back to normal.
- Reduce DailyMotion timeout.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39398
Partially Reverts https://github.com/brave/brave-core/pull/24393

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Check the URL bar to make sure the playlist icon shows up fast enough