### PR TITLE
Add search query and summary from Brave Search SERP when open Leo chat

### DIFF
--- a/browser/ai_chat/android/ai_chat_utils_android.cc
+++ b/browser/ai_chat/android/ai_chat_utils_android.cc
@@ -32,7 +32,7 @@ static void JNI_BraveLeoUtils_OpenLeoQuery(
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
       base::android::ConvertJavaStringToUTF8(query), std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt);
+      base::Time::Now(), std::nullopt, false);
   chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
 #endif
 }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -143,7 +143,7 @@ void AIChatUIPageHandler::SubmitHumanConversationEntry(
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(
       CharacterType::HUMAN, mojom::ActionType::UNSPECIFIED,
       ConversationTurnVisibility::VISIBLE, input, std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt);
+      base::Time::Now(), std::nullopt, false);
   active_chat_tab_helper_->SubmitHumanConversationEntry(std::move(turn));
 }
 

--- a/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
+++ b/chromium_src/chrome/browser/autocomplete/chrome_autocomplete_provider_client.cc
@@ -79,7 +79,7 @@ void ChromeAutocompleteProviderClient::OpenLeo(const std::u16string& query) {
           ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
           base::UTF16ToUTF8(query) /* text */, std::nullopt /* selected_text */,
           std::nullopt /* events */, base::Time::Now(),
-          std::nullopt /* edits */);
+          std::nullopt /* edits */, false /* from_brave_search_SERP */);
 
   chat_tab_helper->SubmitHumanConversationEntry(std::move(turn));
 

--- a/components/ai_chat/content/browser/BUILD.gn
+++ b/components/ai_chat/content/browser/BUILD.gn
@@ -5,6 +5,7 @@
 
 import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
 import("//brave/components/text_recognition/common/buildflags/buildflags.gni")
+import("//tools/json_schema_compiler/json_schema_api.gni")
 
 assert(enable_ai_chat)
 
@@ -23,7 +24,9 @@ static_library("browser") {
   ]
 
   deps = [
+    ":generated_brave_search_responses",
     "//base",
+    "//brave/brave_domains",
     "//brave/components/ai_chat/core/browser",
     "//brave/components/ai_chat/core/common",
     "//brave/components/ai_chat/core/common/buildflags",
@@ -50,4 +53,11 @@ static_library("browser") {
     "//ui/base",
     "//url",
   ]
+}
+
+generated_types("generated_brave_search_responses") {
+  sources = [ "brave_search_responses.idl" ]
+  deps = [ "//base" ]
+  root_namespace = "ai_chat::%(namespace)s"
+  visibility = [ ":browser" ]
 }

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_TAB_HELPER_H_
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,7 @@
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
+#include "brave/components/api_request_helper/api_request_helper.h"
 #include "components/favicon/core/favicon_driver_observer.h"
 #include "components/prefs/pref_change_registrar.h"
 #include "content/public/browser/navigation_handle.h"
@@ -124,6 +126,13 @@ class AIChatTabHelper : public content::WebContentsObserver,
                       std::string_view invalidation_token) override;
   void PrintPreviewFallback(GetPageContentCallback callback) override;
   std::u16string GetPageTitle() const override;
