### PR TITLE
[iOS] Fix web downloads/sharing temporary docs

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadQueue.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadQueue.swift
@@ -171,7 +171,7 @@ extension HTTPDownload: URLSessionTaskDelegate, URLSessionDownloadDelegate {
     // so we must synchonously move the file to a temporary directory first before processing it
     // on a different thread since the Task will execute after this method returns
     let temporaryLocation = FileManager.default.temporaryDirectory
-      .appending(component: location.lastPathComponent)
+      .appending(component: "\(filename)-\(location.lastPathComponent)")
     try? FileManager.default.moveItem(at: location, to: temporaryLocation)
     Task {
       do {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TemporaryDocument.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TemporaryDocument.swift
@@ -143,7 +143,7 @@ extension TemporaryDocument: URLSessionTaskDelegate, URLSessionDownloadDelegate 
     // so we must synchonously move the file to a temporary directory first before processing it
     // on a different thread since the Task will execute after this method returns
     let temporaryLocation = FileManager.default.temporaryDirectory
-      .appending(component: location.lastPathComponent)
+      .appending(component: "\(filename)-\(location.lastPathComponent)")
     try? FileManager.default.moveItem(at: location, to: temporaryLocation)
     Task {
       let tempDirectory = URL(fileURLWithPath: NSTemporaryDirectory()).appending(path: "TempDocs")

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ResourceDownloadScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/ResourceDownloadScriptHandler.swift
@@ -66,13 +66,7 @@ class ResourceDownloadScriptHandler: TabContentScript {
     didReceiveScriptMessage message: WKScriptMessage,
     replyHandler: @escaping (Any?, String?) -> Void
   ) {
-    if !verifyMessage(message: message) {
-      assertionFailure("Missing required security token.")
-      replyHandler(nil, nil)
-      return
-    }
-
-    Task {
+    Task { @MainActor in
       do {
         let response = try DownloadedResourceResponse.from(message: message)
         await tab?.temporaryDocument?.onDocumentDownloaded(document: response, error: nil)

--- a/ios/brave-ios/Sources/Playlist/PlaylistDownloadManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistDownloadManager.swift
@@ -505,7 +505,7 @@ private class PlaylistHLSDownloadManager: NSObject, AVAssetDownloadDelegate {
     // so we must synchonously move the file to a temporary directory first before processing it
     // on a different thread since the Task will execute after this method returns
     let assetUrl = FileManager.default.temporaryDirectory
-      .appending(component: temporaryUrl.lastPathComponent)
+      .appending(component: "\(asset.id)-\(temporaryUrl.lastPathComponent)")
     try? FileManager.default.moveItem(at: temporaryUrl, to: assetUrl)
 
     @Sendable func cleanupAndFailDownload(location: URL?, error: Error) async {


### PR DESCRIPTION
This is a follow-up to the file I/O refactor (#24555), where downloaded files were being saved in the temporary directory already so the initial synchronous move did nothing and the file was deleted by the system before it could be used.

Resolves https://github.com/brave/brave-browser/issues/39169

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

