### PR TITLE
Skip debouncing if canonicalized url's hostname doesn't match unescaped url's hostname

### DIFF
--- a/browser/debounce/debounce_browsertest.cc
+++ b/browser/debounce/debounce_browsertest.cc
@@ -415,6 +415,19 @@ IN_PROC_BROWSER_TEST_F(DebounceBrowserTest, ExcludePrivateRegistries) {
   NavigateToURLAndWaitForRedirects(original_url, landing_url);
 }
 
+// Test that debouncing rule is skipped if the hostname of the new url as
+// extracted via our simple parser doesn't match the host as parsed via GURL
+IN_PROC_BROWSER_TEST_F(DebounceBrowserTest, IgnoreHostnameMismatch) {
+  ASSERT_TRUE(InstallMockExtension());
+  ToggleDebouncePref(true);
+  // The destination decodes to http://evil.com\\@apps.apple.com
+  // If you paste that in Chrome or Brave, the backslashes are changed
+  // to slashes and you end up on http://evil.com//@apps.apple.com
+  GURL original_url = embedded_test_server()->GetURL(
+      "simple.a.com", "/?url=http%3A%2F%2Fevil.com%5C%5C%40apps.apple.com");
+  NavigateToURLAndWaitForRedirects(original_url, original_url);
+}
+
 // Test that debounceable URLs on domain block list are debounced instead.
 IN_PROC_BROWSER_TEST_F(DebounceBrowserTest, DebounceBeforeDomainBlock) {
   GURL base_url = embedded_test_server()->GetURL("blocked.com", "/");

--- a/components/debounce/core/browser/debounce_rule.cc
+++ b/components/debounce/core/browser/debounce_rule.cc
@@ -14,6 +14,8 @@
 #include "base/base64url.h"
 #include "base/json/json_reader.h"
 #include "base/strings/escape.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "base/strings/stringprintf.h"
 #include "base/types/expected.h"
 #include "components/prefs/pref_service.h"
@@ -50,6 +52,36 @@ std::string_view CanonicalizeHostForMatching(std::string_view host_piece) {
     host_piece.remove_suffix(1);
   }
   return host_piece;
+}
+
+// Extract the host from |url| using a simple parsing algorithm
+// WARNING: this is a special-purpose function whose output should not be used.
+std::string NaivelyExtractHostnameFromUrl(const std::string& url) {
+  CHECK(GURL(url).SchemeIsHTTPOrHTTPS());
+
+  const std::string kHttp =
+      base::StrCat({url::kHttpScheme, url::kStandardSchemeSeparator});
+  const std::string kHttps =
+      base::StrCat({url::kHttpsScheme, url::kStandardSchemeSeparator});
+  std::string mutable_url = url;
+
+  if (base::StartsWith(mutable_url, kHttps,
+                       base::CompareCase::INSENSITIVE_ASCII)) {
+    mutable_url = mutable_url.substr(kHttps.length());
+  } else if (base::StartsWith(mutable_url, kHttp,
+                              base::CompareCase::INSENSITIVE_ASCII)) {
+    mutable_url = mutable_url.substr(kHttp.length());
+  }
+
+  // Known limitation: this will not work properly with origins that include
+  // port numbers or with IPv6 hostnames.
+  const std::vector<std::string> parts = base::SplitString(
+      mutable_url, ":/", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  if (parts.size() > 0) {
+    return parts[0];
+  }
+
+  return std::string();
 }
 
 }  // namespace
@@ -309,7 +341,8 @@ bool DebounceRule::Apply(const GURL& original_url,
     }
   }
 
-  GURL new_url(unescaped_value);
+  std::string new_url_spec = unescaped_value;
+  GURL new_url(new_url_spec);
   // Important: If there is a prepend_scheme in the rule BUT the URL is already
   // valid i.e. has a scheme, we treat this as an erroneous rule and do not
   // apply it.
@@ -325,7 +358,7 @@ bool DebounceRule::Apply(const GURL& original_url,
     std::string scheme = (prepend_scheme_ == kDebounceSchemePrependHttp)
                              ? url::kHttpScheme
                              : url::kHttpsScheme;
-    auto new_url_spec =
+    new_url_spec =
         base::StringPrintf("%s://%s", scheme.c_str(), unescaped_value.c_str());
     new_url = GURL(new_url_spec);
     if (new_url.is_valid()) {
@@ -340,6 +373,12 @@ bool DebounceRule::Apply(const GURL& original_url,
 
   // Failsafe: never redirect to the same site.
   if (IsSameETLDForDebounce(original_url, new_url)) {
+    return false;
+  }
+
+  // If the hostname of the new url as extracted via our simple parser doesn't
+  // match the host as parsed via GURL, this rule does not apply
+  if (NaivelyExtractHostnameFromUrl(new_url_spec) != new_url.host()) {
     return false;
   }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39866
Security review: https://github.com/brave/reviews/issues/1714

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Start with a fresh profile. Shields in **normal** mode.
2. Restart the browser to make sure all components are updated and Griffin flags have been set.
3. Open https://go.redirectingat.com/?url=http%3A%2F%2Fevil.com%5C%5C%40apps.apple.com
4. Confirm that it goes to apple.com and **not** to evil.com.