### PR TITLE
Fixed erasing `Sync Client ID` when cleaning cookies. (uplift to 1.69.x)

### DIFF
--- a/browser/browsing_data/BUILD.gn
+++ b/browser/browsing_data/BUILD.gn
@@ -8,6 +8,7 @@ source_set("browser_tests") {
 
   if (!is_android) {
     sources = [
+      "//brave/browser/browsing_data/brave_browsing_data_remover_browsertest.cc",
       "//brave/browser/browsing_data/brave_clear_browsing_data_browsertest.cc",
     ]
 

--- a/browser/browsing_data/brave_browsing_data_remover_browsertest.cc
+++ b/browser/browsing_data/brave_browsing_data_remover_browsertest.cc
@@ -1,0 +1,71 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <stddef.h>
+
+#include "base/base64.h"
+#include "base/rand_util.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/sync/service/glue/sync_transport_data_prefs.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browsing_data_remover_test_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+std::string GenerateCacheGUID() {
+  // Generate a GUID with 128 bits of randomness.
+  const int kGuidBytes = 128 / 8;
+
+  return base::Base64Encode(base::RandBytesAsVector(kGuidBytes));
+}
+
+}  // namespace
+
+class BraveBrowsingDataRemoverBrowserTest : public InProcessBrowserTest {
+ public:
+  BraveBrowsingDataRemoverBrowserTest() = default;
+
+ protected:
+  void RemoveAndWait(uint64_t remove_mask) {
+    content::BrowsingDataRemover* remover =
+        browser()->profile()->GetBrowsingDataRemover();
+    content::BrowsingDataRemoverCompletionObserver completion_observer(remover);
+    remover->RemoveAndReply(
+        base::Time(), base::Time::Max(), remove_mask,
+        content::BrowsingDataRemover::ORIGIN_TYPE_UNPROTECTED_WEB,
+        &completion_observer);
+    completion_observer.BlockUntilCompletion();
+  }
+
+  void KeepSyncGuidAfterClear(uint64_t remove_mask) {
+    // Setup sync prefs including cache_id
+    signin::GaiaIdHash gaia_id_hash =
+        signin::GaiaIdHash::FromGaiaId("user_gaia_id");
+    syncer::SyncTransportDataPrefs sync_transport_data_prefs(
+        browser()->profile()->GetPrefs(), gaia_id_hash);
+    sync_transport_data_prefs.SetCacheGuid(GenerateCacheGUID());
+    EXPECT_FALSE(sync_transport_data_prefs.GetCacheGuid().empty());
+
+    // Clear cookies/storage
+    RemoveAndWait(remove_mask);
+
+    // Ensure cache guid wasn't dropped
+    EXPECT_FALSE(sync_transport_data_prefs.GetCacheGuid().empty());
+  }
+};
+
+IN_PROC_BROWSER_TEST_F(BraveBrowsingDataRemoverBrowserTest,
+                       KeepSyncGuidAfterClearCookies) {
+  KeepSyncGuidAfterClear(content::BrowsingDataRemover::DATA_TYPE_COOKIES);
+}
+
+IN_PROC_BROWSER_TEST_F(BraveBrowsingDataRemoverBrowserTest,
+                       KeepSyncGuidAfterClearOnStoragePartition) {
+  KeepSyncGuidAfterClear(
+      content::BrowsingDataRemover::DATA_TYPE_ON_STORAGE_PARTITION);
+}

--- a/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
+++ b/chromium_src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h
@@ -6,12 +6,33 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_
 
+#include "build/build_config.h"
+
 class BraveBrowsingDataRemoverDelegate;
 
 #define BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H \
   friend class BraveBrowsingDataRemoverDelegate;
 
+#if !BUILDFLAG(IS_ANDROID)
+class FalseBoolStub {
+ public:
+  bool operator=(bool) { return false; }
+  explicit operator bool() const { return false; }
+};
+
+#define should_clear_sync_account_settings_          \
+  unused1_ = false;                                  \
+  FalseBoolStub should_clear_sync_account_settings_; \
+  bool unused2_
+
+#endif  // !BUILDFLAG(IS_ANDROID)
+
 #include "src/chrome/browser/browsing_data/chrome_browsing_data_remover_delegate.h"  // IWYU pragma: export
+
+#if !BUILDFLAG(IS_ANDROID)
+#undef should_clear_sync_account_settings_
+#endif
+
 #undef BRAVE_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSING_DATA_CHROME_BROWSING_DATA_REMOVER_DELEGATE_H_


### PR DESCRIPTION
Uplift of #25147
Resolves https://github.com/brave/brave-browser/issues/40130

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.