### PR TITLE
[iOS] Improve VPN Country Server Details

### DIFF
--- a/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "ff70592ebbcf0591a1691ff8a735f9d3d366f406",
-        "version" : "1.9.2"
+        "revision" : "014e6b17580f28d493a793dcdedb7db6371b3ed0",
+        "version" : "1.9.3"
       }
     },
     {

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -67,7 +67,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.3.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.9.2"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "1.9.3"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(
       url: "https://github.com/venmo/Static",

--- a/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionDetailsView.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionDetailsView.swift
@@ -66,7 +66,11 @@ struct BraveRegionDetailsView: View {
     }
     .onAppear {
       let regions = cityRegions.map {
-        BraveVPNCityRegion(displayName: $0.displayName, regionName: $0.regionName)
+        BraveVPNCityRegion(
+          displayName: $0.displayName,
+          regionName: $0.regionName,
+          serverCount: Int(truncating: $0.serverCount)
+        )
       }
 
       cityRegionDetail.assignSelectedRegion(
@@ -107,14 +111,12 @@ struct BraveRegionDetailsView: View {
               : Color(braveSystemName: .textPrimary)
           )
 
-        if region.isAutomatic == true {
-          Text(Strings.VPN.vpnCityRegionOptimalDescription)
-            .foregroundStyle(
-              cityRegionDetail.selectedRegion == region
-                ? Color(braveSystemName: .textInteractive)
-                : Color(braveSystemName: .textPrimary)
-            )
-        }
+        Text(generateServerCountDetails(for: region))
+          .foregroundStyle(
+            cityRegionDetail.selectedRegion == region
+              ? Color(braveSystemName: .textInteractive)
+              : Color(braveSystemName: .textPrimary)
+          )
       }
       Spacer()
 
@@ -127,6 +129,18 @@ struct BraveRegionDetailsView: View {
     .onTapGesture {
       selectDesignatedVPNCity(region)
     }
+  }
+
+  private func generateServerCountDetails(for region: BraveVPNCityRegion) -> String {
+    let serverCount = region.serverCount
+
+    let serverCountTitle =
+      serverCount > 1
+      ? String(format: Strings.VPN.multipleServerCountTitle, serverCount)
+      : String(format: Strings.VPN.serverCountTitle, serverCount)
+
+    return region.isAutomatic == true
+      ? Strings.VPN.vpnCityRegionOptimalDescription : serverCountTitle
   }
 
   private func selectDesignatedVPNCity(_ region: BraveVPNCityRegion) {

--- a/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionListView.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionListView.swift
@@ -136,7 +136,6 @@ public struct BraveVPNRegionListView: View {
   @ViewBuilder
   private func countryRegionItem(at index: Int, region: GRDRegion) -> some View {
     let isSelectedRegion = region.countryISOCode == BraveVPN.activatedRegion?.countryISOCode
-    let serverCount = region.cities.count
 
     Button {
       selectDesignatedVPNRegion(at: index)
@@ -150,16 +149,12 @@ public struct BraveVPNRegionListView: View {
               isSelectedRegion
                 ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textPrimary)
             )
-          Text(
-            serverCount > 1
-              ? String(format: Strings.VPN.multipleServerCountTitle, serverCount)
-              : String(format: Strings.VPN.serverCountTitle, serverCount)
-          )
-          .font(.footnote)
-          .foregroundStyle(
-            isSelectedRegion
-              ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textSecondary)
-          )
+          Text(generateServerCountDetails(for: region))
+            .font(.footnote)
+            .foregroundStyle(
+              isSelectedRegion
+                ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textSecondary)
+            )
         }
         Spacer()
         if isSelectedRegion {
@@ -197,6 +192,23 @@ public struct BraveVPNRegionListView: View {
     .foregroundStyle(Color(braveSystemName: .textPrimary))
     .tint(.accentColor)
     .listRowBackground(Color(braveSystemName: .containerBackgroundMobile))
+  }
+
+  private func generateServerCountDetails(for region: GRDRegion) -> String {
+    let cityCount = region.cities.count
+    let serverCount = Int(truncating: region.serverCount)
+
+    let cityCountTitle =
+      cityCount > 1
+      ? String(format: Strings.VPN.multipleCityCountTitle, cityCount)
+      : String(format: Strings.VPN.cityCountTitle, cityCount)
+
+    let serverCountTitle =
+      serverCount > 1
+      ? String(format: Strings.VPN.multipleServerCountTitle, serverCount)
+      : String(format: Strings.VPN.serverCountTitle, serverCount)
+
+    return "\(cityCountTitle) - \(serverCountTitle)"
   }
 
   private func enableAutomaticServer(_ enabled: Bool) {

--- a/ios/brave-ios/Sources/BraveVPN/Models/BraveVPNRegion.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Models/BraveVPNRegion.swift
@@ -16,6 +16,7 @@ struct BraveVPNCityRegion: Identifiable, Equatable {
   let id = UUID()
   let displayName: String
   let regionName: String
+  var serverCount: Int = 0
   var isAutomatic = false
 }
 
@@ -31,21 +32,23 @@ class VPNCityRegionDetail: ObservableObject {
   var countryName: String = ""
 
   @Published var selectedRegion: BraveVPNCityRegion? = nil
-  
+
   func assignSelectedRegion(
     countryName: String,
-    cityRegions: [BraveVPNCityRegion])
-  {
+    cityRegions: [BraveVPNCityRegion]
+  ) {
     self.countryName = countryName
     self.cityRegions.append(contentsOf: cityRegions)
-    
-    let selectedCity = cityRegions.first (where: { $0.regionName ==  BraveVPN.selectedRegion?.regionName })
-    
+
+    let selectedCity = cityRegions.first(where: {
+      $0.regionName == BraveVPN.selectedRegion?.regionName
+    })
+
     guard let selectedCity = selectedCity else {
       selectedRegion = self.cityRegions.first
       return
     }
-    
+
     selectedRegion = selectedCity
   }
 }

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -834,20 +834,36 @@ extension Strings {
           "Text for description of toggle that auto selcets the server according to time zone."
       )
 
+    public static let cityCountTitle =
+      NSLocalizedString(
+        "vpn.cityCountTitle",
+        bundle: .module,
+        value: "%ld City",
+        comment: "Text indicating how many cities is used for that country used as Ex: '1 City'"
+      )
+
+    public static let multipleCityCountTitle =
+      NSLocalizedString(
+        "vpn.multipleCityCountTitle",
+        bundle: .module,
+        value: "%ld Cities",
+        comment: "Text indicating how many cities is used for that region used as Ex: '2 Cities'"
+      )
+
     public static let serverCountTitle =
       NSLocalizedString(
         "vpn.serverTitle",
         bundle: .module,
-        value: "%ld server",
-        comment: "Text indicating how many server is used for that region used as Ex: '1 server'"
+        value: "%ld Server",
+        comment: "Text indicating how many server is used for that region used as Ex: '1 Server'"
       )
 
     public static let multipleServerCountTitle =
       NSLocalizedString(
         "vpn.multipleServerCountTitle",
         bundle: .module,
-        value: "%ld servers",
-        comment: "Text indicating how many server is used for that region used as Ex: '2 servers'"
+        value: "%ld Servers",
+        comment: "Text indicating how many server is used for that region used as Ex: '2 Servers'"
       )
 
     public static let connectedRegionDescription =


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39824

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Screenshots:

![1test](https://github.com/user-attachments/assets/b8494f03-6324-4e91-a09f-921e1030f304)


https://github.com/user-attachments/assets/e057c557-eef1-4a21-b09b-f42d1e190880


## Test Plan:

- Check VPN Servers displaying properly server count and city count
