### PR TITLE
[ads] Consider client and server error HTML responses as error pages (uplift to 1.70.x)

### DIFF
--- a/browser/brave_ads/tabs/ads_tab_helper.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper.cc
@@ -149,10 +149,6 @@ bool AdsTabHelper::IsNewNavigation(
 bool AdsTabHelper::IsErrorPage(content::NavigationHandle* navigation_handle) {
   CHECK(navigation_handle);
 
-  if (!navigation_handle->IsErrorPage()) {
-    return false;
-  }
-
   // Only consider client and server error responses as error pages.
   if (const net::HttpResponseHeaders* const response_headers =
           navigation_handle->GetResponseHeaders()) {


### PR DESCRIPTION
Uplift of #25238
Resolves https://github.com/brave/brave-browser/issues/40520

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.