### PR TITLE
Disable few pylint checks.

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,9 +1,6 @@
 [style]
 based_on_style = pep8
 
-# PEP-8 limits to 79 chars. Chromium uses 80 chars everywhere.
-column_limit = 80
-
 # Workaround yapf dict formatting bug.
 # See for details: https://github.com/google/yapf/issues/392
 allow_split_before_dict_value = False

--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -16,8 +16,6 @@ import override_utils
 USE_PYTHON3 = True
 PRESUBMIT_VERSION = '2.0.0'
 
-# pylint: disable=line-too-long
-
 
 # Adds support for chromium_presubmit_config.json5 and some helpers.
 def CheckToModifyInputApi(input_api, _output_api):
@@ -82,7 +80,6 @@ def CheckPatchFormatted(input_api, output_api):
     git_cl_format_cmd.append(input_api.PresubmitLocalPath())
 
     with brave_chromium_utils.sys_path("//brave/vendor/depot_tools"):
-        # pylint: disable=import-outside-toplevel
         import git_cl
 
     # Run git cl format and get return code.
@@ -159,7 +156,6 @@ def CheckESLint(input_api, output_api):
                                              include_deletes=False)
 
     with brave_chromium_utils.sys_path('//tools'):
-        # pylint: disable=import-outside-toplevel
         from web_dev_style import js_checker
         return js_checker.JSChecker(input_api,
                                     output_api).RunEsLintChecks(files_to_check)
@@ -167,7 +163,6 @@ def CheckESLint(input_api, output_api):
 
 def CheckWebDevStyle(input_api, output_api):
     with brave_chromium_utils.sys_path('//tools'):
