### PR TITLE
[iOS] Show new set default screen using Brave.IOS.IsLikelyDefault logic

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
@@ -28,11 +28,9 @@ extension BrowserViewController {
   /// - Rewards
   /// - VPN Link Receipt
   func presentFullScreenCallouts() {
-    presentDefaultBrowserScreenCallout(skipSafeGuards: true)
-
-    //    for type in FullScreenCalloutType.allCases {
-    //      presentScreenCallout(for: type)
-    //    }
+    for type in FullScreenCalloutType.allCases {
+      presentScreenCallout(for: type)
+    }
   }
 
   private func presentScreenCallout(for type: FullScreenCalloutType, skipSafeGuards: Bool = false) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
@@ -47,7 +47,7 @@ extension BrowserViewController {
     case .bottomBar:
       presentBottomBarCallout(skipSafeGuards: skipSafeGuards)
     case .defaultBrowser:
-      presentDefaultBrowserScreenCallout()
+      presentDefaultBrowserScreenCallout(skipSafeGuards: skipSafeGuards)
     case .rewards:
       presentBraveRewardsScreenCallout(skipSafeGuards: skipSafeGuards)
     case .vpnPromotion:
@@ -131,37 +131,16 @@ extension BrowserViewController {
     present(popup, animated: false)
   }
 
-  private func presentDefaultBrowserScreenCallout() {
-    let onboardingController = WelcomeViewController(
-      state: WelcomeViewCalloutState.defaultBrowserCallout(
-        info: WelcomeViewCalloutState.WelcomeViewDefaultBrowserDetails(
-          title: Strings.Callout.defaultBrowserCalloutTitle,
-          details: Strings.Callout.defaultBrowserCalloutDescription,
-          primaryButtonTitle: Strings.Callout.defaultBrowserCalloutPrimaryButtonTitle,
-          secondaryButtonTitle: Strings.Callout.defaultBrowserCalloutSecondaryButtonTitle,
-          primaryButtonAction: { [weak self] in
-            guard let settingsUrl = URL(string: UIApplication.openSettingsURLString) else {
-              return
-            }
+  private func presentDefaultBrowserScreenCallout(skipSafeGuards: Bool = false) {    
+    if !skipSafeGuards {
+      let isLikelyDefault = DefaultBrowserHelper.isBraveLikelyDefaultBrowser()
 
-            Preferences.General.defaultBrowserCalloutDismissed.value = true
-            self?.isOnboardingOrFullScreenCalloutPresented = true
+      guard !isLikelyDefault else {
+        return
+      }
+    }
+    
 
-            UIApplication.shared.open(settingsUrl)
-            self?.dismiss(animated: false)
-          },
-          secondaryButtonAction: { [weak self] in
-            self?.isOnboardingOrFullScreenCalloutPresented = true
-
-            self?.dismiss(animated: false)
-          }
-        )
-      ),
-      p3aUtilities: braveCore.p3aUtils,
-      attributionManager: attributionManager
-    )
-
-    present(onboardingController, animated: true)
   }
 
   private func presentBraveRewardsScreenCallout(skipSafeGuards: Bool = false) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Callout.swift
@@ -28,9 +28,11 @@ extension BrowserViewController {
   /// - Rewards
   /// - VPN Link Receipt
   func presentFullScreenCallouts() {
-    for type in FullScreenCalloutType.allCases {
-      presentScreenCallout(for: type)
-    }
+    presentDefaultBrowserScreenCallout(skipSafeGuards: true)
+
+    //    for type in FullScreenCalloutType.allCases {
+    //      presentScreenCallout(for: type)
+    //    }
   }
 
   private func presentScreenCallout(for type: FullScreenCalloutType, skipSafeGuards: Bool = false) {
@@ -131,7 +133,7 @@ extension BrowserViewController {
     present(popup, animated: false)
   }
 
-  private func presentDefaultBrowserScreenCallout(skipSafeGuards: Bool = false) {    
+  private func presentDefaultBrowserScreenCallout(skipSafeGuards: Bool = false) {
     if !skipSafeGuards {
       let isLikelyDefault = DefaultBrowserHelper.isBraveLikelyDefaultBrowser()
 
@@ -139,8 +141,18 @@ extension BrowserViewController {
         return
       }
     }
-    
 
+    let defaultBrowserCallout = UIHostingController(
+      rootView: FocusSystemSettingsView(
+        screenType: .callout,
+        shouldDismiss: Binding.constant(false)
+      )
+    ).then {
+      $0.isModalInPresentation = true
+      $0.modalPresentationStyle = .overFullScreen
+    }
+
+    present(defaultBrowserCallout, animated: true)
   }
 
   private func presentBraveRewardsScreenCallout(skipSafeGuards: Bool = false) {

--- a/ios/brave-ios/Sources/Onboarding/ProductNotifications/FullScreenCalloutManager.swift
+++ b/ios/brave-ios/Sources/Onboarding/ProductNotifications/FullScreenCalloutManager.swift
@@ -28,7 +28,7 @@ public enum FullScreenCalloutType: CaseIterable {
     case .vpnUpdateBilling: return 0
     case .bottomBar: return 0
     case .vpnPromotion: return 4
-    case .defaultBrowser: return 10
+    case .defaultBrowser: return 7
     case .rewards: return 8
     case .vpnLinkReceipt: return 0
     }

--- a/ios/brave-ios/Sources/Onboarding/Welcome/WelcomeViewCallout.swift
+++ b/ios/brave-ios/Sources/Onboarding/Welcome/WelcomeViewCallout.swift
@@ -58,7 +58,6 @@ public enum WelcomeViewCalloutState {
   case defaultBrowser(info: WelcomeViewDefaultBrowserDetails)
   case settings(title: String, details: String)
   case p3a(info: WelcomeViewDefaultBrowserDetails)
-  case defaultBrowserCallout(info: WelcomeViewDefaultBrowserDetails)
 }
 
 class WelcomeViewCallout: UIView {
@@ -570,90 +569,6 @@ class WelcomeViewCallout: UIView {
       contentStackView.setCustomSpacing(horizontalLayoutMargin, after: actionToggle)
       contentStackView.setCustomSpacing(horizontalLayoutMargin, after: detailsLabel)
       contentStackView.setCustomSpacing(3 * horizontalLayoutMargin, after: actionDescriptionLabel)
-      contentStackView.setCustomSpacing(horizontalLayoutMargin, after: primaryButton)
-    case .defaultBrowserCallout(let info):
-      contentStackView.do {
-        $0.layoutMargins = UIEdgeInsets(
-          top: 2 * UX.verticalLayoutMargin,
-          left: 20,
-          bottom: UX.verticalLayoutMargin,
-          right: 20
-        )
-      }
-
-      titleLabel.do {
-        $0.text = info.title
-        $0.textAlignment = .left
-        $0.font = .preferredFont(for: .title3, weight: .bold)
-        $0.alpha = 1.0
-        $0.isHidden = false
-      }
-
-      detailsLabel.do {
-        $0.text = info.details
-        $0.font = .preferredFont(for: .body, weight: .regular)
-        $0.alpha = 1.0
-        $0.isHidden = false
-      }
-
-      secondaryDetailsLabel.do {
-        $0.text = info.details
-        $0.font = .preferredFont(for: .body, weight: .bold)
-        $0.alpha = 1.0
-        $0.isHidden = false
-      }
-
-      primaryButton.do {
-        $0.setTitle(info.primaryButtonTitle, for: .normal)
-        $0.titleLabel?.font = .preferredFont(for: .body, weight: .regular)
-        $0.addAction(
-          UIAction(
-            identifier: .init(rawValue: "primary.action"),
-            handler: { _ in
-              info.primaryButtonAction()
-            }
-          ),
-          for: .touchUpInside
-        )
-        $0.alpha = 1.0
-        $0.isHidden = false
-      }
-
-      secondaryLabel.do {
-        $0.text = Strings.Callout.defaultBrowserCalloutSecondaryButtonDescription
-        $0.textAlignment = .right
-        $0.font = .preferredFont(for: .body, weight: .regular)
-        $0.alpha = 1.0
-        $0.isHidden = false
-        $0.numberOfLines = 1
-        $0.minimumScaleFactor = 0.7
-        $0.adjustsFontSizeToFitWidth = true
-      }
-
-      secondaryButton.do {
-        $0.setTitle(info.secondaryButtonTitle, for: .normal)
-        $0.titleLabel?.font = .preferredFont(for: .title3, weight: .bold)
-        $0.addAction(
-          UIAction(
-            identifier: .init(rawValue: "secondary.action"),
-            handler: { _ in
-              info.secondaryButtonAction?()
-            }
-          ),
-          for: .touchUpInside
-        )
-        $0.alpha = 1.0
-        $0.isHidden = false
-      }
-
-      secondaryButtonContentView.do {
-        $0.alpha = 1.0
-        $0.isHidden = false
-      }
-
-      contentStackView.setCustomSpacing(horizontalLayoutMargin, after: titleLabel)
-      contentStackView.setCustomSpacing(horizontalLayoutMargin, after: detailsLabel)
-      contentStackView.setCustomSpacing(2 * horizontalLayoutMargin, after: secondaryDetailsLabel)
       contentStackView.setCustomSpacing(horizontalLayoutMargin, after: primaryButton)
     }
   }

--- a/ios/brave-ios/Sources/Onboarding/Welcome/WelcomeViewController.swift
+++ b/ios/brave-ios/Sources/Onboarding/Welcome/WelcomeViewController.swift
@@ -297,30 +297,6 @@ public class WelcomeViewController: UIViewController {
         $0.height.equalTo(180.0)
       }
       calloutView.setState(state: state)
-    case .defaultBrowserCallout:
-      let topTransform = { () -> CGAffineTransform in
-        var transformation = CGAffineTransform.identity
-        transformation = transformation.scaledBy(x: 1.5, y: 1.5)
-        transformation = transformation.translatedBy(x: 0.0, y: -70.0)
-        return transformation
-      }()
-
-      let bottomTransform = { () -> CGAffineTransform in
-        var transformation = CGAffineTransform.identity
-        transformation = transformation.scaledBy(x: 2.0, y: 2.0)
-        transformation = transformation.translatedBy(x: 0.0, y: 40.0)
-        return transformation
-      }()
-
-      topImageView.transform = topTransform
-      bottomImageView.transform = bottomTransform
-      iconView.image = UIImage(named: "welcome-view-phone", in: .module, compatibleWith: nil)!
-      contentContainer.spacing = 0.0
-      iconBackgroundView.alpha = 0.0
-      iconView.snp.remakeConstraints {
-        $0.height.equalTo(175.0)
-      }
-      calloutView.setState(state: state)
     }
   }
 

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusP3AScreenView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusP3AScreenView.swift
@@ -53,7 +53,7 @@ struct FocusP3AScreenView: View {
       .background(Color(braveSystemName: .pageBackground))
       .background {
         NavigationLink("", isActive: $isSystemSettingsViewPresented) {
-          FocusSystemSettingsView(shouldDismiss: $shouldDismiss)
+          FocusSystemSettingsView(screenType: .onboarding, shouldDismiss: $shouldDismiss)
         }
       }
       .toolbar(.hidden, for: .navigationBar)
@@ -66,7 +66,7 @@ struct FocusP3AScreenView: View {
       .background(Color(braveSystemName: .pageBackground))
       .background {
         NavigationLink("", isActive: $isSystemSettingsViewPresented) {
-          FocusSystemSettingsView(shouldDismiss: $shouldDismiss)
+          FocusSystemSettingsView(screenType: .onboarding, shouldDismiss: $shouldDismiss)
         }
       }
       .toolbar(.hidden, for: .navigationBar)

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSystemSettingsView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSystemSettingsView.swift
@@ -15,7 +15,7 @@ public struct FocusSystemSettingsView: View {
   }
 
   @Environment(\.colorScheme) private var colorScheme
-  @Environment(\.presentationMode) @Binding private var presentationMode
+  @Environment(\.dismiss) var dismiss
   @Environment(\.verticalSizeClass) private var verticalSizeClass: UserInterfaceSizeClass?
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
 
@@ -142,12 +142,16 @@ public struct FocusSystemSettingsView: View {
             completeDefaultBrowserInteraction()
           },
           label: {
-            completeActionButtonText
-              .font(.subheadline.weight(.semibold))
-              .foregroundColor(Color(braveSystemName: .textInteractive))
-              .dynamicTypeSize(dynamicTypeRange)
-              .padding()
-              .frame(maxWidth: .infinity)
+            Text(
+              screenType == .onboarding
+                ? "\(Strings.FocusOnboarding.startBrowseActionButtonTitle) \(Image(systemName: "arrow.right"))"
+                : "\(Strings.FocusOnboarding.notNowActionButtonTitle)"
+            )
+            .font(.subheadline.weight(.semibold))
+            .foregroundColor(Color(braveSystemName: .textInteractive))
+            .dynamicTypeSize(dynamicTypeRange)
+            .padding()
+            .frame(maxWidth: .infinity)
           }
         )
         .clipShape(RoundedRectangle(cornerRadius: 12.0, style: .continuous))
@@ -161,23 +165,12 @@ public struct FocusSystemSettingsView: View {
     .padding(.horizontal, shouldUseExtendedDesign ? 75 : 20)
   }
 
-  @ViewBuilder
-  private var completeActionButtonText: some View {
-    if screenType == .onboarding {
-      Text(
-        "\(Strings.FocusOnboarding.startBrowseActionButtonTitle) \(Image(systemName: "arrow.right"))"
-      )
-    } else {
-      Text(Strings.FocusOnboarding.notNowActionButtonTitle)
-    }
-  }
-
   private func completeDefaultBrowserInteraction() {
     if screenType == .onboarding {
       Preferences.FocusOnboarding.urlBarIndicatorShowBeShown.value = true
       shouldDismiss = true
     } else {
-      presentationMode.dismiss()
+      dismiss()
     }
   }
 }

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSystemSettingsView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSystemSettingsView.swift
@@ -8,12 +8,20 @@ import Lottie
 import Preferences
 import SwiftUI
 
-struct FocusSystemSettingsView: View {
+public struct FocusSystemSettingsView: View {
+
+  public enum DefaultBrowserScreenType {
+    case onboarding, callout
+  }
+
   @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.presentationMode) @Binding private var presentationMode
   @Environment(\.verticalSizeClass) private var verticalSizeClass: UserInterfaceSizeClass?
   @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
 
   @Binding var shouldDismiss: Bool
+
+  var screenType: DefaultBrowserScreenType
 
   private var shouldUseExtendedDesign: Bool {
     return horizontalSizeClass == .regular && verticalSizeClass == .regular
@@ -21,7 +29,15 @@ struct FocusSystemSettingsView: View {
 
   private let dynamicTypeRange = (...DynamicTypeSize.xLarge)
 
-  var body: some View {
+  public init(
+    screenType: DefaultBrowserScreenType,
+    shouldDismiss: Binding<Bool>
+  ) {
+    self.screenType = screenType
+    self._shouldDismiss = shouldDismiss
+  }
+
+  public var body: some View {
     if shouldUseExtendedDesign {
       VStack(spacing: 40) {
         VStack {
@@ -33,7 +49,9 @@ struct FocusSystemSettingsView: View {
         .shadow(color: .black.opacity(0.1), radius: 18, x: 0, y: 8)
         .shadow(color: .black.opacity(0.05), radius: 0, x: 0, y: 1)
 
-        FocusStepsPagingIndicator(totalPages: 4, activeIndex: .constant(3))
+        if screenType == .onboarding {
+          FocusStepsPagingIndicator(totalPages: 4, activeIndex: .constant(3))
+        }
       }
       .frame(maxWidth: .infinity, maxHeight: .infinity)
       .background(Color(braveSystemName: .pageBackground))
@@ -41,7 +59,10 @@ struct FocusSystemSettingsView: View {
     } else {
       VStack(spacing: 16) {
         settingsSystemContentView
-        FocusStepsPagingIndicator(totalPages: 4, activeIndex: .constant(3))
+
+        if screenType == .onboarding {
+          FocusStepsPagingIndicator(totalPages: 4, activeIndex: .constant(3))
+        }
       }
       .padding(.bottom, 20)
       .background(Color(braveSystemName: .pageBackground))
@@ -97,8 +118,7 @@ struct FocusSystemSettingsView: View {
               UIApplication.shared.open(settingsUrl)
             }
 
-            Preferences.FocusOnboarding.urlBarIndicatorShowBeShown.value = true
-            shouldDismiss = true
+            completeDefaultBrowserInteraction()
           },
           label: {
             Text(Strings.FocusOnboarding.systemSettingsButtonTitle)
@@ -119,18 +139,15 @@ struct FocusSystemSettingsView: View {
 
         Button(
           action: {
-            Preferences.FocusOnboarding.urlBarIndicatorShowBeShown.value = true
-            shouldDismiss = true
+            completeDefaultBrowserInteraction()
           },
           label: {
-            Text(
-              "\(Strings.FocusOnboarding.startBrowseActionButtonTitle) \(Image(systemName: "arrow.right"))"
-            )
-            .font(.subheadline.weight(.semibold))
-            .foregroundColor(Color(braveSystemName: .textInteractive))
-            .dynamicTypeSize(dynamicTypeRange)
-            .padding()
-            .frame(maxWidth: .infinity)
+            completeActionButtonText
+              .font(.subheadline.weight(.semibold))
+              .foregroundColor(Color(braveSystemName: .textInteractive))
+              .dynamicTypeSize(dynamicTypeRange)
+              .padding()
+              .frame(maxWidth: .infinity)
           }
         )
         .clipShape(RoundedRectangle(cornerRadius: 12.0, style: .continuous))
@@ -143,6 +160,26 @@ struct FocusSystemSettingsView: View {
     .padding(.vertical, shouldUseExtendedDesign ? 48 : 24)
     .padding(.horizontal, shouldUseExtendedDesign ? 75 : 20)
   }
+
+  @ViewBuilder
+  private var completeActionButtonText: some View {
+    if screenType == .onboarding {
+      Text(
+        "\(Strings.FocusOnboarding.startBrowseActionButtonTitle) \(Image(systemName: "arrow.right"))"
+      )
+    } else {
+      Text(Strings.FocusOnboarding.notNowActionButtonTitle)
+    }
+  }
+
+  private func completeDefaultBrowserInteraction() {
+    if screenType == .onboarding {
+      Preferences.FocusOnboarding.urlBarIndicatorShowBeShown.value = true
+      shouldDismiss = true
+    } else {
+      presentationMode.dismiss()
+    }
+  }
 }
 
 #if DEBUG
@@ -150,7 +187,9 @@ struct FocusSystemSettingsView_Previews: PreviewProvider {
   static var previews: some View {
     @State var shouldDismiss: Bool = false
 
-    FocusSystemSettingsView(shouldDismiss: $shouldDismiss)
+    FocusSystemSettingsView(screenType: .onboarding, shouldDismiss: $shouldDismiss)
+
+    FocusSystemSettingsView(screenType: .callout, shouldDismiss: $shouldDismiss)
   }
 }
 #endif

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/Resources/FocusOnboardingStrings.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/Resources/FocusOnboardingStrings.swift
@@ -120,6 +120,14 @@ extension Strings {
       comment: "The title of the button that finishes the onboarding without setting default"
     )
 
+    public static let notNowActionButtonTitle = NSLocalizedString(
+      "focusOnboarding.notNowActionButtonTitle",
+      tableName: "FocusOnboarding",
+      bundle: .module,
+      value: "Not Now",
+      comment: "The title of the button that closes the default browser full screen callout"
+    )
+
     public static let urlBarIndicatorTitle = NSLocalizedString(
       "focusOnboarding.urlBarIndicatorTitle",
       tableName: "FocusOnboarding",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38380

This PR is adding the IsLikelyDefault criteria to show the default browser callout presentation and also changing the 10 days period to 7 days for showing the callout after onboarding. 

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

https://github.com/user-attachments/assets/c27c2606-05b8-4383-b308-247cc3ab80f7

- Check Default browser callout display performs after 7 days.
- And repeat the process of display of default browser callout with IsLikelyDefault logic

IsLikelyDefault is determined whether or not its likely that Brave is the users default browser based on a 14 day usage period


