### PR TITLE
Check in README.chromium license info for assorted packages

### DIFF
--- a/third_party/npm_@thaunknown_idb-chunk-store/README.chromium
+++ b/third_party/npm_@thaunknown_idb-chunk-store/README.chromium
@@ -1,0 +1,4 @@
+Name: @thaunknown/idb-chunk-store
+URL: https://github.com/ThaUnknown/idb-chunk-store
+License: MIT
+License File: /brave/node_modules/@thaunknown/idb-chunk-store/LICENSE

--- a/third_party/npm_@thaunknown_simple-peer/README.chromium
+++ b/third_party/npm_@thaunknown_simple-peer/README.chromium
@@ -1,0 +1,4 @@
+Name: @thaunknown/simple-peer
+URL: https://github.com/ThaUnknown/simple-peer
+License: MIT
+License File: /brave/node_modules/@thaunknown/simple-peer/LICENSE

--- a/third_party/npm_chunk-store-iterator/README.chromium
+++ b/third_party/npm_chunk-store-iterator/README.chromium
@@ -1,0 +1,4 @@
+Name: chunk-store-iterator
+URL: https://github.com/ThaUnknown/chunk-store-iterator
+License: MIT
+License File: /brave/node_modules/chunk-store-iterator/LICENSE

--- a/third_party/npm_cpus/README.chromium
+++ b/third_party/npm_cpus/README.chromium
@@ -1,0 +1,4 @@
+Name: cpus
+URL: https://github.com/feross/cpus
+License: MIT
+License File: /brave/node_modules/cpus/LICENSE

--- a/third_party/npm_cross-fetch-ponyfill/README.chromium
+++ b/third_party/npm_cross-fetch-ponyfill/README.chromium
@@ -1,0 +1,4 @@
+Name: cross-fetch-ponyfill
+URL: https://github.com/ThaUnknown/cross-fetch-ponyfill
+License: MIT
+License File: /brave/node_modules/cross-fetch-ponyfill/LICENSE

--- a/third_party/npm_join-async-iterator/README.chromium
+++ b/third_party/npm_join-async-iterator/README.chromium
@@ -1,0 +1,4 @@
+Name: join-async-iterator
+URL: https://github.com/ThaUnknown/join-async-iterator
+License: MIT
+License File: /brave/node_modules/join-async-iterator/LICENSE

--- a/third_party/npm_lt_donthave/README.chromium
+++ b/third_party/npm_lt_donthave/README.chromium
@@ -1,0 +1,4 @@
+Name: lt_donthave
+URL: https://github.com/webtorrent/lt_donthave
+License: MIT
+License File: /brave/node_modules/lt_donthave/LICENSE

--- a/third_party/npm_speed-limiter/README.chromium
+++ b/third_party/npm_speed-limiter/README.chromium
@@ -1,0 +1,4 @@
+Name: speed-limiter
+URL: https://github.com/alxhotel/speed-limiter
+License: MIT
+License File: /brave/node_modules/speed-limiter/LICENSE

--- a/third_party/npm_streamx/README.chromium
+++ b/third_party/npm_streamx/README.chromium
@@ -1,0 +1,4 @@
+Name: streamx
+URL: https://github.com/mafintosh/streamx
+License: MIT
+License File: /brave/node_modules/streamx/LICENSE

--- a/third_party/npm_throughput/README.chromium
+++ b/third_party/npm_throughput/README.chromium
@@ -1,0 +1,4 @@
+Name: throughput
+URL: https://github.com/ThaUnknown/throughput
+License: MIT
+License File: /brave/node_modules/throughput/LICENSE

--- a/third_party/npm_uint8-util/README.chromium
+++ b/third_party/npm_uint8-util/README.chromium
@@ -1,0 +1,4 @@
+Name: uint8-util
+URL: https://github.com/ThaUnknown/uint8-util
+License: MIT
+License File: /brave/node_modules/uint8-util/LICENSE


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->

This will enable Chromium builds for: 
    @thaunknown/idb-chunk-store
    @thaunknown/simple-peer
    chunk-store-iterator
    cpus
    cross-fetch-ponyfill
    join-async-iterator
    lt-donthave
    speed-limiter
    streamx
    throughput
    uint8-util

Some of these modules lack LICENSE files, which probably need to be checked in first.

Creating a draft PR for now.

