### PR TITLE
[iOS] Add support for running the iPad app on visionOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -226,7 +226,8 @@ extension BrowserViewController: WKNavigationDelegate {
       return (shouldOpen ? .allow : .cancel, preferences)
     }
 
-    if #available(iOS 17.4, *) {
+    if #available(iOS 17.4, *), !ProcessInfo.processInfo.isiOSAppOnVisionOS {
+      // Accessing `MarketplaceKitURIScheme` on Vision OS results in a crash
       if requestURL.scheme == MarketplaceKitURIScheme {
         if let queryItems = URLComponents(url: requestURL, resolvingAgainstBaseURL: false)?
           .queryItems,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/PageZoom/PageZoomView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/PageZoom/PageZoomView.swift
@@ -31,6 +31,7 @@ private struct ZoomView: View {
           .frame(width: buttonWidth)
       }
       .disabled(value == minValue)
+      .hoverEffect()
 
       Divider()
 
@@ -52,6 +53,7 @@ private struct ZoomView: View {
           .frame(width: buttonWidth)
       }
       .disabled(value == maxValue)
+      .hoverEffect()
     }
     .padding(.vertical, 8.0)
     .fixedSize(horizontal: false, vertical: true)
@@ -130,6 +132,7 @@ struct PageZoomView: View {
       }
       .padding(.horizontal)
       .padding(.vertical, 6.0)
+      .hoverEffect()
     }
     .background(Color(UIColor.braveBackground))
     .ignoresSafeArea()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/RecentSearchQRCodeScannerController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/RecentSearchQRCodeScannerController.swift
