### PR TITLE
Support brave-variations test seed testing process

### DIFF
--- a/app/BUILD.gn
+++ b/app/BUILD.gn
@@ -120,6 +120,7 @@ source_set("unit_tests") {
   deps = [
     "//base",
     "//base/test:test_support",
+    "//brave/components/variations:buildflags",
     "//chrome/browser",
     "//chrome/browser/enterprise/connectors/analysis:features",
     "//chrome/browser/ui",

--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -22,7 +22,7 @@
 #include "brave/components/constants/brave_switches.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/update_client/buildflags.h"
-#include "brave/components/variations/buildflags.h"
+#include "brave/components/variations/command_line_utils.h"
 #include "brave/renderer/brave_content_renderer_client.h"
 #include "brave/utility/brave_content_utility_client.h"
 #include "build/build_config.h"
@@ -35,7 +35,6 @@
 #include "components/dom_distiller/core/dom_distiller_switches.h"
 #include "components/embedder_support/switches.h"
 #include "components/sync/base/command_line_switches.h"
-#include "components/variations/variations_switches.h"
 #include "google_apis/gaia/gaia_switches.h"
 
 #if BUILDFLAG(IS_LINUX)
@@ -169,21 +168,7 @@ void BraveMainDelegate::AppendCommandLineOptions() {
                                     brave_sync_service_url.c_str());
   }
 
-  // Brave variations
-  if (!command_line->HasSwitch(variations::switches::kVariationsServerURL)) {
-    command_line->AppendSwitchASCII(variations::switches::kVariationsServerURL,
-                                    BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL));
-  }
-  // Insecure fall-back for variations is set to the same (secure) URL. This is
-  // done so that if VariationsService tries to fall back to insecure url the
-  // check for kHttpScheme in VariationsService::MaybeRetryOverHTTP would
-  // prevent it from doing so as we don't want to use an insecure fall-back.
-  if (!command_line->HasSwitch(
-          variations::switches::kVariationsInsecureServerURL)) {
-    command_line->AppendSwitchASCII(
-        variations::switches::kVariationsInsecureServerURL,
-        BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL));
-  }
+  variations::AppendBraveCommandLineOptions(*command_line);
 }
 
 std::optional<int> BraveMainDelegate::BasicStartupComplete() {

--- a/app/brave_main_delegate_unittest.cc
+++ b/app/brave_main_delegate_unittest.cc
@@ -46,16 +46,9 @@ TEST(BraveMainDelegateUnitTest, OverrideSwitchFromCommandLine) {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
   const std::string override_sync_url = "https://sync.com";
   const std::string override_origin_trials_public_key = "public_key";
-  const std::string override_variations_url = "https://variations.com";
-  const std::string override_insecure_variations_url = "https://variations.com";
   command_line.AppendSwitchASCII(syncer::kSyncServiceURL, override_sync_url);
   command_line.AppendSwitchASCII(embedder_support::kOriginTrialPublicKey,
                                  override_origin_trials_public_key);
-  command_line.AppendSwitchASCII(variations::switches::kVariationsServerURL,
-                                 override_variations_url);
-  command_line.AppendSwitchASCII(
-      variations::switches::kVariationsInsecureServerURL,
-      override_insecure_variations_url);
 
   BraveMainDelegate::AppendCommandLineOptions();
 
@@ -66,14 +59,4 @@ TEST(BraveMainDelegateUnitTest, OverrideSwitchFromCommandLine) {
       override_origin_trials_public_key.c_str(),
       command_line.GetSwitchValueASCII(embedder_support::kOriginTrialPublicKey)
           .c_str());
-  ASSERT_STREQ(
-      override_variations_url.c_str(),
-      command_line
-          .GetSwitchValueASCII(variations::switches::kVariationsServerURL)
-          .c_str());
-  ASSERT_STREQ(override_insecure_variations_url.c_str(),
-               command_line
-                   .GetSwitchValueASCII(
-                       variations::switches::kVariationsInsecureServerURL)
-                   .c_str());
 }

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -443,7 +443,7 @@ if (is_win && is_official_build) {
 brave_chrome_browser_public_deps = [
   "//brave/browser:browser_process",
   "//brave/components/brave_sync:constants",
-  "//brave/components/variations:constants",
+  "//brave/components/variations",
 ]
 
 if (is_mac) {

--- a/chromium_src/components/version_ui/version_handler_helper.cc
+++ b/chromium_src/components/version_ui/version_handler_helper.cc
@@ -25,8 +25,13 @@ base::Value::List GetVariationsList() {
   }
 
   base::Value::List variations_list;
-  for (std::string& variation : variations)
+  const std::string& seed_version = variations::GetSeedVersion();
+  if (!seed_version.empty() && seed_version != "1") {
+    variations_list.Append(seed_version);
+  }
+  for (std::string& variation : variations) {
     variations_list.Append(std::move(variation));
+  }
 
   return variations_list;
 }

--- a/components/variations/BUILD.gn
+++ b/components/variations/BUILD.gn
@@ -11,6 +11,30 @@ buildflag_header("buildflags") {
   flags = [ "BRAVE_VARIATIONS_SERVER_URL=\"$brave_variations_server_url\"" ]
 }
 
-group("constants") {
-  public_deps = [ ":buildflags" ]
+static_library("variations") {
+  sources = [
+    "command_line_utils.cc",
+    "command_line_utils.h",
+    "switches.h",
+  ]
+
+  deps = [
+    ":buildflags",
+    "//base",
+    "//components/variations",
+  ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+
+  sources = [ "command_line_utils_unittest.cc" ]
+
+  deps = [
+    ":buildflags",
+    ":variations",
+    "//base",
+    "//components/variations",
+    "//testing/gtest",
+  ]
 }

--- a/components/variations/command_line_utils.cc
+++ b/components/variations/command_line_utils.cc
@@ -1,0 +1,63 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/variations/command_line_utils.h"
+
+#include <string>
+
+#include "base/command_line.h"
+#include "base/strings/string_util.h"
+#include "brave/components/variations/buildflags.h"
+#include "brave/components/variations/switches.h"
+#include "components/variations/variations_switches.h"
+
+namespace variations {
+
+namespace {
+
+// A GitHub workflow in the brave/brave-variations repository generates the test
+// seed and uploads it to a URL with the following template, where $1 is the
+// pull request number.
+constexpr char kVariationsPrTestSeedUrlTemplate[] =
+    "https://griffin.brave.com/pull/$1/seed";
+
+}  // namespace
+
+void AppendBraveCommandLineOptions(base::CommandLine& command_line) {
+  std::string variations_server_url = BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL);
+
+  if (command_line.HasSwitch(switches::kVariationsPR)) {
+    variations_server_url = base::ReplaceStringPlaceholders(
+        kVariationsPrTestSeedUrlTemplate,
+        {command_line.GetSwitchValueASCII(switches::kVariationsPR)}, nullptr);
+
+    // Generated seed is not signed, so we need to disable signature check.
+    command_line.AppendSwitch(
+        variations::switches::kAcceptEmptySeedSignatureForTesting);
+
+    // Disable fetch throttling to force the fetch at startup on mobile
+    // platforms.
+    command_line.AppendSwitch(
+        variations::switches::kDisableVariationsSeedFetchThrottling);
+  }
+
+  if (!command_line.HasSwitch(variations::switches::kVariationsServerURL)) {
+    command_line.AppendSwitchASCII(variations::switches::kVariationsServerURL,
+                                   variations_server_url);
+  }
+
+  // Insecure fall-back for variations is set to the same (secure) URL. This
+  // is done so that if VariationsService tries to fall back to insecure url
+  // the check for kHttpScheme in VariationsService::MaybeRetryOverHTTP would
+  // prevent it from doing so as we don't want to use an insecure fall-back.
+  if (!command_line.HasSwitch(
+          variations::switches::kVariationsInsecureServerURL)) {
+    command_line.AppendSwitchASCII(
+        variations::switches::kVariationsInsecureServerURL,
+        variations_server_url);
+  }
+}
+
+}  // namespace variations

--- a/components/variations/command_line_utils.h
+++ b/components/variations/command_line_utils.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_VARIATIONS_COMMAND_LINE_UTILS_H_
+#define BRAVE_COMPONENTS_VARIATIONS_COMMAND_LINE_UTILS_H_
+
+namespace base {
+class CommandLine;
+}
+
+namespace variations {
+
+// Appends Brave-specific command line options to fetch variations seed from the
+// correct server.
+void AppendBraveCommandLineOptions(base::CommandLine& command_line);
+
+}  // namespace variations
+
+#endif  // BRAVE_COMPONENTS_VARIATIONS_COMMAND_LINE_UTILS_H_

--- a/components/variations/command_line_utils_unittest.cc
+++ b/components/variations/command_line_utils_unittest.cc
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/variations/command_line_utils.h"
+
+#include <string>
+
+#include "base/command_line.h"
+#include "brave/components/variations/buildflags.h"
+#include "brave/components/variations/switches.h"
+#include "components/variations/variations_switches.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace variations {
+
+TEST(VariationsCommandLineUtils, DefaultVariationsServerUrl) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  AppendBraveCommandLineOptions(command_line);
+
+  EXPECT_EQ(command_line.GetSwitchValueASCII(
+                variations::switches::kVariationsServerURL),
+            BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL));
+  EXPECT_EQ(command_line.GetSwitchValueASCII(
+                variations::switches::kVariationsInsecureServerURL),
+            BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL));
+  EXPECT_FALSE(command_line.HasSwitch(
+      variations::switches::kAcceptEmptySeedSignatureForTesting));
+  EXPECT_FALSE(command_line.HasSwitch(
+      variations::switches::kDisableVariationsSeedFetchThrottling));
+}
+
+TEST(VariationsCommandLineUtils, OverrideVariationsServerUrl) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  const std::string override_variations_url = "https://variations.com";
+  const std::string override_insecure_variations_url = "http://insecure.com";
+  command_line.AppendSwitchASCII(variations::switches::kVariationsServerURL,
+                                 override_variations_url);
+  command_line.AppendSwitchASCII(
+      variations::switches::kVariationsInsecureServerURL,
+      override_insecure_variations_url);
+  AppendBraveCommandLineOptions(command_line);
+
+  EXPECT_EQ(override_variations_url,
+            command_line.GetSwitchValueASCII(
+                variations::switches::kVariationsServerURL));
+  EXPECT_EQ(override_insecure_variations_url,
+            command_line.GetSwitchValueASCII(
+                variations::switches::kVariationsInsecureServerURL));
+}
+
+TEST(VariationsCommandLineUtils, SetVariationsPrParameter) {
+  base::CommandLine command_line(base::CommandLine::NO_PROGRAM);
+  command_line.AppendSwitchASCII(variations::switches::kVariationsPR, "1234");
+  AppendBraveCommandLineOptions(command_line);
+
+  EXPECT_EQ(command_line.GetSwitchValueASCII(
+                variations::switches::kVariationsServerURL),
+            "https://griffin.brave.com/pull/1234/seed");
+  EXPECT_EQ(command_line.GetSwitchValueASCII(
+                variations::switches::kVariationsInsecureServerURL),
+            "https://griffin.brave.com/pull/1234/seed");
+  EXPECT_TRUE(command_line.HasSwitch(
+      variations::switches::kAcceptEmptySeedSignatureForTesting));
+  EXPECT_TRUE(command_line.HasSwitch(
+      variations::switches::kDisableVariationsSeedFetchThrottling));
+}
+
+}  // namespace variations

