### PR TITLE
`kSignedHTTPExchange` to be removed in future releases

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -166,7 +166,6 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &features::kResourceTimingForCancelledNavigationInFrame,
       &features::kSCTAuditing,
       &features::kServiceWorkerAutoPreload,
-      &features::kSignedHTTPExchange,
       &features::kSupportSearchSuggestionForPrerender2,
       &features::kTabHoverCardImages,
 #if !BUILDFLAG(IS_ANDROID)

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -1364,3 +1364,11 @@ GURL BraveContentBrowserClient::SanitizeURL(
   }
   return url_sanitizer_service->SanitizeURL(url);
 }
+
+bool BraveContentBrowserClient::AllowSignedExchange(
+    content::BrowserContext* context) {
+  // This override has been introduced due to the deletion of the flag
+  // `features::kSignedHTTPExchange`, which was being used to disable signed
+  // exchanges.
+  return false;
+}

--- a/browser/brave_content_browser_client.h
+++ b/browser/brave_content_browser_client.h
@@ -174,6 +174,8 @@ class BraveContentBrowserClient : public ChromeContentBrowserClient {
   GURL SanitizeURL(content::RenderFrameHost* render_frame_host,
                    const GURL& url) override;
 
+  bool AllowSignedExchange(content::BrowserContext* context) override;
+
  private:
   void OnAllowGoogleAuthChanged();
 

--- a/chromium_src/content/public/common/content_features.cc
+++ b/chromium_src/content/public/common/content_features.cc
@@ -24,7 +24,6 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kFedCm, base::FEATURE_DISABLED_BY_DEFAULT},
     {kNotificationTriggers, base::FEATURE_DISABLED_BY_DEFAULT},
     {kPrivacySandboxAdsAPIsOverride, base::FEATURE_DISABLED_BY_DEFAULT},
-    {kSignedHTTPExchange, base::FEATURE_DISABLED_BY_DEFAULT},
     {kWebIdentityDigitalCredentials, base::FEATURE_DISABLED_BY_DEFAULT},
 #if BUILDFLAG(IS_ANDROID)
     {kWebNfc, base::FEATURE_DISABLED_BY_DEFAULT},


### PR DESCRIPTION
Although this flag has been deleted upstream, it is still possible to override a method from `ContentBrowserClient` to preserve the behaviour of it being always off.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/38351473816416aa3474ada96c7db1409f8ea2c6

    commit 38351473816416aa3474ada96c7db1409f8ea2c6
    Author: Andrew Williams <awillia@chromium.org>
    Date:   Wed Jul 24 16:47:30 2024 +0000

    Remove kSignedHttpExchange feature flag

    It seems this feature has been enabled for 4 years and is likely no
    longer needed.

    Bug: None

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39961

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

