### PR TITLE
Notify activity recreation when changing theme from network settings

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/BraveWalletNetworksPreference.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveWalletNetworksPreference.java
@@ -11,6 +11,7 @@ import android.util.AttributeSet;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.widget.AppCompatButton;
+import androidx.fragment.app.Fragment;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceViewHolder;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -39,6 +40,7 @@ public class BraveWalletNetworksPreference extends Preference
     private RecyclerView mRecyclerView;
     @Nullable private BraveWalletAddNetworksFragment.Listener mListener;
     private JsonRpcService mJsonRpcService;
+    private Fragment mPreferenceFragment;
 
     public BraveWalletNetworksPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -68,14 +70,23 @@ public class BraveWalletNetworksPreference extends Preference
     }
 
     public void destroy() {
-        mJsonRpcService.close();
+        if (mJsonRpcService != null) {
+            mJsonRpcService.close();
+            mJsonRpcService = null;
+        }
     }
 
     @Override
     public void onConnectionError(MojoException e) {
-        mJsonRpcService.close();
-        mJsonRpcService = null;
-        initJsonRpcService();
+        if (mJsonRpcService != null) {
+            mJsonRpcService.close();
+            mJsonRpcService = null;
+        }
+        if (mPreferenceFragment != null) {
+            // TODO: remove when https://github.com/brave/brave-browser/issues/27887
+            // will be resolved.
+            mPreferenceFragment.requireActivity().recreate();
+        }
     }
 
     @Override
@@ -231,5 +242,9 @@ public class BraveWalletNetworksPreference extends Preference
         }
 
         mJsonRpcService = BraveWalletServiceFactory.getInstance().getJsonRpcService(this);
+    }
+
+    public void setPreferenceFragment(@NonNull final Fragment preferenceFragment) {
+        mPreferenceFragment = preferenceFragment;
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/BraveWalletNetworksPreferenceFragment.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveWalletNetworksPreferenceFragment.java
@@ -67,6 +67,7 @@ public class BraveWalletNetworksPreferenceFragment extends BravePreferenceFragme
                 findPreference(PREF_BRAVE_WALLET_NETWORKS_ADD);
         if (braveWalletNetworksPreference != null) {
             braveWalletNetworksPreference.setListener(this);
+            braveWalletNetworksPreference.setPreferenceFragment(this);
         }
     }
 
@@ -85,15 +86,12 @@ public class BraveWalletNetworksPreferenceFragment extends BravePreferenceFragme
     @NonNull
     @Override
     public RecyclerView.LayoutManager onCreateLayoutManager() {
-        final LinearLayoutManager linearLayoutManager =
-                new LinearLayoutManager(requireContext()) {
-                    @Override
-                    public boolean canScrollVertically() {
-                        return false;
-                    }
-                };
-
-        return linearLayoutManager;
+        return new LinearLayoutManager(requireContext()) {
+            @Override
+            public boolean canScrollVertically() {
+                return false;
+            }
+        };
     }
 
     @Override


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/40496

Notify activity recreation when changing theme in order to avoid mojo bindings crash.

Starting with Android 12.0 (API level 31) there's a feature to change the theme from the Android settings menu. On the previous Android versions changing theme had a less aggressive behavior as it was not immediately changing the theme for the activity in foreground. On the newer versions (API level 31 and upwards) the activity is destroyed and recreated. 
Unfortunately the recreation process leaves the `BraveActivity` instance in an inconsistent state and triggers some exceptions: our mojo calls return `onConnectionError` without providing meaningful info, our base method `getBraveActivity` throws an exception and when recreating the activity we are also hitting this private Chromium issue: ([crbug.com/40793204](http://crbug.com/40793204)).

Calling the method `recreate()` on connection error works very well as it notifes internally about the activity recreation and it fixes all our mojo calls without further issues. 
Ideally we should not fallback to `onConnectionError` at all in the first place, but because the theme recreation is triggered from an external source it might be unavoidable (more investigation required to explore this).

## Demo

https://github.com/user-attachments/assets/d44576b9-2ee2-4415-900f-8e189139d077


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Navigate to network settings
- Change theme
- Observe the network settings screen is correctly displayed and it shows all the available networks