+  void FetchSearchQuerySummary(
+      FetchSearchQuerySummaryCallback callback) override;
+
+  void OnSearchSummarizerKeyFetched(FetchSearchQuerySummaryCallback callback,
+                                    const std::optional<std::string>& key);
+  void OnSearchQuerySummaryFetched(FetchSearchQuerySummaryCallback callback,
+                                   api_request_helper::APIRequestResult result);
 
   void BindPageContentExtractorReceiver(
       mojo::PendingAssociatedReceiver<mojom::PageContentExtractorHost>
@@ -145,6 +154,9 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // A scoper only used for PDF viewing.
   std::unique_ptr<content::ScopedAccessibilityMode> scoped_accessibility_mode_;
+
+  // Used for fetching search query summary.
+  std::unique_ptr<api_request_helper::APIRequestHelper> api_request_helper_;
 
   mojo::AssociatedReceiver<mojom::PageContentExtractorHost>
       page_content_extractor_receiver_{this};

--- a/components/ai_chat/content/browser/brave_search_responses.idl
+++ b/components/ai_chat/content/browser/brave_search_responses.idl
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+namespace brave_search_responses {
+  dictionary Answer {
+    DOMString text;
+  };
+
+  dictionary QuerySummary {
+    Answer[] answer;
+    DOMString query;
+  };
+
+  dictionary QuerySummaryResponse {
+    QuerySummary[] conversation;
+  };
+};

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -10,6 +10,7 @@
 
 #include "base/functional/callback_forward.h"
 #include "base/memory/scoped_refptr.h"
+#include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 
 namespace content {
 class WebContents;
@@ -30,6 +31,10 @@ void FetchPageContent(content::WebContents* web_contents,
                       FetchPageContentCallback callback,
                       scoped_refptr<network::SharedURLLoaderFactory>
                           url_loader_factory = nullptr);
+
+void GetSearchSummarizerKey(
+    content::WebContents* web_contents,
+    mojom::PageContentExtractor::GetSearchSummarizerKeyCallback callback);
 
 }  // namespace ai_chat
 

--- a/components/ai_chat/core/browser/BUILD.gn
+++ b/components/ai_chat/core/browser/BUILD.gn
@@ -40,6 +40,7 @@ static_library("browser") {
     "local_models_updater.h",
     "model_service.cc",
     "model_service.h",
+    "types.h",
     "utils.cc",
     "utils.h",
   ]
@@ -128,6 +129,7 @@ if (!is_ios) {
       "local_models_updater_unittest.cc",
       "model_service_unittest.cc",
       "text_embedder_unittest.cc",
+      "utils_unittest.cc",
     ]
 
     deps = [

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -31,6 +31,8 @@ extern const char kLeoModelSupportUrl[];
 inline constexpr int kCustomModelMaxPageContentLength = 9600;
 inline constexpr int kCustomModelLongConversationCharLimit = 10000;
 
+inline constexpr char kBraveSearchURLPrefix[] = "search";
+
 }  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONSTANTS_H_

--- a/components/ai_chat/core/browser/conversation_driver_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_driver_unittest.cc
@@ -27,6 +27,7 @@
 #include "base/time/time.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
 #include "brave/components/ai_chat/core/browser/text_embedder.h"
+#include "brave/components/ai_chat/core/browser/types.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
@@ -153,6 +154,10 @@ class MockConversationDriver : public ConversationDriver {
               (GetPageContentCallback, std::string_view),
               (override));
   MOCK_METHOD(void, PrintPreviewFallback, (GetPageContentCallback), (override));
+  MOCK_METHOD(void,
+              FetchSearchQuerySummary,
+              (FetchSearchQuerySummaryCallback),
+              (override));
 };
 
 class MockTextEmbedder : public TextEmbedder {
@@ -228,6 +233,22 @@ class ConversationDriverUnitTest : public testing::Test {
   void WaitForOnEngineCompletionComplete() { task_environment_.RunUntilIdle(); }
 
   void TearDown() override {}
+
+  void StageSearchQuerySummary() {
+    std::vector<mojom::ConversationTurnPtr> history;
+    history.push_back(mojom::ConversationTurn::New(
+        mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
+        mojom::ConversationTurnVisibility::VISIBLE, "query", std::nullopt,
+        std::nullopt, base::Time::Now(), std::nullopt, true));
+    std::vector<mojom::ConversationEntryEventPtr> events;
+    events.push_back(mojom::ConversationEntryEvent::NewCompletionEvent(
+        mojom::CompletionEvent::New("summary")));
+    history.push_back(mojom::ConversationTurn::New(
+        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
+        mojom::ConversationTurnVisibility::VISIBLE, "summary", std::nullopt,
+        std::move(events), base::Time::Now(), std::nullopt, true));
+    conversation_driver_->SetChatHistoryForTesting(std::move(history));
+  }
 
  protected:
   base::test::TaskEnvironment task_environment_;
@@ -348,11 +369,11 @@ TEST_F(ConversationDriverUnitTest, SubmitSelectedText) {
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
       l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_SELECTED_TEXT),
-      "I have spoken.", std::nullopt, base::Time::Now(), std::nullopt));
+      "I have spoken.", std::nullopt, base::Time::Now(), std::nullopt, false));
   expected_history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "This is the way.",
-      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt, false));
   EXPECT_EQ(history.size(), expected_history.size());
   for (size_t i = 0; i < history.size(); i++) {
     EXPECT_TRUE(CompareConversationTurn(history[i], expected_history[i]));
@@ -391,20 +412,21 @@ TEST_F(ConversationDriverUnitTest, SubmitSelectedText) {
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
       l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_SELECTED_TEXT),
-      "I have spoken.", std::nullopt, base::Time::Now(), std::nullopt));
+      "I have spoken.", std::nullopt, base::Time::Now(), std::nullopt, false));
   expected_history2.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "This is the way.",
-      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt, false));
   expected_history2.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
       l10n_util::GetStringUTF8(IDS_AI_CHAT_QUESTION_SUMMARIZE_SELECTED_TEXT),
-      "I have spoken again.", std::nullopt, base::Time::Now(), std::nullopt));
+      "I have spoken again.", std::nullopt, base::Time::Now(), std::nullopt,
+      false));
   expected_history2.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "This is the way.",
-      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt, false));
   EXPECT_EQ(history2.size(), expected_history2.size());
   for (size_t i = 0; i < history2.size(); i++) {
     EXPECT_TRUE(CompareConversationTurn(history2[i], expected_history2[i]));
@@ -746,11 +768,11 @@ TEST_F(ConversationDriverUnitTest, ModifyConversation) {
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE, "prompt1", std::nullopt,
-      std::nullopt, created_time1, std::nullopt));
+      std::nullopt, created_time1, std::nullopt, false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "answer1", std::nullopt,
-      std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, base::Time::Now(), std::nullopt, false));
   conversation_driver_->SetChatHistoryForTesting(std::move(history));
 
   // Modify an entry for the first time.
