### PR TITLE
[ads] Fix new tab page video ad media 25 attribution

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -394,9 +394,9 @@ class NewTabPageViewController: UIViewController {
       self?.reportSponsoredBackgroundEvent(.viewedImpression)
     }
 
-    if shouldShowBackgroundVideo() {
-      videoPlayer?.maybeStartAutoplay()
-    }
+    videoPlayer?.loadAndAutoplayVideoAssetIfNeeded(
+      shouldAutoplay: shouldShowBackgroundVideo()
+    )
 
     presentNotification()
 
@@ -416,8 +416,8 @@ class NewTabPageViewController: UIViewController {
 
     backgroundView.imageView.image = parent == nil ? nil : background.backgroundImage
 
-    videoPlayer?.maybeCancelPlay()
     if parent == nil {
+      videoPlayer?.cancelPlayIfNeeded()
       videoPlayer?.resetPlayer()
     } else {
       videoPlayer?.createPlayer()
@@ -472,7 +472,7 @@ class NewTabPageViewController: UIViewController {
     )
   }
 
-  private func fadeInCollectionViewAndShowVideoButtons() {
+  private func fadeInCollectionViewAndHideVideoButtons() {
     videoButtonsView.isHidden = true
     gradientView.isHidden = false
     collectionView.isHidden = false
@@ -503,7 +503,7 @@ class NewTabPageViewController: UIViewController {
       return videoPlayer.togglePlay()
     }
     videoButtonsView.tappedCancelButton = { [weak videoPlayer] in
-      videoPlayer?.maybeCancelPlay()
+      videoPlayer?.cancelPlayIfNeeded()
     }
 
     backgroundButtonsView.activeButton = .none
@@ -516,7 +516,7 @@ class NewTabPageViewController: UIViewController {
 
     videoPlayer?.didCancelPlaybackEvent = { [weak self] in
       guard let self = self else { return }
-      self.fadeInCollectionViewAndShowVideoButtons()
+      self.fadeInCollectionViewAndHideVideoButtons()
     }
     videoPlayer?.didStartAutoplayEvent = { [weak self] in
       self?.backgroundButtonsView.videoAutoplayStarted()
@@ -537,7 +537,7 @@ class NewTabPageViewController: UIViewController {
     }
     videoPlayer?.didFinishPlaybackEvent = { [weak self] in
       guard let self = self else { return }
-      self.fadeInCollectionViewAndShowVideoButtons()
+      self.fadeInCollectionViewAndHideVideoButtons()
       self.reportSponsoredBackgroundEvent(.media100)
     }
     videoPlayer?.didStartPlaybackEvent = { [weak self] in
@@ -563,8 +563,7 @@ class NewTabPageViewController: UIViewController {
     } else {
       // Hide the player layer in landscape mode on iPhone.
       backgroundView.playerLayer.isHidden = true
-      videoPlayer?.cancelAutoplay()
-      videoPlayer?.maybeCancelPlay()
+      videoPlayer?.cancelPlayIfNeeded()
     }
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40090

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Prerequisites to install staging components

New Tab Takeover video ads are available in staging component updater for iOS.
Steps to setup staging component updater on iOS:
* Fresh install
* Launch browser
* Toggle `Use Staging CRX components` in `Settings -> BraveCore Switches`
* Close the browser
* Launch Brave browser
* Join Brave Rewards
* Staging components are downloaded and applied in a minute after start

### Test case
* Get iPhone as a device
* Do Brave fresh install
* Do prerequisites to install staging components
* Rotate iPhone to landscape orientation
* Open New Tab Pages until a tab with New Tab Takeover ad is opened
* Rotate iPhone to portrait orientation
* Check that the NTT video and Play button become visible
* Tap Play button
* Wait until video finishes playing
* Check that Brave Ads media play event was fired
   EXPECTATION: There should be line in Brave Ads logs:
	`[ads] Started playing new tab page video ad with placement id % and creative instance id %`
* Check that Brave Ads media 25 event was fired
   EXPECTATION: There should be line in Brave Ads logs:
	`[ads] Played 25% of new tab page video ad with placement id % and creative instance id %`
* Check that Brave Ads media 100 event was fired
   EXPECTATION: There should be line in Brave Ads logs:
	`[ads] Played 100% of new tab page video ad with placement id % and creative instance id %`
