### PR TITLE
fix(AIChat): Update return button for Leo on software keyboard for iOS (uplift to 1.68.x)

### DIFF
--- a/ios/brave-ios/Sources/AIChat/Components/Input/AIChatPromptInputView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Input/AIChatPromptInputView.swift
@@ -71,7 +71,7 @@ struct AIChatPromptInputView: View {
         prompt: Strings.AIChat.promptPlaceHolderDescription,
         promptColor: UIColor(braveSystemName: .textTertiary),
         font: .preferredFont(forTextStyle: .subheadline),
-        submitLabel: .send,
+        submitLabel: .default,
         onBackspace: { wasEmpty in
           if wasEmpty {
             isShowingSlashTools = false


### PR DESCRIPTION
Uplift of #24462
Resolves https://github.com/brave/brave-browser/issues/39351

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.