### PR TITLE
Disable loading the translate language list (uplift to 1.69.x)

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -19,7 +19,6 @@
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
-#include "brave/components/translate/core/common/brave_translate_features.h"
 #include "build/build_config.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
@@ -27,7 +26,6 @@
 #include "components/component_updater/component_updater_service.h"
 #include "components/prefs/pref_service.h"
 #include "components/sync/base/command_line_switches.h"
-#include "components/translate/core/browser/translate_language_list.h"
 #include "content/public/browser/render_frame_host.h"
 #include "extensions/buildflags/buildflags.h"
 #include "media/base/media_switches.h"
@@ -181,9 +179,6 @@ void BraveBrowserMainParts::PreProfileInit() {
     command_line->RemoveSwitch(syncer::kDisableSync);
   }
 #endif
-
-  if (!translate::ShouldUpdateLanguagesList())
-    translate::TranslateLanguageList::DisableUpdate();
 }
 
 void BraveBrowserMainParts::PostProfileInit(Profile* profile,

--- a/browser/translate/brave_translate_browsertest.cc
+++ b/browser/translate/brave_translate_browsertest.cc
@@ -296,6 +296,7 @@ IN_PROC_BROWSER_TEST_F(BraveTranslateBrowserTest, InternalTranslation) {
   // Check that we haven't tried to update the language lists.
   auto* language_list =
       TranslateDownloadManager::GetInstance()->language_list();
+  language_list->RequestLanguageList();
   EXPECT_FALSE(language_list->HasOngoingLanguageListLoadingForTesting());
 
   // Check used urls.

--- a/chromium_src/components/translate/core/browser/translate_language_list.cc
+++ b/chromium_src/components/translate/core/browser/translate_language_list.cc
@@ -1,0 +1,23 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "components/translate/core/browser/translate_language_list.h"
+
+#include "brave/components/translate/core/common/brave_translate_features.h"
+
+#define TranslateLanguageList TranslateLanguageList_ChromiumImpl
+#include "src/components/translate/core/browser/translate_language_list.cc"
+#undef TranslateLanguageList
+
+namespace translate {
+
+void TranslateLanguageList::SetResourceRequestsAllowed(bool allowed) {
+  if (!ShouldUpdateLanguagesList()) {
+    allowed = false;
+  }
+  TranslateLanguageList_ChromiumImpl::SetResourceRequestsAllowed(allowed);
+}
+
+}  // namespace translate

--- a/chromium_src/components/translate/core/browser/translate_language_list.h
+++ b/chromium_src/components/translate/core/browser/translate_language_list.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_LANGUAGE_LIST_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_LANGUAGE_LIST_H_
+
+#define TranslateLanguageList TranslateLanguageList_ChromiumImpl
+#define SetResourceRequestsAllowed virtual SetResourceRequestsAllowed
+#include "src/components/translate/core/browser/translate_language_list.h"  // IWYU pragma: export
+#undef SetResourceRequestsAllowed
+#undef TranslateLanguageList
+
+namespace translate {
+
+class TranslateLanguageList : public TranslateLanguageList_ChromiumImpl {
+ public:
+  void SetResourceRequestsAllowed(bool allowed) override;
+};
+
+}  // namespace translate
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_TRANSLATE_CORE_BROWSER_TRANSLATE_LANGUAGE_LIST_H_


### PR DESCRIPTION
Uplift of #25375
Resolves https://github.com/brave/brave-browser/issues/40750

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.