### PR TITLE
Fixed news follow button UI regressions from news feed bubble

### DIFF
--- a/browser/ui/views/brave_news/brave_news_feed_item_view.cc
+++ b/browser/ui/views/brave_news/brave_news_feed_item_view.cc
@@ -102,8 +102,12 @@ void BraveNewsFeedItemView::OnPressed() {
     return;
   }
 
-  tab_helper_->ToggleSubscription(feed_url_);
+  // Set true to |loading_| before asking to tab helper because
+  // we could get `OnAvailableFeedsChanged()` in this turn.
+  // Otherwise, |loading_| can have true even after
+  // OnAvailableFeedsChanged() is called by tab_helper.
   loading_ = true;
+  tab_helper_->ToggleSubscription(feed_url_);
   Update();
 }
 

--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -284,7 +284,12 @@ void MdTextButton::UpdateTextColor() {
     return;
   }
 
-  // To prevent set explicitly set color from here.
+  // Don't set MdTextButton's color as explicitly_set_color.
+  // As below LabelButton::SetTextColor() sets its color args as
+  // expliclity_set_color, we cache current explicitly_set_colors here
+  // back to original after calling SetTextColor().
+  // We(also upstream) uses it to check whether the client of MdTextButton
+  // sets another color.
   const auto colors = explicitly_set_colors();
   auto button_colors = GetButtonColors();
   SetTextColor(GetVisualState(), button_colors.text_color);

--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -284,8 +284,11 @@ void MdTextButton::UpdateTextColor() {
     return;
   }
 
-  auto colors = GetButtonColors();
-  SetTextColor(GetVisualState(), colors.text_color);
+  // To prevent set explicitly set color from here.
+  const auto colors = explicitly_set_colors();
+  auto button_colors = GetButtonColors();
+  SetTextColor(GetVisualState(), button_colors.text_color);
+  set_explicitly_set_colors(colors);
 }
 
 void MdTextButton::UpdateBackgroundColor() {

--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -305,7 +305,17 @@ void MdTextButton::UpdateColors() {
 
   // Update the icon color.
   if (icon_) {
+    // Usually, only set for normal state if we want to use same image for all
+    // state. However, upstream MdTextButton updates left-padding when it has
+    // image. As it uses HasImage(GetVisualState()) for checking image,
+    // different padding could be used if we don't set image for all state.
     SetImageModel(ButtonState::STATE_NORMAL,
+                  ui::ImageModel::FromVectorIcon(*icon_, GetCurrentTextColor(),
+                                                 icon_size_));
+    SetImageModel(ButtonState::STATE_HOVERED,
+                  ui::ImageModel::FromVectorIcon(*icon_, GetCurrentTextColor(),
+                                                 icon_size_));
+    SetImageModel(ButtonState::STATE_PRESSED,
                   ui::ImageModel::FromVectorIcon(*icon_, GetCurrentTextColor(),
                                                  icon_size_));
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39576

[simplescreenrecorder-2024-07-09_14.03.34.webm](https://github.com/brave/brave-core/assets/6786187/bdedd5fa-56f5-43a0-9383-dba85714d4d4)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue