### PR TITLE
fix(wallet): Update gas fee precision to 10 digits for lower fee networks

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/PendingTransactionView.swift
@@ -346,6 +346,7 @@ struct PendingTransactionView: View {
                     .multilineTextAlignment(.trailing)
                   Text(confirmationStore.gasFiat)
                     .font(.footnote)
+                    .multilineTextAlignment(.trailing)
                 }
               }
               .font(.callout)

--- a/ios/brave-ios/Sources/BraveWallet/Extensions/WalletAmountFormatter.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/WalletAmountFormatter.swift
@@ -22,7 +22,7 @@ struct WalletAmountFormatter {
     case balance
     /// A format to be used when you want to display a deicmal gas amount.
     ///
-    /// Shows 6 decimals of precision and is rounded. Example: `3.141592`
+    /// Shows 10 decimals of precision and is rounded. Example: `3.141592`
     case gasFee(limit: String, radix: Radix = .decimal)
 
     fileprivate var precision: Int {
@@ -32,7 +32,7 @@ struct WalletAmountFormatter {
       case .balance:
         return 4
       case .gasFee:
-        return 6
+        return 10
       }
     }
 

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -143,8 +143,8 @@ class TransactionParserTests: XCTestCase {
           fromFiat: "$0.123",
           fromTokenMetadata: nil,
           gasFee: .init(
-            fee: "0.000031",
-            fiat: "$0.000031"
+            fee: "0.0000314986",
+            fiat: "$0.0000315"
           )
         )
       )
@@ -248,8 +248,8 @@ class TransactionParserTests: XCTestCase {
           fromFiat: "$0.864",
           fromTokenMetadata: nil,
           gasFee: .init(
-            fee: "0.000078",
-            fiat: "$0.000078"
+            fee: "0.0000776726",
+            fiat: "$0.0000777"
           )
         )
       )
@@ -271,7 +271,7 @@ class TransactionParserTests: XCTestCase {
       XCTFail("Failed to parse erc20Transfer transaction")
       return
     }
-    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+    XCTAssertNoDifference(expectedParsedTransaction, parsedTransaction)
   }
 
   func testEthSwapTransaction() {
@@ -343,7 +343,7 @@ class TransactionParserTests: XCTestCase {
           minBuyAmount: "6.660592362643797387",
           minBuyAmountFiat: "$13.32",
           gasFee: .init(
-            fee: "0.000466",
+            fee: "0.0004663515",
             fiat: "$0.000466"
           )
         )
@@ -366,7 +366,7 @@ class TransactionParserTests: XCTestCase {
       XCTFail("Failed to parse ethSwap transaction")
       return
     }
-    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+    XCTAssertNoDifference(expectedParsedTransaction, parsedTransaction)
   }
 
   func testEthSwapTransactionUSDCToDAI() {
@@ -438,7 +438,7 @@ class TransactionParserTests: XCTestCase {
           minBuyAmount: "0.125259433834718286",
           minBuyAmountFiat: "$0.251",
           gasFee: .init(
-            fee: "0.000466",
+            fee: "0.0004663515",
             fiat: "$0.000466"
           )
         )
@@ -461,7 +461,7 @@ class TransactionParserTests: XCTestCase {
       XCTFail("Failed to parse ethSwap transaction")
       return
     }
-    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+    XCTAssertNoDifference(expectedParsedTransaction, parsedTransaction)
   }
 
   func testErc20ApproveTransaction() {
@@ -527,8 +527,8 @@ class TransactionParserTests: XCTestCase {
           isUnlimited: false,
           spenderAddress: "",
           gasFee: .init(
-            fee: "0.000061",
-            fiat: "$0.000061"
+            fee: "0.0000695985",
+            fiat: "$0.0000696"
           )
         )
       )
@@ -550,7 +550,7 @@ class TransactionParserTests: XCTestCase {
       XCTFail("Failed to parse erc20Approve transaction")
       return
     }
