### PR TITLE
[Uplift]: Tab separator 1.69

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -907,7 +907,7 @@ void AddBravifiedTabStripColorMixer(ui::ColorProvider* provider,
       kColorTabBackgroundActiveFrameActive};
 
   auto divider_color =
-      leo::GetColor(leo::Color::kColorDividerStrong,
+      leo::GetColor(leo::Color::kColorDividerSubtle,
                     key.color_mode == ui::ColorProviderKey::ColorMode::kDark
                         ? leo::Theme::kDark
                         : leo::Theme::kLight);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40608

This is a tweak for 1.69.x - in 1.70 we changed the Nala colors slightly to try and align more closely with Material design. Unfortunately, because 1.69.x didn't have the updated colors the tab divider looks too strong.

|  | Before | After |
|--------|--------|--------|
| Light | ![image](https://github.com/user-attachments/assets/8065c10b-4e36-4f02-88f5-880416ef0255) | ![image](https://github.com/user-attachments/assets/0d3ec9b5-7c3b-432e-9851-87593cb84d0d) |
| Dark | ![image](https://github.com/user-attachments/assets/c3569a61-50b5-4e75-9afe-5d5152641b9f) | ![image](https://github.com/user-attachments/assets/9f3cc9dd-432f-46bc-ab01-72efd0879cf7) | 

cc @aguscruiz does that look right? FWIW, we don't have access to the `DesktopBrowser/TabBar/Pinned tab outline - Horizontal` color in 1.69.x so I've used `kColorDividerSubtle`

There were a few interrelated changes that caused this:
1. Chromium changed the way tab separators are drawn in 128, which broke our overrides in 1.69+
2. In 1.70, we bumped Nala and tweaked some colors
3. In 1.71 we fixed the tab separators
4. We uplifted the fix to 1.70 & 1.69

The patch looks good in 1.71 & 1.70 because we have the new colors. However, in 1.69 we have slightly different colors for the same tokens, which didn't look good (too strong)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See issue