### PR TITLE
[ads] Add Sponsored Images & Videos option to New Tab Page setting

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
@@ -334,11 +334,11 @@ extension BrowserViewController {
       case ntpAndPush = 3
     }
     var answer: Answer = .none
-    if rewards.ads.isEnabled && Preferences.NewTabPage.backgroundSponsoredImages.value {
+    if rewards.ads.isEnabled && Preferences.NewTabPage.backgroundMediaType.isSponsored {
       answer = .ntpAndPush
     } else if rewards.ads.isEnabled {
       answer = .pushOnly
-    } else if Preferences.NewTabPage.backgroundSponsoredImages.value {
+    } else if Preferences.NewTabPage.backgroundMediaType.isSponsored {
       answer = .ntpOnly
     }
     UmaHistogramEnumeration("Brave.Rewards.AdTypesEnabled", sample: answer)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -496,7 +496,7 @@ public class BrowserViewController: UIViewController {
     Preferences.Playlist.enablePlaylistMenuBadge.observe(from: self)
     Preferences.Playlist.enablePlaylistURLBarButton.observe(from: self)
     Preferences.Playlist.syncSharedFoldersAutomatically.observe(from: self)
-    Preferences.NewTabPage.backgroundSponsoredImages.observe(from: self)
+    Preferences.NewTabPage.backgroundMediaTypeRaw.observe(from: self)
     ShieldPreferences.blockAdsAndTrackingLevelRaw.observe(from: self)
     ShieldPreferences.httpsUpgradeLevelRaw.observe(from: self)
     Preferences.Privacy.screenTimeEnabled.observe(from: self)
@@ -3365,7 +3365,7 @@ extension BrowserViewController: PreferencesObserver {
       updateURLBarWalletButton()
     case Preferences.Playlist.syncSharedFoldersAutomatically.key:
       syncPlaylistFolders()
-    case Preferences.NewTabPage.backgroundSponsoredImages.key:
+    case Preferences.NewTabPage.backgroundMediaTypeRaw.key:
       recordAdsUsageType()
     case Preferences.Privacy.screenTimeEnabled.key:
       if Preferences.Privacy.screenTimeEnabled.value {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/HomePanel/NTPDataSource.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/HomePanel/NTPDataSource.swift
@@ -10,11 +10,11 @@ import os.log
 
 enum NTPWallpaper {
   case image(NTPBackgroundImage)
-  case sponsoredImageOrVideo(NTPSponsoredImageBackground)
+  case sponsoredMedia(NTPSponsoredImageBackground)
   case superReferral(NTPSponsoredImageBackground, code: String)
 
   var backgroundVideoPath: URL? {
-    if case .sponsoredImageOrVideo(let background) = self {
+    if case .sponsoredMedia(let background) = self {
       return background.isVideoFile ? background.imagePath : nil
     }
     return nil
@@ -25,7 +25,7 @@ enum NTPWallpaper {
     switch self {
     case .image(let background):
       imagePath = background.imagePath
-    case .sponsoredImageOrVideo(let background):
+    case .sponsoredMedia(let background):
       if background.isVideoFile {
         return nil
       }
@@ -41,7 +41,7 @@ enum NTPWallpaper {
     switch self {
     case .image:
       imagePath = nil
-    case .sponsoredImageOrVideo(let background):
+    case .sponsoredMedia(let background):
       imagePath = background.logo.imagePath
     case .superReferral(let background, _):
       imagePath = background.logo.imagePath
@@ -53,7 +53,7 @@ enum NTPWallpaper {
     switch self {
     case .image:
       return nil  // Will eventually return a real value
-    case .sponsoredImageOrVideo(let background):
+    case .sponsoredMedia(let background):
       return background.focalPoint
     case .superReferral(let background, _):
       return background.focalPoint
@@ -145,7 +145,7 @@ public class NTPDataSource {
 
           if let campaign = sponsor.campaigns[safe: campaignIndex] {
             return (
-              campaign.backgrounds.map(NTPWallpaper.sponsoredImageOrVideo), .sponsoredRotation
+              campaign.backgrounds.map(NTPWallpaper.sponsoredMedia), .sponsoredRotation
             )
           }
         }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackground.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackground.swift
@@ -48,7 +48,7 @@ class NewTabPageBackground: PreferencesObserver {
     self.currentBackground = dataSource.newBackground()
 
     Preferences.NewTabPage.backgroundImages.observe(from: self)
-    Preferences.NewTabPage.backgroundSponsoredImages.observe(from: self)
+    Preferences.NewTabPage.backgroundMediaTypeRaw.observe(from: self)
     Preferences.NewTabPage.selectedCustomTheme.observe(from: self)
 
     recordSponsoredImagesEnabledP3A()
@@ -79,7 +79,7 @@ class NewTabPageBackground: PreferencesObserver {
     // Q26 Is the sponsored new tab page option enabled?
     let isSIEnabled =
       Preferences.NewTabPage.backgroundImages.value
-      && Preferences.NewTabPage.backgroundSponsoredImages.value
+      && Preferences.NewTabPage.backgroundMediaType.isSponsored
     UmaHistogramBoolean("Brave.NTP.SponsoredImagesEnabled", isSIEnabled)
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -224,7 +224,8 @@ class NewTabPageViewController: UIViewController {
     ]
 
     var isBackgroundNTPSI = false
-    if let ntpBackground = background.currentBackground, case .sponsoredImage = ntpBackground {
+    if let ntpBackground = background.currentBackground, case .sponsoredImageOrVideo = ntpBackground
+    {
       isBackgroundNTPSI = true
     }
     let ntpDefaultBrowserCalloutProvider = NTPDefaultBrowserCalloutProvider(
@@ -330,7 +331,7 @@ class NewTabPageViewController: UIViewController {
     }
 
     setupBackgroundImage()
-    setupBackgroundVideo()
+    setupBackgroundVideoIfNeeded()
     backgroundView.snp.makeConstraints {
       $0.edges.equalToSuperview()
     }
@@ -394,6 +395,7 @@ class NewTabPageViewController: UIViewController {
       self?.reportSponsoredBackgroundEvent(.viewedImpression)
     }
 
+    setupBackgroundVideoIfNeeded()
     videoPlayer?.loadAndAutoplayVideoAssetIfNeeded(
       shouldAutoplay: shouldShowBackgroundVideo()
     )
@@ -448,7 +450,7 @@ class NewTabPageViewController: UIViewController {
       switch background {
       case .image, .superReferral:
         hideNotification()
-      case .sponsoredImage:
+      case .sponsoredImageOrVideo:
         // Current background is still a sponsored image so it can stay
         // visible
         break
@@ -486,12 +488,18 @@ class NewTabPageViewController: UIViewController {
     )
   }
 
-  func setupBackgroundVideo() {
+  func setupBackgroundVideoIfNeeded() {
     videoButtonsView.isHidden = true
 
-    guard let backgroundVideoPath = background.backgroundVideoPath else {
+    // Setup the background video only if:
+    // - it hasn't been setup before
+    // - the current NTP background is a video
+    guard videoPlayer == nil,
+      let backgroundVideoPath = background.backgroundVideoPath
+    else {
       return
     }
+
     gradientView.isHidden = false
     videoPlayer = NewTabPageVideoPlayer(backgroundVideoPath)
     backgroundView.setupPlayerLayer(backgroundVideoPath, player: videoPlayer?.player)
@@ -524,7 +532,7 @@ class NewTabPageViewController: UIViewController {
     videoPlayer?.didFinishAutoplayEvent = { [weak self] in
       guard let self = self else { return }
       self.backgroundButtonsView.videoAutoplayFinished()
-      if case .sponsoredImage(let background) = self.background.currentBackground {
+      if case .sponsoredImageOrVideo(let background) = self.background.currentBackground {
         self.backgroundButtonsView.activeButton = .brandLogo(background.logo)
       }
       self.backgroundButtonsView.alpha = 0
@@ -580,7 +588,7 @@ class NewTabPageViewController: UIViewController {
         } else {
           backgroundButtonsView.activeButton = .none
         }
-      case .sponsoredImage(let background):
+      case .sponsoredImageOrVideo(let background):
         backgroundButtonsView.activeButton = .brandLogo(background.logo)
       case .superReferral:
         backgroundButtonsView.activeButton = .qrCode
@@ -642,7 +650,7 @@ class NewTabPageViewController: UIViewController {
     completion: ((_ success: Bool) -> Void)? = nil
   ) {
     if let tab = browserTab,
-      case .sponsoredImage(let sponsoredBackground) = background.currentBackground
+      case .sponsoredImageOrVideo(let sponsoredBackground) = background.currentBackground
     {
       let eventType: NewTabPageP3AHelper.EventType? = {
         switch event {
@@ -682,7 +690,7 @@ class NewTabPageViewController: UIViewController {
     }
 
     var isShowingSponseredImage = false
-    if case .sponsoredImage = background.currentBackground {
+    if case .sponsoredImageOrVideo = background.currentBackground {
       isShowingSponseredImage = true
     }
 
@@ -1083,7 +1091,7 @@ class NewTabPageViewController: UIViewController {
     switch background {
     case .image:
       presentImageCredit(sender)
-    case .sponsoredImage(let background):
+    case .sponsoredImageOrVideo(let background):
       tappedSponsorButton(background.logo)
     case .superReferral(_, let code):
       tappedQRCode(code)
@@ -1336,7 +1344,7 @@ extension NewTabPageViewController {
     newTabsStorage.add(value: 1, to: Date())
     let newTabsCreatedAnswer = newTabsStorage.maximumDaysCombinedValue
 
-    if case .sponsoredImage = background.currentBackground {
+    if case .sponsoredImageOrVideo = background.currentBackground {
       sponsoredStorage.add(value: 1, to: Date())
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -224,8 +224,7 @@ class NewTabPageViewController: UIViewController {
     ]
 
     var isBackgroundNTPSI = false
-    if let ntpBackground = background.currentBackground, case .sponsoredImageOrVideo = ntpBackground
-    {
+    if let ntpBackground = background.currentBackground, case .sponsoredMedia = ntpBackground {
       isBackgroundNTPSI = true
     }
     let ntpDefaultBrowserCalloutProvider = NTPDefaultBrowserCalloutProvider(
@@ -450,7 +449,7 @@ class NewTabPageViewController: UIViewController {
       switch background {
       case .image, .superReferral:
         hideNotification()
-      case .sponsoredImageOrVideo:
+      case .sponsoredMedia:
         // Current background is still a sponsored image so it can stay
         // visible
         break
@@ -532,7 +531,7 @@ class NewTabPageViewController: UIViewController {
     videoPlayer?.didFinishAutoplayEvent = { [weak self] in
       guard let self = self else { return }
       self.backgroundButtonsView.videoAutoplayFinished()
-      if case .sponsoredImageOrVideo(let background) = self.background.currentBackground {
+      if case .sponsoredMedia(let background) = self.background.currentBackground {
         self.backgroundButtonsView.activeButton = .brandLogo(background.logo)
       }
       self.backgroundButtonsView.alpha = 0
@@ -588,7 +587,7 @@ class NewTabPageViewController: UIViewController {
         } else {
           backgroundButtonsView.activeButton = .none
         }
-      case .sponsoredImageOrVideo(let background):
+      case .sponsoredMedia(let background):
         backgroundButtonsView.activeButton = .brandLogo(background.logo)
       case .superReferral:
         backgroundButtonsView.activeButton = .qrCode
@@ -650,7 +649,7 @@ class NewTabPageViewController: UIViewController {
     completion: ((_ success: Bool) -> Void)? = nil
   ) {
     if let tab = browserTab,
-      case .sponsoredImageOrVideo(let sponsoredBackground) = background.currentBackground
+      case .sponsoredMedia(let sponsoredBackground) = background.currentBackground
     {
       let eventType: NewTabPageP3AHelper.EventType? = {
         switch event {
@@ -690,7 +689,7 @@ class NewTabPageViewController: UIViewController {
     }
 
     var isShowingSponseredImage = false
-    if case .sponsoredImageOrVideo = background.currentBackground {
+    if case .sponsoredMedia = background.currentBackground {
       isShowingSponseredImage = true
     }
 
@@ -1091,7 +1090,7 @@ class NewTabPageViewController: UIViewController {
     switch background {
     case .image:
       presentImageCredit(sender)
-    case .sponsoredImageOrVideo(let background):
+    case .sponsoredMedia(let background):
       tappedSponsorButton(background.logo)
     case .superReferral(_, let code):
       tappedQRCode(code)
@@ -1344,7 +1343,7 @@ extension NewTabPageViewController {
     newTabsStorage.add(value: 1, to: Date())
     let newTabsCreatedAnswer = newTabsStorage.maximumDaysCombinedValue
 
-    if case .sponsoredImageOrVideo = background.currentBackground {
+    if case .sponsoredMedia = background.currentBackground {
       sponsoredStorage.add(value: 1, to: Date())
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Notifications/NTPLearnMoreViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Notifications/NTPLearnMoreViewController.swift
@@ -84,7 +84,7 @@ extension NTPLearnMoreViewController: NTPLearnMoreViewDelegate {
   }
 
   func hideSponsoredImagesTapped() {
-    Preferences.NewTabPage.backgroundSponsoredImages.value = false
+    Preferences.NewTabPage.backgroundMediaType = .defaultImages
     self.close()
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -13,6 +13,19 @@ enum TabBarVisibility: Int, CaseIterable {
   case landscapeOnly
 }
 
+enum BackgroundMediaType: Int, CaseIterable {
+  case defaultImages
+  case sponsoredImages
+  case sponsoredImagesAndVideos
+
+  public var isSponsored: Bool {
+    switch self {
+    case .sponsoredImages, .sponsoredImagesAndVideos: return true
+    case .defaultImages: return false
+    }
+  }
+}
+
 extension Preferences {
   public enum AutoCloseTabsOption: Int, CaseIterable {
     case manually
@@ -209,11 +222,22 @@ extension Preferences {
   final public class NewTabPage {
     /// Whether bookmark image are enabled / shown
     static let backgroundImages = Option<Bool>(key: "newtabpage.background-images", default: true)
-    /// Whether sponsored images are included into the background image rotation
-    static let backgroundSponsoredImages = Option<Bool>(
-      key: "newtabpage.background-sponsored-images",
-      default: true
+
+    /// Determines the type of sponsored media to include in the background image rotation
+    /// - Warning: You should not access this directly but  through ``backgroundMediaType``
+    static let backgroundMediaTypeRaw = Option<Int>(
+      key: "newtabpage.background-media-type",
+      default: BackgroundMediaType.sponsoredImagesAndVideos.rawValue
     )
+
+    /// A  variable to access the ``backgroundMediaTypeRaw`` preference value
+    static var backgroundMediaType: BackgroundMediaType {
+      get {
+        BackgroundMediaType(rawValue: backgroundMediaTypeRaw.value)
+          ?? BackgroundMediaType.sponsoredImagesAndVideos
+      }
+      set { backgroundMediaTypeRaw.value = newValue.rawValue }
+    }
 
     /// The counter that indicates what background should be shown, this is used to determine when a new
     ///     sponsored image should be shown. (`1` means, first image in cycle N, should be shown).

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -200,10 +200,6 @@ public class BraveRewards: PreferencesObserver {
     }
   }
 
-  public var shouldShowSponsoredImagesAndVideos: Bool {
-    return ads.shouldShowSponsoredImagesAndVideos()
-  }
-
   // MARK: - Brave Ads Data
 
   /// Clear Brave Ads Data.

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -200,6 +200,10 @@ public class BraveRewards: PreferencesObserver {
     }
   }
 
+  public var shouldShowSponsoredImagesAndVideos: Bool {
+    return ads.shouldShowSponsoredImagesAndVideos()
+  }
+
   // MARK: - Brave Ads Data
 
   /// Clear Brave Ads Data.

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/NTPTableViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Display/NTPTableViewController.swift
@@ -101,7 +101,7 @@ class NTPTableViewController: TableViewController {
     case .sponsoredImages:
       return BackgroundType.sponsoredImages
     case .sponsoredImagesAndVideos:
-      return rewards?.shouldShowSponsoredImagesAndVideos == true
+      return rewards?.ads.shouldShowSponsoredImagesAndVideosSetting() == true
         ? BackgroundType.sponsoredImagesAndVideos(
           Strings.NTP.settingsSponsoredImagesAndVideosSelection
         )
@@ -111,7 +111,7 @@ class NTPTableViewController: TableViewController {
 
   private func backgroundImageOptions() -> [BackgroundType] {
     var available: [BackgroundType] = [.defaultImages]
-    if rewards?.shouldShowSponsoredImagesAndVideos == true {
+    if rewards?.ads.shouldShowSponsoredImagesAndVideosSetting() == true {
       available += [
         .sponsoredImages,
         .sponsoredImagesAndVideos(Strings.NTP.settingsSponsoredImagesAndVideosSelection),

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -671,7 +671,10 @@ class SettingsViewController: TableViewController {
       Row(
         text: Strings.NTP.settingsTitle,
         selection: { [unowned self] in
-          self.navigationController?.pushViewController(NTPTableViewController(), animated: true)
+          self.navigationController?.pushViewController(
+            NTPTableViewController(rewards),
+            animated: true
+          )
         },
         image: UIImage(braveSystemNamed: "leo.window.tab-new"),
         accessory: .disclosureIndicator,

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -25,6 +25,7 @@ public class Migration {
     Preferences.migrateWalletPreferences()
     Preferences.migrateAdAndTrackingProtection()
     Preferences.migrateHTTPSUpgradeLevel()
+    Preferences.migrateBackgroundSponsoredImages()
 
     if Preferences.General.isFirstLaunch.value {
       if UIDevice.current.userInterfaceIdiom == .phone {
@@ -194,6 +195,12 @@ extension Preferences {
       key: "shields.https-everywhere",
       default: true
     )
+
+    /// Whether sponsored images are included into the background image rotation
+    static let backgroundSponsoredImages = Option<Bool>(
+      key: "newtabpage.background-sponsored-images",
+      default: true
+    )
   }
 
   /// Migration preferences
@@ -234,6 +241,11 @@ extension Preferences {
     static let lostTabsWindowIDMigration = Option<Bool>(
       key: "migration.lost-tabs-window-id-two",
       default: !UIApplication.shared.supportsMultipleScenes
+    )
+
+    static let backgroundSponsoredImagesCompleted = Option<Bool>(
+      key: "migration.newtabpage-background-sponsored-images",
+      default: false
     )
   }
 
@@ -369,6 +381,18 @@ extension Preferences {
     )
 
     Preferences.Migration.walletProviderAccountRequestCompleted.value = true
+  }
+
+  fileprivate class func migrateBackgroundSponsoredImages() {
+    guard !Migration.backgroundSponsoredImagesCompleted.value else { return }
+
+    // Migrate old Background Sponsored Images setting
+    DeprecatedPreferences.backgroundSponsoredImages.migrate { isEnabled in
+      Preferences.NewTabPage.backgroundMediaType =
+        isEnabled ? .sponsoredImagesAndVideos : .defaultImages
+    }
+
+    Migration.backgroundSponsoredImagesCompleted.value = true
   }
 }
 

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -4655,14 +4655,14 @@ extension Strings {
       "ntp.settingsBackgroundImages",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Background Images",
-      comment: "A setting to enable or disable background images on the main screen."
+      value: "Background",
+      comment: "A setting to enable or disable background on the NTP screen."
     )
     public static let settingsBackgroundImageSubMenu = NSLocalizedString(
       "ntp.settingsBackgroundImageSubMenu",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Image Type",
+      value: "Media Type",
       comment: "A button that leads to a 'more' menu, letting users configure additional settings."
     )
     public static let settingsDefaultImagesOnly = NSLocalizedString(
@@ -4677,9 +4677,17 @@ extension Strings {
       "ntp.settingsSponsoredImagesSelection",
       tableName: "BraveShared",
       bundle: .module,
-      value: "Sponsored",
+      value: "Sponsored Images",
       comment:
         "A selection to let the users see sponsored image backgrounds when opening a new tab."
+    )
+    public static let settingsSponsoredImagesAndVideosSelection = NSLocalizedString(
+      "ntp.settingsSponsoredImagesAndVideosSelection",
+      tableName: "BraveShared",
+      bundle: .module,
+      value: "Sponsored Images & Videos",
+      comment:
+        "A selection to let the users see sponsored image and video backgrounds when opening a new tab."
     )
     public static let settingsAutoOpenKeyboard = NSLocalizedString(
       "ntp.settingsAutoOpenKeyboard",

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -64,7 +64,8 @@ OBJC_EXPORT
 + (BOOL)shouldSupportSearchResultAds;
 
 /// Returns `true` if should show Sponsored Images & Videos option in settings.
-- (BOOL)shouldShowSponsoredImagesAndVideos;
+/// This function will be deprecated once Sponsored Video is available globally.
+- (BOOL)shouldShowSponsoredImagesAndVideosSetting;
 
 /// Returns `true` if the user opted-in to search result ads.
 - (BOOL)isOptedInToSearchResultAds;

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -63,6 +63,9 @@ OBJC_EXPORT
 /// Returns `true` if search result ads are supported.
 + (BOOL)shouldSupportSearchResultAds;
 
+/// Returns `true` if should show Sponsored Images & Videos option in settings.
+- (BOOL)shouldShowSponsoredImagesAndVideos;
+
 /// Returns `true` if the user opted-in to search result ads.
 - (BOOL)isOptedInToSearchResultAds;
 

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -224,9 +224,10 @@ constexpr NSString* kComponentUpdaterMetadataPrefKey =
   return brave_ads::ShouldSupportSearchResultAds();
 }
 
-- (BOOL)shouldShowSponsoredImagesAndVideos {
+- (BOOL)shouldShowSponsoredImagesAndVideosSetting {
   const std::string country_code =
       brave_l10n::GetCountryCode(self->_localStatePrefService);
+
   // Currently, sponsored videos are only supported in Japan.
   return base::ToLowerASCII(country_code) == "jp";
 }

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -46,6 +46,7 @@
 #include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_rewards/common/pref_registry.h"
 #include "brave/components/brave_rewards/common/rewards_flags.h"
+#include "brave/components/l10n/common/country_code_util.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "brave/components/l10n/common/prefs.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
@@ -221,6 +222,13 @@ constexpr NSString* kComponentUpdaterMetadataPrefKey =
 
 + (BOOL)shouldSupportSearchResultAds {
   return brave_ads::ShouldSupportSearchResultAds();
+}
+
+- (BOOL)shouldShowSponsoredImagesAndVideos {
+  const std::string country_code =
+      brave_l10n::GetCountryCode(self->_localStatePrefService);
+  // Currently, sponsored videos are only supported in Japan.
+  return base::ToLowerASCII(country_code) == "jp";
 }
 
 - (BOOL)isOptedInToSearchResultAds {


### PR DESCRIPTION
`Sponsored Images & Videos` option is currently shown for `Japan` region only:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/fa5cda5a-2230-4de1-81a4-911ae0b55c4c">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/5cfcf9eb-b135-4594-a2cb-3bfe2b9e2c1f">


`Sponsored Images & Videos` option is hidden for all other regions:

<img width="300" alt="image" src="https://github.com/user-attachments/assets/baf970c4-99eb-4ad9-bc33-e3bb4e4401fd">
<img width="300" alt="image" src="https://github.com/user-attachments/assets/12816629-dafb-48ab-bf11-6cb663c0a838">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/38198

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1 (Preferences migration check)
* Set your device region to something other than Japan
* Install the previous version of Brave (version 1.70)
* Make sure that setting `Background Images` -> `Image Type` is set to `Sponsored`
* Install the latest version of Brave (version 1.71 and higher)
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images`
* Make sure Sponsored Images are shown on NTP
* Set setting `Background` -> `Media Type` to `Default Images`
* Make sure that Sponsored Images aren't shown on NTP

### Test case 2 (Preferences migration check)
* Set your device region to something other than Japan
* Install the previous version of Brave (version 1.70)
* Set setting `Background Images` -> `Image Type` to `Default Images`
* Install the latest version of Brave (version 1.71 and higher)
* Make sure that setting `Background` -> `Media Type` is set to `Default Images`
* Make sure that Sponsored Images aren't shown on NTP
* Set setting `Background` -> `Media Type` to `Sponsored Images`
* Make sure Sponsored Images are shown on NTP

### Test case 3 (Preferences migration check)
* Set device region to Japan
* Install the previous version of Brave (version 1.70)
* Make sure that setting `Background Images` -> `Image Type` is set to `Sponsored`
* Install the latest version of Brave (version 1.71 and higher)
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images & Videos`
* Make sure that Sponsored Images (or Sponsored Videos) are shown on NTP

### Test case 4 (Fresh install)
* Set your device region to something other than Japan
* Install the latest version of Brave (version 1.71 and higher)
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images`
* Make sure Sponsored Images are shown on NTP
* Set setting `Background` -> `Media Type` to `Default Images`
* Make sure that Sponsored Images aren't shown on NTP

### Test case 5 (Fresh install)
* Set device region to Japan
* Install the latest version of Brave (version 1.71 and higher)
* Setup Brave to fetch and show NTT sponsored video
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images & Videos`
* Make sure that Sponsored Videos are shown on NTP
* Set setting `Background` -> `Media Type` to `Sponsored Images`
* Make sure that Sponsored Videos are not shown on NTP
