### PR TITLE
[Uplift]: update brave/leo to update to svelte 4.2.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",
-        "@brave/leo": "github:brave/leo#63e98a1bb14cf87dcb8cbd4436e9e38615840447",
+        "@brave/leo": "github:brave/leo#3137f70fbec90bd4bd3b29e2f814186ba626c903",
         "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
         "@brave/wallet-standard-brave": "0.0.13",
         "@dnd-kit/core": "6.0.5",
@@ -2222,11 +2222,11 @@
     },
     "node_modules/@brave/leo": {
       "version": "0.0.1",
-      "resolved": "git+ssh://git@github.com/brave/leo.git#63e98a1bb14cf87dcb8cbd4436e9e38615840447",
-      "integrity": "sha512-iAz07aMlTfMeL1qC1BmgjBLyUGciTY+mWKhiSA4MlxifbmhTslmz/oIiJD3/ulxB3jSnuvYuhBvQuHpCjAQKKA==",
+      "resolved": "git+ssh://git@github.com/brave/leo.git#3137f70fbec90bd4bd3b29e2f814186ba626c903",
+      "integrity": "sha512-Spa8UvbWOgXWhPNSwHCcTbu/p6hQzRmf8otJ/vd5DmITkNV5blJgKfd3O9s3rGE3Z85I0lKwvf0pJb3UrJ50yQ==",
       "dependencies": {
         "@storybook/test": "8.1.11",
-        "svelte": "4.2.18",
+        "svelte": "4.2.19",
         "svelte-preprocess": "5.1.4",
         "tailwindcss": "3.2.6",
         "tslib": "2.5.0"
@@ -25710,9 +25710,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
-      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
+      "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -29834,12 +29834,12 @@
       }
     },
     "@brave/leo": {
-      "version": "git+ssh://git@github.com/brave/leo.git#63e98a1bb14cf87dcb8cbd4436e9e38615840447",
-      "integrity": "sha512-iAz07aMlTfMeL1qC1BmgjBLyUGciTY+mWKhiSA4MlxifbmhTslmz/oIiJD3/ulxB3jSnuvYuhBvQuHpCjAQKKA==",
-      "from": "@brave/leo@github:brave/leo#63e98a1bb14cf87dcb8cbd4436e9e38615840447",
+      "version": "git+ssh://git@github.com/brave/leo.git#3137f70fbec90bd4bd3b29e2f814186ba626c903",
+      "integrity": "sha512-Spa8UvbWOgXWhPNSwHCcTbu/p6hQzRmf8otJ/vd5DmITkNV5blJgKfd3O9s3rGE3Z85I0lKwvf0pJb3UrJ50yQ==",
+      "from": "@brave/leo@github:brave/leo#3137f70fbec90bd4bd3b29e2f814186ba626c903",
       "requires": {
         "@storybook/test": "8.1.11",
-        "svelte": "4.2.18",
+        "svelte": "4.2.19",
         "svelte-preprocess": "5.1.4",
         "tailwindcss": "3.2.6",
         "tslib": "2.5.0"
@@ -47405,9 +47405,9 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "svelte": {
-      "version": "4.2.18",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.18.tgz",
-      "integrity": "sha512-d0FdzYIiAePqRJEb90WlJDkjUEx42xhivxN8muUBmfZnP+tzUgz12DJ2hRJi8sIHCME7jeK1PTMgKPSfTd8JrA==",
+      "version": "4.2.19",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.19.tgz",
+      "integrity": "sha512-IY1rnGr6izd10B0A8LqsBfmlT5OILVuZ7XsI0vdGPEvuonFV7NYEUK4dAkm9Zg2q0Um92kYjTpS1CAP3Nh/KWw==",
       "requires": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",

--- a/package.json
+++ b/package.json
@@ -174,7 +174,7 @@
   },
   "dependencies": {
     "@brave/brave-ui": "0.40.6",
-    "@brave/leo": "github:brave/leo#63e98a1bb14cf87dcb8cbd4436e9e38615840447",
+    "@brave/leo": "github:brave/leo#3137f70fbec90bd4bd3b29e2f814186ba626c903",
     "@brave/leo-sf-symbols": "github:brave/leo-sf-symbols#8685eec0851afa96d23dd424cd152854476e585d",
     "@brave/wallet-standard-brave": "0.0.13",
     "@dnd-kit/core": "6.0.5",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/25408
Fixes https://github.com/brave/brave-browser/issues/40801

**Note:** We've got a 1.69.x branch in brave/leo so we don't pull in a bunch of breaking changes
https://github.com/brave/leo/compare/63e98a1bb14cf87dcb8cbd4436e9e38615840447...3137f70fbec90bd4bd3b29e2f814186ba626c903