### PR TITLE
[Android] Fix crash after cr128 upgrade at TabSwitcherPaneCoordinator

### DIFF
--- a/android/features/tab_ui/brave_tab_management_java_sources.gni
+++ b/android/features/tab_ui/brave_tab_management_java_sources.gni
@@ -1,5 +1,9 @@
-# Copyright 2022 The Brave Authors. All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# Copyright (c) 2022 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
 
-brave_public_tab_management_java_sources = [ "//brave/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabUiFeatureUtilities.java" ]
+brave_public_tab_management_java_sources = [
+  "//brave/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane.java",
+  "//brave/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabUiFeatureUtilities.java",
+]

--- a/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane.java
+++ b/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane.java
@@ -26,7 +26,7 @@ import java.util.function.DoubleConsumer;
 
 public class BraveTabSwitcherPane extends TabSwitcherPane {
 
-    BraveTabSwitcherPane(
+    public BraveTabSwitcherPane(
             @NonNull Context context,
             @NonNull SharedPreferences sharedPreferences,
             @NonNull OneshotSupplier<ProfileProvider> profileProviderSupplier,

--- a/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane.java
+++ b/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane.java
@@ -1,0 +1,63 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.tasks.tab_management;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.view.View.OnClickListener;
+
+import androidx.annotation.NonNull;
+
+import org.chromium.base.BraveReflectionUtil;
+import org.chromium.base.supplier.OneshotSupplier;
+import org.chromium.base.supplier.Supplier;
+import org.chromium.chrome.browser.hub.HubContainerView;
+import org.chromium.chrome.browser.hub.HubLayoutAnimatorProvider;
+import org.chromium.chrome.browser.profiles.ProfileProvider;
+import org.chromium.chrome.browser.tab.Tab;
+import org.chromium.chrome.browser.tabmodel.TabModelFilter;
+import org.chromium.chrome.browser.tasks.tab_management.TabListCoordinator.TabListMode;
+import org.chromium.chrome.browser.user_education.UserEducationHelper;
+
+import java.util.function.DoubleConsumer;
+
+public class BraveTabSwitcherPane extends TabSwitcherPane {
+
+    BraveTabSwitcherPane(
+            @NonNull Context context,
+            @NonNull SharedPreferences sharedPreferences,
+            @NonNull OneshotSupplier<ProfileProvider> profileProviderSupplier,
+            @NonNull TabSwitcherPaneCoordinatorFactory factory,
+            @NonNull Supplier<TabModelFilter> tabModelFilterSupplier,
+            @NonNull OnClickListener newTabButtonClickListener,
+            @NonNull TabSwitcherPaneDrawableCoordinator tabSwitcherDrawableCoordinator,
+            @NonNull DoubleConsumer onToolbarAlphaChange,
+            @NonNull UserEducationHelper userEducationHelper) {
+        super(
+                context,
+                sharedPreferences,
+                profileProviderSupplier,
+                factory,
+                tabModelFilterSupplier,
+                newTabButtonClickListener,
+                tabSwitcherDrawableCoordinator,
+                onToolbarAlphaChange,
+                userEducationHelper);
+    }
+
+    @Override
+    public @NonNull HubLayoutAnimatorProvider createHideHubLayoutAnimatorProvider(
+            @NonNull HubContainerView hubContainerView) {
+        int tabId = getCurrentTabId();
+        if (getTabListMode() != TabListMode.LIST && tabId == Tab.INVALID_TAB_ID) {
+            // Force call TabSwitcherPaneBase.createTabSwitcherPaneCoordinator
+            // to ensure TabSwitcherPaneBase.mTabSwitcherPaneCoordinatorSupplier is set
+            BraveReflectionUtil.InvokeMethod(
+                    TabSwitcherPaneBase.class, this, "createTabSwitcherPaneCoordinator");
+        }
+        return super.createHideHubLayoutAnimatorProvider(hubContainerView);
+    }
+}

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -884,3 +884,7 @@
 -keep class org.chromium.chrome.browser.omnibox.styles.OmniboxResourceProvider {
     *** getToolbarSidePaddingForNtp(...);
 }
+
+-keep class org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneBase {
+    *** createTabSwitcherPaneCoordinator(...);
+}

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -885,6 +885,10 @@
     *** getToolbarSidePaddingForNtp(...);
 }
 
--keep class org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneBase {
-    *** createTabSwitcherPaneCoordinator(...);
+-keep class org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPane {
+    public <init>(...);
+}
+
+-keep class org.chromium.chrome.browser.tasks.tab_management.BraveTabSwitcherPane {
+    public <init>(...);
 }

--- a/android/java/proguard.flags
+++ b/android/java/proguard.flags
@@ -76,3 +76,7 @@
 -keep class org.chromium.chrome.browser.hub.HubManagerImpl {
     *** ensureHubCoordinatorIsInitialized(...);
 }
+
+-keep class org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneBase {
+    *** createTabSwitcherPaneCoordinator(...);
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -994,6 +994,13 @@ public class BytecodeTest {
                         MethodModifier.REGULAR,
                         true,
                         void.class));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/tasks/tab_management/TabSwitcherPaneBase",
+                        "createTabSwitcherPaneCoordinator",
+                        MethodModifier.REGULAR,
+                        true,
+                        void.class));
         // NOTE: Add new checks above. For each new check in this method add proguard exception in
         // `brave/android/java/proguard.flags` file under `Add methods for invocation below`
         // section. Both test and regular apks should have the same exceptions.

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -9,12 +9,14 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.os.Handler;
 import android.util.AttributeSet;
 import android.view.ActionMode;
 import android.view.View;
+import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.view.Window;
@@ -100,6 +102,9 @@ import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider;
 import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
 import org.chromium.chrome.browser.tabmodel.TabModelSelector;
 import org.chromium.chrome.browser.tasks.HomeSurfaceTracker;
+import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPane;
+import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneCoordinatorFactory;
+import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneDrawableCoordinator;
 import org.chromium.chrome.browser.theme.ThemeColorProvider;
 import org.chromium.chrome.browser.theme.TopUiThemeColorProvider;
 import org.chromium.chrome.browser.toolbar.ToolbarDataProvider;
@@ -165,6 +170,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.DoubleConsumer;
 import java.util.function.Function;
 
 /**
@@ -1698,6 +1704,19 @@ public class BytecodeTest {
                 constructorsMatch(
                         "org/chromium/chrome/browser/browsing_data/ClearBrowsingDataFragmentAdvanced", // presubmit: ignore-long-line
                         "org/chromium/chrome/browser/browsing_data/BraveClearBrowsingDataFragmentAdvanced")); // presubmit: ignore-long-line
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/chrome/browser/tasks/tab_management/TabSwitcherPane",
+                        "org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane",
+                        Context.class,
+                        SharedPreferences.class,
+                        OneshotSupplier.class,
+                        TabSwitcherPaneCoordinatorFactory.class,
+                        Supplier.class,
+                        OnClickListener.class,
+                        TabSwitcherPaneDrawableCoordinator.class,
+                        DoubleConsumer.class,
+                        UserEducationHelper.class));
     }
 
     @Test

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -102,7 +102,6 @@ import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider;
 import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
 import org.chromium.chrome.browser.tabmodel.TabModelSelector;
 import org.chromium.chrome.browser.tasks.HomeSurfaceTracker;
-import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPane;
 import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneCoordinatorFactory;
 import org.chromium.chrome.browser.tasks.tab_management.TabSwitcherPaneDrawableCoordinator;
 import org.chromium.chrome.browser.theme.ThemeColorProvider;

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -105,6 +105,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabGroupModelFilterClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabGroupUiCoordinatorClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabHelpersClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabSwitcherPaneClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabUiThemeProviderClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabUiThemeUtilsClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveTabbedActivityClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -66,6 +66,7 @@ public class BraveClassAdapter {
         chain = new BraveManageAccountDevicesLinkViewClassAdapter(chain);
         chain = new BraveManageSyncSettingsClassAdapter(chain);
         chain = new BraveMultiInstanceManagerApi31ClassAdapter(chain);
+        chain = new BraveTabSwitcherPaneClassAdapter(chain);
         chain = new BraveTranslateCompactInfoBarBaseClassAdapter(chain);
         chain = new BraveMenuButtonCoordinatorClassAdapter(chain);
         chain = new BraveMimeUtilsClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveTabSwitcherPaneClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveTabSwitcherPaneClassAdapter.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveTabSwitcherPaneClassAdapter extends BraveClassVisitor {
+    static String sTabSwitcherPaneClassName =
+            "org/chromium/chrome/browser/tasks/tab_management/TabSwitcherPane";
+
+    static String sBraveTabSwitcherPaneClassName =
+            "org/chromium/chrome/browser/tasks/tab_management/BraveTabSwitcherPane";
+
+    public BraveTabSwitcherPaneClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+
+        redirectConstructor(sTabSwitcherPaneClassName, sBraveTabSwitcherPaneClassName);
+    }
+}


### PR DESCRIPTION
Forced invoke of `createTabSwitcherPaneCoordinator` before `TabSwitcherPaneBase.requestAnimationData()` to avoid null access crash.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40422

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
There are no exact STR, but probably crash happens after
1. Press tabs switch button
2. Press back button
