### PR TITLE
Remove the allow-same-origin bypass needed for sandbox isolated frames

### DIFF
--- a/browser/ui/webui/brave_wallet/line_chart/line_chart_ui.cc
+++ b/browser/ui/webui/brave_wallet/line_chart/line_chart_ui.cc
@@ -38,6 +38,7 @@ UntrustedLineChartUI::UntrustedLineChartUI(content::WebUI* web_ui)
       kLineChartDisplayGenerated, kLineChartDisplayGeneratedSize));
   untrusted_source->AddFrameAncestor(GURL(kBraveUIWalletPageURL));
   untrusted_source->AddFrameAncestor(GURL(kBraveUIWalletPanelURL));
+  web_ui->AddRequestableScheme(content::kChromeUIUntrustedScheme);
   webui::SetupWebUIDataSource(untrusted_source,
                               base::make_span(kLineChartDisplayGenerated,
                                               kLineChartDisplayGeneratedSize),

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-fungible-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-fungible-asset.tsx
@@ -486,7 +486,7 @@ export const PortfolioFungibleAsset = () => {
           src={`chrome-untrusted://line-chart-display${
             isLoadingGraphData ? '' : `?${encodedPriceData}`
           }`}
-          sandbox='allow-scripts allow-same-origin'
+          sandbox='allow-scripts'
         />
         <Row padding='0px 20px'>
           <ButtonRow>


### PR DESCRIPTION
Essentially, because we didn't allow the wallet and wallet panel to be able to request the chrome-untrusted:// frame, when the sandbox isolated frames feature was turned on it made it so that the two pages could no longer communicate since they were separated. Once this enabled requesting it appeared to fix the tests, so that we no longer need to add allow-same-origin to bypass the bug.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38771

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [X] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [X] There is a [ticket](https://github.com/brave/brave-browser/issues/38771) for my issue
- [X] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [X] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [X] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [X] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

The following browser tests should pass while `IsolatedSandboxFrames` are enabled:

```
WalletPanelUIBrowserTest.CustomNetworkInSettings
WalletPanelUIBrowserTest.HideNetworkInSettings
WalletPanelUIBrowserTest.SelectRpcEndpoint
```


