### PR TITLE
Add group name for brave content settings types

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
@@ -11,29 +11,26 @@
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
 
 #define HasRegisteredGroupName HasRegisteredGroupName_ChromiumImpl
-#define ContentSettingsTypeToGroupName \
-  ContentSettingsTypeToGroupName_ChromiumImpl
 #define GetVisiblePermissionCategories \
   GetVisiblePermissionCategories_ChromiumImpl
 
 // clang-format off
-#define BRAVE_CONTENT_SETTINGS_TYPE_GROUP_NAMES_LIST               \
-  {ContentSettingsType::BRAVE_ADS, nullptr},                       \
-  {ContentSettingsType::BRAVE_COSMETIC_FILTERING, nullptr},        \
-  {ContentSettingsType::BRAVE_TRACKERS, nullptr},                  \
-  {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES, nullptr}, \
-  {ContentSettingsType::BRAVE_FINGERPRINTING_V2, nullptr},         \
-  {ContentSettingsType::BRAVE_SHIELDS, nullptr},                   \
-  {ContentSettingsType::BRAVE_REFERRERS, nullptr},                 \
-  {ContentSettingsType::BRAVE_COOKIES, nullptr},                   \
-  {ContentSettingsType::BRAVE_SPEEDREADER, nullptr},               \
-  {ContentSettingsType::BRAVE_ETHEREUM, nullptr},                  \
-  {ContentSettingsType::BRAVE_SOLANA, nullptr},                    \
-  {ContentSettingsType::BRAVE_GOOGLE_SIGN_IN, nullptr},            \
-  {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},             \
-  {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},       \
-  {ContentSettingsType::BRAVE_LOCALHOST_ACCESS, nullptr},          \
-                                                                   \
+#define BRAVE_CONTENT_SETTINGS_TYPE_GROUP_NAMES_LIST                  \
+  {ContentSettingsType::BRAVE_ADS, nullptr},                          \
+  {ContentSettingsType::BRAVE_COSMETIC_FILTERING, nullptr},           \
+  {ContentSettingsType::BRAVE_TRACKERS, nullptr},                     \
+  {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES, nullptr},    \
+  {ContentSettingsType::BRAVE_FINGERPRINTING_V2, nullptr},            \
+  {ContentSettingsType::BRAVE_SHIELDS, brave_shields::kBraveShields}, \
+  {ContentSettingsType::BRAVE_REFERRERS, nullptr},                    \
+  {ContentSettingsType::BRAVE_COOKIES, nullptr},                      \
+  {ContentSettingsType::BRAVE_SPEEDREADER, nullptr},                  \
+  {ContentSettingsType::BRAVE_ETHEREUM, "ethereum"},                  \
+  {ContentSettingsType::BRAVE_SOLANA, "solana"},                      \
+  {ContentSettingsType::BRAVE_GOOGLE_SIGN_IN, "googleSignIn"},        \
+  {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},                \
+  {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},          \
+  {ContentSettingsType::BRAVE_LOCALHOST_ACCESS, "localhostAccess"},   \
   {ContentSettingsType::BRAVE_WEBCOMPAT_NONE, nullptr}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_AUDIO, nullptr}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_CANVAS, nullptr}, \
@@ -57,17 +54,11 @@
 
 #define BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_FROM_GROUP_NAME \
   if (name == "autoplay")                                                \
-    return ContentSettingsType::AUTOPLAY;                                \
-  if (name == "googleSignIn")                                            \
-    return ContentSettingsType::BRAVE_GOOGLE_SIGN_IN;                    \
-  if (name == "localhostAccess")                                         \
-    return ContentSettingsType::BRAVE_LOCALHOST_ACCESS;                  \
-  if (name == "ethereum")                                                \
-    return ContentSettingsType::BRAVE_ETHEREUM;                          \
-  if (name == "solana")                                                  \
-    return ContentSettingsType::BRAVE_SOLANA;                            \
-  if (name == brave_shields::kBraveShields)                              \
-    return ContentSettingsType::BRAVE_SHIELDS;
+    return ContentSettingsType::AUTOPLAY;
+
+#define BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_TO_GROUP_NAME \
+  if (type == ContentSettingsType::AUTOPLAY)                           \
+    return "autoplay";
 
 #define kInstalledWebappProvider         \
   kRemoteListProvider:                   \
