### PR TITLE
Fixed news follow button UI regressions from news feed bubble (uplift to 1.68.x)

### DIFF
--- a/browser/ui/views/brave_news/brave_news_feed_item_view.cc
+++ b/browser/ui/views/brave_news/brave_news_feed_item_view.cc
@@ -102,8 +102,12 @@ void BraveNewsFeedItemView::OnPressed() {
     return;
   }
 
-  tab_helper_->ToggleSubscription(feed_url_);
+  // Set true to |loading_| before asking to tab helper because
+  // we could get `OnAvailableFeedsChanged()` in this turn.
+  // Otherwise, |loading_| can have true even after
+  // OnAvailableFeedsChanged() is called by tab_helper.
   loading_ = true;
+  tab_helper_->ToggleSubscription(feed_url_);
   Update();
 }
 

--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -284,8 +284,16 @@ void MdTextButton::UpdateTextColor() {
     return;
   }
 
-  auto colors = GetButtonColors();
-  SetTextColor(GetVisualState(), colors.text_color);
+  // Don't set MdTextButton's color as explicitly_set_color.
+  // As below LabelButton::SetTextColor() sets its color args as
+  // expliclity_set_color, we cache current explicitly_set_colors here
+  // back to original after calling SetTextColor().
+  // We(also upstream) uses it to check whether the client of MdTextButton
+  // sets another color.
+  const auto colors = explicitly_set_colors();
+  auto button_colors = GetButtonColors();
+  SetTextColor(GetVisualState(), button_colors.text_color);
+  set_explicitly_set_colors(colors);
 }
 
 void MdTextButton::UpdateBackgroundColor() {
@@ -305,7 +313,17 @@ void MdTextButton::UpdateColors() {
 
   // Update the icon color.
   if (icon_) {
+    // Usually, only set for normal state if we want to use same image for all
+    // state. However, upstream MdTextButton updates left-padding when it has
+    // image. As it uses HasImage(GetVisualState()) for checking image,
+    // different padding could be used if we don't set image for all state.
     SetImageModel(ButtonState::STATE_NORMAL,
+                  ui::ImageModel::FromVectorIcon(*icon_, GetCurrentTextColor(),
+                                                 icon_size_));
+    SetImageModel(ButtonState::STATE_HOVERED,
+                  ui::ImageModel::FromVectorIcon(*icon_, GetCurrentTextColor(),
+                                                 icon_size_));
+    SetImageModel(ButtonState::STATE_PRESSED,
                   ui::ImageModel::FromVectorIcon(*icon_, GetCurrentTextColor(),
                                                  icon_size_));
   }


### PR DESCRIPTION
Uplift of #24562
Resolves https://github.com/brave/brave-browser/issues/39576

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.