--- a/components/variations/switches.h
+++ b/components/variations/switches.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_VARIATIONS_SWITCHES_H_
+#define BRAVE_COMPONENTS_VARIATIONS_SWITCHES_H_
+
+namespace variations::switches {
+
+// If this flag is set to a brave/brave-variations pull request number, the
+// browser will point "--variations-server-url" to a test seed URL from this
+// pull request.
+inline constexpr char kVariationsPR[] = "variations-pr";
+
+}  // namespace variations::switches
+
+#endif  // BRAVE_COMPONENTS_VARIATIONS_SWITCHES_H_

--- a/ios/app/BUILD.gn
+++ b/ios/app/BUILD.gn
@@ -35,7 +35,7 @@ source_set("app") {
     "//brave/components/p3a:buildflags",
     "//brave/components/skus/browser",
     "//brave/components/update_client:buildflags",
-    "//brave/components/variations:constants",
+    "//brave/components/variations",
     "//brave/ios/app/resources",
     "//brave/ios/browser",
     "//brave/ios/browser/api/ads",

--- a/ios/app/brave_core_switches.h
+++ b/ios/app/brave_core_switches.h
@@ -24,6 +24,11 @@ OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeyVModule;
 ///
 /// Expected value: A URL string
 OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeySyncURL;
+/// Sets the variations URL to a test seed generated in brave/brave-variations
+/// pull request.
+///
+/// Expected value: A brave/brave-variations pull request number
+OBJC_EXPORT const BraveCoreSwitchKey BraveCoreSwitchKeyVariationsPR;
 /// Overrides the variations seed URL. Defaults to production
 ///
 /// Expected value: A URL string

--- a/ios/app/brave_core_switches.mm
+++ b/ios/app/brave_core_switches.mm
@@ -9,6 +9,7 @@
 #include "base/strings/sys_string_conversions.h"
 #include "brave/components/brave_component_updater/browser/switches.h"
 #include "brave/components/p3a/switches.h"
+#include "brave/components/variations/switches.h"
 #include "components/component_updater/component_updater_switches.h"
 #include "components/sync/base/command_line_switches.h"
 #include "components/variations/variations_switches.h"
@@ -23,6 +24,8 @@ const BraveCoreSwitchKey BraveCoreSwitchKeyVModule =
     base::SysUTF8ToNSString(switches::kVModule);
 const BraveCoreSwitchKey BraveCoreSwitchKeySyncURL =
     base::SysUTF8ToNSString(syncer::kSyncServiceURL);
+const BraveCoreSwitchKey BraveCoreSwitchKeyVariationsPR =
+    base::SysUTF8ToNSString(variations::switches::kVariationsPR);
 const BraveCoreSwitchKey BraveCoreSwitchKeyVariationsURL =
     base::SysUTF8ToNSString(variations::switches::kVariationsServerURL);
 // There is no exposed switch for rewards

--- a/ios/app/brave_main_delegate.mm
+++ b/ios/app/brave_main_delegate.mm
@@ -16,7 +16,7 @@
 #include "brave/components/brave_component_updater/browser/switches.h"
 #include "brave/components/brave_sync/buildflags.h"
 #include "brave/components/update_client/buildflags.h"
-#include "brave/components/variations/buildflags.h"
+#include "brave/components/variations/command_line_utils.h"
 #include "components/browser_sync/browser_sync_switches.h"
 #include "components/component_updater/component_updater_switches.h"
 #include "components/sync/base/command_line_switches.h"
@@ -72,19 +72,7 @@ void BraveMainDelegate::BasicStartupComplete() {
                                     BUILDFLAG(BRAVE_SYNC_ENDPOINT));
   }
 