-    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+    XCTAssertNoDifference(expectedParsedTransaction, parsedTransaction)
   }
 
   func testErc20ApproveTransactionUnlimited() {
@@ -617,8 +617,8 @@ class TransactionParserTests: XCTestCase {
           isUnlimited: true,
           spenderAddress: "",
           gasFee: .init(
-            fee: "0.000061",
-            fiat: "$0.000061"
+            fee: "0.0000695985",
+            fiat: "$0.0000696"
           )
         )
       )
@@ -640,7 +640,7 @@ class TransactionParserTests: XCTestCase {
       XCTFail("Failed to parse erc20Approve transaction")
       return
     }
-    XCTAssertEqual(expectedParsedTransaction, parsedTransaction)
+    XCTAssertNoDifference(expectedParsedTransaction, parsedTransaction)
   }
 
   func testErc721TransferFromTransaction() {
@@ -709,8 +709,8 @@ class TransactionParserTests: XCTestCase {
           owner: "0x1111111111aaaaaaaaaa2222222222bbbbbbbbbb",
           tokenId: "token.id",
           gasFee: .init(
-            fee: "0.000031",
-            fiat: "$0.000031"
+            fee: "0.0000314986",
+            fiat: "$0.0000315"
           )
         )
       )

--- a/ios/brave-ios/Tests/BraveWalletTests/TransactionParserTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/TransactionParserTests.swift
@@ -82,6 +82,53 @@ class TransactionParserTests: XCTestCase {
     BraveWallet.BlockchainToken.mockBTCToken.assetRatioId.lowercased(): 62_117,
   ]
 
