### PR TITLE
Backports CLs to reduce Spotify OOMs

### DIFF
--- a/patches/base-task-sequence_manager-tasks.cc.patch
+++ b/patches/base-task-sequence_manager-tasks.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/base/task/sequence_manager/tasks.cc b/base/task/sequence_manager/tasks.cc
+index 5bf10c72f51c39e1d437862d8bd1c83736136a1e..44010aa7d55a347204506f28f73cce5b257ba41e 100644
+--- a/base/task/sequence_manager/tasks.cc
++++ b/base/task/sequence_manager/tasks.cc
+@@ -79,7 +79,6 @@ HeapHandle Task::GetHeapHandle() const {
+ bool Task::IsCanceled() const {
+   CHECK(task);
+   if (task.IsCancelled()) {
+-    DCHECK(!delayed_task_handle_delegate_);
+     return true;
+   }
+ 

--- a/patches/base-task-sequenced_task_runner.h.patch
+++ b/patches/base-task-sequenced_task_runner.h.patch
@@ -1,0 +1,20 @@
+diff --git a/base/task/sequenced_task_runner.h b/base/task/sequenced_task_runner.h
+index d5a6d286b0d1b3081ec59a53b86a154b49ff6ae2..cfae0eb214e64979803523e61479145ea9761919 100644
+--- a/base/task/sequenced_task_runner.h
++++ b/base/task/sequenced_task_runner.h
+@@ -20,6 +20,7 @@
+ 
+ namespace blink {
+ class LowPrecisionTimer;
++class ScriptedIdleTaskController;
+ class TimerBase;
+ class TimerBasedTickProvider;
+ class WebRtcTaskQueue;
+@@ -67,6 +68,7 @@ class PostDelayedTaskPassKey {
+   friend class base::DeadlineTimer;
+   friend class base::MetronomeTimer;
+   friend class blink::LowPrecisionTimer;
++  friend class blink::ScriptedIdleTaskController;
+   friend class blink::TimerBase;
+   friend class blink::TimerBasedTickProvider;
+   friend class blink::WebRtcTaskQueue;

--- a/patches/third_party-blink-renderer-core-DEPS.patch
+++ b/patches/third_party-blink-renderer-core-DEPS.patch
@@ -1,0 +1,14 @@
+diff --git a/third_party/blink/renderer/core/DEPS b/third_party/blink/renderer/core/DEPS
+index b806e591c1554f3ea54c7199a4ef2c57332c5d66..0416f0d36339af5c372ac200afab47736b7b5c66 100644
+--- a/third_party/blink/renderer/core/DEPS
++++ b/third_party/blink/renderer/core/DEPS
+@@ -209,6 +209,9 @@ specific_include_rules = {
+     "media_values.h": [
+         "+ui/base/pointer/pointer_device.h",
+     ],
++    "scripted_idle_task_controller(_test)?.(cc|h)": [
++        "+base/task/delayed_task_handle.h",
++    ],
+     "xml_http_request.cc": [
+         "+net/base/mime_util.h",
+     ],

--- a/patches/third_party-blink-renderer-core-dom-scripted_idle_task_controller.cc.patch
+++ b/patches/third_party-blink-renderer-core-dom-scripted_idle_task_controller.cc.patch
@@ -1,0 +1,205 @@
+diff --git a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+index 2364cc22b0563939fbf16ad10ef651c0b4f731f6..7b25e7cc413933ae21887defbc378475e3f09ed3 100644
+--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
++++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc
+@@ -15,65 +15,22 @@
+ #include "third_party/blink/renderer/platform/instrumentation/tracing/trace_event.h"
+ #include "third_party/blink/renderer/platform/scheduler/public/thread_scheduler.h"
+ #include "third_party/blink/renderer/platform/wtf/functional.h"
+-#include "third_party/blink/renderer/platform/wtf/ref_counted.h"
+-
+ namespace blink {
+ 
+-namespace internal {
+-
+-class IdleRequestCallbackWrapper
+-    : public RefCounted<IdleRequestCallbackWrapper> {
+- public:
+-  static scoped_refptr<IdleRequestCallbackWrapper> Create(
+-      ScriptedIdleTaskController::CallbackId id,
+-      ScriptedIdleTaskController* controller) {
+-    return base::AdoptRef(new IdleRequestCallbackWrapper(id, controller));
+-  }
+-  virtual ~IdleRequestCallbackWrapper() = default;
+-
+-  static void IdleTaskFired(
+-      scoped_refptr<IdleRequestCallbackWrapper> callback_wrapper,
+-      base::TimeTicks deadline) {
+-    if (ScriptedIdleTaskController* controller =
+-            callback_wrapper->Controller()) {
+-      // If we are going to yield immediately, reschedule the callback for
+-      // later.
+-      if (ThreadScheduler::Current()->ShouldYieldForHighPriorityWork()) {
+-        controller->ScheduleCallback(std::move(callback_wrapper),
+-                                     /* timeout_millis */ 0);
+-        return;
+-      }
+-      controller->CallbackFired(callback_wrapper->Id(), deadline,
+-                                IdleDeadline::CallbackType::kCalledWhenIdle);
+-    }
+-    callback_wrapper->Cancel();
+-  }
+-
+-  static void TimeoutFired(
+-      scoped_refptr<IdleRequestCallbackWrapper> callback_wrapper) {
+-    if (ScriptedIdleTaskController* controller =
+-            callback_wrapper->Controller()) {
+-      controller->CallbackFired(callback_wrapper->Id(), base::TimeTicks::Now(),
+-                                IdleDeadline::CallbackType::kCalledByTimeout);
+-    }
+-    callback_wrapper->Cancel();
+-  }
+-
+-  void Cancel() { controller_ = nullptr; }
+-
+-  ScriptedIdleTaskController::CallbackId Id() const { return id_; }
+-  ScriptedIdleTaskController* Controller() const { return controller_; }
+-
+- private:
+-  IdleRequestCallbackWrapper(ScriptedIdleTaskController::CallbackId id,
+-                             ScriptedIdleTaskController* controller)
+-      : id_(id), controller_(controller) {}
+-
+-  ScriptedIdleTaskController::CallbackId id_;
+-  WeakPersistent<ScriptedIdleTaskController> controller_;
+-};
+-
+-}  // namespace internal
++ScriptedIdleTaskController::DelayedTaskCanceler::DelayedTaskCanceler() =
++    default;
++ScriptedIdleTaskController::DelayedTaskCanceler::DelayedTaskCanceler(
++    base::DelayedTaskHandle delayed_task_handle)
++    : delayed_task_handle_(std::move(delayed_task_handle)) {}
++ScriptedIdleTaskController::DelayedTaskCanceler::DelayedTaskCanceler(
++    DelayedTaskCanceler&&) = default;
++ScriptedIdleTaskController::DelayedTaskCanceler&
++ScriptedIdleTaskController::DelayedTaskCanceler::operator=(
++    ScriptedIdleTaskController::DelayedTaskCanceler&&) = default;
++
++ScriptedIdleTaskController::DelayedTaskCanceler::~DelayedTaskCanceler() {
++  delayed_task_handle_.CancelTask();
++}
+ 
+ ScriptedIdleTaskController::ScriptedIdleTaskController(
+     ExecutionContext* context)
+@@ -114,43 +71,70 @@ ScriptedIdleTaskController::RegisterCallback(
+   idle_task->async_task_context()->Schedule(GetExecutionContext(),
+                                             "requestIdleCallback");
+ 
+-  scoped_refptr<internal::IdleRequestCallbackWrapper> callback_wrapper =
+-      internal::IdleRequestCallbackWrapper::Create(id, this);
+-  ScheduleCallback(std::move(callback_wrapper), timeout_millis);
++  ScheduleCallback(id, timeout_millis);
+   DEVTOOLS_TIMELINE_TRACE_EVENT_INSTANT(
+       "RequestIdleCallback", inspector_idle_callback_request_event::Data,
+       GetExecutionContext(), id, timeout_millis);
+   return id;
+ }
+ 
+-void ScriptedIdleTaskController::ScheduleCallback(
+-    scoped_refptr<internal::IdleRequestCallbackWrapper> callback_wrapper,
+-    uint32_t timeout_millis) {
+-  scheduler_->PostIdleTask(
+-      FROM_HERE,
+-      WTF::BindOnce(&internal::IdleRequestCallbackWrapper::IdleTaskFired,
+-                    callback_wrapper));
++void ScriptedIdleTaskController::ScheduleCallback(CallbackId id,
++                                                  uint32_t timeout_millis) {
++  // Note: be careful about memory usage of this method.
++  // 1. In certain corner case scenarios, millions of callbacks per minute could
++  //    be processed. The memory usage per callback should be minimized as much
++  //    as possible.
++  // 2. `timeout_millis` is page-originated and doesn't have any reasonable
++  //    limit. When a callback is processed, it's critical to remove the timeout
++  //    task from the queue. Failure to do so is likely to result in OOM.
++  base::DelayedTaskHandle delayed_task_handle;
+   if (timeout_millis > 0) {
+-    GetExecutionContext()
+-        ->GetTaskRunner(TaskType::kIdleTask)
+-        ->PostDelayedTask(
+-            FROM_HERE,
+-            WTF::BindOnce(&internal::IdleRequestCallbackWrapper::TimeoutFired,
+-                          callback_wrapper),
+-            base::Milliseconds(timeout_millis));
++    auto callback = WTF::BindOnce(&ScriptedIdleTaskController::TimeoutFired,
++                                  WrapWeakPersistent(this), id);
++    delayed_task_handle =
++        GetExecutionContext()
++            ->GetTaskRunner(TaskType::kIdleTask)
++            ->PostCancelableDelayedTask(base::subtle::PostDelayedTaskPassKey(),
++                                        FROM_HERE, std::move(callback),
++                                        base::Milliseconds(timeout_millis));
+   }
++
++  scheduler_->PostIdleTask(
++      FROM_HERE,
++      WTF::BindOnce(&ScriptedIdleTaskController::IdleTaskFired,
++                    WrapWeakPersistent(this), id,
++                    DelayedTaskCanceler(std::move(delayed_task_handle))));
+ }
+ 
+ void ScriptedIdleTaskController::CancelCallback(CallbackId id) {
+   DEVTOOLS_TIMELINE_TRACE_EVENT_INSTANT(
+       "CancelIdleCallback", inspector_idle_callback_cancel_event::Data,
+       GetExecutionContext(), id);
+-  if (!IsValidCallbackId(id))
++  if (!IsValidCallbackId(id)) {
+     return;
++  }
+ 
+   idle_tasks_.erase(id);
+ }
+ 
++void ScriptedIdleTaskController::IdleTaskFired(
++    CallbackId id,
++    ScriptedIdleTaskController::DelayedTaskCanceler /* canceler */,
++    base::TimeTicks deadline) {
++  // If we are going to yield immediately, reschedule the callback for
++  // later.
++  if (ThreadScheduler::Current()->ShouldYieldForHighPriorityWork()) {
++    ScheduleCallback(id, /* timeout_millis */ 0);
++    return;
++  }
++  CallbackFired(id, deadline, IdleDeadline::CallbackType::kCalledWhenIdle);
++}
++
++void ScriptedIdleTaskController::TimeoutFired(CallbackId id) {
++  CallbackFired(id, base::TimeTicks::Now(),
++                IdleDeadline::CallbackType::kCalledByTimeout);
++}
++
+ void ScriptedIdleTaskController::CallbackFired(
+     CallbackId id,
+     base::TimeTicks deadline,
+@@ -234,25 +218,20 @@ void ScriptedIdleTaskController::ContextUnpaused() {
+   // Run any pending timeouts as separate tasks, since it's not allowed to
+   // execute script from lifecycle callbacks.
+   for (auto& id : pending_timeouts_) {
+-    scoped_refptr<internal::IdleRequestCallbackWrapper> callback_wrapper =
+-        internal::IdleRequestCallbackWrapper::Create(id, this);
+     GetExecutionContext()
+         ->GetTaskRunner(TaskType::kIdleTask)
+-        ->PostTask(
+-            FROM_HERE,
+-            WTF::BindOnce(&internal::IdleRequestCallbackWrapper::TimeoutFired,
+-                          callback_wrapper));
++        ->PostTask(FROM_HERE,
++                   WTF::BindOnce(&ScriptedIdleTaskController::TimeoutFired,
++                                 WrapWeakPersistent(this), id));
+   }
+   pending_timeouts_.clear();
+ 
+   // Repost idle tasks for any remaining callbacks.
+   for (auto& idle_task : idle_tasks_) {
+-    scoped_refptr<internal::IdleRequestCallbackWrapper> callback_wrapper =
+-        internal::IdleRequestCallbackWrapper::Create(idle_task.key, this);
+     scheduler_->PostIdleTask(
+-        FROM_HERE,
+-        WTF::BindOnce(&internal::IdleRequestCallbackWrapper::IdleTaskFired,
+-                      callback_wrapper));
++        FROM_HERE, WTF::BindOnce(&ScriptedIdleTaskController::IdleTaskFired,
++                                 WrapWeakPersistent(this), idle_task.key,
++                                 DelayedTaskCanceler()));
+   }
+ }
+ 

--- a/patches/third_party-blink-renderer-core-dom-scripted_idle_task_controller.h.patch
+++ b/patches/third_party-blink-renderer-core-dom-scripted_idle_task_controller.h.patch
@@ -1,0 +1,65 @@
+diff --git a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
+index fe2e38db5e096a71f86f2399d48cb5e2a5408d39..9bbc8e739ca30e80ac1483984d394b1e6c3f68a7 100644
+--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
++++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller.h
+@@ -5,6 +5,7 @@
+ #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DOM_SCRIPTED_IDLE_TASK_CONTROLLER_H_
+ #define THIRD_PARTY_BLINK_RENDERER_CORE_DOM_SCRIPTED_IDLE_TASK_CONTROLLER_H_
+ 
++#include "base/task/delayed_task_handle.h"
+ #include "third_party/blink/renderer/core/core_export.h"
+ #include "third_party/blink/renderer/core/dom/idle_deadline.h"
+ #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_state_observer.h"
+@@ -12,13 +13,9 @@
+ #include "third_party/blink/renderer/platform/bindings/name_client.h"
+ #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_map.h"
+ #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+-#include "third_party/blink/renderer/platform/timer.h"
+ #include "third_party/blink/renderer/platform/wtf/vector.h"
+ 
+ namespace blink {
+-namespace internal {
+-class IdleRequestCallbackWrapper;
+-}
+ 
+ class ExecutionContext;
+ class IdleRequestOptions;
+@@ -72,17 +69,33 @@ class CORE_EXPORT ScriptedIdleTaskController
+   void ContextDestroyed() override;
+   void ContextLifecycleStateChanged(mojom::FrameLifecycleState) override;
+ 
++ private:
++  // A helper class to cancel timeout tasks. Calls `CancelTask()` for
++  // the passed `delayed_task_handle` in dtor.
++  class DelayedTaskCanceler {
++   public:
++    DelayedTaskCanceler();
++    DelayedTaskCanceler(base::DelayedTaskHandle delayed_task_handle);
++    DelayedTaskCanceler(DelayedTaskCanceler&&);
++    DelayedTaskCanceler& operator=(DelayedTaskCanceler&&);
++
++    ~DelayedTaskCanceler();
++
++   private:
++    base::DelayedTaskHandle delayed_task_handle_;
++  };
++
++  void IdleTaskFired(CallbackId id,
++                     DelayedTaskCanceler canceler,
++                     base::TimeTicks deadline);
++  void TimeoutFired(CallbackId id);
+   void CallbackFired(CallbackId,
+                      base::TimeTicks deadline,
+                      IdleDeadline::CallbackType);
+ 
+- private:
+-  friend class internal::IdleRequestCallbackWrapper;
+-
+   void ContextPaused();
+   void ContextUnpaused();
+-  void ScheduleCallback(scoped_refptr<internal::IdleRequestCallbackWrapper>,
+-                        uint32_t timeout_millis);
++  void ScheduleCallback(CallbackId id, uint32_t timeout_millis);
+ 
+   int NextCallbackId();
+ 

--- a/patches/third_party-blink-renderer-core-dom-scripted_idle_task_controller_test.cc.patch
+++ b/patches/third_party-blink-renderer-core-dom-scripted_idle_task_controller_test.cc.patch
@@ -1,0 +1,157 @@
+diff --git a/third_party/blink/renderer/core/dom/scripted_idle_task_controller_test.cc b/third_party/blink/renderer/core/dom/scripted_idle_task_controller_test.cc
+index e24f377ab7e625c395db0af9e235bf10fcbc6091..36e8d497958776ade796087d27dbb2d169980979 100644
+--- a/third_party/blink/renderer/core/dom/scripted_idle_task_controller_test.cc
++++ b/third_party/blink/renderer/core/dom/scripted_idle_task_controller_test.cc
+@@ -26,6 +26,52 @@ namespace {
+ 
+ using ShouldYield = base::StrongAlias<class ShouldYieldTag, bool>;
+ 
++// A facade to a real DelayedTaskHandle instance that hooks CancelTask() call.
++class DelayedTaskHandleDelegateFacade
++    : public base::DelayedTaskHandle::Delegate {
++ public:
++  explicit DelayedTaskHandleDelegateFacade(base::DelayedTaskHandle handle,
++                                           base::OnceClosure on_canceled)
++      : handle_(std::move(handle)), on_canceled_(std::move(on_canceled)) {}
++  ~DelayedTaskHandleDelegateFacade() override = default;
++
++  bool IsValid() const override { return handle_.IsValid(); }
++
++  void CancelTask() override {
++    if (IsValid()) {
++      std::move(on_canceled_).Run();
++    }
++    handle_.CancelTask();
++  }
++
++ private:
++  base::DelayedTaskHandle handle_;
++  base::OnceClosure on_canceled_;
++};
++
++// A variant of `FakeTaskRunner` that counts the number of cancelled tasks.
++class TestTaskRunner : public scheduler::FakeTaskRunner {
++ public:
++  int GetTaskCanceledCount() const { return task_canceled_count_; }
++
++ private:
++  base::DelayedTaskHandle PostCancelableDelayedTask(
++      base::subtle::PostDelayedTaskPassKey pass_key,
++      const base::Location& from_here,
++      base::OnceClosure task,
++      base::TimeDelta delay) override {
++    auto handle = scheduler::FakeTaskRunner::PostCancelableDelayedTask(
++        pass_key, from_here, std::move(task), delay);
++    return base::DelayedTaskHandle(
++        std::make_unique<DelayedTaskHandleDelegateFacade>(
++            std::move(handle),
++            base::BindOnce(&TestTaskRunner::OnTaskCanceled, this)));
++  }
++
++  void OnTaskCanceled() { ++task_canceled_count_; }
++
++  int task_canceled_count_ = 0;
++};
+ class MockScriptedIdleTaskControllerScheduler final : public ThreadScheduler {
+  public:
+   explicit MockScriptedIdleTaskControllerScheduler(ShouldYield should_yield)
+@@ -68,9 +114,9 @@ class MockScriptedIdleTaskControllerScheduler final : public ThreadScheduler {
+ 
+   void RunIdleTask() { std::move(idle_task_).Run(base::TimeTicks()); }
+   bool HasIdleTask() const { return !!idle_task_; }
+-  scoped_refptr<base::SingleThreadTaskRunner> TaskRunner() {
+-    return task_runner_;
+-  }
++  Thread::IdleTask TakeIdleTask() { return std::move(idle_task_); }
++
++  scoped_refptr<TestTaskRunner> TaskRunner() { return task_runner_; }
+ 
+   void AdvanceTimeAndRun(base::TimeDelta delta) {
+     task_runner_->AdvanceTimeAndRun(delta);
+@@ -82,8 +128,8 @@ class MockScriptedIdleTaskControllerScheduler final : public ThreadScheduler {
+   v8::Isolate* isolate_;
+   bool should_yield_;
+   Thread::IdleTask idle_task_;
+-  scoped_refptr<scheduler::FakeTaskRunner> task_runner_ =
+-      base::MakeRefCounted<scheduler::FakeTaskRunner>();
++  scoped_refptr<TestTaskRunner> task_runner_ =
++      base::MakeRefCounted<TestTaskRunner>();
+ };
+ 
+ class IdleTaskControllerFrameScheduler : public FrameScheduler {
+@@ -205,7 +251,7 @@ TEST(ScriptedIdleTaskControllerTest, RunCallback) {
+   EXPECT_FALSE(scheduler.HasIdleTask());
+   int id = controller->RegisterCallback(idle_task, options);
+   EXPECT_TRUE(scheduler.HasIdleTask());
+-  EXPECT_NE(0, id);
++  EXPECT_NE(id, 0);
+ 
+   EXPECT_CALL(*idle_task, invoke(testing::_));
+   scheduler.RunIdleTask();
+@@ -272,4 +318,66 @@ TEST(ScriptedIdleTaskControllerTest, RunCallbacksAsyncWhenUnpaused) {
+   testing::Mock::VerifyAndClearExpectations(idle_task);
+ }
+ 
++TEST(ScriptedIdleTaskControllerTest, LongTimeoutShouldBeRemoveFromQueue) {
++  test::TaskEnvironment task_environment;
++  MockScriptedIdleTaskControllerScheduler scheduler(ShouldYield(false));
++  ScopedSchedulerOverrider scheduler_overrider(&scheduler,
++                                               scheduler.TaskRunner());
++  ScopedNullExecutionContext execution_context(
++      std::make_unique<IdleTaskControllerFrameScheduler>(&scheduler));
++  ScriptedIdleTaskController* controller = ScriptedIdleTaskController::Create(
++      &execution_context.GetExecutionContext());
++
++  // Register an idle task with a deadline.
++  Persistent<MockIdleTask> idle_task(MakeGarbageCollected<MockIdleTask>());
++  IdleRequestOptions* options = IdleRequestOptions::Create();
++  options->setTimeout(1000000);
++  int id = controller->RegisterCallback(idle_task, options);
++  EXPECT_NE(id, 0);
++  EXPECT_EQ(scheduler.TaskRunner()->GetTaskCanceledCount(), 0);
++
++  // Run the task.
++  EXPECT_CALL(*idle_task, invoke(testing::_));
++  scheduler.RunIdleTask();
++  testing::Mock::VerifyAndClearExpectations(idle_task);
++
++  // The timeout task should be removed from the task queue.
++  // Failure to do so is likely to result in OOM.
++  EXPECT_EQ(scheduler.TaskRunner()->GetTaskCanceledCount(), 1);
++}
++
++TEST(ScriptedIdleTaskControllerTest, RunAfterSchedulerWasDeleted) {
++  test::TaskEnvironment task_environment;
++  scoped_refptr<TestTaskRunner> task_runner;
++  Thread::IdleTask thead_idle_task;
++
++  Persistent<MockIdleTask> idle_task(MakeGarbageCollected<MockIdleTask>());
++  IdleRequestOptions* options = IdleRequestOptions::Create();
++  options->setTimeout(1);
++
++  {
++    MockScriptedIdleTaskControllerScheduler scheduler(ShouldYield(false));
++    task_runner = scheduler.TaskRunner();
++    ScopedSchedulerOverrider scheduler_overrider(&scheduler, task_runner);
++    ScopedNullExecutionContext execution_context(
++        std::make_unique<IdleTaskControllerFrameScheduler>(&scheduler));
++    ScriptedIdleTaskController* controller = ScriptedIdleTaskController::Create(
++        &execution_context.GetExecutionContext());
++
++    // Register an idle task with a deadline.
++    int id = controller->RegisterCallback(idle_task, options);
++    EXPECT_NE(id, 0);
++
++    thead_idle_task = scheduler.TakeIdleTask();
++
++    // `scheduler` is deleted here.
++  }
++
++  EXPECT_CALL(*idle_task, invoke(testing::_)).Times(0);
++  std::move(thead_idle_task).Run(base::TimeTicks());
++  testing::Mock::VerifyAndClearExpectations(idle_task);
++
++  EXPECT_EQ(task_runner->GetTaskCanceledCount(), 1);
++}
++
+ }  // namespace blink

--- a/patches/third_party-blink-renderer-platform-scheduler-test-fake_task_runner.h.patch
+++ b/patches/third_party-blink-renderer-platform-scheduler-test-fake_task_runner.h.patch
@@ -1,0 +1,22 @@
+diff --git a/third_party/blink/renderer/platform/scheduler/test/fake_task_runner.h b/third_party/blink/renderer/platform/scheduler/test/fake_task_runner.h
+index 06257a927140c1ffd122a4fce925990e59d373da..97570910d8cde38631068a8233e5c9377d674605 100644
+--- a/third_party/blink/renderer/platform/scheduler/test/fake_task_runner.h
++++ b/third_party/blink/renderer/platform/scheduler/test/fake_task_runner.h
+@@ -42,6 +42,8 @@ class FakeTaskRunner : public base::SingleThreadTaskRunner {
+   Deque<PendingTask> TakePendingTasksForTesting();
+ 
+  protected:
++  ~FakeTaskRunner() override;
++
+   bool PostDelayedTask(const base::Location& location,
+                        base::OnceClosure task,
+                        base::TimeDelta delay) override;
+@@ -55,8 +57,6 @@ class FakeTaskRunner : public base::SingleThreadTaskRunner {
+                                   base::TimeDelta delay) override;
+ 
+  private:
+-  ~FakeTaskRunner() override;
+-
+   class Data;
+   class BaseTaskRunner;
+   scoped_refptr<Data> data_;

--- a/patches/third_party-blink-tools-blinkpy-presubmit-audit_non_blink_usage.py.patch
+++ b/patches/third_party-blink-tools-blinkpy-presubmit-audit_non_blink_usage.py.patch
@@ -1,0 +1,21 @@
+diff --git a/third_party/blink/tools/blinkpy/presubmit/audit_non_blink_usage.py b/third_party/blink/tools/blinkpy/presubmit/audit_non_blink_usage.py
+index 02a23e9788a6b28b853b67b12b109bc089d2a62d..3bf43e8d1dbcd129e5ba9b02c4c51bef2c0db0c8 100755
+--- a/third_party/blink/tools/blinkpy/presubmit/audit_non_blink_usage.py
++++ b/third_party/blink/tools/blinkpy/presubmit/audit_non_blink_usage.py
+@@ -1136,6 +1136,16 @@ _CONFIG = [
+             'media::OutputDeviceStatus',
+         ],
+     },
++    {
++        'paths': [
++            'third_party/blink/renderer/core/dom/scripted_idle_task_controller.cc',
++            'third_party/blink/renderer/core/dom/scripted_idle_task_controller.h',
++            ],
++        'allowed': [
++            'base::DelayedTaskHandle',
++            'base::subtle::PostDelayedTaskPassKey',
++        ],
++    },
+     {
+         'paths': ['third_party/blink/renderer/core/style/computed_style.h'],
+         'allowed': [


### PR DESCRIPTION
For https://github.com/brave/brave-browser/issues/36356

Back-porting a successfully upstreamed CL to reduce the number of OOM in ScriptedIdleTaskController.
I hope that helps to reduce the number of Spotify background crashes.

The main CL: https://crrev.com/c/5670619
A DCHECK fix: https://crrev.com/c/5698346

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

