### PR TITLE
fix(wallet): set send amount to 1 when navigating to send NFT screen (uplift to 1.68.x)

### DIFF
--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -117,7 +117,9 @@ export const SendScreen = React.memo((props: Props) => {
   )
 
   // State
-  const [sendAmount, setSendAmount] = React.useState<string>('')
+  const [sendAmount, setSendAmount] = React.useState<string>(
+    selectedSendOption === '#nft' ? '1' : ''
+  )
   const [sendingMaxAmount, setSendingMaxAmount] = React.useState<boolean>(false)
   const [toAddressOrUrl, setToAddressOrUrl] = React.useState<string>('')
   const [resolvedDomainAddress, setResolvedDomainAddress] =


### PR DESCRIPTION
Uplift of #24778
Resolves https://github.com/brave/brave-browser/issues/39916

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.