### PR TITLE
[iOS] Add an explicit "Block connections without VPN" setting to VPN (VPN Kill Switch Toggle)

### DIFF
--- a/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
+++ b/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
@@ -279,6 +279,13 @@ public class BraveVPN {
       completion?(status)
     }
   }
+  
+  public static func reconnectVPN(completion: ((Bool) -> Void)? = nil) {
+    helper.forceDisconnectVPNIfNecessary()
+    connectToVPN { status in
+      completion?(status)
+    }
+  }
 
   public static func changePreferredTransportProtocol(
     with transportProtocol: TransportProtocol,

--- a/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
+++ b/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
@@ -188,7 +188,7 @@ public class BraveVPN {
 
   /// Reconnects to the vpn.
   /// The vpn must be configured prior to that otherwise it does nothing.
-  public static func reconnect() {
+  public static func reconnect(completion: ((Bool) -> Void)? = nil) {
     if reconnectPending {
       logAndStoreError("Can't reconnect the vpn while another reconnect is pending.")
       return
@@ -196,7 +196,9 @@ public class BraveVPN {
 
     reconnectPending = true
 
-    connectToVPN()
+    connectToVPN { status in
+      completion?(status)
+    }
   }
 
   /// Disconnects the vpn.
@@ -275,13 +277,6 @@ public class BraveVPN {
     helper.forceDisconnectVPNIfNecessary()
     GRDVPNHelper.clearVpnConfiguration()
 
-    connectToVPN { status in
-      completion?(status)
-    }
-  }
-  
-  public static func reconnectVPN(completion: ((Bool) -> Void)? = nil) {
-    helper.forceDisconnectVPNIfNecessary()
     connectToVPN { status in
       completion?(status)
     }

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -271,15 +271,15 @@ public class BraveVPNSettingsViewController: TableViewController {
     )
     
     return Section(
-      header: .title("KILL SWITCH"),
+      header: .title(Strings.VPN.settingsKillSwitchTitle.capitalized),
       rows: [
         Row(
-          text: "Kill Switch",
+          text: Strings.VPN.settingsKillSwitchTitle,
           accessory: .view(killSwitchView),
           uuid: killSwitchSectionCellId
         )
       ],
-      footer: .title("Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN."),
+      footer: .title(Strings.VPN.settingsKillSwitchDescription),
       uuid: killSwitchSectionCellId
     )
   }
@@ -339,6 +339,7 @@ public class BraveVPNSettingsViewController: TableViewController {
       vpnStatusSection,
       subscriptionSection,
       serverSection,
+      killSwitchSection,
       techSupportSection
     ]
   }

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -281,6 +281,24 @@ extension Strings {
         comment:
           "Table cell title for vpn's transport protocol and which open opens protocol select"
       )
+    
+    public static let settingsKillSwitchTitle =
+      NSLocalizedString(
+        "vpn.settingsKillSwitch",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Kill Switch",
+        comment: "Title for the row when clicked it enables 'Kill Switch' on VPN connection"
+      )
+    
+    public static let settingsKillSwitchDescription =
+      NSLocalizedString(
+        "vpn.settingsKillSwitchDescription",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
+        comment: "Description for the row when clicked it enables 'Kill Switch' on VPN connection"
+      )
 
     public static let settingsContactSupport =
       NSLocalizedString(

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -281,7 +281,7 @@ extension Strings {
         comment:
           "Table cell title for vpn's transport protocol and which open opens protocol select"
       )
-    
+
     public static let settingsKillSwitchTitle =
       NSLocalizedString(
         "vpn.settingsKillSwitch",
@@ -290,15 +290,42 @@ extension Strings {
         value: "Kill Switch",
         comment: "Title for the row when clicked it enables 'Kill Switch' on VPN connection"
       )
-    
+
     public static let settingsKillSwitchDescription =
       NSLocalizedString(
         "vpn.settingsKillSwitchDescription",
         tableName: "BraveShared",
         bundle: .module,
-        value: "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
+        value:
+          "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
         comment: "Description for the row when clicked it enables 'Kill Switch' on VPN connection"
       )
+
+    public static let settingsKillSwitchToggleErrorTitle =
+      NSLocalizedString(
+        "vpn.settingsKillSwitchToggleErrorTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Couldnt Toggle Kill Switch",
+        comment: "Title for the error while toggling vpn kill switch"
+      )
+
+    public static let settingsKillSwitchToggleErrorDescription =
+      NSLocalizedString(
+        "vpn.settingsKillSwitchToggleErrorDescription",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Description of the error goes here. TO BE CONFIRMED",
+        comment: "Description for the error while toggling vpn kill switch"
+      )
+
+    public static let settingsRetryActionTitle = NSLocalizedString(
+      "aichat.settingsRetryActionTitle",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Retry",
+      comment: "The title for button for re-try"
+    )
 
     public static let settingsContactSupport =
       NSLocalizedString(

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -191,6 +191,15 @@ extension Strings {
         comment: "Header title for vpn settings server section."
       )
 
+    public static let settingsSupportSection =
+      NSLocalizedString(
+        "vpn.settingsSupportSection",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Support",
+        comment: "Header title for vpn support server section."
+      )
+
     public static let settingsSubscriptionStatus =
       NSLocalizedString(
         "vpn.settingsSubscriptionStatus",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38057

Details TBD

Security Review: TBD

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Screenshots:

![11111](https://github.com/user-attachments/assets/3de3e4f6-984d-4a38-b5b6-f1730e6ceb26)


https://github.com/user-attachments/assets/e6a7c7f9-2674-47a8-979a-3d2fd4b31b0e



## Test Plan:

Also TBD soon
