### PR TITLE
style(wallet): Accounts List Grouping

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
@@ -19,11 +19,19 @@ export const StyledWrapper = styled.div<{
   justify-content: center;
   flex-direction: column;
   width: 100%;
-  padding-right: 8px;
-  border-radius: 12px;
-  border: 1px solid ${leo.color.divider.subtle};
-  margin-bottom: 8px;
+  padding-right: 14px;
+  border-bottom: 1px solid ${leo.color.divider.subtle};
   transition: background-color 300ms ease-out;
+  &:first-child {
+    border-radius: ${leo.radius.l} ${leo.radius.l} 0px 0px;
+  }
+  &:last-child {
+    border-bottom: none;
+    border-radius: 0px 0px ${leo.radius.l} ${leo.radius.l};
+  }
+  &:only-child {
+    border-radius: ${leo.radius.l};
+  }
   &:hover {
     background-color: ${(p) =>
       p.isRewardsAccount ? 'transparent' : leo.color.page.background};
@@ -42,7 +50,7 @@ export const AccountButton = styled(WalletButton)`
   border: none;
   color: none;
   margin: 0px;
-  padding: 8px 0px 8px 8px;
+  padding: 14px 0px 14px 14px;
   &:disabled {
     cursor: default;
   }

--- a/components/brave_wallet_ui/components/desktop/views/accounts/accounts.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/accounts.tsx
@@ -24,7 +24,7 @@ import { makeAccountRoute } from '../../../../utils/routes-utils'
 import { getPriceIdForToken } from '../../../../utils/api-utils'
 
 // Styled Components
-import { SectionTitle } from './style'
+import { SectionTitle, AccountsListWrapper } from './style'
 
 import { Column, Row } from '../../../shared/style'
 
@@ -136,7 +136,7 @@ export const Accounts = () => {
 
   const trezorList = React.useMemo(() => {
     return trezorKeys.map((key) => (
-      <Column
+      <AccountsListWrapper
         fullWidth={true}
         alignItems='flex-start'
         key={key}
@@ -154,7 +154,7 @@ export const Accounts = () => {
             />
           )
         )}
-      </Column>
+      </AccountsListWrapper>
     ))
   }, [
     trezorKeys,
@@ -172,7 +172,7 @@ export const Accounts = () => {
 
   const ledgerList = React.useMemo(() => {
     return ledgerKeys.map((key) => (
-      <Column
+      <AccountsListWrapper
         fullWidth={true}
         alignItems='flex-start'
         key={key}
@@ -190,7 +190,7 @@ export const Accounts = () => {
             />
           )
         )}
-      </Column>
+      </AccountsListWrapper>
     ))
   }, [
     ledgerKeys,
@@ -217,7 +217,7 @@ export const Accounts = () => {
       >
         <SectionTitle>{getLocale('braveWalletAccounts')}</SectionTitle>
       </Row>
-      <Column
+      <AccountsListWrapper
         fullWidth={true}
         alignItems='flex-start'
         margin='0px 0px 24px 0px'
@@ -233,7 +233,7 @@ export const Accounts = () => {
             isLoadingSpotPrices={isLoadingSpotPrices}
           />
         ))}
-      </Column>
+      </AccountsListWrapper>
 
       {importedAccounts.length !== 0 && (
         <>
@@ -245,7 +245,7 @@ export const Accounts = () => {
               {getLocale('braveWalletAccountsSecondary')}
             </SectionTitle>
           </Row>
-          <Column
+          <AccountsListWrapper
             fullWidth={true}
             alignItems='flex-start'
             margin='0px 0px 24px 0px'
@@ -261,7 +261,7 @@ export const Accounts = () => {
                 isLoadingSpotPrices={isLoadingSpotPrices}
               />
             ))}
-          </Column>
+          </AccountsListWrapper>
         </>
       )}
 
@@ -296,7 +296,7 @@ export const Accounts = () => {
               {getLocale('braveWalletConnectedAccounts')}
             </SectionTitle>
           </Row>
-          <Column
+          <AccountsListWrapper
             fullWidth={true}
             alignItems='flex-start'
             margin='0px 0px 24px 0px'
@@ -310,7 +310,7 @@ export const Accounts = () => {
               spotPriceRegistry={spotPriceRegistry}
               isLoadingSpotPrices={isLoadingSpotPrices}
             />
-          </Column>
+          </AccountsListWrapper>
         </>
       )}
     </WalletPageWrapper>

--- a/components/brave_wallet_ui/components/desktop/views/accounts/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/style.ts
@@ -50,3 +50,8 @@ export const EmptyStateWrapper = styled(Column)`
     padding: 16px;
   }
 `
+
+export const AccountsListWrapper = styled(Column)`
+  border-radius: ${leo.radius.l};
+  border: 1px solid ${leo.color.divider.subtle};
+`


### PR DESCRIPTION
## Description 

Updates the `Accounts List` grouping style on the `Accounts` page to wrap each account section in a `bordered` container.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/38923>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Accounts` page
2. Accounts should now be wrapped in a `bordered` container for each `Account` section.

Before:

![Screenshot](https://github.com/user-attachments/assets/672b7166-5a3e-4a99-9d2c-9248e881fcec)

![Screenshot 1](https://github.com/user-attachments/assets/e2c837db-f923-456d-ae8b-6e0257d7193f)

After:

![Screenshot 2](https://github.com/user-attachments/assets/a4b1b12c-5b78-4747-a374-9e39b908725e)

![Screenshot 3](https://github.com/user-attachments/assets/3b959145-7c83-43c3-94a5-221c39b639de)