+  let mockGasEstimation = BraveWallet.GasEstimation1559(
+    slowMaxPriorityFeePerGas: "0x0",
+    slowMaxFeePerGas: "0x9",
+    avgMaxPriorityFeePerGas: "0x59672ead",
+    avgMaxFeePerGas: "0x59672eb6",
+    fastMaxPriorityFeePerGas: "0x59682f00",
+    fastMaxFeePerGas: "0x59682f09",
+    baseFeePerGas: "0x9"
+  )
+  let mockSwapGasEstimation = BraveWallet.GasEstimation1559(
+    slowMaxPriorityFeePerGas: "0x4ed3152b",
+    slowMaxFeePerGas: "0x4ed31534",
+    avgMaxPriorityFeePerGas: "0x59672ead",
+    avgMaxFeePerGas: "0x59672eb6",
+    fastMaxPriorityFeePerGas: "0x59682f00",
+    fastMaxFeePerGas: "0x59682f09",
+    baseFeePerGas: "0x9"
+  )
+
+  private func mockTransaction(
+    fromAccount: BraveWallet.AccountInfo,
+    txDataUnion: BraveWallet.TxDataUnion,
+    txType: BraveWallet.TransactionType,
+    txArgs: [String] = [],
+    chainId: String = BraveWallet.MainnetChainId,
+    effectiveRecipient: String
+  ) -> BraveWallet.TransactionInfo {
+    BraveWallet.TransactionInfo(
+      id: "1",
+      fromAddress: fromAccount.address,
+      from: fromAccount.accountId,
+      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+      txDataUnion: txDataUnion,
+      txStatus: .unapproved,
+      txType: txType,
+      txParams: [],
+      txArgs: txArgs,
+      createdTime: Date(),
+      submittedTime: Date(),
+      confirmedTime: Date(),
+      originInfo: nil,
+      chainId: chainId,
+      effectiveRecipient: effectiveRecipient,
+      isRetriable: false
+    )
+  }
+
   func testEthSendTransaction() {
     let network: BraveWallet.NetworkInfo = .mockMainnet
 
@@ -99,33 +146,14 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59672ead",
       maxFeePerGas: "0x59672eb6",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x0",
-        slowMaxFeePerGas: "0x9",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "1",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .ethSend,
-      txParams: [],
       txArgs: [],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -203,34 +231,14 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59672ead",
       maxFeePerGas: "0x59672eb6",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x0",
-        slowMaxFeePerGas: "0x9",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "2",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .erc20Transfer,
-      txParams: [],
-      // toAddress, 0.4321
       txArgs: ["0x0987654321098765432109876543210987654321", "0x5ff20a91f724000"],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -291,38 +299,19 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59682f00",
       maxFeePerGas: "0x59682f09",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x4ed3152b",
-        slowMaxFeePerGas: "0x4ed31534",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockSwapGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "3",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .ethSwap,
-      txParams: [],
       txArgs: [
         // eth -> dai
         "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeead6d458402f60fd3bd25163575031acdce07538d",
         "0x1b6951ef585a000",  // 0.12345 eth
         "0x5c6f2d76e910358b",  // 6.660592362643797387 dai
       ],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -386,38 +375,19 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59682f00",
       maxFeePerGas: "0x59682f09",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x4ed3152b",
-        slowMaxFeePerGas: "0x4ed31534",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockSwapGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "3",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .ethSwap,
-      txParams: [],
       txArgs: [
         // usdc -> dai
         "0x07865c6e87b9f70255377e024ace6630c1eaa37fad6d458402f60fd3bd25163575031acdce07538d",
         "0x16e360",  // 1.5 USDC
         "0x1bd02ca9a7c244e",  // ~0.1253 DAI
       ],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -481,33 +451,14 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59682f00",
       maxFeePerGas: "0x59682f09",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x0",
-        slowMaxFeePerGas: "0x9",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "4",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .erc20Approve,
-      txParams: [],
       txArgs: ["", "0x2386f26fc10000"],  // 0.01
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -570,34 +521,15 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59682f00",
       maxFeePerGas: "0x59682f09",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x0",
-        slowMaxFeePerGas: "0x9",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "5",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .erc20Approve,
-      txParams: [],
       // unlimited
       txArgs: ["", "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -660,37 +592,18 @@ class TransactionParserTests: XCTestCase {
       chainId: network.chainId,
       maxPriorityFeePerGas: "0x59672ead",
       maxFeePerGas: "0x59672eb6",
-      gasEstimation: .init(
-        slowMaxPriorityFeePerGas: "0x0",
-        slowMaxFeePerGas: "0x9",
-        avgMaxPriorityFeePerGas: "0x59672ead",
-        avgMaxFeePerGas: "0x59672eb6",
-        fastMaxPriorityFeePerGas: "0x59682f00",
-        fastMaxFeePerGas: "0x59682f09",
-        baseFeePerGas: "0x9"
-      )
+      gasEstimation: mockGasEstimation
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "6",
-      fromAddress: accountInfos[0].address,
-      from: accountInfos[0].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[0],
       txDataUnion: .init(ethTxData1559: transactionData),
-      txStatus: .confirmed,
       txType: .erc721TransferFrom,
-      txParams: [],
       txArgs: [
         "0x1111111111aaaaaaaaaa2222222222bbbbbbbbbb",  // owner
         "0x0987654321098765432109876543210987654321",  // toAddress
         "token.id",
       ],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
-      chainId: BraveWallet.MainnetChainId,
-      effectiveRecipient: transactionData.baseData.to,
-      isRetriable: false
+      effectiveRecipient: transactionData.baseData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -765,23 +678,13 @@ class TransactionParserTests: XCTestCase {
       signTransactionParam: nil,
       feeEstimation: nil
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "7",
-      fromAddress: accountInfos[2].address,
-      from: accountInfos[2].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[2],
       txDataUnion: .init(solanaTxData: transactionData),
-      txStatus: .confirmed,
       txType: .solanaSystemTransfer,
-      txParams: [],
       txArgs: [],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
       chainId: BraveWallet.SolanaMainnet,
-      effectiveRecipient: nil,
-      isRetriable: false
+      effectiveRecipient: transactionData.toWalletAddress
     )
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
@@ -872,23 +775,13 @@ class TransactionParserTests: XCTestCase {
       signTransactionParam: nil,
       feeEstimation: nil
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "7",
-      fromAddress: accountInfos[2].address,
-      from: accountInfos[2].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[2],
       txDataUnion: .init(solanaTxData: transactionData),
-      txStatus: .confirmed,
       txType: .solanaSplTokenTransfer,
-      txParams: [],
       txArgs: [],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
       chainId: BraveWallet.SolanaMainnet,
-      effectiveRecipient: nil,
-      isRetriable: false
+      effectiveRecipient: transactionData.toWalletAddress
     )
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
@@ -962,23 +855,13 @@ class TransactionParserTests: XCTestCase {
       signTransactionParam: nil,
       feeEstimation: nil
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "7",
-      fromAddress: accountInfos[2].address,
-      from: accountInfos[2].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffff1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[2],
       txDataUnion: .init(solanaTxData: transactionData),
-      txStatus: .confirmed,
       txType: .solanaSplTokenTransfer,
-      txParams: [],
       txArgs: [],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
       chainId: BraveWallet.SolanaMainnet,
-      effectiveRecipient: nil,
-      isRetriable: false
+      effectiveRecipient: transactionData.toWalletAddress
     )
     let expectedParsedTransaction = ParsedTransaction(
       transaction: transaction,
@@ -1224,23 +1107,12 @@ class TransactionParserTests: XCTestCase {
       to: accountInfos[5].address,
       value: "1000000000000000000"
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "8",
-      fromAddress: accountInfos[4].address,
-      from: accountInfos[4].accountId,
-      txHash: "0xaaaaaaaaaabbbbbbbbbbccccccccccddddddddddeeeeeeeeeeffffffffffggggg1234",
+    let transaction = mockTransaction(
+      fromAccount: accountInfos[4],
       txDataUnion: .init(filTxData: transactionData),
-      txStatus: .unapproved,
       txType: .other,
-      txParams: [],
-      txArgs: [],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
       chainId: BraveWallet.FilecoinTestnet,
-      effectiveRecipient: nil,
-      isRetriable: false
+      effectiveRecipient: transactionData.to
     )
 
     let expectedParsedTransaction = ParsedTransaction(
@@ -1320,23 +1192,12 @@ class TransactionParserTests: XCTestCase {
       inputs: [],
       outputs: []
     )
-    let transaction = BraveWallet.TransactionInfo(
-      id: "9",
-      fromAddress: mockFromAccount.address,
-      from: mockFromAccount.accountId,
-      txHash: "cc0b6ef00effdd4e4a1f29cd4a5e9c1f74ea6a9c3ef2f1f5929d344eee86b71b",
+    let transaction = mockTransaction(
+      fromAccount: mockFromAccount,
       txDataUnion: .init(btcTxData: transactionData),
-      txStatus: .unapproved,
       txType: .other,
-      txParams: [],
-      txArgs: [],
-      createdTime: Date(),
-      submittedTime: Date(),
-      confirmedTime: Date(),
-      originInfo: nil,
       chainId: network.chainId,
-      effectiveRecipient: mockToAccountAddress,
-      isRetriable: false
+      effectiveRecipient: mockToAccountAddress
     )
 
     let expectedParsedTransaction = ParsedTransaction(

--- a/ios/brave-ios/Tests/BraveWalletTests/WalletAmountFormatterTests.swift
+++ b/ios/brave-ios/Tests/BraveWalletTests/WalletAmountFormatterTests.swift
@@ -50,7 +50,7 @@ class WalletAmountFormatterTests: XCTestCase {
     let formatter = WalletAmountFormatter(decimalFormatStyle: .gasFee(limit: "100"))
     XCTAssertEqual(
       try XCTUnwrap(formatter.decimalString(for: "31050382080585020020", decimals: 18)),
-      "3105.038208"
+      "3105.0382080585"
     )
   }
   func testInvalidString() {


### PR DESCRIPTION
Currently the gas fees are rounded to 6 digits after the decimal, but this can cause some rounding issues on networks with lower gas fees like Optimism. Increasing the digits to 10 helps this so we aren't showing 0 ETH as the gas fee.

Resolves https://github.com/brave/brave-browser/issues/39733

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a transaction on Optimism
2. Verify Gas Fee does not display as 0 ETH

<img src="https://github.com/user-attachments/assets/9b8806fb-a030-4fdb-aeb4-3355514a29a4" width="250">