### PR TITLE
[ads] Ensure A/B tests always comply with privacy, discarding all A/B tests if more than one Griffin A/B test study is present

### DIFF
--- a/components/brave_ads/core/internal/account/user_data/fixed/studies_user_data.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/studies_user_data.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/account/user_data/fixed/studies_user_data.h"
 
+#include <optional>
 #include <utility>
 
 #include "brave/components/brave_ads/core/internal/settings/settings.h"
@@ -29,11 +30,11 @@ base::Value::Dict BuildStudiesUserData() {
 
   base::Value::List list;
 
-  for (const auto& active_field_trial_group :
-       GetActiveFieldTrialStudyGroups()) {
+  if (const std::optional<base::FieldTrial::ActiveGroup>
+          active_field_trial_group = GetActiveFieldTrialStudyGroup()) {
     list.Append(base::Value::Dict()
-                    .Set(kTrialNameKey, active_field_trial_group.trial_name)
-                    .Set(kGroupNameKey, active_field_trial_group.group_name));
+                    .Set(kTrialNameKey, active_field_trial_group->trial_name)
+                    .Set(kGroupNameKey, active_field_trial_group->group_name));
   }
 
   user_data.Set(kStudiesKey, std::move(list));

--- a/components/brave_ads/core/internal/account/user_data/fixed/studies_user_data_unittest.cc
+++ b/components/brave_ads/core/internal/account/user_data/fixed/studies_user_data_unittest.cc
@@ -16,70 +16,10 @@ namespace brave_ads {
 
 class BraveAdsStudiesUserDataTest : public test::TestBase {};
 
-TEST_F(BraveAdsStudiesUserDataTest, BuildStudiesUserDataForRewardsUser) {
-  // Arrange
-  const scoped_refptr<base::FieldTrial> field_trial_1 =
-      base::FieldTrialList::CreateFieldTrial("BraveAds.FooStudy", "GroupA");
-  field_trial_1->group_name();
-
-  const scoped_refptr<base::FieldTrial> field_trial_2 =
-      base::FieldTrialList::CreateFieldTrial("BraveAds.BarStudy", "GroupB");
-  field_trial_2->group_name();
-
-  const scoped_refptr<base::FieldTrial> field_trial_3 =
-      base::FieldTrialList::CreateFieldTrial("FooBarStudy", "GroupC");
-  field_trial_3->group_name();
-
-  ASSERT_EQ(3U, base::FieldTrialList::GetFieldTrialCount());
-
-  // Act
-  const base::Value::Dict user_data = BuildStudiesUserData();
-
-  // Assert
-  EXPECT_EQ(base::test::ParseJsonDict(
-                R"(
-                    {
-                      "studies": [
-                        {
-                          "group": "GroupB",
-                          "name": "BraveAds.BarStudy"
-                        },
-                        {
-                          "group": "GroupA",
-                          "name": "BraveAds.FooStudy"
-                        }
-                      ]
-                    }
-                )"),
-            user_data);
-}
-
-TEST_F(BraveAdsStudiesUserDataTest, BuildStudiesUserDataForNonRewardsUser) {
-  // Arrange
-  test::DisableBraveRewards();
-
-  const scoped_refptr<base::FieldTrial> field_trial_1 =
-      base::FieldTrialList::CreateFieldTrial("BraveAds.FooStudy", "GroupA");
-  field_trial_1->group_name();
-
-  const scoped_refptr<base::FieldTrial> field_trial_2 =
-      base::FieldTrialList::CreateFieldTrial("BraveAds.BarStudy", "GroupB");
-  field_trial_2->group_name();
-
-  const scoped_refptr<base::FieldTrial> field_trial_3 =
-      base::FieldTrialList::CreateFieldTrial("FooBarStudy", "GroupC");
-  field_trial_3->group_name();
-
-  ASSERT_EQ(3U, base::FieldTrialList::GetFieldTrialCount());
-
-  // Act
-  const base::Value::Dict user_data = BuildStudiesUserData();
-
-  // Assert
-  EXPECT_THAT(user_data, ::testing::IsEmpty());
-}
-
 TEST_F(BraveAdsStudiesUserDataTest, BuildStudiesUserDataIfNoFieldTrials) {
+  // Arrange
+  ASSERT_EQ(0U, base::FieldTrialList::GetFieldTrialCount());
+
   // Act
   const base::Value::Dict user_data = BuildStudiesUserData();
 
@@ -90,6 +30,75 @@ TEST_F(BraveAdsStudiesUserDataTest, BuildStudiesUserDataIfNoFieldTrials) {
                       "studies": []
                     })"),
             user_data);
+}
+
+TEST_F(BraveAdsStudiesUserDataTest,
+       BuildStudiesUserDataForSingleFieldTrialAndRewardsUser) {
+  // Arrange
+  const scoped_refptr<base::FieldTrial> field_trial =
+      base::FieldTrialList::CreateFieldTrial("BraveAds.FooStudy", "GroupA");
+  field_trial->group_name();
+
+  ASSERT_EQ(1U, base::FieldTrialList::GetFieldTrialCount());
+
+  // Act
+  const base::Value::Dict user_data = BuildStudiesUserData();
+
+  // Assert
+  EXPECT_EQ(base::test::ParseJsonDict(
+                R"(
+                    {
+                      "studies": [
+                        {
+                          "group": "GroupA",
+                          "name": "BraveAds.FooStudy"
+                        }
+                      ]
+                    }
+                )"),
+            user_data);
+}
+
+TEST_F(BraveAdsStudiesUserDataTest,
+       BuildStudiesUserDataForMultipleFieldTrialsAndRewardsUser) {
+  // Arrange
+  const scoped_refptr<base::FieldTrial> field_trial_1 =
+      base::FieldTrialList::CreateFieldTrial("BraveAds.FooStudy", "GroupA");
+  field_trial_1->group_name();
+
+  const scoped_refptr<base::FieldTrial> field_trial_2 =
+      base::FieldTrialList::CreateFieldTrial("BraveAds.BarStudy", "GroupB");
+  field_trial_2->group_name();
+
+  ASSERT_EQ(2U, base::FieldTrialList::GetFieldTrialCount());
+
+  // Act
+  const base::Value::Dict user_data = BuildStudiesUserData();
+
+  // Assert
+  EXPECT_EQ(base::test::ParseJsonDict(
+                R"(
+                    {
+                      "studies": []
+                    })"),
+            user_data);
+}
+
+TEST_F(BraveAdsStudiesUserDataTest, BuildStudiesUserDataForNonRewardsUser) {
+  // Arrange
+  test::DisableBraveRewards();
+
+  const scoped_refptr<base::FieldTrial> field_trial =
+      base::FieldTrialList::CreateFieldTrial("BraveAds.FooStudy", "GroupA");
+  field_trial->group_name();
+
+  ASSERT_EQ(1U, base::FieldTrialList::GetFieldTrialCount());
+
+  // Act
+  const base::Value::Dict user_data = BuildStudiesUserData();
+
+  // Assert
+  EXPECT_THAT(user_data, ::testing::IsEmpty());
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/studies/studies.cc
+++ b/components/brave_ads/core/internal/studies/studies.cc
@@ -22,7 +22,7 @@ Studies::~Studies() {
 ///////////////////////////////////////////////////////////////////////////////
 
 void Studies::OnNotifyDidInitializeAds() {
-  LogActiveStudies();
+  LogActiveFieldTrialStudyGroups();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/studies/studies_util.h
+++ b/components/brave_ads/core/internal/studies/studies_util.h
@@ -6,13 +6,15 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_STUDIES_STUDIES_UTIL_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_STUDIES_STUDIES_UTIL_H_
 
+#include <optional>
+
 #include "base/metrics/field_trial.h"
 
 namespace brave_ads {
 
-base::FieldTrial::ActiveGroups GetActiveFieldTrialStudyGroups();
+std::optional<base::FieldTrial::ActiveGroup> GetActiveFieldTrialStudyGroup();
 
-void LogActiveStudies();
+void LogActiveFieldTrialStudyGroups();
 
 }  // namespace brave_ads
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/39991

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Verify that `BraveAds.` Griffin A/B test studies are skipped if there is more than one (`"studies": []` will be included in the confirmation token redemption payload). If there is only one study, it should function as expected, and the confirmation token redemption payload should contain `"studies": [...]`, where `...` includes the study group and name.