### PR TITLE
Opt-out telemetry after the sync done

### DIFF
--- a/build/commands/lib/depotTools.js
+++ b/build/commands/lib/depotTools.js
@@ -140,23 +140,27 @@ function installDepotTools(options = config.defaultOptions) {
         stdio: 'pipe'
       })
     }
-
-    // Opt-out of chromium build telemetry. See for details:
-    // https://chromium.googlesource.com/chromium/tools/depot_tools/+/main/ninjalog.README.md
-    util.run('vpython3',
-             [path.join(config.depotToolsDir, 'build_telemetry.py'), 'opt-out'],
-             options)
-
-    // The old way to opt-out of chromium build telemetry.
-    // Could be removed after https://crrev.com/c/5669094 is merged.
-    const ninjalogUploaderWrapperPath =
-        path.join(config.depotToolsDir, 'ninjalog_uploader_wrapper.py')
-    if (fs.existsSync(ninjalogUploaderWrapperPath)) {
-      util.run('vpython3', [ninjalogUploaderWrapperPath, 'opt-out'], options)
-    }
   })
 }
 
+// Opt-out of chromium build telemetry. See for details:
+// https://chromium.googlesource.com/chromium/tools/depot_tools/+/main/ninjalog.README.md
+function optOutOfBuildTelemetry() {
+  util.run('vpython3',
+    [path.join(config.depotToolsDir, 'build_telemetry.py'), 'opt-out'],
+    config.defaultOptions)
+
+  // The old way to opt-out of chromium build telemetry.
+  // Could be removed after https://crrev.com/c/5669094 is merged.
+  const ninjalogUploaderWrapperPath =
+  path.join(config.depotToolsDir, 'ninjalog_uploader_wrapper.py')
+  if (fs.existsSync(ninjalogUploaderWrapperPath)) {
+    util.run('vpython3', [ninjalogUploaderWrapperPath, 'opt-out'],
+             config.defaultOptions)
+  }
+}
+
 module.exports = {
-  installDepotTools
+  installDepotTools,
+  optOutOfBuildTelemetry
 }

--- a/build/commands/lib/depotTools.js
+++ b/build/commands/lib/depotTools.js
@@ -146,14 +146,16 @@ function installDepotTools(options = config.defaultOptions) {
 // Opt-out of chromium build telemetry. See for details:
 // https://chromium.googlesource.com/chromium/tools/depot_tools/+/main/ninjalog.README.md
 function optOutOfBuildTelemetry() {
-  util.run('vpython3',
-    [path.join(config.depotToolsDir, 'build_telemetry.py'), 'opt-out'],
-    config.defaultOptions)
+  const buildTelemetryPath =
+    path.join(config.depotToolsDir, 'build_telemetry.py')
+  if (fs.existsSync(buildTelemetryPath)) {
+    util.run('vpython3', [buildTelemetryPath, 'opt-out'], config.defaultOptions)
+  }
 
   // The old way to opt-out of chromium build telemetry.
   // Could be removed after https://crrev.com/c/5669094 is merged.
   const ninjalogUploaderWrapperPath =
-  path.join(config.depotToolsDir, 'ninjalog_uploader_wrapper.py')
+    path.join(config.depotToolsDir, 'ninjalog_uploader_wrapper.py')
   if (fs.existsSync(ninjalogUploaderWrapperPath)) {
     util.run('vpython3', [ninjalogUploaderWrapperPath, 'opt-out'],
              config.defaultOptions)

--- a/build/commands/lib/depotTools.js
+++ b/build/commands/lib/depotTools.js
@@ -158,7 +158,7 @@ function optOutOfBuildTelemetry() {
     path.join(config.depotToolsDir, 'ninjalog_uploader_wrapper.py')
   if (fs.existsSync(ninjalogUploaderWrapperPath)) {
     util.run('vpython3', [ninjalogUploaderWrapperPath, 'opt-out'],
-             config.defaultOptions)
+      config.defaultOptions)
   }
 }
 

--- a/build/commands/scripts/sync.js
+++ b/build/commands/scripts/sync.js
@@ -84,6 +84,8 @@ async function RunCommand() {
     }
   })
 
+  depotTools.optOutOfBuildTelemetry()
+
   await util.applyPatches()
 
   if (!program.nohooks) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
For https://github.com/brave/brave-browser/issues/39757

The PR moves telemetry opt-out after `gclient sync` call.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

