### PR TITLE
Feat(wallet): add watch only label and alerts to unowned NFTs

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -48,6 +48,7 @@ inline constexpr char kSimpleHashBraveProxyUrl[] =
 inline constexpr size_t kSimpleHashMaxBatchSize = 50;
 
 inline constexpr webui::LocalizedString kLocalizedStrings[] = {
+    {"braveWalletWatchOnly", IDS_BRAVE_WALLET_WATCH_ONLY},
     {"braveWalletNftSymbolFieldExplanation",
      IDS_BRAVE_WALLET_NFT_SYMBOL_FIELD_EXPLANATION},
     {"braveWalletNftNameFieldExplanation",

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -58,6 +58,7 @@ import {
   getTokenCollectionName,
   getTokensWithBalanceForAccounts,
   groupSpamAndNonSpamNfts,
+  isTokenWatchOnly,
   searchNftCollectionsAndGetTotalNftsFound,
   searchNfts
 } from '../../../../../utils/asset-utils'
@@ -192,22 +193,11 @@ export const Nfts = ({
   const userNonSpamNftIds =
     userTokensRegistry?.nonSpamTokenIds ?? emptyTokenIdsList
 
-  const shouldFetchSpamNftBalances =
-    selectedTab === 'hidden' &&
-    !isLoadingSpamNfts &&
-    hideUnownedNfts &&
-    accounts.length > 0 &&
-    networks.length > 0
-
-  const { data: spamTokenBalancesRegistry } = useBalancesFetcher(
-    shouldFetchSpamNftBalances
-      ? {
-          accounts,
-          networks,
-          isSpamRegistry: true
-        }
-      : skipToken
-  )
+  const { data: spamTokenBalancesRegistry } = useBalancesFetcher({
+    accounts,
+    networks,
+    isSpamRegistry: true
+  })
 
   // mutations
   const [setNftDiscovery] = useSetNftDiscoveryEnabledMutation()
@@ -412,7 +402,9 @@ export const Nfts = ({
       isFetchingLatestAssetIdsByCollectionNameRegistry) ||
     (selectedTab === 'hidden' &&
       (isLoadingSpamNfts ||
-        (shouldFetchSpamNftBalances && !spamTokenBalancesRegistry)))
+        // (shouldFetchSpamNftBalances &&
+        !spamTokenBalancesRegistry))
+  // )
 
   // methods
   const onSearchValueChange = React.useCallback(
@@ -602,6 +594,12 @@ export const Nfts = ({
                         onSelectAsset={onSelectAsset}
                         isTokenHidden={isHidden}
                         isTokenSpam={isSpam}
+                        isWatchOnly={isTokenWatchOnly(
+                          nft,
+                          allAccounts,
+                          tokenBalancesRegistry,
+                          spamTokenBalancesRegistry
+                        )}
                       />
                     )
                   })}

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nfts.tsx
@@ -401,10 +401,7 @@ export const Nfts = ({
     (groupNftsByCollection &&
       isFetchingLatestAssetIdsByCollectionNameRegistry) ||
     (selectedTab === 'hidden' &&
-      (isLoadingSpamNfts ||
-        // (shouldFetchSpamNftBalances &&
-        !spamTokenBalancesRegistry))
-  // )
+      (isLoadingSpamNfts || !spamTokenBalancesRegistry))
 
   // methods
   const onSearchValueChange = React.useCallback(

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item.stories.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item.stories.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+// components
+import {
+  WalletPanelStory //
+} from '../../../../../../stories/wrappers/wallet-panel-story-wrapper'
+import { PanelWrapper } from '../../../../../../panel/style'
+import { NFTGridViewItem } from './nft-grid-view-item'
+
+// mocks
+import {
+  mockMoonCatNFT //
+} from '../../../../../../stories/mock-data/mock-asset-options'
+
+export const _NftGridViewItem = {
+  render: () => {
+    return (
+      <WalletPanelStory>
+        <PanelWrapper>
+          <NFTGridViewItem
+            isTokenHidden={false}
+            isTokenSpam={false}
+            onSelectAsset={() => undefined}
+            token={mockMoonCatNFT}
+            isWatchOnly={false}
+          />
+        </PanelWrapper>
+      </WalletPanelStory>
+    )
+  }
+}
+export const _JunkAndWatchOnlyNftGridViewItem = {
+  render: () => {
+    return (
+      <WalletPanelStory>
+        <PanelWrapper>
+          <NFTGridViewItem
+            isTokenHidden={false}
+            isTokenSpam={true}
+            onSelectAsset={() => undefined}
+            token={mockMoonCatNFT}
+            isWatchOnly={true}
+          />
+        </PanelWrapper>
+      </WalletPanelStory>
+    )
+  }
+}
+export default {
+  component: NFTGridViewItem
+}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item.tsx
@@ -46,7 +46,8 @@ import {
   NFTSymbol,
   MoreButton,
   JunkMarker,
-  JunkIcon
+  JunkIcon,
+  WatchOnlyMarker
 } from './style'
 import { Row } from '../../../../../shared/style'
 
@@ -55,10 +56,16 @@ interface Props {
   isTokenHidden: boolean
   isTokenSpam: boolean
   onSelectAsset: (token: BraveWallet.BlockchainToken) => void
+  isWatchOnly?: boolean
 }
 
-export const NFTGridViewItem = (props: Props) => {
-  const { token, isTokenHidden, isTokenSpam, onSelectAsset } = props
+export const NFTGridViewItem = ({
+  token,
+  isTokenHidden,
+  isTokenSpam,
+  onSelectAsset,
+  isWatchOnly
+}: Props) => {
   const tokenImageURL = stripERC20TokenImageURL(token.logo)
   const [showRemoveNftModal, setShowRemoveNftModal] =
     React.useState<boolean>(false)
@@ -164,6 +171,14 @@ export const NFTGridViewItem = (props: Props) => {
             {getLocale('braveWalletNftJunk')}
             <JunkIcon />
           </JunkMarker>
+        )}
+        {isWatchOnly && (
+          <WatchOnlyMarker>
+            {
+              //
+              getLocale('braveWalletWatchOnly')
+            }
+          </WatchOnlyMarker>
         )}
         <IconWrapper>
           <DecoratedNftIcon

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item.tsx
@@ -175,8 +175,7 @@ export const NFTGridViewItem = ({
         {isWatchOnly && (
           <WatchOnlyMarker>
             {
-              //
-              getLocale('braveWalletWatchOnly')
+              getLocale('braveWalletWatchOnly') //
             }
           </WatchOnlyMarker>
         )}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/nft-grid-view/style.ts
@@ -121,7 +121,7 @@ export const MoreIcon = styled(Icon).attrs({
 
 export const JunkMarker = styled.div`
   display: inline-flex;
-  height: 20px;
+  min-height: 20px;
   padding: 0px ${leo.spacing.s};
   align-items: center;
   gap: ${leo.spacing.s};
@@ -139,6 +139,13 @@ export const JunkMarker = styled.div`
   line-height: normal;
   text-transform: uppercase;
   z-index: 2;
+`
+
+export const WatchOnlyMarker = styled(JunkMarker)`
+  background-color: ${leo.color.gray[20]};
+  color: ${leo.color.gray[60]};
+  left: unset;
+  right: 12px;
 `
 
 export const JunkIcon = styled(Icon).attrs({

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1239,7 +1239,10 @@ provideStrings({
   braveWalletEditNftModalTitle: 'Edit NFT',
   braveWalletNftMoveToSpam: 'Mark as junk',
   braveWalletNftUnspam: 'Mark as not junk',
+
+  // NFT Labels
   braveWalletNftJunk: 'Junk',
+  braveWalletWatchOnly: 'Watch-only',
 
   // Add NFT modal
   braveWalletAddNftModalTitle: 'Add NFT',

--- a/components/brave_wallet_ui/stories/mock-data/mock-asset-options.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-asset-options.ts
@@ -253,7 +253,7 @@ export const mockUSDCoin = {
   chainId: BraveWallet.MAINNET_CHAIN_ID
 }
 
-export const mockMoonCatNFT = {
+export const mockMoonCatNFT: BraveWallet.BlockchainToken = {
   contractAddress: '0xc3f733ca98E0daD0386979Eb96fb1722A1A05E69',
   name: 'MoonCats',
   symbol: 'AMC',

--- a/components/brave_wallet_ui/stories/wallet-components.tsx
+++ b/components/brave_wallet_ui/stories/wallet-components.tsx
@@ -23,7 +23,6 @@ import {
   ContainerCard,
   LayoutCardWrapper
 } from '../components/desktop/wallet-page-wrapper/wallet-page-wrapper.style'
-import { NFTGridViewItem } from '../components/desktop/views/portfolio/components/nft-grid-view/nft-grid-view-item'
 import { TabOption, Tabs } from '../components/shared/tabs/tabs'
 import { AutoDiscoveryEmptyState } from '../components/desktop/views/nfts/components/auto-discovery-empty-state/auto-discovery-empty-state'
 import { MarketGrid } from '../components/shared/market-grid/market-grid'
@@ -114,8 +113,6 @@ _BuySendSwapDeposit.story = {
   name: 'Buy/Send/Swap/Deposit'
 }
 
-
-
 export const _NftsEmptyState = () => {
   return <NftsEmptyState onImportNft={() => console.log('On import NFT')} />
 }
@@ -167,19 +164,6 @@ export const _AutoDiscoveryEmptyState = () => {
 
 _AutoDiscoveryEmptyState.story = {
   title: 'NFT Auto Discovery Empty State'
-}
-
-export const _NFTGridViewItem = () => {
-  return (
-    <WalletPageStory>
-      <NFTGridViewItem
-        isTokenHidden={false}
-        isTokenSpam={false}
-        token={mockErc721Token}
-        onSelectAsset={() => {}}
-      />
-    </WalletPageStory>
-  )
 }
 
 export const _Tabs = () => {

--- a/components/brave_wallet_ui/utils/asset-utils.test.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.test.ts
@@ -3,13 +3,23 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+// types
+import {
+  TokenBalancesRegistry //
+} from '../common/slices/entities/token-balance.entity'
+
+// utils
 import {
   checkIfTokensMatch,
   checkIfTokenNeedsNetworkIcon,
   searchNftCollectionsAndGetTotalNftsFound,
   getTokenCollectionName,
-  getAssetIdKey
+  getAssetIdKey,
+  isTokenWatchOnly
 } from './asset-utils'
+import { getAccountBalancesKey } from './balance-utils'
+
+// mocks
 import { mockEthMainnet } from '../stories/mock-data/mock-networks'
 import {
   mockEthToken,
@@ -17,6 +27,7 @@ import {
   mockMoonCatNFT,
   mockErc721Token
 } from '../stories/mock-data/mock-asset-options'
+import { mockAccounts } from '../stories/mock-data/mock-wallet-accounts'
 
 const ethToken = mockEthToken
 const batToken = mockBasicAttentionToken
@@ -34,6 +45,34 @@ const mockCollectionAssetIdsRegistry = {
     getAssetIdKey({ ...nftTokenTwo, tokenId: '' })
   ],
   'Invisible Friends': [getAssetIdKey({ ...mockErc721Token, tokenId: '' })]
+}
+
+const mockUserTokenBalancesRegistry: TokenBalancesRegistry = {
+  accounts: {
+    [getAccountBalancesKey(mockAccounts[0].accountId)]: {
+      chains: {
+        [mockMoonCatNFT.chainId]: {
+          tokenBalances: {
+            [mockMoonCatNFT.contractAddress.toLowerCase()]: '1'
+          }
+        }
+      }
+    }
+  }
+}
+
+const mockEmptyUserTokenBalancesRegistry: TokenBalancesRegistry = {
+  accounts: {
+    [getAccountBalancesKey(mockAccounts[0].accountId)]: {
+      chains: {
+        [mockMoonCatNFT.chainId]: {
+          tokenBalances: {
+            [mockMoonCatNFT.contractAddress.toLowerCase()]: '0'
+          }
+        }
+      }
+    }
+  }
 }
 
 describe('Check if tokens match', () => {
@@ -124,5 +163,26 @@ describe('getTokenCollectionName', () => {
     )
     expect(moonCatCollectionName).toBe('MoonCatsRescue')
     expect(invisibleFriendCollectionName).toBe('Invisible Friends')
+  })
+})
+
+describe('isTokenWatchOnly', () => {
+  it('should check if the token has a balance', () => {
+    expect(
+      isTokenWatchOnly(
+        mockMoonCatNFT,
+        mockAccounts,
+        mockUserTokenBalancesRegistry,
+        mockUserTokenBalancesRegistry
+      )
+    ).toBe(false)
+    expect(
+      isTokenWatchOnly(
+        mockMoonCatNFT,
+        mockAccounts,
+        mockEmptyUserTokenBalancesRegistry,
+        mockEmptyUserTokenBalancesRegistry
+      )
+    ).toBe(true)
   })
 })

--- a/components/brave_wallet_ui/utils/asset-utils.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.ts
@@ -387,6 +387,23 @@ export const compareTokensByName = (
   b: Pick<BraveWallet.BlockchainToken, 'name'>
 ) => a.name.localeCompare(b.name)
 
+export function isTokenWatchOnly(
+  token: BraveWallet.BlockchainToken,
+  allAccounts: BraveWallet.AccountInfo[],
+  tokenBalancesRegistry: TokenBalancesRegistry | null | undefined,
+  spamTokenBalancesRegistry: TokenBalancesRegistry | null | undefined
+) {
+  return !allAccounts.some((account) => {
+    const balance = getBalance(account.accountId, token, tokenBalancesRegistry)
+    const spamBalance = getBalance(
+      account.accountId,
+      token,
+      spamTokenBalancesRegistry
+    )
+    return (balance && balance !== '0') || (spamBalance && spamBalance !== '0')
+  })
+}
+
 export function getTokensWithBalanceForAccounts(
   tokens: BraveWallet.BlockchainToken[],
   filteredAccounts: BraveWallet.AccountInfo[],

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1082,5 +1082,5 @@
   <message name="IDS_BRAVE_WALLET_EXEMPLI_GRATIA" desc="Placeholder text for an example value">e.g <ph name="VALUE">$1<ex>0xDEADBEEF</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_NFT_NAME_FIELD_EXPLANATION" desc="An explaination for the purpose of the NFT name field">The token name for an NFT refers to the specific name given to a non-fungible token within a particular collection or project. This name distinguishes one NFT from another within the same collection.</message>
   <message name="IDS_BRAVE_WALLET_NFT_SYMBOL_FIELD_EXPLANATION" desc="An explaination for the purpose of the NFT symbol field">The NFT symbol refers to the unique identifier used to distinguish the NFT collection or project.</message>
-  <message name="IDS_BRAVE_WALLET_WATCH_ONLY" desc="Label to indicate that an asset is watch-only. This means that the asset can not owned by the user or it cannot be transferred">Watch-only</message>
+  <message name="IDS_BRAVE_WALLET_WATCH_ONLY" desc="Label to indicate that an asset is watch-only. This means that the asset is not owned by the user or it cannot be transferred">Watch-only</message>
 </grit-part>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1082,4 +1082,5 @@
   <message name="IDS_BRAVE_WALLET_EXEMPLI_GRATIA" desc="Placeholder text for an example value">e.g <ph name="VALUE">$1<ex>0xDEADBEEF</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_NFT_NAME_FIELD_EXPLANATION" desc="An explaination for the purpose of the NFT name field">The token name for an NFT refers to the specific name given to a non-fungible token within a particular collection or project. This name distinguishes one NFT from another within the same collection.</message>
   <message name="IDS_BRAVE_WALLET_NFT_SYMBOL_FIELD_EXPLANATION" desc="An explaination for the purpose of the NFT symbol field">The NFT symbol refers to the unique identifier used to distinguish the NFT collection or project.</message>
+  <message name="IDS_BRAVE_WALLET_WATCH_ONLY" desc="Label to indicate that an asset is watch-only. This means that the asset can not owned by the user or it cannot be transferred">Watch-only</message>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39652
Resolves https://github.com/brave/brave-browser/issues/39653

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Add an NFT that is not owned by one of you accounts to the assets list view the "Add NFT form"
- View the NFT details screen (ensure that "hide unowned NFTS is unchecked)
- The NFT in the portfolio grid should have a "Watch Only" label
- Click the NFT
- The NFT details screen should display an info-alert explaining that the NFT is not owned by any of the user's accounts

![Screenshot 2024-07-09 at 1 32 59 PM](https://github.com/brave/brave-core/assets/30185185/fd0c91e1-dc09-4fd5-9ba5-3bda47fd76f3)

![Screenshot 2024-07-09 at 1 33 11 PM](https://github.com/brave/brave-core/assets/30185185/cabd6dbb-20e8-456e-a534-a3699198e2d6)

