### PR TITLE
Show indicator when doing page content refining

### DIFF
--- a/components/ai_chat/core/browser/constants.cc
+++ b/components/ai_chat/core/browser/constants.cc
@@ -106,6 +106,8 @@ base::span<const webui::LocalizedString> GetLocalizedStrings() {
       {"gotItButtonLabel", IDS_CHAT_UI_GOT_IT_BUTTON_LABEL},
       {"pageContentTooLongWarning", IDS_CHAT_UI_PAGE_CONTENT_TOO_LONG_WARNING},
       {"pageContentRefinedWarning", IDS_CHAT_UI_PAGE_CONTENT_REFINED_WARNING},
+      {"pageContentRefinedInProgress",
+       IDS_CHAT_UI_PAGE_CONTENT_REFINED_IN_PROGRESS},
       {"errorConversationEnd", IDS_CHAT_UI_CONVERSATION_END_ERROR},
       {"searchInProgress", IDS_CHAT_UI_SEARCH_IN_PROGRESS},
       {"searchQueries", IDS_CHAT_UI_SEARCH_QUERIES},

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -898,6 +898,9 @@ void ConversationHandler::PerformAssistantGeneration(
                        std::move(data_received_callback),
                        std::move(data_completed_callback), page_content,
                        is_video));
+    UpdateOrCreateLastAssistantEntry(
+        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
+            mojom::PageContentRefineEvent::New()));
     return;
   } else if (!should_refine_page_content && is_content_refined_) {
     // If we previously refined content but we're not anymore (perhaps the

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -1269,6 +1269,16 @@ TEST_P(PageContentRefineTest, TextEmbedder) {
     }
     conversation_handler_->PerformAssistantGeneration(
         test_case.prompt, test_case.page_content, false, "");
+
+    if (test_case.should_refine_page_content && IsPageContentRefineEnabled()) {
+      const auto& conversation_history =
+          conversation_handler_->GetConversationHistory();
+      ASSERT_FALSE(conversation_history.empty());
+      ASSERT_FALSE(conversation_history.back()->events->empty());
+      EXPECT_TRUE(conversation_history.back()
+                      ->events->back()
+                      ->is_page_content_refine_event());
+    }
   }
 }
 
