### PR TITLE
Updated history page's item font style (uplift to 1.68.x)

### DIFF
--- a/browser/resources/history/brave_overrides/history_item.ts
+++ b/browser/resources/history/brave_overrides/history_item.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import {RegisterStyleOverride} from 'chrome://resources/brave/polymer_overriding.js'
+import {html} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
+
+RegisterStyleOverride(
+  'history-item',
+  html`
+    <style>
+      .website-title {
+        font-size: 13px;
+        font-weight: 400;
+      }
+    </style>
+  `
+)

--- a/browser/resources/history/brave_overrides/index.ts
+++ b/browser/resources/history/brave_overrides/index.ts
@@ -4,4 +4,5 @@
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 
 import './app.js'
+import './history_item.js'
 import './side_bar.js'

--- a/browser/resources/history/sources.gni
+++ b/browser/resources/history/sources.gni
@@ -7,6 +7,7 @@ brave_history_web_component_files = [ "brave_history_item.ts" ]
 
 brave_history_non_web_component_files = [
   "brave_overrides/app.ts",
+  "brave_overrides/history_item.ts",
   "brave_overrides/side_bar.ts",
   "brave_overrides/index.ts",
 ]


### PR DESCRIPTION
Uplift of #24646
fix https://github.com/brave/brave-browser/issues/39722

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.