### PR TITLE
Disables suggested top sites from upstream on initial start (uplift to 1.68.x)

### DIFF
--- a/chromium_src/components/ntp_tiles/features.cc
+++ b/chromium_src/components/ntp_tiles/features.cc
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/ntp_tiles/features.cc"
+
+#include "base/feature_override.h"
+
+namespace ntp_tiles {
+
+// Disables fetching suggested web sites favicons
+OVERRIDE_FEATURE_DEFAULT_STATES({{
+    {kPopularSitesBakedInContentFeature, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kNtpMostLikelyFaviconsFromServerFeature,
+     base::FEATURE_DISABLED_BY_DEFAULT},
+    {kUsePopularSitesSuggestions, base::FEATURE_DISABLED_BY_DEFAULT},
+}});
+
+}  // namespace ntp_tiles


### PR DESCRIPTION
Uplift of #24511
Resolves https://github.com/brave/brave-browser/issues/39541

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.