### PR TITLE
feat(wallet): View on Block Explorer Modal

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -412,6 +412,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletAccountsEditVisibleAssets",
      IDS_BRAVE_WALLET_ACCOUNTS_EDIT_VISIBLE_ASSETS},
     {"braveWalletAccountBalance", IDS_BRAVE_WALLET_ACCOUNT_BALANCE},
+    {"braveWalletViewAddressOn", IDS_BRAVE_WALLET_VIEW_ADDRESS_ON},
+    {"braveWalletNetworkExplorer", IDS_BRAVE_WALLET_NETWORK_EXPLORER},
     {"braveWalletAddAccountCreate", IDS_BRAVE_WALLET_ADD_ACCOUNT_CREATE},
     {"braveWalletCreateAccount", IDS_BRAVE_WALLET_CREATE_ACCOUNT},
     {"braveWalletCreateAccountButton", IDS_BRAVE_WALLET_CREATE_ACCOUNT_BUTTON},

--- a/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/account-details-header.tsx
@@ -192,6 +192,17 @@ export const AccountDetailsHeader = (props: Props) => {
         (option: AccountButtonOptionsObjectType) => option.id !== 'privateKey'
       )
     }
+    // We are currently not able to support viewing a
+    // BTC or ZEC account on a block explorer.
+    // Link to issue https://github.com/brave/brave-browser/issues/39699
+    if (
+      account.accountId.coin === BraveWallet.CoinType.BTC ||
+      account.accountId.coin === BraveWallet.CoinType.ZEC
+    ) {
+      options = options.filter(
+        (option: AccountButtonOptionsObjectType) => option.id !== 'explorer'
+      )
+    }
     return options
   }, [account])
 

