### PR TITLE
refactor(wallet): use RTK for fetching active origin

### DIFF
--- a/components/brave_wallet_ui/common/actions/wallet_actions.ts
+++ b/components/brave_wallet_ui/common/actions/wallet_actions.ts
@@ -7,7 +7,6 @@ import { WalletActions } from '../slices/wallet.slice'
 
 // We must re-export actions here until we remove all imports of this file
 export const {
-  activeOriginChanged,
   autoLockMinutesChanged,
   backedUp,
   defaultBaseCryptocurrencyChanged,

--- a/components/brave_wallet_ui/common/async/handlers.ts
+++ b/components/brave_wallet_ui/common/async/handlers.ts
@@ -62,10 +62,7 @@ handler.on(
 handler.on(
   WalletActions.initialize.type,
   async (store, payload: RefreshOpts) => {
-    // Initialize active origin state.
-    const { braveWalletService, walletHandler, keyringService } = getAPIProxy()
-    const { originInfo } = await braveWalletService.getActiveOrigin()
-    store.dispatch(WalletActions.activeOriginChanged(originInfo))
+    const { walletHandler, keyringService } = getAPIProxy()
     const { walletInfo } = await walletHandler.getWalletInfo()
     const { allAccounts } = await keyringService.getAllAccounts()
     store.dispatch(WalletActions.initialized({ walletInfo, allAccounts }))

--- a/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
@@ -27,4 +27,3 @@ export const isRefreshingNetworksAndTokens = ({ wallet }: State) =>
 // and lists)
 export const allowedNewWalletAccountTypeNetworkIds = ({ wallet }: State) =>
   wallet.allowedNewWalletAccountTypeNetworkIds
-export const activeOrigin = ({ wallet }: State) => wallet.activeOrigin

--- a/components/brave_wallet_ui/common/slices/api-base.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api-base.slice.ts
@@ -75,7 +75,8 @@ export function createWalletApiBase() {
       'PendingSignAllTransactionsRequests',
       'PinnableNftIds',
       'PendingSignMessageRequests',
-      'PendingSignMessageErrors'
+      'PendingSignMessageErrors',
+      'ActiveOrigin'
     ],
     endpoints: ({ mutation, query }) => ({})
   })

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -191,6 +191,7 @@ export const {
   useGetAccountInfosRegistryQuery,
   useGetAccountTokenCurrentBalanceQuery,
   useGetActiveOriginConnectedAccountIdsQuery,
+  useGetActiveOriginQuery,
   useGetAddressByteCodeQuery,
   useGetAddressFromNameServiceUrlQuery,
   useGetAllKnownNetworksQuery,

--- a/components/brave_wallet_ui/common/slices/endpoints/wallet.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/wallet.endpoints.ts
@@ -119,6 +119,27 @@ export const walletEndpoints = ({
       providesTags: ['IsMetaMaskInstalled']
     }),
 
+    getActiveOrigin: query<BraveWallet.OriginInfo, void>({
+      queryFn: async (arg, { endpoint }, extraOptions, baseQuery) => {
+        try {
+          const { data: api } = baseQuery(undefined)
+          const { braveWalletService } = api
+
+          const { originInfo } = await braveWalletService.getActiveOrigin()
+          return {
+            data: originInfo
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'unable to get active origin',
+            error
+          )
+        }
+      },
+      providesTags: ['ActiveOrigin']
+    }),
+
     createWallet: mutation<true, { password: string }>({
       queryFn: async (
         arg,

--- a/components/brave_wallet_ui/common/slices/wallet.slice.ts
+++ b/components/brave_wallet_ui/common/slices/wallet.slice.ts
@@ -30,10 +30,6 @@ const defaultState: WalletState = {
   isWalletCreated: false,
   isWalletLocked: true,
   addUserAssetError: false,
-  activeOrigin: {
-    eTldPlusOne: '',
-    originSpec: ''
-  },
   passwordAttempts: 0,
   assetAutoDiscoveryCompleted: true,
   isAnkrBalancesFeatureEnabled: false,
@@ -74,13 +70,6 @@ export const createWalletSlice = (initialState: WalletState = defaultState) => {
     name: 'wallet',
     initialState,
     reducers: {
-      activeOriginChanged(
-        state: WalletState,
-        { payload }: PayloadAction<BraveWallet.OriginInfo>
-      ) {
-        state.activeOrigin = payload
-      },
-
       initialized(
         state: WalletState,
         { payload }: PayloadAction<WalletInitializedPayload>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -10,7 +10,6 @@ import { skipToken } from '@reduxjs/toolkit/query'
 import { reduceAddress } from '../../../utils/reduce-address'
 import Amount from '../../../utils/amount'
 import { getLocale } from '../../../../common/locale'
-import { WalletSelectors } from '../../../common/selectors'
 import {
   openAssociatedTokenAccountSupportArticleTab //
 } from '../../../utils/routes-utils'
@@ -19,12 +18,10 @@ import {
 import { usePendingTransactions } from '../../../common/hooks/use-pending-transaction'
 import { useExplorer } from '../../../common/hooks/explorer'
 import {
+  useGetActiveOriginQuery,
   useGetAddressByteCodeQuery,
   useGetDefaultFiatCurrencyQuery
 } from '../../../common/slices/api.slice'
-import {
-  useUnsafeWalletSelector //
-} from '../../../common/hooks/use-safe-selector'
 
 // Components
 import CreateSiteOrigin from '../../shared/create-site-origin/index'
@@ -85,10 +82,9 @@ const ICON_CONFIG = { size: 'big', marginLeft: 0, marginRight: 0 } as const
 const NftAssetIconWithPlaceholder = withPlaceholderIcon(NftIcon, ICON_CONFIG)
 
 export const ConfirmTransactionPanel = () => {
-  // redux
-  const activeOrigin = useUnsafeWalletSelector(WalletSelectors.activeOrigin)
-
   // queries
+  const { data: activeOrigin = { eTldPlusOne: '', originSpec: '' } } =
+    useGetActiveOriginQuery()
   const { data: defaultFiatCurrency = 'usd' } = useGetDefaultFiatCurrencyQuery()
 
   // custom hooks

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
@@ -6,7 +6,6 @@
 import * as React from 'react'
 
 // Utils
-import { WalletSelectors } from '../../../common/selectors'
 import { getLocale } from '../../../../common/locale'
 
 // Styled components
@@ -28,15 +27,10 @@ import { SwapBase } from '../swap'
 
 // Hooks
 import { usePendingTransactions } from '../../../common/hooks/use-pending-transaction'
-import {
-  useUnsafeWalletSelector //
-} from '../../../common/hooks/use-safe-selector'
 import { useSwapTransactionParser } from '../../../common/hooks/use-swap-tx-parser'
+import { useGetActiveOriginQuery } from '../../../common/slices/api.slice'
 
 export function ConfirmSwapTransaction() {
-  // redux
-  const activeOrigin = useUnsafeWalletSelector(WalletSelectors.activeOrigin)
-
   // state
   const [showAdvancedTransactionSettings, setShowAdvancedTransactionSettings] =
     React.useState<boolean>(false)
@@ -60,6 +54,10 @@ export function ConfirmSwapTransaction() {
     insufficientFundsError,
     insufficientFundsForGasError
   } = usePendingTransactions()
+
+  // queries
+  const { data: activeOrigin = { eTldPlusOne: '', originSpec: '' } } =
+    useGetActiveOriginQuery()
 
   // computed
   const originInfo = selectedPendingTransaction?.originInfo ?? activeOrigin

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-main.tsx
@@ -6,18 +6,13 @@
 import * as React from 'react'
 import Button from '@brave/leo/react/button'
 
-// Selectors
-import {
-  useUnsafeWalletSelector //
-} from '../../../common/hooks/use-safe-selector'
-import { WalletSelectors } from '../../../common/selectors'
-
 // Types
 import { DAppConnectionOptionsType } from 'components/brave_wallet_ui/constants/types'
 import { BraveWallet, DAppSupportedCoinTypes } from '../../../constants/types'
 
 // Queries
 import {
+  useGetActiveOriginQuery,
   useGetDefaultFiatCurrencyQuery,
   useGetSelectedChainQuery,
   useRemoveSitePermissionMutation,
@@ -71,10 +66,9 @@ export const DAppConnectionMain = (props: Props) => {
     onSelectOption,
     getAccountsFiatValue
   } = props
-  // Selectors
-  const activeOrigin = useUnsafeWalletSelector(WalletSelectors.activeOrigin)
-
   // Queries
+  const { data: activeOrigin = { eTldPlusOne: '', originSpec: '' } } =
+    useGetActiveOriginQuery()
   const { data: selectedNetwork } = useGetSelectedChainQuery()
   const { data: selectedAccount } = useSelectedAccountQuery()
   const { data: defaultFiatCurrency } = useGetDefaultFiatCurrencyQuery()

--- a/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-settings.tsx
+++ b/components/brave_wallet_ui/components/extension/dapp-connection-settings/dapp-connection-settings.tsx
@@ -20,12 +20,6 @@ import {
 import getWalletPanelApiProxy from '../../../panel/wallet_panel_api_proxy'
 import { useApiProxy } from '../../../common/hooks/use-api-proxy'
 
-// Selectors
-import {
-  useUnsafeWalletSelector //
-} from '../../../common/hooks/use-safe-selector'
-import { WalletSelectors } from '../../../common/selectors'
-
 // Types
 import {
   BraveWallet,
@@ -40,7 +34,8 @@ import {
   useGetTokenSpotPricesQuery,
   useGetDefaultFiatCurrencyQuery,
   useGetActiveOriginConnectedAccountIdsQuery,
-  useGetUserTokensRegistryQuery
+  useGetUserTokensRegistryQuery,
+  useGetActiveOriginQuery
 } from '../../../common/slices/api.slice'
 import {
   useSelectedAccountQuery //
@@ -78,7 +73,6 @@ export const DAppConnectionSettings = () => {
   // Selectors
   const { data: connectedAccounts = [] } =
     useGetActiveOriginConnectedAccountIdsQuery()
-  const activeOrigin = useUnsafeWalletSelector(WalletSelectors.activeOrigin)
 
   // State
   const [showSettings, setShowSettings] = React.useState<boolean>(false)
@@ -93,6 +87,8 @@ export const DAppConnectionSettings = () => {
   const settingsMenuRef = React.useRef<HTMLDivElement>(null)
 
   // Queries
+  const { data: activeOrigin = { eTldPlusOne: '', originSpec: '' } } =
+    useGetActiveOriginQuery()
   const { currentData: selectedNetwork } = useGetSelectedChainQuery(undefined)
   const selectedCoin = selectedNetwork?.coin
   const { data: selectedAccount } = useSelectedAccountQuery()
@@ -140,11 +136,10 @@ export const DAppConnectionSettings = () => {
   // Hooks
   useOnClickOutside(settingsMenuRef, () => setShowSettings(false), showSettings)
 
-  // Memos
-  const isChromeOrigin = React.useMemo(() => {
-    return activeOrigin.originSpec.startsWith('chrome')
-  }, [activeOrigin.originSpec])
+  // Computed
+  const isChromeOrigin = activeOrigin?.originSpec.startsWith('chrome')
 
+  // Memos
   const isConnected = React.useMemo((): boolean => {
     if (!selectedAccount || isPermissionDenied) {
       return false

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -203,7 +203,6 @@ export interface WalletState {
   isWalletCreated: boolean
   isWalletLocked: boolean
   addUserAssetError: boolean
-  activeOrigin: BraveWallet.OriginInfo
   allowedNewWalletAccountTypeNetworkIds: EntityId[]
   passwordAttempts: number
   assetAutoDiscoveryCompleted: boolean

--- a/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
@@ -10,10 +10,6 @@ import { BraveWallet, WalletState } from '../../constants/types'
 import { networkEntityAdapter } from '../../common/slices/entities/network.entity'
 
 export const mockWalletState: WalletState = {
-  activeOrigin: {
-    originSpec: 'https://app.uniswap.org',
-    eTldPlusOne: 'uniswap.org'
-  },
   addUserAssetError: false,
   hasInitialized: true,
   isBitcoinEnabled: true,

--- a/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
+++ b/components/brave_wallet_ui/stories/wallet-extension-panels.tsx
@@ -10,8 +10,7 @@ import './locale'
 import {
   BraveWallet,
   SerializableTransactionInfo,
-  UIState,
-  WalletState
+  UIState
 } from '../constants/types'
 
 // Components
@@ -377,10 +376,6 @@ const transactionList = [
   ...transactionDummyData[1]
 ]
 
-const mockCustomStoreState: Partial<WalletState> = {
-  activeOrigin: originInfo
-}
-
 const mockCustomUiState: Partial<UIState> = {
   selectedPendingTransactionId: mockTransactionInfo.id,
   transactionProviderErrorRegistry: {}
@@ -396,7 +391,6 @@ export const _ConfirmTransaction = {
       <Provider
         store={createMockStore(
           {
-            walletStateOverride: mockCustomStoreState,
             uiStateOverride: mockCustomUiState
           },
           mockApiData


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40007

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Scenario 1
1. go to https://metamask.github.io/test-dapp/
2. open the wallet panel and unlock the wallet
3. the wallet connection button should show the correct favicon
4. click the favicon
5. the correct origin should be show
![Screenshot 2024-07-25 at 12 10 17 PM](https://github.com/user-attachments/assets/b52a9765-868c-4e70-9998-3b991a5661aa)

Scenario 2
1. go to brave://wallet-panel.top-chrome
2. click the favicon
3. no active origin should be shown (only the active network selector should be shown)
![Screenshot 2024-07-25 at 12 10 33 PM](https://github.com/user-attachments/assets/a1edbce3-1500-495e-8016-19aebc645f9b)

