### PR TITLE
fix(design): iOS button style updates

### DIFF
--- a/ios/brave-ios/Sources/AIChat/Components/AIChatTermsAndConditionsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/AIChatTermsAndConditionsView.swift
@@ -52,7 +52,7 @@ public struct AIChatTermsAndConditionsView: View {
             .padding([.top, .bottom], 12)
             .padding([.leading, .trailing], 16)
             .frame(maxWidth: .infinity)
-            .foregroundStyle(.white)
+            .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
             .background(
               Color(braveSystemName: .buttonBackground),
               in: Capsule()
@@ -69,6 +69,7 @@ public struct AIChatTermsAndConditionsView: View {
 struct AIChatTermsAndConditionsView_Preview: PreviewProvider {
   static var previews: some View {
     AIChatTermsAndConditionsView(termsAndConditionsAccepted: .constant(false))
+      .previewColorSchemes()
       .previewLayout(.sizeThatFits)
   }
 }

--- a/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatBusyErrorView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatBusyErrorView.swift
@@ -28,9 +28,8 @@ struct AIChatBusyErrorView: View {
           label: {
             Text(Strings.AIChat.retryActionTitle)
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.white))
               .padding()
-              .foregroundStyle(.white)
+              .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
               .background(
                 Color(braveSystemName: .buttonBackground),
                 in: Capsule()
@@ -52,6 +51,7 @@ struct AIChatBusyErrorView_Preview: PreviewProvider {
     AIChatBusyErrorView {
       print("Retry")
     }
+    .previewColorSchemes()
     .previewLayout(.sizeThatFits)
   }
 }

--- a/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatContextLimitErrorView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatContextLimitErrorView.swift
@@ -28,9 +28,8 @@ struct AIChatContextLimitErrorView: View {
           label: {
             Text(Strings.AIChat.newChatActionTitle)
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.white))
               .padding()
-              .foregroundStyle(.white)
+              .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
               .background(
                 Color(braveSystemName: .buttonBackground),
                 in: Capsule()
@@ -52,6 +51,7 @@ struct AIChatContextLimitErrorView_Preview: PreviewProvider {
     AIChatContextLimitErrorView {
       print("New Chat")
     }
+    .previewColorSchemes()
     .previewLayout(.sizeThatFits)
   }
 }

--- a/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatNetworkErrorView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatNetworkErrorView.swift
@@ -28,7 +28,7 @@ struct AIChatNetworkErrorView: View {
           label: {
             Text(Strings.AIChat.retryActionTitle)
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.white))
+              .foregroundColor(Color(braveSystemName: .schemesOnPrimary))
               .padding()
               .foregroundStyle(.white)
               .background(
@@ -50,6 +50,7 @@ struct AIChatNetworkErrorView: View {
 struct AIChatNetworkErrorView_Preview: PreviewProvider {
   static var previews: some View {
     AIChatNetworkErrorView {}
+      .previewColorSchemes()
       .previewLayout(.sizeThatFits)
   }
 }

--- a/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatSessionExpiredErrorView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Errors/AIChatSessionExpiredErrorView.swift
@@ -28,9 +28,8 @@ struct AIChatSessionExpiredErrorView: View {
           label: {
             Text(Strings.AIChat.refreshCredentialsActionTitle)
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.white))
               .padding()
-              .foregroundStyle(.white)
+              .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
               .background(
                 Color(braveSystemName: .buttonBackground),
                 in: Capsule()
@@ -52,6 +51,7 @@ struct AIChatSessionExpiredErrorView_Preview: PreviewProvider {
     AIChatSessionExpiredErrorView {
       print("Refresh Credentials")
     }
+    .previewColorSchemes()
     .previewLayout(.sizeThatFits)
   }
 }

--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatUserMessageView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatUserMessageView.swift
@@ -160,7 +160,7 @@ private struct EditingUserMessageView: View {
           action: { submitEditedText(text) },
           label: {
             Image(braveSystemName: "leo.check.normal")
-              .foregroundStyle(Color.white)
+              .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
               .frame(width: buttonSize, height: buttonSize)
               .background(
                 Color(braveSystemName: .buttonBackground)

--- a/ios/brave-ios/Sources/AIChat/Components/Paywall/AIChatPremiumUpsellView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Paywall/AIChatPremiumUpsellView.swift
@@ -87,7 +87,7 @@ struct PremiumUpsellActionView: View {
           .padding([.top, .bottom], 12.0)
           .padding([.leading, .trailing], 16.0)
           .frame(maxWidth: .infinity)
-          .foregroundStyle(.white)
+          .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
           .background(
             Color(braveSystemName: .buttonBackground),
             in: RoundedRectangle(cornerRadius: 12.0, style: .continuous)
@@ -294,6 +294,7 @@ private struct PremiumUpsellTopicView: View {
 struct AIChatPremiumUpsellView_Preview: PreviewProvider {
   static var previews: some View {
     AIChatPremiumUpsellView(upsellType: .premium)
+      .previewColorSchemes()
       .previewLayout(.sizeThatFits)
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioHeaderView.swift
@@ -209,7 +209,7 @@ struct PortfolioHeaderButton: View {
           .frame(width: 48, height: 48)
           .overlay(
             Image(braveSystemName: style.iconName)
-              .foregroundColor(.white)
+              .foregroundColor(Color(braveSystemName: .schemesOnPrimary))
               .font(.title3.weight(.semibold))
               .dynamicTypeSize(...DynamicTypeSize.xLarge)
           )

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioSegmentedControl.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioSegmentedControl.swift
@@ -66,10 +66,10 @@ struct WalletSegmentedControl<Item: WalletSegmentedControlItem>: View {
   @GestureState private var isDragGestureActive: Bool = false
 
   var body: some View {
-    Capsule()
+    RoundedRectangle(cornerRadius: 8)
       .fill(Color(braveSystemName: .containerHighlight))
-      .overlay {  // selected capsule
-        Capsule()
+      .overlay {  // selected item
+        RoundedRectangle(cornerRadius: 8)
           .fill(Color(braveSystemName: .containerBackground))
           .padding(4)
           .frame(width: itemWidth)
@@ -142,7 +142,7 @@ struct WalletSegmentedControl<Item: WalletSegmentedControlItem>: View {
         state = true
       }
       .onChanged { value in
-        // `location` is the middle of capsule
+        // `location` is the middle of RoundedRectangle
         let minX = itemWidth / 2
         let maxX = viewSize.width - minX
         let newX = min(max(value.location.x, minX), maxX)

--- a/ios/brave-ios/Sources/DesignSystem/Views/BraveButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Views/BraveButtonStyle.swift
@@ -42,14 +42,14 @@ public struct BraveFilledButtonStyle: ButtonStyle {
     configuration.label
       .opacity(configuration.isPressed ? 0.7 : 1.0)
       .font(size.font)
-      .foregroundColor(.white)
+      .foregroundColor(Color(braveSystemName: .schemesOnPrimary))
       .padding(size.padding)
       .background(
         Group {
           if isEnabled {
-            Color(.braveBlurpleTint).opacity(configuration.isPressed ? 0.7 : 1.0)
+            Color(braveSystemName: .buttonBackground).opacity(configuration.isPressed ? 0.7 : 1.0)
           } else {
-            Color(.braveDisabled)
+            Color(braveSystemName: .buttonDisabled)
           }
         }
       )


### PR DESCRIPTION

Resolves https://github.com/brave/brave-browser/issues/40094

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Button text on button background:

Leo upsell light | Leo upsell dark
--|--
<img width="302" alt="Leo Upsell - light" src="https://github.com/user-attachments/assets/28112673-08fa-4537-ba49-25992b5b9cd2"> | <img width="310" alt="Leo Upsell - dark" src="https://github.com/user-attachments/assets/7a678804-c7f9-4e48-8191-6d965257f000">
Leo terms light | Leo terms dark
<img width="238" alt="Leo terms - light" src="https://github.com/user-attachments/assets/f9d0d838-422a-412c-8d84-20c371a413c3"> | <img width="241" alt="Leo terms - dark" src="https://github.com/user-attachments/assets/ecee1dfe-bba8-4b2d-a1fb-b4523c1c8573">
Leo warning light | Leo warning dark
<img width="240" alt="Leo busy - light" src="https://github.com/user-attachments/assets/2c1573b7-6f4f-4cd4-bd7c-6cbedc58c085"> | <img width="245" alt="Leo busy - dark" src="https://github.com/user-attachments/assets/7ccb42ce-ebb5-4e81-aff5-2ed2b5413b74">
Leo error light - Leo error dark
<img width="240" alt="Leo context limit - light" src="https://github.com/user-attachments/assets/9dc9c229-38aa-48aa-a7f4-f087d572c244"> | <img width="241" alt="Leo context limit - dark" src="https://github.com/user-attachments/assets/8724db68-6c99-4c5b-8872-bd8bf3879f8b">
Wallet unlock light | Wallet unlock dark
![Wallet unlock - light](https://github.com/user-attachments/assets/2507306d-a641-4f3e-bc4a-2193c99cee01) | ![Wallet unlock - dark](https://github.com/user-attachments/assets/212a6972-4810-48ce-b96c-e0a04476a3c0)

Button icon on button background, segmented control corner radius
Wallet Portfolio light (buy/send/swap/deposit, segmented control) | Wallet Portfolio dark
--|--
![Wallet Portfolio - light](https://github.com/user-attachments/assets/7ba390ba-6478-4858-af0e-ea4b34931b31) | ![Wallet Portfolio - dark](https://github.com/user-attachments/assets/d8d1e309-3c7f-417d-92c2-766a147abbe9)

