### PR TITLE
Add group name for brave content settings types (uplift to 1.69.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
@@ -11,29 +11,26 @@
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
 
 #define HasRegisteredGroupName HasRegisteredGroupName_ChromiumImpl
-#define ContentSettingsTypeToGroupName \
-  ContentSettingsTypeToGroupName_ChromiumImpl
 #define GetVisiblePermissionCategories \
   GetVisiblePermissionCategories_ChromiumImpl
 
 // clang-format off
-#define BRAVE_CONTENT_SETTINGS_TYPE_GROUP_NAMES_LIST               \
-  {ContentSettingsType::BRAVE_ADS, nullptr},                       \
-  {ContentSettingsType::BRAVE_COSMETIC_FILTERING, nullptr},        \
-  {ContentSettingsType::BRAVE_TRACKERS, nullptr},                  \
-  {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES, nullptr}, \
-  {ContentSettingsType::BRAVE_FINGERPRINTING_V2, nullptr},         \
-  {ContentSettingsType::BRAVE_SHIELDS, nullptr},                   \
-  {ContentSettingsType::BRAVE_REFERRERS, nullptr},                 \
-  {ContentSettingsType::BRAVE_COOKIES, nullptr},                   \
-  {ContentSettingsType::BRAVE_SPEEDREADER, nullptr},               \
-  {ContentSettingsType::BRAVE_ETHEREUM, nullptr},                  \
-  {ContentSettingsType::BRAVE_SOLANA, nullptr},                    \
-  {ContentSettingsType::BRAVE_GOOGLE_SIGN_IN, nullptr},            \
-  {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},             \
-  {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},       \
-  {ContentSettingsType::BRAVE_LOCALHOST_ACCESS, nullptr},          \
-                                                                   \
+#define BRAVE_CONTENT_SETTINGS_TYPE_GROUP_NAMES_LIST                  \
+  {ContentSettingsType::BRAVE_ADS, nullptr},                          \
+  {ContentSettingsType::BRAVE_COSMETIC_FILTERING, nullptr},           \
+  {ContentSettingsType::BRAVE_TRACKERS, nullptr},                     \
+  {ContentSettingsType::BRAVE_HTTP_UPGRADABLE_RESOURCES, nullptr},    \
+  {ContentSettingsType::BRAVE_FINGERPRINTING_V2, nullptr},            \
+  {ContentSettingsType::BRAVE_SHIELDS, brave_shields::kBraveShields}, \
+  {ContentSettingsType::BRAVE_REFERRERS, nullptr},                    \
+  {ContentSettingsType::BRAVE_COOKIES, nullptr},                      \
+  {ContentSettingsType::BRAVE_SPEEDREADER, nullptr},                  \
+  {ContentSettingsType::BRAVE_ETHEREUM, "ethereum"},                  \
+  {ContentSettingsType::BRAVE_SOLANA, "solana"},                      \
+  {ContentSettingsType::BRAVE_GOOGLE_SIGN_IN, "googleSignIn"},        \
+  {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},                \
+  {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},          \
+  {ContentSettingsType::BRAVE_LOCALHOST_ACCESS, "localhostAccess"},   \
   {ContentSettingsType::BRAVE_WEBCOMPAT_NONE, nullptr}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_AUDIO, nullptr}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_CANVAS, nullptr}, \
@@ -57,17 +54,11 @@
 
 #define BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_FROM_GROUP_NAME \
   if (name == "autoplay")                                                \
-    return ContentSettingsType::AUTOPLAY;                                \
-  if (name == "googleSignIn")                                            \
-    return ContentSettingsType::BRAVE_GOOGLE_SIGN_IN;                    \
-  if (name == "localhostAccess")                                         \
-    return ContentSettingsType::BRAVE_LOCALHOST_ACCESS;                  \
-  if (name == "ethereum")                                                \
-    return ContentSettingsType::BRAVE_ETHEREUM;                          \
-  if (name == "solana")                                                  \
-    return ContentSettingsType::BRAVE_SOLANA;                            \
-  if (name == brave_shields::kBraveShields)                              \
-    return ContentSettingsType::BRAVE_SHIELDS;
+    return ContentSettingsType::AUTOPLAY;
+
+#define BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_TO_GROUP_NAME \
+  if (type == ContentSettingsType::AUTOPLAY)                           \
+    return "autoplay";
 
 #define kInstalledWebappProvider         \
   kRemoteListProvider:                   \
