### PR TITLE
Parse Onion-Location header like Tor Browser

### DIFF
--- a/browser/tor/test/onion_location_navigation_throttle_browsertest.cc
+++ b/browser/tor/test/onion_location_navigation_throttle_browsertest.cc
@@ -40,7 +40,10 @@
 namespace {
 
 constexpr char kTestOnionPath[] = "/onion";
-constexpr char kTestOnionURL[] = "https://brave.onion";
+// URLs inside the Location or Onion-Location headers are allowed to
+// include commas and it's not a special character.
+constexpr char kTestOnionURL[] = "https://brave.onion/,https://brave2.onion";
+constexpr char kTestOnionURL2[] = "https://brave3.onion/";
 constexpr char kTestInvalidScheme[] = "/invalid_scheme";
 constexpr char kTestInvalidSchemeURL[] = "brave://brave.onion";
 constexpr char kTestNotOnion[] = "/not_onion";
@@ -57,6 +60,8 @@ std::unique_ptr<net::test_server::HttpResponse> HandleOnionLocation(
   http_response->set_content("<html><head></head></html>");
   if (request.GetURL().path_piece() == kTestOnionPath) {
     http_response->AddCustomHeader("onion-location", kTestOnionURL);
+    // Subsequent headers should be ignored.
+    http_response->AddCustomHeader("onion-location", kTestOnionURL2);
   } else if (request.GetURL().path_piece() == kTestInvalidScheme) {
     http_response->AddCustomHeader("onion-location", kTestInvalidSchemeURL);
   } else if (request.GetURL().path_piece() == kTestNotOnion) {

--- a/chromium_src/net/http/http_util.cc
+++ b/chromium_src/net/http/http_util.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "net/http/http_util.h"
+
+#define IsNonCoalescingHeader IsNonCoalescingHeader_ChromiumImpl
+#include "src/net/http/http_util.cc"
+#undef IsNonCoalescingHeader
+
+namespace net {
+
+// static
+bool HttpUtil::IsNonCoalescingHeader(std::string_view name) {
+  if (base::EqualsCaseInsensitiveASCII(name, "onion-location")) {
+    return true;
+  }
+  return IsNonCoalescingHeader_ChromiumImpl(name);
+}
+
+}  // namespace net

--- a/chromium_src/net/http/http_util.h
+++ b/chromium_src/net/http/http_util.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_NET_HTTP_HTTP_UTIL_H_
+#define BRAVE_CHROMIUM_SRC_NET_HTTP_HTTP_UTIL_H_
+
+#define IsNonCoalescingHeader                   \
+  IsNonCoalescingHeader(std::string_view name); \
+  static bool IsNonCoalescingHeader_ChromiumImpl
+
+#include "src/net/http/http_util.h"  // IWYU pragma: export
+
+#undef IsNonCoalescingHeader
+
+#endif  // BRAVE_CHROMIUM_SRC_NET_HTTP_HTTP_UTIL_H_


### PR DESCRIPTION
Fixes brave/brave-browser#39578

Security review: https://github.com/brave/reviews/issues/1702

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Open https://fmarier.org/test/onion-location1.html and ensure that clicking the `.onion` button in the URL bar takes you to the following 404 page on Brave's website:
```
https://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/index.html,http:/ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion/
```
and **not** any of these:
- `https://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/`
- `https://brave4u7jddbv7cyviptqjc7jusxh72uik7zt6adtckl5f4nwy2v72qd.onion/index.html,http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion,%20https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/`
- `https://duckduckgogg42xjoc72x3sjasowoarfbgcmvfimaftt6twagswzczad.onion/`
