### PR TITLE
fix(wallet): Panel Dark Theme Colors

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
@@ -44,6 +44,9 @@ export const Button = styled(WalletButton)<{
 export const ButtonIcon = styled(Icon)`
   --leo-icon-size: 24px;
   color: ${leo.color.white};
+  @media (prefers-color-scheme: dark) {
+    color: ${leo.color.schemes.onPrimary};
+  }
 `
 
 export const ButtonText = styled.span`

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav-button/wallet-nav-button.style.ts
@@ -10,10 +10,6 @@ import { WalletButton, Text } from '../../../shared/style'
 import { layoutSmallWidth } from '../../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const StyledButton = styled(WalletButton)<{ isSelected?: boolean }>`
-  --button-background-hover: ${leo.color.container.highlight};
-  @media (prefers-color-scheme: dark) {
-    --button-background-hover: ${leo.color.primitive.neutral[80]};
-  }
   --icon-color: ${(p) =>
     p.isSelected ? leo.color.icon.interactive : leo.color.neutral[30]};
   --text-color: ${(p) =>
@@ -45,9 +41,9 @@ export const StyledButton = styled(WalletButton)<{ isSelected?: boolean }>`
     margin-bottom: 0px;
     margin-right: 8px;
     background-color: ${(p) =>
-      p.isSelected ? 'var(--button-background-hover)' : 'none'};
+      p.isSelected ? leo.color.container.highlight : 'none'};
     &:hover {
-      background-color: var(--button-background-hover);
+      background-color: ${leo.color.container.highlight};
     }
     &:last-child {
       margin-right: 0px;

--- a/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-nav/wallet-nav.style.ts
@@ -16,17 +16,11 @@ import {
 export const Wrapper = styled.div<{
   isPanel: boolean
 }>`
-  --nav-background: ${leo.color.container.background};
-  @media (prefers-color-scheme: dark) {
-    /* #1C2026 does not exist in design system */
-    --nav-background: ${(p) =>
-      p.isPanel ? '#1C2026' : leo.color.container.background};
-  }
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: column;
-  background-color: var(--nav-background);
+  background-color: ${leo.color.container.background};
   border-radius: 16px;
   position: absolute;
   top: ${layoutTopPosition}px;


### PR DESCRIPTION
## Description 

Fixes the dark-theme colors in the `Wallet Panel` for

- `Buy/SendSwap` buttons `Icon` color
- Panel `Nav` buttons `hover` and `selected` background color

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/40215>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to brave://settings and change the theme to `dark`
2. Open the `Wallet` Panel
3. The 'Buy/SendSwap' buttons `Icon` color should be correct
4. The `Nav` buttons `hover` and `selected` background color should correct

Before:

![Screenshot 49](https://github.com/user-attachments/assets/8ed91152-9349-4283-97cc-77da0983a5a3)

After:

![Image](https://github.com/user-attachments/assets/70d75d73-5d3e-4979-94cc-a1da5899ce91)

