### PR TITLE
[Tab Strip]: Fix divider colors

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -23,6 +23,7 @@
 #include "ui/base/ui_base_features.h"
 #include "ui/color/color_id.h"
 #include "ui/color/color_provider.h"
+#include "ui/color/color_provider_key.h"
 #include "ui/color/color_recipe.h"
 #include "ui/gfx/color_palette.h"
 #include "ui/gfx/color_utils.h"
@@ -748,6 +749,8 @@ void AddBravePrivateThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorSidebarPanelHeaderButtonHovered] = {
       leo::GetColor(leo::Color::kColorNeutral60,
                     is_dark ? leo::Theme::kDark : leo::Theme::kLight)};
+  mixer[kColorTabDividerFrameInactive] = {SkColorSetRGB(0x3F, 0x32, 0x56)};
+  mixer[kColorTabDividerFrameActive] = {SkColorSetRGB(0x3F, 0x32, 0x56)};
 }
 
 void AddBraveTorThemeColorMixer(ui::ColorProvider* provider,
@@ -824,6 +827,8 @@ void AddTorThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorToolbarContentAreaSeparator] = {kColorToolbar};
   mixer[ui::kColorFrameActive] = {kPrivateTorFrame};
   mixer[ui::kColorFrameInactive] = {kPrivateTorFrame};
+  mixer[kColorTabDividerFrameInactive] = {SkColorSetRGB(0x5A, 0x53, 0x66)};
+  mixer[kColorTabDividerFrameActive] = {SkColorSetRGB(0x5A, 0x53, 0x66)};
 }
 
 void AddBraveOmniboxPrivateThemeColorMixer(ui::ColorProvider* provider,
@@ -901,4 +906,12 @@ void AddBravifiedTabStripColorMixer(ui::ColorProvider* provider,
       is_dark ? leo::kColorPrimitiveNeutral20 : SK_ColorWHITE};
   mixer[kColorTabBackgroundActiveFrameInactive] = {
       kColorTabBackgroundActiveFrameActive};
+
+  auto divider_color =
+      leo::GetColor(leo::Color::kColorDividerStrong,
+                    key.color_mode == ui::ColorProviderKey::ColorMode::kDark
+                        ? leo::Theme::kDark
+                        : leo::Theme::kLight);
+  mixer[kColorTabDividerFrameInactive] = {divider_color};
+  mixer[kColorTabDividerFrameActive] = {divider_color};
 }

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -197,33 +197,6 @@ void BraveTabStrip::AddedToWidget() {
   }
 }
 
-SkColor BraveTabStrip::GetTabSeparatorColor() const {
-  if (ShouldShowVerticalTabs()) {
-    return SK_ColorTRANSPARENT;
-  }
-
-  Profile* profile = controller()->GetProfile();
-  if (!profile->IsRegularProfile()) {
-    if (profile->IsTor()) {
-      return SkColorSetRGB(0x5A, 0x53, 0x66);
-    }
-
-    // For incognito/guest window.
-    return SkColorSetRGB(0x3F, 0x32, 0x56);
-  }
-
-  // If custom theme is used, follow upstream separator color.
-  auto* theme_service = ThemeServiceFactory::GetForProfile(profile);
-  if (theme_service->GetThemeSupplier()) {
-    return TabStrip::GetTabSeparatorColor();
-  }
-
-  bool dark_mode = dark_mode::GetActiveBraveDarkModeType() ==
-                   dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_DARK;
-  return dark_mode ? SkColorSetRGB(0x39, 0x38, 0x38)
-                   : SkColorSetRGB(0xBE, 0xBF, 0xBF);
-}
-
 std::optional<int> BraveTabStrip::GetCustomBackgroundId(
     BrowserFrameActiveState active_state) const {
   if (!ShouldShowVerticalTabs()) {

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -49,7 +49,6 @@ class BraveTabStrip : public TabStrip {
   TabContainer* GetTabContainerForTesting();
 
   // TabStrip overrides:
-  SkColor GetTabSeparatorColor() const override;
   bool ShouldDrawStrokes() const override;
   void Layout(PassKey) override;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40425

| | Before | After |
|--------|--------|--------|
| Light | ![image](https://github.com/user-attachments/assets/0ce810ca-5a72-4fab-a6e7-e1a74db3ae1d) | ![image](https://github.com/user-attachments/assets/d44c334c-bb61-419f-9cc1-a48924f87f92) |
| Dark | ![image](https://github.com/user-attachments/assets/469cf26a-a128-45b4-91ba-50ea4c48571f) | ![image](https://github.com/user-attachments/assets/51770aa1-0b9e-4438-a9ce-f283c0e1ada9) |
| Private | ![image](https://github.com/user-attachments/assets/e757c476-3c90-4c65-8ddc-3d0078bbb52a) | ![image](https://github.com/user-attachments/assets/6efe5bdc-eebf-4d79-95fb-b4ac692c378a) |
| Tor | ![image](https://github.com/user-attachments/assets/bd308d36-7f19-48da-a4b2-0ddc13dd12ef) | ![image](https://github.com/user-attachments/assets/ad54b2e8-8b3d-4891-8dd2-39349bf1bbe3) | 

Seems like this only really affected Light mode. Looks like Chromium introduced some new ColorIds for these, and as a result, started ignoring the `GetTabSeparatorColor` in some cases. I completely removed the function, as vertical tabs isn't affected anyway.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See issue