### PR TITLE
News: re-encode images downloaded from third parties

### DIFF
--- a/brave_domains/BUILD.gn
+++ b/brave_domains/BUILD.gn
@@ -27,7 +27,10 @@ buildflag_header("buildflags") {
   ]
 
   # Consumers should use the brave_domains helper functions.
-  visibility = [ ":*" ]
+  visibility = [
+    ":*",
+    "//brave/components/brave_news/browser/test:*",
+  ]
 }
 
 source_set("unit_tests") {

--- a/components/brave_news/browser/DEPS
+++ b/components/brave_news/browser/DEPS
@@ -1,7 +1,9 @@
 include_rules = [
   "+net",
   "+content/public/browser/browser_thread.h",
+  "+services/data_decoder/public",
   "+services/network/public",
   "+services/network/public/mojom",
   "+third_party/re2",
+  "+ui/gfx/codec",
 ]

--- a/components/brave_news/browser/brave_news_controller.h
+++ b/components/brave_news/browser/brave_news_controller.h
@@ -33,6 +33,7 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "mojo/public/cpp/bindings/remote_set.h"
 #include "net/base/network_change_notifier.h"
+#include "services/data_decoder/public/cpp/data_decoder.h"
 #include "services/network/public/cpp/network_connection_tracker.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 
@@ -169,6 +170,12 @@ class BraveNewsController
                                SubscribeToNewDirectFeedCallback callback,
                                bool is_valid,
                                const std::string& feed_title);
+  void OnGetImageDataFetched(GetImageDataCallback callback,
+                             const bool is_padded,
+                             const int response_code,
+                             const std::string& body);
+  void OnGetImageDataDecoded(GetImageDataCallback callback,
+                             const SkBitmap& decoded_image);
 
   void NotifyPublishersChanged(mojom::PublishersEventPtr event);
   void NotifyChannelsChanged(mojom::ChannelsEventPtr event);
@@ -215,6 +222,12 @@ class BraveNewsController
   mojo::RemoteSet<mojom::ChannelsListener> channels_listeners_;
   mojo::RemoteSet<mojom::FeedListener> feed_listeners_;
   mojo::RemoteSet<mojom::ConfigurationListener> configuration_listeners_;
+
+  // The instance of the Data Decoder used to perform any image decoding
+  // operations. The underlying service instance is
+  // started lazily when needed and torn down when not in use.
+  data_decoder::DataDecoder data_decoder_;
+
   base::WeakPtrFactory<BraveNewsController> weak_ptr_factory_{this};
 };
 

