### PR TITLE
[MacOS] fixes crash importing Chrome profile with extensions. (uplift to 1.70.x)

### DIFF
--- a/chromium_src/chrome/browser/extensions/extension_install_prompt_show_params.cc
+++ b/chromium_src/chrome/browser/extensions/extension_install_prompt_show_params.cc
@@ -1,0 +1,24 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/extensions/extension_install_prompt_show_params.h"
+
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_MAC)
+// On MacOS, the call to parent_web_contents_->GetTopLevelNativeWindow in
+// ExtensionInstallPromptShowParams::ExtensionInstallPromptShowParams returns
+// nullptr and hits CHECK_IS_TEST when this code is triggered from importing
+// Chrome profile.
+// Filed an upstream issue https://issues.chromium.org/issues/360321351
+#include "base/check_is_test.h"
+#undef CHECK_IS_TEST
+#define CHECK_IS_TEST()
+#endif
+
+#include "src/chrome/browser/extensions/extension_install_prompt_show_params.cc"
+#if BUILDFLAG(IS_MAC)
+#undef CHECK_IS_TEST
+#endif


### PR DESCRIPTION
Uplift of #25159
Resolves https://github.com/brave/brave-browser/issues/40470

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.