### PR TITLE
Start/stop P3A `MessageManager` depending on P3A enabled setting

### DIFF
--- a/browser/ntp_background/ntp_p3a_helper_impl_unittest.cc
+++ b/browser/ntp_background/ntp_p3a_helper_impl_unittest.cc
@@ -71,6 +71,8 @@ class NTPP3AHelperImplTest : public testing::Test {
         &local_state_, p3a_service_.get(), &prefs_, true);
   }
 
+  void TearDown() override { p3a_service_ = nullptr; }
+
   std::string GetExpectedHistogramName(const std::string& event_type) {
     return base::StrCat(
         {kHistogramPrefix, kTestCreativeMetricId, ".", event_type});

--- a/components/p3a/message_manager.h
+++ b/components/p3a/message_manager.h
@@ -74,7 +74,8 @@ class MessageManager : public MetricLogStore::Delegate {
 
   static void RegisterPrefs(PrefRegistrySimple* registry);
 
-  void Init(scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  void Start(scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  void Stop();
 
   // If only_update_for_constellation is null, the value will be updated for
   // both STAR and Constellation. If true, only the Constellation log store will

--- a/components/p3a/message_manager_unittest.cc
+++ b/components/p3a/message_manager_unittest.cc
@@ -161,7 +161,7 @@ class P3AMessageManagerTest : public testing::Test,
     message_manager_ = std::make_unique<MessageManager>(
         *local_state_, &p3a_config_, *this, "release", "2099-01-01");
 
-    message_manager_->Init(shared_url_loader_factory_);
+    message_manager_->Start(shared_url_loader_factory_);
 
     task_environment_.RunUntilIdle();
   }
@@ -661,6 +661,7 @@ TEST_F(P3AMessageManagerTest, ShouldNotSendIfDisabled) {
     }
 
     local_state_->SetBoolean(kP3AEnabled, false);
+    message_manager_->Stop();
 
     task_environment_.FastForwardBy(
         base::Seconds(kUploadIntervalSeconds * 100));
@@ -678,6 +679,20 @@ TEST_F(P3AMessageManagerTest, ShouldNotSendIfDisabled) {
     EXPECT_EQ(points_requests_made_[log_type], 0U);
     EXPECT_EQ(p3a_constellation_sent_messages_[log_type].size(), 0U);
   }
+}
+
+TEST_F(P3AMessageManagerTest, ShouldNotSendIfStopped) {
+  InitFeatures(true);
+  SetUpManager();
+
+  message_manager_->Stop();
+
+  task_environment_.FastForwardBy(base::Seconds(kUploadIntervalSeconds * 100));
+
+  EXPECT_TRUE(points_requests_made_.empty());
+  EXPECT_TRUE(p3a_json_sent_metrics_.empty());
+  EXPECT_TRUE(p2a_json_sent_metrics_.empty());
+  EXPECT_TRUE(p3a_constellation_sent_messages_.empty());
 }
 
 }  // namespace p3a

--- a/components/p3a/p3a_service.h
+++ b/components/p3a/p3a_service.h
@@ -21,6 +21,7 @@
 #include "brave/components/p3a/message_manager.h"
 #include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/p3a_config.h"
+#include "components/prefs/pref_change_registrar.h"
 
 class PrefRegistrySimple;
 class PrefService;
@@ -112,6 +113,8 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
 
   void LoadDynamicMetrics();
 
+  void OnP3AEnabledChanged();
+
   void OnHistogramChangedOnUI(const char* histogram_name,
                               base::HistogramBase::Sample sample,
                               size_t bucket);
@@ -127,6 +130,9 @@ class P3AService : public base::RefCountedThreadSafe<P3AService>,
 
   const raw_ref<PrefService> local_state_;
   P3AConfig config_;
+
+  PrefChangeRegistrar pref_change_registrar_;
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
 
   // Contains metrics added via `RegisterDynamicMetric`
   base::flat_map<std::string, MetricLogType> dynamic_metric_log_types_;

--- a/components/p3a/p3a_service_unittest.cc
+++ b/components/p3a/p3a_service_unittest.cc
@@ -82,6 +82,8 @@ class P3AServiceTest : public testing::Test {
     config_.p3a_creative_upload_url = GURL(kTestP3ACreativeHost);
   }
 
+  void TearDown() override { p3a_service_ = nullptr; }
+
   void SetUpP3AService() {
     p3a_service_ = scoped_refptr(new P3AService(
         local_state_, "release", "2049-01-01", P3AConfig(config_)));


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38712

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Ensure measurements are sent to `collector.bsg.brave.com`, and requests are sent to `star-randsrv.bsg.brave.com` ONLY if P3A is enabled. Disable the `BraveP3ATypicalJSONDeprecation` and `BraveP3AOtherJSONDeprecation` features and ensure that requests are sent to `p3a-json.brave.com` ONLY if P3A is enabled.
