### PR TITLE
Update day-zero browser UI experiment

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -69,10 +69,6 @@
 #include "extensions/browser/extension_system.h"
 #endif
 
-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
-#include "brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
-#endif
-
 BraveBrowserMainParts::BraveBrowserMainParts(bool is_integration_test,
                                              StartupData* startup_data)
     : ChromeBrowserMainParts(is_integration_test, startup_data) {}
@@ -96,13 +92,6 @@ void BraveBrowserMainParts::PreBrowserStart() {
   // TODO(keur): Can we DCHECK the latter condition?
   DCHECK(sessions::ContentSerializedNavigationDriver::GetInstance());
   speedreader::SpeedreaderExtendedInfoHandler::Register();
-#endif
-
-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
-  // As DayZeroBrowserUIExptManager uses first run sentinel time,
-  // PreBrowserStart() is good place to initialize.
-  day_zero_browser_ui_expt_manager_ =
-      DayZeroBrowserUIExptManager::Create(g_browser_process->profile_manager());
 #endif
 
   ChromeBrowserMainParts::PreBrowserStart();

--- a/browser/brave_browser_main_parts.h
+++ b/browser/brave_browser_main_parts.h
@@ -6,13 +6,7 @@
 #ifndef BRAVE_BROWSER_BRAVE_BROWSER_MAIN_PARTS_H_
 #define BRAVE_BROWSER_BRAVE_BROWSER_MAIN_PARTS_H_
 
-#include <memory>
-
 #include "chrome/browser/chrome_browser_main.h"
-
-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
-class DayZeroBrowserUIExptManager;
-#endif
 
 class BraveBrowserMainParts : public ChromeBrowserMainParts {
  public:
@@ -31,11 +25,6 @@ class BraveBrowserMainParts : public ChromeBrowserMainParts {
 
  private:
   friend class ChromeBrowserMainExtraPartsTor;
-
-#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
-  std::unique_ptr<DayZeroBrowserUIExptManager>
-      day_zero_browser_ui_expt_manager_;
-#endif
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_BROWSER_MAIN_PARTS_H_

--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -94,6 +94,10 @@
 #include "brave/components/brave_vpn/browser/connection/brave_vpn_connection_manager.h"
 #endif
 
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
+#include "brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
+#endif
+
 using brave_component_updater::BraveComponent;
 using ntp_background_images::NTPBackgroundImagesService;
 
@@ -153,6 +157,11 @@ void BraveBrowserProcessImpl::Init() {
       tor::prefs::kTorDisabled,
       base::BindRepeating(&BraveBrowserProcessImpl::OnTorEnabledChanged,
                           base::Unretained(this)));
+#endif
+
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
+  day_zero_browser_ui_expt_manager_ =
+      DayZeroBrowserUIExptManager::Create(profile_manager());
 #endif
 
   InitSystemRequestHandlerCallback();

--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -89,6 +89,10 @@ class BraveStatsHelper;
 class ResourceComponent;
 }  // namespace brave_ads
 
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
+class DayZeroBrowserUIExptManager;
+#endif
+
 class BraveBrowserProcessImpl : public BraveBrowserProcess,
                                 public BrowserProcessImpl {
  public:
@@ -219,6 +223,11 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
   std::unique_ptr<brave::BraveFarblingService> brave_farbling_service_;
   std::unique_ptr<misc_metrics::ProcessMiscMetrics> process_misc_metrics_;
   std::unique_ptr<brave_ads::BraveStatsHelper> brave_stats_helper_;
+
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
+  std::unique_ptr<DayZeroBrowserUIExptManager>
+      day_zero_browser_ui_expt_manager_;
+#endif
 };
 
 #endif  // BRAVE_BROWSER_BRAVE_BROWSER_PROCESS_IMPL_H_

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -44,6 +44,10 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
+#include "brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
+#endif
+
 #if BUILDFLAG(ENABLE_TOR)
 #include "brave/components/tor/tor_profile_service.h"
 #endif
@@ -155,6 +159,10 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN) || BUILDFLAG(ENABLE_AI_CHAT)
   skus::RegisterLocalStatePrefs(registry);
+#endif
+
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_ANDROID)
+  DayZeroBrowserUIExptManager::RegisterLocalStatePrefs(registry);
 #endif
 
   registry->RegisterStringPref(::prefs::kBraveVpnDnsConfig, std::string());

