### PR TITLE
Fix crash when pinning tabs that are grouped in vertical tab strip

### DIFF
--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -10,14 +10,17 @@
 #include <iterator>
 #include <vector>
 
+#include "base/containers/adapters.h"
 #include "base/containers/span.h"
 #include "base/ranges/algorithm.h"
 #include "brave/browser/ui/brave_browser_window.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/tabs/tab_group_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_delegate.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "components/prefs/pref_service.h"
@@ -43,6 +46,28 @@ void BraveTabStripModel::SelectRelativeTab(TabRelativeDirection direction,
   } else {
     TabStripModel::SelectRelativeTab(direction, detail);
   }
+}
+
+void BraveTabStripModel::ExecuteContextMenuCommand(
+    int context_index,
+    ContextMenuCommand command_id) {
+  Browser* browser = chrome::FindBrowserWithTab(GetWebContentsAt(0));
+  if (tabs::utils::ShouldShowVerticalTabs(browser) &&
+      command_id == CommandTogglePinned && WillContextMenuPin(context_index)) {
+    // For vertical tabs, we need to ungroup the tabs before pinning tabs in
+    // order to avoid NOTREACHED.
+    // https://github.com/brave/brave-browser/issues/40201
+    auto indices = GetIndicesForCommand(context_index);
+    for (auto index : base::Reversed(indices)) {
+      if (!GetTabGroupForTab(index).has_value()) {
+        continue;
+      }
+
+      RemoveFromGroup({index});
+    }
+  }
+
+  TabStripModel::ExecuteContextMenuCommand(context_index, command_id);
 }
 
 void BraveTabStripModel::SelectMRUTab(TabRelativeDirection direction,

--- a/browser/ui/tabs/brave_tab_strip_model.h
+++ b/browser/ui/tabs/brave_tab_strip_model.h
@@ -25,9 +25,6 @@ class BraveTabStripModel : public TabStripModel {
   BraveTabStripModel(const BraveTabStripModel&) = delete;
   BraveTabStripModel operator=(const BraveTabStripModel&) = delete;
 
-  void SelectRelativeTab(TabRelativeDirection direction,
-                         TabStripUserGestureDetails detail) override;
-
   // Set the next tab when doing a MRU cycling with Ctrl-tab
   void SelectMRUTab(
       TabRelativeDirection direction,
@@ -44,6 +41,12 @@ class BraveTabStripModel : public TabStripModel {
   void CloseTabs(
       base::span<int> indices,
       uint32_t close_flags = TabCloseTypes::CLOSE_CREATE_HISTORICAL_TAB);
+
+  // TabStripModel:
+  void SelectRelativeTab(TabRelativeDirection direction,
+                         TabStripUserGestureDetails detail) override;
+  void ExecuteContextMenuCommand(int context_index,
+                                 ContextMenuCommand command_id) override;
 
  private:
   // List of tab indexes sorted by most recently used

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -737,6 +737,19 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, OriginalTabSearchButton) {
   EXPECT_FALSE(original_tab_search_button->GetVisible());
 }
 
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, PinningGroupedTab) {
+  // Regression check for https://github.com/brave/brave-browser/issues/40201
+  ToggleVerticalTabStrip();
+
+  // Given that we have a grouped tab
+  browser()->tab_strip_model()->ExecuteContextMenuCommand(
+      0, TabStripModel::CommandToggleGrouped);
+
+  // When pinning the tab shouldn't cause crash.
+  browser()->tab_strip_model()->ExecuteContextMenuCommand(
+      0, TabStripModel::CommandTogglePinned);
+}
+
 class VerticalTabStripDragAndDropBrowserTest
     : public VerticalTabStripBrowserTest {
  public:

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
@@ -10,8 +10,10 @@
 #define TAB_STRIP_MODEL_H_ friend class BraveTabStripModel;
 #define IsReadLaterSupportedForAny virtual IsReadLaterSupportedForAny
 #define TabDragController TabDragControllerChromium
+#define ExecuteContextMenuCommand virtual ExecuteContextMenuCommand
 
 #include "src/chrome/browser/ui/tabs/tab_strip_model.h"  // IWYU pragma: export
+#undef ExecuteContextMenuCommand
 #undef IsReadLaterSupportedForAny
 #undef SelectRelativeTab
 #undef TAB_STRIP_MODEL_H_


### PR DESCRIPTION
This behavior hits NOTREACHED that assuming no pinned tab is grouped. In order to avoid that, ungroup tabs before pinning them.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40201

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
* enable vertical tab strip 
* add a tab top a group
* try to pin the tab
* there should be no crash
