### PR TITLE
fix(AIChat): Update Leo advanced settings header copy (uplift to 1.69.x)

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -556,7 +556,7 @@ extension Strings {
       "aichat.advancedSettingsHeaderTitle",
       tableName: "BraveLeo",
       bundle: .module,
-      value: "Leo is an AI-powered smart assistant. Built right into the browser.",
+      value: "Leo is an AI-powered smart assistant, built right into the browser.",
       comment: "The title for the header for adjusting leo ai settings"
     )
     public static let advancedSettingsSubscriptionStatusTitle = NSLocalizedString(


### PR DESCRIPTION
Uplift of #24710
Resolves https://github.com/brave/brave-browser/issues/39800

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.