@@ -981,6 +1003,207 @@ TEST_P(PageContentRefineTest, TextEmbedderInitialized) {
     conversation_driver_->PerformAssistantGeneration(
         "prompt", 0, std::string(max_page_content_length + 1, 'A'), false, "");
   }
+}
+
+TEST_F(ConversationDriverUnitTest, MaybeFetchOrClearSearchQuerySummary) {
+  // Fetch with result should update the conversation history and call
+  // OnHistoryUpdate on observers.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(
+          testing::Return(GURL("https://search.brave.com/search?q=test")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary)
+      .WillOnce(base::test::RunOnceCallback<0>(
+          SearchQuerySummary("query", "summary")));
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(1);  // From fetch.
+
+  // User opting in would trigger MaybeFetchOrClearSearchQuerySummary being
+  // called.
+  EmulateUserOptedIn();
+  EXPECT_TRUE(conversation_driver_->is_conversation_active_);
+  EXPECT_TRUE(conversation_driver_->should_send_page_contents_);
+
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+
+  auto& history = conversation_driver_->GetConversationHistory();
+  std::vector<mojom::ConversationTurnPtr> expected_history;
+  expected_history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
+      mojom::ConversationTurnVisibility::VISIBLE, "query", std::nullopt,
+      std::nullopt, base::Time::Now(), std::nullopt, true));
+  std::vector<mojom::ConversationEntryEventPtr> events;
+  events.push_back(mojom::ConversationEntryEvent::NewCompletionEvent(
+      mojom::CompletionEvent::New("summary")));
+  expected_history.push_back(mojom::ConversationTurn::New(
+      mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
+      mojom::ConversationTurnVisibility::VISIBLE, "summary", std::nullopt,
+      std::move(events), base::Time::Now(), std::nullopt, true));
+  ASSERT_EQ(history.size(), expected_history.size());
+  for (size_t i = 0; i < history.size(); i++) {
+    expected_history[i]->created_time = history[i]->created_time;
+    EXPECT_EQ(history[i], expected_history[i]);
+  }
+}
+
+TEST_F(ConversationDriverUnitTest,
+       MaybeFetchOrClearSearchQuerySummary_NoResult) {
+  EmulateUserOptedIn();
+  ASSERT_TRUE(conversation_driver_->should_send_page_contents_);
+
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(
+          testing::Return(GURL("https://search.brave.com/search?q=test")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary)
+      .WillOnce(base::test::RunOnceCallback<0>(std::nullopt));
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(0);
+
+  conversation_driver_->MaybeFetchOrClearSearchQuerySummary();
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_TRUE(conversation_driver_->GetConversationHistory().empty());
+}
+
+TEST_F(ConversationDriverUnitTest,
+       MaybeFetchOrClearSearchQuerySummary_NotOptedIn) {
+  EmulateUserOptedIn();
+  ASSERT_TRUE(conversation_driver_->should_send_page_contents_);
+  StageSearchQuerySummary();
+
+  // Fetch should not be called when user is not opted in, staged query
+  // and summary will be cleared.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(
+          testing::Return(GURL("https://search.brave.com/search?q=test")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary).Times(0);
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(1);  // From clear.
+
+  // User opted in pref change would trigger MaybeFetchOrClearSearchQuerySummary
+  // being called.
+  conversation_driver_->SetUserOptedIn(false);
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_TRUE(conversation_driver_->GetConversationHistory().empty());
+}
+
+TEST_F(ConversationDriverUnitTest,
+       MaybeFetchOrClearSearchQuerySummary_NoPageContent) {
+  EmulateUserOptedIn();
+  ASSERT_TRUE(conversation_driver_->should_send_page_contents_);
+  StageSearchQuerySummary();
+
+  // Fetch should not be called if page content is not linked, staged query
+  // and summary will be cleared.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(
+          testing::Return(GURL("https://search.brave.com/search?q=test")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary).Times(0);
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(1);  // From clear.
+
+  // MaybeFetchOrClearSearchQuerySummary would be triggered by below.
+  conversation_driver_->SetShouldSendPageContents(false);
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_TRUE(conversation_driver_->GetConversationHistory().empty());
+}
+
+TEST_F(ConversationDriverUnitTest,
+       MaybeFetchOrClearSearchQuerySummary_NotBraveSearchSERP) {
+  EmulateUserOptedIn();
+  ASSERT_TRUE(conversation_driver_->should_send_page_contents_);
+  StageSearchQuerySummary();
+
+  // Fetch should not be called if page URL is not Brave Search SERP, staged
+  // query and summary will be cleared.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(testing::Return(GURL("https://search.brave.com")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary).Times(0);
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(1);  // From clear.
+
+  conversation_driver_->MaybeFetchOrClearSearchQuerySummary();
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_TRUE(conversation_driver_->GetConversationHistory().empty());
+}
+
+TEST_F(ConversationDriverUnitTest,
+       MaybeFetchOrClearSearchQuerySummary_OnNewPage) {
+  EmulateUserOptedIn();
+  ASSERT_TRUE(conversation_driver_->should_send_page_contents_);
+  StageSearchQuerySummary();
+
+  // Fetch should not be called when navigating away to non-Brave Search SERP
+  // and staged query and summary will be cleared.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(testing::Return(GURL("https://search.brave.com")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary).Times(0);
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(1);  // From clear.
+
+  // MaybeFetchOrClearSearchQuerySummary would be triggered by below.
+  conversation_driver_->OnNewPage(conversation_driver_->current_navigation_id_ +
+                                  1);
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_TRUE(conversation_driver_->GetConversationHistory().empty());
+
+  // Fetch should be called when navigating back to Brave Search SERP.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(
+          testing::Return(GURL("https://search.brave.com/search?q=test")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary)
+      .WillOnce(base::test::RunOnceCallback<0>(
+          SearchQuerySummary("query", "summary")));
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(2);  // From clear and fetch.
+  // MaybeFetchOrClearSearchQuerySummary would be triggered by below.
+  conversation_driver_->OnNewPage(conversation_driver_->current_navigation_id_ +
+                                  1);
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_EQ(conversation_driver_->GetConversationHistory().size(), 2u);
+}
+
+TEST_F(ConversationDriverUnitTest,
+       MaybeFetchOrClearSearchQuerySummary_OnConversationActiveChanged) {
+  EmulateUserOptedIn();
+  ASSERT_TRUE(conversation_driver_->should_send_page_contents_);
+  ASSERT_TRUE(conversation_driver_->is_conversation_active_);
+  StageSearchQuerySummary();
+
+  // Fetch should not be called when conversation is inactive and staged query
+  // and summary will be kept.
+  ON_CALL(*conversation_driver_, GetPageURL)
+      .WillByDefault(
+          testing::Return(GURL("https://search.brave.com/search?q=test")));
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary).Times(0);
+  MockConversationDriverObserver observer(conversation_driver_.get());
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(0);
+  // MaybeFetchOrClearSearchQuerySummary would be triggered by below.
+  conversation_driver_->OnConversationActiveChanged(false);
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_EQ(conversation_driver_->GetConversationHistory().size(), 2u);
+
+  // No fetch should be called when conversation is active again.
+  EXPECT_CALL(*conversation_driver_, FetchSearchQuerySummary).Times(0);
+  conversation_driver_->OnConversationActiveChanged(true);
+  EXPECT_CALL(observer, OnHistoryUpdate()).Times(0);
+  task_environment_.RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(conversation_driver_.get());
+  testing::Mock::VerifyAndClearExpectations(&observer);
+  EXPECT_EQ(conversation_driver_->GetConversationHistory().size(), 2u);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
@@ -74,11 +74,11 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Which show is this catchphrase from?", "I have spoken.", std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt, false));
   auto* mock_remote_completion_client = GetMockRemoteCompletionClient();
   std::string prompt_before_time_and_date =
       "\n\nHuman: Here is the text of a web page in <page> tags:\n<page>\nThis "

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -215,16 +215,16 @@ TEST_F(EngineConsumerConversationAPIUnitTest,
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Which show is this catchphrase from?", "I have spoken.", std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt, false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Is it related to a broader series?", std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
   std::string expected_events = R"([
     {"role": "user", "type": "pageText", "content": "This is my page. I have spoken."},
     {"role": "user", "type": "pageExcerpt", "content": "I have spoken."},
@@ -292,7 +292,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_ModifyReply) {
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Which show is 'This is the way' from?", std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
 
   std::vector<mojom::ConversationEntryEventPtr> events;
   auto search_event = mojom::ConversationEntryEvent::NewSearchStatusEvent(
@@ -312,19 +312,19 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_ModifyReply) {
   auto edit = mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt, std::move(modified_events), base::Time::Now(),
-      std::nullopt);
+      std::nullopt, std::move(modified_events), base::Time::Now(), std::nullopt,
+      false);
   std::vector<mojom::ConversationTurnPtr> edits;
   edits.push_back(std::move(edit));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "Mandalorian.", std::nullopt,
-      std::move(events), base::Time::Now(), std::move(edits)));
+      std::move(events), base::Time::Now(), std::move(edits), false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Is it related to a broader series?", std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
   std::string expected_events = R"([
     {"role": "user", "type": "pageText", "content": "I have spoken."},
     {"role": "user", "type": "chatMessage",

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
@@ -72,11 +72,11 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Which show is this catchphrase from?", "This is the way.", std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, std::nullopt, base::Time::Now(), std::nullopt, false));
   auto* mock_remote_completion_client =
       static_cast<MockRemoteCompletionClient*>(engine_->GetAPIForTesting());
   std::string prompt_before_time_and_date =

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
@@ -206,12 +206,12 @@ TEST_F(EngineConsumerOAIUnitTest, TestGenerateAssistantResponse) {
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::SUMMARIZE_SELECTED_TEXT,
       mojom::ConversationTurnVisibility::VISIBLE, human_input, selected_text,
-      std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, base::Time::Now(), std::nullopt, false));
 
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, assistant_input, std::nullopt,
-      std::nullopt, base::Time::Now(), std::nullopt));
+      std::nullopt, base::Time::Now(), std::nullopt, false));
 
   std::string date_and_time_string =
       base::UTF16ToUTF8(TimeFormatFriendlyDateAndTime(base::Time::Now()));

