### PR TITLE
[Brave News]: Comma separate locales in enabled locales list (uplift to 1.69.x)

### DIFF
--- a/components/brave_news/common/locales_helper.cc
+++ b/components/brave_news/common/locales_helper.cc
@@ -37,7 +37,7 @@ constexpr auto kEnabledLanguages =
 constexpr auto kEnabledLocales =
     base::MakeFixedFlatSet<std::string_view>(base::sorted_unique,
                                              {
-                                                 "de_DE"
+                                                 "de_DE",
                                                  "es_AR",
                                                  "es_ES",
                                                  "es_MX",


### PR DESCRIPTION
Uplift of #25390
Resolves https://github.com/brave/brave-browser/issues/37839

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.