### PR TITLE
Fixed some toolbar UI regressions from cr127

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1352,8 +1352,13 @@ source_set("ui") {
 source_set("unit_tests") {
   if (!is_android) {
     testonly = true
-    sources = []
-    deps = []
+    sources = [ "brave_layout_constants_unittest.cc" ]
+    deps = [
+      "//chrome/browser/ui",
+      "//testing/gtest",
+      "//ui/base:test_support",
+      "//ui/gfx",
+    ]
 
     if (enable_brave_vpn) {
       sources += [ "views/toolbar/brave_vpn_button_unittest.cc" ]

--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -19,6 +19,10 @@ std::optional<gfx::Insets> GetBraveLayoutInsets(LayoutInset inset) {
       return gfx::Insets::VH(6, 6);
     case LOCATION_BAR_PAGE_ACTION_ICON_PADDING:
       return gfx::Insets::VH(4, 4);
+    case TOOLBAR_BUTTON:
+      // Use 5 inset - (TOOLBAR_BUTTON_HEIGHT(28) - icon size(18)) / 2
+      // icon size - ToolbarButton::kDefaultIconSize
+      return gfx::Insets(touch_ui ? 12 : 5);
     case TOOLBAR_INTERIOR_MARGIN:
       return touch_ui ? gfx::Insets() : gfx::Insets::VH(4, 8);
     default:
@@ -30,11 +34,6 @@ std::optional<gfx::Insets> GetBraveLayoutInsets(LayoutInset inset) {
 // Returns a |nullopt| if the UI color is not handled by Brave.
 std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
   const bool touch = ui::TouchUiController::Get()->touch_ui();
-  // const bool hybrid = mode == ui::MaterialDesignController::MATERIAL_HYBRID;
-  // const bool touch_optimized_material =
-  //     ui::MaterialDesignController::touch_ui();
-  // const bool newer_material =
-  //     ui::MaterialDesignController::IsNewerMaterialUi();
   switch (constant) {
     case TAB_HEIGHT: {
       if (HorizontalTabsUpdateEnabled()) {
@@ -62,6 +61,9 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
     }
     case TAB_SEPARATOR_HEIGHT: {
       return 24;
+    }
+    case TOOLBAR_BUTTON_HEIGHT: {
+      return touch ? 48 : 28;
     }
     case TOOLBAR_CORNER_RADIUS: {
       return 0;

--- a/browser/ui/brave_layout_constants_unittest.cc
+++ b/browser/ui/brave_layout_constants_unittest.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/layout_constants.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/pointer/mock_touch_ui_controller.h"
+#include "ui/gfx/geometry/insets.h"
+
+TEST(BraveLayoutConstantsTest, BraveValueTest) {
+  ui::MockTouchUiController controller;
+  EXPECT_FALSE(controller.touch_ui());
+
+  EXPECT_EQ(gfx::Insets(5), GetLayoutInsets(TOOLBAR_BUTTON));
+  EXPECT_EQ(28, GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT));
+}

--- a/browser/ui/color/BUILD.gn
+++ b/browser/ui/color/BUILD.gn
@@ -18,3 +18,16 @@ source_set("leo_colors") {
     "//ui/gfx",
   ]
 }
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "brave_color_mixers_unittest.cc" ]
+
+  deps = [
+    "//chrome/browser/ui/color:color_headers",
+    "//chrome/browser/ui/color:mixers",
+    "//testing/gtest",
+    "//ui/color",
+  ]
+}

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -443,6 +443,8 @@ void AddBravifiedChromeThemeColorMixer(ui::ColorProvider* provider,
   AddMaterialSidePanelColorMixer(provider, key);
 
   // TODO(simonhong): Use leo color when it's ready.
+  // TODO(simonhong): Move these overriding to
+  // AddChromeColorMixerForAllThemes().
   ui::ColorMixer& mixer = provider->AddMixer();
   mixer[kColorAppMenuHighlightSeverityLow] = {
       PickColorContrastingToToolbar(key, mixer, SkColorSetRGB(0x00, 0x46, 0x07),
@@ -453,6 +455,7 @@ void AddBravifiedChromeThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorAppMenuHighlightSeverityHigh] = {
       PickColorContrastingToToolbar(key, mixer, SkColorSetRGB(0x7D, 0x00, 0x1A),
                                     SkColorSetRGB(0xFF, 0xB3, 0xB2))};
+  mixer[kColorInfoBarBackground] = {kColorToolbar};
 
   if (key.custom_theme) {
     return;

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -455,7 +455,6 @@ void AddBravifiedChromeThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorAppMenuHighlightSeverityHigh] = {
       PickColorContrastingToToolbar(key, mixer, SkColorSetRGB(0x7D, 0x00, 0x1A),
                                     SkColorSetRGB(0xFF, 0xB3, 0xB2))};
-  mixer[kColorInfoBarBackground] = {kColorToolbar};
 
   if (key.custom_theme) {
     return;

--- a/browser/ui/color/brave_color_mixers_unittest.cc
+++ b/browser/ui/color/brave_color_mixers_unittest.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/color/chrome_color_id.h"
+#include "chrome/browser/ui/color/chrome_color_mixers.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/color/color_provider.h"
+#include "ui/color/color_provider_key.h"
+
+class BraveColorMixersTest : public testing::Test {
+ public:
+  BraveColorMixersTest() = default;
+
+  ui::ColorProvider& color_provider() { return color_provider_; }
+
+  void AddColorMixers() {
+    // AddChromeColorMixers() calls all our mixers.
+    AddChromeColorMixers(&color_provider_, color_provider_key_);
+  }
+
+ private:
+  ui::ColorProvider color_provider_;
+  ui::ColorProviderKey color_provider_key_;
+};
+
+TEST_F(BraveColorMixersTest, ColorOverrideTest) {
+  AddColorMixers();
+
+  EXPECT_EQ(color_provider().GetColor(kColorToolbar),
+            color_provider().GetColor(kColorInfoBarBackground));
+}

--- a/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
+++ b/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
@@ -17,6 +17,7 @@
 #include "brave/components/l10n/common/localization_util.h"
 #include "brave/components/vector_icons/vector_icons.h"
 #include "brave/grit/brave_generated_resources.h"
+#include "build/build_config.h"
 #include "chrome/app/vector_icons/vector_icons.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
@@ -70,7 +71,19 @@ class BraveAvatarButtonHighlightPathGenerator
 }  // namespace
 
 BraveAvatarToolbarButton::BraveAvatarToolbarButton(BrowserView* browser_view)
-    : AvatarToolbarButton(browser_view) {}
+    : AvatarToolbarButton(browser_view) {
+  // Our toolbar button height is 28.
+  // Icon image size 18 + vertical insets 10(5x2).
+  // However, avatar button's icon image size is 16.
+  // So, set delta insets to make its height to 28.
+#if BUILDFLAG(IS_LINUX)
+  // On linux, only add horizontal delta as its size is 26x28.
+  // TODO(simonhong): check why it's different from other platforms.
+  SetLayoutInsetDelta(gfx::Insets::VH(0, 1));
+#else
+  SetLayoutInsetDelta(gfx::Insets(1));
+#endif
+}
 
 BraveAvatarToolbarButton::~BraveAvatarToolbarButton() = default;
 

--- a/browser/ui/views/sidebar/sidebar_container_view_browsertest.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view_browsertest.cc
@@ -59,6 +59,8 @@ IN_PROC_BROWSER_TEST_F(SidebarContainerViewBrowserTest,
   EXPECT_TRUE(sidebar());
   EXPECT_TRUE(toolbar_button());
   EXPECT_TRUE(toolbar_button()->GetVisible());
+  EXPECT_EQ(GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT),
+            toolbar_button()->height());
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarContainerViewBrowserTest, ButtonIsHiddenByPref) {

--- a/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_app_menu_browsertest.cc
@@ -98,6 +98,9 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuBrowserTest, AppMenuButtonUpgradeAlertTest) {
        AppMenuIconController::Severity::HIGH});
   EXPECT_EQ(brave_menu_button->GetHighlightColor(),
             SkColorSetRGB(0x7D, 0x00, 0x1A));
+
+  EXPECT_EQ(GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT),
+            brave_menu_button->height());
 }
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -150,6 +150,14 @@ void BraveToolbarView::Init() {
 
   Profile* profile = browser()->profile();
 
+  // We don't use divider between extensions container and other toolbar
+  // buttons. Upstream conditionally creates |toolbar_divider_|, they check
+  // whether it's null or not. So safe to make remove here.
+  if (toolbar_divider_) {
+    container_view->RemoveChildView(toolbar_divider_.get());
+    toolbar_divider_ = nullptr;
+  }
+
   // Track changes in profile count
   if (IsAvatarButtonHideable(profile)) {
     profile_observer_.Observe(

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -53,6 +53,8 @@ class BraveToolbarView : public ToolbarView,
       const views::ViewHierarchyChangedDetails& details) override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(BraveToolbarViewTest, ToolbarDividerNotShownTest);
+
   void LoadImages() override;
   void ResetLocationBarBounds();
   void ResetButtonBounds();
@@ -67,6 +69,8 @@ class BraveToolbarView : public ToolbarView,
                            const std::u16string& profile_name) override;
 
   void UpdateWalletButtonVisibility();
+
+  views::View* toolbar_divider_for_testing() { return toolbar_divider_; }
 
   raw_ptr<BraveBookmarkButton> bookmark_ = nullptr;
   // Tracks the preference to determine whether bookmark editing is allowed.

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -153,6 +153,11 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest, VPNButtonVisibility) {
 }
 #endif
 
+IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest, ToolbarDividerNotShownTest) {
+  // As we don't use divider in toolbar, it should be null always.
+  EXPECT_TRUE(!toolbar_view_->toolbar_divider_for_testing());
+}
+
 IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
                        AvatarButtonNotShownSingleProfile) {
   EXPECT_EQ(false, is_avatar_button_shown());

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -227,6 +227,10 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
   ASSERT_TRUE(!!app_menu);
   EXPECT_EQ(container->GetIndexOf(avatar).value(),
             container->GetIndexOf(app_menu).value() - 1ul);
+
+  // Check avatar button's size.
+  const int avatar_size = GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT);
+  EXPECT_EQ(gfx::Size(avatar_size, avatar_size), avatar->size());
 }
 
 IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,

