### PR TITLE
Make brave extension background page conditional

### DIFF
--- a/browser/brave_content_browser_client_browsertest.cc
+++ b/browser/brave_content_browser_client_browsertest.cc
@@ -39,6 +39,7 @@
 #include "extensions/browser/extension_registry.h"
 #include "extensions/browser/extension_system.h"
 #include "extensions/common/constants.h"
+#include "extensions/common/manifest_handlers/background_info.h"
 #include "net/dns/mock_host_resolver.h"
 #include "url/origin.h"
 
@@ -725,4 +726,10 @@ IN_PROC_BROWSER_TEST_F(BraveContentBrowserClientTest, CheckExpectedExtensions) {
       registry->GenerateInstalledExtensionsSet().GetIDs();
 
   EXPECT_EQ(expected_extensions, installed_extensions);
+
+  const auto* brave_extension =
+      registry->GetInstalledExtension(brave_extension_id);
+
+  // Brave Extension background page should be disabled by default.
+  EXPECT_FALSE(extensions::BackgroundInfo::HasBackgroundPage(brave_extension));
 }

--- a/browser/extensions/brave_component_loader.cc
+++ b/browser/extensions/brave_component_loader.cc
@@ -6,14 +6,17 @@
 #include "brave/browser/extensions/brave_component_loader.h"
 
 #include <string>
+#include <utility>
 
 #include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
+#include "base/json/json_reader.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
 #include "brave/components/brave_component_updater/browser/brave_component_installer.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
 #include "brave/components/brave_extension/grit/brave_extension.h"
+#include "brave/components/brave_rewards/common/pref_names.h"
 #include "brave/components/brave_webtorrent/grit/brave_webtorrent_resources.h"
 #include "brave/components/constants/brave_switches.h"
 #include "brave/components/constants/pref_names.h"
@@ -29,6 +32,7 @@
 #include "extensions/browser/extension_system.h"
 #include "extensions/common/constants.h"
 #include "extensions/common/mojom/manifest.mojom.h"
+#include "ui/base/resource/resource_bundle.h"
 
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED)
 #include "brave/browser/ethereum_remote_client/ethereum_remote_client_constants.h"
@@ -46,7 +50,19 @@ BraveComponentLoader::BraveComponentLoader(ExtensionSystem* extension_system,
                                            Profile* profile)
     : ComponentLoader(extension_system, profile),
       profile_(profile),
-      profile_prefs_(profile->GetPrefs()) {}
+      profile_prefs_(profile->GetPrefs()) {
+  pref_change_registrar_.Init(profile_prefs_);
+
+  pref_change_registrar_.Add(
+      kWebDiscoveryEnabled,
+      base::BindRepeating(&BraveComponentLoader::UpdateBraveExtension,
+                          base::Unretained(this)));
+
+  pref_change_registrar_.Add(
+      brave_rewards::prefs::kEnabled,
+      base::BindRepeating(&BraveComponentLoader::UpdateBraveExtension,
+                          base::Unretained(this)));
+}
 
 BraveComponentLoader::~BraveComponentLoader() = default;
 
