### PR TITLE
Enable constructorsMatch test for BraveLogoMediator

### DIFF
--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -673,9 +673,9 @@
 }
 
 -keep class org.chromium.chrome.browser.logo.LogoMediator {
+    <init>(...);
     *** mLogoModel;
     *** mShouldShowLogo;
-    public <init>(...);
     *** updateVisibility(...);
 }
 

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -69,6 +69,8 @@ import org.chromium.chrome.browser.hub.ResourceButtonData;
 import org.chromium.chrome.browser.keyboard_accessory.ManualFillingComponentSupplier;
 import org.chromium.chrome.browser.layouts.LayoutManager;
 import org.chromium.chrome.browser.lifecycle.ActivityLifecycleDispatcher;
+import org.chromium.chrome.browser.logo.CachedTintedBitmap;
+import org.chromium.chrome.browser.logo.LogoCoordinator;
 import org.chromium.chrome.browser.multiwindow.MultiInstanceManager;
 import org.chromium.chrome.browser.multiwindow.MultiWindowModeStateDispatcher;
 import org.chromium.chrome.browser.new_tab_url.DseNewTabUrlManager;
@@ -1416,33 +1418,17 @@ public class BytecodeTest {
                         "org/chromium/chrome/browser/BraveSwipeRefreshHandler",
                         Tab.class));
 
-        // TODO(alexeybarabash): test is disabled because it fails at Release
-        // configuration without obvious reason.
-        // Difference in args:
-        //
-        // LogoMediator(
-        //
-        // android.content.Context,org.chromium.base.Callback,org.chromium.ui.modelutil.PropertyModel,boolean,org.chromium.base.Callback,LS)
-        // BraveLogoMediator(
-        //
-        // android.content.Context,org.chromium.base.Callback,org.chromium.ui.modelutil.PropertyModel,boolean,org.chromium.base.Callback,yy1,LS)
-        // So it looks `VisibilityObserver visibilityObserver` arg at LogoMediator.ctor is missing.
-        // This test succeed on Debug. apk_for_test.flags
-        // has required entries. Other workaround is to make LogoMediator.ctor
-        // public.
-        // import org.chromium.chrome.browser.logo.CachedTintedBitmap;
-        // import org.chromium.chrome.browser.logo.LogoCoordinator;
-        // Assert.assertTrue(
-        //         constructorsMatch(
-        //                 "org/chromium/chrome/browser/logo/LogoMediator",
-        //                 "org/chromium/chrome/browser/logo/BraveLogoMediator",
-        //                 Context.class,
-        //                 Callback.class,
-        //                 PropertyModel.class,
-        //                 boolean.class,
-        //                 Callback.class,
-        //                 LogoCoordinator.VisibilityObserver.class,
-        //                 CachedTintedBitmap.class));
+        Assert.assertTrue(
+                constructorsMatch(
+                        "org/chromium/chrome/browser/logo/LogoMediator",
+                        "org/chromium/chrome/browser/logo/BraveLogoMediator",
+                        Context.class,
+                        Callback.class,
+                        PropertyModel.class,
+                        boolean.class,
+                        Callback.class,
+                        LogoCoordinator.VisibilityObserver.class,
+                        CachedTintedBitmap.class));
         Assert.assertTrue(
                 constructorsMatch(
                         "org/chromium/chrome/browser/notifications/permissions/NotificationPermissionRationaleDialogController",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40672

Originally https://github.com/brave/brave-core/commit/5d86b1bfdcccb4df22678ec813bcd1c6f23a5cb7 had a problem because at `apk_for_test.flags` class `LogoMediator`  was marked as a public, so the Proguard exception rule wasn't triggered, as mentioned in the issue.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`npm run test --  brave_unit_tests  Release  --target_os=android --target_arch=x86`

