### PR TITLE
[Tabs]: Increase opacity, decrease size of separator… (uplift to 1.70.x)

### DIFF
--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -62,7 +62,7 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
     case LOCATION_BAR_CHILD_CORNER_RADIUS:
       return 4;
     case TAB_SEPARATOR_HEIGHT: {
-      return 24;
+      return 16;
     }
     case TOOLBAR_BUTTON_HEIGHT: {
       return touch ? 48 : 28;

--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -907,11 +907,12 @@ void AddBravifiedTabStripColorMixer(ui::ColorProvider* provider,
   mixer[kColorTabBackgroundActiveFrameInactive] = {
       kColorTabBackgroundActiveFrameActive};
 
-  auto divider_color =
-      leo::GetColor(leo::Color::kColorDividerStrong,
-                    key.color_mode == ui::ColorProviderKey::ColorMode::kDark
-                        ? leo::Theme::kDark
-                        : leo::Theme::kLight);
+  auto divider_color = ui::AlphaBlend(
+      {leo::GetColor(leo::Color::kColorDividerStrong,
+                     key.color_mode == ui::ColorProviderKey::ColorMode::kDark
+                         ? leo::Theme::kDark
+                         : leo::Theme::kLight)},
+      {kColorTabBackgroundInactiveFrameActive}, 0.75 * 0xff);
   mixer[kColorTabDividerFrameInactive] = {divider_color};
   mixer[kColorTabDividerFrameActive] = {divider_color};
 }

--- a/patches/chrome-browser-ui-views-tabs-tab_style_views.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab_style_views.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/tabs/tab_style_views.cc b/chrome/browser/ui/views/tabs/tab_style_views.cc
-index 65676013fece9815be2046fcbf554ca857ce896c..8a541ff9f709822fcec5612dd2839f641ad72e53 100644
+index 65676013fece9..3d3c8a6c02e7d 100644
 --- a/chrome/browser/ui/views/tabs/tab_style_views.cc
 +++ b/chrome/browser/ui/views/tabs/tab_style_views.cc
 @@ -138,6 +138,7 @@ class TabStyleViewsImpl : public TabStyleViews {
@@ -18,19 +18,7 @@ index 65676013fece9815be2046fcbf554ca857ce896c..8a541ff9f709822fcec5612dd2839f64
  
    SkPath path;
  
-@@ -668,9 +670,10 @@ TabStyle::SeparatorBounds TabStyleViewsImpl::GetSeparatorBounds(
-   TabStyle::SeparatorBounds separator_bounds;
- 
-   const int extra_vertical_space =
-+      2 * (
-       aligned_bounds.height() -
-       (separator_size.height() + separator_margin.bottom() +
--       separator_margin.top());
-+       separator_margin.top()));
- 
-   separator_bounds.leading = gfx::RectF(
-       aligned_bounds.x() + corner_radius - separator_margin.right() -
-@@ -1042,14 +1045,18 @@ void TabStyleViewsImpl::PaintSeparators(gfx::Canvas* canvas) const {
+@@ -1042,14 +1044,18 @@ void TabStyleViewsImpl::PaintSeparators(gfx::Canvas* canvas) const {
                                                     SK_AlphaOPAQUE));
    };
  


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/40714
Uplift from https://github.com/brave/brave-core/pull/25353

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