@@ -85,8 +76,8 @@
 #undef kInstalledWebappProvider
 #undef BRAVE_CONTENT_SETTINGS_TYPE_GROUP_NAMES_LIST
 #undef BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_FROM_GROUP_NAME
+#undef BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_TO_GROUP_NAME
 #undef GetVisiblePermissionCategories
-#undef ContentSettingsTypeToGroupName
 #undef HasRegisteredGroupName
 
 namespace site_settings {
@@ -106,23 +97,6 @@ bool HasRegisteredGroupName(ContentSettingsType type) {
   if (type == ContentSettingsType::BRAVE_SHIELDS)
     return true;
   return HasRegisteredGroupName_ChromiumImpl(type);
-}
-
-std::string_view ContentSettingsTypeToGroupName(ContentSettingsType type) {
-  if (type == ContentSettingsType::AUTOPLAY)
-    return "autoplay";
-  if (type == ContentSettingsType::BRAVE_GOOGLE_SIGN_IN)
-    return "googleSignIn";
-  if (type == ContentSettingsType::BRAVE_LOCALHOST_ACCESS) {
-    return "localhostAccess";
-  }
-  if (type == ContentSettingsType::BRAVE_ETHEREUM)
-    return "ethereum";
-  if (type == ContentSettingsType::BRAVE_SOLANA)
-    return "solana";
-  if (type == ContentSettingsType::BRAVE_SHIELDS)
-    return brave_shields::kBraveShields;
-  return ContentSettingsTypeToGroupName_ChromiumImpl(type);
 }
 
 std::vector<ContentSettingsType> GetVisiblePermissionCategories(

--- a/patches/chrome-browser-ui-webui-settings-site_settings_helper.cc.patch
+++ b/patches/chrome-browser-ui-webui-settings-site_settings_helper.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/webui/settings/site_settings_helper.cc b/chrome/browser/ui/webui/settings/site_settings_helper.cc
-index eb56ea4bd8c50e6e63b6150c92ec2cd8ecc4985f..aa4b35537a8223fb1acd2f9f323172c924274932 100644
+index eb56ea4bd8c50e6e63b6150c92ec2cd8ecc4985f..8ad81f26fcd84a752693ee720066532efb5d7991 100644
 --- a/chrome/browser/ui/webui/settings/site_settings_helper.cc
 +++ b/chrome/browser/ui/webui/settings/site_settings_helper.cc
 @@ -229,6 +229,7 @@ const ContentSettingsTypeNameEntry kContentSettingsTypeGroupNames[] = {
@@ -18,3 +18,11 @@ index eb56ea4bd8c50e6e63b6150c92ec2cd8ecc4985f..aa4b35537a8223fb1acd2f9f323172c9
    for (const auto& entry : kContentSettingsTypeGroupNames) {
      // Content setting types that aren't represented in the settings UI
      // will have `nullptr` as their `name`. However, converting `nullptr`
+@@ -487,6 +489,7 @@ ContentSettingsType ContentSettingsTypeFromGroupName(std::string_view name) {
+ }
+ 
+ std::string_view ContentSettingsTypeToGroupName(ContentSettingsType type) {
++  BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_TO_GROUP_NAME
+   for (const auto& entry : kContentSettingsTypeGroupNames) {
+     if (type == entry.type) {
+       // Content setting types that aren't represented in the settings UI


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40072

`ContentSettingsTypeToGroupName` is now called in chrome/browser/ui/webui/settings/site_settings_helper.cc (https://chromiumdash.appspot.com/commit/3521ac22c431d148c2a9f40f7b4291c129e55b4f), our current override won't work because that function call will also be renamed to ContentSettingsTypeToGroupName_ChromiumImpl.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

