### PR TITLE
Fix XCode precreation scheme script

### DIFF
--- a/ios/brave-ios/scripts/xcode_scheme_preaction.sh
+++ b/ios/brave-ios/scripts/xcode_scheme_preaction.sh
@@ -14,12 +14,18 @@ if [[ $RUN_CLANG_STATIC_ANALYZER = "NO" ]]; then
     if [[ -s "$HOME/.nvm/nvm.sh" ]]; then
       . "$HOME/.nvm/nvm.sh"
     else
-      if [[ -x "$(command -v brew)" ]]; then
-        if [[ -s "$(brew --prefix nvm)/nvm.sh" ]]; then
-          . "$(brew --prefix nvm)/nvm.sh"
+        BREW='brew'
+        if [[ $(uname -p) == 'arm' ]]; then
+            # On Apple Silicon (M1, M2, M3) Brew is not part
+            # of the PATH.
+            BREW='/opt/homebrew/bin/brew'
+        fi
+      if [[ -x "$(command -v $BREW)" ]]; then
+        if [[ -s "$($BREW --prefix nvm)/nvm.sh" ]]; then
+          . "$($BREW --prefix nvm)/nvm.sh"
         else
           # Fixup PATH for brew users
-          export PATH="$PATH:$(brew --prefix)/bin"
+          eval "$($BREW shellenv)"
         fi
       fi
     fi


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/39569

Fixes the script on Apple Silicon machine prepending the full path of Brew (`/opt/homebrew/bin/`) when it detects an ARM machine. The behavior was left untouched for Intel machines and it fixes the use case where Node and Npm were installed using Brew.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Dev Test Plan:
- Test the build on Intel machine where Npm and Node were installed using Brew
- Test the build on Intel machine where Npm and Node were installed using `nvm`
- Test the build on Apple Silicon where Npm and Node were installed using `nvm`.
