### PR TITLE
[iOS] Wrap HTTPS-by-default logic around feature flags (uplift to 1.69.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -1818,7 +1818,7 @@ extension BrowserViewController: WKUIDelegate {
     }
 
     // Attempt to upgrade to HTTPS
-    if ShieldPreferences.httpsUpgradeLevel.isEnabled,
+    if FeatureList.kBraveHttpsByDefault.enabled, ShieldPreferences.httpsUpgradeLevel.isEnabled,
       let upgradedURL = braveCore.httpsUpgradeExceptionsService.upgradeToHTTPS(for: requestURL)
     {
       Self.log.debug(
@@ -1847,7 +1847,7 @@ extension BrowserViewController: WKUIDelegate {
       return nil
     }
 
-    if ShieldPreferences.httpsUpgradeLevel.isStrict,
+    if FeatureList.kHttpsOnlyMode.enabled, ShieldPreferences.httpsUpgradeLevel.isStrict,
       let url = originalURL.encodeEmbeddedInternalURL(for: .httpBlocked)
     {
       Self.log.debug(

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/DefaultShieldsSectionView.swift
@@ -40,16 +40,49 @@ struct DefaultShieldsSectionView: View {
         )
       }
 
-      Picker(selection: $settings.httpsUpgradeLevel) {
-        ForEach(HTTPSUpgradeLevel.allCases) { level in
-          Text(level.localizedTitle)
-            .foregroundColor(Color(.secondaryBraveLabel))
-            .tag(level)
+      if FeatureList.kBraveHttpsByDefault.enabled {
+        if FeatureList.kHttpsOnlyMode.enabled {
+          Picker(selection: $settings.httpsUpgradeLevel) {
+            ForEach(HTTPSUpgradeLevel.allCases) { level in
+              Text(level.localizedTitle)
+                .foregroundColor(Color(.secondaryBraveLabel))
+                .tag(level)
+            }
+          } label: {
+            LabelView(
+              title: Strings.Shields.upgradeConnectionsToHTTPS,
+              subtitle: nil
+            )
+          }
+        } else {
+          ToggleView(
+            title: Strings.Shields.upgradeConnectionsToHTTPS,
+            toggle: Binding(
+              get: {
+                settings.httpsUpgradeLevel.isEnabled
+              },
+              set: { newValue in
+                settings.httpsUpgradeLevel =
+                  !newValue
+                  ? .disabled : (ShieldPreferences.httpsUpgradePriorEnabledLevel ?? .standard)
+              }
+            )
+          )
         }
-      } label: {
-        LabelView(
-          title: Strings.Shields.upgradeConnectionsToHTTPS,
-          subtitle: nil
+      } else {
+        ToggleView(
+          title: Strings.HTTPSEverywhere,
+          subtitle: Strings.HTTPSEverywhereDescription,
+          toggle: Binding(
+            get: {
+              settings.httpsUpgradeLevel.isEnabled
+            },
+            set: { newValue in
+              settings.httpsUpgradeLevel =
+                !newValue
+                ? .disabled : (ShieldPreferences.httpsUpgradePriorEnabledLevel ?? .standard)
+            }
+          )
         )
       }
 

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -347,6 +347,15 @@ extension Preferences {
   }
 
   fileprivate class func migrateHTTPSUpgradeLevel() {
+    // If the feature flag for https by default is off but we've already stored a user pref for it
+    // then assign that enabled level a preference so that if a user toggles HTTPS Everywhere off
+    // and on it will correctly set the underlying upgarde level to the level they had set when
+    // the feature flag was on.
+    if !FeatureList.kBraveHttpsByDefault.enabled || !FeatureList.kHttpsOnlyMode.enabled,
+      ShieldPreferences.httpsUpgradeLevel.isEnabled
+    {
+      ShieldPreferences.httpsUpgradePriorEnabledLevel = ShieldPreferences.httpsUpgradeLevel
+    }
     guard !Migration.httpsUpgradesLivelCompleted.value else { return }
 
     // Migrate old tracking protection setting to new BraveShields setting

--- a/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldPreferences.swift
@@ -25,6 +25,14 @@ public class ShieldPreferences {
     default: defaultHTTPsUpgradeLevel.rawValue
   )
 
+  /// Get the enabled level for https upgrade for when the kBraveHttpsByDefault feature flag is off
+  /// This preserves the value the user had set (possibly `strict` or `standard`) when they enable
+  /// https everywhere
+  public static var httpsUpgradePriorEnabledLevelRaw = Preferences.Option<String?>(
+    key: "shields.https-upgrade-prior-enabled-level",
+    default: nil
+  )
+
   /// Get the level of the https upgrade setting as a stored preference
   /// - Warning: You should not access this directly but  through ``httpsUpgradeLevel``
   private static var shredLevelRaw = Preferences.Option<String?>(
@@ -46,6 +54,14 @@ public class ShieldPreferences {
       HTTPSUpgradeLevel(rawValue: httpsUpgradeLevelRaw.value) ?? defaultHTTPsUpgradeLevel
     }
     set { httpsUpgradeLevelRaw.value = newValue.rawValue }
+  }
+
+  /// Get the prior enabled level of HTTPS upgrades
+  public static var httpsUpgradePriorEnabledLevel: HTTPSUpgradeLevel? {
+    get {
+      httpsUpgradePriorEnabledLevelRaw.value.flatMap { HTTPSUpgradeLevel(rawValue: $0) }
+    }
+    set { httpsUpgradePriorEnabledLevelRaw.value = newValue?.rawValue }
   }
 
   /// Get the global shred level value

--- a/ios/browser/api/features/BUILD.gn
+++ b/ios/browser/api/features/BUILD.gn
@@ -29,6 +29,8 @@ source_set("features") {
     "//brave/components/skus/common:common",
     "//brave/ios/browser/playlist",
     "//build:blink_buildflags",
+    "//ios/components/security_interstitials/https_only_mode:feature",
+    "//net",
   ]
 
   frameworks = [ "Foundation.framework" ]

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -72,6 +72,8 @@ OBJC_EXPORT
 @property(class, nonatomic, readonly) Feature* kUseDevUpdaterUrl;
 @property(class, nonatomic, readonly) Feature* kVerboseLoggingFeature;
 @property(class, nonatomic, readonly) Feature* kNewPlaylistUI;
+@property(class, nonatomic, readonly) Feature* kBraveHttpsByDefault;
+@property(class, nonatomic, readonly) Feature* kHttpsOnlyMode;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -26,6 +26,8 @@
 #include "brave/ios/browser/playlist/features.h"
 #import "build/blink_buildflags.h"
 #include "build/build_config.h"
+#include "ios/components/security_interstitials/https_only_mode/feature.h"
+#include "net/base/features.h"
 
 @interface Feature () {
   const base::Feature* _feature;
@@ -295,6 +297,15 @@
 
 + (Feature*)kNewPlaylistUI {
   return [[Feature alloc] initWithFeature:&playlist::features::kNewPlaylistUI];
+}
+
++ (Feature*)kBraveHttpsByDefault {
+  return [[Feature alloc] initWithFeature:&net::features::kBraveHttpsByDefault];
+}
+
++ (Feature*)kHttpsOnlyMode {
+  return [[Feature alloc]
+      initWithFeature:&security_interstitials::features::kHttpsOnlyMode];
 }
 
 @end

--- a/ios/browser/flags/BUILD.gn
+++ b/ios/browser/flags/BUILD.gn
@@ -20,5 +20,6 @@ source_set("flags") {
     "//brave/components/skus/common",
     "//brave/ios/browser/playlist",
     "//components/flags_ui",
+    "//net",
   ]
 }

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -21,6 +21,8 @@
 #include "build/build_config.h"
 #include "components/flags_ui/feature_entry_macros.h"
 #include "components/flags_ui/flags_state.h"
+#include "ios/components/security_interstitials/https_only_mode/feature.h"
+#include "net/base/features.h"
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #include "brave/components/ai_chat/core/common/features.h"
@@ -74,16 +76,34 @@
                                  kBraveWalletTransactionSimulationsFeature),  \
       })
 
-#define BRAVE_SHIELDS_FEATURE_ENTRIES                                    \
-  EXPAND_FEATURE_ENTRIES({                                               \
-      "brave-shred",                                                     \
-      "Enable Brave 'Shred' Feature",                                    \
-      "Enable the Brave ‘Shred’ feature which will allow a user to " \
-      "easily delete all site data on demand or automatically when "     \
-      "closing a site or terminating the application.",                  \
-      flags_ui::kOsIos,                                                  \
-      FEATURE_VALUE_TYPE(brave_shields::features::kBraveShredFeature),   \
-  })
+#define BRAVE_SHIELDS_FEATURE_ENTRIES                                        \
+  EXPAND_FEATURE_ENTRIES(                                                    \
+      {                                                                      \
+          "brave-shred",                                                     \
+          "Enable Brave 'Shred' Feature",                                    \
+          "Enable the Brave ‘Shred’ feature which will allow a user to " \
+          "easily delete all site data on demand or automatically when "     \
+          "closing a site or terminating the application.",                  \
+          flags_ui::kOsIos,                                                  \
+          FEATURE_VALUE_TYPE(brave_shields::features::kBraveShredFeature),   \
+      },                                                                     \
+      {                                                                      \
+          "https-by-default",                                                \
+          "Use HTTPS by Default",                                            \
+          "Attempt to connect to all websites using HTTPS before falling "   \
+          "back to HTTP.",                                                   \
+          flags_ui::kOsIos,                                                  \
+          FEATURE_VALUE_TYPE(net::features::kBraveHttpsByDefault),           \
+      },                                                                     \
+      {                                                                      \
+          "https-only-mode",                                                 \
+          "Enable HTTPS By Default Strict Mode",                             \
+          "Connect to all websites using HTTPS and display an intersitital " \
+          "to fallback to HTTP",                                             \
+          flags_ui::kOsIos,                                                  \
+          FEATURE_VALUE_TYPE(                                                \
+              security_interstitials::features::kHttpsOnlyMode),             \
+      })
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
 #define BRAVE_AI_CHAT                                          \


### PR DESCRIPTION
Uplift of #25263
Resolves https://github.com/brave/brave-browser/issues/40634

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.