-  // Brave variations
-  if (!command_line->HasSwitch(variations::switches::kVariationsServerURL)) {
-    command_line->AppendSwitchASCII(variations::switches::kVariationsServerURL,
-                                    BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL));
-
-    // Insecure fall-back for variations is set to the same (secure) URL. This
-    // is done so that if VariationsService tries to fall back to insecure url
-    // the check for kHttpScheme in VariationsService::MaybeRetryOverHTTP would
-    // prevent it from doing so as we don't want to use an insecure fall-back.
-    command_line->AppendSwitchASCII(
-        variations::switches::kVariationsInsecureServerURL,
-        BUILDFLAG(BRAVE_VARIATIONS_SERVER_URL));
-  }
+  variations::AppendBraveCommandLineOptions(*command_line);
 
   if (!command_line->HasSwitch(switches::kVModule)) {
     command_line->AppendSwitchASCII(switches::kVModule, "*/brave/*=0");

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/BraveCoreDebugSwitchesView.swift
@@ -17,6 +17,8 @@ extension BraveCoreSwitchKey {
       return "Component Updater"
     case .syncURL:
       return "Sync URL"
+    case .variationsPR:
+      return "Variations PR"
     case .variationsURL:
       return "Variations URL"
     case .p3aDoNotRandomizeUploadInterval:
@@ -317,14 +319,18 @@ struct BraveCoreDebugSwitchesView: View {
       }
       Section {
         Group {
-          // Sync URL
           NavigationLink {
             BasicStringInputView(coreSwitch: .syncURL)
               .keyboardType(.URL)
           } label: {
             SwitchContainer(.syncURL)
           }
-          // Variations URL
+          NavigationLink {
+            BasicStringInputView(coreSwitch: .variationsPR)
+              .keyboardType(.numberPad)
+          } label: {
+            SwitchContainer(.variationsPR)
+          }
           NavigationLink {
             BasicStringInputView(coreSwitch: .variationsURL)
               .keyboardType(.URL)

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -261,6 +261,7 @@ test("brave_unit_tests") {
     "//brave/components/time_period_storage",
     "//brave/components/tor/buildflags",
     "//brave/components/url_sanitizer/browser:unittests",
+    "//brave/components/variations:unit_tests",
     "//brave/components/version_info:unit_tests",
     "//brave/extensions:common",
     "//brave/mojo/brave_ast_patcher:unit_tests",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Pull requests to brave-variations now [can generate test seeds](https://github.com/brave/brave-variations/pull/1121#issuecomment-2222601321), but these seeds are not signed. To simplify the testing process of these seeds, this PR introduces a new command line flag `--variations-pr=<number>` that can receive a pull request number. When this flag is set, the browser will configure itself to fetch the seed from a pull request and accept it without the signature.

On desktop versions the flag can be passed via command line.
On Android the flag can be passed via debug menu.
On iOS the flag value can be set via debug menu.
I've tested all platforms, the feature works correctly everywhere.

The PR also adds seed version display as the first line in "Active Variations" to have a clear understanding what exact seed is active right now. Currently we hardcode the seed version to `1`, but we will start to fill it with a more sane value in our pipelines later. Example how it looks:
![image](https://github.com/brave/brave-core/assets/5928869/9a682eb1-87de-41ec-b807-dc0a8317f264)

Resolves https://github.com/brave/brave-browser/issues/39689

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

