### PR TITLE
Fixed erasing `Sync Client ID` when cleaning cookies.

### DIFF
--- a/browser/browsing_data/BUILD.gn
+++ b/browser/browsing_data/BUILD.gn
@@ -8,6 +8,7 @@ source_set("browser_tests") {
 
   if (!is_android) {
     sources = [
+      "//brave/browser/browsing_data/brave_browsing_data_remover_browsertest.cc",
       "//brave/browser/browsing_data/brave_clear_browsing_data_browsertest.cc",
     ]
 

--- a/browser/browsing_data/brave_browsing_data_remover_browsertest.cc
+++ b/browser/browsing_data/brave_browsing_data_remover_browsertest.cc
@@ -1,0 +1,61 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <stddef.h>
+
+#include "base/base64.h"
+#include "base/rand_util.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/sync/service/glue/sync_transport_data_prefs.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browsing_data_remover_test_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+std::string GenerateCacheGUID() {
+  // Generate a GUID with 128 bits of randomness.
+  const int kGuidBytes = 128 / 8;
+
+  return base::Base64Encode(base::RandBytesAsVector(kGuidBytes));
+}
+
+}  // namespace
+
+class BraveBrowsingDataRemoverBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveBrowsingDataRemoverBrowserTest() = default;
+
+ protected:
+  void RemoveAndWait(uint64_t remove_mask) {
+    content::BrowsingDataRemover* remover =
+        browser()->profile()->GetBrowsingDataRemover();
+    content::BrowsingDataRemoverCompletionObserver completion_observer(remover);
+    remover->RemoveAndReply(
+        base::Time(), base::Time::Max(), remove_mask,
+        content::BrowsingDataRemover::ORIGIN_TYPE_UNPROTECTED_WEB,
+        &completion_observer);
+    completion_observer.BlockUntilCompletion();
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BraveBrowsingDataRemoverBrowserTest,
+                       KeepSyncGuidAfterClearCookies) {
+  // Setup sync prefs including cache_id
+  signin::GaiaIdHash gaia_id_hash =
+      signin::GaiaIdHash::FromGaiaId("user_gaia_id");
+  syncer::SyncTransportDataPrefs sync_transport_data_prefs(
+      browser()->profile()->GetPrefs(), gaia_id_hash);
+  sync_transport_data_prefs.SetCacheGuid(GenerateCacheGUID());
+  EXPECT_FALSE(sync_transport_data_prefs.GetCacheGuid().empty());
+
+  // Clear cookies
+  RemoveAndWait(content::BrowsingDataRemover::DATA_TYPE_COOKIES);
+
+  // Ensure cache guid wasn't dropped
+  EXPECT_FALSE(sync_transport_data_prefs.GetCacheGuid().empty());
+}

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
@@ -6,12 +6,28 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_
 
+#include "build/build_config.h"
+
 class BraveBrowsingDataRemoverDelegate;
+
+#if !BUILDFLAG(IS_ANDROID)
+class FalseBoolStub {
+ public:
+  bool operator=(bool) { return false; }
+  explicit operator bool() const { return false; }
+};
+#endif
 
 #define BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H \
   friend class BraveBrowsingDataRemoverDelegate;
 
+#define should_clear_sync_account_settings_          \
+  unused1_ = false;                                  \
+  FalseBoolStub should_clear_sync_account_settings_; \
+  bool unused2_
+
 #include "src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h"  // IWYU pragma: export
+#undef should_clear_sync_account_settings_
 #undef BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
@@ -10,24 +10,29 @@
 
 class BraveBrowsingDataRemoverDelegate;
 
+#define BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H \
+  friend class BraveBrowsingDataRemoverDelegate;
+
 #if !BUILDFLAG(IS_ANDROID)
 class FalseBoolStub {
  public:
   bool operator=(bool) { return false; }
   explicit operator bool() const { return false; }
 };
-#endif
-
-#define BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H \
-  friend class BraveBrowsingDataRemoverDelegate;
 
 #define should_clear_sync_account_settings_          \
   unused1_ = false;                                  \
   FalseBoolStub should_clear_sync_account_settings_; \
   bool unused2_
 
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 #include "src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h"  // IWYU pragma: export
+
+#if !BUILDFLAG(IS_ANDROID)
 #undef should_clear_sync_account_settings_
+#endif
+
 #undef BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_


### PR DESCRIPTION
This PR turns off the block 
```
if (should_clear_sync_account_settings_) { 
   ... 
} 
```
at upstream's `ChromeBrowsingDataRemoverDelegate::OnTaskComplete`.

Upstream's Sync relies on Google account, and deleting cookies causes logout from sync account. The mentioned  upstream's  code fragment has comment 
```
  // Note: These usually get cleared automatically when the Google cookies are
  // deleted, but there is one edge case where that doesn't work
```
For Brave Sync this fragment would cause clearing of device cache id, but Brave Sync continues to work with regenerating of device cache id and further device duplication.

By these reasons Brave Sync needs to have this code disabled, this is done in the current PR. 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40130

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
See the issue
