### PR TITLE
Fix partitioned cookie cleanup logic (upstream crash). (uplift to 1.68.x)

### DIFF
--- a/patches/net-cookies-cookie_monster.cc.patch
+++ b/patches/net-cookies-cookie_monster.cc.patch
@@ -1,0 +1,19 @@
+diff --git a/net/cookies/cookie_monster.cc b/net/cookies/cookie_monster.cc
+index 8e1134654e2b1db09f08f58036cc76c7978a7072..a0297fd573e61aa9fcf0c1f72c5df42c019e80f2 100644
+--- a/net/cookies/cookie_monster.cc
++++ b/net/cookies/cookie_monster.cc
+@@ -737,9 +737,13 @@ void CookieMonster::GetCookieListWithOptions(
+ 
+     if (!cookie_partition_key_collection.IsEmpty()) {
+       if (cookie_partition_key_collection.ContainsAllKeys()) {
++        std::vector<CookiePartitionKey> cookie_partition_keys;
+         for (const auto& it : partitioned_cookies_) {
++          cookie_partition_keys.push_back(it.first);
++        }
++        for (const auto& key : cookie_partition_keys) {
+           std::vector<CanonicalCookie*> partitioned_cookie_ptrs =
+-              FindPartitionedCookiesForRegistryControlledHost(it.first, url);
++              FindPartitionedCookiesForRegistryControlledHost(key, url);
+           cookie_ptrs.insert(cookie_ptrs.end(), partitioned_cookie_ptrs.begin(),
+                              partitioned_cookie_ptrs.end());
+         }


### PR DESCRIPTION
Uplift of #24647
Resolves https://github.com/brave/brave-browser/issues/39734

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.