### PR TITLE
Fixed wrong text color for MdTextButton's disabled state

### DIFF
--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -137,7 +137,7 @@ const base::flat_map<MdTextButtonStyleKey, ButtonStyle>& GetButtonThemes() {
              ButtonState::STATE_DISABLED},
             {.background_color = std::nullopt,
              .border_color = gfx::kColorButtonDisabled,
-             .text_color = gfx::kColorTextDisabled}},
+             .text_color = gfx::kColorTextDisabledDark}},
 
            {{ui::ButtonStyle::kTonal, ColorScheme::kLight,
              ButtonState::STATE_NORMAL},
@@ -205,7 +205,7 @@ const base::flat_map<MdTextButtonStyleKey, ButtonStyle>& GetButtonThemes() {
              ButtonState::STATE_DISABLED},
             {.background_color = std::nullopt,
              .border_color = std::nullopt,
-             .text_color = gfx::kColorTextDisabled}}});
+             .text_color = gfx::kColorTextDisabledDark}}});
 
   return *button_themes;
 }

--- a/chromium_src/ui/views/controls/button/md_text_button.h
+++ b/chromium_src/ui/views/controls/button/md_text_button.h
@@ -71,6 +71,8 @@ class VIEWS_EXPORT MdTextButton : public MdTextButtonBase {
   void UpdateColors() override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(MdTextButtonTest, ButtonColorsTest);
+
   ButtonColors GetButtonColors();
   ui::ButtonStyle GetBraveStyle() const;
 

--- a/ui/views/BUILD.gn
+++ b/ui/views/BUILD.gn
@@ -5,10 +5,14 @@
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "menu_config_unittest.cc" ]
+  sources = [
+    "md_text_button_unittest.cc",
+    "menu_config_unittest.cc",
+  ]
 
   deps = [
     "//testing/gtest",
+    "//ui/native_theme",
     "//ui/views",
     "//ui/views:test_support",
   ]

--- a/ui/views/DEPS
+++ b/ui/views/DEPS
@@ -1,1 +1,5 @@
-include_rules = [ "+ui/views" ]
+include_rules = [
+  "+ui/gfx",
+  "+ui/native_theme",
+  "+ui/views",
+]

--- a/ui/views/md_text_button_unittest.cc
+++ b/ui/views/md_text_button_unittest.cc
@@ -1,0 +1,38 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "ui/views/controls/button/md_text_button.h"
+
+#include <memory>
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/color_palette.h"
+#include "ui/native_theme/native_theme.h"
+#include "ui/views/test/views_test_base.h"
+#include "ui/views/test/widget_test.h"
+
+namespace views {
+
+using ColorScheme = ui::NativeTheme::PreferredColorScheme;
+using MdTextButtonTest = ViewsTestBase;
+
+TEST_F(MdTextButtonTest, ButtonColorsTest) {
+  std::unique_ptr<Widget> widget =
+      CreateTestWidget(views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET);
+
+  auto* button = widget->SetContentsView(
+      std::make_unique<MdTextButton>(Button::PressedCallback(), u" "));
+  button->SetEnabled(false);
+
+  // Check proper text color is used for each theme options.
+  auto* const native_theme = widget->GetNativeTheme();
+  native_theme->set_preferred_color_scheme(ColorScheme::kLight);
+  EXPECT_EQ(gfx::kColorTextDisabled, button->GetButtonColors().text_color);
+
+  native_theme->set_preferred_color_scheme(ColorScheme::kDark);
+  EXPECT_EQ(gfx::kColorTextDisabledDark, button->GetButtonColors().text_color);
+}
+
+}  // namespace views


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/39719

So far, we set wrong text for disabled state for some MdTextButton's style.
It's revealed by https://github.com/brave/brave-core/pull/24562.
Before #24562, normal text color was also used for disabled state.

![image](https://github.com/user-attachments/assets/89464cf2-12cf-49a2-b0f3-cff141e65fad)
![image](https://github.com/user-attachments/assets/c2dc26c6-a4e0-4baa-81b6-8dd38d4eb4d8)

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`MdTextButtonTest.ButtonColorsTest`
See the linked issue.