### PR TITLE
Delete pref-based webcompat setting when it matches remote setting

### DIFF
--- a/chromium_src/chrome/browser/content_settings/host_content_settings_map_factory.cc
+++ b/chromium_src/chrome/browser/content_settings/host_content_settings_map_factory.cc
@@ -6,6 +6,8 @@
 #include "chrome/browser/content_settings/host_content_settings_map_factory.h"
 
 #include "brave/components/content_settings/core/browser/remote_list_provider.h"
+#include "brave/components/webcompat/content/browser/webcompat_exceptions_observer.h"
+#include "brave/components/webcompat/content/browser/webcompat_exceptions_service.h"
 #include "build/buildflag.h"
 #include "chrome/browser/supervised_user/supervised_user_settings_service_factory.h"
 #include "components/keyed_service/content/browser_context_keyed_service_factory.h"
@@ -25,12 +27,15 @@
 scoped_refptr<RefcountedKeyedService>
 HostContentSettingsMapFactory::BuildServiceInstanceFor(
     content::BrowserContext* context) const {
-  scoped_refptr<RefcountedKeyedService> settings_map =
+  scoped_refptr<RefcountedKeyedService> settings_map_keyed_service =
       BuildServiceInstanceFor_ChromiumImpl(context);
   auto remote_list_provider_ptr =
       std::make_unique<content_settings::RemoteListProvider>();
-  static_cast<HostContentSettingsMap*>(settings_map.get())
-      ->RegisterProvider(ProviderType::kRemoteListProvider,
-                         std::move(remote_list_provider_ptr));
-  return settings_map;
+  auto* settings_map =
+      static_cast<HostContentSettingsMap*>(settings_map_keyed_service.get());
+  settings_map->RegisterProvider(ProviderType::kRemoteListProvider,
+                                 std::move(remote_list_provider_ptr));
+  webcompat::WebcompatExceptionsService::AddObserver(settings_map);
+  settings_map->RemoveRedundantWebcompatSettings();
+  return settings_map_keyed_service;
 }

--- a/chromium_src/components/content_settings/core/browser/DEPS
+++ b/chromium_src/components/content_settings/core/browser/DEPS
@@ -2,4 +2,5 @@ include_rules = [
   "+brave/components/content_settings/core/browser",
   "+brave/components/brave_shields/core/common",
   "+brave/components/constants",
+  "+brave/components/webcompat/content/browser",
 ]

--- a/chromium_src/components/content_settings/core/browser/host_content_settings_map.cc
+++ b/chromium_src/components/content_settings/core/browser/host_content_settings_map.cc
@@ -6,10 +6,15 @@
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 
 #include "base/containers/contains.h"
+#include "base/trace_event/trace_event.h"
 #include "brave/components/content_settings/core/browser/remote_list_provider.h"
+#include "brave/components/webcompat/content/browser/webcompat_exceptions_service.h"
 #include "build/build_config.h"
+#include "components/content_settings/core/browser/content_settings_provider.h"
 #include "components/content_settings/core/browser/content_settings_utils.h"
+#include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/content_settings/core/common/content_settings_types.h"
+#include "components/content_settings/core/common/content_settings_utils.h"
 #include "components/content_settings/core/common/features.h"
 
 #if !BUILDFLAG(IS_IOS)
