### PR TITLE
Fixes a missing space in fr/fr-CA l10n of a string. (uplift to 1.68.x)

### DIFF
--- a/browser/ui/android/strings/translations/android_brave_strings_fr-CA.xtb
+++ b/browser/ui/android/strings/translations/android_brave_strings_fr-CA.xtb
@@ -702,7 +702,7 @@ Voulez-vous vraiment continuer?</translation>
 <translation id="6748319398471481216">Renouvellement mensuel</translation>
 <translation id="7734634586133069282"><ph name="MONTHLY_AMOUNT"/>/mois.</translation>
 <translation id="1163809943099641131">Un an</translation>
-<translation id="172859718096975160">Renouvelez annuellement<ph name="DISCOUNT_TEXT_START"/>économisez <ph name="PERCENTAGE_AMOUNT"/> %%<ph name="DISCOUNT_TEXT_END"/></translation>
+<translation id="172859718096975160">Renouvelez annuellement <ph name="DISCOUNT_TEXT_START"/>économisez <ph name="PERCENTAGE_AMOUNT"/> %%<ph name="DISCOUNT_TEXT_END"/></translation>
 <translation id="5452539666808679230"><ph name="YEARLY_AMOUNT"/>/an.</translation>
 <translation id="5125233570742276182">Les abonnements seront facturés via votre compte Google. Toute période d’essai gratuite non utilisée sera annulée en cas d’achat d’un abonnement.\n\nVotre abonnement sera automatiquement renouvelé, sauf en cas d’annulation au moins 24 heures avant la fin de la période en cours.\n\nVous pouvez gérer vos abonnements dans Paramètres.\nEn utilisant Brave, vous acceptez les Conditions d’utilisation et la Politique de confidentialité.</translation>
 <translation id="5035172357624830412">Vous avez déjà acheté sur brave.com?</translation>

--- a/browser/ui/android/strings/translations/android_brave_strings_fr.xtb
+++ b/browser/ui/android/strings/translations/android_brave_strings_fr.xtb
@@ -702,7 +702,7 @@ Voulez-vous vraiment continuer ?</translation>
 <translation id="6748319398471481216">Renouvellement mensuel</translation>
 <translation id="7734634586133069282"><ph name="MONTHLY_AMOUNT"/>/mois.</translation>
 <translation id="1163809943099641131">Un an</translation>
-<translation id="172859718096975160">Renouvelez annuellement<ph name="DISCOUNT_TEXT_START"/>économisez <ph name="PERCENTAGE_AMOUNT"/> %%<ph name="DISCOUNT_TEXT_END"/></translation>
+<translation id="172859718096975160">Renouvelez annuellement <ph name="DISCOUNT_TEXT_START"/>économisez <ph name="PERCENTAGE_AMOUNT"/> %%<ph name="DISCOUNT_TEXT_END"/></translation>
 <translation id="5452539666808679230"><ph name="YEARLY_AMOUNT"/>/an.</translation>
 <translation id="5125233570742276182">Les abonnements seront facturés via votre compte Google. Toute période d’essai gratuite non utilisée sera annulée en cas d’achat d’un abonnement.\n\nVotre abonnement sera automatiquement renouvelé, sauf en cas d’annulation au moins 24 heures avant la fin de la période en cours.\n\nVous pouvez gérer vos abonnements dans Paramètres.\nEn utilisant Brave, vous acceptez les Conditions d’utilisation et la Politique de confidentialité.</translation>
 <translation id="5035172357624830412">Vous avez déjà acheté sur brave.com ?</translation>


### PR DESCRIPTION
Uplift of #24839
Resolves https://github.com/brave/brave-browser/issues/39951

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.