### PR TITLE
[ads] Allow non-Rewards users to clear `Brave Ads data` from `Delete browsing data`

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -548,6 +548,9 @@
   <message name="IDS_SETTINGS_BRAVE_ON_EXIT" desc="Clear Browsing Data dialog On exit tab label">
     On exit
   </message>
+  <message name="IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA" desc="The label for the link to clear 'Brave Ads' data">
+    Clear Brave Ads data...
+  </message>
   <message name="IDS_SETTINGS_RESET_REWARDS_DATA" desc="The label for opening rewards manage wallet dialog">
     Reset Brave Rewards data...
   </message>

--- a/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_proxy.ts
+++ b/browser/resources/settings/brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_proxy.ts
@@ -1,0 +1,30 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+ import {sendWithPromise} from 'chrome://resources/js/cr.js';
+
+ export interface BraveClearBrowsingDataDialogBrowserProxy {
+  getBraveRewardsEnabled(): Promise<boolean>;
+  clearBraveAdsData(): void;
+ }
+
+ export class BraveClearBrowsingDataDialogBrowserProxyImpl
+    implements BraveClearBrowsingDataDialogBrowserProxy {
+
+   getBraveRewardsEnabled() {
+    return sendWithPromise('getBraveRewardsEnabled');
+  }
+
+  clearBraveAdsData() {
+    chrome.send('clearBraveAdsData');
+  }
+
+  static getInstance(): BraveClearBrowsingDataDialogBrowserProxyImpl {
+    return instance ||
+        (instance = new BraveClearBrowsingDataDialogBrowserProxyImpl());
+  }
+}
+
+let instance: BraveClearBrowsingDataDialogBrowserProxyImpl|null = null;

--- a/browser/resources/settings/brave_overrides/clear_browsing_data_dialog.ts
+++ b/browser/resources/settings/brave_overrides/clear_browsing_data_dialog.ts
@@ -19,7 +19,7 @@ RegisterStyleOverride(
       :host {
         --body-container-height: 372px !important;
       }
-      #rewards-reset-data {
+      #reset-brave-rewards-data, #clear-brave-ads-data {
         display: block;
         margin-top: 10px;
       }
