### PR TITLE
[iOS] - Fix slash tools displaying empty on non-slash command (uplift to 1.68.x)

### DIFF
--- a/ios/brave-ios/Sources/AIChat/Components/SlashTools/AIChatSlashToolsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/SlashTools/AIChatSlashToolsView.swift
@@ -122,7 +122,11 @@ struct AIChatSlashToolsView: View {
       return text.replacing(#/\s/#, with: "").uppercased()
     }
 
-    let prompt = normalizeText(prompt.hasPrefix("/") ? String(prompt.dropFirst()) : prompt)
+    if !prompt.hasPrefix("/") {
+      return slashActions
+    }
+
+    let prompt = normalizeText(String(prompt.dropFirst()))
     if prompt.isEmpty {
       return slashActions
     }


### PR DESCRIPTION
Uplift of #24492
Resolves https://github.com/brave/brave-browser/issues/39538

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.