--- a/components/brave_news/browser/test/BUILD.gn
+++ b/components/brave_news/browser/test/BUILD.gn
@@ -25,11 +25,14 @@ source_set("brave_news_unit_tests") {
     "//brave/components/brave_news/browser/publishers_parsing_unittest.cc",
     "//brave/components/brave_news/browser/suggestions_controller_unittest.cc",
     "//brave/components/brave_news/browser/topics_fetcher_unittest.cc",
+    "//brave/components/brave_news/browser/urls_unittest.cc",
   ]
 
   deps = [
     ":brave_news_unit_tests_support",
     "//base/test:test_support",
+    "//brave/brave_domains",
+    "//brave/brave_domains:buildflags",
     "//brave/components/api_request_helper",
     "//brave/components/brave_news/browser",
     "//brave/components/brave_news/common",

--- a/components/brave_news/browser/urls.cc
+++ b/components/brave_news/browser/urls.cc
@@ -7,12 +7,34 @@
 
 #include <string>
 
+#include "base/logging.h"
+#include "base/strings/strcat.h"
 #include "brave/brave_domains/service_domains.h"
 
 namespace brave_news {
 
+namespace {
+const char kBraveNewsHostnamePrefix[] = "brave-today-cdn";
+const char kPCDNHostnamePrefix[] = "pcdn";
+}  // namespace
+
 std::string GetHostname() {
-  return brave_domains::GetServicesDomain("brave-today-cdn");
+  return brave_domains::GetServicesDomain(kBraveNewsHostnamePrefix);
+}
+
+std::string GetMatchingPCDNHostname() {
+  // Check for expected PCDN hostname in the feed returned from the server
+  // that the feed files are fetched from (brave-today-cdn.xyz)
+  std::string feed_hostname = GetHostname();
+  if (!feed_hostname.starts_with(kBraveNewsHostnamePrefix)) {
+    // Format has changed, return something that otherwise makes sense
+    DLOG(ERROR) << "Feed hostname \"" << feed_hostname
+                << "\" unexpectedly did not start with prefix \""
+                << kBraveNewsHostnamePrefix << "\"";
+    return brave_domains::GetServicesDomain(kPCDNHostnamePrefix);
+  }
+  auto base = feed_hostname.substr(strlen(kBraveNewsHostnamePrefix));
+  return base::StrCat({kPCDNHostnamePrefix, base});
 }
 
 }  // namespace brave_news

--- a/components/brave_news/browser/urls.h
+++ b/components/brave_news/browser/urls.h
@@ -13,6 +13,7 @@ namespace brave_news {
 inline constexpr char kRegionUrlPart[] = "global.";
 
 std::string GetHostname();
+std::string GetMatchingPCDNHostname();
 
 }  // namespace brave_news
 

--- a/components/brave_news/browser/urls_unittest.cc
+++ b/components/brave_news/browser/urls_unittest.cc
@@ -1,0 +1,68 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_news/browser/urls.h"
+
+#include <cstring>
+
+#include "base/command_line.h"
+#include "base/debug/debugging_buildflags.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_util.h"
+#include "brave/brave_domains/buildflags.h"
+#include "brave/brave_domains/service_domains.h"
+#include "build/build_config.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_news {
+
+namespace {
+
+const char kBraveNewsHostnamePrefix[] = "brave-today-cdn";
+const char kPCDNHostnamePrefix[] = "pcdn";
+
+// Setup expected answers based on the brave_services buildflag values
+const char kProductionValue[] = BUILDFLAG(BRAVE_SERVICES_PRODUCTION_DOMAIN);
+const char kStagingValue[] = BUILDFLAG(BRAVE_SERVICES_STAGING_DOMAIN);
+
+}  // namespace
+
+TEST(BraveNewsURLs, GetMatchingPCDNHostname_Regular) {
+  // Sanity check, we don't need to test this as it's covered in
+  // brave_domains::GetServicesDomain tests.
+  EXPECT_EQ(GetHostname(),
+            base::StrCat({kBraveNewsHostnamePrefix, ".", kProductionValue}));
+  // Test the string manipulation is working ok
+  EXPECT_EQ(GetMatchingPCDNHostname(),
+            base::StrCat({kPCDNHostnamePrefix, ".", kProductionValue}));
+}
+
+TEST(BraveNewsURLs, GetMatchingPCDNHostname_Staging) {
+  base::CommandLine* cl = base::CommandLine::ForCurrentProcess();
+  cl->AppendSwitchASCII(base::StrCat({"env-", kBraveNewsHostnamePrefix}),
+                        "staging");
+  // Both should be staging even though we only override the main brave news
+  // hostname.
+  EXPECT_EQ(GetHostname(),
+            base::StrCat({kBraveNewsHostnamePrefix, ".", kStagingValue}));
+  EXPECT_EQ(GetMatchingPCDNHostname(),
+            base::StrCat({kPCDNHostnamePrefix, ".", kStagingValue}));
+}
+
+TEST(BraveNewsURLs, GetMatchingPCDNHostname_AvoidPCDNOverride) {
+  base::CommandLine* cl = base::CommandLine::ForCurrentProcess();
+  cl->AppendSwitchASCII(base::StrCat({"env-", kPCDNHostnamePrefix}), "staging");
+  // We never want the actual PCDN override (which may be specified by a user
+  // for another component?) to affect the output of this function.
+  EXPECT_EQ(GetHostname(),
+            base::StrCat({kBraveNewsHostnamePrefix, ".", kProductionValue}));
+  EXPECT_EQ(GetMatchingPCDNHostname(),
+            base::StrCat({kPCDNHostnamePrefix, ".", kProductionValue}));
+  // Sanity check
+  EXPECT_EQ(brave_domains::GetServicesDomain(kPCDNHostnamePrefix),
+            base::StrCat({kPCDNHostnamePrefix, ".", kStagingValue}));
+}
+
+}  // namespace brave_news


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40620

Performs re-encode if:
- ~Not android~
- Image is not both padded and from pcdn.brave.com

Shares a data decoder utility process with the all similar operations. Performs re-encode on a parallel task.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