-        # pylint: disable=import-outside-toplevel
         from web_dev_style import presubmit_support, js_checker
         # Disable RunEsLintChecks, it's run separately in CheckESLint.
         with override_utils.override_scope_function(
@@ -185,9 +180,15 @@ def CheckChangeLintsClean(input_api, output_api):
 
 def CheckPylint(input_api, output_api):
     extra_paths_list = os.environ['PYTHONPATH'].split(os.pathsep)
-    return input_api.canned_checks.RunPylint(input_api,
-                                             output_api,
-                                             extra_paths_list=extra_paths_list)
+    disabled_warnings = [
+        'import-outside-toplevel',
+        'line-too-long',
+    ]
+    return input_api.canned_checks.RunPylint(
+        input_api,
+        output_api,
+        extra_paths_list=extra_paths_list,
+        disabled_warnings=disabled_warnings)
 
 
 def CheckLicense(input_api, output_api):
@@ -467,7 +468,6 @@ def CheckJavaStyle(_original_check, input_api, output_api):
         return []
 
     with brave_chromium_utils.sys_path('//tools/android/checkstyle'):
-        # pylint: disable=import-outside-toplevel
         import checkstyle
 
     files_to_skip = input_api.DEFAULT_FILES_TO_SKIP

--- a/android/xml_processor.py
+++ b/android/xml_processor.py
@@ -89,8 +89,10 @@ def _XMLTransform(source_pairs, outputs_zip):
                 continue
 
             root = ET.XML(xml_content)
-            result = loaded_module._ProcessXML(root)  # pylint: disable=line-too-long,protected-access
-            output = ET.tostring(result, encoding='utf-8', xml_declaration=True)
+            result = loaded_module._ProcessXML(root)  # pylint: disable=protected-access
+            output = ET.tostring(result,
+                                 encoding='utf-8',
+                                 xml_declaration=True)
 
             # Parse output path
             # For simplicity, we assume input path will always has java/res in

--- a/chromium_src/PRESUBMIT.py
+++ b/chromium_src/PRESUBMIT.py
@@ -50,7 +50,6 @@ def CheckOverriddenHeadersDeclareIWYUExport(input_api, output_api):
 def CheckOverrides(input_api, output_api):
     items = []
     with brave_chromium_utils.sys_path('//brave/tools/chromium_src'):
-        # pylint: disable=import-outside-toplevel
         import check_chromium_src
     overrides = [
         f.AbsoluteLocalPath() for f in input_api.AffectedSourceFiles(None)

--- a/chromium_src/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
+++ b/chromium_src/third_party/blink/renderer/bindings/scripts/bind_gen/interface.py
@@ -8,7 +8,7 @@ import re
 import brave_chromium_utils
 import override_utils
 
-# pylint: disable=relative-beyond-top-level,line-too-long
+# pylint: disable=relative-beyond-top-level
 from .code_node import SymbolNode, TextNode
 from .codegen_accumulator import CodeGenAccumulator
 from .codegen_context import CodeGenContext

--- a/chromium_src/third_party/blink/renderer/build/scripts/make_instrumenting_probes.py
+++ b/chromium_src/third_party/blink/renderer/build/scripts/make_instrumenting_probes.py
@@ -6,8 +6,6 @@
 import brave_chromium_utils
 import override_utils
 
-# pylint: disable=line-too-long
-
 # Get gn arg to enable PageGraph.
 _IS_PG_ENABLED = brave_chromium_utils.get_gn_arg("enable_brave_page_graph")
 # Get gn arg to enable WebAPI probes.

--- a/chromium_src/third_party/catapult/common/py_utils/py_utils/cloud_storage.py
+++ b/chromium_src/third_party/catapult/common/py_utils/py_utils/cloud_storage.py
@@ -7,7 +7,7 @@ import brave_chromium_utils
 import override_utils
 
 with brave_chromium_utils.sys_path('//brave/tools/perf'):
-    from components.cloud_storage import CloudFolder, DownloadFileFromCloudStorage  # pylint: disable=import-outside-toplevel
+    from components.cloud_storage import CloudFolder, DownloadFileFromCloudStorage
 
 
 @override_utils.override_function(globals())

--- a/chromium_src/tools/json_schema_compiler/feature_compiler.py
+++ b/chromium_src/tools/json_schema_compiler/feature_compiler.py
@@ -3,8 +3,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-# pylint: disable=line-too-long
-
 import brave_chromium_utils
 import override_utils
 

--- a/script/brave_chromium_utils.py
+++ b/script/brave_chromium_utils.py
@@ -124,7 +124,7 @@ def get_gn_args(output_dir: str) -> Dict[str, Any]:
         raise FileNotFoundError(f"{ARGS_GN} not found in {output_dir}")
 
     with sys_path('//build'):
-        import gn_helpers  # pylint: disable=import-outside-toplevel
+        import gn_helpers
     with open(args_gn_filename, "r") as f:
         return gn_helpers.FromGNArgs(f.read())
 

--- a/script/chromium_presubmit_overrides.py
+++ b/script/chromium_presubmit_overrides.py
@@ -15,7 +15,7 @@ import traceback
 import brave_chromium_utils
 import override_utils
 
-# pylint: disable=line-too-long,protected-access,unused-variable
+# pylint: disable=protected-access,unused-variable
 
 CANNED_CHECKS_KEY = 'canned'
 
@@ -23,7 +23,6 @@ CANNED_CHECKS_KEY = 'canned'
 # Helper to load json5 presubmit config.
 def load_presubmit_config():
     with brave_chromium_utils.sys_path('//third_party/pyjson5/src'):
-        # pylint: disable=import-outside-toplevel
         import json5
         return json5.load(
             open(

--- a/tools/chromium_src/check_chromium_src.py
+++ b/tools/chromium_src/check_chromium_src.py
@@ -31,10 +31,8 @@ BRAVE_SRC = os.path.abspath(
 BRAVE_CHROMIUM_SRC = os.path.join(BRAVE_SRC, 'chromium_src')
 CHROMIUM_SRC = os.path.abspath(os.path.dirname(BRAVE_SRC))
 
-# pylint: disable=line-too-long
 NORMAL_DEFINITIONS_REGEXP = r'^#define[\s\\]+([a-zA-Z0-9_]+[^\s\(]*)(?:[ \t]+\\\s*|[ \t])?([a-zA-Z0-9_]+[^\s\(]*)?$'
 FUNCTION_LIKE_DEFINITIONS_REGEXP = r'^#define[\s\\]+([a-zA-Z0-9_]+)[\s\\]*\(.*?\)(?:[ \t]+\\\s*|[ \t])?([a-zA-Z0-9_]*[\s\\]*\(.*?\))?'
-# pylint: enable=line-too-long
 
 
 def strip_comments(content):
@@ -456,7 +454,6 @@ class ChromiumSrcOverridesChecker:
             json5_path = os.path.join(CHROMIUM_SRC, 'third_party', 'pyjson5',
                                       'src')
             sys.path.append(json5_path)
-            # pylint: disable=import-outside-toplevel
             import json5
 
             with open(config_path, "r", encoding='utf-8') as exclusions_file:


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Disable unnecessary/conflicting pylint checks. Line length is enforced by `yapf` in most cases. Non-top level imports are specific to the Chromium codebase.

Resolves https://github.com/brave/brave-browser/issues/38590

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

