### PR TITLE
Fix crash when changing settings and there is a pending update on macOS

### DIFF
--- a/browser/mac/sparkle_glue.h
+++ b/browser/mac/sparkle_glue.h
@@ -22,7 +22,7 @@
 
 - (void)checkForUpdates;
 
-- (void)relaunch;
+- (BOOL)relaunch;
 
 - (AutoupdateStatus)recentStatus;
 

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -297,8 +297,8 @@ std::string GetDescriptionFromAppcastItem(id item) {
 
   AutoupdateStatus status;
   if (_updateWillBeInstalledOnQuit) {
-    // If an update was successfully installed and this object saw it happen,
-    // then don't even bother comparing versions.
+    // If this object was notified that an update will be installed, then don't
+    // even bother to compare versions.
     status = kAutoupdateInstalled;
   } else {
     NSString* currentVersion = base::SysUTF8ToNSString(chrome::kChromeVersion);

--- a/browser/mac/sparkle_glue.mm
+++ b/browser/mac/sparkle_glue.mm
@@ -58,7 +58,7 @@ std::string GetDescriptionFromAppcastItem(id item) {
   SUUpdater* __strong _su_updater;
 
   BOOL _registered;
-  BOOL _updateSuccessfullyInstalled;
+  BOOL _updateWillBeInstalledOnQuit;
 
   NSString* __strong _appPath;
   NSString* __strong _new_version;
@@ -168,7 +168,7 @@ std::string GetDescriptionFromAppcastItem(id item) {
   // We don't know currently installed version from property list because
   // sparkle updates it when relaunching.
   // So, caching version when new candidate is found and use it.
-  if (_updateSuccessfullyInstalled) {
+  if (_updateWillBeInstalledOnQuit) {
     return _new_version;
   }
 
@@ -192,9 +192,13 @@ std::string GetDescriptionFromAppcastItem(id item) {
   [_su_updater checkForUpdatesInBackgroundWithoutUi];
 }
 
-- (void)relaunch {
-  [_su_updater.driver installWithToolAndRelaunch:YES
-                         displayingUserInterface:NO];
+- (BOOL)relaunch {
+  if (_updateWillBeInstalledOnQuit && _su_updater.driver) {
+    [_su_updater.driver installWithToolAndRelaunch:YES
+                           displayingUserInterface:NO];
+    return true;
+  }
+  return false;
 }
 
 - (void)checkForUpdatesInBackground {
@@ -292,7 +296,7 @@ std::string GetDescriptionFromAppcastItem(id item) {
   DCHECK(NSThread.isMainThread);
 
   AutoupdateStatus status;
-  if (_updateSuccessfullyInstalled) {
+  if (_updateWillBeInstalledOnQuit) {
     // If an update was successfully installed and this object saw it happen,
     // then don't even bother comparing versions.
     status = kAutoupdateInstalled;
@@ -308,7 +312,7 @@ std::string GetDescriptionFromAppcastItem(id item) {
     } else {
       // If the version on disk doesn't match what's currently running, an
       // update must have been applied in the background, without this app's
-      // direct participation.  Leave _updateSuccessfullyInstalled alone
+      // direct participation.  Leave _updateWillBeInstalledOnQuit alone
       // because there's no direct knowledge of what actually happened.
       status = kAutoupdateInstalled;
     }
@@ -386,7 +390,7 @@ std::string GetDescriptionFromAppcastItem(id item) {
   VLOG(0) << "brave update: will install update on quit with " +
              GetDescriptionFromAppcastItem(item);
 
-  _updateSuccessfullyInstalled = YES;
+  _updateWillBeInstalledOnQuit = YES;
 
   [self determineUpdateStatusAsync];
 }

--- a/browser/ui/webui/settings/brave_relaunch_handler_mac.h
+++ b/browser/ui/webui/settings/brave_relaunch_handler_mac.h
@@ -8,7 +8,7 @@
 
 namespace brave_relaunch_handler {
 
-void RelaunchOnMac();
+bool RelaunchOnMac();
 
 }  // namespace brave_relaunch_handler
 

--- a/browser/ui/webui/settings/brave_relaunch_handler_mac.mm
+++ b/browser/ui/webui/settings/brave_relaunch_handler_mac.mm
@@ -9,8 +9,9 @@
 
 namespace brave_relaunch_handler {
 
-void RelaunchOnMac() {
-  [[SparkleGlue sharedSparkleGlue] relaunch];
+bool RelaunchOnMac() {
+  return [SparkleGlue sharedSparkleGlue] &&
+         [[SparkleGlue sharedSparkleGlue] relaunch];
 }
 
 }  // namespace brave_relaunch_handler

--- a/build/mac/cross-compile/pkg-dmg-linux.py
+++ b/build/mac/cross-compile/pkg-dmg-linux.py
@@ -29,7 +29,7 @@ def main():
     assert args.source == '/var/empty', 'Only --source=/var/empty is supported.'
     to_copy = list(map(parse_copy_arg, args.copy))
     required_size = sum(get_size(tpl[0]) for tpl in to_copy)
-    safe_size_mb = required_size // 2**20 + 20
+    safe_size_mb = required_size // 2**20 + 25
     with TemporaryDirectory(dir=args.tempdir) as tmp:
         image = join(tmp, 'image.hfs')
         run_with_output([

--- a/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
+++ b/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
@@ -8,22 +8,33 @@
 #include "brave/browser/sparkle_buildflags.h"
 
 #if BUILDFLAG(ENABLE_SPARKLE)
+
 #include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
-#endif
 
 #define AttemptRestart AttemptRestart_ChromiumImpl
+#define RelaunchIgnoreUnloadHandlers RelaunchIgnoreUnloadHandlers_ChromiumImpl
+
 #include "src/chrome/browser/lifetime/application_lifetime_desktop.cc"
+
+#undef RelaunchIgnoreUnloadHandlers
 #undef AttemptRestart
 
 namespace chrome {
 
 void AttemptRestart() {
-#if BUILDFLAG(ENABLE_SPARKLE)
-  if (brave_relaunch_handler::RelaunchOnMac()) {
-    return;
+  if (!brave_relaunch_handler::RelaunchOnMac()) {
+    AttemptRestart_ChromiumImpl();
   }
-#endif
-  AttemptRestart_ChromiumImpl();
+}
+
+void RelaunchIgnoreUnloadHandlers() {
+  if (!brave_relaunch_handler::RelaunchOnMac()) {
+    RelaunchIgnoreUnloadHandlers_ChromiumImpl();
+  }
 }
 
 }  // namespace chrome
+
+#else
+#include "src/chrome/browser/lifetime/application_lifetime_desktop.cc"
+#endif  // BUILDFLAG(ENABLE_SPARKLE)

--- a/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
+++ b/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
@@ -5,7 +5,9 @@
 
 #include "chrome/browser/lifetime/application_lifetime_desktop.h"
 
+#if BUILDFLAG(ENABLE_SPARKLE)
 #include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
+#endif
 
 #define AttemptRestart AttemptRestart_ChromiumImpl
 #include "src/chrome/browser/lifetime/application_lifetime_desktop.cc"
@@ -14,7 +16,7 @@
 namespace chrome {
 
 void AttemptRestart() {
-#if BUILDFLAG(IS_MAC)
+#if BUILDFLAG(ENABLE_SPARKLE)
   if (brave_relaunch_handler::RelaunchOnMac()) {
     return;
   }

--- a/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
+++ b/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/lifetime/application_lifetime_desktop.h"
+
+#include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
+
+#define AttemptRestart AttemptRestart_ChromiumImpl
+#include "src/chrome/browser/lifetime/application_lifetime_desktop.cc"
+#undef AttemptRestart
+
+namespace chrome {
+
+void AttemptRestart() {
+#if BUILDFLAG(IS_MAC)
+  if (brave_relaunch_handler::RelaunchOnMac()) {
+    return;
+  }
+#endif
+  return AttemptRestart_ChromiumImpl();
+}
+
+}  // namespace chrome

--- a/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
+++ b/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
@@ -5,6 +5,8 @@
 
 #include "chrome/browser/lifetime/application_lifetime_desktop.h"
 
+#include "brave/browser/sparkle_buildflags.h"
+
 #if BUILDFLAG(ENABLE_SPARKLE)
 #include "brave/browser/ui/webui/settings/brave_relaunch_handler_mac.h"
 #endif

--- a/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
+++ b/chromium_src/chrome/browser/lifetime/application_lifetime_desktop.cc
@@ -19,7 +19,7 @@ void AttemptRestart() {
     return;
   }
 #endif
-  return AttemptRestart_ChromiumImpl();
+  AttemptRestart_ChromiumImpl();
 }
 
 }  // namespace chrome

--- a/chromium_src/chrome/browser/ui/webui/settings/browser_lifetime_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/browser_lifetime_handler.cc
@@ -22,10 +22,11 @@ BrowserLifetimeHandler::~BrowserLifetimeHandler() {}
 
 void BrowserLifetimeHandler::HandleRelaunch(const base::Value::List& args) {
 #if BUILDFLAG(ENABLE_SPARKLE) && !BUILDFLAG(BRAVE_ENABLE_UPDATER)
-  brave_relaunch_handler::RelaunchOnMac();
-#else
-  BrowserLifetimeHandler_ChromiumImpl::HandleRelaunch(args);
+  if (brave_relaunch_handler::RelaunchOnMac()) {
+    return;
+  }
 #endif
+  BrowserLifetimeHandler_ChromiumImpl::HandleRelaunch(args);
 }
 
 }  // namespace settings


### PR DESCRIPTION
Resolves the macOS side of https://github.com/brave/brave-browser/issues/11055.

I am also including a small fix for cross-compiling.

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

First, please check that updating the browser on macOS still works, both in the background and via `brave://settings/help`. It is very critical functionality and I think it is very important to be sure that nothing in it is broken.

Then, please test that the bug is fixed:

1. Install a version of Brave that has this fix, but which is not the latest public version.
2. Go to `brave://settings/help` to trigger an on-demand update check.
3. Wait until this page offers to relaunch Brave to install the new version.
5. Go to `brave://settings/privacy`.
6. Toggle "Use Google services for push messaging". This should bring up a "Relaunch" button.
7. Click the Relaunch button.

Brave should relaunch, restoring the previous session.

It could also be interesting to test variations of this, with other Relaunch buttons, and with background updates.