### PR TITLE
Try to avoid crash from SidePanelCoordinator::PopulateSidePanel()

### DIFF
--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -6,7 +6,10 @@
 #include "brave/browser/ui/views/side_panel/brave_side_panel_coordinator.h"
 
 #include <optional>
+#include <string>
+#include <utility>
 
+#include "base/debug/crash_logging.h"
 #include "base/debug/dump_without_crashing.h"
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
@@ -145,4 +148,22 @@ void BraveSidePanelCoordinator::UpdateToolbarButtonHighlight(
         side_panel_visible ? IDS_TOOLTIP_SIDEBAR_HIDE
                            : IDS_TOOLTIP_SIDEBAR_SHOW));
   }
+}
+
+void BraveSidePanelCoordinator::PopulateSidePanel(
+    bool supress_animations,
+    SidePanelEntry* entry,
+    std::optional<std::unique_ptr<views::View>> content_view) {
+  CHECK(entry);
+  actions::ActionItem* const action_item = GetActionItem(entry->key());
+  if (!action_item) {
+    const std::string entry_id = SidePanelEntryIdToString(entry->key().id());
+    LOG(ERROR) << __func__ << " no side panel action item for " << entry_id;
+    SCOPED_CRASH_KEY_STRING64("SidePanel", "entry_id", entry_id);
+    base::debug::DumpWithoutCrashing();
+    return;
+  }
+
+  SidePanelCoordinator::PopulateSidePanel(supress_animations, entry,
+                                          std::move(content_view));
 }

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.h
@@ -30,6 +30,10 @@ class BraveSidePanelCoordinator : public SidePanelCoordinator {
               SidePanelUtil::SidePanelOpenTrigger open_trigger) override;
   void OnViewVisibilityChanged(views::View* observed_view,
                                views::View* starting_from) override;
+  void PopulateSidePanel(
+      bool supress_animations,
+      SidePanelEntry* entry,
+      std::optional<std::unique_ptr<views::View>> content_view) override;
 
  private:
   // Returns the last active entry or the default entry if no last active

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
@@ -32,9 +32,11 @@
   virtual std::unique_ptr<views::View> CreateHeader
 
 #define UpdateToolbarButtonHighlight virtual UpdateToolbarButtonHighlight
+#define PopulateSidePanel virtual PopulateSidePanel
 
 #include "src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h"  // IWYU pragma: export
 
+#undef PopulateSidePanel
 #undef UpdateToolbarButtonHighlight
 #undef CreateHeader
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/39099

Not sure what cause that crash exactly but one possible situation is action_item is null for requested entry.
Let's see which entry made this if this case happens.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

n/a