@@ -53,9 +58,56 @@ bool IsMorePermissive_BraveImpl(ContentSettingsType content_type,
 
 #define IsMorePermissive(a, b) IsMorePermissive_BraveImpl(content_type, a, b)
 
+// Insert code into HostContentSettingsMap::ShutdownOnUIThread() body:
+#define clear() \
+  clear();      \
+  webcompat::WebcompatExceptionsService::RemoveObserver(this)
+
 #include "src/components/content_settings/core/browser/host_content_settings_map.cc"
 
+#undef clear
 #undef IsMorePermissive
+
+void HostContentSettingsMap::RemoveRedundantWebcompatSettingsByType(
+    ContentSettingsType settings_type) {
+  auto* svc = webcompat::WebcompatExceptionsService::GetInstance();
+  if (!svc) {
+    return;
+  }
+  const auto& patterns = svc->GetPatterns(settings_type);
+  for (const ContentSettingPatternSource& setting :
+       GetSettingsForOneType(settings_type)) {
+    if (setting.source == ProviderType::kPrefProvider) {
+      const auto prefSettingValue =
+          content_settings::ValueToContentSetting(setting.setting_value);
+      bool patternExists = std::find(patterns.begin(), patterns.end(),
+                                     setting.primary_pattern) != patterns.end();
+      if ((prefSettingValue == CONTENT_SETTING_BLOCK && !patternExists) ||
+          (prefSettingValue == CONTENT_SETTING_ALLOW && patternExists)) {
+        SetContentSettingCustomScope(setting.primary_pattern,
+                                     ContentSettingsPattern::Wildcard(),
+                                     settings_type, CONTENT_SETTING_DEFAULT);
+      }
+    }
+  }
+}
+
+// Removes all webcompat settings set by user in Prefs that are the same as
+// those provided by the remote webcompat exceptions list.
+void HostContentSettingsMap::RemoveRedundantWebcompatSettings() {
+  for (auto settings_type = ContentSettingsType::BRAVE_WEBCOMPAT_NONE;
+       settings_type != ContentSettingsType::BRAVE_WEBCOMPAT_ALL;
+       settings_type = static_cast<ContentSettingsType>(
+           static_cast<int32_t>(settings_type) + 1)) {
+    RemoveRedundantWebcompatSettingsByType(settings_type);
+  }
+  RemoveRedundantWebcompatSettingsByType(
+      ContentSettingsType::BRAVE_FINGERPRINTING_V2);
+}
+
+void HostContentSettingsMap::OnWebcompatRulesUpdated() {
+  RemoveRedundantWebcompatSettings();
+}
 
 #if !BUILDFLAG(IS_IOS)
 #undef PrefProvider

--- a/chromium_src/components/content_settings/core/browser/host_content_settings_map.h
+++ b/chromium_src/components/content_settings/core/browser/host_content_settings_map.h
@@ -6,10 +6,25 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_HOST_CONTENT_SETTINGS_MAP_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_HOST_CONTENT_SETTINGS_MAP_H_
 
+#include "brave/components/webcompat/content/browser/webcompat_exceptions_observer.h"
+#include "components/keyed_service/core/refcounted_keyed_service.h"
+
 #define PREF_PROVIDER PREF_PROVIDER, REMOTE_LIST_PROVIDER
+
+#define RefcountedKeyedService \
+  RefcountedKeyedService, public webcompat::WebcompatExceptionsObserver
+
+#define FlushLossyWebsiteSettings()            \
+  RemoveRedundantWebcompatSettings();          \
+  void RemoveRedundantWebcompatSettingsByType( \
+      ContentSettingsType settings_type);      \
+  void OnWebcompatRulesUpdated() override;     \
+  void FlushLossyWebsiteSettings()
 
 #include "src/components/content_settings/core/browser/host_content_settings_map.h"  // IWYU pragma: export
 
+#undef FlushLossyWebsiteSettings
+#undef RefcountedKeyedService
 #undef PREF_PROVIDER
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_CORE_BROWSER_HOST_CONTENT_SETTINGS_MAP_H_

--- a/components/brave_shields/content/browser/BUILD.gn
+++ b/components/brave_shields/content/browser/BUILD.gn
@@ -65,6 +65,7 @@ static_library("browser") {
     "//brave/components/p3a",
     "//brave/components/p3a_utils",
     "//brave/components/resources:static_resources_grit",
+    "//brave/components/webcompat/content/browser",
     "//components/component_updater:component_updater",
     "//components/content_settings/core/browser",
     "//components/content_settings/core/browser:cookie_settings",

--- a/components/webcompat/content/browser/BUILD.gn
+++ b/components/webcompat/content/browser/BUILD.gn
@@ -7,6 +7,7 @@ import("//brave/build/config.gni")
 
 source_set("browser") {
   sources = [
+    "webcompat_exceptions_observer.h",
     "webcompat_exceptions_service.cc",
     "webcompat_exceptions_service.h",
   ]

--- a/components/webcompat/content/browser/webcompat_exceptions_observer.h
+++ b/components/webcompat/content/browser/webcompat_exceptions_observer.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_WEBCOMPAT_CONTENT_BROWSER_WEBCOMPAT_EXCEPTIONS_OBSERVER_H_
+#define BRAVE_COMPONENTS_WEBCOMPAT_CONTENT_BROWSER_WEBCOMPAT_EXCEPTIONS_OBSERVER_H_
+
+namespace webcompat {
+
+class WebcompatExceptionsObserver {
+ public:
+  virtual void OnWebcompatRulesUpdated() = 0;
+  virtual ~WebcompatExceptionsObserver() = default;
+};
+
+}  // namespace webcompat
+
+#endif  // BRAVE_COMPONENTS_WEBCOMPAT_CONTENT_BROWSER_WEBCOMPAT_EXCEPTIONS_OBSERVER_H_

--- a/components/webcompat/content/browser/webcompat_exceptions_service.h
+++ b/components/webcompat/content/browser/webcompat_exceptions_service.h
@@ -17,6 +17,7 @@
 #include "base/values.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_observer.h"
 #include "brave/components/brave_component_updater/browser/local_data_files_service.h"
+#include "brave/components/webcompat/content/browser/webcompat_exceptions_observer.h"
 #include "components/content_settings/core/common/content_settings_pattern.h"
 #include "components/content_settings/core/common/content_settings_types.h"
 
@@ -50,6 +51,8 @@ class WebcompatExceptionsService
   std::vector<ContentSettingsPattern> GetPatterns(
       ContentSettingsType webcompat_type);
   void SetRulesForTesting(PatternsByWebcompatTypeMap patterns_by_webcompat_type);
+  static void AddObserver(WebcompatExceptionsObserver* observer);
+  static void RemoveObserver(WebcompatExceptionsObserver* observer);
 
  private:
   void LoadWebcompatExceptions(const base::FilePath& install_dir);

--- a/components/webcompat/content/test/webcompat_exceptions_browsertest.cc
+++ b/components/webcompat/content/test/webcompat_exceptions_browsertest.cc
@@ -140,45 +140,48 @@ class WebcompatExceptionsBrowserTest : public PlatformBrowserTest {
 IN_PROC_BROWSER_TEST_F(WebcompatExceptionsBrowserTest, RemoteSettingsTest) {
   NavigateToURL("a.test", "/simple.html");
   const auto pattern = ContentSettingsPattern::FromString("*://a.test/*");
+  const webcompat::PatternsByWebcompatTypeMap rule_map_empty;
   auto* webcompat_exceptions_service =
       webcompat::WebcompatExceptionsService::CreateInstance(
           g_brave_browser_process->local_data_files_service());
   auto* map = content_settings();
+  ContentSetting observed_setting;
   for (const auto& test_case : kTestCases) {
-    // Check the default setting
-    const auto observed_setting_default =
-        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
-    EXPECT_NE(observed_setting_default, CONTENT_SETTING_ALLOW);
-
-    // Create a rule and then reload the page.
     webcompat::PatternsByWebcompatTypeMap rule_map;
     rule_map[test_case.type] = std::vector<ContentSettingsPattern>({pattern});
+
+    // Check the default setting
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_NE(observed_setting, CONTENT_SETTING_ALLOW);
+
+    // Set a remote rule and then reload the page.
     webcompat_exceptions_service->SetRulesForTesting(rule_map);
     NavigateToURL("a.test", "/simple.html");
 
     // Check the remote setting gets used
-    const auto observed_setting_remote =
+    observed_setting =
         map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
-    EXPECT_EQ(observed_setting_remote, CONTENT_SETTING_ALLOW);
+    EXPECT_EQ(observed_setting, CONTENT_SETTING_ALLOW);
 
     // Check that the remote setting doesn't leak to another domain
-    const auto observed_setting_cross_site =
+    observed_setting =
         map->GetContentSetting(GURL("https://b.test"), GURL(), test_case.type);
-    EXPECT_NE(observed_setting_cross_site, CONTENT_SETTING_ALLOW);
+    EXPECT_NE(observed_setting, CONTENT_SETTING_ALLOW);
 
     // Check that manual setting can override the remote setting
     brave_shields::SetWebcompatEnabled(map, test_case.type, false,
                                        GURL("https://a.test"), nullptr);
-    const auto observed_setting_override1 =
+    observed_setting =
         map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
-    EXPECT_EQ(observed_setting_override1, CONTENT_SETTING_BLOCK);
+    EXPECT_EQ(observed_setting, CONTENT_SETTING_BLOCK);
 
     // Check that manual setting can override the remote setting
     brave_shields::SetWebcompatEnabled(map, test_case.type, true,
                                        GURL("https://b.test"), nullptr);
-    const auto observed_setting_override2 =
+    observed_setting =
         map->GetContentSetting(GURL("https://b.test"), GURL(), test_case.type);
-    EXPECT_EQ(observed_setting_override2, CONTENT_SETTING_ALLOW);
+    EXPECT_EQ(observed_setting, CONTENT_SETTING_ALLOW);
 
     // Check that webcompat returns false for non-http URLs.
     bool result = brave_shields::IsWebcompatEnabled(map, test_case.type,
@@ -189,5 +192,73 @@ IN_PROC_BROWSER_TEST_F(WebcompatExceptionsBrowserTest, RemoteSettingsTest) {
     bool result2 = brave_shields::IsWebcompatEnabled(map, test_case.type,
                                                      GURL("https://b.test"));
     EXPECT_TRUE(result2);
+
+    // Check that an enabled setting is deleted once the remote
+    // setting matches it.
+    brave_shields::SetWebcompatEnabled(map, test_case.type, true,
+                                       GURL("https://a.test"), nullptr);
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_EQ(observed_setting, CONTENT_SETTING_ALLOW);
+    // Enable exception via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map);
+    // Now disable it via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map_empty);
+    // Confirm that the exception is disabled (BLOCK fingerprinting).
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_EQ(observed_setting, test_case.type == BRAVE_FINGERPRINTING_V2
+                                    ? CONTENT_SETTING_ASK
+                                    : CONTENT_SETTING_BLOCK);
+
+    // Check that a disabled setting is deleted once the remote
+    // setting matches it.
+    brave_shields::SetWebcompatEnabled(map, test_case.type, false,
+                                       GURL("https://a.test"), nullptr);
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_EQ(observed_setting, test_case.type == BRAVE_FINGERPRINTING_V2
+                                    ? CONTENT_SETTING_ASK
+                                    : CONTENT_SETTING_BLOCK);
+    // Disable exception via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map_empty);
+    // Now enable it via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map);
+    // Confirm that the exception is enabled (ALLOW fingerprinting).
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_EQ(observed_setting, CONTENT_SETTING_ALLOW);
+
+    // Check that a pref is deleted when set to ALLOW if it is redundant.
+    // First, disable exception via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map_empty);
+    // Now, enable exception via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map);
+    // Set a redundant pref (should get deleted)
+    brave_shields::SetWebcompatEnabled(map, test_case.type, true,
+                                       GURL("https://a.test"), nullptr);
+    // Disable exception via remote list again.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map_empty);
+    // Confirm that the exception is disabled (BLOCK fingerprinting).
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_EQ(observed_setting, test_case.type == BRAVE_FINGERPRINTING_V2
+                                    ? CONTENT_SETTING_ASK
+                                    : CONTENT_SETTING_BLOCK);
+
+    // Check that a pref is deleted when set to BLOCK if it is redundant.
+    // First, enable exception via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map);
+    // Now, disable exception via remote list.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map_empty);
+    // Set a redundant pref (should get deleted)
+    brave_shields::SetWebcompatEnabled(map, test_case.type, false,
+                                       GURL("https://a.test"), nullptr);
+    // Enable exception via remote list again.
+    webcompat_exceptions_service->SetRulesForTesting(rule_map);
+    // Confirm that the exception is enabled (ALLOW fingerprinting).
+    observed_setting =
+        map->GetContentSetting(GURL("https://a.test"), GURL(), test_case.type);
+    EXPECT_EQ(observed_setting, CONTENT_SETTING_ALLOW);
   }
 }


### PR DESCRIPTION
Check pref-based settings whenever:
1. The remote list changes
2. A webcompat pref-setting changes

If the pref-based webcompat exception setting is the same as the setting from the remote list, we delete the pref.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39919

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

