### PR TITLE
Disable the Google Hangouts extension (included by Chromium) by default.

### DIFF
--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -627,11 +627,11 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, MixedContentForOnion) {
 
 #if BUILDFLAG(ENABLE_HANGOUT_SERVICES_EXTENSION)
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,
-                       HangoutsEnabledByDefault) {
-  ASSERT_TRUE(browser()->profile()->GetPrefs()->GetBoolean(kHangoutsEnabled));
+                       HangoutsDisabledByDefault) {
+  ASSERT_FALSE(browser()->profile()->GetPrefs()->GetBoolean(kHangoutsEnabled));
   extensions::ExtensionRegistry* registry =
       extensions::ExtensionRegistry::Get(browser()->profile());
-  ASSERT_TRUE(registry->enabled_extensions().Contains(hangouts_extension_id));
+  ASSERT_FALSE(registry->enabled_extensions().Contains(hangouts_extension_id));
 }
 
 IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest,

--- a/browser/brave_prefs_browsertest.cc
+++ b/browser/brave_prefs_browsertest.cc
@@ -94,7 +94,7 @@ IN_PROC_BROWSER_TEST_F(BraveProfilePrefsBrowserTest, MiscBravePrefs) {
   EXPECT_TRUE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       kBraveWaybackMachineEnabled));
 #endif
-  EXPECT_TRUE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
+  EXPECT_FALSE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       kHangoutsEnabled));
   EXPECT_TRUE(chrome_test_utils::GetProfile(this)->GetPrefs()->GetBoolean(
       brave_rewards::prefs::kShowLocationBarButton));

--- a/browser/brave_profile_prefs.cc
+++ b/browser/brave_profile_prefs.cc
@@ -303,8 +303,9 @@ void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
                                 base::Value(false));
 #endif
 
-  // Hangouts
-  registry->RegisterBooleanPref(kHangoutsEnabled, true);
+  // Disable the Google Hangouts extension (included by Chromium) by default.
+  // See https://github.com/brave/brave-browser/issues/39660 for more info.
+  registry->RegisterBooleanPref(kHangoutsEnabled, false);
 
   // Restore last profile on restart
   registry->SetDefaultPrefValue(


### PR DESCRIPTION
Disabling will add the extension to a block list.
This won't affect people who have toggled the setting - for example, someone who manually enabled or disabled.

Google Meet seems to work great with this extension blocked.

Fix https://github.com/brave/brave-browser/issues/39664

First step towards fixing https://github.com/brave/brave-browser/issues/39660

Long term goal would be to remove the extension code: https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/resources/hangout_services/manifest_v3.json;l=24-30

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Person has never edited setting
1. Have a version of Brave before this change - clean profile.
2. Visit brave://settings/extensions
3. `Hangouts` should be enabled by default
4. Upgrade to a version of Brave which has this fix
5. Visit brave://settings/extensions
6. `Hangouts` should be disabled by default

### Person has edited setting
1. Have a version of Brave before this change - clean profile.
2. Visit brave://settings/extensions
3. `Hangouts` should be enabled by default. Toggle it to OFF. Then back to ON.
4. Upgrade to a version of Brave which has this fix
5. Visit brave://settings/extensions
6. `Hangouts` should be enabled because it was last set by the person

### Testing disabled is disabling the extension
1. Have any version of Brave
2. Visit brave://settings/extensions
3. Toggle `Hangouts` to OFF
4. Visit brave://extensions-internals/
5. All extension data showing as JSON. Search page for `nkeimhogjdpnpccoofpliimaahmaaome`
6. You should see the hangouts extension. Verify it has `"disable_reasons": [ "DISABLE_BLOCKED_BY_POLICY" ],`

### Testing enabling allows the extension
1. Have any version of Brave
2. Visit brave://settings/extensions
3. Toggle `Hangouts` to ON
4. Visit brave://extensions-internals/
5. All extension data showing as JSON. Search page for `nkeimhogjdpnpccoofpliimaahmaaome`
6. You should see the hangouts extension. Verify the JSON does NOT have `disable_reasons` in it.