### PR TITLE
[C128] Potential fix for "Relaunch to Update Brave" menu item doesn't relaunch the browser (uplift to 1.70.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -149,6 +149,9 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &features::kDigitalGoodsApi,
       &features::kDIPS,
       &features::kFedCm,
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+      &features::kFewerUpdateConfirmations,
+#endif
 #if !BUILDFLAG(IS_ANDROID)
       &features::kHaTSWebUI,
 #endif

--- a/chromium_src/chrome/browser/ui/ui_features.cc
+++ b/chromium_src/chrome/browser/ui/ui_features.cc
@@ -12,6 +12,9 @@ namespace features {
 
 OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kChromeLabs, base::FEATURE_DISABLED_BY_DEFAULT},
+#if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
+    {kFewerUpdateConfirmations, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
 #if !BUILDFLAG(IS_ANDROID)
     {kHaTSWebUI, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif


### PR DESCRIPTION
Uplift of #25192
Resolves https://github.com/brave/brave-browser/issues/40475

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.