### PR TITLE
Add AdGuard URL Tracking Protection Filters license

### DIFF
--- a/components/third_party/adblock/lists/adguard_url/README.chromium
+++ b/components/third_party/adblock/lists/adguard_url/README.chromium
@@ -1,0 +1,4 @@
+Name: AdGuard URL Tracking Protection Filters
+URL: https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_17_TrackParam/filter.txt 
+License: GPL-3.0-or-later
+License File: /brave/common/licenses/GPL-3.0


### PR DESCRIPTION
Add license info from added: `https://raw.githubusercontent.com/AdguardTeam/FiltersRegistry/master/filters/filter_17_TrackParam/filter.txt`

PR: https://github.com/brave/adblock-resources/pull/197