### PR TITLE
Checkout brave-variations automatically

### DIFF
--- a/tools/perf/components/browser_type.py
+++ b/tools/perf/components/browser_type.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 
 import components.git_tools as git_tools
+import components.path_util as path_util
 
 from distutils.dir_util import copy_tree
 from enum import Enum

--- a/tools/perf/components/browser_type.py
+++ b/tools/perf/components/browser_type.py
@@ -9,12 +9,15 @@ import os
 import re
 import shutil
 import sys
+import tempfile
+
+import components.git_tools as git_tools
+
 from distutils.dir_util import copy_tree
 from enum import Enum
 from typing import List, Optional, Tuple
 from dataclasses import dataclass
 
-import components.path_util as path_util
 from components.version import BraveVersion
 from components.common_options import CommonOptions
 from components.perf_test_utils import (DownloadArchiveAndUnpack, DownloadFile,
@@ -160,8 +163,6 @@ class BrowserType:
       return None
     if version is None:
       raise RuntimeError('version must be set to use Griffin trials')
-    if not common_options.variations_repo_dir:
-      raise RuntimeError('Set --variations-repo-dir to use Griffin trials')
     return _MakeTestingFieldTrials(artifacts_dir, version,
                                    common_options.variations_repo_dir)
 
@@ -230,8 +231,15 @@ class BraveBrowserTypeImpl(BrowserType):
     return os.path.join(out_dir, self.GetBinaryPath(target_os))
 
 
-def _MakeTestingFieldTrials(artifacts_dir: str, version: BraveVersion,
-                            variations_repo_dir: str) -> FieldTrialConfig:
+def _MakeTestingFieldTrials(
+    artifacts_dir: str, version: BraveVersion,
+    variations_repo_dir: Optional[str]) -> FieldTrialConfig:
+  if variations_repo_dir is None:
+    variations_repo_dir = os.path.join(tempfile.gettempdir(),
+                                       'brave-variations')
+    git_tools.EnsureRepositoryUpdated(git_tools.GH_BRAVE_VARIATIONS_GIT_URL,
+                                      'main', variations_repo_dir)
+
   combined_version: str = version.combined_version()
   logging.debug('Generating trials for combined_version %s', combined_version)
   target_path = os.path.join(artifacts_dir, 'fieldtrial_testing_config.json')

--- a/tools/perf/components/git_tools.py
+++ b/tools/perf/components/git_tools.py
@@ -14,6 +14,7 @@ import components.path_util as path_util
 from components.perf_test_utils import GetProcessOutput
 
 GH_BRAVE_CORE_GIT_URL = 'git@github.com:brave/brave-core.git'
+GH_BRAVE_VARIATIONS_GIT_URL = 'git@github.com:brave/brave-variations.git'
 GH_BRAVE_PERF_TEAM = 'brave/perf-team'
 
 
@@ -84,3 +85,18 @@ def GetFileAtRevision(filepath: str, revision: str) -> Optional[str]:
       cwd=path_util.GetBraveDir(),
       output_to_debug=False)
   return content if success else None
+
+def Clone(url: str, branch: Optional[str], target_dir: str) -> None:
+  args = ['git', 'clone', url, target_dir]
+  if branch:
+    args.extend(['--branch', branch])
+  GetProcessOutput(args, path_util.GetBraveDir(), check=True)
+
+
+def EnsureRepositoryUpdated(url: str, branch: str, directory: str) -> None:
+  if not os.path.exists(directory):
+    Clone(url, branch, directory)
+    return
+
+  GetProcessOutput(['git', 'fetch', url, branch], directory, check=True)
+  GetProcessOutput(['git', 'checkout', 'FETCH_HEAD'], directory, check=True)

--- a/tools/perf/components/git_tools.py
+++ b/tools/perf/components/git_tools.py
@@ -86,6 +86,7 @@ def GetFileAtRevision(filepath: str, revision: str) -> Optional[str]:
       output_to_debug=False)
   return content if success else None
 
+
 def Clone(url: str, branch: Optional[str], target_dir: str) -> None:
   args = ['git', 'clone', url, target_dir]
   if branch:

--- a/tools/perf/run_perftests.py
+++ b/tools/perf/run_perftests.py
@@ -101,12 +101,10 @@ def main():
       epilog=R'''
 To some launch tests locally:
 npm run perf_tests -- compare/compare_with_on_off_feature.json5
-     --variations-repo-dir=~/work/brave-variations
 
 On CI:
 npm run perf_tests -- smoke-brave.json5 v1.58.45
      --working-directory=e:\work\brave\src\out\100
-     --variations-repo-dir=e:\work\brave-variations
      --ci-mode
 ''')
   CommonOptions.add_parser_args(parser)


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40671
The PR simplifies running the perf tests locally: if you don't specify brave-variations dir, now it checks out and update it automatically.  

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

