### PR TITLE
[CodeHealth] Remove uses of `base::SupportsWeakPtr`

### DIFF
--- a/browser/brave_ads/application_state/background_helper/background_helper_android.cc
+++ b/browser/brave_ads/application_state/background_helper/background_helper_android.cc
@@ -11,9 +11,9 @@
 namespace brave_ads {
 
 BackgroundHelperAndroid::BackgroundHelperAndroid() {
-  app_status_listener_ =
-      base::android::ApplicationStatusListener::New(base::BindRepeating(
-          &BackgroundHelperAndroid::OnApplicationStateChange, AsWeakPtr()));
+  app_status_listener_ = base::android::ApplicationStatusListener::New(
+      base::BindRepeating(&BackgroundHelperAndroid::OnApplicationStateChange,
+                          weak_ptr_factory_.GetWeakPtr()));
 
   last_state_ = base::android::ApplicationStatusListener::GetState();
 }

--- a/browser/brave_ads/application_state/background_helper/background_helper_android.h
+++ b/browser/brave_ads/application_state/background_helper/background_helper_android.h
@@ -14,9 +14,7 @@
 
 namespace brave_ads {
 
-class BackgroundHelperAndroid
-    : public BackgroundHelper,
-      public base::SupportsWeakPtr<BackgroundHelperAndroid> {
+class BackgroundHelperAndroid final : public BackgroundHelper {
  public:
   BackgroundHelperAndroid(const BackgroundHelperAndroid&) = delete;
   BackgroundHelperAndroid& operator=(const BackgroundHelperAndroid&) = delete;
@@ -42,6 +40,7 @@ class BackgroundHelperAndroid
       app_status_listener_;
 
   base::android::ApplicationState last_state_;
+  base::WeakPtrFactory<BackgroundHelperAndroid> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_ads

--- a/browser/brave_ads/application_state/background_helper/background_helper_linux.cc
+++ b/browser/brave_ads/application_state/background_helper/background_helper_linux.cc
@@ -66,4 +66,8 @@ void BackgroundHelperLinux::OnBrowserNoLongerActive(Browser* browser) {
       base::BindOnce(&BackgroundHelperLinux::TriggerOnBackground, AsWeakPtr()));
 }
 
+base::WeakPtr<BackgroundHelperLinux> BackgroundHelperLinux::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 }  // namespace brave_ads

--- a/browser/brave_ads/application_state/background_helper/background_helper_linux.h
+++ b/browser/brave_ads/application_state/background_helper/background_helper_linux.h
@@ -12,10 +12,8 @@
 
 namespace brave_ads {
 
-class BackgroundHelperLinux
-    : public BackgroundHelper,
-      public base::SupportsWeakPtr<BackgroundHelperLinux>,
-      public BrowserListObserver {
+class BackgroundHelperLinux final : public BackgroundHelper,
+                                    public BrowserListObserver {
  public:
   BackgroundHelperLinux(const BackgroundHelperLinux&) = delete;
   BackgroundHelperLinux& operator=(const BackgroundHelperLinux&) = delete;
@@ -37,6 +35,10 @@ class BackgroundHelperLinux
 
   // BackgroundHelper impl
   bool IsForeground() const override;
+
+  base::WeakPtr<BackgroundHelperLinux> AsWeakPtr();
+
+  base::WeakPtrFactory<BackgroundHelperLinux> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_ads

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_android.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_android.h
@@ -6,14 +6,11 @@
 #ifndef BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_ANDROID_H_
 #define BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_ANDROID_H_
 
-#include "base/memory/weak_ptr.h"
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h"
 
 namespace brave_ads {
 
-class NotificationHelperImplAndroid
-    : public NotificationHelperImpl,
-      public base::SupportsWeakPtr<NotificationHelperImplAndroid> {
+class NotificationHelperImplAndroid final : public NotificationHelperImpl {
  public:
   NotificationHelperImplAndroid(const NotificationHelperImplAndroid&) = delete;
   NotificationHelperImplAndroid& operator=(

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_linux.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_linux.h
@@ -6,14 +6,11 @@
 #ifndef BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_LINUX_H_
 #define BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_LINUX_H_
 
-#include "base/memory/weak_ptr.h"
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h"
 
 namespace brave_ads {
 
-class NotificationHelperImplLinux
-    : public NotificationHelperImpl,
-      public base::SupportsWeakPtr<NotificationHelperImplLinux> {
+class NotificationHelperImplLinux final : public NotificationHelperImpl {
  public:
   NotificationHelperImplLinux(const NotificationHelperImplLinux&) = delete;
   NotificationHelperImplLinux& operator=(const NotificationHelperImplLinux&) =

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_mac.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_mac.h
@@ -6,14 +6,11 @@
 #ifndef BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_MAC_H_
 #define BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_MAC_H_
 
-#include "base/memory/weak_ptr.h"
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h"
 
 namespace brave_ads {
 
-class NotificationHelperImplMac
-    : public NotificationHelperImpl,
-      public base::SupportsWeakPtr<NotificationHelperImplMac> {
+class NotificationHelperImplMac final : public NotificationHelperImpl {
  public:
   NotificationHelperImplMac(const NotificationHelperImplMac&) = delete;
   NotificationHelperImplMac& operator=(const NotificationHelperImplMac&) =

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_win.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_win.h
@@ -9,14 +9,13 @@
 #include <windows.ui.notifications.h>
 #include <wrl/event.h>
 
-#include "base/memory/weak_ptr.h"
+#include <string>
+
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h"
 
 namespace brave_ads {
 
-class NotificationHelperImplWin
-    : public NotificationHelperImpl,
-      public base::SupportsWeakPtr<NotificationHelperImplWin> {
+class NotificationHelperImplWin final : public NotificationHelperImpl {
  public:
   NotificationHelperImplWin(const NotificationHelperImplWin&) = delete;
   NotificationHelperImplWin& operator=(const NotificationHelperImplWin&) =

--- a/browser/brave_ads/tooltips/ads_tooltips_controller.cc
+++ b/browser/brave_ads/tooltips/ads_tooltips_controller.cc
@@ -61,6 +61,11 @@ void AdsTooltipsController::CloseCaptchaTooltip() {
   brave_tooltips::BraveTooltipPopupHandler::Close(kScheduledCaptchaTooltipId);
 }
 
+base::WeakPtr<brave_tooltips::BraveTooltipDelegate>
+AdsTooltipsController::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 void AdsTooltipsController::OnTooltipWidgetDestroyed(
     const std::string& tooltip_id) {
   brave_tooltips::BraveTooltipPopupHandler::Destroy(kScheduledCaptchaTooltipId);

--- a/browser/brave_ads/tooltips/ads_tooltips_controller.h
+++ b/browser/brave_ads/tooltips/ads_tooltips_controller.h
@@ -17,8 +17,9 @@ class Profile;
 
 namespace brave_ads {
 
-class AdsTooltipsController : public AdsTooltipsDelegate,
-                              public brave_tooltips::BraveTooltipDelegate {
+class AdsTooltipsController final
+    : public AdsTooltipsDelegate,
+      public brave_tooltips::BraveTooltipDelegate {
  public:
   explicit AdsTooltipsController(Profile* profile);
 
@@ -39,11 +40,14 @@ class AdsTooltipsController : public AdsTooltipsDelegate,
       SnoozeScheduledCaptchaCallback snooze_captcha_callback) override;
   void CloseCaptchaTooltip() override;
 
+  base::WeakPtr<brave_tooltips::BraveTooltipDelegate> AsWeakPtr() override;
+
  private:
   // brave_tooltips::BraveTooltipDelegate:
   void OnTooltipWidgetDestroyed(const std::string& tooltip_id) override;
 
   raw_ptr<Profile> profile_ = nullptr;  // NOT OWNED
+  base::WeakPtrFactory<BraveTooltipDelegate> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_ads

--- a/browser/ethereum_remote_client/ethereum_remote_client_service.h
+++ b/browser/ethereum_remote_client/ethereum_remote_client_service.h
@@ -29,9 +29,7 @@ namespace content {
 class BrowserContext;
 }  // namespace content
 
-class EthereumRemoteClientService
-    : public KeyedService,
-      public base::SupportsWeakPtr<EthereumRemoteClientService> {
+class EthereumRemoteClientService final : public KeyedService {
  public:
   explicit EthereumRemoteClientService(
       content::BrowserContext* context,

--- a/browser/ui/brave_tooltips/brave_tooltip_delegate.h
+++ b/browser/ui/brave_tooltips/brave_tooltip_delegate.h
@@ -12,8 +12,7 @@
 
 namespace brave_tooltips {
 
-class BraveTooltipDelegate
-    : public base::SupportsWeakPtr<BraveTooltipDelegate> {
+class BraveTooltipDelegate {
  public:
   virtual ~BraveTooltipDelegate() = default;
 
@@ -33,6 +32,9 @@ class BraveTooltipDelegate
 
   // Called when the Cancel button is pressed
   virtual void OnTooltipCancelButtonPressed(const std::string& tooltip_id) {}
+
+  // Returns a WeakPtr to the implementation instance.
+  virtual base::WeakPtr<BraveTooltipDelegate> AsWeakPtr() = 0;
 };
 
 }  // namespace brave_tooltips

--- a/browser/ui/views/brave_tooltips/brave_tooltips_unittest.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltips_unittest.cc
@@ -30,8 +30,13 @@ class MockBraveTooltipDelegate : public brave_tooltips::BraveTooltipDelegate {
 
   void WaitForWidgetDestroyedNotification() { run_loop_.Run(); }
 
+  base::WeakPtr<BraveTooltipDelegate> AsWeakPtr() override {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
  private:
   base::RunLoop run_loop_;
+  base::WeakPtrFactory<BraveTooltipDelegate> weak_ptr_factory_{this};
 };
 
 class BraveTooltipsTest : public ChromeViewsTestBase {

--- a/components/body_sniffer/body_sniffer_throttle.cc
+++ b/components/body_sniffer/body_sniffer_throttle.cc
@@ -75,7 +75,8 @@ void BodySnifferThrottle::WillProcessResponse(
   mojo::ScopedDataPipeConsumerHandle body;
 
   std::tie(new_remote, new_receiver, url_loader, body) =
-      BodySnifferURLLoader::CreateLoader(AsWeakPtr(), response_head->Clone(),
+      BodySnifferURLLoader::CreateLoader(weak_factory_.GetWeakPtr(),
+                                         response_head->Clone(),
                                          std::move(handler), task_runner_);
   InterceptAndStartLoader(std::move(new_remote), std::move(new_receiver),
                           url_loader, std::move(body));

--- a/components/body_sniffer/body_sniffer_throttle.h
+++ b/components/body_sniffer/body_sniffer_throttle.h
@@ -21,8 +21,7 @@ class BodyHandler;
 class BodyProducer;
 
 // Base throttle used for implementing sniffing functionality
-class BodySnifferThrottle : public blink::URLLoaderThrottle,
-                            public base::SupportsWeakPtr<BodySnifferThrottle> {
+class BodySnifferThrottle final : public blink::URLLoaderThrottle {
  public:
   // |task_runner| is used to bind the right task runner for handling incoming
   // IPC in BodySnifferUrlLoader. |task_runner| is supposed to be bound to the

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -262,6 +262,10 @@ AdsServiceImpl::~AdsServiceImpl() {
   rewards_service_->RemoveObserver(this);
 }
 
+base::WeakPtr<AdsServiceImpl> AdsServiceImpl::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 
 bool AdsServiceImpl::IsBatAdsServiceBound() const {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -64,13 +64,12 @@ class Database;
 class DeviceId;
 struct NewTabPageAdInfo;
 
-class AdsServiceImpl : public AdsService,
-                       public bat_ads::mojom::BatAdsClient,
-                       public bat_ads::mojom::BatAdsObserver,
-                       BackgroundHelper::Observer,
-                       public ResourceComponentObserver,
-                       public brave_rewards::RewardsServiceObserver,
-                       public base::SupportsWeakPtr<AdsServiceImpl> {
+class AdsServiceImpl final : public AdsService,
+                             public bat_ads::mojom::BatAdsClient,
+                             public bat_ads::mojom::BatAdsObserver,
+                             BackgroundHelper::Observer,
+                             public ResourceComponentObserver,
+                             public brave_rewards::RewardsServiceObserver {
  public:
   explicit AdsServiceImpl(
       Profile* profile,
@@ -90,6 +89,8 @@ class AdsServiceImpl : public AdsService,
   AdsServiceImpl& operator=(AdsServiceImpl&&) noexcept = delete;
 
   ~AdsServiceImpl() override;
+
+  base::WeakPtr<AdsServiceImpl> AsWeakPtr();
 
  private:
   using SimpleURLLoaderList =
@@ -460,6 +461,8 @@ class AdsServiceImpl : public AdsService,
       bat_ads_client_notifier_remote_;
   mojo::PendingReceiver<bat_ads::mojom::BatAdsClientNotifier>
       bat_ads_client_notifier_pending_receiver_;
+
+  base::WeakPtrFactory<AdsServiceImpl> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_delegate.h
+++ b/components/brave_ads/core/internal/account/utility/redeem_confirmation/redeem_confirmation_delegate.h
@@ -12,8 +12,7 @@ namespace brave_ads {
 
 struct ConfirmationInfo;
 
-class RedeemConfirmationDelegate
-    : public base::SupportsWeakPtr<RedeemConfirmationDelegate> {
+class RedeemConfirmationDelegate {
  public:
   // Invoked to tell the delegate that the `confirmation` was redeemed.
   virtual void OnDidRedeemConfirmation(const ConfirmationInfo& confirmation) {}

--- a/components/brave_rewards/browser/diagnostic_log.cc
+++ b/components/brave_rewards/browser/diagnostic_log.cc
@@ -339,6 +339,11 @@ void DiagnosticLog::Write(const std::string& log_entry,
   Write(formatted_log_entry, std::move(callback));
 }
 
+base::WeakPtr<DiagnosticLog> DiagnosticLog::AsWeakPtr() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 void DiagnosticLog::Delete(StatusCallback callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   file_task_runner_->PostTaskAndReplyWithResult(

--- a/components/brave_rewards/browser/diagnostic_log.h
+++ b/components/brave_rewards/browser/diagnostic_log.h
@@ -18,7 +18,7 @@ namespace brave_rewards {
 // This class provides access to a diagnostic log file. If the file
 // size ever exceeds the provided maximum file size, it is trimmed to
 // keep only the last n lines.
-class DiagnosticLog : public base::SupportsWeakPtr<DiagnosticLog> {
+class DiagnosticLog {
  public:
   DiagnosticLog(const base::FilePath& path,
                 int64_t max_file_size,
@@ -48,6 +48,8 @@ class DiagnosticLog : public base::SupportsWeakPtr<DiagnosticLog> {
   // Deletes the file.
   void Delete(StatusCallback callback);
 
+  base::WeakPtr<DiagnosticLog> AsWeakPtr();
+
  private:
   void OnReadLastNLines(ReadCallback callback, const std::string& data);
   void OnWrite(StatusCallback callback, bool result);
@@ -60,6 +62,7 @@ class DiagnosticLog : public base::SupportsWeakPtr<DiagnosticLog> {
   bool first_write_;
 
   SEQUENCE_CHECKER(sequence_checker_);
+  base::WeakPtrFactory<DiagnosticLog> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_rewards

--- a/components/brave_rewards/browser/rewards_notification_service_impl.h
+++ b/components/brave_rewards/browser/rewards_notification_service_impl.h
@@ -24,10 +24,8 @@ namespace brave_rewards {
 
 class ExtensionRewardsNotificationServiceObserver;
 
-class RewardsNotificationServiceImpl
-    : public RewardsNotificationService,
-      public RewardsServiceObserver,
-      public base::SupportsWeakPtr<RewardsNotificationServiceImpl> {
+class RewardsNotificationServiceImpl final : public RewardsNotificationService,
+                                             public RewardsServiceObserver {
  public:
   explicit RewardsNotificationServiceImpl(Profile* profile);
   RewardsNotificationServiceImpl(const RewardsNotificationServiceImpl&) =

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -2492,6 +2492,10 @@ void RewardsServiceImpl::GetRewardsWallet(GetRewardsWalletCallback callback) {
   engine_->GetRewardsWallet(std::move(callback));
 }
 
+base::WeakPtr<RewardsServiceImpl> RewardsServiceImpl::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 bool RewardsServiceImpl::IsBitFlyerCountry() const {
   return base::Contains(kBitflyerCountries, GetCountryCode());
 }

--- a/components/brave_rewards/browser/rewards_service_impl.h
+++ b/components/brave_rewards/browser/rewards_service_impl.h
@@ -94,12 +94,11 @@ using GetTestResponseCallback = base::RepeatingCallback<void(
 
 using StopEngineCallback = base::OnceCallback<void(mojom::Result)>;
 
-class RewardsServiceImpl : public RewardsService,
-                           public mojom::RewardsEngineClient,
+class RewardsServiceImpl final : public RewardsService,
 #if BUILDFLAG(ENABLE_GREASELION)
-                           public greaselion::GreaselionService::Observer,
+                                 public greaselion::GreaselionService::Observer,
 #endif
-                           public base::SupportsWeakPtr<RewardsServiceImpl> {
+                                 public mojom::RewardsEngineClient {
  public:
   RewardsServiceImpl(Profile* profile,
 #if BUILDFLAG(ENABLE_GREASELION)
@@ -289,6 +288,8 @@ class RewardsServiceImpl : public RewardsService,
                      DecryptStringCallback callback) override;
 
   void GetRewardsWallet(GetRewardsWalletCallback callback) override;
+
+  base::WeakPtr<RewardsServiceImpl> AsWeakPtr();
 
   // Testing methods
   void SetEngineEnvForTesting();
@@ -583,6 +584,7 @@ class RewardsServiceImpl : public RewardsService,
   p3a::ConversionMonitor conversion_monitor_;
 
   SEQUENCE_CHECKER(sequence_checker_);
+  base::WeakPtrFactory<RewardsServiceImpl> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_rewards

--- a/components/brave_shields/content/browser/ad_block_engine.cc
+++ b/components/brave_shields/content/browser/ad_block_engine.cc
@@ -379,4 +379,8 @@ void AdBlockEngine::RemoveObserverForTest() {
   test_observer_ = nullptr;
 }
 
+base::WeakPtr<AdBlockEngine> AdBlockEngine::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 }  // namespace brave_shields

--- a/components/brave_shields/content/browser/ad_block_engine.h
+++ b/components/brave_shields/content/browser/ad_block_engine.h
@@ -34,7 +34,7 @@ class PerfPredictorTabHelperTest;
 namespace brave_shields {
 
 // Service managing an adblock engine.
-class AdBlockEngine : public base::SupportsWeakPtr<AdBlockEngine> {
+class AdBlockEngine {
  public:
   explicit AdBlockEngine(bool is_default_engine);
   AdBlockEngine(const AdBlockEngine&) = delete;
@@ -82,6 +82,8 @@ class AdBlockEngine : public base::SupportsWeakPtr<AdBlockEngine> {
   void AddObserverForTest(TestObserver* observer);
   void RemoveObserverForTest();
 
+  base::WeakPtr<AdBlockEngine> AsWeakPtr();
+
  protected:
   void AddKnownTagsToAdBlockInstance();
   void UpdateAdBlockClient(rust::Box<adblock::Engine> ad_block_client,
@@ -112,6 +114,7 @@ class AdBlockEngine : public base::SupportsWeakPtr<AdBlockEngine> {
   bool is_default_engine_;
 
   SEQUENCE_CHECKER(sequence_checker_);
+  base::WeakPtrFactory<AdBlockEngine> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_shields

--- a/components/brave_shields/content/browser/ad_block_subscription_download_manager.cc
+++ b/components/brave_shields/content/browser/ad_block_subscription_download_manager.cc
@@ -106,6 +106,11 @@ bool AdBlockSubscriptionDownloadManager::IsAvailableForDownloads() const {
   return is_available_for_downloads_;
 }
 
+base::WeakPtr<AdBlockSubscriptionDownloadManager>
+AdBlockSubscriptionDownloadManager::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 void AdBlockSubscriptionDownloadManager::Shutdown() {
   is_available_for_downloads_ = false;
   CancelAllPendingDownloads();

--- a/components/brave_shields/content/browser/ad_block_subscription_download_manager.h
+++ b/components/brave_shields/content/browser/ad_block_subscription_download_manager.h
@@ -30,9 +30,7 @@ class AdBlockSubscriptionServiceManager;
 class AdBlockSubscriptionDownloadClient;
 
 // Manages the downloads of filter lists for custom subscriptions.
-class AdBlockSubscriptionDownloadManager
-    : public KeyedService,
-      public base::SupportsWeakPtr<AdBlockSubscriptionDownloadManager> {
+class AdBlockSubscriptionDownloadManager final : public KeyedService {
  public:
   using DownloadManagerGetter = base::OnceCallback<void(
       base::OnceCallback<void(AdBlockSubscriptionDownloadManager*)>)>;
@@ -72,6 +70,8 @@ class AdBlockSubscriptionDownloadManager
       base::RepeatingCallback<void(const GURL&)> on_download_failed_callback) {
     on_download_failed_callback_ = on_download_failed_callback;
   }
+
+  base::WeakPtr<AdBlockSubscriptionDownloadManager> AsWeakPtr();
 
  private:
   friend class AdBlockSubscriptionDownloadClient;
@@ -143,6 +143,9 @@ class AdBlockSubscriptionDownloadManager
       subscription_path_callback_;
   base::RepeatingCallback<void(const GURL&)> on_download_succeeded_callback_;
   base::RepeatingCallback<void(const GURL&)> on_download_failed_callback_;
+
+  base::WeakPtrFactory<AdBlockSubscriptionDownloadManager> weak_ptr_factory_{
+      this};
 };
 
 }  // namespace brave_shields

--- a/components/brave_shields/content/browser/blocked_domain_1pes_lifetime.cc
+++ b/components/brave_shields/content/browser/blocked_domain_1pes_lifetime.cc
@@ -63,6 +63,11 @@ void BlockedDomain1PESLifetime::AddOnReadyCallback(
   }
 }
 
+base::WeakPtr<BlockedDomain1PESLifetime>
+BlockedDomain1PESLifetime::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
+}
+
 void BlockedDomain1PESLifetime::Start1PESEnableRequest() {
   key_.first->Enable1PESForUrlIfPossible(
       key_.second,

--- a/components/brave_shields/content/browser/blocked_domain_1pes_lifetime.h
+++ b/components/brave_shields/content/browser/blocked_domain_1pes_lifetime.h
@@ -26,9 +26,8 @@ namespace brave_shields {
 // BlockedDomain1PESLifetime::Key. When the last top-level frame holding a
 // reference is destroyed or navigates to a non-blocked domain, 1PES will be
 // disabled.
-class BlockedDomain1PESLifetime
-    : public base::RefCounted<BlockedDomain1PESLifetime>,
-      public base::SupportsWeakPtr<BlockedDomain1PESLifetime> {
+class BlockedDomain1PESLifetime final
+    : public base::RefCounted<BlockedDomain1PESLifetime> {
  public:
   using Key = std::pair<ephemeral_storage::EphemeralStorageService*, GURL>;
 
@@ -40,6 +39,8 @@ class BlockedDomain1PESLifetime
 
   void AddOnReadyCallback(base::OnceCallback<void(bool)> on_ready);
 
+  base::WeakPtr<BlockedDomain1PESLifetime> AsWeakPtr();
+
  private:
   friend class RefCounted<BlockedDomain1PESLifetime>;
   virtual ~BlockedDomain1PESLifetime();
@@ -50,6 +51,8 @@ class BlockedDomain1PESLifetime
   const Key key_;
   std::vector<base::OnceCallback<void(bool)>> on_ready_;
   std::optional<bool> is_1pes_enabled_;
+
+  base::WeakPtrFactory<BlockedDomain1PESLifetime> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_shields

--- a/components/tor/tor_control.h
+++ b/components/tor/tor_control.h
@@ -51,7 +51,7 @@ class TorControl {
   using CmdCallback = base::OnceCallback<
       void(bool error, const std::string& status, const std::string& reply)>;
 
-  class Delegate : public base::SupportsWeakPtr<Delegate> {
+  class Delegate {
    public:
     virtual ~Delegate() = default;
     virtual void OnTorControlReady() = 0;
@@ -70,6 +70,9 @@ class TorControl {
                              const std::string& line) {}
     virtual void OnTorRawEnd(const std::string& status,
                              const std::string& line) {}
+
+    // Returns a WeakPtr to the implementation instance.
+    virtual base::WeakPtr<Delegate> AsWeakPtr() = 0;
   };
 
   TorControl(base::WeakPtr<TorControl::Delegate> delegate,

--- a/components/tor/tor_control_unittest.cc
+++ b/components/tor/tor_control_unittest.cc
@@ -17,7 +17,7 @@
 
 namespace tor {
 namespace {
-class MockTorControlDelegate : public TorControl::Delegate {
+class MockTorControlDelegate final : public TorControl::Delegate {
  public:
   MOCK_METHOD0(OnTorControlReady, void());
   MOCK_METHOD1(OnTorControlClosed, void(bool));
@@ -29,6 +29,13 @@ class MockTorControlDelegate : public TorControl::Delegate {
   MOCK_METHOD2(OnTorRawAsync, void(const std::string&, const std::string&));
   MOCK_METHOD2(OnTorRawMid, void(const std::string&, const std::string&));
   MOCK_METHOD2(OnTorRawEnd, void(const std::string&, const std::string&));
+
+  base::WeakPtr<tor::TorControl::Delegate> AsWeakPtr() override {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
+ private:
+  base::WeakPtrFactory<tor::TorControl::Delegate> weak_ptr_factory_{this};
 };
 }  // namespace
 

--- a/components/tor/tor_launcher_factory.cc
+++ b/components/tor/tor_launcher_factory.cc
@@ -66,10 +66,10 @@ TorLauncherFactory::TorLauncherFactory()
     : is_starting_(false),
       is_connected_(false),
       tor_pid_(-1),
-      control_(new tor::TorControl(this->AsWeakPtr(),
-                                   content::GetIOThreadTaskRunner({})),
-               base::OnTaskRunnerDeleter(content::GetIOThreadTaskRunner({}))),
-      weak_ptr_factory_(this) {
+      control_(nullptr,
+               base::OnTaskRunnerDeleter(content::GetIOThreadTaskRunner({}))) {
+  control_.reset(new tor::TorControl(this->AsWeakPtr(),
+                                     content::GetIOThreadTaskRunner({})));
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 }
 
@@ -470,4 +470,8 @@ void TorLauncherFactory::OnTorRawEnd(const std::string& status,
                                      const std::string& line) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   VLOG(3) << "TOR CONTROL: end " << status << " " << line;
+}
+
+base::WeakPtr<tor::TorControl::Delegate> TorLauncherFactory::AsWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
 }

--- a/components/tor/tor_launcher_factory.h
+++ b/components/tor/tor_launcher_factory.h
@@ -68,6 +68,7 @@ class TorLauncherFactory : public tor::TorControl::Delegate {
                      const std::string& line) override;
   void OnTorRawMid(const std::string& status, const std::string& line) override;
   void OnTorRawEnd(const std::string& status, const std::string& line) override;
+  base::WeakPtr<tor::TorControl::Delegate> AsWeakPtr() override;
 
  private:
   friend base::NoDestructor<TorLauncherFactory>;
@@ -119,7 +120,7 @@ class TorLauncherFactory : public tor::TorControl::Delegate {
   };
   std::optional<InitializationMessage> last_init_message_;
 
-  base::WeakPtrFactory<TorLauncherFactory> weak_ptr_factory_;
+  base::WeakPtrFactory<TorLauncherFactory> weak_ptr_factory_{this};
 };
 
 #endif  // BRAVE_COMPONENTS_TOR_TOR_LAUNCHER_FACTORY_H_

--- a/components/tor/tor_tab_helper.cc
+++ b/components/tor/tor_tab_helper.cc
@@ -33,7 +33,7 @@ void TorTabHelper::DidFinishNavigation(
     return;
   base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE,
-      base::BindOnce(&TorTabHelper::ReloadTab, AsWeakPtr(),
+      base::BindOnce(&TorTabHelper::ReloadTab, weak_ptr_factory_.GetWeakPtr(),
                      navigation_handle->GetWebContents()),
       base::Seconds(1));
 }

--- a/components/tor/tor_tab_helper.h
+++ b/components/tor/tor_tab_helper.h
@@ -17,9 +17,8 @@ class WebContents;
 
 namespace tor {
 
-class TorTabHelper : public content::WebContentsObserver,
-                     public content::WebContentsUserData<TorTabHelper>,
-                     public base::SupportsWeakPtr<TorTabHelper> {
+class TorTabHelper final : public content::WebContentsObserver,
+                           public content::WebContentsUserData<TorTabHelper> {
  public:
   TorTabHelper(const TorTabHelper&) = delete;
   TorTabHelper& operator=(const TorTabHelper&) = delete;
@@ -37,6 +36,8 @@ class TorTabHelper : public content::WebContentsObserver,
       content::NavigationHandle* navigation_handle) override;
 
   void ReloadTab(content::WebContents* web_contents);
+
+  base::WeakPtrFactory<TorTabHelper> weak_ptr_factory_{this};
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();
 };


### PR DESCRIPTION
In upcoming chromium version, `base::SupportsWeakPtr` will be marked as deprecated, and eventually removed. This class is being removed as it leaves the weak ptr factory to be invalidated last, which can cause the us of half-destroyed objects.

This change removes the use of the deprecated base class in favour of composition, by having the factory as a member, and marking the class as `final`, when possible, to make sure that the factory is the invalidated first during destruction.

Some classes in this PR were deriving from `SupportsWeakPtr`, and yet making no use of weak ptrs, and in these cases, all weak ptr references are being removed.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/fe3114c4af662797ee08f1580951c4037e507ac1

    commit fe3114c4af662797ee08f1580951c4037e507ac1
    Author: David Bertoni <dbertoni@chromium.org>
    Date:   Thu Jul 11 17:21:14 2024 +0000

        [Code Health] Add deprecation comment for base::SupportsWeakPtr.

        This class is deprecated, per the Code Health bug, and multiple
        reviewers have requested a comment to help avoid its use in new
        code.

        In addition, the constructor of this class is now private and the
        remaining uses are allowed via friend declarations. These will be
        cleaned up as the remaining uses are fixed.

        Bug: 40485134

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39737

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

