### PR TITLE
[Uplift]: update brave/leo to update to svelte 4.2.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#45e18a71888194b16681caf3b47c86117bd37afd",
+        "@brave/leo": "github:brave/leo#d870507981111bf5f2e45623f075ec3c05b91191",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2",
         "@brave/wallet-standard-brave": "0.0.13",
         "@dnd-kit/core": "6.0.5",
@@ -2221,8 +2221,8 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#45e18a71888194b16681caf3b47c86117bd37afd",
-      "integrity": "sha512-4GbhC1YeCT3MgvPbigNY/I+3zoMWu8szbHnKplOQHRNVVcr2dz85MZhe2OyfrCqc1TTGEjjYj11Ppwh/aFbTGg==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#d870507981111bf5f2e45623f075ec3c05b91191",
+      "integrity": "sha512-vCuvyxRjndMueXyDzbzlNaQwQcREZ3MFy2uM0n1inH2dajMa+G37UiSr9HrLDLsGawjm19inEo3z4V6IyVD6XA==",
       "dependencies": {
         "@storybook/test": "8.1.11",
         "svelte": "4.2.19",
@@ -29835,9 +29835,9 @@
       }
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#45e18a71888194b16681caf3b47c86117bd37afd",
-      "integrity": "sha512-4GbhC1YeCT3MgvPbigNY/I+3zoMWu8szbHnKplOQHRNVVcr2dz85MZhe2OyfrCqc1TTGEjjYj11Ppwh/aFbTGg==",
-      "from": "@brave/leo@github:brave/leo#45e18a71888194b16681caf3b47c86117bd37afd",
+      "version": "git+ssh://git@github.com/brave/leo.git#d870507981111bf5f2e45623f075ec3c05b91191",
+      "integrity": "sha512-vCuvyxRjndMueXyDzbzlNaQwQcREZ3MFy2uM0n1inH2dajMa+G37UiSr9HrLDLsGawjm19inEo3z4V6IyVD6XA==",
+      "from": "@brave/leo@github:brave/leo#d870507981111bf5f2e45623f075ec3c05b91191",
       "requires": {
         "@storybook/test": "8.1.11",
         "svelte": "4.2.19",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#7de60c1f950c109251b9b07193d87bc15bfc5e5a",
+        "@brave/leo": "github:brave/leo#45e18a71888194b16681caf3b47c86117bd37afd",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2",
         "@brave/wallet-standard-brave": "0.0.13",
         "@dnd-kit/core": "6.0.5",
@@ -2221,11 +2221,11 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#7de60c1f950c109251b9b07193d87bc15bfc5e5a",
-      "integrity": "sha512-FKHDcSSNxFu6WcA2QpRrIQN0Pu9E0MPyC2mNDmQ0UogNXiloxaujk2Lnt4JtHWrwXAr/RGnCcSUf4XobQSW5Kg==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#45e18a71888194b16681caf3b47c86117bd37afd",
+      "integrity": "sha512-4GbhC1YeCT3MgvPbigNY/I+3zoMWu8szbHnKplOQHRNVVcr2dz85MZhe2OyfrCqc1TTGEjjYj11Ppwh/aFbTGg==",
       "dependencies": {
         "@storybook/test": "8.1.11",
-        "svelte": "4.2.18",
+        "svelte": "4.2.19",
         "svelte-preprocess": "5.1.4",
         "tailwindcss": "3.2.6",
         "tslib": "2.5.0"
@@ -25710,9 +25710,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
-      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
+      "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -29835,12 +29835,12 @@
       }
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#7de60c1f950c109251b9b07193d87bc15bfc5e5a",
-      "integrity": "sha512-FKHDcSSNxFu6WcA2QpRrIQN0Pu9E0MPyC2mNDmQ0UogNXiloxaujk2Lnt4JtHWrwXAr/RGnCcSUf4XobQSW5Kg==",
-      "from": "@brave/leo@github:brave/leo#7de60c1f950c109251b9b07193d87bc15bfc5e5a",
+      "version": "git+ssh://git@github.com/brave/leo.git#45e18a71888194b16681caf3b47c86117bd37afd",
+      "integrity": "sha512-4GbhC1YeCT3MgvPbigNY/I+3zoMWu8szbHnKplOQHRNVVcr2dz85MZhe2OyfrCqc1TTGEjjYj11Ppwh/aFbTGg==",
+      "from": "@brave/leo@github:brave/leo#45e18a71888194b16681caf3b47c86117bd37afd",
       "requires": {
         "@storybook/test": "8.1.11",
-        "svelte": "4.2.18",
+        "svelte": "4.2.19",
         "svelte-preprocess": "5.1.4",
         "tailwindcss": "3.2.6",
         "tslib": "2.5.0"
@@ -47414,9 +47414,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "svelte": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
-      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
+      "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "requires": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#7de60c1f950c109251b9b07193d87bc15bfc5e5a",
+    "@brave/leo": "github:brave/leo#45e18a71888194b16681caf3b47c86117bd37afd",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2",
     "@brave/wallet-standard-brave": "0.0.13",
     "@dnd-kit/core": "6.0.5",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#45e18a71888194b16681caf3b47c86117bd37afd",
+    "@brave/leo": "github:brave/leo#d870507981111bf5f2e45623f075ec3c05b91191",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#f66f5701f8330253c1c113228c08f129178941c2",
     "@brave/wallet-standard-brave": "0.0.13",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/25408
Fixes https://github.com/brave/brave-browser/issues/40801

**Note:** We've got a 1.69.x branch in brave/leo so we don't pull in a bunch of breaking changes
https://github.com/brave/leo/compare/7de60c1f950c109251b9b07193d87bc15bfc5e5a...45e18a71888194b16681caf3b47c86117bd37afd