@@ -73,7 +73,7 @@ RegisterPolymerTemplateModifications({
       saveButton.textContent = loadTimeData.getString('save')
     }
 
-    // Append rewards reset data link
+    // Append clear Brave Ads data link
     const body = templateContent.querySelector('[slot="body"]')
     if (!body) {
       console.error(
@@ -83,12 +83,34 @@ RegisterPolymerTemplateModifications({
     body.insertAdjacentHTML(
       'beforeend',
       getTrustedHTML`
-        <a id="rewards-reset-data" href="chrome://rewards/#reset"></a>
+        <a id="clear-brave-ads-data"
+          href="chrome://settings/privacy"
+          onClick="[[onClearBraveAdsDataClickHandler_]]"
+          hidden="[[braveRewardsEnabled_]]">
+        </a>
+      `)
+    const clearBraveAdsLink =
+      templateContent.getElementById('clear-brave-ads-data')
+    if (!clearBraveAdsLink) {
+      console.error('[Settings] missing clear Brave Ads link')
+    } else {
+      clearBraveAdsLink.textContent =
+        loadTimeData.getString('clearBraveAdsData')
+    }
+
+    // Append reset Brave Rewards data link
+    body.insertAdjacentHTML(
+      'beforeend',
+      getTrustedHTML`
+        <a id="reset-brave-rewards-data"
+          href="chrome://rewards/#reset"
+          hidden="[[!braveRewardsEnabled_]]">
+        </a>
       `)
     const rewardsResetLink =
-      templateContent.getElementById('rewards-reset-data')
+      templateContent.getElementById('reset-brave-rewards-data')
     if (!rewardsResetLink) {
-      console.error('[Settings] missing Rewards reset link')
+      console.error('[Settings] missing reset Brave Rewards link')
     } else {
       rewardsResetLink.textContent = loadTimeData.getString('resetRewardsData')
     }

--- a/browser/resources/settings/sources.gni
+++ b/browser/resources/settings/sources.gni
@@ -60,6 +60,7 @@ brave_settings_web_component_files = [
 brave_settings_non_web_component_files = [
   "brave_appearance_page/brave_appearance_browser_proxy.ts",
   "brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_behavior.ts",
+  "brave_clear_browsing_data_dialog/brave_clear_browsing_data_dialog_proxy.ts",
   "brave_autofill_page/brave_autofill_page.ts",
   "brave_add_site_dialog/brave_add_site_dialog.ts",
   "brave_data_collection_page/brave_data_collection_browser_proxy.ts",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -271,6 +271,8 @@ source_set("ui") {
       "webui/settings/brave_adblock_handler.h",
       "webui/settings/brave_appearance_handler.cc",
       "webui/settings/brave_appearance_handler.h",
+      "webui/settings/brave_clear_browsing_data_handler.cc",
+      "webui/settings/brave_clear_browsing_data_handler.h",
       "webui/settings/brave_import_bulk_data_handler.cc",
       "webui/settings/brave_import_bulk_data_handler.h",
       "webui/settings/brave_import_data_handler.cc",

--- a/browser/ui/webui/settings/brave_clear_browsing_data_handler.cc
+++ b/browser/ui/webui/settings/brave_clear_browsing_data_handler.cc
@@ -1,0 +1,78 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/webui/settings/brave_clear_browsing_data_handler.h"
+
+#include "base/functional/bind.h"
+#include "brave/browser/brave_ads/ads_service_factory.h"
+#include "brave/components/brave_ads/browser/ads_service.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
+#include "chrome/browser/profiles/profile.h"
+#include "components/prefs/pref_service.h"
+
+namespace settings {
+
+BraveClearBrowsingDataHandler::BraveClearBrowsingDataHandler(
+    content::WebUI* webui,
+    Profile* profile)
+    : ClearBrowsingDataHandler(webui, profile), profile_(profile) {
+  CHECK(profile_);
+
+  pref_change_registrar_.Init(profile_->GetPrefs());
+  pref_change_registrar_.Add(
+      brave_rewards::prefs::kEnabled,
+      base::BindRepeating(
+          &BraveClearBrowsingDataHandler::OnRewardsEnabledPreferenceChanged,
+          base::Unretained(this)));
+}
+
+BraveClearBrowsingDataHandler::~BraveClearBrowsingDataHandler() = default;
+
+void BraveClearBrowsingDataHandler::RegisterMessages() {
+  ClearBrowsingDataHandler::RegisterMessages();
+
+  web_ui()->RegisterMessageCallback(
+      "getBraveRewardsEnabled",
+      base::BindRepeating(
+          &BraveClearBrowsingDataHandler::HandleGetBraveRewardsEnabled,
+          base::Unretained(this)));
+  web_ui()->RegisterMessageCallback(
+      "clearBraveAdsData",
+      base::BindRepeating(
+          &BraveClearBrowsingDataHandler::HandleClearBraveAdsData,
+          base::Unretained(this)));
+}
+
+void BraveClearBrowsingDataHandler::HandleGetBraveRewardsEnabled(
+    const base::Value::List& args) {
+  CHECK_EQ(args.size(), 1U);
+
+  const bool rewards_enabled =
+      profile_->GetPrefs()->GetBoolean(brave_rewards::prefs::kEnabled);
+
+  AllowJavascript();
+  ResolveJavascriptCallback(args[0], rewards_enabled);
+}
+
+void BraveClearBrowsingDataHandler::HandleClearBraveAdsData(
+    const base::Value::List& /*args*/) {
+  if (auto* ads_service =
+          brave_ads::AdsServiceFactory::GetForProfile(profile_)) {
+    ads_service->ClearData();
+  }
+}
+
+void BraveClearBrowsingDataHandler::OnRewardsEnabledPreferenceChanged() {
+  if (!IsJavascriptAllowed()) {
+    return;
+  }
+
+  const bool rewards_enabled =
+      profile_->GetPrefs()->GetBoolean(brave_rewards::prefs::kEnabled);
+  FireWebUIListener("brave-rewards-enabled-changed",
+                    base::Value(rewards_enabled));
+}
+
+}  // namespace settings

--- a/browser/ui/webui/settings/brave_clear_browsing_data_handler.h
+++ b/browser/ui/webui/settings/brave_clear_browsing_data_handler.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_CLEAR_BROWSING_DATA_HANDLER_H_
+#define BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_CLEAR_BROWSING_DATA_HANDLER_H_
+
+#include "base/values.h"
+#include "chrome/browser/ui/webui/settings/settings_clear_browsing_data_handler.h"
+#include "components/prefs/pref_change_registrar.h"
+
+class Profile;
+
+namespace settings {
+
+class BraveClearBrowsingDataHandler : public ClearBrowsingDataHandler {
+ public:
+  BraveClearBrowsingDataHandler(content::WebUI* webui, Profile* profile);
+  BraveClearBrowsingDataHandler(const BraveClearBrowsingDataHandler&) = delete;
+  BraveClearBrowsingDataHandler& operator=(
+      const BraveClearBrowsingDataHandler&) = delete;
+  ~BraveClearBrowsingDataHandler() override;
+
+ private:
+  // ClearBrowsingDataHandler:
+  void RegisterMessages() override;
+
+  void HandleGetBraveRewardsEnabled(const base::Value::List& args);
+
+  void HandleClearBraveAdsData(const base::Value::List& args);
+
+  void OnRewardsEnabledPreferenceChanged();
+
+  raw_ptr<Profile> profile_ = nullptr;
+
+  PrefChangeRegistrar pref_change_registrar_;
+};
+
+}  // namespace settings
+
+#endif  // BRAVE_BROWSER_UI_WEBUI_SETTINGS_BRAVE_CLEAR_BROWSING_DATA_HANDLER_H_

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -502,6 +502,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       {"braveRewardsPageLabel", IDS_SETTINGS_BRAVE_REWARDS_PAGE_LABEL},
       {"braveRewardsShowBraveRewardsButtonLabel",
        IDS_SETTINGS_BRAVE_REWARDS_SHOW_BRAVE_REWARDS_BUTTON_LABEL},
+
+      // Delete browsing data settings
+      {"clearBraveAdsData", IDS_SETTINGS_CLEAR_BRAVE_ADS_DATA},
+      {"resetRewardsData", IDS_SETTINGS_RESET_REWARDS_DATA},
+
       // Misc (TODO: Organize this)
       {"showSearchTabsBtn", IDS_SETTINGS_TABS_SEARCH_SHOW},
       {"onExitPageTitle", IDS_SETTINGS_BRAVE_ON_EXIT},
@@ -585,7 +590,6 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       {"p3aEnableTitle", IDS_BRAVE_P3A_ENABLE_SETTING},
       {"p3aEnabledDesc", IDS_BRAVE_P3A_ENABLE_SETTING_SUBITEM},
       {"siteSettings", IDS_SETTINGS_SITE_AND_SHIELDS_SETTINGS},
-      {"resetRewardsData", IDS_SETTINGS_RESET_REWARDS_DATA},
       {"showFullUrls", IDS_SETTINGS_ALWAYS_SHOW_FULL_URLS},
       {"resetWallet", IDS_SETTINGS_WALLET_RESET},
       {"resetTransactionInfo", IDS_SETTINGS_WALLET_RESET_TRANSACTION_INFO},

--- a/chromium_src/chrome/browser/ui/webui/settings/settings_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/settings_ui.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/webui/settings/brave_clear_browsing_data_handler.h"
 #include "brave/browser/ui/webui/settings/brave_import_data_handler.h"
 #include "brave/browser/ui/webui/settings/brave_search_engines_handler.h"
 #include "brave/browser/ui/webui/settings/brave_site_settings_handler.h"
@@ -20,7 +21,9 @@
 #define SiteSettingsHandler BraveSiteSettingsHandler
 #define ImportDataHandler BraveImportDataHandler
 #define SearchEnginesHandler BraveSearchEnginesHandler
+#define ClearBrowsingDataHandler BraveClearBrowsingDataHandler
 #include "src/chrome/browser/ui/webui/settings/settings_ui.cc"
+#undef ClearBrowsingDataHandler
 #undef SearchEnginesHandler
 #undef ImportDataHandler
 #undef SiteSettingsHandler

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -153,6 +153,9 @@ class AdsService : public KeyedService {
                             base::Time to_time,
                             GetAdHistoryCallback callback) = 0;
 
+  // Called to clear Brave Ads data.
+  virtual void ClearData() = 0;
+
   // Called to like an ad. This is a toggle, so calling it again returns the
   // setting to the neutral state. The callback takes one argument - `bool` is
   // set to `true` if successful otherwise `false`.

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -261,6 +261,8 @@ class AdsServiceImpl final : public AdsService,
                     base::Time to_time,
                     GetAdHistoryCallback callback) override;
 
+  void ClearData() override;
+
   void ToggleLikeAd(base::Value::Dict value,
                     ToggleReactionCallback callback) override;
   void ToggleDislikeAd(base::Value::Dict value,
@@ -450,7 +452,7 @@ class AdsServiceImpl final : public AdsService,
 
   const scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
 
-  const base::FilePath base_path_;
+  const base::FilePath ads_service_path_;
 
   const raw_ptr<NotificationDisplayService> display_service_ =
       nullptr;  // NOT OWNED

--- a/components/brave_ads/browser/ads_service_mock.h
+++ b/components/brave_ads/browser/ads_service_mock.h
@@ -90,6 +90,8 @@ class AdsServiceMock : public AdsService {
               GetAdHistory,
               (base::Time, base::Time, GetAdHistoryCallback));
 
+  MOCK_METHOD(void, ClearData, ());
+
   MOCK_METHOD(void, ToggleLikeAd, (base::Value::Dict, ToggleReactionCallback));
   MOCK_METHOD(void,
               ToggleDislikeAd,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -464,6 +464,7 @@ extension BrowserViewController: TopToolbarDelegate {
           feedDataSource: self.feedDataSource,
           debounceService: DebounceServiceFactory.get(privateMode: false),
           braveCore: braveCore,
+          rewards: rewards,
           clearDataCallback: { [weak self] isLoading, isHistoryCleared in
             guard let self else { return }
             guard let view = self.navigationController?.view, view.window != nil else {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -372,14 +372,7 @@ public class BrowserViewController: UIViewController {
     }
 
     rewards.ads.captchaHandler = self
-    // Start Brave Ads if one of the following is true:
-    // - Brave Rewards is enabled
-    // - Brave News is enabled
-    // - `ShouldAlwaysRunBraveAdsService` feature is enabled
-    let shouldStartAds =
-      rewards.ads.isEnabled || Preferences.BraveNews.isEnabled.value
-      || BraveAds.shouldAlwaysRunService()
-    if shouldStartAds {
+    if rewards.shouldStartAds {
       // Only start rewards service automatically if ads is enabled
       if rewards.isEnabled {
         rewards.startRewardsService(nil)

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/Clearables.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/Clearables.swift
@@ -246,3 +246,20 @@ class RecentSearchClearable: Clearable {
     RecentSearch.removeAll()
   }
 }
+
+class BraveAdsDataClearable: Clearable {
+
+  private let rewards: BraveRewards?
+
+  init(rewards: BraveRewards?) {
+    self.rewards = rewards
+  }
+
+  var label: String {
+    return Strings.Ads.braveAdsDataToggleOption
+  }
+
+  func clear() async throws {
+    await rewards?.clearAdsData()
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -279,6 +279,7 @@ class SettingsViewController: TableViewController {
                   feedDataSource: self.feedDataSource,
                   debounceService: DebounceServiceFactory.get(privateMode: false),
                   braveCore: braveCore,
+                  rewards: rewards,
                   clearDataCallback: { [weak self] isLoading, isHistoryCleared in
                     guard let view = self?.navigationController?.view, view.window != nil else {
                       assertionFailure()

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -9183,6 +9183,16 @@ extension Strings {
       value: "Brave Rewards",
       comment: ""
     )
+
+    public static let braveAdsDataToggleOption =
+      NSLocalizedString(
+        "ads.braveAdsDataToggleOption",
+        tableName: "BraveShared",
+        bundle: .module,
+        value: "Brave Ads Data",
+        comment:
+          "Text for the toggle switch to clear 'Brave Ads' data in settings"
+      )
   }
 }
 

--- a/ios/browser/api/ads/BUILD.gn
+++ b/ios/browser/api/ads/BUILD.gn
@@ -39,6 +39,7 @@ source_set("ads") {
     "//components/prefs",
     "//ios/chrome/browser/shared/model/application_context",
     "//ios/chrome/browser/shared/model/browser_state",
+    "//sql:sql",
   ]
 
   frameworks = [

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -137,6 +137,8 @@ OBJC_EXPORT
            advertiserId:(NSString*)advertiserId
                 segment:(NSString*)segment;
 
+- (void)clearData:(void (^)())completion;
+
 #pragma mark - Ads client notifier
 
 // See `components/brave_ads/core/public/ads_client/ads_client_notifier.h`.


### PR DESCRIPTION
Enabled clearing of `Brave Ads data` from the settings for non-Rewards users. Clearing of Brave Ads data deletes/clears the following data in users Profile:
- **Default/ads_service/database.sqlite**
- **Default/ads_service/client.json**
- **Default/ads_service/confirmations.json**
- **Default/Preferences/brave/brave_ads**


**On Desktop**:
Option is available in `Delete browsing data` dialog for non-Rewards users. If user has joined Brave Rewards then it is replaced by `Reset rewards data...` link, which leads to brave://rewards/#reset.
<img width="350" alt="image" src="https://github.com/user-attachments/assets/1dd69eb4-a2bb-403a-bea6-6b151655f37a">

**On iOS**:
Option is available in `Brave Shields & Privacy` dialog non-Rewards users. If user enabled Brave Rewards, the this option is hidden.
<img width="250" alt="image" src="https://github.com/user-attachments/assets/2d50a0bb-63d2-41e7-a8b1-a21eac889867">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39051

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1 (Desktop)
* Fresh install
* Trigger search result ad for a staging server with the `giraffe` request
* Click search result ad
* Convert search result ad by visiting https://www.brave.com/vertical-tabs/
* Check that following tables in `ads_service/database.sqlite` are not empty:
    - ad_events
    - creative_set_conversions
* Open `Settings` -> `History` -> `Delete browsing data`
* Click `Clear Brave Ads data...` link
* Make sure that Brave Ads service is restarted
* Check that following tables in `ads_service/database.sqlite` are empty:
    - ad_events
    - creative_set_conversions
    - confirmation_queue
    - transactions
* Check that `ads_service/client.json` contains json with empty fields
* Check that `ads_service/confirmations.json` contains json with empty fields

### Test case 2 (Desktop)
* Fresh install
* Join Brave News
* Trigger search result ad for a staging server with the `giraffe` request
* Click search result ad
* Convert search result ad by visiting https://www.brave.com/vertical-tabs/
* View/click/land Brave News ad
* Convert Brave News ad
* Check that following tables in `ads_service/database.sqlite` are not empty:
    - ad_events
    - creative_set_conversions
* Open `Settings` -> `History` -> `Delete browsing data`
* Click `Clear Brave Ads data...` link
* Make sure that Brave Ads service is restarted
* Check that following tables in `ads_service/database.sqlite` are empty:
    - ad_events
    - confirmation_queue
    - transactions
* Check that `creative_set_conversions` table doesn't contain row with creative_set_id =  `d81220f2-b7c6-4f3e-b3fa-5e0f579407a5`
* Check that `ads_service/client.json` contains json with empty fields
* Check that `ads_service/confirmations.json` contains json with empty fields

### Test case 3 (Desktop)
* Fresh install
* Join Brave Rewards
* Open `Settings` -> `History` -> `Delete browsing data`
* Make sure `Reset Brave Rewards data...` link is shown

### Test case 4 (iOS)
* Fresh install
* Trigger search result ad for a staging server with the `giraffe` request
* Click search result ad
* Convert search result ad by visiting https://www.brave.com/vertical-tabs/
* Check that following tables in `ads/Ads.sqlite` are not empty:
    - ad_events
    - creative_set_conversions
* Toggle `Settings` -> `Shields & Privacy` -> `CLEAR PRIVATE DATA` -> `Brave Ads Data`
* Tap `Clear Data Now` button
* Make sure that Brave Ads service is restarted
* Check that following tables in `ads/Ads.sqlite` are empty:
    - ad_events
    - creative_set_conversions
    - confirmation_queue
    - transactions
* Check that `ads/client.json` contains json with empty fields
* Check that `ads/confirmations.json` contains json with empty fields

### Test case 5 (iOS)
* Fresh install
* Join Brave News
* Trigger search result ad for a staging server with the `giraffe` request
* Click search result ad
* Convert search result ad by visiting https://www.brave.com/vertical-tabs/
* View/click/land Brave News ad
* Convert Brave News ad
* Check that following tables in `ads/Ads.sqlite` are not empty:
    - ad_events
    - creative_set_conversions
* Toggle `Settings` -> `Shields & Privacy` -> `CLEAR PRIVATE DATA` -> `Brave Ads Data`
* Tap `Clear Data Now` button
* Make sure that Brave Ads service is restarted
* Check that following tables in `ads/Ads.sqlite` are empty:
    - ad_events
    - confirmation_queue
    - transactions
* Check that `creative_set_conversions` table doesn't contain row with creative_set_id =  `d81220f2-b7c6-4f3e-b3fa-5e0f579407a5`
* Check that `ads/client.json` contains json with empty fields
* Check that `ads/confirmations.json` contains json with empty fields

### Test case 6 (iOS)
* Fresh install
* Join Brave Rewards
* Go to `Settings` -> `Shields & Privacy` -> `CLEAR PRIVATE DATA`
* Make sure `Brave Ads Data` toggle is not visible
