### PR TITLE
Revert "Count base::LaunchProcess in system_health"

### DIFF
--- a/chromium_src/tools/perf/benchmarks/system_health.py
+++ b/chromium_src/tools/perf/benchmarks/system_health.py
@@ -9,9 +9,7 @@ import override_utils
 
 
 def _add_brave_metrics(options):
-    tracing_categories = options.config.chrome_trace_config.category_filter
-    tracing_categories.AddIncludedCategory('base')
-    options.ExtendTimelineBasedMetric(['braveTraceBasedMetric'])
+    options.ExtendTimelineBasedMetric(['braveNavigationMetric'])
     return options
 
 

--- a/tools/perf/brave_benchmarks/brave_loading_desktop.py
+++ b/tools/perf/brave_benchmarks/brave_loading_desktop.py
@@ -53,7 +53,7 @@ class LoadingDesktopBrave(perf_benchmark.PerfBenchmark):
 
   def CreateCoreTimelineBasedMeasurementOptions(self):
     return CreateCoreTBMOptions(
-        ['braveGeneralUmaMetric', 'braveTraceBasedMetric'])
+        ['braveGeneralUmaMetric', 'braveNavigationMetric'])
 
   def WillRunStory(self, _story):
     time.sleep(10)

--- a/tools/perf/metrics/brave_all_metrics.html
+++ b/tools/perf/metrics/brave_all_metrics.html
@@ -7,4 +7,4 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
 
 <link rel="import" href="/brave/tools/perf/metrics/brave_general_uma_metrics.html">
 <link rel="import" href="/brave/tools/perf/metrics/brave_startup_uma_metrics.html">
-<link rel="import" href="/brave/tools/perf/metrics/brave_trace_based_metrics.html">
+<link rel="import" href="/brave/tools/perf/metrics/brave_navigation_metrics.html">

--- a/tools/perf/metrics/brave_navigation_metrics.html
+++ b/tools/perf/metrics/brave_navigation_metrics.html
@@ -31,7 +31,7 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
         url.startsWith('chrome-untrusted://');
     }
 
-    function braveTraceBasedMetric(histograms, model) {
+    function braveNavigationMetric(histograms, model) {
       const chromeHelper = model.getOrCreateHelper(
         tr.model.helpers.ChromeModelHelper);
 
@@ -47,13 +47,9 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
         histogram.addSample(sample);
 
       };
-      let launchProcessCount = 0;
       for (const helper of chromeHelper.browserHelpers) {
         helper.iterAllThreads(function (thread) {
-          for (const slice of thread.sliceGroup.slices) {
-            if ((slice.title === 'LaunchProcess' || slice.title === 'LaunchElevatedProcess')) {
-              launchProcessCount++;
-            }
+          for (const slice of thread.asyncSliceGroup.slices) {
             if (slice.title === 'Navigation StartToCommit' &&
               !isSpecialUrl(slice.args.URL)) {
               addSample(
@@ -64,18 +60,14 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
           }
         });
       }
-      addSample(
-        'LaunchProcessCount',
-        tr.b.Unit.byName.unitlessNumber_smallerIsBetter,
-        launchProcessCount);
     }
 
-    tr.metrics.MetricRegistry.register(braveTraceBasedMetric, {
+    tr.metrics.MetricRegistry.register(braveNavigationMetric, {
       requiredCategories: ['benchmark'],
     });
 
     return {
-      braveTraceBasedMetric,
+      braveNavigationMetric,
     };
   });
 </script>


### PR DESCRIPTION
Reverts brave/brave-core#25101
Fixes https://github.com/brave/brave-browser/issues/40577

The original PR enabled the extra tracing category `base`. That resulted in using a lot of CPU because there is a lot of related event. If we want to catch `base::LaunchProcess` we need to make a custom trace event or use UMAs.