### PR TITLE
Fixed wrong text color for MdTextButton's disabled state (uplift to 1.68.x)

### DIFF
--- a/chromium_src/ui/views/controls/button/md_text_button.cc
+++ b/chromium_src/ui/views/controls/button/md_text_button.cc
@@ -137,7 +137,7 @@ const base::flat_map<MdTextButtonStyleKey, ButtonStyle>& GetButtonThemes() {
              ButtonState::STATE_DISABLED},
             {.background_color = std::nullopt,
              .border_color = gfx::kColorButtonDisabled,
-             .text_color = gfx::kColorTextDisabled}},
+             .text_color = gfx::kColorTextDisabledDark}},
 
            {{ui::ButtonStyle::kTonal, ColorScheme::kLight,
              ButtonState::STATE_NORMAL},
@@ -205,7 +205,7 @@ const base::flat_map<MdTextButtonStyleKey, ButtonStyle>& GetButtonThemes() {
              ButtonState::STATE_DISABLED},
             {.background_color = std::nullopt,
              .border_color = std::nullopt,
-             .text_color = gfx::kColorTextDisabled}}});
+             .text_color = gfx::kColorTextDisabledDark}}});
 
   return *button_themes;
 }

--- a/chromium_src/ui/views/controls/button/md_text_button.h
+++ b/chromium_src/ui/views/controls/button/md_text_button.h
@@ -71,6 +71,8 @@ class VIEWS_EXPORT MdTextButton : public MdTextButtonBase {
   void UpdateColors() override;
 
  private:
+  FRIEND_TEST_ALL_PREFIXES(MdTextButtonTest, ButtonColorsTest);
+
   ButtonColors GetButtonColors();
   ui::ButtonStyle GetBraveStyle() const;
 

--- a/ui/views/BUILD.gn
+++ b/ui/views/BUILD.gn
@@ -5,10 +5,14 @@
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "menu_config_unittest.cc" ]
+  sources = [
+    "md_text_button_unittest.cc",
+    "menu_config_unittest.cc",
+  ]
 
   deps = [
     "//testing/gtest",
+    "//ui/native_theme",
     "//ui/views",
     "//ui/views:test_support",
   ]

--- a/ui/views/DEPS
+++ b/ui/views/DEPS
@@ -1,1 +1,5 @@
-include_rules = [ "+ui/views" ]
+include_rules = [
+  "+ui/gfx",
+  "+ui/native_theme",
+  "+ui/views",
+]

--- a/ui/views/md_text_button_unittest.cc
+++ b/ui/views/md_text_button_unittest.cc
@@ -1,0 +1,38 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "ui/views/controls/button/md_text_button.h"
+
+#include <memory>
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/gfx/color_palette.h"
+#include "ui/native_theme/native_theme.h"
+#include "ui/views/test/views_test_base.h"
+#include "ui/views/test/widget_test.h"
+
+namespace views {
+
+using ColorScheme = ui::NativeTheme::PreferredColorScheme;
+using MdTextButtonTest = ViewsTestBase;
+
+TEST_F(MdTextButtonTest, ButtonColorsTest) {
+  std::unique_ptr<Widget> widget =
+      CreateTestWidget(views::Widget::InitParams::WIDGET_OWNS_NATIVE_WIDGET);
+
+  auto* button = widget->SetContentsView(
+      std::make_unique<MdTextButton>(Button::PressedCallback(), u" "));
+  button->SetEnabled(false);
+
+  // Check proper text color is used for each theme options.
+  auto* const native_theme = widget->GetNativeTheme();
+  native_theme->set_preferred_color_scheme(ColorScheme::kLight);
+  EXPECT_EQ(gfx::kColorTextDisabled, button->GetButtonColors().text_color);
+
+  native_theme->set_preferred_color_scheme(ColorScheme::kDark);
+  EXPECT_EQ(gfx::kColorTextDisabledDark, button->GetButtonColors().text_color);
+}
+
+}  // namespace views


### PR DESCRIPTION
Uplift of #24644
fix https://github.com/brave/brave-browser/issues/39719

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.