### PR TITLE
Empty SyncServiceAndroidBridge::KeepAccountSettingsPrefsOnlyForUsers method (uplift to 1.68.x)

### DIFF
--- a/chromium_src/components/sync/android/sync_service_android_bridge.cc
+++ b/chromium_src/components/sync/android/sync_service_android_bridge.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/sync/android/sync_service_android_bridge.h"
+
+#include "components/sync/service/sync_user_settings.h"
+
+#define KeepAccountSettingsPrefsOnlyForUsers \
+  KeepAccountSettingsPrefsOnlyForUsers_Unused
+#include "src/components/sync/android/sync_service_android_bridge.cc"
+#undef KeepAccountSettingsPrefsOnlyForUsers
+
+// Along with SyncUserSettings::KeepAccountSettingsPrefsOnlyForUsers_Unused
+// makes this method do nothing.
+// We need it on Android because Brave Browser doesn't use Google Account
+// to run Brave Sync. Otherwise empty gaia_ids arrives to
+// SyncTransportDataPrefs::KeepAccountSettingsPrefsOnlyForUsers, where
+// "Clears all account-keyed preferences for all accounts that are NOT in
+// `available_gaia_ids`." So all kSyncTransportDataPerAccount gets wiped.
+// Then ValidateSyncTransportData at sync_engine_impl.cc fails and
+// SyncEngineImpl::Initialize overwrites sync transport prefs. Device with new
+// generated cache guid is sent to the chain and all other devices see the
+// duplicated entry in addition to other possible mess.
+// To avoid this, override with empty implementation.
+void SyncServiceAndroidBridge::KeepAccountSettingsPrefsOnlyForUsers(
+    JNIEnv* env,
+    const base::android::JavaParamRef<jobjectArray>& gaia_ids) {}

--- a/chromium_src/components/sync/android/sync_service_android_bridge.h
+++ b/chromium_src/components/sync/android/sync_service_android_bridge.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ANDROID_SYNC_SERVICE_ANDROID_BRIDGE_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ANDROID_SYNC_SERVICE_ANDROID_BRIDGE_H_
+
+#define KeepAccountSettingsPrefsOnlyForUsers                                   \
+  KeepAccountSettingsPrefsOnlyForUsers_Unused(                                 \
+      JNIEnv* env, const base::android::JavaParamRef<jobjectArray>& gaia_ids); \
+  void KeepAccountSettingsPrefsOnlyForUsers
+
+#include "src/components/sync/android/sync_service_android_bridge.h"  // IWYU pragma: export
+
+#undef KeepAccountSettingsPrefsOnlyForUsers
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_ANDROID_SYNC_SERVICE_ANDROID_BRIDGE_H_

--- a/chromium_src/components/sync/service/sync_user_settings.h
+++ b/chromium_src/components/sync/service/sync_user_settings.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_USER_SETTINGS_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_USER_SETTINGS_H_
+
+// We need to expand SyncUserSettings with
+// KeepAccountSettingsPrefsOnlyForUsers_Unused method to match override at
+// SyncServiceAndroidBridge::KeepAccountSettingsPrefsOnlyForUsers because it now
+// call internally
+// GetUserSettings()->KeepAccountSettingsPrefsOnlyForUsers_Unused(gaia_id_hashes);
+
+#define KeepAccountSettingsPrefsOnlyForUsers                        \
+  KeepAccountSettingsPrefsOnlyForUsers_Unused(                      \
+      const std::vector<signin::GaiaIdHash>& available_gaia_ids) {} \
+  virtual void KeepAccountSettingsPrefsOnlyForUsers
+
+#include "src/components/sync/service/sync_user_settings.h"  // IWYU pragma: export
+
+#undef KeepAccountSettingsPrefsOnlyForUsers
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_USER_SETTINGS_H_


### PR DESCRIPTION
Uplift of #24535
Resolves https://github.com/brave/brave-browser/issues/39470

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.