### PR TITLE
Implement a trusted source check for `Elevator::InstallVPNServices`

### DIFF
--- a/chromium_src/chrome/elevation_service/elevator.cc
+++ b/chromium_src/chrome/elevation_service/elevator.cc
@@ -28,6 +28,34 @@
 namespace elevation_service {
 
 HRESULT Elevator::InstallVPNServices() {
+  HRESULT hr = ::CoImpersonateClient();
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  {
+    absl::Cleanup revert_to_self = [] { ::CoRevertToSelf(); };
+
+    const auto process = GetCallingProcess();
+    if (!process.IsValid()) {
+      return kErrorCouldNotObtainCallingProcess;
+    }
+    const auto validation_data = GenerateValidationData(
+        ProtectionLevel::PROTECTION_PATH_VALIDATION, process);
+    if (!validation_data.has_value()) {
+      return validation_data.error();
+    }
+    const auto data = std::vector<uint8_t>(validation_data->cbegin(),
+                                           validation_data->cend());
+
+    // Note: Validation should always be done using caller impersonation token.
+    std::string log_message;
+    HRESULT validation_result = ValidateData(process, data, &log_message);
+    if (FAILED(validation_result)) {
+      return validation_result;
+    }
+  }
+
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   if (!brave_vpn::IsBraveVPNHelperServiceInstalled()) {
     auto success = brave_vpn::InstallBraveVPNHelperService(


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/39029

Uses caller validation logic from https://source.chromium.org/chromium/chromium/src/+/main:chrome/elevation_service/caller_validation.cc

Specifically, `ProtectionLevel::PROTECTION_PATH_VALIDATION` which calls `ValidatePath`.

This is based on an example from Chromium in:
https://source.chromium.org/chromium/chromium/src/+/main:chrome/elevation_service/elevator.cc

Please see the references in the code there to `ValidateData`.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used GitHub [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Testing before the fix
1. Install a version of Brave which does NOT have the fix
    - if you are installing a release channel version:
        - make sure UAC elevation happens.
    - if you are installing a PR builder version:
        - you will need to open an admin command prompt
        - you can then call the PR builder installer with the argument ` --system-level` so that it does an admin install
2. If a profile exists for this install, remove it or rename the folder so you get fresh profile
3. Check if the VPN services are already installed
    - Open `services.msc`
    - Check for the release channel specific version of the services
    - For example, if you installed `Development` check for `Brave Development Vpn Service (BraveDevelopmentVpnService)` and `Brave Development Vpn Wireguard Service (BraveDevelopmentVpnWireguardService)`
    - If those services exist, we need to remove them. You can do so with an admin command prompt
        - For Development version (for example), you could delete with:
            - `sc delete BraveDevelopmentVpnService`
            - `sc delete BraveDevelopmentVpnWireguardService`
4. The VPN services should NOT be installed by this point (if they were there, they should be deleted in step 3).
5. Contact Clifton to get a proof of concept executable for this release channel
6. Copy the proof of concept executable to the desktop and run it from `cmd.exe`
7. The proof of concept should report back:
    ```
    pElevator->InstallVPNServices(): Successfully installed VPNServices.
    Invoking Vpn Installation is successful.
    ````
8. Open `services.msc`
9. Ensure the VPN services ARE installed
    - Check for the release channel specific version of the services
    - For example, if you installed `Development` check for `Brave Development Vpn Service (BraveDevelopmentVpnService)` and `Brave Development Vpn Wireguard Service (BraveDevelopmentVpnWireguardService)`

### Testing after the fix
1. Install a version of Brave which DOES have the fix
    - if you are installing a release channel version:
        - make sure UAC elevation happens.
    - if you are installing a PR builder version:
        - you will need to open an admin command prompt
        - you can then call the PR builder installer with the argument ` --system-level` so that it does an admin install
2. If a profile exists for this install, remove it or rename the folder so you get fresh profile
3. Check if the VPN services are already installed
    - Open `services.msc`
    - Check for the release channel specific version of the services
    - For example, if you installed `Development` check for `Brave Development Vpn Service (BraveDevelopmentVpnService)` and `Brave Development Vpn Wireguard Service (BraveDevelopmentVpnWireguardService)`
    - If those services exist, we need to remove them. You can do so with an admin command prompt
        - For Development version (for example), you could delete with:
            - `sc delete BraveDevelopmentVpnService`
            - `sc delete BraveDevelopmentVpnWireguardService`
4. The VPN services should NOT be installed by this point (if they were there, they should be deleted in step 3).
5. Contact Clifton to get a proof of concept executable for this release channel
6. Copy the proof of concept executable to the desktop and run it from `cmd.exe`
7. The proof of concept should report back:
    ```
    pElevator->InstallVPNServices(): Failed
    failed PROTECTION_PATH_VALIDATION
    Invoking Vpn Installation has failed.
    ```
8. Open `services.msc`
9. Ensure the VPN services are NOT installed