### PR TITLE
[iOS] Add an explicit "Block connections without VPN" setting to VPN (VPN Kill Switch Toggle)

### DIFF
--- a/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
+++ b/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
@@ -279,6 +279,13 @@ public class BraveVPN {
       completion?(status)
     }
   }
+  
+  public static func reconnectVPN(completion: ((Bool) -> Void)? = nil) {
+    helper.forceDisconnectVPNIfNecessary()
+    connectToVPN { status in
+      completion?(status)
+    }
+  }
 
   public static func changePreferredTransportProtocol(
     with transportProtocol: TransportProtocol,

--- a/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
+++ b/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
@@ -188,7 +188,7 @@ public class BraveVPN {
 
   /// Reconnects to the vpn.
   /// The vpn must be configured prior to that otherwise it does nothing.
-  public static func reconnect() {
+  public static func reconnect(completion: ((Bool) -> Void)? = nil) {
     if reconnectPending {
       logAndStoreError("Can't reconnect the vpn while another reconnect is pending.")
       return
@@ -196,7 +196,9 @@ public class BraveVPN {
 
     reconnectPending = true
 
-    connectToVPN()
+    connectToVPN { status in
+      completion?(status)
+    }
   }
 
   /// Disconnects the vpn.
@@ -275,13 +277,6 @@ public class BraveVPN {
     helper.forceDisconnectVPNIfNecessary()
     GRDVPNHelper.clearVpnConfiguration()
 
-    connectToVPN { status in
-      completion?(status)
-    }
-  }
-  
-  public static func reconnectVPN(completion: ((Bool) -> Void)? = nil) {
-    helper.forceDisconnectVPNIfNecessary()
     connectToVPN { status in
       completion?(status)
     }

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -9,14 +9,14 @@ import GuardianConnect
 import Preferences
 import Shared
 import Static
+import SwiftUI
 import UIKit
 import os.log
-import SwiftUI
 
 public class BraveVPNSettingsViewController: TableViewController {
 
   public var openURL: ((URL) -> Void)?
-  
+
   // MARK: Internal
 
   private let iapObserver: BraveVPNInAppPurchaseObserver
@@ -37,7 +37,7 @@ public class BraveVPNSettingsViewController: TableViewController {
 
     return dateFormatter.string(from: expirationDate)
   }
-  
+
   private var vpnReconfigurationPending = false {
     didSet {
       DispatchQueue.main.async {
@@ -45,9 +45,9 @@ public class BraveVPNSettingsViewController: TableViewController {
       }
     }
   }
-  
+
   private var vpnConnectionStatusToggle: SwitchAccessoryView?
-  
+
   private var vpnKillSwitchStatusToggle: SwitchAccessoryView?
 
   /// Loading view with an transparent overlay
@@ -60,7 +60,7 @@ public class BraveVPNSettingsViewController: TableViewController {
       tableView.isScrollEnabled = true
 
       if !isLoading { return }
-      
+
       let loaderView = LoaderView(size: .normal).then {
         $0.tintColor = UIColor(braveSystemName: .iconInteractive)
       }
@@ -73,17 +73,17 @@ public class BraveVPNSettingsViewController: TableViewController {
       overlay.addSubview(loaderView)
 
       overlay.frame = CGRect(size: tableView.contentSize)
-      loaderView.frame.origin = 
+      loaderView.frame.origin =
         CGPoint(x: tableView.bounds.midX - (loaderView.bounds.width / 2), y: tableView.bounds.midY)
-      
+
       loaderView.start()
       overlayView = overlay
       tableView.isScrollEnabled = false
     }
   }
-  
+
   // MARK: Section Details
-  
+
   private let vpnStatusSectionCellId = "status"
   private let serverSectionId = "server"
   private let hostCellId = "host"
@@ -91,9 +91,9 @@ public class BraveVPNSettingsViewController: TableViewController {
   private let protocolCellId = "protocol"
   private let resetCellId = "reset"
   private let killSwitchSectionCellId = "killswitch"
-  
+
   // Section - VPN Status
-  
+
   private var vpnStatusSection: Static.Section {
     let statusSwitchView = SwitchAccessoryView(
       initialValue: BraveVPN.isConnected,
@@ -125,9 +125,9 @@ public class BraveVPNSettingsViewController: TableViewController {
       uuid: vpnStatusSectionCellId
     )
   }
-  
+
   // Section - Subscription
-  
+
   private var subscriptionSection: Static.Section {
     let (subscriptionStatus, statusDetailColor) = { () -> (String, UIColor) in
       if Preferences.VPN.vpnReceiptStatus.value
@@ -144,7 +144,7 @@ public class BraveVPNSettingsViewController: TableViewController {
     }()
 
     let expiration = BraveVPN.vpnState == .expired ? "-" : expirationDate
-    
+
     var linkReceiptRows: [Row] {
       var rows = [Row]()
 
@@ -214,9 +214,9 @@ public class BraveVPNSettingsViewController: TableViewController {
       footer: .title(Strings.VPN.settingsLinkReceiptFooter)
     )
   }
-  
+
   // Section - Server
-  
+
   private var serverSection: Static.Section {
     let locationCity = BraveVPN.serverLocationDetailed.city ?? "-"
     let locationCountry = BraveVPN.serverLocationDetailed.country ?? hostname
@@ -262,21 +262,21 @@ public class BraveVPNSettingsViewController: TableViewController {
       uuid: serverSectionId
     )
   }
-  
+
   private var killSwitchSection: Static.Section {
     let killSwitchView = SwitchAccessoryView(
       initialValue: true,
       valueChange: { [weak self] killSwitchON in
         guard let self = self else { return }
-                
+
         BraveVPN.helper.killSwitchEnabled = killSwitchON
-        
+
         self.performAllNetworkReconnect()
       }
     )
-    
+
     vpnKillSwitchStatusToggle = killSwitchView
-    
+
     return Section(
       header: .title(Strings.VPN.settingsKillSwitchTitle.capitalized),
       rows: [
@@ -290,7 +290,7 @@ public class BraveVPNSettingsViewController: TableViewController {
       uuid: killSwitchSectionCellId
     )
   }
-  
+
   private var techSupportSection: Static.Section {
     return Section(
       header: .title(Strings.VPN.settingsSupportSection),
@@ -308,12 +308,13 @@ public class BraveVPNSettingsViewController: TableViewController {
             self.openURL?(.brave.braveVPNFaq)
           },
           cellClass: ButtonCell.self
-        )
-      ])
+        ),
+      ]
+    )
   }
-  
+
   // MARK: Lifecycle
-  
+
   public init(iapObserver: BraveVPNInAppPurchaseObserver) {
     self.iapObserver = iapObserver
     super.init(style: .insetGrouped)
@@ -323,7 +324,7 @@ public class BraveVPNSettingsViewController: TableViewController {
   required init(coder: NSCoder) {
     fatalError()
   }
-  
+
   deinit {
     NotificationCenter.default.removeObserver(self)
   }
@@ -332,7 +333,7 @@ public class BraveVPNSettingsViewController: TableViewController {
     super.viewDidLoad()
 
     title = Strings.VPN.vpnName
-    
+
     // Add VPN Status Observer
     NotificationCenter.default.addObserver(
       self,
@@ -347,25 +348,25 @@ public class BraveVPNSettingsViewController: TableViewController {
       subscriptionSection,
       serverSection,
       killSwitchSection,
-      techSupportSection
+      techSupportSection,
     ]
   }
-  
+
   /// Reconnecting VPN after Kill Switch toggle is set
   private func performAllNetworkReconnect() {
-   isLoading = true
+    isLoading = true
 
-    BraveVPN.reconnect() { [weak self] connected in
+    BraveVPN.reconnect { [weak self] connected in
       guard let self = self else { return }
-        
+
       DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
         self.isLoading = false
-        
+
         guard connected else {
           self.showEnableKillSwitchError()
           return
         }
-        
+
         // Normally the connected server should not change
         // This is added in case there is an unexpected change happens on server side
         self.updateServerSectionInfo()
@@ -503,7 +504,7 @@ extension BraveVPNSettingsViewController {
 
     present(alert, animated: true)
   }
-  
+
   private func showEnableKillSwitchError() {
     let alert = UIAlertController(
       title: Strings.VPN.settingsKillSwitchToggleErrorTitle,
@@ -518,13 +519,14 @@ extension BraveVPNSettingsViewController {
         guard let self = self, let toggleStatus = self.vpnKillSwitchStatusToggle?.isOn else {
           return
         }
-        
+
         // Re-try canceled
         // Kill switch and UI is set  previous toggle status
         BraveVPN.helper.killSwitchEnabled = !toggleStatus
         self.vpnKillSwitchStatusToggle?.isOn = !toggleStatus
-    })
-    
+      }
+    )
+
     let retry = UIAlertAction(
       title: Strings.VPN.settingsRetryActionTitle,
       style: .default,

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -271,15 +271,15 @@ public class BraveVPNSettingsViewController: TableViewController {
     )
     
     return Section(
-      header: .title("KILL SWITCH"),
+      header: .title(Strings.VPN.settingsKillSwitchTitle.capitalized),
       rows: [
         Row(
-          text: "Kill Switch",
+          text: Strings.VPN.settingsKillSwitchTitle,
           accessory: .view(killSwitchView),
           uuid: killSwitchSectionCellId
         )
       ],
-      footer: .title("Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN."),
+      footer: .title(Strings.VPN.settingsKillSwitchDescription),
       uuid: killSwitchSectionCellId
     )
   }
@@ -339,6 +339,7 @@ public class BraveVPNSettingsViewController: TableViewController {
       vpnStatusSection,
       subscriptionSection,
       serverSection,
+      killSwitchSection,
       techSupportSection
     ]
   }

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -281,6 +281,24 @@ extension Strings {
         comment:
           "Table cell title for vpn's transport protocol and which open opens protocol select"
       )
+    
+    public static let settingsKillSwitchTitle =
+      NSLocalizedString(
+        "vpn.settingsKillSwitch",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Kill Switch",
+        comment: "Title for the row when clicked it enables 'Kill Switch' on VPN connection"
+      )
+    
+    public static let settingsKillSwitchDescription =
+      NSLocalizedString(
+        "vpn.settingsKillSwitchDescription",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
+        comment: "Description for the row when clicked it enables 'Kill Switch' on VPN connection"
+      )
 
     public static let settingsContactSupport =
       NSLocalizedString(

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -281,7 +281,7 @@ extension Strings {
         comment:
           "Table cell title for vpn's transport protocol and which open opens protocol select"
       )
-    
+
     public static let settingsKillSwitchTitle =
       NSLocalizedString(
         "vpn.settingsKillSwitch",
@@ -290,15 +290,42 @@ extension Strings {
         value: "Kill Switch",
         comment: "Title for the row when clicked it enables 'Kill Switch' on VPN connection"
       )
-    
+
     public static let settingsKillSwitchDescription =
       NSLocalizedString(
         "vpn.settingsKillSwitchDescription",
         tableName: "BraveShared",
         bundle: .module,
-        value: "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
+        value:
+          "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
         comment: "Description for the row when clicked it enables 'Kill Switch' on VPN connection"
       )
+
+    public static let settingsKillSwitchToggleErrorTitle =
+      NSLocalizedString(
+        "vpn.settingsKillSwitchToggleErrorTitle",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Couldnt Toggle Kill Switch",
+        comment: "Title for the error while toggling vpn kill switch"
+      )
+
+    public static let settingsKillSwitchToggleErrorDescription =
+      NSLocalizedString(
+        "vpn.settingsKillSwitchToggleErrorDescription",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Description of the error goes here. TO BE CONFIRMED",
+        comment: "Description for the error while toggling vpn kill switch"
+      )
+
+    public static let settingsRetryActionTitle = NSLocalizedString(
+      "aichat.settingsRetryActionTitle",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "Retry",
+      comment: "The title for button for re-try"
+    )
 
     public static let settingsContactSupport =
       NSLocalizedString(

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -191,6 +191,15 @@ extension Strings {
         comment: "Header title for vpn settings server section."
       )
 
+    public static let settingsSupportSection =
+      NSLocalizedString(
+        "vpn.settingsSupportSection",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Support",
+        comment: "Header title for vpn support server section."
+      )
+
     public static let settingsSubscriptionStatus =
       NSLocalizedString(
         "vpn.settingsSubscriptionStatus",

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -194,7 +194,6 @@ extension Strings {
     public static let settingsSupportSection =
       NSLocalizedString(
         "vpn.settingsSupportSection",
-        tableName: "BraveShared",
         bundle: .module,
         value: "Support",
         comment: "Header title for vpn support server section."
@@ -285,7 +284,6 @@ extension Strings {
     public static let settingsKillSwitchTitle =
       NSLocalizedString(
         "vpn.settingsKillSwitch",
-        tableName: "BraveShared",
         bundle: .module,
         value: "Kill Switch",
         comment: "Title for the row when clicked it enables 'Kill Switch' on VPN connection"
@@ -294,7 +292,6 @@ extension Strings {
     public static let settingsKillSwitchDescription =
       NSLocalizedString(
         "vpn.settingsKillSwitchDescription",
-        tableName: "BraveShared",
         bundle: .module,
         value:
           "Ensures your data stays protected if the VPN disconnects unexpectedly. When enabled, it blocks all internet traffic if the VPN connection drops, preventing accidental data leaks. Note: Enabling or disabling this feature will briefly reconnect your VPN.",
@@ -304,7 +301,6 @@ extension Strings {
     public static let settingsKillSwitchToggleErrorTitle =
       NSLocalizedString(
         "vpn.settingsKillSwitchToggleErrorTitle",
-        tableName: "BraveShared",
         bundle: .module,
         value: "Couldnt Toggle Kill Switch",
         comment: "Title for the error while toggling vpn kill switch"
@@ -313,7 +309,6 @@ extension Strings {
     public static let settingsKillSwitchToggleErrorDescription =
       NSLocalizedString(
         "vpn.settingsKillSwitchToggleErrorDescription",
-        tableName: "BraveShared",
         bundle: .module,
         value: "Description of the error goes here. TO BE CONFIRMED",
         comment: "Description for the error while toggling vpn kill switch"
@@ -321,7 +316,6 @@ extension Strings {
 
     public static let settingsRetryActionTitle = NSLocalizedString(
       "aichat.settingsRetryActionTitle",
-      tableName: "BraveLeo",
       bundle: .module,
       value: "Retry",
       comment: "The title for button for re-try"
@@ -753,23 +747,6 @@ extension Strings {
         comment: "Disclaimer for user purchasing the VPN plan."
       )
 
-    public static let regionPickerTitle =
-      NSLocalizedString(
-        "vpn.regionPickerTitle",
-        bundle: .module,
-        value: "Server Region",
-        comment: "Title for vpn region selector screen"
-      )
-
-    public static let regionPickerAutomaticDescription =
-      NSLocalizedString(
-        "vpn.regionPickerAutomaticDescription",
-        bundle: .module,
-        value:
-          "A server region most proximate to you will be automatically selected, based on your system timezone. This is recommended in order to ensure fast internet speeds.",
-        comment: "Description of what automatic server selection does."
-      )
-
     public static let regionPickerErrorTitle =
       NSLocalizedString(
         "vpn.regionPickerErrorTitle",
@@ -784,6 +761,14 @@ extension Strings {
         bundle: .module,
         value: "Failed to switch servers, please try again later.",
         comment: "Message for error when we fail to switch vpn server for the user"
+      )
+
+    public static let vpnRegionChangedTitle =
+      NSLocalizedString(
+        "vpn.protocolPickerDescription",
+        bundle: .module,
+        value: "VPN Region Changed",
+        comment: "The alert title showing vpn region is changed"
       )
 
     public static let protocolPickerTitle =
@@ -801,14 +786,6 @@ extension Strings {
         value:
           "Please select your preferred transport protocol. Once switched your existing VPN credentials will be cleared and you will be reconnected if a VPN connection is currently established.",
         comment: "Description of vpn tunnel protocol"
-      )
-
-    public static let regionSwitchSuccessPopupText =
-      NSLocalizedString(
-        "vpn.regionSwitchSuccessPopupText",
-        bundle: .module,
-        value: "VPN region changed.",
-        comment: "Message that we show after successfully changing vpn region."
       )
 
     public static let protocolPickerErrorTitle =
@@ -937,12 +914,5 @@ extension Strings {
         comment: "Title showing which country serves list showing. Ex: 'Brazil Server"
       )
 
-    public static let vpnRegionChangedTitle =
-      NSLocalizedString(
-        "vpn.protocolPickerDescription",
-        bundle: .module,
-        value: "VPN Region Changed",
-        comment: "The alert title showing vpn region is changed"
-      )
   }
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38057

Details TBD

Security Review: TBD

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Screenshots:

![11111](https://github.com/user-attachments/assets/3de3e4f6-984d-4a38-b5b6-f1730e6ceb26)


https://github.com/user-attachments/assets/e6a7c7f9-2674-47a8-979a-3d2fd4b31b0e



## Test Plan:

Also TBD soon
