### PR TITLE
[ads] Enable background audio during NTT video autoplay

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoAdButtonsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoAdButtonsView.swift
@@ -11,9 +11,9 @@ import Shared
 import SnapKit
 import UIKit
 
-/// The foreground view of the New Tab Page video player. It contains the cancel
-/// button and handles user tap gestures to play/pause the video.
-class NewTabPageVideoButtonsView: UIView {
+/// The foreground view of the New Tab Page video ad player. It contains the
+/// cancel button and handles user tap gestures to play/pause the video.
+class NewTabPageVideoAdButtonsView: UIView {
   var tappedBackgroundVideo: (() -> Bool)?
   var tappedCancelButton: (() -> Void)?
 
@@ -109,7 +109,7 @@ class NewTabPageVideoButtonsView: UIView {
   }
 }
 
-extension NewTabPageVideoButtonsView {
+extension NewTabPageVideoAdButtonsView {
   private class CancelButton: SpringButton {
     let imageView = UIImageView(
       image: UIImage(braveSystemNamed: "leo.close")!

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoAdPlayer.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoAdPlayer.swift
@@ -12,10 +12,11 @@ import Shared
 import SnapKit
 import UIKit
 
-/// The class is responsible for managing the video playback on the New Tab Page.
-/// It handles events such as play finished, played 25 percent, autoplay finished,
-/// play cancelled, and video loaded.
-class NewTabPageVideoPlayer {
+// The NewTabPageVideoAdPlayer class is responsible for handling video ads on a
+// new tab page. It sets up the video player, controls playback (play, pause,
+// stop), and manages user interactions. The class also listens for events like
+// video start, pause, and completion, and tracks ad performance metrics.
+class NewTabPageVideoAdPlayer {
   var didStartAutoplayEvent: (() -> Void)?
   var didFinishAutoplayEvent: (() -> Void)?
   var didStartPlaybackEvent: (() -> Void)?
@@ -217,7 +218,7 @@ class NewTabPageVideoPlayer {
       seekToStopFrame()
     }
 
-    disallowBackgroundAudioDuringPlayback()
+    stopBackgroundAudioDuringPlayback()
 
     didFinishAutoplayEvent?()
   }
@@ -282,13 +283,11 @@ class NewTabPageVideoPlayer {
   }
 
   private func allowBackgroundAudioDuringAutoplay() {
-    // When the video is autoplaying, audio is muted, so background audio should always be
-    // allowed to continue playing.
     try? AVAudioSession.sharedInstance().setCategory(.playback, options: [.mixWithOthers])
     try? AVAudioSession.sharedInstance().setActive(true)
   }
 
-  private func disallowBackgroundAudioDuringPlayback() {
+  private func stopBackgroundAudioDuringPlayback() {
     try? AVAudioSession.sharedInstance().setActive(false)
     try? AVAudioSession.sharedInstance().setCategory(
       .playback,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoAdPlayer.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageVideoAdPlayer.swift
@@ -72,8 +72,8 @@ class NewTabPageVideoAdPlayer {
 
       addMediaObservers()
 
-      if isPlaylistActive() {
-        PlaylistCoordinator.shared.mediaPlayer?.pause()
+      if PlaylistCoordinator.shared.isPictureInPictureActive {
+        PlaylistCoordinator.shared.pauseAllPlayback()
       }
 
       player?.isMuted = false
@@ -183,8 +183,8 @@ class NewTabPageVideoAdPlayer {
       self.frameRate = Double(frameRate)
     }
 
-    if !shouldAutoplay || isPlaylistActive() {
-      finishAutoplayIfNeeded(didStartAutoplay: false)
+    if !shouldAutoplay || PlaylistCoordinator.shared.isPictureInPictureActive {
+      finishAutoplayIfNeeded()
       return
     }
 
@@ -209,11 +209,15 @@ class NewTabPageVideoAdPlayer {
     player?.play()
   }
 
-  private func finishAutoplayIfNeeded(shouldSeekToStopFrame: Bool = true, didStartAutoplay: Bool = true) {
+  private func finishAutoplayIfNeeded(shouldSeekToStopFrame: Bool = true) {
     if didFinishAutoplay {
       return
     }
     didFinishAutoplay = true
+
+    // The autoplayPausedObserver is assigned a value only when autoplay has
+    // started.
+    let didStartAutoplay = autoplayPausedObserver != nil
 
     removeAutoplayPausedObserver()
     player?.currentItem?.forwardPlaybackEndTime = CMTime()
@@ -302,10 +306,6 @@ class NewTabPageVideoAdPlayer {
       policy: .default,
       options: []
     )
-  }
-
-  private func isPlaylistActive() -> Bool {
-    return PlaylistCoordinator.shared.playlistController != nil
   }
 
   private func parseStopFrameFromFilename(filename: String) -> Double? {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -265,7 +265,7 @@ class NewTabPageViewController: UIViewController {
       // Load the video asset here, as viewDidAppear is not called when the view
       // is already visible
       if isTabVisible {
-        videoPlayer?.loadAndAutoplayVideoAssetIfNeeded(
+        videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
           shouldAutoplay: false
         )
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -118,8 +118,8 @@ class NewTabPageViewController: UIViewController {
   private var background: NewTabPageBackground
   private let backgroundView = NewTabPageBackgroundView()
   private let backgroundButtonsView: NewTabPageBackgroundButtonsView
-  private var videoPlayer: NewTabPageVideoPlayer?
-  private var videoButtonsView = NewTabPageVideoButtonsView()
+  private var videoAdPlayer: NewTabPageVideoAdPlayer?
+  private var videoButtonsView = NewTabPageVideoAdButtonsView()
 
   /// A gradient to display over background images to ensure visibility of
   /// the NTP contents and sponsored logo
@@ -393,7 +393,7 @@ class NewTabPageViewController: UIViewController {
     // to use it.
     backgroundView.layoutIfNeeded()
 
-    updateVideoPlayer()
+    updateVideoAdPlayer()
 
     calculateBackgroundCenterPoints()
   }
@@ -405,7 +405,7 @@ class NewTabPageViewController: UIViewController {
       self?.reportSponsoredBackgroundEvent(.viewedImpression)
     }
 
-    videoPlayer?.loadAndAutoplayVideoAssetIfNeeded(
+    videoAdPlayer?.loadAndAutoplayVideoAssetIfNeeded(
       shouldAutoplay: shouldShowBackgroundVideo()
     )
 
@@ -428,13 +428,13 @@ class NewTabPageViewController: UIViewController {
     backgroundView.imageView.image = parent == nil ? nil : background.backgroundImage
 
     if parent == nil {
-      videoPlayer?.cancelPlayIfNeeded()
-      videoPlayer?.resetPlayer()
+      videoAdPlayer?.cancelPlayIfNeeded()
+      videoAdPlayer?.resetPlayer()
     } else {
-      videoPlayer?.createPlayer()
-      videoPlayer?.seekToStopFrame()
+      videoAdPlayer?.createPlayer()
+      videoAdPlayer?.seekToStopFrame()
     }
-    backgroundView.playerLayer.player = videoPlayer?.player
+    backgroundView.playerLayer.player = videoAdPlayer?.player
   }
 
   override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -492,7 +492,7 @@ class NewTabPageViewController: UIViewController {
       withDuration: 0.3,
       animations: { [weak self] in
         self?.collectionView.alpha = 1
-        self?.videoPlayer?.seekToStopFrame()
+        self?.videoAdPlayer?.seekToStopFrame()
       }
     )
   }
@@ -501,46 +501,46 @@ class NewTabPageViewController: UIViewController {
     videoButtonsView.isHidden = true
 
     guard let backgroundVideoPath = background.backgroundVideoPath else {
-      videoPlayer = nil
+      videoAdPlayer = nil
       backgroundView.resetPlayerLayer()
       backgroundButtonsView.resetVideoBackgroundButtons()
       return
     }
 
     gradientView.isHidden = false
-    videoPlayer = NewTabPageVideoPlayer(backgroundVideoPath)
+    videoAdPlayer = NewTabPageVideoAdPlayer(backgroundVideoPath)
     if shouldCreatePlayer {
-      videoPlayer?.createPlayer()
+      videoAdPlayer?.createPlayer()
     }
 
-    backgroundView.setupPlayerLayer(backgroundVideoPath, player: videoPlayer?.player)
+    backgroundView.setupPlayerLayer(backgroundVideoPath, player: videoAdPlayer?.player)
 
-    videoButtonsView.tappedBackgroundVideo = { [weak videoPlayer] in
-      guard let videoPlayer else {
+    videoButtonsView.tappedBackgroundVideo = { [weak videoAdPlayer] in
+      guard let videoAdPlayer else {
         return false
       }
-      return videoPlayer.togglePlay()
+      return videoAdPlayer.togglePlay()
     }
-    videoButtonsView.tappedCancelButton = { [weak videoPlayer] in
-      videoPlayer?.cancelPlayIfNeeded()
+    videoButtonsView.tappedCancelButton = { [weak videoAdPlayer] in
+      videoAdPlayer?.cancelPlayIfNeeded()
     }
 
     backgroundButtonsView.activeButton = .none
     backgroundButtonsView.tappedPlayButton = { [weak self] in
-      self?.videoPlayer?.startPlayback()
+      self?.videoAdPlayer?.startPlayback()
     }
     backgroundButtonsView.tappedBackgroundDuringAutoplay = { [weak self] in
-      self?.videoPlayer?.startPlayback()
+      self?.videoAdPlayer?.startPlayback()
     }
 
-    videoPlayer?.didCancelPlaybackEvent = { [weak self] in
+    videoAdPlayer?.didCancelPlaybackEvent = { [weak self] in
       guard let self = self else { return }
       self.fadeInCollectionViewAndHideVideoButtons()
     }
-    videoPlayer?.didStartAutoplayEvent = { [weak self] in
+    videoAdPlayer?.didStartAutoplayEvent = { [weak self] in
       self?.backgroundButtonsView.videoAutoplayStarted()
     }
-    videoPlayer?.didFinishAutoplayEvent = { [weak self] in
+    videoAdPlayer?.didFinishAutoplayEvent = { [weak self] in
       guard let self = self else { return }
       self.backgroundButtonsView.videoAutoplayFinished()
       if case .sponsoredMedia(let background) = self.background.currentBackground {
@@ -554,17 +554,17 @@ class NewTabPageViewController: UIViewController {
         }
       )
     }
-    videoPlayer?.didFinishPlaybackEvent = { [weak self] in
+    videoAdPlayer?.didFinishPlaybackEvent = { [weak self] in
       guard let self = self else { return }
       self.fadeInCollectionViewAndHideVideoButtons()
       self.reportSponsoredBackgroundEvent(.media100)
     }
-    videoPlayer?.didStartPlaybackEvent = { [weak self] in
+    videoAdPlayer?.didStartPlaybackEvent = { [weak self] in
       guard let self = self else { return }
       self.fadeOutCollectionViewAndShowVideoButtons()
       self.reportSponsoredBackgroundEvent(.mediaPlay)
     }
-    videoPlayer?.didPlay25PercentEvent = { [weak self] in
+    videoAdPlayer?.didPlay25PercentEvent = { [weak self] in
       self?.reportSponsoredBackgroundEvent(.media25)
     }
   }
@@ -574,7 +574,7 @@ class NewTabPageViewController: UIViewController {
     return !(isLandscape && UIDevice.isPhone)
   }
 
-  private func updateVideoPlayer() {
+  private func updateVideoAdPlayer() {
     backgroundView.playerLayer.frame = view.bounds
 
     if shouldShowBackgroundVideo() {
@@ -582,7 +582,7 @@ class NewTabPageViewController: UIViewController {
     } else {
       // Hide the player layer in landscape mode on iPhone.
       backgroundView.playerLayer.isHidden = true
-      videoPlayer?.cancelPlayIfNeeded()
+      videoAdPlayer?.cancelPlayIfNeeded()
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCoordinator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCoordinator.swift
@@ -230,6 +230,20 @@ public class PlaylistCoordinator: NSObject {
     }
   }
 
+  func pauseAllPlayback() {
+    if FeatureList.kNewPlaylistUI.enabled {
+      playerModel?.pause()
+    } else {
+      mediaPlayer?.pause()
+    }
+  }
+
+  var isPictureInPictureActive: Bool {
+    FeatureList.kNewPlaylistUI.enabled
+      ? playerModel?.isPictureInPictureActive == true
+      : mediaPlayer?.pictureInPictureController?.isPictureInPictureActive == true
+  }
+
   private func destroyPlayerModelIfUnused() {
     guard let playerModel else { return }
     // The player model should stay alive if any of these are true:

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -165,7 +165,7 @@ public final class PlayerModel: ObservableObject {
     player.play()
   }
 
-  func pause() {
+  public func pause() {
     if !isPlaying {
       return
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39845

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Fresh install
* Setup NTT video player staging component
* Run the background audio
* Start the Browser
* Open new tab pages until NTT video is shown
* Make sure that background audio is not interrupted during NTT video autoplay
* Tap play button
* Make sure that background audio is interrupted during NTT video playback
