### PR TITLE
fix(wallet): remove insurance field from LiFi routes (uplift to 1.69.x)

### DIFF
--- a/components/brave_wallet/browser/swap_response_parser.cc
+++ b/components/brave_wallet/browser/swap_response_parser.cc
@@ -555,11 +555,6 @@ mojom::LiFiQuotePtr ParseQuoteResponse(const base::Value& json_value) {
     route->to_amount_min = route_value.to_amount_min;
     route->to_address = route_value.to_address;
 
-    auto insurance = mojom::LiFiInsurance::New();
-    insurance->state = route_value.insurance.state;
-    insurance->fee_amount_usd = route_value.insurance.fee_amount_usd;
-    route->insurance = std::move(insurance);
-
     for (const auto& step_value : route_value.steps) {
       auto step = ParseStep(step_value);
       if (!step) {

--- a/components/brave_wallet/browser/swap_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/swap_response_parser_unittest.cc
@@ -859,10 +859,6 @@ TEST(SwapResponseParserUnitTest, ParseLiFiQuoteResponse) {
               "integrator": "jumper.exchange"
             }
           ],
-          "insurance": {
-            "state": "NOT_INSURABLE",
-            "feeAmountUsd": "0"
-          },
           "tags": [
             "RECOMMENDED",
             "CHEAPEST",
@@ -1073,8 +1069,6 @@ TEST(SwapResponseParserUnitTest, ParseLiFiQuoteResponse) {
     EXPECT_EQ(included_step_2_gas_cost->token->logo, "eth.png");
     EXPECT_FALSE(included_step_2->included_steps);
 
-    EXPECT_EQ(route->insurance->state, "NOT_INSURABLE");
-    EXPECT_EQ(route->insurance->fee_amount_usd, "0");
     ASSERT_EQ(route->tags.size(), 3u);
     EXPECT_EQ(route->tags.at(0), "RECOMMENDED");
     EXPECT_EQ(route->tags.at(1), "CHEAPEST");

--- a/components/brave_wallet/browser/swap_responses.idl
+++ b/components/brave_wallet/browser/swap_responses.idl
@@ -179,11 +179,6 @@ namespace swap_responses {
     DOMString logoURI;
   };
 
-  dictionary LiFiInsurance {
-    DOMString state;
-    DOMString feeAmountUsd;
-  };
-
   dictionary LiFiStep {
     DOMString id;
     DOMString type;
@@ -209,7 +204,6 @@ namespace swap_responses {
     LiFiToken toToken;
     DOMString toAddress;
     LiFiStep[] steps;
-    LiFiInsurance insurance;
     DOMString[] tags;
   };
 

--- a/components/brave_wallet/browser/swap_service_unittest.cc
+++ b/components/brave_wallet/browser/swap_service_unittest.cc
@@ -288,9 +288,6 @@ mojom::LiFiQuotePtr GetCannedLiFiQuote() {
       ->included_steps->at(0)
       ->estimate->gas_costs.push_back(gas_cost.Clone());
 
-  quote->routes[0]->insurance = mojom::LiFiInsurance::New();
-  quote->routes[0]->insurance->state = "NOT_INSURABLE";
-  quote->routes[0]->insurance->fee_amount_usd = "0";
   quote->routes[0]->tags = {"RECOMMENDED", "CHEAPEST", "FASTEST"};
 
   return quote;
@@ -1388,11 +1385,7 @@ TEST_F(SwapServiceUnitTest, GetLiFiQuote) {
             "RECOMMENDED",
             "CHEAPEST",
             "FASTEST"
-          ],
-          "insurance": {
-            "state": "NOT_INSURABLE",
-            "feeAmountUsd": "0"
-          }
+          ]
         }
       ],
       "unavailableRoutes": {

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -558,11 +558,6 @@ struct LiFiToolDetails {
   string logo;
 };
 
-struct LiFiInsurance {
-  string state;
-  string fee_amount_usd;
-};
-
 struct LiFiAction {
   BlockchainToken from_token;
   string from_amount;
@@ -625,7 +620,6 @@ struct LiFiRoute {
   string to_amount_min;
   string to_address;
   array<LiFiStep> steps;
-  LiFiInsurance insurance;
   array<string> tags;
 };
 

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockContent.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockContent.swift
@@ -714,7 +714,6 @@ extension BraveWallet.LiFiQuote {
             includedSteps: nil
           )
         ],
-        insurance: .init(state: "", feeAmountUsd: "0"),
         tags: []
       )
     ]


### PR DESCRIPTION
Uplift of #24771
Resolves https://github.com/brave/brave-browser/issues/39906

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.