--- a/components/ai_chat/core/browser/engine/test_utils.cc
+++ b/components/ai_chat/core/browser/engine/test_utils.cc
@@ -19,7 +19,7 @@ std::vector<mojom::ConversationTurnPtr> GetHistoryWithModifiedReply() {
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Which show is 'This is the way' from?", std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
 
   std::vector<mojom::ConversationEntryEventPtr> events;
   auto search_event = mojom::ConversationEntryEvent::NewSearchStatusEvent(
@@ -36,19 +36,19 @@ std::vector<mojom::ConversationTurnPtr> GetHistoryWithModifiedReply() {
   auto edit = mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "The Mandalorian.",
-      std::nullopt, std::move(modified_events), base::Time::Now(),
-      std::nullopt);
+      std::nullopt, std::move(modified_events), base::Time::Now(), std::nullopt,
+      false);
   std::vector<mojom::ConversationTurnPtr> edits;
   edits.push_back(std::move(edit));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
       mojom::ConversationTurnVisibility::VISIBLE, "Mandalorian.", std::nullopt,
-      std::move(events), base::Time::Now(), std::move(edits)));
+      std::move(events), base::Time::Now(), std::move(edits), false));
   history.push_back(mojom::ConversationTurn::New(
       mojom::CharacterType::HUMAN, mojom::ActionType::QUERY,
       mojom::ConversationTurnVisibility::VISIBLE,
       "Is it related to a broader series?", std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
 
   return history;
 }

--- a/components/ai_chat/core/browser/types.h
+++ b/components/ai_chat/core/browser/types.h
@@ -1,0 +1,27 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_TYPES_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_TYPES_H_
+
+#include <string>
+
+namespace ai_chat {
+
+struct SearchQuerySummary {
+  std::string query;
+  std::string summary;
+
+  SearchQuerySummary(const std::string& query, const std::string& summary)
+      : query(query), summary(summary) {}
+
+  bool operator==(const SearchQuerySummary& other) const {
+    return query == other.query && summary == other.summary;
+  }
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_TYPES_H_

--- a/components/ai_chat/core/browser/utils.cc
+++ b/components/ai_chat/core/browser/utils.cc
@@ -10,11 +10,14 @@
 #include "base/task/bind_post_task.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
+#include "brave/brave_domains/service_domains.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/l10n/common/locale_util.h"
 #include "components/prefs/pref_service.h"
 #include "components/user_prefs/user_prefs.h"
+#include "url/url_constants.h"
 
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
 #include "brave/components/text_recognition/browser/text_recognition.h"
@@ -78,6 +81,19 @@ void SetUserOptedIn(PrefService* prefs, bool opted_in) {
   } else {
     prefs->ClearPref(prefs::kLastAcceptedDisclaimer);
   }
+}
+
+bool IsBraveSearchSERP(const GURL& url) {
+  if (!url.is_valid()) {
+    return false;
+  }
+
+  // https://search.brave.com/search?q=test
+  return url.SchemeIs(url::kHttpsScheme) &&
+         url.host_piece() ==
+             brave_domains::GetServicesDomain(kBraveSearchURLPrefix) &&
+         url.path_piece() == "/search" &&
+         base::StartsWith(url.query_piece(), "q=");
 }
 
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)

--- a/components/ai_chat/core/browser/utils.h
+++ b/components/ai_chat/core/browser/utils.h
@@ -9,6 +9,7 @@
 #include "base/functional/callback_forward.h"
 #include "brave/components/text_recognition/common/buildflags/buildflags.h"
 #include "third_party/skia/include/core/SkBitmap.h"
+#include "url/gurl.h"
 
 class PrefService;
 
@@ -18,6 +19,8 @@ namespace ai_chat {
 bool IsAIChatEnabled(PrefService* prefs);
 bool HasUserOptedIn(PrefService* prefs);
 void SetUserOptedIn(PrefService* prefs, bool opted_in);
+
+bool IsBraveSearchSERP(const GURL& url);
 
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
 using GetOCRTextCallback = base::OnceCallback<void(std::string)>;

--- a/components/ai_chat/core/browser/utils_unittest.cc
+++ b/components/ai_chat/core/browser/utils_unittest.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/core/browser/utils.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+TEST(AIChatUtilsUnitTest, IsBraveSearchSERP) {
+  EXPECT_TRUE(IsBraveSearchSERP(GURL("https://search.brave.com/search?q=foo")));
+  // Missing or wrong path.
+  EXPECT_FALSE(IsBraveSearchSERP(GURL("https://search.brave.com?q=foo")));
+  EXPECT_FALSE(
+      IsBraveSearchSERP(GURL("https://search.brave.com/test.html?q=foo")));
+  // Missing or wrong query parameter.
+  EXPECT_FALSE(IsBraveSearchSERP(GURL("https://search.brave.com/search")));
+  EXPECT_FALSE(IsBraveSearchSERP(GURL("https://search.brave.com/search?t=t")));
+  // HTTP scheme.
+  EXPECT_FALSE(IsBraveSearchSERP(GURL("http://search.brave.com/search?q=foo")));
+  // Wrong host.
+  EXPECT_FALSE(IsBraveSearchSERP(GURL("https://brave.com/search?q=foo")));
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -159,6 +159,9 @@ struct ConversationTurn {
   // instead of the original turn text when submitting the turn to the AI
   // engine or displaying the most recent text to users.
   array<ConversationTurn>? edits;
+
+  // Whether the turn was generated from Brave Search SERP.
+  bool from_brave_search_SERP = false;
 };
 
 // Represents an AI engine model choice, usually for the user to choose for a

--- a/components/ai_chat/core/common/mojom/page_content_extractor.mojom
+++ b/components/ai_chat/core/common/mojom/page_content_extractor.mojom
@@ -28,6 +28,10 @@ struct PageContent {
 // RenderFrame.
 interface PageContentExtractor {
   ExtractPageContent() => (PageContent? page_content);
+
+  // Get summarizer-key meta tag from Brave Search SERP if it exists.
+  // This should only be called when the last commited URL is Brave Search SERP.
+  GetSearchSummarizerKey() => (string? key);
 };
 
 // Allows the renderer to notify the browser process of meaningful changes to

--- a/components/ai_chat/renderer/BUILD.gn
+++ b/components/ai_chat/renderer/BUILD.gn
@@ -31,6 +31,7 @@ static_library("renderer") {
     "//third_party/blink/public:blink",
     "//third_party/blink/public/common",
     "//third_party/blink/public/strings",
+    "//third_party/re2",
     "//v8",
   ]
 

--- a/components/ai_chat/renderer/DEPS
+++ b/components/ai_chat/renderer/DEPS
@@ -7,6 +7,7 @@ include_rules = [
   "+content/public/renderer",
   "+third_party/abseil-cpp/absl",
   "+third_party/blink/public",
+  "+third_party/re2",
   "+v8/include",
   "+ui/accessibility",
 ]

--- a/components/ai_chat/renderer/page_content_extractor.h
+++ b/components/ai_chat/renderer/page_content_extractor.h
@@ -56,6 +56,9 @@ class PageContentExtractor
   void ExtractPageContent(
       mojom::PageContentExtractor::ExtractPageContentCallback callback)
       override;
+  void GetSearchSummarizerKey(
+      mojom::PageContentExtractor::GetSearchSummarizerKeyCallback callback)
+      override;
 
   // AIChatResourceSnifferThrottleDelegate
   void OnInterceptedPageContentChanged(

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -57,8 +57,14 @@ function Main() {
     siteInfo === null && // SiteInfo request has finished and this is a standalone conversation
     !context.isPremiumUser
 
+  const isLastTurnBraveSearchSERPSummary =
+    context.conversationHistory.at(-1)?.fromBraveSearchSERP ?? false
+
   const shouldDisplayNewChatIcon = context.conversationHistory.length >= 1
-  const showContextToggle = context.conversationHistory.length === 0 && siteInfo?.isContentAssociationPossible
+  const showContextToggle =
+    (context.conversationHistory.length === 0 ||
+      isLastTurnBraveSearchSERPSummary) &&
+    siteInfo?.isContentAssociationPossible
 
   let currentErrorElement = null
 

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -55,7 +55,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -65,7 +66,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getCompletionEvent('The ways that animals move are just about as myriad as the animal kingdom itself. They walk, run, swim, crawl, fly and slither — and within each of those categories lies a tremendous number of subtly different movement types. A seagull and a *hummingbird* both have wings, but otherwise their flight techniques and abilities are poles apart. Orcas and **piranhas** both have tails, but they accomplish very different types of swimming. Even a human walking or running is moving their body in fundamentally different ways.')]
+    events: [getCompletionEvent('The ways that animals move are just about as myriad as the animal kingdom itself. They walk, run, swim, crawl, fly and slither — and within each of those categories lies a tremendous number of subtly different movement types. A seagull and a *hummingbird* both have wings, but otherwise their flight techniques and abilities are poles apart. Orcas and **piranhas** both have tails, but they accomplish very different types of swimming. Even a human walking or running is moving their body in fundamentally different ways.')],
+    fromBraveSearchSERP: false
   },
   {
     text: 'What is pointer compression?',
@@ -75,7 +77,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -85,7 +88,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getCompletionEvent(`## How We Created an Accessible, Scalable Color Palette\n\nDuring the latter part of 2021, I reflected on the challenges we were facing at Modern Health. One recurring problem that stood out was our struggle to create new products with an unstructured color palette. This resulted in poor [communication](https://www.google.com) between designers and developers, an inconsistent product brand, and increasing accessibility problems.\n\n1. Inclusivity: our palette provides easy ways to ensure our product uses accessible contrasts.\n 2. Efficiency: our palette is diverse enough for our current and future product design, yet values are still predictable and constrained.\n 3. Reusability: our palette is on-brand but versatile. There are very few one-offs that fall outside the palette.\n\n This article shares the process I followed to apply these principles to develop a more adaptable color palette that prioritizes accessibility and is built to scale into all of our future product **design** needs.`)]
+    events: [getCompletionEvent(`## How We Created an Accessible, Scalable Color Palette\n\nDuring the latter part of 2021, I reflected on the challenges we were facing at Modern Health. One recurring problem that stood out was our struggle to create new products with an unstructured color palette. This resulted in poor [communication](https://www.google.com) between designers and developers, an inconsistent product brand, and increasing accessibility problems.\n\n1. Inclusivity: our palette provides easy ways to ensure our product uses accessible contrasts.\n 2. Efficiency: our palette is diverse enough for our current and future product design, yet values are still predictable and constrained.\n 3. Reusability: our palette is on-brand but versatile. There are very few one-offs that fall outside the palette.\n\n This article shares the process I followed to apply these principles to develop a more adaptable color palette that prioritizes accessibility and is built to scale into all of our future product **design** needs.`)],
+    fromBraveSearchSERP: false
   },
   {
     text: 'What is taylor series?',
@@ -95,7 +99,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -105,7 +110,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getCompletionEvent('The partial sum formed by the first n + 1 terms of a Taylor series is a polynomial of degree n that is called the nth Taylor polynomial of the function. Taylor polynomials are approximations of a function, which become generally better as n increases.')]
+    events: [getCompletionEvent('The partial sum formed by the first n + 1 terms of a Taylor series is a polynomial of degree n that is called the nth Taylor polynomial of the function. Taylor polynomials are approximations of a function, which become generally better as n increases.')],
+    fromBraveSearchSERP: false
   },
   {
     text: 'Write a hello world program in c++',
@@ -115,7 +121,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -125,7 +132,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getCompletionEvent("Hello! As a helpful and respectful AI assistant, I'd be happy to assist you with your question. However, I'm a text-based AI and cannot provide code in a specific programming language like C++. Instead, I can offer a brief explanation of how to write a \"hello world\" program in C++.\n\nTo write a \"hello world\" program in C++, you can use the following code:\n\n```c++\n#include <iostream>\n\nint main() {\n    std::cout << \"Hello, world!\" << std::endl;\n    return 0;\n}\n```\nThis code will print \"Hello, world!\" and uses `iostream` std library. If you have any further questions or need more information, please don't hesitate to ask!")]
+    events: [getCompletionEvent("Hello! As a helpful and respectful AI assistant, I'd be happy to assist you with your question. However, I'm a text-based AI and cannot provide code in a specific programming language like C++. Instead, I can offer a brief explanation of how to write a \"hello world\" program in C++.\n\nTo write a \"hello world\" program in C++, you can use the following code:\n\n```c++\n#include <iostream>\n\nint main() {\n    std::cout << \"Hello, world!\" << std::endl;\n    return 0;\n}\n```\nThis code will print \"Hello, world!\" and uses `iostream` std library. If you have any further questions or need more information, please don't hesitate to ask!")],
+    fromBraveSearchSERP: false
   },
   {
     text: 'Summarize this excerpt',
@@ -135,7 +143,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: 'Pointer compression is a memory optimization technique where pointers (memory addresses) are stored in a compressed format to save memory. The basic idea is that since most pointers will be clustered together and point to objects allocated around the same time, you can store a compressed representation of the pointer and decompress it when needed. Some common ways this is done: Store an offset from a base pointer instead of the full pointer value Store increments/decrements from the previous pointer instead of the full value Use pointer tagging to store extra information in the low bits of the pointer Encode groups of pointers together The tradeoff is some extra CPU cost to decompress the pointers, versus saving memory. This technique is most useful in memory constrained environments.',
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -145,7 +154,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getCompletionEvent('Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.')]
+    events: [getCompletionEvent('Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.')],
+    fromBraveSearchSERP: false
   },
   {
     text: 'Shorten this selected text',
@@ -155,7 +165,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: 'Pointer compression is a memory optimization technique where pointers are stored in a compressed format to save memory.',
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -165,7 +176,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getSearchStatusEvent(), getSearchEvent(['pointer compression', 'c++ language specification']), getCompletionEvent('Pointer compression is a memory optimization technique.')]
+    events: [getSearchStatusEvent(), getSearchEvent(['pointer compression', 'c++ language specification']), getCompletionEvent('Pointer compression is a memory optimization technique.')],
+    fromBraveSearchSERP: false
   },
   {
     text: 'Will an LTT store backpack fit in a Tesla Model Y frunk?',
@@ -181,10 +193,12 @@ const HISTORY: mojom.ConversationTurn[] = [
       selectedText: '',
       createdTime: { internalValue: BigInt('13278618001000000') },
       edits: [],
-      events: []
+      events: [],
+      fromBraveSearchSERP: false
     }],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: []
