### PR TITLE
Fix issue with subframe engine scripts not working (uplift to 1.69.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/FrameCheckWrapper.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/FrameCheckWrapper.js
@@ -3,18 +3,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-'use strict'
-
 window.__firefox__.execute(function ($) {
   (_ => {
     // Because we can't inject scripts to specific frames (except main frame),
     // we need to check if this script belongs to this specific frame
     // so that it doesn't execute on the wrong frame.
-    const requiredHref = "$<required_href>"
+    const requiredHref = "$<required_href>";
     if (window.location.href !== requiredHref) {
-      return
+      return;
     }
 
     $<scriplet>
-  })()
-})
+  })();
+});


### PR DESCRIPTION
Uplift of #24739
Resolves https://github.com/brave/brave-browser/issues/39860

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.