### PR TITLE
feat(wallet): Add Info Tooltip to Price Impact

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -287,6 +287,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletMaxSlippage", IDS_BRAVE_WALLET_MAX_SLIPPAGE},
     {"braveWalletMaxSlippageDescription",
      IDS_BRAVE_WALLET_SLIPPAGE_DESCRIPTION},
+    {"braveWalletPriceImpactDescription",
+     IDS_BRAVE_WALLET_PRICE_IMPACT_DESCRIPTION},
     {"braveWalletSuggestedValues", IDS_BRAVE_WALLET_SUGGESTED_VALUES},
     {"braveWalletMainstreamAssetPairs",
      IDS_BRAVE_WALLET_MAINSTREAM_ASSET_PAIRS},

--- a/components/brave_wallet_ui/page/screens/swap/components/swap/quote-info/quote-info.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/components/swap/quote-info/quote-info.tsx
@@ -65,6 +65,9 @@ import {
   BottomSheet //
 } from '../../../../../../components/shared/bottom_sheet/bottom_sheet'
 import { MaxSlippage } from '../max_slippage/max_slippage'
+import {
+  InfoIconTooltip //
+} from '../../../../../../components/shared/info_icon_tooltip/info_icon_tooltip'
 
 // Styled Components
 import {
@@ -559,13 +562,23 @@ export const QuoteInfo = (props: Props) => {
             )}
 
             <Row justifyContent='space-between'>
-              <Text
-                textSize='12px'
-                textColor='secondary'
-                textAlign='left'
+              <Row
+                width='unset'
+                gap='4px'
               >
-                {getLocale('braveSwapPriceImpact')}
-              </Text>
+                <Text
+                  textSize='12px'
+                  textColor='secondary'
+                  textAlign='left'
+                >
+                  {getLocale('braveSwapPriceImpact')}
+                </Text>
+                <InfoIconTooltip
+                  placement='right'
+                  text={getLocale('braveWalletPriceImpactDescription')}
+                  maxContentWidth={isPanel ? '200px' : undefined}
+                />
+              </Row>
               <Text
                 textSize='12px'
                 isBold={true}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -605,11 +605,14 @@ provideStrings({
   braveWalletChangeProvider: 'Change provider',
   braveWalletRoute: 'Route',
   braveWalletMaxSlippage: 'Max slippage',
-
   braveWalletMaxSlippageDescription:
     'When the deviation between the price of the transaction you ' +
     'submitted and the price at the time of the transaction on chain is ' +
     'greater than this set value, the transaction will fail.',
+  braveWalletPriceImpactDescription:
+    'Price impact is how much your trade might move the market price. ' +
+    'Some tokens with low liquidity are more sensitive to trades, so even ' +
+    'smaller trades can shift the price a lot.',
   braveWalletSuggestedValues: 'Suggested Values:',
   braveWalletMainstreamAssetPairs: 'Mainstream Asset Pairs: $1%',
   braveWalletStablecoinPairs: 'Stablecoin Pairs: $1%',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -125,6 +125,7 @@
   <message name="IDS_BRAVE_WALLET_ROUTE" desc="Swap route label">Route</message>
   <message name="IDS_BRAVE_WALLET_MAX_SLIPPAGE" desc="Swap max slippage label">Max slippage</message>
   <message name="IDS_BRAVE_WALLET_SLIPPAGE_DESCRIPTION" desc="Swap max slippage description">When the deviation between the price of the transaction you submitted and the price at the time of the transaction on chain is greater than this set value, the transaction will fail.</message>
+  <message name="IDS_BRAVE_WALLET_PRICE_IMPACT_DESCRIPTION" desc="Swap price impact description">Price impact is how much your trade might move the market price. Some tokens with low liquidity are more sensitive to trades, so even smaller trades can shift the price a lot.</message>
   <message name="IDS_BRAVE_WALLET_SUGGESTED_VALUES" desc="Swap max slippage suggested values label">Suggested Values:</message>
   <message name="IDS_BRAVE_WALLET_MAINSTREAM_ASSET_PAIRS" desc="Swap max slippage mainstream asset pairs label">Mainstream Asset Pairs: <ph name="SLIPPAGE_PERCENT"><ex>0.5</ex>$1</ph>%</message>
   <message name="IDS_BRAVE_WALLET_STABLECOIN_PAIRS" desc="Swap max slippage stablecoin pairs label">Stablecoin Pairs: <ph name="SLIPPAGE_PERCENT"><ex>0.5</ex>$1</ph>%</message>


### PR DESCRIPTION
## Description 

- Adds a `Info Tooltip` description to the `Price Impact` section for `Swap` and `Bridge`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/39683>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Swap` or `Bridge` screen
2. Select some tokens and get a quote
3. Expand the `Advanced details` in the `Quote Info`
4. Hover over the `Tooltip` for the `Price Impact` section to view the description info.

![Screenshot 20](https://github.com/user-attachments/assets/3468b5ef-c055-4159-8f65-4cc5fca29308)

![Screenshot 21](https://github.com/user-attachments/assets/300496c9-c8b0-4a68-8bb9-d4d3359d2789)