@@ -1338,6 +1348,16 @@ TEST_P(PageContentRefineTest, TextEmbedderInitialized) {
 
     conversation_handler_->PerformAssistantGeneration(
         test_prompt, test_page_content, false, "");
+
+    if (test_case.is_initialized || test_case.initialize_result) {
+      const auto& conversation_history =
+          conversation_handler_->GetConversationHistory();
+      ASSERT_FALSE(conversation_history.empty());
+      ASSERT_FALSE(conversation_history.back()->events->empty());
+      EXPECT_TRUE(conversation_history.back()
+                      ->events->back()
+                      ->is_page_content_refine_event());
+    }
 
     testing::Mock::VerifyAndClearExpectations(mock_engine);
     testing::Mock::VerifyAndClearExpectations(mock_text_embedder);

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -14,4 +14,22 @@ bool EngineConsumer::SupportsDeltaTextResponses() const {
   return false;
 }
 
+bool EngineConsumer::CanPerformCompletionRequest(
+    const ConversationHistory& conversation_history) const {
+  if (conversation_history.empty()) {
+    return false;
+  }
+
+  // Page refine event is fired between a human message and an assistant
+  // response.
+  const auto& last_turn = conversation_history.back();
+  if (last_turn->character_type != mojom::CharacterType::HUMAN &&
+      (!last_turn->events->empty() &&
+       !last_turn->events->back()->is_page_content_refine_event())) {
+    return false;
+  }
+
+  return true;
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -82,6 +82,11 @@ class EngineConsumer {
   }
 
  protected:
+  // Check if we should call GenerationCompletedCallback early based on the
+  // conversation history. Ex. empty history, or if the last entry is not a
+  // human message except page refine event.
+  bool CanPerformCompletionRequest(
+      const ConversationHistory& conversation_history) const;
   int max_page_content_length_ = 0;
 };
 

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
@@ -252,17 +252,12 @@ void EngineConsumerClaudeRemote::GenerateAssistantResponse(
     const std::string& human_input,
     GenerationDataCallback data_received_callback,
     GenerationCompletedCallback completed_callback) {
-  if (conversation_history.empty()) {
+  if (!CanPerformCompletionRequest(conversation_history)) {
     std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
     return;
   }
 
-  const mojom::ConversationTurnPtr& last_turn = conversation_history.back();
-  if (last_turn->character_type != CharacterType::HUMAN) {
-    std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
-    return;
-  }
-
+  const auto& last_turn = conversation_history.back();
   std::optional<std::string> selected_text = std::nullopt;
   if (last_turn->selected_text.has_value()) {
     selected_text =

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -97,13 +97,7 @@ void EngineConsumerConversationAPI::GenerateAssistantResponse(
     const std::string& human_input,
     GenerationDataCallback data_received_callback,
     GenerationCompletedCallback completed_callback) {
-  if (conversation_history.empty()) {
-    std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
-    return;
-  }
-
-  const mojom::ConversationTurnPtr& last_turn = conversation_history.back();
-  if (last_turn->character_type != mojom::CharacterType::HUMAN) {
+  if (!CanPerformCompletionRequest(conversation_history)) {
     std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
     return;
   }
@@ -128,6 +122,7 @@ void EngineConsumerConversationAPI::GenerateAssistantResponse(
     const std::string& text = (message->edits && !message->edits->empty())
                                   ? message->edits->back()->text
                                   : message->text;
+    const auto& last_turn = conversation_history.back();
     event.content = (message == last_turn) ? human_input : text;
 
     // TODO(petemill): Shouldn't the server handle the map of mojom::ActionType

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.cc
@@ -434,15 +434,12 @@ void EngineConsumerLlamaRemote::GenerateAssistantResponse(
     const std::string& human_input,
     GenerationDataCallback data_received_callback,
     GenerationCompletedCallback completed_callback) {
-  if (conversation_history.empty()) {
+  if (!CanPerformCompletionRequest(conversation_history)) {
     std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
     return;
   }
-  const mojom::ConversationTurnPtr& last_turn = conversation_history.back();
-  if (last_turn->character_type != mojom::CharacterType::HUMAN) {
-    std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
-    return;
-  }
+
+  const auto& last_turn = conversation_history.back();
   std::optional<std::string> selected_text = std::nullopt;
   if (last_turn->selected_text.has_value()) {
     selected_text =

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
@@ -234,17 +234,12 @@ void EngineConsumerOAIRemote::GenerateAssistantResponse(
     const std::string& human_input,
     GenerationDataCallback data_received_callback,
     GenerationCompletedCallback completed_callback) {
-  if (conversation_history.empty()) {
+  if (!CanPerformCompletionRequest(conversation_history)) {
     std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
     return;
   }
 
-  const mojom::ConversationTurnPtr& last_turn = conversation_history.back();
-  if (last_turn->character_type != CharacterType::HUMAN) {
-    std::move(completed_callback).Run(base::unexpected(mojom::APIError::None));
-    return;
-  }
-
+  const auto& last_turn = conversation_history.back();
   std::optional<std::string> selected_text = std::nullopt;
   if (last_turn->selected_text.has_value()) {
     selected_text =

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -109,6 +109,10 @@ enum ActionType {
   EXPAND,
 };
 
+struct PageContentRefineEvent {
+  bool is_refining = true;
+};
+
 struct SearchQueriesEvent {
   array<string> search_queries;
 };
@@ -124,6 +128,7 @@ struct CompletionEvent {
 // Events that occur during a conversation turn (only assistant for now)
 union ConversationEntryEvent {
   CompletionEvent completion_event;
+  PageContentRefineEvent page_content_refine_event;
   SearchQueriesEvent search_queries_event;
   SearchStatusEvent search_status_event;
 };

--- a/components/ai_chat/resources/page/components/assistant_response/index.tsx
+++ b/components/ai_chat/resources/page/components/assistant_response/index.tsx
@@ -67,7 +67,12 @@ export default function AssistantResponse(props: { entry: mojom.ConversationTurn
       }
       if (event.searchStatusEvent && props.isEntryInProgress && !hasCompletionStarted) {
         return (
-          <div className={styles.searchInProgress}><ProgressRing />Improving answer with Brave Search…</div>
+          <div className={styles.actionInProgress}><ProgressRing />Improving answer with Brave Search…</div>
+        )
+      }
+      if (event.pageContentRefineEvent && props.isEntryInProgress && !hasCompletionStarted) {
+        return (
+          <div className={styles.actionInProgress}><ProgressRing />{getLocale('pageContentRefinedInProgress')}</div>
         )
       }
       // TODO(petemill): Consider displaying in-progress queries if the API

--- a/components/ai_chat/resources/page/components/assistant_response/style.module.scss
+++ b/components/ai_chat/resources/page/components/assistant_response/style.module.scss
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-.searchInProgress {
+.actionInProgress {
   font: var(--leo-font-small-regular);
   color: var(--leo-color-text-primary);
   --leo-progressring-color: var(--leo-color-icon-interactive);

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -22,6 +22,7 @@ import styles from './style.module.scss'
 function getCompletionEvent(text: string): mojom.ConversationEntryEvent {
   return {
     completionEvent: { completion: text },
+    pageContentRefineEvent: undefined,
     searchQueriesEvent: undefined,
     searchStatusEvent: undefined
   }
@@ -30,6 +31,7 @@ function getCompletionEvent(text: string): mojom.ConversationEntryEvent {
 function getSearchEvent(queries: string[]): mojom.ConversationEntryEvent {
   return {
     completionEvent: undefined,
+    pageContentRefineEvent: undefined,
     searchQueriesEvent: { searchQueries: queries },
     searchStatusEvent: undefined
   }
@@ -38,8 +40,18 @@ function getSearchEvent(queries: string[]): mojom.ConversationEntryEvent {
 function getSearchStatusEvent(): mojom.ConversationEntryEvent {
   return {
     completionEvent: undefined,
+    pageContentRefineEvent: undefined,
     searchQueriesEvent: undefined,
     searchStatusEvent: { isSearching: true }
+  }
+}
+
+function getPageContentRefineEvent(): mojom.ConversationEntryEvent {
+  return {
+    completionEvent: undefined,
+    pageContentRefineEvent: { isRefining: true },
+    searchQueriesEvent: undefined,
+    searchStatusEvent: undefined
   }
 }
 
@@ -86,6 +98,17 @@ const HISTORY: mojom.ConversationTurn[] = [
     edits: [],
     createdTime: { internalValue: BigInt('13278618001000000') },
     events: [getCompletionEvent(`## How We Created an Accessible, Scalable Color Palette\n\nDuring the latter part of 2021, I reflected on the challenges we were facing at Modern Health. One recurring problem that stood out was our struggle to create new products with an unstructured color palette. This resulted in poor [communication](https://www.google.com) between designers and developers, an inconsistent product brand, and increasing accessibility problems.\n\n1. Inclusivity: our palette provides easy ways to ensure our product uses accessible contrasts.\n 2. Efficiency: our palette is diverse enough for our current and future product design, yet values are still predictable and constrained.\n 3. Reusability: our palette is on-brand but versatile. There are very few one-offs that fall outside the palette.\n\n This article shares the process I followed to apply these principles to develop a more adaptable color palette that prioritizes accessibility and is built to scale into all of our future product **design** needs.`)],
+    fromBraveSearchSERP: false
+  },
+  {
+    text: '',
+    characterType: mojom.CharacterType.ASSISTANT,
+    actionType: mojom.ActionType.UNSPECIFIED,
+    visibility: mojom.ConversationTurnVisibility.VISIBLE,
+    selectedText: undefined,
+    edits: [],
+    createdTime: { internalValue: BigInt('13278618001000000') },
+    events: [getPageContentRefineEvent()],
     fromBraveSearchSERP: false
   },
   {

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -238,6 +238,9 @@
   <message name="IDS_CHAT_UI_PAGE_CONTENT_REFINED_WARNING" desc="A warning issued when the page content has been refined">
     The page content has been refined through extracting the most relevant information from the page because it was too long for Leo.
   </message>
+  <message name="IDS_CHAT_UI_PAGE_CONTENT_REFINED_IN_PROGRESS" desc="An indicator to show page content refined is in progress">
+    Finding the relevant parts of the web page...
+  </message>
   <message name="IDS_CHAT_UI_CONVERSATION_END_ERROR" desc="An error issued when the user cannot continue chatting">
     This conversation is too long and cannot continue. There may be other models available with which Leo is capable of maintaining accuracy for longer conversations.
   </message>

--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -920,6 +920,15 @@ extension Strings {
       comment:
         "The text displayed on the loading screen when searching for a user query"
     )
+    public static let leoPageContentRefineInProgress = NSLocalizedString(
+      "aichat.leoPageContentRefineInProgress",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value:
+        "Finding the relevant parts of the web page...",
+      comment:
+        "An indicator to show page content refined is in progress"
+    )
     public static let leoImprovedAnswerBraveSearch = NSLocalizedString(
       "aichat.leoImprovedAnswerBraveSearch",
       tableName: "BraveLeo",

--- a/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatResponseMessageView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Messages/AIChatResponseMessageView.swift
@@ -114,6 +114,26 @@ struct AIChatResponseMessageView: View {
           }
           .fixedSize()
           .frame(maxWidth: .infinity, alignment: .leading)
+        } else if event.tag == .pageContentRefineEvent && isEntryInProgress && !hasCompletionStarted
+        {
+          HStack {
+            ProgressView()
+              .progressViewStyle(
+                CircularProgressViewStyle(
+                  thickness: 4.0
+                )
+              )
+              .foregroundStyle(Color(braveSystemName: .iconDefault))
+              .backgroundStyle(Color(braveSystemName: .iconInteractive))
+
+            Text(Strings.AIChat.leoPageContentRefineInProgress)
+              .font(.subheadline)
+              .foregroundStyle(Color(braveSystemName: .textPrimary))
+              .multilineTextAlignment(.leading)
+              .frame(maxWidth: .infinity, alignment: .leading)
+          }
+          .fixedSize()
+          .frame(maxWidth: .infinity, alignment: .leading)
         }
       }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40618

Use newly added `PageContentRefineEvent` to propagate refining in progress so we can show the indicator with same style as `SearchStatusEvent`

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Make sure brave://flags/#brave-ai-chat-page-content-refine is enabled
2. Navigate to content will be truncated site ex. https://www.brianbondy.com/blog/187/cocodona-2024
3. Ask a question like "Who was the pacer?"
4. There should be an indicator like this 
<img width="362" alt="Screenshot 2024-09-04 at 11 11 30" src="https://github.com/user-attachments/assets/c595234d-ae0d-42a2-a19c-201199db9def">


5. We should be able to get correct answer mentioning "Viktoria" and there is a warning saying "Page content is refined"
6. Ask another question like "How long does it take to finish the race?"
7. The indicator will show for a bit (embedding is cached so it is way faster than the first question)
8. We should get "91 hours 9 minutes"