@@ -85,8 +76,8 @@
 #undef kInstalledWebappProvider
 #undef BRAVE_CONTENT_SETTINGS_TYPE_GROUP_NAMES_LIST
 #undef BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_FROM_GROUP_NAME
+#undef BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_TO_GROUP_NAME
 #undef GetVisiblePermissionCategories
-#undef ContentSettingsTypeToGroupName
 #undef HasRegisteredGroupName
 
 namespace site_settings {
@@ -106,23 +97,6 @@ bool HasRegisteredGroupName(ContentSettingsType type) {
   if (type == ContentSettingsType::BRAVE_SHIELDS)
     return true;
   return HasRegisteredGroupName_ChromiumImpl(type);
-}
-
-std::string_view ContentSettingsTypeToGroupName(ContentSettingsType type) {
-  if (type == ContentSettingsType::AUTOPLAY)
-    return "autoplay";
-  if (type == ContentSettingsType::BRAVE_GOOGLE_SIGN_IN)
-    return "googleSignIn";
-  if (type == ContentSettingsType::BRAVE_LOCALHOST_ACCESS) {
-    return "localhostAccess";
-  }
-  if (type == ContentSettingsType::BRAVE_ETHEREUM)
-    return "ethereum";
-  if (type == ContentSettingsType::BRAVE_SOLANA)
-    return "solana";
-  if (type == ContentSettingsType::BRAVE_SHIELDS)
-    return brave_shields::kBraveShields;
-  return ContentSettingsTypeToGroupName_ChromiumImpl(type);
 }
 
 std::vector<ContentSettingsType> GetVisiblePermissionCategories(

--- a/patches/chrome-browser-ui-webui-settings-site_settings_helper.cc.patch
+++ b/patches/chrome-browser-ui-webui-settings-site_settings_helper.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/webui/settings/site_settings_helper.cc b/chrome/browser/ui/webui/settings/site_settings_helper.cc
-index eb56ea4bd8c50e6e63b6150c92ec2cd8ecc4985f..aa4b35537a8223fb1acd2f9f323172c924274932 100644
+index eb56ea4bd8c50e6e63b6150c92ec2cd8ecc4985f..8ad81f26fcd84a752693ee720066532efb5d7991 100644
 --- a/chrome/browser/ui/webui/settings/site_settings_helper.cc
 +++ b/chrome/browser/ui/webui/settings/site_settings_helper.cc
 @@ -229,6 +229,7 @@ const ContentSettingsTypeNameEntry kContentSettingsTypeGroupNames[] = {
@@ -18,3 +18,11 @@ index eb56ea4bd8c50e6e63b6150c92ec2cd8ecc4985f..aa4b35537a8223fb1acd2f9f323172c9
    for (const auto& entry : kContentSettingsTypeGroupNames) {
      // Content setting types that aren't represented in the settings UI
      // will have `nullptr` as their `name`. However, converting `nullptr`
+@@ -487,6 +489,7 @@ ContentSettingsType ContentSettingsTypeFromGroupName(std::string_view name) {
+ }
+ 
+ std::string_view ContentSettingsTypeToGroupName(ContentSettingsType type) {
++  BRAVE_SITE_SETTINGS_HELPER_CONTENT_SETTINGS_TYPE_TO_GROUP_NAME
+   for (const auto& entry : kContentSettingsTypeGroupNames) {
+     if (type == entry.type) {
+       // Content setting types that aren't represented in the settings UI


### PR DESCRIPTION
Uplift of #24897
Resolves https://github.com/brave/brave-browser/issues/40072

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.