### PR TITLE
[Release/iOS]: HTTPS strict mode interstitial shown at wrong time (partial uplift to 1.69.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -956,6 +956,7 @@ extension BrowserViewController: WKNavigationDelegate {
 
   public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
     guard let tab = tab(for: webView) else { return }
+    tab.upgradedHTTPSRequest = nil
 
     // Set the committed url which will also set tab.url
     tab.committedURL = webView.url

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -956,6 +956,8 @@ extension BrowserViewController: WKNavigationDelegate {
 
   public func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
     guard let tab = tab(for: webView) else { return }
+
+    // Reset the stored http request now that load has committed.
     tab.upgradedHTTPSRequest = nil
 
     // Set the committed url which will also set tab.url


### PR DESCRIPTION
- When an http url is entered, we store it using Tab's `upgradedHTTPSRequest`. This property not being reset when page changes (ex. successful http->https upgrade, user tapped browser back button) resulting in the interstitial being shown at incorrect times. 
- This was already being reset here in later versions: https://github.com/brave/brave-core/pull/25027/files#diff-348b0ca220f2c6c15e6acd06769d042b9eb7d26355cfb397bb4bc6bab53c8c17R959

Resolves https://github.com/brave/brave-browser/issues/40617

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**Incorrectly showing strict mode interstitial / Flow 1:**
1. Fresh install
2. Enable HTTPS Strict mode
3. Open a new tab
4. Enter `http://badssl.com` (important it's http)
5. Tap "expired"
6. Verify SSL interstitial shown for `https://expired.badssl.com`

** Incorrectly showing strict mode interstitial / Flow 2: **:
1. Enable HTTPS Strict mode
2. Open a new tab (important)
3. Visit [badssl.com](http://badssl.com/)
4. Tap on any "http-" item you haven't allowlisted. For example, "http-password"  ---> shows the HTTPS Strict interstitial (expected)
5. Hit the _browser_ back button (not "Go back" on interstitial) and now scroll up & tap on "expired"
6. Verify SSL interstitial shown for `https://expired.badssl.com`

Other testing:
Verify `Proceed` is still working on https strict interstitial. 
1. Enable HTTPS Strict mode
2. Open a new tab
3. Visit `http://http-login.badssl.com/`
4. Tap "Proceed"
5. Verify you are taken to `http://http-login.badssl.com/`