### PR TITLE
[Nala]: Bump to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#8f981cd78e484cd97348855350ab5ade2f3dc1db",
+        "@brave/leo": "github:brave/leo#bd22cb0e60f40204c63ab5c2959d50f05b002b95",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
         "@brave/wallet-standard-brave": "0.0.13",
         "@dnd-kit/core": "6.0.5",
@@ -2213,8 +2213,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#8f981cd78e484cd97348855350ab5ade2f3dc1db",
-      "integrity": "sha512-Qmd2IYkZy12z5wGP4EZPg2n2DQ3hLUt9Kkem8lDU0ZJwJF/3ZYLYsOdaXyJqA+DfKcwwxiEMeCmiRrnijDfpqg==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#bd22cb0e60f40204c63ab5c2959d50f05b002b95",
+      "integrity": "sha512-iT9GH0vaiJRNyx8HTpdhASOeqN0iqJ+SmFrzS5NCUEBut4Jx2zWg9P84USeL6dHDrlSfbOO9NnLcIuHXKwzLqg==",
       "dependencies": {
         "@storybook/test": "8.1.11",
         "svelte": "4.2.18",
@@ -29779,9 +29779,9 @@
       }
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#8f981cd78e484cd97348855350ab5ade2f3dc1db",
-      "integrity": "sha512-Qmd2IYkZy12z5wGP4EZPg2n2DQ3hLUt9Kkem8lDU0ZJwJF/3ZYLYsOdaXyJqA+DfKcwwxiEMeCmiRrnijDfpqg==",
-      "from": "@brave/leo@github:brave/leo#8f981cd78e484cd97348855350ab5ade2f3dc1db",
+      "version": "git+ssh://git@github.com/brave/leo.git#bd22cb0e60f40204c63ab5c2959d50f05b002b95",
+      "integrity": "sha512-iT9GH0vaiJRNyx8HTpdhASOeqN0iqJ+SmFrzS5NCUEBut4Jx2zWg9P84USeL6dHDrlSfbOO9NnLcIuHXKwzLqg==",
+      "from": "@brave/leo@github:brave/leo#bd22cb0e60f40204c63ab5c2959d50f05b002b95",
       "requires": {
         "@storybook/test": "8.1.11",
         "svelte": "4.2.18",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#8f981cd78e484cd97348855350ab5ade2f3dc1db",
+    "@brave/leo": "github:brave/leo#bd22cb0e60f40204c63ab5c2959d50f05b002b95",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
     "@brave/wallet-standard-brave": "0.0.13",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
Changes https://github.com/brave/leo/compare/8f981cd78e484cd97348855350ab5ade2f3dc1db...bd22cb0e60f40204c63ab5c2959d50f05b002b95
- [Icons]: Updated with new icons
- [[Typescript]: Convert internal scripts to use Typescript](https://github.com/brave/leo/commit/99f1fa38d5a847c5b39110cde61d2ff3f83b0fdd)
- [[Tokens](Tailwind): Only wrap shadow colors in function if necessary](https://github.com/brave/leo/commit/8df205b2e681da96f164a7bdfa4b84a697daaa3a)
- [Dependencies]: Various dependabot & rennovate bumps
- [[Button]: Fix JSDOM in brave-core tests](https://github.com/brave/leo/commit/f773fced49436f62e431dea4b17a285b537dd7a0)
- [[Storybook]: Fix story background color](https://github.com/brave/leo/commit/38add6979cbf075c3cff17d05e297f6fb4262ea6)
- [[Tokens]: Fix mode support](https://github.com/brave/leo/commit/721718afc0e1c771a35afa1541124a86cccfa5b1)
- [[SegmentedControl]: Update styles for pill background and hover background](https://github.com/brave/leo/commit/1deb5e2f312e04008be255009d7b06a90d0ed899)
- [[Alert]: Fix the padding on the Alert when removing the icon](https://github.com/brave/leo/commit/bd22cb0e60f40204c63ab5c2959d50f05b002b95)

cc @simonhong for Alert changes and @StephenHeaps for the mode support fixes