@@ -16,7 +16,11 @@ class RecentSearchQRCodeScannerController: UIViewController {
   private var onDidScan: (_ string: String) -> Void
 
   public static var hasCameraSupport: Bool {
-    !AVCaptureDevice.DiscoverySession(
+    if ProcessInfo.processInfo.isiOSAppOnVisionOS {
+      // Apps on VisionOS can't access the main camera
+      return false
+    }
+    return !AVCaptureDevice.DiscoverySession(
       deviceTypes: [.builtInWideAngleCamera],
       mediaType: .video,
       position: .back

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/ToolbarVisibilityViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/ToolbarVisibilityViewModel.swift
@@ -147,6 +147,11 @@ import UIKit
   }
 
   func send(action: Action) {
+    if ProcessInfo.processInfo.isiOSAppOnVisionOS {
+      // Trying to expand a collapsed URL bar on vision OS is difficult, until further changes
+      // can be made to the UI itself, we will disable collapsing it on VisionOS
+      return
+    }
     if !isEnabled { return }
     switch action {
     case .dragged(let snapshot, let panData):

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -215,7 +215,7 @@ extension Preferences {
     /// Enables the Apple's Screen Time feature.
     public static let screenTimeEnabled = Option<Bool>(
       key: "privacy.screentime-toggle",
-      default: AppConstants.buildChannel != .release
+      default: AppConstants.buildChannel != .release && !ProcessInfo.processInfo.isiOSAppOnVisionOS
     )
 
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/OtherPrivacySettingsSectionView.swift
@@ -82,14 +82,17 @@ struct OtherPrivacySettingsSectionView: View {
         ),
         option: Preferences.Shields.googleSafeBrowsing
       )
-      OptionToggleView(
-        title: Strings.screenTimeSetting,
-        subtitle: String.localizedStringWithFormat(
-          Strings.screenTimeSettingDescription,
-          URL.brave.screenTimeHelp.absoluteString
-        ),
-        option: Preferences.Privacy.screenTimeEnabled
-      )
+      if !ProcessInfo.processInfo.isiOSAppOnVisionOS {
+        // Vision OS does not support ScreenTime for web pages
+        OptionToggleView(
+          title: Strings.screenTimeSetting,
+          subtitle: String.localizedStringWithFormat(
+            Strings.screenTimeSettingDescription,
+            URL.brave.screenTimeHelp.absoluteString
+          ),
+          option: Preferences.Privacy.screenTimeEnabled
+        )
+      }
       ToggleView(
         title: Strings.P3A.settingTitle,
         subtitle: Strings.P3A.settingSubtitle,

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
@@ -376,6 +376,7 @@ private struct ShieldsPanelDisclosureStyle: DisclosureGroupStyle {
       .buttonStyle(.plain)
       .frame(maxWidth: .infinity, alignment: .center)
       .background(Color(.secondaryBraveBackground))
+      .hoverEffect()
 
       if configuration.isExpanded {
         configuration.content

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncPairWordsViewController.swift
@@ -117,7 +117,10 @@ class SyncPairWordsViewController: SyncViewController {
     loadingView.addSubview(loadingSpinner)
 
     view.addSubview(loadingView)
-    view.addSubview(useCameraButton)
+
+    if !ProcessInfo.processInfo.isiOSAppOnVisionOS {
+      view.addSubview(useCameraButton)
+    }
 
     scrollView.snp.makeConstraints {
       $0.edges.equalTo(view)
@@ -156,11 +159,13 @@ class SyncPairWordsViewController: SyncViewController {
       $0.center.equalTo(loadingView)
     }
 
-    useCameraButton.snp.makeConstraints {
-      $0.top.equalTo(containerView.snp.bottom).offset(16)
-      $0.left.equalTo(view)
-      $0.right.equalTo(view)
-      $0.centerX.equalTo(view)
+    if !ProcessInfo.processInfo.isiOSAppOnVisionOS {
+      useCameraButton.snp.makeConstraints {
+        $0.top.equalTo(containerView.snp.bottom).offset(16)
+        $0.left.equalTo(view)
+        $0.right.equalTo(view)
+        $0.centerX.equalTo(view)
+      }
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncWelcomeViewController.swift
@@ -292,6 +292,13 @@ class SyncWelcomeViewController: SyncViewController {
 
   @objc
   private func existingUserAction() {
+    if ProcessInfo.processInfo.isiOSAppOnVisionOS {
+      // VisionOS can't access the main camera, so we skip showing QR code scan screen entirely
+      let wordsVC = SyncPairWordsViewController(syncAPI: syncAPI)
+      wordsVC.delegate = self
+      navigationController?.pushViewController(wordsVC, animated: true)
+      return
+    }
     let pairCamera = SyncPairCameraViewController(syncAPI: syncAPI)
     pairCamera.delegate = self
     navigationController?.pushViewController(pairCamera, animated: true)

--- a/ios/brave-ios/Sources/BraveNews/Cards/BraveNewsOptInView.swift
+++ b/ios/brave-ios/Sources/BraveNews/Cards/BraveNewsOptInView.swift
@@ -62,6 +62,12 @@ public class BraveNewsOptInView: UIView, FeedCardContent {
     $0.setTitle(Strings.BraveNews.learnMoreTitle, for: .normal)
     $0.titleLabel?.font = .systemFont(ofSize: 15.0, weight: .semibold)
     $0.setTitleColor(.white, for: .normal)
+    if #available(iOS 17.0, *) {
+      $0.hoverStyle = .init(
+        effect: .highlight,
+        shape: .capsule.inset(by: .init(top: 0, left: -8, bottom: 0, right: -8))
+      )
+    }
   }
 
   public required init() {

--- a/ios/brave-ios/Sources/BraveShared/Extensions/ProcessInfoExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/ProcessInfoExtensions.swift
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import LocalAuthentication
+
+extension ProcessInfo {
+  public var isiOSAppOnVisionOS: Bool {
+    #if targetEnvironment(simulator)
+    return environment["SIMULATOR_MODEL_IDENTIFIER"]?.hasPrefix("RealityDevice") ?? false
+    #else
+    if #available(iOS 17.0, *) {
+      // Vision Pro ships with iOS 17.0 so this will always execute
+      let authContext = LAContext()
+      _ = authContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+      return authContext.biometryType == .opticID
+        || NSClassFromString("UIWindowSceneGeometryPreferencesVision") != nil
+    }
+    return false
+    #endif
+  }
+}

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/TableCellButtonStyle.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/TableCellButtonStyle.swift
@@ -9,6 +9,7 @@ import SwiftUI
 /// A button style that mimics a table cell being highlighted in the background
 public struct TableCellButtonStyle: ButtonStyle {
   @Environment(\.colorScheme) private var colorScheme: ColorScheme
+
   public init() {}
   public func makeBody(configuration: Configuration) -> some View {
     configuration.label
@@ -17,5 +18,6 @@ public struct TableCellButtonStyle: ButtonStyle {
         Color(colorScheme == .dark ? .white : .black)
           .opacity(configuration.isPressed ? 0.1 : 0.0)
       )
+      .hoverEffect(.highlight)
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Accounts/AccountsView.swift
@@ -277,10 +277,12 @@ private struct AccountCardView: View {
             Label(Strings.Wallet.exportButtonTitle, braveSystemImage: "leo.key")
           }
         }
-        Button {
-          action(.depositToAccount)
-        } label: {
-          Label(Strings.Wallet.deposit, braveSystemImage: "leo.qr.code")
+        if !ProcessInfo.processInfo.isiOSAppOnVisionOS {
+          Button {
+            action(.depositToAccount)
+          } label: {
+            Label(Strings.Wallet.deposit, braveSystemImage: "leo.qr.code")
+          }
         }
       } label: {
         RoundedRectangle(cornerRadius: 8)

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/BackupNotifyView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/BackupNotifyView.swift
@@ -16,27 +16,30 @@ struct BackupNotifyView: View {
 
   var body: some View {
     let closeImage = Image(systemName: "xmark")
-    ZStack(alignment: .topTrailing) {
-      Button(action: action) {
-        HStack {
-          Text(Strings.Wallet.backupWalletWarningMessage)
-            .font(.subheadline.weight(.semibold))
-            .foregroundColor(Color(.braveLabel))
-            .fixedSize(horizontal: false, vertical: true)
-            .frame(maxWidth: .infinity, alignment: .leading)
-          closeImage.hidden()
-        }
+    Button(action: action) {
+      HStack {
+        Text(Strings.Wallet.backupWalletWarningMessage)
+          .font(.subheadline.weight(.semibold))
+          .foregroundColor(Color(.braveLabel))
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: .infinity, alignment: .leading)
+        closeImage.hidden()
       }
-      .padding(12)
+    }
+    .padding(12)
+    .frame(maxWidth: .infinity)
+    .background(Color(.braveErrorBackground))
+    .hoverEffect()
+    .clipShape(backgroundShape)
+    .overlay(alignment: .topTrailing) {
       Button(action: onDismiss) {
         closeImage
           .foregroundColor(Color(.braveLabel))
           .padding(12)  // To make the hit-area a bit bigger
       }
+      .contentShape(.hoverEffect, .rect(cornerRadius: 4).inset(by: -4))
+      .hoverEffect()
     }
-    .frame(maxWidth: .infinity)
-    .background(Color(.braveErrorBackground))
-    .clipShape(backgroundShape)
   }
 }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioSegmentedControl.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Portfolio/PortfolioSegmentedControl.swift
@@ -134,6 +134,7 @@ struct WalletSegmentedControl<Item: WalletSegmentedControlItem>: View {
       .dynamicTypeSize(dynamicTypeRange)
       .allowsHitTesting(false)
       .frame(width: itemWidth)
+      .hoverEffect()
   }
 
   private var dragGesture: some Gesture {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/WalletActions/SendTokenView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/WalletActions/SendTokenView.swift
@@ -227,15 +227,20 @@ struct SendTokenView: View {
                   .font(.body)
               }
               .buttonStyle(PlainButtonStyle())
-              Button {
-                isShowingScanner = true
-              } label: {
-                Label(Strings.Wallet.scanQRCodeAccessibilityLabel, braveSystemImage: "leo.qr.code")
+              if !ProcessInfo.processInfo.isiOSAppOnVisionOS {
+                Button {
+                  isShowingScanner = true
+                } label: {
+                  Label(
+                    Strings.Wallet.scanQRCodeAccessibilityLabel,
+                    braveSystemImage: "leo.qr.code"
+                  )
                   .labelStyle(.iconOnly)
                   .foregroundColor(Color(.primaryButtonTint))
                   .font(.body)
+                }
+                .buttonStyle(PlainButtonStyle())
               }
-              .buttonStyle(PlainButtonStyle())
             }
             Group {
               if sendTokenStore.isResolvingAddress {

--- a/ios/brave-ios/Sources/DesignSystem/Views/BraveButtonStyle.swift
+++ b/ios/brave-ios/Sources/DesignSystem/Views/BraveButtonStyle.swift
@@ -55,6 +55,7 @@ public struct BraveFilledButtonStyle: ButtonStyle {
       )
       .clipShape(clipShape)
       .contentShape(clipShape)
+      .hoverEffect()
       .animation(.linear(duration: 0.15), value: isEnabled)
   }
 }

--- a/ios/brave-ios/Sources/Onboarding/Callouts/OnboardingPlaylistView.swift
+++ b/ios/brave-ios/Sources/Onboarding/Callouts/OnboardingPlaylistView.swift
@@ -558,6 +558,7 @@ private struct PlaylistButtonStyle: ButtonStyle {
       )
       .clipShape(clipShape)
       .contentShape(clipShape)
+      .hoverEffect()
   }
 }
 

--- a/ios/brave-ios/Sources/PlaylistUI/MediaScrubber.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaScrubber.swift
@@ -105,7 +105,9 @@ struct MediaScrubber<Label: View>: View {
               Circle()
                 .foregroundStyle(.tint)
                 .frame(width: thumbSize, height: thumbSize)
-                .contentShape(.rect)
+                .contentShape(.circle.inset(by: -8))
+                .contentShape(.hoverEffect, .circle.inset(by: -8))
+                .hoverEffect(.lift)
                 .scaleEffect(isScrubbing ? 1.5 : 1)
                 .animation(.spring(response: 0.2, dampingFraction: 0.7), value: isScrubbing)
                 .offset(

--- a/ios/brave-ios/Sources/PlaylistUI/PlaybackControlButtonStyle.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaybackControlButtonStyle.swift
@@ -77,7 +77,9 @@ struct PlaybackControlButtonStyle: ButtonStyle {
       .font(.system(fontStyle))
       .frame(height: multiplier * length)
       .contentShape(.rect)
+      .contentShape(.hoverEffect, .rect(cornerRadius: 8, style: .continuous).inset(by: -8))
       .foregroundStyle(.tint)
+      .hoverEffect()
       .background {
         if isPressed {
           RoundedRectangle(cornerRadius: 8, style: .continuous)

--- a/ios/brave-ios/Sources/PlaylistUI/SpringButtonStyle.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/SpringButtonStyle.swift
@@ -31,6 +31,8 @@ public struct SpringButtonStyle: ButtonStyle {
       }
       .scaleEffect(isPressed ? scale : 1.0)
       .opacity(isPressed ? 0.95 : 1.0)
+      .contentShape(.hoverEffect, .rect(cornerRadius: 8, style: .continuous))
+      .hoverEffect()
       .onChange(
         of: configuration.isPressed,
         perform: { value in


### PR DESCRIPTION
This change removes support for certain features that are unavailable on VisionOS, such as accessing the camera to scan QR codes, using the Screen Time feature, and handling third-party marketplace URLs. It also adjusts adds hover effects to a number of buttons to make it easier to use the iPad app on VisionOS

Resolves https://github.com/brave/brave-browser/issues/40579

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

