### PR TITLE
Fixed inactive tab hover color

### DIFF
--- a/browser/ui/tabs/brave_tab_style.h
+++ b/browser/ui/tabs/brave_tab_style.h
@@ -8,10 +8,7 @@
 
 #include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/features.h"
-#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/layout_constants.h"
-#include "ui/color/color_provider.h"
-#include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/insets.h"
 
 // A subclass of TabStyle used to customize tab layout and visuals. It is
@@ -77,35 +74,6 @@ class BraveTabStyle : public TabStyleBase {
   }
 
   int GetSeparatorCornerRadius() const override { return 0; }
-
-  SkColor GetTabBackgroundColor(
-      const TabStyleBase::TabSelectionState state,
-      bool hovered,
-      const bool frame_active,
-      const ui::ColorProvider& color_provider) const override {
-    const SkColor active_color = color_provider.GetColor(
-        frame_active ? kColorTabBackgroundActiveFrameActive
-                     : kColorTabBackgroundActiveFrameInactive);
-    const SkColor inactive_color = color_provider.GetColor(
-        frame_active ? kColorTabBackgroundInactiveFrameActive
-                     : kColorTabBackgroundInactiveFrameInactive);
-
-    if (hovered) {
-      return active_color;
-    }
-
-    switch (state) {
-      case TabStyleBase::TabSelectionState::kActive:
-        return active_color;
-      case TabStyleBase::TabSelectionState::kSelected:
-        return color_utils::AlphaBlend(active_color, inactive_color,
-                                       TabStyleBase::GetSelectedTabOpacity());
-      case TabStyleBase::TabSelectionState::kInactive:
-        return inactive_color;
-      default:
-        NOTREACHED_NORETURN();
-    }
-  }
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_BRAVE_TAB_STYLE_H_


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/40486

We need to use different color for hover state.

Right side tab is inactive with hovered.

<img width="423" alt="Screenshot 2024-08-20 at 2 31 09 PM" src="https://github.com/user-attachments/assets/0c6ff1eb-2213-4d79-b6f3-bb15d91cf982">
<img width="394" alt="Screenshot 2024-08-20 at 2 31 24 PM" src="https://github.com/user-attachments/assets/a26ae3a3-24be-4306-a6e8-edce64419096">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

