### PR TITLE
Webpack: don't use 'auto' for public path, always specify root path unless overriden (uplift to 1.69.x)

### DIFF
--- a/components/webpack/webpack.config.js
+++ b/components/webpack/webpack.config.js
@@ -70,7 +70,8 @@ module.exports = async function (env, argv) {
   const output = {
     path: process.env.TARGET_GEN_DIR,
     filename: '[name].bundle.js',
-    chunkFilename: '[name].chunk.js'
+    chunkFilename: '[name].chunk.js',
+    publicPath: '/'
   }
   if (env.output_public_path) {
     output.publicPath = env.output_public_path


### PR DESCRIPTION
Uplift of #25379
Resolves https://github.com/brave/brave-browser/issues/40765
Resolves https://github.com/brave/brave-browser/issues/40841

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.