### PR TITLE
Fixed crash from ntp background images module with some urls

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_source.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_source.cc
@@ -103,8 +103,7 @@ std::string NTPBackgroundImagesSource::GetMimeType(const GURL& url) {
   } else if (file_path.MatchesExtension(FILE_PATH_LITERAL(".avif"))) {
     return "image/avif";
   } else {
-    NOTREACHED_IN_MIGRATION();
-    return "image/jpeg";
+    return "";
   }
 }
 

--- a/components/ntp_background_images/browser/ntp_background_images_source_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_source_unittest.cc
@@ -85,6 +85,7 @@ TEST_F(NTPBackgroundImagesSourceTest, SponsoredImagesTest) {
             source_->GetMimeType(GURL("brave://test/wallpaper-0.png")));
   EXPECT_EQ("image/avif",
             source_->GetMimeType(GURL("brave://test/wallpaper-0.avif")));
+  EXPECT_EQ("", source_->GetMimeType(GURL("brave://test/")));
 }
 
 TEST_F(NTPBackgroundImagesSourceTest, BackgroundImagesFormatTest) {
@@ -96,6 +97,7 @@ TEST_F(NTPBackgroundImagesSourceTest, BackgroundImagesFormatTest) {
             bg_source_->GetMimeType(GURL("brave://test/wallpaper-0.png")));
   EXPECT_EQ("image/avif",
             bg_source_->GetMimeType(GURL("brave://test/wallpaper-0.avif")));
+  EXPECT_EQ("", bg_source_->GetMimeType(GURL("brave://test/")));
 }
 
 TEST_F(NTPBackgroundImagesSourceTest, BackgroundImagesTest) {

--- a/components/ntp_background_images/browser/ntp_sponsored_images_source.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_images_source.cc
@@ -109,8 +109,7 @@ std::string NTPSponsoredImagesSource::GetMimeType(const GURL& url) {
   } else if (file_path.MatchesExtension(FILE_PATH_LITERAL(".avif"))) {
     return "image/avif";
   } else {
-    NOTREACHED_IN_MIGRATION();
-    return "image/jpeg";
+    return "";
   }
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/40807

GetMimeType() should return empty string if request url is not supported in image source..

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`NTPBackgroundImagesSourceTest.*`

1. Load brave://branded-wallpaper/ or brave://background-wallpaper/
2. No crash