### PR TITLE
fix(wallet): Updates network selection in adding custom asset

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -9,6 +9,11 @@ import DesignSystem
 import SwiftUI
 
 struct NetworkSelectionView: View {
+  
+  enum NetworkSelectionType {
+    case addCustomAsset
+    case other
+  }
 
   var keyringStore: KeyringStore
   @ObservedObject var networkStore: NetworkStore
@@ -18,11 +23,13 @@ struct NetworkSelectionView: View {
   init(
     keyringStore: KeyringStore,
     networkStore: NetworkStore,
-    networkSelectionStore: NetworkSelectionStore
+    networkSelectionStore: NetworkSelectionStore,
+    networkSelectionType: NetworkSelectionType = .other
   ) {
     self.keyringStore = keyringStore
     self.networkStore = networkStore
     self.store = networkSelectionStore
+    self.networkSelectionType = networkSelectionType
   }
 
   private var selectedNetwork: BraveWallet.NetworkInfo {
@@ -44,11 +51,24 @@ struct NetworkSelectionView: View {
     }
   }
 
+  private var networkSelectionType: NetworkSelectionType
+
+  private var allSelectableNetworks: [BraveWallet.NetworkInfo] {
+    switch networkSelectionType {
+    case .addCustomAsset:
+      return networkStore.visibleChains.filter {
+        $0.coin == .eth || $0.coin == .sol
+      }
+    case .other:
+      return networkStore.visibleChains
+    }
+  }
+
   var body: some View {
     NetworkSelectionRootView(
       navigationTitle: navigationTitle,
       selectedNetworks: [selectedNetwork],
-      allNetworks: networkStore.visibleChains,
+      allNetworks: allSelectableNetworks,
       selectNetwork: { network in
         selectNetwork(network)
       }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/NetworkSelectionView.swift
@@ -9,7 +9,7 @@ import DesignSystem
 import SwiftUI
 
 struct NetworkSelectionView: View {
-  
+
   enum NetworkSelectionType {
     case addCustomAsset
     case other

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -98,7 +98,7 @@ struct AddCustomAssetView: View {
               )
               .foregroundColor(
                 networkSelectionStore.networkSelectionInForm == nil
-                  ? .gray.opacity(0.6) : Color(.braveLabel)
+                  ? Color(braveSystemName: .textDisabled) : Color(.braveLabel)
               )
             }
             Spacer()

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/AddCustomAssetView.swift
@@ -86,6 +86,28 @@ struct AddCustomAssetView: View {
           }
         }
         Section(
+          header: WalletListHeaderView(title: Text(Strings.Wallet.customTokenNetworkHeader))
+        ) {
+          HStack {
+            Button {
+              isPresentingNetworkSelection = true
+            } label: {
+              Text(
+                networkSelectionStore.networkSelectionInForm?.chainName
+                  ?? Strings.Wallet.customTokenNetworkButtonTitle
+              )
+              .foregroundColor(
+                networkSelectionStore.networkSelectionInForm == nil
+                  ? .gray.opacity(0.6) : Color(.braveLabel)
+              )
+            }
+            Spacer()
+            Image(systemName: "chevron.down.circle")
+              .foregroundColor(Color(.braveBlurpleTint))
+          }
+          .listRowBackground(Color(.secondaryBraveGroupedBackground))
+        }
+        Section(
           header: WalletListHeaderView(
             title: networkSelectionStore.networkSelectionInForm?.coin == .sol
               ? Text(Strings.Wallet.tokenMintAddress) : Text(Strings.Wallet.tokenAddress)
@@ -113,28 +135,6 @@ struct AddCustomAssetView: View {
             .autocorrectionDisabled()
             .disabled(userAssetStore.isSearchingToken)
             .listRowBackground(Color(.secondaryBraveGroupedBackground))
-        }
-        Section(
-          header: WalletListHeaderView(title: Text(Strings.Wallet.customTokenNetworkHeader))
-        ) {
-          HStack {
-            Button {
-              isPresentingNetworkSelection = true
-            } label: {
-              Text(
-                networkSelectionStore.networkSelectionInForm?.chainName
-                  ?? Strings.Wallet.customTokenNetworkButtonTitle
-              )
-              .foregroundColor(
-                networkSelectionStore.networkSelectionInForm == nil
-                  ? .gray.opacity(0.6) : Color(.braveLabel)
-              )
-            }
-            Spacer()
-            Image(systemName: "chevron.down.circle")
-              .foregroundColor(Color(.braveBlurpleTint))
-          }
-          .listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
         Section(
           header: WalletListHeaderView(title: Text(Strings.Wallet.tokenName))
@@ -298,7 +298,8 @@ struct AddCustomAssetView: View {
               NetworkSelectionView(
                 keyringStore: keyringStore,
                 networkStore: networkStore,
-                networkSelectionStore: networkSelectionStore
+                networkSelectionStore: networkSelectionStore,
+                networkSelectionType: .addCustomAsset
               )
             }
             .accentColor(Color(.braveBlurpleTint))


### PR DESCRIPTION
Only eth and sol coin type networks are supported in adding custom network.
move network selection to the top of form. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves 
https://github.com/brave/brave-browser/issues/39435
https://github.com/brave/brave-browser/issues/40013

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/39435) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open wallet and try to add a custom asset or NFT
2. Observe network picker is now the first in the form 
3. Tap network picker 
4. Observe only eth and sol coin type networks are displayed 
