### PR TITLE
Add feature flag for compact horizontal tabs

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -370,35 +370,42 @@
 #endif  // BUILDFLAG(IS_ANDROID)
 
 #if !BUILDFLAG(IS_ANDROID)
-#define BRAVE_TABS_FEATURE_ENTRIES                                        \
-  EXPAND_FEATURE_ENTRIES(                                                 \
-      {                                                                   \
-          "brave-shared-pinned-tabs",                                     \
-          "Shared pinned tab",                                            \
-          "Pinned tabs are shared across windows",                        \
-          kOsWin | kOsMac | kOsLinux,                                     \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs),     \
-      },                                                                  \
-      {                                                                   \
-          "brave-horizontal-tabs-update",                                 \
-          "Updated horizontal tabs design",                               \
-          "Updates the look and feel or horizontal tabs",                 \
-          kOsWin | kOsMac | kOsLinux,                                     \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveHorizontalTabsUpdate), \
-      },                                                                  \
-      {                                                                   \
-          "brave-vertical-tab-scroll-bar",                                \
-          "Show scroll bar on vertical tab strip",                        \
-          "Shows scroll bar on vertical tab strip when it overflows",     \
-          kOsWin | kOsMac | kOsLinux,                                     \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabScrollBar), \
-      },                                                                  \
-      {                                                                   \
-          kSplitViewFeatureInternalName,                                  \
-          "Enable split view",                                            \
-          "Enables split view",                                           \
-          kOsWin | kOsMac | kOsLinux,                                     \
-          FEATURE_VALUE_TYPE(tabs::features::kBraveSplitView),            \
+#define BRAVE_TABS_FEATURE_ENTRIES                                         \
+  EXPAND_FEATURE_ENTRIES(                                                  \
+      {                                                                    \
+          "brave-shared-pinned-tabs",                                      \
+          "Shared pinned tab",                                             \
+          "Pinned tabs are shared across windows",                         \
+          kOsWin | kOsMac | kOsLinux,                                      \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveSharedPinnedTabs),      \
+      },                                                                   \
+      {                                                                    \
+          "brave-horizontal-tabs-update",                                  \
+          "Updated horizontal tabs design",                                \
+          "Updates the look and feel or horizontal tabs",                  \
+          kOsWin | kOsMac | kOsLinux,                                      \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveHorizontalTabsUpdate),  \
+      },                                                                   \
+      {                                                                    \
+          "brave-compact-horizontal-tabs",                                 \
+          "Compact horizontal tabs design",                                \
+          "Reduces the height of horizontal tabs",                         \
+          kOsWin | kOsMac | kOsLinux,                                      \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveCompactHorizontalTabs), \
+      },                                                                   \
+      {                                                                    \
+          "brave-vertical-tab-scroll-bar",                                 \
+          "Show scroll bar on vertical tab strip",                         \
+          "Shows scroll bar on vertical tab strip when it overflows",      \
+          kOsWin | kOsMac | kOsLinux,                                      \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveVerticalTabScrollBar),  \
+      },                                                                   \
+      {                                                                    \
+          kSplitViewFeatureInternalName,                                   \
+          "Enable split view",                                             \
+          "Enables split view",                                            \
+          kOsWin | kOsMac | kOsLinux,                                      \
+          FEATURE_VALUE_TYPE(tabs::features::kBraveSplitView),             \
       })
 #else
 #define BRAVE_TABS_FEATURE_ENTRIES

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -196,6 +196,7 @@ source_set("ui") {
       "startup/brave_startup_tab_provider_impl.h",
       "tabs/brave_tab_color_mixer.cc",
       "tabs/brave_tab_color_mixer.h",
+      "tabs/brave_tab_layout_constants.cc",
       "tabs/brave_tab_layout_constants.h",
       "tabs/brave_tab_menu_model.cc",
       "tabs/brave_tab_menu_model.h",

--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -37,13 +37,13 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
   switch (constant) {
     case TAB_HEIGHT: {
       if (HorizontalTabsUpdateEnabled()) {
-        return brave_tabs::kHorizontalTabHeight;
+        return brave_tabs::GetHorizontalTabHeight();
       }
       return (touch ? 41 : 30) + GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
     }
     case TAB_STRIP_HEIGHT: {
       if (HorizontalTabsUpdateEnabled()) {
-        return brave_tabs::kHorizontalTabStripHeight;
+        return brave_tabs::GetHorizontalTabStripHeight();
       }
       return std::nullopt;
     }

--- a/browser/ui/tabs/brave_tab_layout_constants.cc
+++ b/browser/ui/tabs/brave_tab_layout_constants.cc
@@ -1,0 +1,42 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
+
+#include "base/feature_list.h"
+#include "brave/browser/ui/tabs/features.h"
+
+namespace brave_tabs {
+
+namespace {
+
+bool UseCompact() {
+  return base::FeatureList::IsEnabled(
+      tabs::features::kBraveCompactHorizontalTabs);
+}
+
+}  // namespace
+
+int GetHorizontalTabHeight() {
+  return UseCompact() ? 28 : 32;
+}
+
+int GetHorizontalTabStripHeight() {
+  return GetHorizontalTabHeight() + (kHorizontalTabVerticalSpacing * 2);
+}
+
+int GetHorizontalTabPadding() {
+  return UseCompact() ? 4 : 8;
+}
+
+int GetTabGroupTitleVerticalInset() {
+  return (GetHorizontalTabHeight() - kTabGroupLineHeight) / 2;
+}
+
+int GetTabGroupTitleHorizontalInset() {
+  return UseCompact() ? 6 : 10;
+}
+
+}  // namespace brave_tabs

--- a/browser/ui/tabs/brave_tab_layout_constants.h
+++ b/browser/ui/tabs/brave_tab_layout_constants.h
@@ -18,7 +18,7 @@ namespace brave_tabs {
 // The visual height of tabs in horizontal tabs mode. Note that the height of
 // the view may be greater than the visual height of the tab shape. See also
 // `kHorizontalTabVerticalSpacing`.
-inline constexpr int kHorizontalTabHeight = 32;
+int GetHorizontalTabHeight();
 
 // The amount of space before the first tab view.
 inline constexpr int kHorizontalTabStripLeftMargin = 3;
@@ -29,8 +29,7 @@ inline constexpr int kHorizontalTabStripLeftMargin = 3;
 inline constexpr int kHorizontalTabVerticalSpacing = 4;
 
 // The height of the tab strip in horizontal mode.
-inline constexpr int kHorizontalTabStripHeight =
-    kHorizontalTabHeight + (kHorizontalTabVerticalSpacing * 2);
+int GetHorizontalTabStripHeight();
 
 // The visual gap between tabs.
 inline constexpr int kHorizontalTabGap = 4;
@@ -46,7 +45,7 @@ inline constexpr int kHorizontalTabInset =
     (kHorizontalTabGap + kHorizontalTabOverlap) / 2;
 
 // The content padding within a tab.
-inline constexpr int kHorizontalTabPadding = 8;
+int GetHorizontalTabPadding();
 
 // The horizontal difference between the visual edge of a tab group and the
 // bounds of the group underline.
@@ -55,18 +54,15 @@ inline constexpr int kHorizontalGroupUnderlineInset = 2;
 // The tab border radius.
 inline constexpr int kTabBorderRadius = 8;
 
-// The size of the group header slot when the title is empty.
-inline constexpr int kEmptyGroupTitleSize = 32;
-
 // The line height of the tab group header text.
 inline constexpr int kTabGroupLineHeight = 24;
 
 // The amount of padding at the top and bottom of tab group header "chips"
 // (i.e. the rectangle enclosing the tab group title).
-inline constexpr int kTabGroupTitleVerticalInset = 4;
+int GetTabGroupTitleVerticalInset();
 
 // The amount of padding at sides of tab group header "chips".
-inline constexpr int kTabGroupTitleHorizontalInset = 10;
+int GetTabGroupTitleHorizontalInset();
 
 }  // namespace brave_tabs
 

--- a/browser/ui/tabs/brave_tab_style.h
+++ b/browser/ui/tabs/brave_tab_style.h
@@ -45,15 +45,15 @@ class BraveTabStyle : public TabStyleBase {
     if (!tabs::features::HorizontalTabsUpdateEnabled()) {
       return TabStyleBase::GetContentsInsets();
     }
-    return gfx::Insets::VH(
-        0, brave_tabs::kHorizontalTabPadding + brave_tabs::kHorizontalTabInset);
+    return gfx::Insets::VH(0, brave_tabs::GetHorizontalTabPadding() +
+                                  brave_tabs::kHorizontalTabInset);
   }
 
   int GetPinnedWidth() const override {
     if (!tabs::features::HorizontalTabsUpdateEnabled()) {
       return TabStyleBase::GetPinnedWidth();
     }
-    return brave_tabs::kHorizontalTabHeight +
+    return brave_tabs::GetHorizontalTabHeight() +
            brave_tabs::kHorizontalTabInset * 2;
   }
 

--- a/browser/ui/tabs/features.cc
+++ b/browser/ui/tabs/features.cc
@@ -21,6 +21,10 @@ BASE_FEATURE(kBraveHorizontalTabsUpdate,
              "BraveHorizontalTabsUpdate",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kBraveCompactHorizontalTabs,
+             "BraveCompactHorizontalTabs",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 BASE_FEATURE(kBraveVerticalTabScrollBar,
              "BraveVerticalTabScrollBar",
              base::FEATURE_DISABLED_BY_DEFAULT);

--- a/browser/ui/tabs/features.h
+++ b/browser/ui/tabs/features.h
@@ -19,6 +19,8 @@ BASE_DECLARE_FEATURE(kBraveSharedPinnedTabs);
 
 BASE_DECLARE_FEATURE(kBraveHorizontalTabsUpdate);
 
+BASE_DECLARE_FEATURE(kBraveCompactHorizontalTabs);
+
 BASE_DECLARE_FEATURE(kBraveVerticalTabScrollBar);
 
 BASE_DECLARE_FEATURE(kBraveSplitView);

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_group_style.cc
@@ -71,8 +71,8 @@ gfx::Insets TabGroupStyle::GetInsetsForHeaderChip(
     return insets;
   }
   if (!ShouldShowVerticalTabs()) {
-    return gfx::Insets::VH(brave_tabs::kTabGroupTitleVerticalInset,
-                           brave_tabs::kTabGroupTitleHorizontalInset);
+    return gfx::Insets::VH(brave_tabs::GetTabGroupTitleVerticalInset(),
+                           brave_tabs::GetTabGroupTitleHorizontalInset());
   }
   return insets;
 }
@@ -94,7 +94,7 @@ float TabGroupStyle::GetEmptyChipSize() const {
   if (!tabs::features::HorizontalTabsUpdateEnabled()) {
     return TabGroupStyle_ChromiumImpl::GetEmptyChipSize();
   }
-  return brave_tabs::kEmptyGroupTitleSize;
+  return brave_tabs::GetHorizontalTabHeight();
 }
 
 int TabGroupStyle::GetChipCornerRadius() const {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40044

<img width="1228" alt="Screenshot 2024-07-26 at 5 30 58 PM" src="https://github.com/user-attachments/assets/134a893e-e7f1-4920-8adf-0f60d3883cc6">


https://github.com/user-attachments/assets/e3baa0bd-060c-47f0-a69c-63d868129319



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:


