### PR TITLE
Fix crash when pinning tabs that are grouped in vertical tab strip (uplift to 1.69.x)

### DIFF
--- a/browser/ui/tabs/brave_tab_strip_model.cc
+++ b/browser/ui/tabs/brave_tab_strip_model.cc
@@ -10,14 +10,17 @@
 #include <iterator>
 #include <vector>
 
+#include "base/containers/adapters.h"
 #include "base/containers/span.h"
 #include "base/ranges/algorithm.h"
 #include "brave/browser/ui/brave_browser_window.h"
+#include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "chrome/browser/ui/browser_window.h"
+#include "chrome/browser/ui/tabs/tab_group_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_delegate.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "components/prefs/pref_service.h"
@@ -43,6 +46,28 @@ void BraveTabStripModel::SelectRelativeTab(TabRelativeDirection direction,
   } else {
     TabStripModel::SelectRelativeTab(direction, detail);
   }
+}
+
+void BraveTabStripModel::ExecuteContextMenuCommand(
+    int context_index,
+    ContextMenuCommand command_id) {
+  Browser* browser = chrome::FindBrowserWithTab(GetWebContentsAt(0));
+  if (tabs::utils::ShouldShowVerticalTabs(browser) &&
+      command_id == CommandTogglePinned && WillContextMenuPin(context_index)) {
+    // For vertical tabs, we need to ungroup the tabs before pinning tabs in
+    // order to avoid NOTREACHED.
+    // https://github.com/brave/brave-browser/issues/40201
+    auto indices = GetIndicesForCommand(context_index);
+    for (auto index : base::Reversed(indices)) {
+      if (!GetTabGroupForTab(index).has_value()) {
+        continue;
+      }
+
+      RemoveFromGroup({index});
+    }
+  }
+
+  TabStripModel::ExecuteContextMenuCommand(context_index, command_id);
 }
 
 void BraveTabStripModel::SelectMRUTab(TabRelativeDirection direction,

--- a/browser/ui/tabs/brave_tab_strip_model.h
+++ b/browser/ui/tabs/brave_tab_strip_model.h
@@ -25,9 +25,6 @@ class BraveTabStripModel : public TabStripModel {
   BraveTabStripModel(const BraveTabStripModel&) = delete;
   BraveTabStripModel operator=(const BraveTabStripModel&) = delete;
 
-  void SelectRelativeTab(TabRelativeDirection direction,
-                         TabStripUserGestureDetails detail) override;
-
   // Set the next tab when doing a MRU cycling with Ctrl-tab
   void SelectMRUTab(
       TabRelativeDirection direction,
@@ -44,6 +41,12 @@ class BraveTabStripModel : public TabStripModel {
   void CloseTabs(
       base::span<int> indices,
       uint32_t close_flags = TabCloseTypes::CLOSE_CREATE_HISTORICAL_TAB);
+
+  // TabStripModel:
+  void SelectRelativeTab(TabRelativeDirection direction,
+                         TabStripUserGestureDetails detail) override;
+  void ExecuteContextMenuCommand(int context_index,
+                                 ContextMenuCommand command_id) override;
 
  private:
   // List of tab indexes sorted by most recently used

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -639,6 +639,19 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, OriginalTabSearchButton) {
   EXPECT_FALSE(original_tab_search_button->GetVisible());
 }
 
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, PinningGroupedTab) {
+  // Regression check for https://github.com/brave/brave-browser/issues/40201
+  ToggleVerticalTabStrip();
+
+  // Given that we have a grouped tab
+  browser()->tab_strip_model()->ExecuteContextMenuCommand(
+      0, TabStripModel::CommandToggleGrouped);
+
+  // When pinning the tab shouldn't cause crash.
+  browser()->tab_strip_model()->ExecuteContextMenuCommand(
+      0, TabStripModel::CommandTogglePinned);
+}
+
 class VerticalTabStripDragAndDropBrowserTest
     : public VerticalTabStripBrowserTest {
  public:

--- a/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
+++ b/chromium_src/chrome/browser/ui/tabs/tab_strip_model.h
@@ -10,8 +10,10 @@
 #define TAB_STRIP_MODEL_H_ friend class BraveTabStripModel;
 #define IsReadLaterSupportedForAny virtual IsReadLaterSupportedForAny
 #define TabDragController TabDragControllerChromium
+#define ExecuteContextMenuCommand virtual ExecuteContextMenuCommand
 
 #include "src/chrome/browser/ui/tabs/tab_strip_model.h"  // IWYU pragma: export
+#undef ExecuteContextMenuCommand
 #undef IsReadLaterSupportedForAny
 #undef SelectRelativeTab
 #undef TAB_STRIP_MODEL_H_


### PR DESCRIPTION
Uplift of #25016
Resolves https://github.com/brave/brave-browser/issues/40201

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.