### PR TITLE
add "all-fingerprinting" remote option to webcompat exceptions service

### DIFF
--- a/components/brave_shields/content/browser/brave_shields_util.cc
+++ b/components/brave_shields/content/browser/brave_shields_util.cc
@@ -574,7 +574,8 @@ void SetFingerprintingControlType(HostContentSettingsMap* map,
   base::Value web_setting = map->GetWebsiteSetting(
       url, GURL(), ContentSettingsType::BRAVE_FINGERPRINTING_V2, &setting_info);
   bool was_default =
-      web_setting.is_none() || setting_info.primary_pattern.MatchesAllHosts();
+      web_setting.is_none() || setting_info.primary_pattern.MatchesAllHosts() ||
+      setting_info.source == content_settings::SettingSource::kRemoteList;
 
   ContentSetting content_setting;
   if (type == ControlType::DEFAULT || type == ControlType::BLOCK_THIRD_PARTY) {

--- a/components/webcompat/content/browser/webcompat_exceptions_service.cc
+++ b/components/webcompat/content/browser/webcompat_exceptions_service.cc
@@ -45,6 +45,7 @@ constexpr std::vector<ContentSettingsPattern> kEmptyPatternVector;
 
 constexpr auto kWebcompatNamesToType =
     base::MakeFixedFlatMap<std::string_view, ContentSettingsType>({
+        {"all-fingerprinting", BRAVE_FINGERPRINTING_V2},
         {"audio", BRAVE_WEBCOMPAT_AUDIO},
         {"canvas", BRAVE_WEBCOMPAT_CANVAS},
         {"device-memory", BRAVE_WEBCOMPAT_DEVICE_MEMORY},

--- a/components/webcompat/content/test/webcompat_exceptions_browsertest.cc
+++ b/components/webcompat/content/test/webcompat_exceptions_browsertest.cc
@@ -51,6 +51,7 @@ struct TestCase {
 };
 
 constexpr TestCase kTestCases[] = {
+    {"all-fingerprinting", BRAVE_FINGERPRINTING_V2},
     {"audio", BRAVE_WEBCOMPAT_AUDIO},
     {"canvas", BRAVE_WEBCOMPAT_CANVAS},
     {"device-memory", BRAVE_WEBCOMPAT_DEVICE_MEMORY},
@@ -147,7 +148,7 @@ IN_PROC_BROWSER_TEST_F(WebcompatExceptionsBrowserTest, RemoteSettingsTest) {
     // Check the default setting
     const auto observed_setting_default =
         map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
-    EXPECT_EQ(observed_setting_default, CONTENT_SETTING_BLOCK);
+    EXPECT_NE(observed_setting_default, CONTENT_SETTING_ALLOW);
 
     // Create a rule and then reload the page.
     webcompat::PatternsByWebcompatTypeMap rule_map;
@@ -163,7 +164,7 @@ IN_PROC_BROWSER_TEST_F(WebcompatExceptionsBrowserTest, RemoteSettingsTest) {
     // Check that the remote setting doesn't leak to another domain
     const auto observed_setting_cross_site =
         map->GetContentSetting(GURL("https://b.test"), GURL(), test_case.type);
-    EXPECT_EQ(observed_setting_cross_site, CONTENT_SETTING_BLOCK);
+    EXPECT_NE(observed_setting_cross_site, CONTENT_SETTING_ALLOW);
 
     // Check that manual setting can override the remote setting
     brave_shields::SetWebcompatEnabled(map, test_case.type, false,


### PR DESCRIPTION
The "all-fingerprinting" option disables fingerprinting protections. This is reflected in the shields fingerprinting setting.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39924

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