--- a/browser/day_zero_browser_ui_expt/BUILD.gn
+++ b/browser/day_zero_browser_ui_expt/BUILD.gn
@@ -27,7 +27,6 @@ source_set("unit_tests") {
 }
 
 source_set("browser_tests") {
-if (is_win) {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
 
@@ -37,10 +36,10 @@ if (is_win) {
     "//base",
     "//brave/components/brave_rewards/common",
     "//chrome/browser",
+    "//chrome/browser:browser_process",
     "//chrome/browser/ui",
     "//chrome/test:test_support_ui",
     "//components/prefs",
     "//content/test:test_support",
   ]
-  }
 }

--- a/browser/day_zero_browser_ui_expt/BUILD.gn
+++ b/browser/day_zero_browser_ui_expt/BUILD.gn
@@ -17,6 +17,7 @@ source_set("unit_tests") {
     "//brave/components/brave_wallet/browser:pref_names",
     "//brave/components/ntp_background_images/browser",
     "//brave/components/ntp_background_images/common",
+    "//brave/components/p3a",
     "//chrome/browser/ui",
     "//chrome/test:test_support",
     "//components/prefs",

--- a/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_browsertest.cc
+++ b/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_browsertest.cc
@@ -3,10 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <variant>
+
 #include "base/command_line.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/brave_browser_features.h"
+#include "brave/browser/day_zero_browser_ui_expt/pref_names.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/first_run/first_run.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -17,12 +21,9 @@
 #include "content/public/test/browser_test.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-// Check DayZeroBrowserUIExptManager is initialized properly.
-// This test will catch first run sentinel creation time fetching timing
-// changes.
 class DayZeroBrowserUIExptBrowserTest
     : public InProcessBrowserTest,
-      public testing::WithParamInterface<bool> {
+      public ::testing::WithParamInterface<std::tuple<bool, bool>> {
  public:
   DayZeroBrowserUIExptBrowserTest() {
     if (IsDayZeroEnabled()) {
@@ -36,10 +37,12 @@ class DayZeroBrowserUIExptBrowserTest
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
     // In browser test, first run sentinel file is not created w/o this switch.
-    command_line->AppendSwitch(switches::kForceFirstRun);
+    command_line->AppendSwitch(IsFirstRun() ? switches::kForceFirstRun
+                                            : switches::kNoFirstRun);
   }
 
-  bool IsDayZeroEnabled() { return GetParam(); }
+  bool IsDayZeroEnabled() { return std::get<0>(GetParam()); }
+  bool IsFirstRun() { return std::get<1>(GetParam()); }
 
   base::test::ScopedFeatureList feature_list_;
 };
@@ -47,12 +50,49 @@ class DayZeroBrowserUIExptBrowserTest
 IN_PROC_BROWSER_TEST_P(DayZeroBrowserUIExptBrowserTest, InitTest) {
   auto* prefs = browser()->profile()->GetPrefs();
 
-  // Button is hidden by default when expt feature is enabled.
   const bool button_is_hidden =
       !prefs->GetBoolean(brave_rewards::prefs::kShowLocationBarButton);
+
+  // We don't apply day-zero experiment to existing users.
+  if (!IsFirstRun()) {
+    EXPECT_FALSE(button_is_hidden);
+    return;
+  }
+
+  // Button is hidden by default when expt feature is enabled.
   EXPECT_EQ(IsDayZeroEnabled(), button_is_hidden);
 }
 
 INSTANTIATE_TEST_SUITE_P(DayZeroExpt,
                          DayZeroBrowserUIExptBrowserTest,
-                         testing::Bool());
+                         testing::Combine(testing::Bool(), testing::Bool()));
+
+class DayZeroBrowserUIExptSecondLaunchBrowserTest
+    : public InProcessBrowserTest {
+ public:
+  DayZeroBrowserUIExptSecondLaunchBrowserTest() {
+    feature_list_.InitAndEnableFeatureWithParameters(
+        features::kBraveDayZeroExperiment, {{"variant", "a"}});
+  }
+
+  ~DayZeroBrowserUIExptSecondLaunchBrowserTest() override = default;
+
+  base::test::ScopedFeatureList feature_list_;
+};
+
+IN_PROC_BROWSER_TEST_F(DayZeroBrowserUIExptSecondLaunchBrowserTest,
+                       PRE_SecondLaunch) {
+  // To simulate this is first run and day-zero experiment is applied.
+  g_browser_process->local_state()->SetBoolean(kDayZeroExperimentTargetInstall,
+                                               true);
+}
+
+// Check day-zero experiment is stiil applied at non first run if it's applied
+// at first run.
+IN_PROC_BROWSER_TEST_F(DayZeroBrowserUIExptSecondLaunchBrowserTest,
+                       SecondLaunch) {
+  auto* prefs = browser()->profile()->GetPrefs();
+  const bool button_is_hidden =
+      !prefs->GetBoolean(brave_rewards::prefs::kShowLocationBarButton);
+  EXPECT_TRUE(button_is_hidden);
+}

--- a/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc
+++ b/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc
@@ -6,11 +6,10 @@
 #include "brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h"
 
 #include <string>
-#include "base/check_is_test.h"
-#include "base/command_line.h"
-#include "base/time/time.h"
+
 #include "brave/browser/brave_browser_features.h"
 #include "brave/browser/brave_stats/first_run_util.h"
+#include "brave/browser/day_zero_browser_ui_expt/pref_names.h"
 #include "brave/components/brave_news/common/locales_helper.h"
 #include "brave/components/brave_news/common/pref_names.h"
 #include "brave/components/brave_rewards/common/pref_names.h"
@@ -20,6 +19,7 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/profiles/profile_manager.h"
+#include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -28,9 +28,11 @@
 #include "brave/build/android/jni_headers/DayZeroHelper_jni.h"
 #endif  // #BUILDFLAG(IS_ANDROID)
 
-namespace {
-constexpr int kDayZeroFeatureDurationInDays = 1;
-}  // namespace
+// static
+void DayZeroBrowserUIExptManager::RegisterLocalStatePrefs(
+    PrefRegistrySimple* registry) {
+  registry->RegisterBooleanPref(kDayZeroExperimentTargetInstall, false);
+}
 
 // static
 std::unique_ptr<DayZeroBrowserUIExptManager>
@@ -39,37 +41,34 @@ DayZeroBrowserUIExptManager::Create(ProfileManager* profile_manager) {
     return nullptr;
   }
 
-  // This class should be instantiated after getting valid first run time;
-  if (brave_stats::GetFirstRunTime(g_browser_process->local_state())
-          .is_null()) {
-    // This should not be happened in production but not 100% in the wild(ex,
-    // corrupted user data). Just early return for safe. If upstream changes the
-    // timing of fetching first run time, browser test will catch this.
-    LOG(ERROR) << __func__ << " This should be happened only on test.";
-    return nullptr;
-  }
-
   std::optional<std::string> day_zero_variant;
   if (base::FeatureList::IsEnabled(features::kBraveDayZeroExperiment)) {
     day_zero_variant = features::kBraveDayZeroExperimentVariant.Get();
   }
 
+  CHECK(g_browser_process && g_browser_process->local_state());
+  auto* local_state = g_browser_process->local_state();
   if (!day_zero_variant) {
-    LOG(ERROR) << __func__ << "Day zero Expt variant is not available";
+    VLOG(2) << __func__ << ": Day zero Expt variant is not available";
+    local_state->SetBoolean(kDayZeroExperimentTargetInstall, false);
     return nullptr;
   }
 
   if (day_zero_variant != "a") {
-    LOG(ERROR) << __func__ << "Day zero Expt variant is not 'a'";
+    VLOG(2) << __func__ << ": Day zero Expt variant is not 'a'";
+    local_state->SetBoolean(kDayZeroExperimentTargetInstall, false);
     return nullptr;
   }
 
-  // If one day passed since first run, we don't need to touch original default
-  // pref values. Just early return and this class is no-op.
-  if (base::Time::Now() -
-          brave_stats::GetFirstRunTime(g_browser_process->local_state()) >=
-      base::Days(kDayZeroFeatureDurationInDays)) {
-    VLOG(2) << __func__ << " Already passed day zero feature duration.";
+  if (brave_stats::IsFirstRun(local_state)) {
+    VLOG(2) << __func__ << ": Set Day zero experiment to this fresh user.";
+    local_state->SetBoolean(kDayZeroExperimentTargetInstall, true);
+  }
+
+  if (!local_state->GetBoolean(kDayZeroExperimentTargetInstall)) {
+    VLOG(2) << __func__
+            << ": This is existing user. Day zero experiment is only applied "
+               "to fresh user.";
     return nullptr;
   }
 
@@ -78,10 +77,8 @@ DayZeroBrowserUIExptManager::Create(ProfileManager* profile_manager) {
 }
 
 DayZeroBrowserUIExptManager::DayZeroBrowserUIExptManager(
-    ProfileManager* profile_manager,
-    std::optional<base::Time> mock_first_run_time)
-    : profile_manager_(*profile_manager),
-      first_run_time_for_testing_(mock_first_run_time) {
+    ProfileManager* profile_manager)
+    : profile_manager_(*profile_manager) {
   for (auto* profile : profile_manager_->GetLoadedProfiles()) {
     if (!profile->IsRegularProfile()) {
       continue;
@@ -91,7 +88,6 @@ DayZeroBrowserUIExptManager::DayZeroBrowserUIExptManager(
   }
 
   observation_.Observe(&(*profile_manager_));
-  StartResetTimer();
 }
 
 DayZeroBrowserUIExptManager::~DayZeroBrowserUIExptManager() {
@@ -163,38 +159,4 @@ void DayZeroBrowserUIExptManager::ResetBrowserUIStateForAllProfiles() {
 
     ResetForDayZeroBrowserUI(profile);
   }
-}
-
-void DayZeroBrowserUIExptManager::StartResetTimer() {
-  auto remained_time_to_expt_duration_since_first_run =
-      GetFirstRunTime() - base::Time::Now();
-
-  // Convenient switch only for testing purpose.
-  constexpr char kUseShortExpirationForDayZeroExpt[] =
-      "use-short-expiration-for-day-zero-expt";
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          kUseShortExpirationForDayZeroExpt)) {
-    remained_time_to_expt_duration_since_first_run += base::Minutes(2);
-  } else {
-    remained_time_to_expt_duration_since_first_run +=
-        base::Days(kDayZeroFeatureDurationInDays);
-  }
-
-  // If remained time is negative, reset to original here.
-  if (remained_time_to_expt_duration_since_first_run < base::TimeDelta()) {
-    ResetBrowserUIStateForAllProfiles();
-    return;
-  }
-
-  reset_timer_.Start(
-      FROM_HERE, remained_time_to_expt_duration_since_first_run, this,
-      &DayZeroBrowserUIExptManager::ResetBrowserUIStateForAllProfiles);
-}
-
-base::Time DayZeroBrowserUIExptManager::GetFirstRunTime() const {
-  if (first_run_time_for_testing_) {
-    return *first_run_time_for_testing_;
-  }
-
-  return brave_stats::GetFirstRunTime(g_browser_process->local_state());
 }

--- a/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h
+++ b/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h
@@ -11,15 +11,16 @@
 
 #include "base/memory/raw_ref.h"
 #include "base/scoped_observation.h"
-#include "base/time/time.h"
-#include "base/timer/timer.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
 
+class PrefRegistrySimple;
 class Profile;
 class ProfileManager;
 
+// Handling browser UI for day-zero experiment.
 class DayZeroBrowserUIExptManager : public ProfileManagerObserver {
  public:
+  static void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
   static std::unique_ptr<DayZeroBrowserUIExptManager> Create(
       ProfileManager* profile_manager);
 
@@ -35,21 +36,13 @@ class DayZeroBrowserUIExptManager : public ProfileManagerObserver {
  private:
   friend class DayZeroBrowserUIExptTest;
 
-  // |mock_first_run_time| only for testing.
-  DayZeroBrowserUIExptManager(
-      ProfileManager* profile_manager,
-      std::optional<base::Time> mock_first_run_time = std::nullopt);
+  explicit DayZeroBrowserUIExptManager(ProfileManager* profile_manager);
 
   void SetForDayZeroBrowserUI(Profile* profile);
   void ResetForDayZeroBrowserUI(Profile* profile);
   void ResetBrowserUIStateForAllProfiles();
-  void StartResetTimer();
-  base::Time GetFirstRunTime() const;
 
-  // When fire, we'll reset browser UI to original.
-  base::OneShotTimer reset_timer_;
   raw_ref<ProfileManager> profile_manager_;
-  std::optional<base::Time> first_run_time_for_testing_;
   base::ScopedObservation<ProfileManager, ProfileManagerObserver> observation_{
       this};
 };

--- a/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h
+++ b/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h
@@ -7,13 +7,15 @@
 #define BRAVE_BROWSER_DAY_ZERO_BROWSER_UI_EXPT_DAY_ZERO_BROWSER_UI_EXPT_MANAGER_H_
 
 #include <memory>
-#include <optional>
+#include <string>
 
 #include "base/memory/raw_ref.h"
 #include "base/scoped_observation.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
+#include "components/prefs/pref_member.h"
 
 class PrefRegistrySimple;
+class PrefService;
 class Profile;
 class ProfileManager;
 
@@ -36,13 +38,18 @@ class DayZeroBrowserUIExptManager : public ProfileManagerObserver {
  private:
   friend class DayZeroBrowserUIExptTest;
 
-  explicit DayZeroBrowserUIExptManager(ProfileManager* profile_manager);
+  DayZeroBrowserUIExptManager(ProfileManager* profile_manager,
+                              PrefService* local_state);
 
   void SetForDayZeroBrowserUI(Profile* profile);
   void ResetForDayZeroBrowserUI(Profile* profile);
   void ResetBrowserUIStateForAllProfiles();
+  void OnP3AEnabledChanged(const std::string& pref_names);
+  bool IsP3AEnabled() const;
+  void SetDayZeroBrowserUIForAllProfiles();
 
   raw_ref<ProfileManager> profile_manager_;
+  BooleanPrefMember p3a_enabled_;
   base::ScopedObservation<ProfileManager, ProfileManagerObserver> observation_{
       this};
 };

--- a/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_unittest.cc
+++ b/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_unittest.cc
@@ -13,11 +13,14 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
+#include "brave/components/p3a/p3a_service.h"
+#include "brave/components/p3a/pref_names.h"
 #include "chrome/browser/profiles/profile_manager_observer.h"
 #include "chrome/test/base/testing_browser_process.h"
 #include "chrome/test/base/testing_profile.h"
 #include "chrome/test/base/testing_profile_manager.h"
 #include "components/prefs/pref_service.h"
+#include "components/prefs/testing_pref_service.h"
 #include "components/sync_preferences/testing_pref_service_syncable.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -32,10 +35,12 @@ class DayZeroBrowserUIExptTest : public testing::Test,
   void SetUp() override {
     ASSERT_TRUE(testing_profile_manager_.SetUp());
     observation_.Observe(g_browser_process->profile_manager());
+    p3a::P3AService::RegisterPrefs(testing_local_state_.registry(), true);
+
     if (IsDayZeroEnabled()) {
       // base::WrapUnique for using private ctor.
       manager_ = base::WrapUnique(new DayZeroBrowserUIExptManager(
-          g_browser_process->profile_manager()));
+          g_browser_process->profile_manager(), &testing_local_state_));
     }
   }
 
@@ -84,6 +89,7 @@ class DayZeroBrowserUIExptTest : public testing::Test,
   }
 
   content::BrowserTaskEnvironment task_environment_;
+  TestingPrefServiceSimple testing_local_state_;
   TestingProfileManager testing_profile_manager_;
   base::test::ScopedFeatureList feature_list_;
   std::unique_ptr<DayZeroBrowserUIExptManager> manager_;
@@ -105,6 +111,11 @@ TEST_P(DayZeroBrowserUIExptTest, PrefsTest) {
     CheckBrowserHasOriginalUI(profile);
     CheckBrowserHasOriginalUI(profile2);
   }
+
+  // Disable p3a and check ui is back to original.
+  testing_local_state_.SetBoolean(p3a::kP3AEnabled, false);
+  CheckBrowserHasOriginalUI(profile);
+  CheckBrowserHasOriginalUI(profile2);
 }
 
 INSTANTIATE_TEST_SUITE_P(DayZeroExpt,

--- a/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_unittest.cc
+++ b/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_unittest.cc
@@ -27,26 +27,15 @@ class DayZeroBrowserUIExptTest : public testing::Test,
                                  public testing::WithParamInterface<bool> {
  public:
   DayZeroBrowserUIExptTest()
-      : task_environment_(base::test::TaskEnvironment::TimeSource::MOCK_TIME),
-        testing_profile_manager_(TestingBrowserProcess::GetGlobal()) {
-    if (IsDayZeroEnabled()) {
-      feature_list_.InitAndEnableFeature(features::kBraveDayZeroExperiment);
-    }
-  }
+      : testing_profile_manager_(TestingBrowserProcess::GetGlobal()) {}
 
   void SetUp() override {
     ASSERT_TRUE(testing_profile_manager_.SetUp());
     observation_.Observe(g_browser_process->profile_manager());
     if (IsDayZeroEnabled()) {
-      // Get mock first run time and uset it for current time also.
-      base::Time first_run_time;
-      if (base::Time::FromString("2500-01-01", &first_run_time)) {
-        task_environment_.AdvanceClock(first_run_time - base::Time::Now());
-      }
-
       // base::WrapUnique for using private ctor.
       manager_ = base::WrapUnique(new DayZeroBrowserUIExptManager(
-          g_browser_process->profile_manager(), first_run_time));
+          g_browser_process->profile_manager()));
     }
   }
 