--- a/components/brave_wallet_ui/components/desktop/popup-modals/style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/style.ts
@@ -75,6 +75,9 @@ export const Header = styled.div<{
 export const Title = styled.span`
   color: ${leo.color.text.primary};
   font: ${leo.font.heading.h2};
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    font: ${leo.font.heading.h4};
+  }
 `
 
 export const HeaderButton = styled(WalletButton)`

--- a/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/network_button.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/network_button.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+
+// Types
+import { BraveWallet } from '../../../../constants/types'
+
+// Custom hooks
+import { useExplorer } from '../../../../common/hooks/explorer'
+
+// Utils
+import { getLocale } from '../../../../../common/locale'
+
+// Components
+import { CreateNetworkIcon } from '../../../shared/create-network-icon'
+
+// Styles
+import { Button, LaunchIcon } from './view_on_block_explorer_modal.style'
+import { Text, Row } from '../../../shared/style'
+
+interface Props {
+  network: BraveWallet.NetworkInfo
+  address: string
+}
+
+export const NetworkButton = (props: Props) => {
+  const { network, address } = props
+
+  // Hooks
+  const onClickViewOnBlockExplorer = useExplorer(network)
+
+  return (
+    <Button onClick={onClickViewOnBlockExplorer('address', address)}>
+      <Row width='unset'>
+        <CreateNetworkIcon
+          network={network}
+          marginRight={12}
+          size='big'
+        />
+        <Text
+          isBold={true}
+          textColor='primary'
+          textSize='14px'
+        >
+          {getLocale('braveWalletNetworkExplorer').replace(
+            '$1',
+            network.chainName
+          )}
+        </Text>
+      </Row>
+      <LaunchIcon />
+    </Button>
+  )
+}

--- a/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal.style.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
+import Icon from '@brave/leo/react/icon'
+
+// Shared Styled
+import { Row, WalletButton, Column, Text } from '../../../shared/style'
+
+export const StyledWrapper = styled(Column)`
+  overflow: hidden;
+`
+
+export const AccountInfoRow = styled(Row)`
+  background-color: ${leo.color.container.highlight};
+  border-radius: ${leo.radius.xl};
+  padding: 8px;
+`
+
+export const AddressText = styled(Text)`
+  word-break: break-all;
+`
+
+export const Button = styled(WalletButton)`
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  background: none;
+  background-color: none;
+  outline: none;
+  border: none;
+  border-radius: ${leo.radius.m};
+  width: 100%;
+  padding: 16px;
+  --icon-display: none;
+  &:hover {
+    background-color: ${leo.color.container.highlight};
+    --icon-display: block;
+  }
+`
+
+export const LaunchIcon = styled(Icon).attrs({
+  name: 'launch'
+})`
+  display: var(--icon-display);
+  --leo-icon-size: 16px;
+  color: ${leo.color.icon.interactive};
+`

--- a/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal.tsx
@@ -1,0 +1,118 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+
+// Types
+import { BraveWallet } from '../../../../constants/types'
+
+// Queries
+import {
+  useGetVisibleNetworksQuery //
+} from '../../../../common/slices/api.slice'
+
+// Utils
+import { getLocale } from '../../../../../common/locale'
+import {
+  getNetworkId //
+} from '../../../../common/slices/entities/network.entity'
+
+// Components
+import { PopupModal } from '../../popup-modals/index'
+import {
+  CreateAccountIcon //
+} from '../../../shared/create-account-icon/create-account-icon'
+import { NetworkButton } from './network_button'
+
+// Styles
+import {
+  AccountInfoRow,
+  StyledWrapper,
+  AddressText
+} from './view_on_block_explorer_modal.style'
+import { Column, Text, Row, ScrollableColumn } from '../../../shared/style'
+
+interface Props {
+  account: BraveWallet.AccountInfo
+  onClose: () => void
+}
+
+export const ViewOnBlockExplorerModal = (props: Props) => {
+  const { account, onClose } = props
+
+  // Queries
+  const { data: visibleNetworks = [] } = useGetVisibleNetworksQuery()
+
+  // Memos
+  const networksByAccountCoinType = React.useMemo(() => {
+    return visibleNetworks.filter(
+      (network) => network.coin === account.accountId.coin
+    )
+  }, [visibleNetworks, account])
+
+  return (
+    <PopupModal
+      title={getLocale('braveWalletTransactionExplorer')}
+      onClose={onClose}
+      width='520px'
+    >
+      <StyledWrapper
+        fullWidth={true}
+        fullHeight={true}
+        alignItems='flex-start'
+        justifyContent='flex-start'
+        padding='0px 16px 16px 16px'
+      >
+        <AccountInfoRow
+          justifyContent='flex-start'
+          marginBottom={16}
+        >
+          <CreateAccountIcon
+            account={account}
+            size='huge'
+            marginRight={16}
+          />
+          <Column alignItems='flex-start'>
+            <Text
+              isBold={true}
+              textColor='primary'
+              textSize='14px'
+            >
+              {account.name}
+            </Text>
+            <AddressText
+              isBold={false}
+              textColor='secondary'
+              textSize='12px'
+              textAlign='left'
+            >
+              {account.address}
+            </AddressText>
+          </Column>
+        </AccountInfoRow>
+        <Row
+          padding='16px'
+          justifyContent='flex-start'
+        >
+          <Text
+            isBold={true}
+            textColor='primary'
+            textSize='14px'
+          >
+            {getLocale('braveWalletViewAddressOn')}
+          </Text>
+        </Row>
+        <ScrollableColumn>
+          {networksByAccountCoinType.map((network) => (
+            <NetworkButton
+              key={getNetworkId(network)}
+              network={network}
+              address={account.accountId.address}
+            />
+          ))}
+        </ScrollableColumn>
+      </StyledWrapper>
+    </PopupModal>
+  )
+}

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -20,7 +20,8 @@ import {
   CoinTypesMap,
   WalletRoutes,
   AccountModalTypes,
-  AccountPageTabs
+  AccountPageTabs,
+  SupportedTestNetworks
 } from '../../../../constants/types'
 
 // utils
@@ -86,6 +87,9 @@ import {
 import {
   EmptyTokenListState //
 } from '../portfolio/components/empty-token-list-state/empty-token-list-state'
+import {
+  ViewOnBlockExplorerModal //
+} from '../../popup-modals/view_on_block_explorer_modal/view_on_block_explorer_modal'
 
 // options
 import { AccountDetailsOptions } from '../../../../options/nav-options'
@@ -105,10 +109,18 @@ import {
 import {
   useBalancesFetcher //
 } from '../../../../common/hooks/use-balances-fetcher'
+import { useExplorer } from '../../../../common/hooks/explorer'
 
 // Actions
 import { AccountsTabActions } from '../../../../page/reducers/accounts-tab-reducer'
 import { useAccountsQuery } from '../../../../common/slices/api.slice.extra'
+
+const INDIVIDUAL_TESTNET_ACCOUNT_KEYRING_IDS = [
+  BraveWallet.KeyringId.kBitcoin84Testnet,
+  BraveWallet.KeyringId.kBitcoinImportTestnet,
+  BraveWallet.KeyringId.kFilecoinTestnet,
+  BraveWallet.KeyringId.kZCashTestnet
+]
 
 const removedNFTsRouteOptions = AccountDetailsOptions.filter(
   (option) => option.id !== 'nfts'
@@ -169,9 +181,41 @@ export const Account = () => {
 
   // state
   const [showAddNftModal, setShowAddNftModal] = React.useState<boolean>(false)
+  const [showViewOnBlockExplorerModal, setShowViewOnBlockExplorerModal] =
+    React.useState<boolean>(false)
 
-  // custom hooks
+  // custom hooks & memos
   const scrollIntoView = useScrollIntoView()
+
+  const networksFilteredByAccountsCoinType = React.useMemo(() => {
+    return !selectedAccount
+      ? []
+      : networkList.filter(
+          (network) => network.coin === selectedAccount.accountId.coin
+        )
+  }, [networkList, selectedAccount])
+
+  const networkForSelectedAccount = React.useMemo(() => {
+    if (!selectedAccount) {
+      return
+    }
+    // BTC, ZEC and FIL use different accounts for testnet.
+    // This checks if the selectedAccount is a testnet account
+    // and finds the appropriate network to use.
+    if (
+      INDIVIDUAL_TESTNET_ACCOUNT_KEYRING_IDS.includes(
+        selectedAccount.accountId.keyringId
+      )
+    )
+      return networksFilteredByAccountsCoinType.find((network) =>
+        SupportedTestNetworks.includes(network.chainId)
+      )
+    return networksFilteredByAccountsCoinType.find(
+      (network) => !SupportedTestNetworks.includes(network.chainId)
+    )
+  }, [selectedAccount, networksFilteredByAccountsCoinType])
+
+  const onClickViewOnBlockExplorer = useExplorer(networkForSelectedAccount)
 
   // memos
   const transactionList = React.useMemo(() => {
@@ -349,11 +393,36 @@ export const Account = () => {
         onRemoveAccount()
         return
       }
+      if (
+        option === 'explorer' &&
+        // Only show the Block Explorer modal if there is
+        // more than 1 network to show and if CoinType is
+        // ETH or SOL.
+        networksFilteredByAccountsCoinType.length > 1 &&
+        (selectedAccount?.accountId.coin === BraveWallet.CoinType.ETH ||
+          selectedAccount?.accountId.coin === BraveWallet.CoinType.SOL)
+      ) {
+        setShowViewOnBlockExplorerModal(true)
+        return
+      }
+      if (option === 'explorer' && selectedAccount?.accountId.address) {
+        onClickViewOnBlockExplorer(
+          'address',
+          selectedAccount.accountId.address
+        )()
+        return
+      }
       dispatch(AccountsTabActions.setShowAccountModal(true))
       dispatch(AccountsTabActions.setAccountModalType(option))
       dispatch(AccountsTabActions.setSelectedAccount(selectedAccount))
     },
-    [dispatch, onRemoveAccount, selectedAccount]
+    [
+      dispatch,
+      onRemoveAccount,
+      networksFilteredByAccountsCoinType,
+      selectedAccount,
+      onClickViewOnBlockExplorer
+    ]
   )
 
   const checkIsTransactionFocused = React.useCallback(
@@ -525,6 +594,13 @@ export const Account = () => {
             </Column>
           )}
         </>
+      )}
+
+      {showViewOnBlockExplorerModal && (
+        <ViewOnBlockExplorerModal
+          account={selectedAccount}
+          onClose={() => setShowViewOnBlockExplorerModal(false)}
+        />
       )}
 
       {showAddNftModal && (

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -840,6 +840,7 @@ export type AccountModalTypes =
   | 'details'
   | 'remove'
   | 'buy'
+  | 'explorer'
 
 export interface AccountButtonOptionsObjectType {
   name: string

--- a/components/brave_wallet_ui/options/account-details-menu-options.ts
+++ b/components/brave_wallet_ui/options/account-details-menu-options.ts
@@ -12,6 +12,11 @@ export const AccountDetailsMenuOptions: AccountButtonOptionsObjectType[] = [
     icon: 'edit-pencil'
   },
   {
+    id: 'explorer',
+    name: 'braveWalletTransactionExplorer',
+    icon: 'web3-blockexplorer'
+  },
+  {
     id: 'deposit',
     name: 'braveWalletAccountsDeposit',
     icon: 'money-bag-coins'

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -395,6 +395,8 @@ provideStrings({
   braveWalletAccountsAssets: 'Assets',
   braveWalletAccountsEditVisibleAssets: 'Visible assets',
   braveWalletAccountBalance: 'Account balance',
+  braveWalletViewAddressOn: 'View address on:',
+  braveWalletNetworkExplorer: '$1 Explorer',
 
   // Add Account Options
   braveWalletCreateAccount: 'Create $1 account',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -230,6 +230,8 @@
   <message name="IDS_BRAVE_WALLET_ACCOUNTS_ASSETS" desc="Accounts screen assets title">Assets</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNTS_EDIT_VISIBLE_ASSETS" desc="Accounts screen visible assets button">Visible assets</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_BALANCE" desc="Account Details account balance">Account balance</message>
+  <message name="IDS_BRAVE_WALLET_VIEW_ADDRESS_ON" desc="View address on explorer label">View address on:</message>
+  <message name="IDS_BRAVE_WALLET_NETWORK_EXPLORER" desc="Blockchain network explorer name"><ph name="BLOCKCHAIN_NETWORK_NAME"><ex>Ethereum Mainnet</ex>$1</ph> Explorer</message>
   <message name="IDS_BRAVE_WALLET_ADD_ACCOUNT_CREATE" desc="Add account modal create button">Create</message>
   <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT_BUTTON" desc="Add account modal create account button">Create account</message>
   <message name="IDS_BRAVE_WALLET_CREATE_ACCOUNT" desc="Add account modal create account header title">Create <ph name="BLOCKCHAIN_NETWORK"><ex>Ethereum</ex>$1</ph> account</message>

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -383,6 +383,7 @@ leo_icons = [
   "warning-triangle-filled.svg",
   "warning-triangle-outline.svg",
   "web3.svg",
+  "web3-blockexplorer.svg",
   "web3-bridge.svg",
   "widget-generic.svg",
   "window-content.svg",


### PR DESCRIPTION
## Description 

- Introduces a `View on block explorer` button on the `Account Details` page
- Introduces a `View on block explorer` modal for `EVM` and `SVM` networks, to allow user to select which `Block Explorer` to view their account on.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/39655>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Accounts` page.
2. Click on an `Ethereum` account and then click on the `View on block explorer` button
3. You should see the `View on block explorer` modal
4. Test clicking on networks to view on it's `Block Explorer`.
5. Follow these same steps for a `Solana` account
6. Now test clicking on the `View on block explorer` button for a `Filecion` and `Filecoin Testnet` account
7. It should open directly to the `Block Explorer`
8. `BTC` and `ZEC` accounts are currently not supported for this feature, so there should not be a `View on block explorer` button.

https://github.com/brave/brave-core/assets/40611140/92fa1c3d-22f2-4969-ab66-a79598a24e1f
