### PR TITLE
[Uplift 1.69] [Brave News] Autosize Brave News Bubble

### DIFF
--- a/browser/ui/views/brave_news/brave_news_bubble_view.cc
+++ b/browser/ui/views/brave_news/brave_news_bubble_view.cc
@@ -74,7 +74,8 @@ BraveNewsBubbleView::BraveNewsBubbleView(views::View* action_view,
                                          content::WebContents* contents)
     : views::BubbleDialogDelegateView(action_view,
                                       views::BubbleBorder::TOP_RIGHT,
-                                      views::BubbleBorder::STANDARD_SHADOW),
+                                      views::BubbleBorder::STANDARD_SHADOW,
+                                      /*autosize=*/true),
       contents_(contents) {
   DCHECK(contents);
 


### PR DESCRIPTION
requesting uplift of https://github.com/brave/brave-core/pull/25121 which fixes https://github.com/brave/brave-browser/issues/40441
- 1.69.x: