### PR TITLE
[iOS] Playlist Revamp Improvements

### DIFF
--- a/ios/brave-ios/Sources/Data/models/PlaylistItem.swift
+++ b/ios/brave-ios/Sources/Data/models/PlaylistItem.swift
@@ -23,8 +23,7 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
   @NSManaged public var uuid: String?
   @NSManaged public var playlistFolder: PlaylistFolder?
 
-  public var cachedDataURL: URL? {
-    guard let cachedData else { return nil }
+  static public func resolvingCachedData(_ cachedData: Data) async -> URL? {
     do {
       var isStale: Bool = false
       let url = try URL(resolvingBookmarkData: cachedData, bookmarkDataIsStale: &isStale)

--- a/ios/brave-ios/Sources/DesignSystem/Icons/Symbols.xcassets/leo.1.2x.symbolset/Contents.json
+++ b/ios/brave-ios/Sources/DesignSystem/Icons/Symbols.xcassets/leo.1.2x.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/ios/brave-ios/Sources/DesignSystem/Icons/Symbols.xcassets/leo.forward.filled.symbolset/Contents.json
+++ b/ios/brave-ios/Sources/DesignSystem/Icons/Symbols.xcassets/leo.forward.filled.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/ios/brave-ios/Sources/DesignSystem/Icons/Symbols.xcassets/leo.rewind.filled.symbolset/Contents.json
+++ b/ios/brave-ios/Sources/DesignSystem/Icons/Symbols.xcassets/leo.rewind.filled.symbolset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/ios/brave-ios/Sources/PlaylistUI/EditFolderView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/EditFolderView.swift
@@ -47,7 +47,7 @@ struct EditFolderView: View {
         ForEach(items) { item in
           PlaylistItemView(
             title: item.name,
-            assetURL: item.assetURL,
+            assetURL: URL(string: item.mediaSrc),
             pageURL: URL(string: item.pageSrc),
             duration: .init(item.duration),
             isSelected: false,

--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -39,24 +39,7 @@ struct MediaContentView: View {
         }
         .overlay {
           if !isFullScreen {
-            GeometryReader { proxy in
-              Color.clear
-                .contentShape(.rect.inset(by: 20))
-                .onTapGesture(count: 2) { point in
-                  if point.x < proxy.size.width / 2 {
-                    Task {
-                      await model.seekBackwards()
-                    }
-                  } else {
-                    Task {
-                      await model.seekForwards()
-                    }
-                  }
-                }
-                .onTapGesture {
-                  model.isPlaying.toggle()
-                }
-            }
+            PlayerGestureShortcutsView(model: model)
           }
         }
       if !isFullScreen {

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerGestureShortcutsView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerGestureShortcutsView.swift
@@ -1,0 +1,94 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import SwiftUI
+
+/// An overlay on top of the PlayerView that allows the user to quickly activate certain shortcuts
+/// by performing gestures on it such as tap to play/pause, double-tap to seek in a direction
+struct PlayerGestureShortcutsView: View {
+  var model: PlayerModel
+
+  enum SeekDirection {
+    case backwards
+    case forwards
+  }
+
+  @State private var autoHideSeekNoticeTask: Task<Void, Error>?
+  @State private var seekDirectionNoticeVisible: SeekDirection?
+  @State private var seekIntervalPower: CGFloat = 0
+
+  private func hideSeekNoticeAfterDelay() {
+    autoHideSeekNoticeTask = Task {
+      try await Task.sleep(for: .seconds(1))
+      withAnimation(.linear(duration: 0.1)) {
+        seekDirectionNoticeVisible = nil
+      }
+      seekIntervalPower = 0
+    }
+  }
+
+  var body: some View {
+    GeometryReader { proxy in
+      Color.clear
+        .contentShape(.rect.inset(by: 20))
+        .onTapGesture(count: 2) { point in
+          autoHideSeekNoticeTask?.cancel()
+          var seekAdjustment = model.seekInterval * pow(2.0, seekIntervalPower)
+          if point.x < proxy.size.width / 2 {
+            seekDirectionNoticeVisible = .backwards
+            seekAdjustment *= -1
+          } else {
+            seekDirectionNoticeVisible = .forwards
+          }
+          let seekTarget = model.currentTime + seekAdjustment
+          seekIntervalPower += 1
+          Task {
+            await model.seek(to: seekTarget, accurately: false)
+            hideSeekNoticeAfterDelay()
+          }
+        }
+        .onTapGesture {
+          model.isPlaying.toggle()
+        }
+        .onChange(of: seekDirectionNoticeVisible) { _ in
+          // Reset if the notice changes
+          seekIntervalPower = 0
+        }
+        .overlay(alignment: seekDirectionNoticeVisible == .backwards ? .leading : .trailing) {
+          if let seekDirectionNoticeVisible {
+            VStack(
+              alignment: seekDirectionNoticeVisible == .backwards ? .leading : .trailing,
+              spacing: 4
+            ) {
+              Image(
+                braveSystemName: seekDirectionNoticeVisible == .backwards
+                  ? "leo.rewind.filled" : "leo.forward.filled"
+              )
+              Text(
+                Duration.seconds(model.seekInterval * pow(2.0, seekIntervalPower)),
+                format: .units(allowed: [.seconds], width: .abbreviated)
+              )
+            }
+            .font(.footnote.weight(.semibold))
+            .padding()
+            .frame(
+              width: proxy.size.width / 2,
+              height: proxy.size.height,
+              alignment: seekDirectionNoticeVisible == .backwards ? .leading : .trailing
+            )
+            .background {
+              LinearGradient(
+                colors: [.black.opacity(0.6), .black.opacity(0)],
+                startPoint: seekDirectionNoticeVisible == .backwards ? .leading : .trailing,
+                endPoint: seekDirectionNoticeVisible == .backwards ? .trailing : .leading
+              )
+            }
+            .allowsHitTesting(false)
+          }
+        }
+    }
+  }
+}

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -182,7 +182,7 @@ public final class PlayerModel: ObservableObject {
     }
   }
 
-  private let seekInterval: TimeInterval = 15.0
+  let seekInterval: TimeInterval = 15.0
 
   func seekBackwards() async {
     guard let currentItem = player.currentItem, currentItem.status == .readyToPlay else {

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -343,6 +343,9 @@ public final class PlayerModel: ObservableObject {
             itemTimeForDisplay: nil
           )
         else {
+          DispatchQueue.main.async {
+            continuation.yield(.init())
+          }
           return
         }
         let ciImage = CIImage(cvPixelBuffer: buffer)

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -264,12 +264,16 @@ public final class PlayerModel: ObservableObject {
     }
 
     static let normal = Self(rate: 1.0, braveSystemName: "leo.1x")
+    static let audio = Self(rate: 1.2, braveSystemName: "leo.1.2x")
     static let fast = Self(rate: 1.5, braveSystemName: "leo.1.5x")
     static let faster = Self(rate: 2.0, braveSystemName: "leo.2x")
 
+    static let supportedSpeeds: [Self] = [.normal, .audio, .fast, .faster]
+
     mutating func cycle() {
       switch self {
-      case .normal: self = .fast
+      case .normal: self = .audio
+      case .audio: self = .fast
       case .fast: self = .faster
       case .faster: self = .normal
       default: self = .fast
@@ -1051,10 +1055,6 @@ extension PlayerModel.RepeatMode {
     case .all: return .all
     }
   }
-}
-
-extension PlayerModel.PlaybackSpeed {
-  static var supportedSpeeds: [Self] = [.normal, .fast, .faster]
 }
 
 #if DEBUG

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -553,6 +553,11 @@ public final class PlayerModel: ObservableObject {
     )
   }
 
+  /// Whether or not calling `playNextItem` will result in playing anything
+  @MainActor var canPlayNextItem: Bool {
+    nextItemID != nil
+  }
+
   @MainActor private var nextItemID: PlaylistItem.ID? {
     guard let selectedItemID, let currentItemIndex = itemQueue.firstIndex(of: selectedItemID) else {
       return nil

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
@@ -160,6 +160,14 @@ extension PlayerView {
           .toggleStyle(.button)
           RepeatModePicker(repeatMode: $model.repeatMode)
             .disabled(model.duration.isIndefinite)
+          Button {
+            Task {
+              await model.playNextItem()
+            }
+          } label: {
+            Label("Next Item", braveSystemImage: "leo.next.outline")
+          }
+          .disabled(!model.canPlayNextItem)
         }
         Spacer()
         VStack {

--- a/ios/brave-ios/Sources/PlaylistUI/PopulateNewPlaylistView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PopulateNewPlaylistView.swift
@@ -110,7 +110,7 @@ private struct ItemToggle: View {
         Color.clear
           .aspectRatio(1.333, contentMode: .fit)
           .overlay {
-            if let assetURL = item.assetURL, let pageURL = URL(string: item.pageSrc) {
+            if let assetURL = URL(string: item.mediaSrc), let pageURL = URL(string: item.pageSrc) {
               MediaThumbnail(assetURL: assetURL, pageURL: pageURL)
             }
           }

--- a/ios/brave-ios/Tests/PlaylistUITests/PlayerModelTests.swift
+++ b/ios/brave-ios/Tests/PlaylistUITests/PlayerModelTests.swift
@@ -210,6 +210,7 @@ class PlayerModelTests: CoreDataTestCase {
     await playerModel.prepareItemQueue()
 
     XCTAssertEqual(playerModel.selectedItemID, items[9].id)
+    XCTAssertFalse(playerModel.canPlayNextItem)
 
     await playerModel.playNextItem()
 
@@ -235,6 +236,7 @@ class PlayerModelTests: CoreDataTestCase {
     await playerModel.playNextItem()
 
     XCTAssertEqual(playerModel.selectedItemID, itemsIDs.first)
+    XCTAssertTrue(playerModel.canPlayNextItem)
 
     await playerModel.playNextItem()
 
@@ -260,10 +262,12 @@ class PlayerModelTests: CoreDataTestCase {
     playerModel.repeatMode = .all
 
     XCTAssertEqual(playerModel.selectedItemID, items[8].id)
+    XCTAssertTrue(playerModel.canPlayNextItem)
 
     await playerModel.playNextItem()
 
     XCTAssertEqual(playerModel.selectedItemID, items[9].id)
+    XCTAssertTrue(playerModel.canPlayNextItem)
 
     await playerModel.playNextItem()
 
@@ -407,7 +411,7 @@ class PlayerModelTests: CoreDataTestCase {
     XCTAssertTrue(playerModel.isPlaying)
 
     await playerModel.seek(to: 5, accurately: true)
-    XCTAssertEqual(playerModel.currentTime, 5)
+    XCTAssertEqual(playerModel.currentTime.rounded(), 5)
 
     playerModel.pause()
     XCTAssertFalse(playerModel.isPlaying)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
         "@brave/leo": "github:brave/leo#765fc137fcd02d0ce54ee14ddbd38f7380b6d43a",
-        "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2",
+        "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
         "@brave/wallet-standard-brave": "0.0.13",
         "@dnd-kit/core": "6.0.5",
         "@dnd-kit/sortable": "7.0.1",
@@ -2240,9 +2240,9 @@
     },
     "node_modules/@brave/leo-sf-symbols": {
       "name": "leo-sf-symbols",
-      "version": "1.0.58",
-      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#f66f5701f8330253c1c113228c08f129178941c2",
-      "integrity": "sha512-siyUfMhRcepr26MKegYqtH2UsHUq4qM1q/ZJaMCh0t8ztP5ujJRV/fCM0DlRtr2awKPIEqw+X3bHd/08xAqI7A==",
+      "version": "1.0.60",
+      "resolved": "git+ssh://git@github.com/brave/leo-sf-symbols.git#8685eec0851afa96d23dd424cd152854476e585d",
+      "integrity": "sha512-6D+TLgBi03/PMF8MF37Xf/0/m6ZfEijZTQ4lDSZ4NtCc0eDOzneygEMDsi3HwfIp4sume2PiA6v/zrM3O5/3mg==",
       "license": "MPL-2.0"
     },
     "node_modules/@brave/leo/node_modules/debug": {
@@ -29855,9 +29855,9 @@
       }
     },
     "@brave/leo-sf-symbols": {
-      "version": "git+ssh://git@github.com/brave/leo-sf-symbols.git#f66f5701f8330253c1c113228c08f129178941c2",
-      "integrity": "sha512-siyUfMhRcepr26MKegYqtH2UsHUq4qM1q/ZJaMCh0t8ztP5ujJRV/fCM0DlRtr2awKPIEqw+X3bHd/08xAqI7A==",
-      "from": "@brave/leo-sf-symbols@github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2"
+      "version": "git+ssh://git@github.com/brave/leo-sf-symbols.git#8685eec0851afa96d23dd424cd152854476e585d",
+      "integrity": "sha512-6D+TLgBi03/PMF8MF37Xf/0/m6ZfEijZTQ4lDSZ4NtCc0eDOzneygEMDsi3HwfIp4sume2PiA6v/zrM3O5/3mg==",
+      "from": "@brave/leo-sf-symbols@github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d"
     },
     "@brave/wallet-standard-brave": {
       "version": "0.0.13",

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
     "@brave/leo": "github:brave/leo#765fc137fcd02d0ce54ee14ddbd38f7380b6d43a",
-    "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2",
+    "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
     "@brave/wallet-standard-brave": "0.0.13",
     "@dnd-kit/core": "6.0.5",
     "@dnd-kit/sortable": "7.0.1",


### PR DESCRIPTION
This further improves the new playlist based on feedback

- Adds 1.2x rate (bumps `leo-sf-symbols` to get the new icon)
- Adds UI when double-tapping video player to seek backwards/forwards
- Adds a button to go to the next item while fullscreen
- Fixes a severe hang due to an XPC lock when calling `AVPlayer.replaceCurrentItem(with:)` on the main thread 

Reminder: This feature is behind a feature flag (disabled by default) and must be enabled to test

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

