### PR TITLE
Modify readme for is_abp

### DIFF
--- a/components/third_party/adblock/lists/is_abp/README.chromium
+++ b/components/third_party/adblock/lists/is_abp/README.chromium
@@ -1,4 +1,4 @@
 Name: Icelandic ABP List
-URL: https://adblock.gardar.net/
+URL: https://github.com/brave/adblock-lists/blob/master/custom/is.txt 
 License: GPL-3.0-or-later OR CC-BY-SA-3.0
 License File: /brave/common/licenses/EasyList


### PR DESCRIPTION
Update URL to match the newly hosted list on https://github.com/brave/adblock-lists

From the previous broken; https://github.com/brave/brave-core/pull/24764