### PR TITLE
[Nala]: Support including the Nala CSS

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/theme_source.cc
+++ b/chromium_src/chrome/browser/ui/webui/theme_source.cc
@@ -1,0 +1,46 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/webui/theme_source.h"
+
+#include <string>
+
+#include "base/strings/strcat.h"
+#include "chrome/browser/ui/color/chrome_color_provider_utils.h"
+
+namespace {
+
+std::string MaybeNalaMappings(std::vector<std::string_view>& color_id_sets) {
+  auto it = base::ranges::find(color_id_sets, "nala");
+  if (it == color_id_sets.end()) {
+    return std::string();
+  }
+  color_id_sets.erase(it);
+
+  const std::vector<std::string> colors = {
+      "primary", "secondary", "tertiary", "neutral", "neutral-variant", "error",
+  };
+
+  const std::vector<char> tones = {0,  5,  10, 15, 20, 25, 30, 35, 40,
+                                   50, 60, 70, 80, 90, 95, 98, 99, 100};
+
+  std::string result;
+  for (const auto& color : colors) {
+    for (const auto& tone : tones) {
+      auto leo_color = base::StrCat(
+          {"--leo-color-", color, "-", base::NumberToString(tone)});
+      auto ui_color =
+          base::StrCat({"--color-ref-", color, base::NumberToString(tone)});
+      result += base::StrCat({leo_color, ":var(", ui_color, ");"});
+    }
+  }
+  return result;
+}
+
+}  // namespace
+
+#define ChromeColorIdName ChromeColorIdName), MaybeNalaMappings(color_id_sets
+#include "src/chrome/browser/ui/webui/theme_source.cc"
+#undef ChromeColorIdName

--- a/chromium_src/chrome/browser/ui/webui/theme_source.cc
+++ b/chromium_src/chrome/browser/ui/webui/theme_source.cc
@@ -7,17 +7,16 @@
 
 #include <string>
 
+#include "base/containers/contains.h"
 #include "base/strings/strcat.h"
 #include "chrome/browser/ui/color/chrome_color_provider_utils.h"
 
 namespace {
 
-std::string MaybeNalaMappings(std::vector<std::string_view>& color_id_sets) {
-  auto it = base::ranges::find(color_id_sets, "nala");
-  if (it == color_id_sets.end()) {
+std::string MaybeNalaMappings(const std::string& sets_param) {
+  if (!base::Contains(sets_param, "ui")) {
     return std::string();
   }
-  color_id_sets.erase(it);
 
   const std::vector<std::string> colors = {
       "primary", "secondary", "tertiary", "neutral", "neutral-variant", "error",
@@ -30,7 +29,7 @@ std::string MaybeNalaMappings(std::vector<std::string_view>& color_id_sets) {
   for (const auto& color : colors) {
     for (const auto& tone : tones) {
       auto leo_color = base::StrCat(
-          {"--leo-color-", color, "-", base::NumberToString(tone)});
+          {"--leo-color-primitive-", color, "-", base::NumberToString(tone)});
       auto ui_color =
           base::StrCat({"--color-ref-", color, base::NumberToString(tone)});
       result += base::StrCat({leo_color, ":var(", ui_color, ");"});
@@ -41,6 +40,6 @@ std::string MaybeNalaMappings(std::vector<std::string_view>& color_id_sets) {
 
 }  // namespace
 
-#define ChromeColorIdName ChromeColorIdName), MaybeNalaMappings(color_id_sets
+#define ChromeColorIdName ChromeColorIdName), MaybeNalaMappings(sets_param
 #include "src/chrome/browser/ui/webui/theme_source.cc"
 #undef ChromeColorIdName


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

Hey @petemill this is a little PoC of overriding the Nala material variables - if you include `nala` in the list of sets this will override the variables.

chrome://theme/colors.css?sets=ui,nala

Questions:
- Do we want to specify the `nala` set, or should it be implicit?
- Do we want to include the normal nala variables here?

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

