### PR TITLE
Fixed inactive tab hover color (uplift to 1.69.x)

### DIFF
--- a/browser/ui/tabs/brave_tab_style.h
+++ b/browser/ui/tabs/brave_tab_style.h
@@ -8,10 +8,7 @@
 
 #include "brave/browser/ui/tabs/brave_tab_layout_constants.h"
 #include "brave/browser/ui/tabs/features.h"
-#include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/ui/layout_constants.h"
-#include "ui/color/color_provider.h"
-#include "ui/gfx/color_utils.h"
 #include "ui/gfx/geometry/insets.h"
 
 // A subclass of TabStyle used to customize tab layout and visuals. It is
@@ -77,35 +74,6 @@ class BraveTabStyle : public TabStyleBase {
   }
 
   int GetSeparatorCornerRadius() const override { return 0; }
-
-  SkColor GetTabBackgroundColor(
-      const TabStyleBase::TabSelectionState state,
-      bool hovered,
-      const bool frame_active,
-      const ui::ColorProvider& color_provider) const override {
-    const SkColor active_color = color_provider.GetColor(
-        frame_active ? kColorTabBackgroundActiveFrameActive
-                     : kColorTabBackgroundActiveFrameInactive);
-    const SkColor inactive_color = color_provider.GetColor(
-        frame_active ? kColorTabBackgroundInactiveFrameActive
-                     : kColorTabBackgroundInactiveFrameInactive);
-
-    if (hovered) {
-      return active_color;
-    }
-
-    switch (state) {
-      case TabStyleBase::TabSelectionState::kActive:
-        return active_color;
-      case TabStyleBase::TabSelectionState::kSelected:
-        return color_utils::AlphaBlend(active_color, inactive_color,
-                                       TabStyleBase::GetSelectedTabOpacity());
-      case TabStyleBase::TabSelectionState::kInactive:
-        return inactive_color;
-      default:
-        NOTREACHED_NORETURN();
-    }
-  }
 };
 
 #endif  // BRAVE_BROWSER_UI_TABS_BRAVE_TAB_STYLE_H_


### PR DESCRIPTION
Uplift of #25215
fix https://github.com/brave/brave-browser/issues/40486

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.