### PR TITLE
style(wallet): Segmented Controls zIndex

### DIFF
--- a/components/brave_wallet_ui/components/shared/segmented_control/segmented_control.style.ts
+++ b/components/brave_wallet_ui/components/shared/segmented_control/segmented_control.style.ts
@@ -14,6 +14,7 @@ export const StyledWrapper = styled.div<{ width?: string }>`
   flex-direction: row;
   align-items: center;
   justify-content: center;
+  z-index: 0;
 `
 
 export const SegmentedControl = styled(


### PR DESCRIPTION
## Description 

Fixes the `Segmented Controls` z-index in the `Wallet` so it does not overlap `Wallet Menus`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/40828>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open the `Wallet` and navigate to the `Portfolio` page
2. Shrink your window size down and then open the top right `Wallet Menu`
3. The `Segmented Controller` should not overlap the `Menu`
4. Navigate to the `Accounts` page and view an account
5. Open both available `Wallet Menus`
6. The `Segmented Controller` should not overlap the `Menus`

Before:

![Screenshot 51](https://github.com/user-attachments/assets/56c09290-6737-4017-b58d-d85117eb1ab9)

![Screenshot 52](https://github.com/user-attachments/assets/f32fcb60-b3ea-45e3-a856-19fc0ea9e51d)

![Screenshot 53](https://github.com/user-attachments/assets/5cf16e22-2a62-49e5-92f3-4b15263525e6)

After:

![Screenshot 54](https://github.com/user-attachments/assets/a6750844-9655-4c1b-955b-9aa51f2288bb)

![Screenshot 55](https://github.com/user-attachments/assets/d0379b02-ab95-4d64-b5c6-723be292090e)

![Screenshot 56](https://github.com/user-attachments/assets/ed8c0a34-9d75-453a-a4fa-731749e2a87a)
