### PR TITLE
Disable macOS dialogs in npm run start

### DIFF
--- a/build/commands/lib/start.js
+++ b/build/commands/lib/start.js
@@ -84,6 +84,15 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
     killSignal: 'SIGTERM'
   }
 
+  if (process.platform === 'darwin' && !config.isReleaseBuild()) {
+    // Disable 'accept incoming network connections' and 'keychain access'
+    // dialogs in MacOS. See //docs/mac_build_instructions.md for details.
+    braveArgs.push(
+      '--use-mock-keychain',
+      '--disable-features=DialMediaRouteProvider'
+    )
+  }
+
   let outputPath = options.output_path
   if (!outputPath) {
     outputPath = path.join(config.outputDir, 'brave')

--- a/build/commands/lib/start.js
+++ b/build/commands/lib/start.js
@@ -62,6 +62,16 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
   if (options.brave_ads_staging) {
     braveArgs.push('--brave-ads-staging')
   }
+
+  if (process.platform === 'darwin') {
+    // Disable 'accept incoming network connections' and 'keychain access'
+    // dialogs in MacOS. See //docs/mac_build_instructions.md for details.
+    if (!options.use_real_keychain)
+      braveArgs.push('--use-mock-keychain')
+    if (!passthroughArgs.some((s) => s.startsWith('--disable-features')))
+      braveArgs.push('--disable-features=DialMediaRouteProvider')
+  }
+
   braveArgs = braveArgs.concat(passthroughArgs)
 
   let user_data_dir
@@ -82,15 +92,6 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
     continueOnFail: false,
     shell: process.platform === 'darwin' ? true : false,
     killSignal: 'SIGTERM'
-  }
-
-  if (process.platform === 'darwin' && !config.isReleaseBuild()) {
-    // Disable 'accept incoming network connections' and 'keychain access'
-    // dialogs in MacOS. See //docs/mac_build_instructions.md for details.
-    braveArgs.push('--use-mock-keychain')
-    if (!braveArgs.some((s) => s.startsWith('--disable-features'))) {
-      braveArgs.push('--disable-features=DialMediaRouteProvider')
-    }
   }
 
   let outputPath = options.output_path

--- a/build/commands/lib/start.js
+++ b/build/commands/lib/start.js
@@ -87,10 +87,10 @@ const start = (passthroughArgs, buildConfig = config.defaultBuildConfig, options
   if (process.platform === 'darwin' && !config.isReleaseBuild()) {
     // Disable 'accept incoming network connections' and 'keychain access'
     // dialogs in MacOS. See //docs/mac_build_instructions.md for details.
-    braveArgs.push(
-      '--use-mock-keychain',
-      '--disable-features=DialMediaRouteProvider'
-    )
+    braveArgs.push('--use-mock-keychain')
+    if (!braveArgs.some((s) => s.startsWith('--disable-features'))) {
+      braveArgs.push('--disable-features=DialMediaRouteProvider')
+    }
   }
 
   let outputPath = options.output_path

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -219,6 +219,7 @@ program
   .option('--brave_ads_staging', 'ads staging')
   .option('--brave_ads_debug', 'ads debug')
   .option('--single_process', 'use a single process')
+  .option('--use_real_keychain', 'don\'t add --use-mock-keychain for macOS')
   .option('--output_path [pathname]', 'use the Brave binary located at [pathname]')
   .arguments('[build_config]')
   .action(start.bind(null, parsedArgs.unknown))

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -219,7 +219,7 @@ program
   .option('--brave_ads_staging', 'ads staging')
   .option('--brave_ads_debug', 'ads debug')
   .option('--single_process', 'use a single process')
-  .option('--use_real_keychain', 'don\'t add --use-mock-keychain for macOS')
+  .option('--use_real_keychain', 'don\'t add --use-mock-keychain in macOS')
   .option('--output_path [pathname]', 'use the Brave binary located at [pathname]')
   .arguments('[build_config]')
   .action(start.bind(null, parsedArgs.unknown))


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40780
The details in the issue description.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

