### PR TITLE
[Nala]: Fix sidebar header

### DIFF
--- a/browser/ui/color/brave_color_mixer.cc
+++ b/browser/ui/color/brave_color_mixer.cc
@@ -682,12 +682,27 @@ void AddBravePrivateThemeColorMixer(ui::ColorProvider* provider,
   // side panel contents.
   const bool is_dark = dark_mode::GetActiveBraveDarkModeType() ==
                        dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_DARK;
-  mixer[kColorSidebarPanelHeaderSeparator] = {nala::kColorDividerSubtle};
+  // These colors should be nala colors, but we don't necessarily match the
+  // theme in the browser, so we hardcode light/dark values.
+  // kColorDividerSubtle
+  mixer[kColorSidebarPanelHeaderSeparator] = {
+      is_dark ? nala::kColorPrimitiveNeutral20
+              : nala::kColorPrimitiveNeutral90};
+  // kColorContainerBackground
   mixer[kColorSidebarPanelHeaderBackground] = {
-      is_dark ? gfx::kGoogleGrey900 : nala::kColorContainerBackground};
-  mixer[kColorSidebarPanelHeaderTitle] = {nala::kColorTextPrimary};
-  mixer[kColorSidebarPanelHeaderButton] = {nala::kColorIconDefault};
-  mixer[kColorSidebarPanelHeaderButtonHovered] = {nala::kColorNeutral60};
+      is_dark ? nala::kColorPrimitiveNeutral5
+              : nala::kColorPrimitiveNeutral100};
+  mixer[kColorSidebarPanelHeaderTitle] = {is_dark
+                                              ? nala::kColorPrimitiveNeutral90
+                                              : nala::kColorPrimitiveNeutral10};
+  // kColorIconDefault
+  mixer[kColorSidebarPanelHeaderButton] = {
+      is_dark ? nala::kColorPrimitiveNeutral90
+              : nala::kColorPrimitiveNeutral10};
+  // kColorNeutral60
+  mixer[kColorSidebarPanelHeaderButtonHovered] = {
+      is_dark ? nala::kColorPrimitiveNeutral80
+              : nala::kColorPrimitiveNeutral25};
 }
 
 void AddBraveTorThemeColorMixer(ui::ColorProvider* provider,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40749

Before:
![image](https://github.com/user-attachments/assets/232e7f6d-69ef-4e6e-9994-16b20739d33c)

After:
![image](https://github.com/user-attachments/assets/ff5f4bad-27d4-4051-bccf-17b4783214b5)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open a new profile in a light theme
2. Open a private/tor window
3. Open the sidebar
4. View the bookmarks/reading list tab
5. They should not have a yellow header