### PR TITLE
[iOS] Add Leo to shortcuts widget

### DIFF
--- a/ios/brave-ios/App/BraveWidgets/Base.lproj/BraveWidgets.intentdefinition
+++ b/ios/brave-ios/App/BraveWidgets/Base.lproj/BraveWidgets.intentdefinition
@@ -178,6 +178,16 @@
 					<key>INEnumValueName</key>
 					<string>braveNews</string>
 				</dict>
+				<dict>
+					<key>INEnumValueDisplayName</key>
+					<string>Leo AI</string>
+					<key>INEnumValueDisplayNameID</key>
+					<string>U0eRbw</string>
+					<key>INEnumValueIndex</key>
+					<integer>11</integer>
+					<key>INEnumValueName</key>
+					<string>braveLeo</string>
+				</dict>
 			</array>
 		</dict>
 	</array>
@@ -186,11 +196,11 @@
 	<key>INIntentDefinitionNamespace</key>
 	<string>88xZPY</string>
 	<key>INIntentDefinitionSystemVersion</key>
-	<string>22D49</string>
+	<string>23F79</string>
 	<key>INIntentDefinitionToolsBuildVersion</key>
-	<string>14C18</string>
+	<string>15E204a</string>
 	<key>INIntentDefinitionToolsVersion</key>
-	<string>14.2</string>
+	<string>15.3</string>
 	<key>INIntents</key>
 	<array>
 		<dict>
@@ -308,7 +318,7 @@
 			<key>INIntentIneligibleForSuggestions</key>
 			<true/>
 			<key>INIntentLastParameterTag</key>
-			<integer>9</integer>
+			<integer>11</integer>
 			<key>INIntentName</key>
 			<string>ShortcutsConfiguration</string>
 			<key>INIntentParameters</key>
@@ -490,6 +500,66 @@
 					</array>
 					<key>INIntentParameterTag</key>
 					<integer>9</integer>
+					<key>INIntentParameterType</key>
+					<string>Integer</string>
+				</dict>
+				<dict>
+					<key>INIntentParameterConfigurable</key>
+					<true/>
+					<key>INIntentParameterDisplayName</key>
+					<string>#4</string>
+					<key>INIntentParameterDisplayNameID</key>
+					<string>M2Y1rg</string>
+					<key>INIntentParameterDisplayPriority</key>
+					<integer>4</integer>
+					<key>INIntentParameterEnumType</key>
+					<string>WidgetShortcut</string>
+					<key>INIntentParameterEnumTypeNamespace</key>
+					<string>88xZPY</string>
+					<key>INIntentParameterMetadata</key>
+					<dict>
+						<key>INIntentParameterMetadataDefaultValue</key>
+						<string>braveLeo</string>
+					</dict>
+					<key>INIntentParameterName</key>
+					<string>slot4</string>
+					<key>INIntentParameterPromptDialogs</key>
+					<array>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Configuration</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Primary</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>There are ${count} options matching ‘${slot4}’.</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>z517nu</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>DisambiguationIntroduction</string>
+						</dict>
+						<dict>
+							<key>INIntentParameterPromptDialogCustom</key>
+							<true/>
+							<key>INIntentParameterPromptDialogFormatString</key>
+							<string>Just to confirm, you wanted ‘${slot4}’?</string>
+							<key>INIntentParameterPromptDialogFormatStringID</key>
+							<string>EvESs0</string>
+							<key>INIntentParameterPromptDialogType</key>
+							<string>Confirmation</string>
+						</dict>
+					</array>
+					<key>INIntentParameterTag</key>
+					<integer>11</integer>
 					<key>INIntentParameterType</key>
 					<string>Integer</string>
 				</dict>

--- a/ios/brave-ios/App/BraveWidgets/ShortcutsWidget.swift
+++ b/ios/brave-ios/App/BraveWidgets/ShortcutsWidget.swift
@@ -46,6 +46,7 @@ private struct ShortcutProvider: IntentTimelineProvider {
         configuration.slot1,
         configuration.slot2,
         configuration.slot3,
+        configuration.slot4,
       ]
     )
     completion(entry)
@@ -69,6 +70,7 @@ private struct ShortcutProvider: IntentTimelineProvider {
         configuration.slot1,
         configuration.slot2,
         configuration.slot3,
+        configuration.slot4,
       ]
     )
     completion(.init(entries: [entry], policy: .never))
@@ -97,7 +99,7 @@ private struct ShortcutLink<Content: View>: View {
               .font(.system(size: 20))
               .frame(height: 24)
             Text(verbatim: text)
-              .font(.system(size: 13, weight: .medium))
+              .font(.system(size: 10, weight: .medium))
               .multilineTextAlignment(.center)
           }
           .padding(8)
@@ -144,6 +146,8 @@ extension WidgetShortcut {
       return Strings.Widgets.QRCode
     case .braveNews:
       return Strings.Widgets.braveNews
+    case .braveLeo:
+      return Strings.Widgets.braveLeo
     @unknown default:
       assertionFailure()
       return ""
@@ -175,6 +179,8 @@ extension WidgetShortcut {
       return Image(braveSystemName: "leo.qr.code")
     case .braveNews:
       return Image(braveSystemName: "leo.product.brave-news")
+    case .braveLeo:
+      return Image(braveSystemName: "leo.product.brave-leo")
     @unknown default:
       assertionFailure()
       return Image(systemName: "xmark.octagon")

--- a/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
+++ b/ios/brave-ios/App/BraveWidgets/WidgetStrings.swift
@@ -178,5 +178,11 @@ extension Strings {
       value: "Brave News",
       comment: "The name of the feature"
     )
+    public static let braveLeo = NSLocalizedString(
+      "widgets.braveLeo",
+      bundle: widgetBundle,
+      value: "Leo AI",
+      comment: "The name of the feature"
+    )
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -166,6 +166,9 @@ public enum NavigationPath: Equatable {
         return
       }
       newTabPageController.scrollToBraveNews()
+    case .braveLeo:
+      bvc.popToBVC()
+      bvc.openBraveLeo()
     @unknown default:
       assertionFailure()
       break


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/39886

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Add a new shortcut widget to both home screen and lock screen
- Verify that the new widget shows "Leo AI" as the 4th option by default
- Verify that the home screen widget shows "Leo AI" when editing its configuration 
- Verify that the lock screen widget shows "Leo AI" when editing its configuration 