### PR TITLE
Fixed NOTREACHED() from SidePanelIdFromSideBarItemType() (uplift to 1.68.x)

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -808,6 +808,27 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, UnManagedPanelEntryTest) {
   EXPECT_EQ(SidePanelEntryId::kBookmarks, panel_ui->GetCurrentEntryId());
 }
 
+IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
+                       OpenUnManagedPanelAfterDeletingDefaultWebTypeItem) {
+  auto* panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser());
+  const auto items = model()->GetAllSidebarItems();
+  const auto wallet_item_iter =
+      base::ranges::find(items, SidebarItem::BuiltInItemType::kWallet,
+                         &SidebarItem::built_in_item_type);
+  ASSERT_NE(wallet_item_iter, items.cend());
+  const int wallet_item_index = std::distance(items.cbegin(), wallet_item_iter);
+  SidebarServiceFactory::GetForProfile(browser()->profile())
+      ->RemoveItemAt(wallet_item_index);
+  EXPECT_FALSE(!!model()->GetIndexOf(SidebarItem::BuiltInItemType::kWallet));
+
+  // Test with upstream's side panel that runs only with chrome://new-tab-page.
+  ASSERT_TRUE(
+      ui_test_utils::NavigateToURL(browser(), GURL("chrome://new-tab-page/")));
+  panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
+  WaitUntil(base::BindLambdaForTesting(
+      [&]() { return GetSidePanel()->GetVisible(); }));
+}
+
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {
   auto* guest_browser = static_cast<BraveBrowser*>(CreateGuestBrowser());
   auto* controller = guest_browser->sidebar_controller();

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -808,27 +808,6 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, UnManagedPanelEntryTest) {
   EXPECT_EQ(SidePanelEntryId::kBookmarks, panel_ui->GetCurrentEntryId());
 }
 
-IN_PROC_BROWSER_TEST_F(SidebarBrowserTest,
-                       OpenUnManagedPanelAfterDeletingDefaultWebTypeItem) {
-  auto* panel_ui = SidePanelUI::GetSidePanelUIForBrowser(browser());
-  const auto items = model()->GetAllSidebarItems();
-  const auto wallet_item_iter =
-      base::ranges::find(items, SidebarItem::BuiltInItemType::kWallet,
-                         &SidebarItem::built_in_item_type);
-  ASSERT_NE(wallet_item_iter, items.cend());
-  const int wallet_item_index = std::distance(items.cbegin(), wallet_item_iter);
-  SidebarServiceFactory::GetForProfile(browser()->profile())
-      ->RemoveItemAt(wallet_item_index);
-  EXPECT_FALSE(!!model()->GetIndexOf(SidebarItem::BuiltInItemType::kWallet));
-
-  // Test with upstream's side panel that runs only with chrome://new-tab-page.
-  ASSERT_TRUE(
-      ui_test_utils::NavigateToURL(browser(), GURL("chrome://new-tab-page/")));
-  panel_ui->Show(SidePanelEntryId::kCustomizeChrome);
-  WaitUntil(base::BindLambdaForTesting(
-      [&]() { return GetSidePanel()->GetVisible(); }));
-}
-
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {
   auto* guest_browser = static_cast<BraveBrowser*>(CreateGuestBrowser());
   auto* controller = guest_browser->sidebar_controller();

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -141,16 +141,16 @@ SidePanelEntryId SidePanelIdFromSideBarItemType(BuiltInItemType type) {
     case BuiltInItemType::kHistory:
       [[fallthrough]];
     case BuiltInItemType::kNone:
-      // Add a new case for any new types which we want to support.
-      NOTREACHED_IN_MIGRATION()
-          << "Asked for a panel Id from a sidebar item which should "
-             "not have a panel Id, sending Reading List instead.";
-      return SidePanelEntryId::kReadingList;
+      break;
   }
+
+  NOTREACHED_NORETURN()
+      << "Asked for a panel Id from a sidebar item which could "
+         "not have a panel Id.";
 }
 
 SidePanelEntryId SidePanelIdFromSideBarItem(const SidebarItem& item) {
-  DCHECK(item.open_in_panel);
+  CHECK(item.open_in_panel) << static_cast<int>(item.built_in_item_type);
   return SidePanelIdFromSideBarItemType(item.built_in_item_type);
 }
 
@@ -163,7 +163,8 @@ std::optional<SidebarItem> AddItemForSidePanelIdIfNeeded(Browser* browser,
   }
 
   for (const auto& item : hidden_default_items) {
-    if (id == sidebar::SidePanelIdFromSideBarItem(item)) {
+    // Only panel item could have panel id.
+    if (item.open_in_panel && id == sidebar::SidePanelIdFromSideBarItem(item)) {
       GetSidebarService(browser)->AddItem(item);
       return item;
     }


### PR DESCRIPTION
Uplift of #24362
Resolves https://github.com/brave/brave-browser/issues/39055
Resolves https://github.com/brave/brave-browser/issues/40262

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.