+    events: [],
+    fromBraveSearchSERP: false
   },
   {
     text: '',
@@ -194,7 +208,8 @@ const HISTORY: mojom.ConversationTurn[] = [
     selectedText: undefined,
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
-    events: [getSearchStatusEvent(), getSearchEvent(['LTT store backpack dimensions', 'Tesla Model Y frunk dimensions'])]
+    events: [getSearchStatusEvent(), getSearchEvent(['LTT store backpack dimensions', 'Tesla Model Y frunk dimensions'])],
+    fromBraveSearchSERP: false
   }
 ]
 

--- a/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/AIChatView.swift
@@ -735,7 +735,8 @@ struct AIChatView_Preview: PreviewProvider {
                   selectedText: nil,
                   events: nil,
                   createdTime: Date.now,
-                  edits: nil
+                  edits: nil,
+                  fromBraveSearchSerp: false
                 ),
               isEntryInProgress: false,
               lastEdited: nil,

--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatResponseMessageView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatResponseMessageView.swift
@@ -334,7 +334,8 @@ struct AIChatResponseMessageView_Previews: PreviewProvider {
           selectedText: nil,
           events: nil,
           createdTime: Date.now,
-          edits: nil
+          edits: nil,
+          fromBraveSearchSerp: false
         ),
       isEntryInProgress: false,
       lastEdited: Date(),