--- a/chromium_src/chrome/browser/ui/color/chrome_color_provider_utils.cc
+++ b/chromium_src/chrome/browser/ui/color/chrome_color_provider_utils.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/color/chrome_color_provider_utils.h"
+
+#define ShouldApplyChromeMaterialOverrides \
+  ShouldApplyChromeMaterialOverrides_UnUsed
+
+#include "src/chrome/browser/ui/color/chrome_color_provider_utils.cc"
+
+#undef ShouldApplyChromeMaterialOverrides
+
+bool ShouldApplyChromeMaterialOverrides(const ui::ColorProviderKey& key) {
+  return false;
+}

--- a/chromium_src/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc
@@ -7,7 +7,7 @@
 
 #include "brave/browser/ui/toolbar/brave_app_menu_model.h"
 
-#define FromVectorIcon(icon, color) FromVectorIcon(icon, color, 16)
+#define FromVectorIcon(icon, color) FromVectorIcon(icon, color, GetIconSize())
 #define AppMenuModel BraveAppMenuModel
 #include "src/chrome/browser/ui/views/toolbar/browser_app_menu_button.cc"
 #undef AppMenuModel

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -437,6 +437,7 @@ test("brave_unit_tests") {
       "//brave/browser/download/bubble:unit_tests",
       "//brave/browser/renderer_context_menu/test:unit_tests",
       "//brave/browser/ui/bookmark:unittest",
+      "//brave/browser/ui/color:unit_tests",
       "//brave/browser/ui/commands:unit_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_unit_test",
       "//brave/browser/ui/views/download/bubble:unit_tests",

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -242,6 +242,9 @@
 # causes OptimizationGuideKeyedServiceFactory::GetForProfile return a nullptr.
 -WallpaperSearchHandlerTest.*
 
+# These tests fail because we don't use upstream's material colors.
+-MaterialNewTabPageColorMixerTest.*
+
 # These tests fail because we disable kFirstPartySets.
 -RelatedWebsiteSetsSourceTest.RWS
 -RelatedWebsiteSetsSourceTest.RWS_Empty


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/39580
fix https://github.com/brave/brave-browser/issues/39565

Upstream doesn't use toolbar color for it anymore since cr127.
But, we want to have same bg color with toolbar.

<img width="1564" alt="Screenshot 2024-07-05 at 11 56 33 AM" src="https://github.com/brave/brave-core/assets/6786187/7ca71ef6-8b12-4d80-bbb4-accbfadd339d">
<img width="1559" alt="Screenshot 2024-07-05 at 11 57 12 AM" src="https://github.com/brave/brave-core/assets/6786187/68d2b2b8-fbf2-44ec-bf65-3c6f93573651">
<img width="1562" alt="Screenshot 2024-07-05 at 11 57 38 AM" src="https://github.com/brave/brave-core/assets/6786187/e853f68d-da51-4274-b252-a4648b05e840">
<img width="1544" alt="Screenshot 2024-07-05 at 11 58 00 AM" src="https://github.com/brave/brave-core/assets/6786187/0e4fcc91-5ded-4588-aacb-fb5f07025038">

No divider between extensions container and other toolbar buttons
<img width="245" alt="image" src="https://github.com/brave/brave-core/assets/6786187/b394b77c-60c0-4625-83c1-5bcec995e677">

Proper hover/pressed color of toolbar button
<img width="301" alt="Screenshot 2024-07-08 at 1 04 58 PM" src="https://github.com/brave/brave-core/assets/6786187/35bf9d97-94a9-4b9f-bbaf-678dac897c45">
<img width="296" alt="Screenshot 2024-07-08 at 1 05 11 PM" src="https://github.com/brave/brave-core/assets/6786187/88083f8a-8f3a-4745-ba4b-9d83117b074f">

Use exact 28px height of all toolbar buttons
<img width="299" alt="Screenshot 2024-07-08 at 1 06 59 PM" src="https://github.com/brave/brave-core/assets/6786187/fed736aa-e9db-4a7e-8162-83c8f99b954f">
<img width="342" alt="Screenshot 2024-07-08 at 1 06 51 PM" src="https://github.com/brave/brave-core/assets/6786187/7903dac2-d072-4d7b-8a74-96a4c74f26ee">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveColorMixersTest.ColorOverrideTest`
`BraveLayoutConstantsTest.BraveValueTest`
`BraveAppMenuBrowserTest.AppMenuButtonUpgradeAlertTest`
`BraveToolbarViewTest.ToolbarDividerNotShownTest`
`BraveToolbarViewTest.AvatarButtonIsShownMultipleProfiles`
See the linked issue for manual test.