@@ -102,15 +118,7 @@ void BraveComponentLoader::AddExtension(const std::string& extension_id,
 void BraveComponentLoader::AddDefaultComponentExtensions(
     bool skip_session_components) {
   ComponentLoader::AddDefaultComponentExtensions(skip_session_components);
-
-  const base::CommandLine& command_line =
-      *base::CommandLine::ForCurrentProcess();
-  if (!command_line.HasSwitch(switches::kDisableBraveExtension)) {
-    base::FilePath brave_extension_path(FILE_PATH_LITERAL(""));
-    brave_extension_path =
-        brave_extension_path.Append(FILE_PATH_LITERAL("brave_extension"));
-    Add(IDR_BRAVE_EXTENSION, brave_extension_path);
-  }
+  UpdateBraveExtension();
 }
 
 #if BUILDFLAG(ETHEREUM_REMOTE_CLIENT_ENABLED)
@@ -151,6 +159,51 @@ void BraveComponentLoader::AddWebTorrentExtension() {
         brave_webtorrent_path.Append(FILE_PATH_LITERAL("brave_webtorrent"));
     Add(IDR_BRAVE_WEBTORRENT, brave_webtorrent_path);
   }
+}
+
+bool BraveComponentLoader::UseBraveExtensionBackgroundPage() {
+  // Keep sync with `pref_change_registrar_` in the ctor.
+  return profile_prefs_->GetBoolean(brave_rewards::prefs::kEnabled) ||
+         profile_prefs_->GetBoolean(kWebDiscoveryEnabled);
+}
+
+void BraveComponentLoader::UpdateBraveExtension() {
+  const base::CommandLine& command_line =
+      *base::CommandLine::ForCurrentProcess();
+  if (command_line.HasSwitch(switches::kDisableBraveExtension)) {
+    return;
+  }
+
+  base::FilePath brave_extension_path(FILE_PATH_LITERAL(""));
+  brave_extension_path =
+      brave_extension_path.Append(FILE_PATH_LITERAL("brave_extension"));
+  auto& resource_bundle = ui::ResourceBundle::GetSharedInstance();
+  std::optional<base::Value::Dict> manifest = base::JSONReader::ReadDict(
+      resource_bundle.GetRawDataResource(IDR_BRAVE_EXTENSION));
+  CHECK(manifest) << "invalid Brave Extension manifest";
+
+  // The background page is a conditional. Replace MAYBE_background in the
+  // manifest to "background" or remove it.
+  auto background_value = manifest->Extract("MAYBE_background");
+  if (UseBraveExtensionBackgroundPage() && background_value) {
+    manifest->Set("background", std::move(*background_value));
+  }
+
+  extensions::ExtensionRegistry* registry =
+      extensions::ExtensionRegistry::Get(profile_);
+  const Extension* current_extension =
+      registry->GetInstalledExtension(brave_extension_id);
+
+  if (current_extension) {
+    const auto* current_manifest = current_extension->manifest();
+    if (current_manifest && *current_manifest->value() == *manifest) {
+      return;  // Skip reload, nothing is actually changed.
+    }
+    Remove(brave_extension_id);
+  }
+
+  const auto id = Add(std::move(*manifest), brave_extension_path);
+  CHECK_EQ(id, brave_extension_id);
 }
 
 }  // namespace extensions

--- a/browser/extensions/brave_component_loader.h
+++ b/browser/extensions/brave_component_loader.h
@@ -12,6 +12,7 @@
 #include "base/memory/raw_ptr.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
 #include "chrome/browser/extensions/component_loader.h"
+#include "components/prefs/pref_change_registrar.h"
 
 class PrefService;
 class Profile;
@@ -50,11 +51,16 @@ class BraveComponentLoader : public ComponentLoader {
 
  private:
   void ReinstallAsNonComponent(std::string extension_id);
+  void UpdateBraveExtension();
+
+  bool UseBraveExtensionBackgroundPage();
 
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<PrefService> profile_prefs_ = nullptr;
   std::string ethereum_remote_client_manifest_;
   base::FilePath ethereum_remote_client_install_dir_;
+
+  PrefChangeRegistrar pref_change_registrar_;
 };
 
 }  // namespace extensions

--- a/chromium_src/chrome/browser/ssl/https_upgrades_browsertest.cc
+++ b/chromium_src/chrome/browser/ssl/https_upgrades_browsertest.cc
@@ -5,22 +5,11 @@
 
 #include "net/base/features.h"
 
-// Prevent re-dfining ExpectTotalCount.
-#include "base/test/metrics/histogram_tester.h"
 // Prevent re-defining InitWithFeatures definition.
 #include "base/test/scoped_feature_list.h"
 
 #define InitWithFeatures(...) \
   InitWithFeaturesAndDisable(net::features::kBraveHttpsByDefault, __VA_ARGS__)
 
-// Add one to total count for Brave extension
-// (chrome-extension://mnojpmjdmbbfmejpflffifhffcmidifd/) background page.
-#define ExpectTotalCount(NAME, COUNT)                                          \
-  ExpectTotalCount(                                                            \
-      NAME, std::string_view(NAME) == kNavigationRequestSecurityLevelHistogram \
-                ? COUNT + 1                                                    \
-                : COUNT)
-
 #include "src/chrome/browser/ssl/https_upgrades_browsertest.cc"
-#undef ExpectTotalCount
 #undef InitWithFeatures

--- a/components/brave_extension/extension/brave_extension/manifest.json
+++ b/components/brave_extension/extension/brave_extension/manifest.json
@@ -12,7 +12,7 @@
     "128": "assets/img/icon-128.png",
     "256": "assets/img/icon-256.png"
   },
-  "background": {
+  "MAYBE_background":{
     "scripts": [
       "out/brave_extension_background.bundle.js"
     ],


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
For https://github.com/brave/brave-browser/issues/39610 

The PR stops spawning a background page (=an extra renderer by default).
If a user enables WDP or Rewards then background page will be launched.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
https://github.com/brave/brave-browser/issues/39610#issuecomment-2352471054
