### PR TITLE
[Playlist] Show 'New playlist' and 'Back' option as clickable

### DIFF
--- a/browser/ui/color/brave_color_id.h
+++ b/browser/ui/color/brave_color_id.h
@@ -140,7 +140,8 @@
     E_CPONLY(kColorBravePlaylistMoveDialogDescription)                \
     E_CPONLY(kColorBravePlaylistMoveDialogCreatePlaylistAndMoveTitle) \
     E_CPONLY(kColorBravePlaylistNewPlaylistDialogNameLabel)           \
-    E_CPONLY(kColorBravePlaylistNewPlaylistDialogItemsLabel)
+    E_CPONLY(kColorBravePlaylistNewPlaylistDialogItemsLabel)          \
+    E_CPONLY(kColorBravePlaylistTextInteractive)
 
 #define BRAVE_OMNIBOX_COLOR_IDS \
     E_CPONLY(kColorBraveOmniboxResultViewSeparator) \

--- a/browser/ui/color/playlist/playlist_color_mixer.cc
+++ b/browser/ui/color/playlist/playlist_color_mixer.cc
@@ -32,6 +32,8 @@ void AddThemeColorMixer(ui::ColorProvider* provider,
       leo::GetColor(leo::Color::kColorTextPrimary, theme)};
   mixer[kColorBravePlaylistNewPlaylistDialogItemsLabel] = {
       leo::GetColor(leo::Color::kColorTextSecondary, theme)};
+  mixer[kColorBravePlaylistTextInteractive] = {
+      leo::GetColor(leo::Color::kColorTextInteractive, theme)};
 }
 
 }  // namespace playlist

--- a/browser/ui/views/playlist/playlist_action_dialogs.cc
+++ b/browser/ui/views/playlist/playlist_action_dialogs.cc
@@ -20,6 +20,7 @@
 #include "chrome/browser/ui/singleton_tabs.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_ui.h"
+#include "ui/base/cursor/cursor.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/button/label_button.h"
@@ -251,6 +252,32 @@ void ClosePanel(content::WebContents* contents) {
     ui->Close();
   }
 }
+
+namespace {
+class PlaylistLabelButton : public views::LabelButton {
+  METADATA_HEADER(PlaylistLabelButton, views::LabelButton)
+ public:
+  PlaylistLabelButton(views::Button::PressedCallback callback = {},
+                      const std::u16string& text = std::u16string())
+      : LabelButton(std::move(callback), text) {
+    SetEnabledTextColorIds(kColorBravePlaylistTextInteractive);
+    label()->SetFontList(label()->font_list().Derive(
+        0, gfx::Font::FontStyle::NORMAL, gfx::Font::Weight::NORMAL));
+  }
+
+  ~PlaylistLabelButton() override = default;
+
+  ui::Cursor GetCursor(const ui::MouseEvent& event) override {
+    if (!GetEnabled()) {
+      return ui::Cursor();
+    }
+    return ui::mojom::CursorType::kHand;
+  }
+};
+
+BEGIN_METADATA(PlaylistLabelButton)
+END_METADATA
+}  // namespace
 
 }  // namespace playlist
 
@@ -564,7 +591,7 @@ void PlaylistMoveDialog::EnterChoosePlaylistMode() {
                                    base::Unretained(this)));
 
   // This view owns the button so it's okay to bind Unretained(this).
-  SetExtraView(std::make_unique<views::MdTextButton>(
+  SetExtraView(std::make_unique<playlist::PlaylistLabelButton>(
       base::BindRepeating(&PlaylistMoveDialog::OnNewPlaylistPressed,
                           base::Unretained(this)),
       l10n_util::GetStringUTF16(IDS_PLAYLIST_MOVE_MEDIA_DIALOG_NEW_PLAYLIST)));
@@ -602,7 +629,7 @@ void PlaylistMoveDialog::EnterCreatePlaylistMode() {
                                    base::Unretained(this)));
 
   // This view owns the button so it's okay to bind Unretained(this).
-  SetExtraView(std::make_unique<views::MdTextButton>(
+  SetExtraView(std::make_unique<playlist::PlaylistLabelButton>(
       base::BindRepeating(&PlaylistMoveDialog::OnBackPressed,
                           base::Unretained(this)),
       l10n_util::GetStringUTF16(IDS_PLAYLIST_MOVE_MEDIA_DIALOG_BACK)));

--- a/browser/ui/views/playlist/playlist_action_dialogs.cc
+++ b/browser/ui/views/playlist/playlist_action_dialogs.cc
@@ -23,6 +23,7 @@
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/button/label_button.h"
+#include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
 #include "ui/views/layout/fill_layout.h"
 
@@ -563,7 +564,7 @@ void PlaylistMoveDialog::EnterChoosePlaylistMode() {
                                    base::Unretained(this)));
 
   // This view owns the button so it's okay to bind Unretained(this).
-  SetExtraView(std::make_unique<views::LabelButton>(
+  SetExtraView(std::make_unique<views::MdTextButton>(
       base::BindRepeating(&PlaylistMoveDialog::OnNewPlaylistPressed,
                           base::Unretained(this)),
       l10n_util::GetStringUTF16(IDS_PLAYLIST_MOVE_MEDIA_DIALOG_NEW_PLAYLIST)));
@@ -601,7 +602,7 @@ void PlaylistMoveDialog::EnterCreatePlaylistMode() {
                                    base::Unretained(this)));
 
   // This view owns the button so it's okay to bind Unretained(this).
-  SetExtraView(std::make_unique<views::LabelButton>(
+  SetExtraView(std::make_unique<views::MdTextButton>(
       base::BindRepeating(&PlaylistMoveDialog::OnBackPressed,
                           base::Unretained(this)),
       l10n_util::GetStringUTF16(IDS_PLAYLIST_MOVE_MEDIA_DIALOG_BACK)));

--- a/browser/ui/views/playlist/playlist_action_dialogs.cc
+++ b/browser/ui/views/playlist/playlist_action_dialogs.cc
@@ -24,7 +24,6 @@
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/button/label_button.h"
-#include "ui/views/controls/button/md_text_button.h"
 #include "ui/views/controls/textfield/textfield.h"
 #include "ui/views/layout/fill_layout.h"
 
@@ -254,6 +253,7 @@ void ClosePanel(content::WebContents* contents) {
 }
 
 namespace {
+// A button that shows a label and changes the cursor to a hand when hovered.
 class PlaylistLabelButton : public views::LabelButton {
   METADATA_HEADER(PlaylistLabelButton, views::LabelButton)
  public:
@@ -261,8 +261,9 @@ class PlaylistLabelButton : public views::LabelButton {
                       const std::u16string& text = std::u16string())
       : LabelButton(std::move(callback), text) {
     SetEnabledTextColorIds(kColorBravePlaylistTextInteractive);
+    const int size_diff = 13 - label()->font_list().GetFontSize();
     label()->SetFontList(label()->font_list().Derive(
-        0, gfx::Font::FontStyle::NORMAL, gfx::Font::Weight::NORMAL));
+        size_diff, gfx::Font::FontStyle::NORMAL, gfx::Font::Weight::SEMIBOLD));
   }
 
   ~PlaylistLabelButton() override = default;


### PR DESCRIPTION
- Create and use customized label button to show 'New playlist' and 'Back' option is a clickable button in `Move Media` dialog


**Outcome:**

[brave_playlist_button_fix_2.webm](https://github.com/user-attachments/assets/9f995c2a-ff5b-4cc2-b690-0d32887ed148)



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40243

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

