### PR TITLE
Disables show ntp at startup flag on Android (uplift to 1.67.x)

### DIFF
--- a/base/android/java/src/org/chromium/base/cached_flags/BraveCachedFlag.java
+++ b/base/android/java/src/org/chromium/base/cached_flags/BraveCachedFlag.java
@@ -15,6 +15,7 @@ public class BraveCachedFlag extends CachedFlag {
     private static final String START_SURFACE_ANDROID = "StartSurfaceAndroid";
     private static final String INCOGNITO_REAUTHENTICATION_FOR_ANDROID =
             "IncognitoReauthenticationForAndroid";
+    private static final String SHOW_NTP_AT_STARTUP_ANDROID = "ShowNtpAtStartupAndroid";
     private static final String SURFACE_POLISH = "SurfacePolish";
 
     // Set of flags to override.
@@ -23,6 +24,7 @@ public class BraveCachedFlag extends CachedFlag {
     static {
         sFlags = new HashMap<String, Boolean>();
         sFlags.put(ANDROID_HUB, false);
+        sFlags.put(SHOW_NTP_AT_STARTUP_ANDROID, false);
         sFlags.put(START_SURFACE_ANDROID, false);
         sFlags.put(SURFACE_POLISH, false);
         sFlags.put(INCOGNITO_REAUTHENTICATION_FOR_ANDROID, true);

--- a/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
+++ b/chromium_src/chrome/browser/flags/android/chrome_feature_list.cc
@@ -62,6 +62,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kAndroidHub, base::FEATURE_DISABLED_BY_DEFAULT},
     {kIncognitoReauthenticationForAndroid, base::FEATURE_ENABLED_BY_DEFAULT},
     {kShowScrollableMVTOnNTPAndroid, base::FEATURE_ENABLED_BY_DEFAULT},
+    {kShowNtpAtStartupAndroid, base::FEATURE_DISABLED_BY_DEFAULT},
     {kStartSurfaceAndroid, base::FEATURE_DISABLED_BY_DEFAULT},
     {kSurfacePolish, base::FEATURE_DISABLED_BY_DEFAULT},
     {kAdaptiveButtonInTopToolbarCustomizationV2,


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/24513
Resolves https://github.com/brave/brave-browser/issues/38635