--- a/ios/browser/api/ai_chat/ai_chat.mm
+++ b/ios/browser/api/ai_chat/ai_chat.mm
@@ -121,7 +121,7 @@
       ai_chat::mojom::ActionType::UNSPECIFIED,
       ai_chat::mojom::ConversationTurnVisibility::VISIBLE,
       base::SysNSStringToUTF8(text), std::nullopt, std::nullopt,
-      base::Time::Now(), std::nullopt));
+      base::Time::Now(), std::nullopt, false));
 }
 
 - (void)submitSummarizationRequest {

--- a/test/data/leo/search
+++ b/test/data/leo/search
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Brave Search SERP test</title>
+    <meta name='description' content='Brave Search SERP test'>
+</head>
+<body>
+    <div style='font: 30px Arial'>I have spoken</div>
+</body>
+</html>

--- a/test/data/leo/summarizer_key_meta.html
+++ b/test/data/leo/summarizer_key_meta.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <!-- mimicking the real case -->
+  <meta name="summarizer-key" content="&#123;&quot;query&quot;:&quot;test&quot;,&quot;results_hash&quot;:&quot;hash&quot;&#125;"></meta>
+  <meta name="summarizer-key" content="&#123;&quot;query&quot;:&quot;test2&quot;,&quot;results_hash&quot;:&quot;hash&quot;&#125;" />
+  <meta name="summarizer-key" content="&#123;&quot;query&quot;:&quot;test3&quot;,&quot;results_hash&quot;:&quot;hash&quot;&#125;">
+  <meta id="other_attr" name="summarizer-key" content="&#123;&quot;test&quot;&#125;" other="&#123;&quot;tt&quot;&#125;"></meta>
+  <meta id="empty" name="summarizer-key" content=""></meta>
+  <meta id="empty_with_other_attr" name="summarizer-key" content="" other="&#123;&quot;tt&quot;&#125;"></meta>
+</head>
+<body>
+  <p>hello</p>
+</body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40615

- Add search query and summary from Brave Search SERP to conversation
  history when summarizer-key tag is present.
- Also add a new from_brave_search_SERP property in ConversationTurn to identify the
  conversation entries from Brave Search SERP.
- Modify UI to show the page context toggle when search query and summary are
  staged.
- Staged search query and summary (at the end of the conversation history) will
  be cleared if user opted out, page was unlinked, or user navigated away to a new page

For more details, please check requirement # 1 in https://docs.google.com/document/d/1idelFPpUEcKDNcyKYf3M5yw91tuIddjrlYfpaWEJjNk/edit

Security/Privacy review: https://github.com/brave/reviews/issues/1732

<img width="2555" alt="Screenshot 2024-08-22 at 2 32 58 PM" src="https://github.com/user-attachments/assets/657a0d6b-524f-4156-90b1-28caf991be10">

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable Brave Search `Experimental features` switch
2. Put a query in Brave Search and click `Answer with AI`
3. Wait until the answer is fully generated, open Leo panel, should see the query and summary in the panel.
4. Toggle off the page context switch should clear the staged query and summary
5. Toggle it back on should see re-staged query and summary
6. Type a follow-up question from the summary should work