### PR TITLE
[iOS] Tab switch button stops working and wrong webpage is shown when using Switch CTA button

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -212,9 +212,17 @@ extension BrowserViewController: TabManagerDelegate {
     }
 
     // If BVC isnt visible hold on to this toast until viewDidAppear
-    if self.view.window == nil {
-      self.pendingToast = toast
+    if view.window == nil {
+      pendingToast = toast
       return
+    }
+
+    if toast is ButtonToast {
+      if activeButtonToast != nil {
+        activeButtonToast?.dismiss(false, animated: false)
+      } else {
+        activeButtonToast = toast
+      }
     }
 
     toast.showToast(
@@ -224,6 +232,11 @@ extension BrowserViewController: TabManagerDelegate {
       makeConstraints: { make in
         make.left.right.equalTo(self.view)
         make.bottom.equalTo(self.webViewContainer)
+      },
+      completion: {
+        if toast is ButtonToast {
+          self.activeButtonToast = nil
+        }
       }
     )
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -208,6 +208,8 @@ public class BrowserViewController: UIViewController {
   var pendingToast: Toast?
   /// A toast that is showing the combined download progress
   var downloadToast: DownloadToast?
+  /// A toast which is active and not yet dismissed
+  var activeButtonToast: Toast?
   /// A boolean to determine If AddToListActivity should be added
   var addToPlayListActivityItem: (enabled: Bool, item: PlaylistInfo?)?
   /// A boolean to determine if OpenInPlaylistActivity should be shown

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ButtonToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ButtonToast.swift
@@ -171,7 +171,8 @@ class ButtonToast: Toast {
     viewController: UIViewController? = nil,
     delay: DispatchTimeInterval = SimpleToastUX.toastDelayBefore,
     duration: DispatchTimeInterval? = SimpleToastUX.toastDismissAfter,
-    makeConstraints: @escaping (SnapKit.ConstraintMaker) -> Swift.Void
+    makeConstraints: @escaping (ConstraintMaker) -> Void,
+    completion: (() -> Void)? = nil
   ) {
     super.showToast(
       viewController: viewController,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Onboarding & Toast/PlaylistToast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Onboarding & Toast/PlaylistToast.swift
@@ -272,7 +272,8 @@ class PlaylistToast: Toast {
     viewController: UIViewController? = nil,
     delay: DispatchTimeInterval,
     duration: DispatchTimeInterval?,
-    makeConstraints: @escaping (SnapKit.ConstraintMaker) -> Swift.Void
+    makeConstraints: @escaping (ConstraintMaker) -> Void,
+    completion: (() -> Void)? = nil
   ) {
     super.showToast(viewController: viewController, delay: delay, duration: duration) {
       guard let viewController = viewController as? BrowserViewController else {
@@ -288,34 +289,8 @@ class PlaylistToast: Toast {
     }
   }
 
-  override func dismiss(_ buttonPressed: Bool) {
+  func dismiss(_ buttonPressed: Bool) {
     self.dismiss(buttonPressed, animated: true)
-  }
-
-  func dismiss(_ buttonPressed: Bool, animated: Bool) {
-    if displayState == .pendingDismiss || displayState == .dismissed {
-      return
-    }
-
-    displayState = .pendingDismiss
-    superview?.removeGestureRecognizer(gestureRecognizer)
-    layer.removeAllAnimations()
-
-    let duration = animated ? SimpleToastUX.toastAnimationDuration : 0.1
-    UIView.animate(
-      withDuration: duration,
-      animations: {
-        self.animationConstraint?.update(offset: SimpleToastUX.toastHeight)
-        self.layoutIfNeeded()
-      },
-      completion: { finished in
-        self.displayState = .dismissed
-        self.removeFromSuperview()
-        if !buttonPressed {
-          self.completionHandler?(false)
-        }
-      }
-    )
   }
 
   private var shadowLayerZOrder: Int {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toast.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toast.swift
@@ -35,7 +35,8 @@ class Toast: UIView {
     viewController: UIViewController? = nil,
     delay: DispatchTimeInterval,
     duration: DispatchTimeInterval?,
-    makeConstraints: @escaping (SnapKit.ConstraintMaker) -> Swift.Void
+    makeConstraints: @escaping (ConstraintMaker) -> Void,
+    completion: (() -> Void)? = nil
   ) {
     self.viewController = viewController
 
@@ -58,7 +59,7 @@ class Toast: UIView {
           self.displayState = .showing
           if let duration = duration {
             DispatchQueue.main.asyncAfter(deadline: .now() + duration) {
-              self.dismiss(false)
+              self.dismiss(false, completion: completion)
             }
           }
         }
@@ -66,7 +67,7 @@ class Toast: UIView {
     }
   }
 
-  func dismiss(_ buttonPressed: Bool) {
+  func dismiss(_ buttonPressed: Bool, animated: Bool = true, completion: (() -> Void)? = nil) {
     if displayState == .pendingDismiss || displayState == .dismissed {
       return
     }
@@ -75,8 +76,10 @@ class Toast: UIView {
     superview?.removeGestureRecognizer(gestureRecognizer)
     layer.removeAllAnimations()
 
+    let duration = animated ? SimpleToastUX.toastAnimationDuration : 0.1
+
     UIView.animate(
-      withDuration: SimpleToastUX.toastAnimationDuration,
+      withDuration: duration,
       animations: {
         self.animationConstraint?.update(offset: SimpleToastUX.toastHeight)
         self.layoutIfNeeded()
@@ -87,6 +90,8 @@ class Toast: UIView {
         if !buttonPressed {
           self.completionHandler?(false)
         }
+
+        completion?()
       }
     )
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40085

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

![samestr](https://github.com/user-attachments/assets/97d53d12-4f23-4002-be51-6ad1769ffedf)

- Launch Brave
- Open reddit.com, for example
- Tap and hold any link to another article > Open in New Tab
- Confirm that the bottom-sheet pop-up with the Switch CTA button is shown
- Quickly while that opo-up has not disappeared, tap and hold the same or another link
- Tap Open in New Private Tab this time
- When Private Tab opens, tap Switch button quickly > Observe

