### PR TITLE
Lay out JavascriptTabModalDialog to related web view in Split view mode

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -432,6 +432,8 @@ source_set("ui") {
       "views/bookmarks/saved_tab_groups/brave_saved_tab_group_button.h",
       "views/brave_first_run_dialog.cc",
       "views/brave_first_run_dialog.h",
+      "views/brave_javascript_tab_modal_dialog_view_views.cc",
+      "views/brave_javascript_tab_modal_dialog_view_views.h",
       "views/brave_layout_provider.cc",
       "views/brave_layout_provider.h",
       "views/brave_news/brave_news_bubble_view.cc",

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h"
+#include "chrome/browser/ui/views/chrome_widget_sublevel.h"
 #include "components/web_modal/web_contents_modal_dialog_host.h"
 #include "components/web_modal/web_contents_modal_dialog_manager.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
@@ -39,7 +40,7 @@ BraveJavaScriptTabModalDialogViewViews::BraveJavaScriptTabModalDialogViewViews(
   auto* widget = GetWidget();
   CHECK(widget);
 
-  widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
+  widget->SetZOrderSublevel(kSublevelSecurity);
 
   widget->widget_delegate()->set_desired_position_delegate(base::BindRepeating(
       [](base::WeakPtr<BraveJavaScriptTabModalDialogViewViews> dialog_view) {

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
@@ -39,6 +39,8 @@ BraveJavaScriptTabModalDialogViewViews::BraveJavaScriptTabModalDialogViewViews(
   auto* widget = GetWidget();
   CHECK(widget);
 
+  widget->SetZOrderLevel(ui::ZOrderLevel::kSecuritySurface);
+
   widget->widget_delegate()->set_desired_position_delegate(base::BindRepeating(
       [](base::WeakPtr<BraveJavaScriptTabModalDialogViewViews> dialog_view) {
         if (!dialog_view) {

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
@@ -1,0 +1,160 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h"
+
+#include <utility>
+
+#include "base/functional/bind.h"
+#include "brave/browser/ui/tabs/split_view_browser_data.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h"
+#include "components/web_modal/web_contents_modal_dialog_host.h"
+#include "components/web_modal/web_contents_modal_dialog_manager.h"
+#include "ui/base/metadata/metadata_impl_macros.h"
+
+BraveJavaScriptTabModalDialogViewViews::BraveJavaScriptTabModalDialogViewViews(
+    content::WebContents* parent_web_contents,
+    content::WebContents* alerting_web_contents,
+    const std::u16string& title,
+    content::JavaScriptDialogType dialog_type,
+    const std::u16string& message_text,
+    const std::u16string& default_prompt_text,
+    content::JavaScriptDialogManager::DialogClosedCallback dialog_callback,
+    base::OnceClosure dialog_force_closed_callback)
+    : JavaScriptTabModalDialogViewViews(
+          parent_web_contents,
+          alerting_web_contents,
+          title,
+          dialog_type,
+          message_text,
+          default_prompt_text,
+          std::move(dialog_callback),
+          std::move(dialog_force_closed_callback)),
+      alerting_web_contents_(alerting_web_contents) {
+  // JavaScriptTabModalDialogViewViews already created Widget.
+  auto* widget = GetWidget();
+  CHECK(widget);
+
+  widget->widget_delegate()->set_desired_position_delegate(base::BindRepeating(
+      [](base::WeakPtr<BraveJavaScriptTabModalDialogViewViews> dialog_view) {
+        if (!dialog_view) {
+          return gfx::Point();
+        }
+        return dialog_view->GetDesiredPositionConsideringSplitView();
+      },
+      weak_ptr_factory_.GetWeakPtr()));
+
+  UpdateWidgetBounds();
+}
+
+BraveJavaScriptTabModalDialogViewViews::
+    ~BraveJavaScriptTabModalDialogViewViews() = default;
+
+base::WeakPtr<javascript_dialogs::TabModalDialogView>
+JavaScriptTabModalDialogManagerDelegateDesktop::CreateNewDialog(
+    content::WebContents* alerting_web_contents,
+    const std::u16string& title,
+    content::JavaScriptDialogType dialog_type,
+    const std::u16string& message_text,
+    const std::u16string& default_prompt_text,
+    content::JavaScriptDialogManager::DialogClosedCallback dialog_callback,
+    base::OnceClosure dialog_force_closed_callback) {
+  auto* browser = chrome::FindBrowserWithTab(alerting_web_contents);
+  if (!browser) {
+    // Can be popup up or other type of window.
+    return CreateNewDialog_ChromiumImpl(
+        alerting_web_contents, title, dialog_type, message_text,
+        default_prompt_text, std::move(dialog_callback),
+        std::move(dialog_force_closed_callback));
+  }
+
+  if (!SplitViewBrowserData::FromBrowser(browser)) {
+    // Split view isn't enabled.
+    return CreateNewDialog_ChromiumImpl(
+        alerting_web_contents, title, dialog_type, message_text,
+        default_prompt_text, std::move(dialog_callback),
+        std::move(dialog_force_closed_callback));
+  }
+
+  return (new BraveJavaScriptTabModalDialogViewViews(
+              web_contents_, alerting_web_contents, title, dialog_type,
+              message_text, default_prompt_text, std::move(dialog_callback),
+              std::move(dialog_force_closed_callback)))
+      ->weak_ptr_factory_.GetWeakPtr();
+}
+
+web_modal::WebContentsModalDialogHost*
+BraveJavaScriptTabModalDialogViewViews::GetModalDialogHost() {
+  web_modal::WebContentsModalDialogManager* manager =
+      web_modal::WebContentsModalDialogManager::FromWebContents(
+          alerting_web_contents_);
+  CHECK(manager);
+
+  auto* modal_dialog_host =
+      manager->delegate()->GetWebContentsModalDialogHost();
+  CHECK(modal_dialog_host);
+
+  return modal_dialog_host;
+}
+
+void BraveJavaScriptTabModalDialogViewViews::UpdateWidgetBounds() {
+  auto* widget = GetWidget();
+  if (!widget) {
+    return;
+  }
+
+  CHECK(has_desired_bounds_delegate());
+  widget->SetBounds(GetDesiredWidgetBounds());
+}
+
+gfx::Point BraveJavaScriptTabModalDialogViewViews::
+    GetDesiredPositionConsideringSplitView() {
+  auto* widget = GetWidget();
+  CHECK(widget);
+
+  auto* modal_dialog_host = GetModalDialogHost();
+
+  // When a tab is in split view mode, We want javascript dialog to be
+  // centered to the relevant web view.
+  gfx::Rect bounds = widget->GetWindowBoundsInScreen();
+  bounds.set_origin(modal_dialog_host->GetDialogPosition(bounds.size()));
+
+  // 1. Check if the tab is in split view mode.
+  auto* browser = chrome::FindBrowserWithTab(alerting_web_contents_);
+  CHECK(browser);
+
+  auto* tab_strip_model = browser->tab_strip_model();
+  auto tab_handle = tab_strip_model->GetTabHandleAt(
+      tab_strip_model->GetIndexOfWebContents(alerting_web_contents_));
+
+  auto* split_view_browser_data = SplitViewBrowserData::FromBrowser(browser);
+  CHECK(split_view_browser_data);
+
+  auto tile = split_view_browser_data->GetTile(tab_handle);
+  if (!tile) {
+    return bounds.origin();
+  }
+
+  // 2. It's in split view mode. Center the dialog to the relevant web
+  // view.
+  auto* browser_view = static_cast<BraveBrowserView*>(browser->window());
+  auto* target_web_view =
+      tab_strip_model->GetActiveTab()->GetHandle() == tab_handle
+          ? browser_view->contents_web_view()
+          : browser_view->secondary_contents_web_view();
+  auto target_web_view_bounds = target_web_view->bounds();
+
+  // Adjust X position
+  bounds.set_x(target_web_view_bounds.CenterPoint().x() - bounds.width() / 2);
+  target_web_view_bounds =
+      views::View::ConvertRectToWidget(target_web_view_bounds);
+
+  return bounds.origin();
+}
+
+BEGIN_METADATA(BraveJavaScriptTabModalDialogViewViews)
+END_METADATA

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.cc
@@ -36,7 +36,7 @@ BraveJavaScriptTabModalDialogViewViews::BraveJavaScriptTabModalDialogViewViews(
           default_prompt_text,
           std::move(dialog_callback),
           std::move(dialog_force_closed_callback)),
-      alerting_web_contents_(*alerting_web_contents) {
+      web_contents_(*parent_web_contents) {
   // JavaScriptTabModalDialogViewViews already created Widget.
   auto* widget = GetWidget();
   CHECK(widget);
@@ -95,7 +95,7 @@ web_modal::WebContentsModalDialogHost&
 BraveJavaScriptTabModalDialogViewViews::GetModalDialogHost() {
   web_modal::WebContentsModalDialogManager* manager =
       web_modal::WebContentsModalDialogManager::FromWebContents(
-          base::to_address(alerting_web_contents_));
+          base::to_address(web_contents_));
   CHECK(manager);
 
   auto* modal_dialog_host =
@@ -126,17 +126,15 @@ gfx::Point BraveJavaScriptTabModalDialogViewViews::
   bounds.set_origin(modal_dialog_host.GetDialogPosition(bounds.size()));
 
   // 1. Check if the tab is in split view mode.
-  auto* browser =
-      chrome::FindBrowserWithTab(base::to_address(alerting_web_contents_));
+  auto* browser = chrome::FindBrowserWithTab(base::to_address(web_contents_));
   if (!browser) {
     // This can happen on shutting down.
     return bounds.origin();
   }
 
   auto* tab_strip_model = browser->tab_strip_model();
-  auto tab_handle =
-      tab_strip_model->GetTabHandleAt(tab_strip_model->GetIndexOfWebContents(
-          base::to_address(alerting_web_contents_)));
+  auto tab_handle = tab_strip_model->GetTabHandleAt(
+      tab_strip_model->GetIndexOfWebContents(base::to_address(web_contents_)));
 
   auto* split_view_browser_data = SplitViewBrowserData::FromBrowser(browser);
   CHECK(split_view_browser_data);

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_JAVASCRIPT_TAB_MODAL_DIALOG_VIEW_VIEWS_H_
+#define BRAVE_BROWSER_UI_VIEWS_BRAVE_JAVASCRIPT_TAB_MODAL_DIALOG_VIEW_VIEWS_H_
+
+#include "base/memory/weak_ptr.h"
+#include "chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.h"
+#include "ui/base/metadata/metadata_header_macros.h"
+#include "ui/views/widget/widget_observer.h"
+
+namespace web_modal {
+class WebContentsModalDialogHost;
+}  // namespace web_modal
+
+class BraveJavaScriptTabModalDialogViewViews
+    : public JavaScriptTabModalDialogViewViews,
+      public views::WidgetObserver {
+  METADATA_HEADER(BraveJavaScriptTabModalDialogViewViews,
+                  JavaScriptTabModalDialogViewViews)
+ public:
+  BraveJavaScriptTabModalDialogViewViews(
+      content::WebContents* parent_web_contents,
+      content::WebContents* alerting_web_contents,
+      const std::u16string& title,
+      content::JavaScriptDialogType dialog_type,
+      const std::u16string& message_text,
+      const std::u16string& default_prompt_text,
+      content::JavaScriptDialogManager::DialogClosedCallback dialog_callback,
+      base::OnceClosure dialog_force_closed_callback);
+  ~BraveJavaScriptTabModalDialogViewViews() override;
+
+ private:
+  friend class JavaScriptTabModalDialogManagerDelegateDesktop;
+
+  web_modal::WebContentsModalDialogHost* GetModalDialogHost();
+
+  void UpdateWidgetBounds();
+
+  // This returns point in dialog host's widget coordinate.
+  gfx::Point GetDesiredPositionConsideringSplitView();
+
+  raw_ptr<content::WebContents> alerting_web_contents_ = nullptr;
+
+  base::WeakPtrFactory<BraveJavaScriptTabModalDialogViewViews>
+      weak_ptr_factory_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_BRAVE_JAVASCRIPT_TAB_MODAL_DIALOG_VIEW_VIEWS_H_

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h
@@ -45,7 +45,7 @@ class BraveJavaScriptTabModalDialogViewViews
   // This returns point in dialog host's widget coordinate.
   gfx::Point GetDesiredPositionConsideringSplitView();
 
-  raw_ref<content::WebContents> alerting_web_contents_;
+  raw_ref<content::WebContents> web_contents_;
 
   base::WeakPtrFactory<BraveJavaScriptTabModalDialogViewViews>
       weak_ptr_factory_{this};

--- a/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h
+++ b/browser/ui/views/brave_javascript_tab_modal_dialog_view_views.h
@@ -15,6 +15,9 @@ namespace web_modal {
 class WebContentsModalDialogHost;
 }  // namespace web_modal
 
+// This class overrides JavaScriptTabModalDialogViewViews to customize the
+// position of the dialog. In split view mode, we want dialogs to be centered to
+// its relevant web view.
 class BraveJavaScriptTabModalDialogViewViews
     : public JavaScriptTabModalDialogViewViews,
       public views::WidgetObserver {
@@ -35,14 +38,14 @@ class BraveJavaScriptTabModalDialogViewViews
  private:
   friend class JavaScriptTabModalDialogManagerDelegateDesktop;
 
-  web_modal::WebContentsModalDialogHost* GetModalDialogHost();
+  web_modal::WebContentsModalDialogHost& GetModalDialogHost();
 
   void UpdateWidgetBounds();
 
   // This returns point in dialog host's widget coordinate.
   gfx::Point GetDesiredPositionConsideringSplitView();
 
-  raw_ptr<content::WebContents> alerting_web_contents_ = nullptr;
+  raw_ref<content::WebContents> alerting_web_contents_;
 
   base::WeakPtrFactory<BraveJavaScriptTabModalDialogViewViews>
       weak_ptr_factory_{this};

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -322,6 +322,7 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
 
     auto* contents_layout_manager = static_cast<BraveContentsLayoutManager*>(
         contents_container()->GetLayoutManager());
+    contents_layout_manager->set_browser_view(this);
     contents_layout_manager->set_secondary_contents_view(
         secondary_contents_web_view_);
     contents_layout_manager->set_secondary_devtools_view(
@@ -771,6 +772,10 @@ void BraveBrowserView::ShowWaybackMachineBubble() {
 
 WalletButton* BraveBrowserView::GetWalletButton() {
   return static_cast<BraveToolbarView*>(toolbar())->wallet_button();
+}
+
+void BraveBrowserView::NotifyDialogPositionRequiresUpdate() {
+  GetBrowserViewLayout()->NotifyDialogPositionRequiresUpdate();
 }
 
 views::View* BraveBrowserView::GetWalletButtonAnchorView() {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -131,7 +131,7 @@ class BraveBrowserView : public BrowserView,
   void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) override;
   void OnSwapTabsInTile(const SplitViewBrowserData::Tile& tile) override;
 
-  auto secondary_contents_web_view() {
+  views::WebView* secondary_contents_web_view() {
     return secondary_contents_web_view_.get();
   }
 

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -81,6 +81,9 @@ class BraveBrowserView : public BrowserView,
   WalletButton* GetWalletButton();
   views::View* GetWalletButtonAnchorView();
 
+  // Triggers layout of web modal dialogs
+  void NotifyDialogPositionRequiresUpdate();
+
   // BrowserView overrides:
   void Layout(PassKey) override;
   void StartTabCycling() override;
@@ -127,6 +130,10 @@ class BraveBrowserView : public BrowserView,
   void OnTileTabs(const SplitViewBrowserData::Tile& tile) override;
   void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) override;
   void OnSwapTabsInTile(const SplitViewBrowserData::Tile& tile) override;
+
+  auto secondary_contents_web_view() {
+    return secondary_contents_web_view_.get();
+  }
 
  private:
   class TabCyclingEventHandler;

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -7,6 +7,8 @@
 
 #include "base/feature_list.h"
 #include "brave/browser/ui/tabs/features.h"
+#include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "chrome/browser/ui/browser_navigator_params.h"
 #include "ui/views/view.h"
 
 namespace {
@@ -122,5 +124,9 @@ void BraveContentsLayoutManager::LayoutImpl() {
     layout_web_contents_and_devtools(bounds, secondary_contents_view_,
                                      secondary_devtools_view_,
                                      secondary_strategy_);
+  }
+
+  if (browser_view_) {
+    browser_view_->NotifyDialogPositionRequiresUpdate();
   }
 }

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -10,6 +10,7 @@
 #include "brave/browser/ui/views/split_view/split_view_separator_delegate.h"
 #include "chrome/browser/ui/views/frame/contents_layout_manager.h"
 
+class BraveBrowserView;
 class SplitViewBrowserData;
 
 class BraveContentsLayoutManager : public ContentsLayoutManager,
@@ -20,6 +21,10 @@ class BraveContentsLayoutManager : public ContentsLayoutManager,
 
   using ContentsLayoutManager::ContentsLayoutManager;
   ~BraveContentsLayoutManager() override;
+
+  void set_browser_view(BraveBrowserView* browser_view) {
+    browser_view_ = browser_view;
+  }
 
   void set_secondary_contents_view(views::View* secondary_contents_view) {
     secondary_contents_view_ = secondary_contents_view;
@@ -59,6 +64,8 @@ class BraveContentsLayoutManager : public ContentsLayoutManager,
 
  private:
   friend class BraveContentsLayoutManagerUnitTest;
+
+  raw_ptr<BraveBrowserView> browser_view_ = nullptr;
 
   raw_ptr<SplitViewBrowserData> split_view_browser_data_ = nullptr;
   raw_ptr<views::View> secondary_contents_view_ = nullptr;

--- a/browser/ui/views/frame/split_view_browsertest.cc
+++ b/browser/ui/views/frame/split_view_browsertest.cc
@@ -194,3 +194,25 @@ IN_PROC_BROWSER_TEST_F(
 
   EXPECT_EQ(web_view_bounds.CenterPoint().x(), dialog_bounds.CenterPoint().x());
 }
+IN_PROC_BROWSER_TEST_F(
+    SplitViewBrowserTest,
+    JavascriptTabModalDialogView_DialogShouldBeCenteredToRelatedWebView_InVerticalTab) {
+  brave::ToggleVerticalTabStrip(browser());
+  brave::NewSplitViewForTab(browser());
+  auto* active_contents = chrome_test_utils::GetActiveWebContents(this);
+
+  auto* dialog = new BraveJavaScriptTabModalDialogViewViews(
+      active_contents, active_contents, u"title",
+      content::JAVASCRIPT_DIALOG_TYPE_ALERT, u"message", u"default prompt",
+      base::DoNothing(), base::DoNothing());
+  ASSERT_TRUE(dialog);
+  auto* widget = dialog->GetWidget();
+  ASSERT_TRUE(widget);
+
+  const auto dialog_bounds = widget->GetWindowBoundsInScreen();
+
+  auto web_view_bounds = contents_web_view().GetLocalBounds();
+  views::View::ConvertRectToScreen(&contents_web_view(), &web_view_bounds);
+
+  EXPECT_EQ(web_view_bounds.CenterPoint().x(), dialog_bounds.CenterPoint().x());
+}

--- a/chromium_src/chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h
+++ b/chromium_src/chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h
@@ -1,0 +1,25 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_JAVASCRIPT_DIALOGS_JAVASCRIPT_TAB_MODAL_DIALOG_MANAGER_DELEGATE_DESKTOP_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_JAVASCRIPT_DIALOGS_JAVASCRIPT_TAB_MODAL_DIALOG_MANAGER_DELEGATE_DESKTOP_H_
+
+#include "components/javascript_dialogs/tab_modal_dialog_manager_delegate.h"
+
+#define CreateNewDialog                                                       \
+  CreateNewDialog_ChromiumImpl(                                               \
+      content::WebContents* alerting_web_contents,                            \
+      const std::u16string& title, content::JavaScriptDialogType dialog_type, \
+      const std::u16string& message_text,                                     \
+      const std::u16string& default_prompt_text,                              \
+      content::JavaScriptDialogManager::DialogClosedCallback dialog_callback, \
+      base::OnceClosure dialog_closed_callback);                              \
+  base::WeakPtr<javascript_dialogs::TabModalDialogView> CreateNewDialog
+
+#include "src/chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h"  // IWYU pragma: export
+
+#undef CreateNewDialog
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_JAVASCRIPT_DIALOGS_JAVASCRIPT_TAB_MODAL_DIALOG_MANAGER_DELEGATE_DESKTOP_H_

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.cc
@@ -26,3 +26,7 @@
 #undef SidePanel
 #undef BRAVE_BROWSER_VIEW_LAYOUT_CONVERTED_HIT_TEST
 #undef SupportsWindowFeature
+
+void BrowserViewLayout::NotifyDialogPositionRequiresUpdate() {
+  dialog_host_->NotifyPositionRequiresUpdate();
+}

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
@@ -15,9 +15,14 @@
 #define LayoutBookmarkAndInfoBars virtual LayoutBookmarkAndInfoBars
 #define LayoutInfoBar virtual LayoutInfoBar
 #define LayoutContentsContainerView virtual LayoutContentsContainerView
+#define set_contents_border_widget           \
+  set_contents_border_widget_unused();       \
+  void NotifyDialogPositionRequiresUpdate(); \
+  void set_contents_border_widget
 
 #include "src/chrome/browser/ui/views/frame/browser_view_layout.h"  // IWYU pragma: export
 
+#undef set_contents_border_widget
 #undef LayoutContentsContainerView
 #undef LayoutInfoBar
 #undef LayoutBookmarkAndInfoBars

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
@@ -16,7 +16,8 @@
 #define LayoutInfoBar virtual LayoutInfoBar
 #define LayoutContentsContainerView virtual LayoutContentsContainerView
 
-// Add a new method: NotifyDialogPositionRequiresUpdate()
+// Add a new method: NotifyDialogPositionRequiresUpdate(). This is needed for
+// split view to update the dialog position when the split view is resized.
 #define set_contents_border_widget           \
   set_contents_border_widget_unused();       \
   void NotifyDialogPositionRequiresUpdate(); \

--- a/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_view_layout.h
@@ -15,6 +15,8 @@
 #define LayoutBookmarkAndInfoBars virtual LayoutBookmarkAndInfoBars
 #define LayoutInfoBar virtual LayoutInfoBar
 #define LayoutContentsContainerView virtual LayoutContentsContainerView
+
+// Add a new method: NotifyDialogPositionRequiresUpdate()
 #define set_contents_border_widget           \
   set_contents_border_widget_unused();       \
   void NotifyDialogPositionRequiresUpdate(); \

--- a/chromium_src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.cc
+++ b/chromium_src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h"
+
+#define CreateNewDialog CreateNewDialog_ChromiumImpl
+
+#include "src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.cc"
+
+#undef CreateNewDialog

--- a/chromium_src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.cc
+++ b/chromium_src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.cc
@@ -5,6 +5,10 @@
 
 #include "chrome/browser/ui/javascript_dialogs/javascript_tab_modal_dialog_manager_delegate_desktop.h"
 
+// CreateNewDialog is a function declared in
+// JavaScriptTabModalDialogManagerDelegateDesktop. As we want our own factory
+// function, replaces the function name. Our version will be in the
+// brave_javascript_tab_modal_dialog_view_views.cc.
 #define CreateNewDialog CreateNewDialog_ChromiumImpl
 
 #include "src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.cc"

--- a/chromium_src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.h
+++ b/chromium_src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_JAVASCRIPT_TAB_MODAL_DIALOG_VIEW_VIEWS_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_JAVASCRIPT_TAB_MODAL_DIALOG_VIEW_VIEWS_H_
+
+#define JavaScriptTabModalDialogManagerDelegateDesktop \
+  JavaScriptTabModalDialogManagerDelegateDesktop;      \
+  friend class BraveJavaScriptTabModalDialogViewViews
+
+#include "src/chrome/browser/ui/views/javascript_tab_modal_dialog_view_views.h"  // IWYU pragma: export
+
+#undef JavaScriptTabModalDialogManagerDelegateDesktop
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_JAVASCRIPT_TAB_MODAL_DIALOG_VIEW_VIEWS_H_

--- a/chromium_src/components/constrained_window/constrained_window_views.cc
+++ b/chromium_src/components/constrained_window/constrained_window_views.cc
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/web_modal/modal_dialog_host.h"
+
+#define GetDialogPosition(size)                                              \
+  GetDialogPosition(size);                                                   \
+  if (auto* widget_delegate = widget->widget_delegate();                     \
+      widget_delegate && widget_delegate->has_desired_position_delegate()) { \
+    position = widget_delegate->get_desired_position();                      \
+  }
+
+#include "src/components/constrained_window/constrained_window_views.cc"
+
+#undef GetDialogPosition

--- a/chromium_src/ui/views/widget/widget_delegate.h
+++ b/chromium_src/ui/views/widget/widget_delegate.h
@@ -6,6 +6,10 @@
 #ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_DELEGATE_H_
 #define BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_DELEGATE_H_
 
+// Adds interfaces for overriding desired bounds' position. These are used by
+// constrained window views. We need separate method from the existing
+// desired_bounds_delegate() so that we can override position in the middle of
+// desired_bounds_delegate() without falling into infinite recursion.
 #define set_desired_bounds_delegate                                 \
   set_desired_bounds_delegate_unused();                             \
   gfx::Point get_desired_position() {                               \

--- a/chromium_src/ui/views/widget/widget_delegate.h
+++ b/chromium_src/ui/views/widget/widget_delegate.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_DELEGATE_H_
+
+#define set_desired_bounds_delegate                                 \
+  set_desired_bounds_delegate_unused();                             \
+  gfx::Point get_desired_position() {                               \
+    return desired_position_delegate_.Run();                        \
+  }                                                                 \
+  bool has_desired_position_delegate() const {                      \
+    return static_cast<bool>(desired_position_delegate_);           \
+  }                                                                 \
+  void set_desired_position_delegate(                               \
+      base::RepeatingCallback<gfx::Point()> delegate) {             \
+    desired_position_delegate_ = std::move(delegate);               \
+  }                                                                 \
+                                                                    \
+ private:                                                           \
+  base::RepeatingCallback<gfx::Point()> desired_position_delegate_; \
+                                                                    \
+ public:                                                            \
+  void set_desired_bounds_delegate
+
+#include "src/ui/views/widget/widget_delegate.h"  // IWYU pragma: export
+
+#undef set_desired_bounds_delegate
+
+#endif  // BRAVE_CHROMIUM_SRC_UI_VIEWS_WIDGET_WIDGET_DELEGATE_H_


### PR DESCRIPTION
In split view mode, it's hard to find which web view triggered javascript tab modal dialog, such as alert, confirm, prompt.

This PR lays out the modal dialogs centered to the related web view so that users can easily recognize which web view triggered the dialog.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39598

https://github.com/brave/brave-core/assets/5474642/4c9f9746-35c1-4afb-91b2-451c9cc63ec5

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

