### PR TITLE
Disabled immersive fullscreen feature by default (uplift to 1.70.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -176,6 +176,7 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
 #endif
 #if BUILDFLAG(IS_MAC)
       &features::kUseChromiumUpdater,
+      &features::kImmersiveFullscreen,
 #endif
 #if !BUILDFLAG(IS_ANDROID)
       &features::kUseMoveNotCopyInMergeTreeUpdate,

--- a/chromium_src/chrome/common/chrome_features.cc
+++ b/chromium_src/chrome/common/chrome_features.cc
@@ -28,6 +28,7 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
 #endif
 #if BUILDFLAG(IS_MAC)
     {kUseChromiumUpdater, base::FEATURE_DISABLED_BY_DEFAULT},
+    {kImmersiveFullscreen, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
 #if !BUILDFLAG(IS_ANDROID)
     {kWebAppUniversalInstall, base::FEATURE_DISABLED_BY_DEFAULT},


### PR DESCRIPTION
Uplift of #25276
fix https://github.com/brave/brave-browser/issues/40587

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.