### PR TITLE
Fixes a crash on TabGroupUiCoordinator destroy method when it destroys before native part been initialised (uplift to 1.69.x)

### DIFF
--- a/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
+++ b/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
@@ -114,8 +114,12 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
 
     @Override
     public void destroy() {
-        super.destroy();
-
+        try {
+            super.destroy();
+        } catch (NullPointerException ignore) {
+            // mTabStripCoordinator could be null in a base class.
+            // https://github.com/brave/brave-browser/issues/40673
+        }
         mIncognitoStateProvider.removeObserver(mIncognitoStateObserver);
     }
 }


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/25323
Resolves https://github.com/brave/brave-browser/issues/40673