### PR TITLE
[ads] Add NTP media type p3a metric

### DIFF
--- a/browser/profiles/profile_util.cc
+++ b/browser/profiles/profile_util.cc
@@ -50,7 +50,7 @@ void RecordSponsoredImagesEnabledP3A(Profile* profile) {
       profile->GetPrefs()->GetBoolean(kNewTabPageShowBackgroundImage) &&
       profile->GetPrefs()->GetBoolean(
           kNewTabPageShowSponsoredImagesBackgroundImage);
-  UMA_HISTOGRAM_BOOLEAN("Brave.NTP.SponsoredImagesEnabled",
+  UMA_HISTOGRAM_BOOLEAN("Brave.NTP.SponsoredMediaType",
                         is_sponsored_image_enabled);
 }
 

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -68,7 +68,7 @@ inline constexpr auto kCollectedTypicalHistograms =
     "Brave.Importer.ImporterSource.2",
     "Brave.NTP.CustomizeUsageStatus.2",
     "Brave.NTP.NewTabsCreated.3",
-    "Brave.NTP.SponsoredImagesEnabled",
+    "Brave.NTP.SponsoredMediaType",
     "Brave.NTP.SponsoredNewTabsCreated.2",
     "Brave.Omnibox.SearchCount.3",
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackground.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/Backgrounds/NewTabPageBackground.swift
@@ -54,7 +54,6 @@ class NewTabPageBackground: PreferencesObserver {
     Preferences.NewTabPage.backgroundMediaTypeRaw.observe(from: self)
     Preferences.NewTabPage.selectedCustomTheme.observe(from: self)
 
-    recordSponsoredImagesEnabledP3A()
     recordSponsoredMediaTypeP3A()
   }
 
@@ -74,18 +73,9 @@ class NewTabPageBackground: PreferencesObserver {
       block: { [weak self] _ in
         guard let self = self else { return }
         self.currentBackground = self.dataSource.newBackground()
-        self.recordSponsoredImagesEnabledP3A()
         self.recordSponsoredMediaTypeP3A()
       }
     )
-  }
-
-  private func recordSponsoredImagesEnabledP3A() {
-    // Q26 Is the sponsored new tab page option enabled?
-    let isSIEnabled =
-      Preferences.NewTabPage.backgroundImages.value
-      && Preferences.NewTabPage.backgroundMediaType.isSponsored
-    UmaHistogramBoolean("Brave.NTP.SponsoredImagesEnabled", isSIEnabled)
   }
 
   private func recordSponsoredMediaTypeP3A() {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -163,7 +163,7 @@ class NewTabPageViewController: UIViewController {
       privateBrowsingManager: privateBrowsingManager
     )
     self.p3aHelper = p3aHelper
-    background = NewTabPageBackground(dataSource: dataSource)
+    background = NewTabPageBackground(dataSource: dataSource, rewards: rewards)
     notifications = NewTabPageNotifications(rewards: rewards)
     collectionView = NewTabCollectionView(frame: .zero, collectionViewLayout: layout)
     super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40507

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
* Setup device region to Japan
* Fresh Brave install
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images & Videos`
* Set setting `Background` -> `Media Type` to `Sponsored Images`
* Make sure that `Brave.NTP.SponsoredMediaType` metric is reported with values 1 and 2

### Test case 2
* Setup device region to Japan
* Fresh Brave install
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images & Videos`
* Set setting `Background` -> `Media Type` to `Default Images`
* Make sure that `Brave.NTP.SponsoredMediaType` metric is reported with values 0 and 2

### Test case 3
* Setup device region to any country except Japan
* Fresh Brave install
* Make sure that setting `Background` -> `Media Type` is set to `Sponsored Images`
* Set setting `Background` -> `Media Type` to `Default Images`
* Make sure that `Brave.NTP.SponsoredMediaType` metric is reported with values 0 and 1
