### PR TITLE
Enable search suggestions by default

### DIFF
--- a/browser/brave_browser_process_impl.cc
+++ b/browser/brave_browser_process_impl.cc
@@ -78,7 +78,9 @@
 #if BUILDFLAG(IS_ANDROID)
 #include "chrome/browser/flags/android/chrome_feature_list.h"
 #else
+#include "brave/browser/search_engines/search_engine_provider_util.h"
 #include "brave/browser/ui/brave_browser_command_controller.h"
+#include "chrome/browser/first_run/first_run.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_list.h"
 #endif
@@ -171,6 +173,9 @@ void BraveBrowserProcessImpl::Init() {
     // suppressed it from previous os.
     local_state()->ClearPref(prefs::kSuppressUnsupportedOSWarning);
   }
+
+  brave::PrepareSearchSuggestionsConfig(local_state(),
+                                        first_run::IsChromeFirstRun());
 #endif
 }
 

--- a/browser/brave_local_state_prefs.cc
+++ b/browser/brave_local_state_prefs.cc
@@ -56,6 +56,7 @@
 
 #if !BUILDFLAG(IS_ANDROID)
 #include "brave/browser/p3a/p3a_core_metrics.h"
+#include "brave/browser/search_engines/pref_names.h"
 #include "brave/browser/ui/whats_new/whats_new_util.h"
 #include "chrome/browser/first_run/first_run.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
@@ -127,6 +128,8 @@ void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
   BraveWindowTracker::RegisterPrefs(registry);
   dark_mode::RegisterBraveDarkModeLocalStatePrefs(registry);
   whats_new::RegisterLocalStatePrefs(registry);
+
+  registry->RegisterBooleanPref(kEnableSearchSuggestionsByDefault, false);
 #endif
 
 #if defined(TOOLKIT_VIEWS)

--- a/browser/search_engines/normal_window_search_engine_provider_service.cc
+++ b/browser/search_engines/normal_window_search_engine_provider_service.cc
@@ -7,6 +7,7 @@
 
 #include "base/functional/bind.h"
 #include "brave/browser/search_engines/search_engine_provider_util.h"
+#include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "components/search_engines/search_engines_pref_names.h"
@@ -15,6 +16,8 @@
 NormalWindowSearchEngineProviderService::
     NormalWindowSearchEngineProviderService(Profile* profile)
     : profile_(profile) {
+  brave::UpdateDefaultSearchSuggestionsPrefs(g_browser_process->local_state(),
+                                             profile_->GetPrefs());
   private_search_provider_guid_.Init(
       prefs::kSyncedDefaultPrivateSearchProviderGUID, profile_->GetPrefs(),
       base::BindRepeating(

--- a/browser/search_engines/pref_names.h
+++ b/browser/search_engines/pref_names.h
@@ -11,4 +11,8 @@ inline constexpr char kUseAlternativePrivateSearchEngineProvider[] =
 inline constexpr char kShowAlternativePrivateSearchEngineProviderToggle[] =
     "brave.show_alternate_private_search_engine_toggle";
 
+// local state
+inline constexpr char kEnableSearchSuggestionsByDefault[] =
+    "brave.enable_search_suggestions_by_default";
+
 #endif  // BRAVE_BROWSER_SEARCH_ENGINES_PREF_NAMES_H_

--- a/browser/search_engines/search_engine_provider_util.h
+++ b/browser/search_engines/search_engine_provider_util.h
@@ -29,6 +29,10 @@ void PrepareDefaultPrivateSearchProviderDataIfNeeded(Profile* profile);
 void UpdateDefaultPrivateSearchProviderData(Profile* profile);
 void ResetDefaultPrivateSearchProvider(Profile* profile);
 
+void PrepareSearchSuggestionsConfig(PrefService* local_state, bool first_run);
+void UpdateDefaultSearchSuggestionsPrefs(PrefService* local_state,
+                                         PrefService* profile_prefs);
+
 }  // namespace brave
 
 #endif  // BRAVE_BROWSER_SEARCH_ENGINES_SEARCH_ENGINE_PROVIDER_UTIL_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/29517

Enable search suggestions for fresh user in target countries.
Set true to `kEnableSearchSuggestionsByDefault` when this is fresh user and from supported country.
When it's true, `kSearchSuggestEnabled`'s default value is changed to `true` when profile loaded.

<!-- Add brave-browser issue below that this PR will resolve -->


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**Test case 1** - fresh user from target countries
1. Set system local to one of target countries (`IN / CA / DE / FR / GB / US / AT / ES / MX / BR / AR / IT`)
2. Launch browser with clean profile
3. Check seach suggestions option is enabled by default in brave://settings/search

**Test case 2** - existing user from target countries
1. Set system local to one of target countries (`IN / CA / DE / FR / GB / US / AT / ES / MX / BR / AR / IT`)
2. Launch browser with existing profile that search suggestions option is not touched yet
3. Check search suggestions option is not enabled by default in brave://settings/search

**Test case 3** - all users from outside of target countries
1. Set system local to any countries **_except_** target countries (`IN / CA / DE / FR / GB / US / AT / ES / MX / BR / AR / IT`)
2. Launch browser with any profile(new or existing)
3. Check search suggestions option is not enabled by default in brave://settings/search