### PR TITLE
Adds back certain UA client hints.

### DIFF
--- a/browser/test/disabled_features/disable_client_hints_browsertest.cc
+++ b/browser/test/disabled_features/disable_client_hints_browsertest.cc
@@ -176,9 +176,17 @@ class ClientHintsBrowserTest : public InProcessBrowserTest,
   void PopulateAllowedClientHints() {
     const auto& hints_map = network::GetClientHintToNameMap();
     allowed_hints_.push_back(
+        hints_map.at(network::mojom::WebClientHintsType::kUAArch));
+    allowed_hints_.push_back(
+        hints_map.at(network::mojom::WebClientHintsType::kUABitness));
+    allowed_hints_.push_back(
+        hints_map.at(network::mojom::WebClientHintsType::kUAFullVersionList));
+    allowed_hints_.push_back(
         hints_map.at(network::mojom::WebClientHintsType::kUAModel));
     allowed_hints_.push_back(
         hints_map.at(network::mojom::WebClientHintsType::kUAPlatformVersion));
+    allowed_hints_.push_back(
+        hints_map.at(network::mojom::WebClientHintsType::kUAWoW64));
   }
 
   void MonitorResourceRequest(const net::test_server::HttpRequest& request) {
@@ -224,7 +232,7 @@ IN_PROC_BROWSER_TEST_P(ClientHintsBrowserTest, ClientHintsDisabled) {
   }
 
   const size_t expected_default_client_hints_count = 3u;
-  const size_t expected_allowed_client_hints_count = 2u;
+  const size_t expected_allowed_client_hints_count = 6u;
 
   ASSERT_TRUE(
       ui_test_utils::NavigateToURL(browser(), no_client_hints_headers_url()));

--- a/chromium_src/components/embedder_support/user_agent_utils.cc
+++ b/chromium_src/components/embedder_support/user_agent_utils.cc
@@ -5,6 +5,8 @@
 
 #include "components/embedder_support/user_agent_utils.h"
 
+#include "base/strings/strcat.h"
+
 namespace {
 
 constexpr char kBraveBrandNameForCHUA[] = "Brave";
@@ -20,5 +22,9 @@ constexpr char kBraveBrandNameForCHUA[] = "Brave";
 // can't use it here in the //components.
 #define BRAVE_GET_USER_AGENT_BRAND_LIST brand = kBraveBrandNameForCHUA;
 
+#define BRAVE_BRAND_VERSION_OVERRIDE_FOR_FULL_BRAND_VERSION_TYPE \
+  base::StrCat({major_version, ".0.0.0"})
+
 #include "src/components/embedder_support/user_agent_utils.cc"
+#undef BRAVE_BRAND_VERSION_OVERRIDE_FOR_FULL_BRAND_VERSION_TYPE
 #undef BRAVE_GET_USER_AGENT_BRAND_LIST

--- a/chromium_src/third_party/blink/common/client_hints/enabled_client_hints.cc
+++ b/chromium_src/third_party/blink/common/client_hints/enabled_client_hints.cc
@@ -13,11 +13,15 @@
 #undef SetIsEnabled
 
 // By default we will send three (3) non-privacy-risking CHs: kUA, kUAMobile,
-// and kUAPlatform. Additionally, if we receive CH requests for
-// kUAPlatformVersion and/or kUAModel, we will send these, but:
-// - kUAModel will be always set to an empty string;
-// - kUAPlatformVersion will be clamped to the same value we report in the
-//   User-Agent string.
+// and kUAPlatform.
+// Additionally:
+//   - if we receive CH requests for kUAArch, kUABitness, kUAFullVersionList, or
+//   kUAWoW64, we will send these.
+//   - if we receive CH requests for kUAPlatformVersion and/or kUAModel, we will
+//   send these, too, but:
+//     - kUAModel will be always set to an empty string;
+//     - kUAPlatformVersion will be clamped to the same value we report in the
+//     User-Agent string.
 
 namespace blink {
 
@@ -26,10 +30,14 @@ void EnabledClientHints::SetIsEnabled(const WebClientHintsType type,
   bool type_is_enabled = false;
   switch (type) {
     case WebClientHintsType::kUA:
+    case WebClientHintsType::kUAArch:
+    case WebClientHintsType::kUABitness:
+    case WebClientHintsType::kUAFullVersionList:
     case WebClientHintsType::kUAMobile:
     case WebClientHintsType::kUAModel:
     case WebClientHintsType::kUAPlatform:
     case WebClientHintsType::kUAPlatformVersion:
+    case WebClientHintsType::kUAWoW64:
       type_is_enabled = true;
       break;
     default:

--- a/patches/components-embedder_support-user_agent_utils.cc.patch
+++ b/patches/components-embedder_support-user_agent_utils.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
-index 0d9ed98759c4bc39ae06b1c554079b6e12d3463d..b80d1c9e0d03b7be5c89bcaf2ddfeb19e827e53a 100644
+index 0d9ed98759c4bc39ae06b1c554079b6e12d3463d..6db0f586834fac7c787bd52c19d305903cbd8891 100644
 --- a/components/embedder_support/user_agent_utils.cc
 +++ b/components/embedder_support/user_agent_utils.cc
 @@ -190,6 +190,7 @@ const blink::UserAgentBrandList GetUserAgentBrandList(
@@ -10,3 +10,12 @@ index 0d9ed98759c4bc39ae06b1c554079b6e12d3463d..b80d1c9e0d03b7be5c89bcaf2ddfeb19
    std::optional<std::string> maybe_brand_override =
        base::GetFieldTrialParamValueByFeature(features::kGreaseUACH,
                                               "brand_override");
+@@ -203,7 +204,7 @@ const blink::UserAgentBrandList GetUserAgentBrandList(
+ 
+   std::string brand_version =
+       output_version_type == blink::UserAgentBrandVersionType::kFullVersion
+-          ? full_version
++          ? BRAVE_BRAND_VERSION_OVERRIDE_FOR_FULL_BRAND_VERSION_TYPE
+           : major_version;
+ 
+   return GenerateBrandVersionList(major_version_number, brand, brand_version,


### PR DESCRIPTION
- `Sec-CH-UA-Arch`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Arch
- `Sec-CH-UA-Bitness`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Bitness
- `Sec-CH-UA-Full-Version-List`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-Full-Version-List
- `Sec-CH-UA-WoW64`: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-CH-UA-WoW64

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/25694
Security review: https://github.com/brave/reviews/issues/1696

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Load YouTube live streams that have the chat enabled (e.g. https://www.youtube.com/watch?v=_uMuuHk_KkQ) multiple times, and make sure the `https://www.youtube.com/live_chat?continuation=...` requests never hang (i.e. live chat loads right away/together with the video/page — and not with a 20-sec delay). The 20-sec delay can easily be reprod on any channel/any version at the moment.