@@ -116,13 +105,6 @@ TEST_P(DayZeroBrowserUIExptTest, PrefsTest) {
     CheckBrowserHasOriginalUI(profile);
     CheckBrowserHasOriginalUI(profile2);
   }
-
-  // Advance 1-day and check prefs value are reset.
-  task_environment_.AdvanceClock(base::Days(1));
-  base::RunLoop().RunUntilIdle();
-
-  CheckBrowserHasOriginalUI(profile);
-  CheckBrowserHasOriginalUI(profile2);
 }
 
 INSTANTIATE_TEST_SUITE_P(DayZeroExpt,

--- a/browser/day_zero_browser_ui_expt/pref_names.h
+++ b/browser/day_zero_browser_ui_expt/pref_names.h
@@ -1,0 +1,12 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_DAY_ZERO_BROWSER_UI_EXPT_PREF_NAMES_H_
+#define BRAVE_BROWSER_DAY_ZERO_BROWSER_UI_EXPT_PREF_NAMES_H_
+
+inline constexpr char kDayZeroExperimentTargetInstall[] =
+    "brave.day_zero_experiment.target_install";
+
+#endif  // BRAVE_BROWSER_DAY_ZERO_BROWSER_UI_EXPT_PREF_NAMES_H_

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -339,8 +339,6 @@ if (ethereum_remote_client_enabled) {
 if (is_android) {
   brave_chrome_browser_sources += [
     "//brave/browser/android/brave_init_android.cc",
-    "//brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc",
-    "//brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h",
     "//brave/browser/sync/brave_sync_devices_android.cc",
     "//brave/browser/sync/brave_sync_devices_android.h",
     "//chrome/browser/bookmarks/bookmark_html_writer.cc",
@@ -421,8 +419,6 @@ if (is_win) {
   brave_chrome_browser_sources += [
     "//brave/browser/brave_shell_integration_win.cc",
     "//brave/browser/brave_shell_integration_win.h",
-    "//brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc",
-    "//brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h",
     "//brave/browser/default_protocol_handler_utils_win.cc",
     "//brave/browser/default_protocol_handler_utils_win.h",
   ]
@@ -430,6 +426,14 @@ if (is_win) {
   brave_chrome_browser_deps += [
     "//chrome/install_static:install_static_util",
     "//chrome/installer/util:with_no_strings",
+  ]
+}
+
+if (is_win || is_android) {
+  brave_chrome_browser_sources += [
+    "//brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.cc",
+    "//brave/browser/day_zero_browser_ui_expt/day_zero_browser_ui_expt_manager.h",
+    "//brave/browser/day_zero_browser_ui_expt/pref_names.h",
   ]
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/39810

Deleted one-day expiration timer. day-zero browser UI experiment will be activated when feature is enabled.
Disabled day-zero experiment when p3a is disabled.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`DayZeroBrowserUIExptTest.PrefsTest`
`DayZeroBrowserUIExptBrowserTest`
`DayZeroBrowserUIExptSecondLaunchBrowserTest`

#### Fresh user
1. Launch with clean profile with `--enable-features=BraveDayZeroExperiment:variant/a` cmd args
2. Open NTP
3. Check day-zero UI change is applied (See https://github.com/brave/brave-core/pull/24116 for UI changes)

#### Existing user
1. Launch with existing profile with `--enable-features=BraveDayZeroExperiment:variant/a` cmd args
2. Check day-zero UI change is not applied

#### p3a testing
1. Launch with clean profile with `--enable-features=BraveDayZeroExperiment:variant/a` cmd args
2. Disable p3a in the welcome flow
3. Open NTP
4. Check day-zero UI change is not applied


#### For android testing
Please refer https://github.com/brave/brave-core/pull/24617
Like desktop, android also should off experiment when p3a is disabled
NOTE: don't need to check `One-day timeout test` part.