### PR TITLE
style(wallet): Segmented Control Sizing and Padding

### DIFF
--- a/components/brave_wallet_ui/components/desktop/card-headers/explorer_web3_header.style.ts
+++ b/components/brave_wallet_ui/components/desktop/card-headers/explorer_web3_header.style.ts
@@ -1,0 +1,18 @@
+// Copyright (c) 2023 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import styled from 'styled-components'
+
+// Shared Styles
+import { Row } from '../../shared/style'
+import {
+  layoutSmallWidth //
+} from '../wallet-page-wrapper/wallet-page-wrapper.style'
+
+export const HeaderWrapper = styled(Row)`
+  padding: 24px 24px 0px 24px;
+  @media screen and (max-width: ${layoutSmallWidth}px) {
+    padding: 16px 16px 0px 16px;
+  }
+`

--- a/components/brave_wallet_ui/components/desktop/card-headers/explorer_web3_header.tsx
+++ b/components/brave_wallet_ui/components/desktop/card-headers/explorer_web3_header.tsx
@@ -5,15 +5,25 @@
 
 import * as React from 'react'
 
-// utils
-import { ExploreNavOptions } from '../../../../options/nav-options'
+// Options
+import { ExploreNavOptions } from '../../../options/nav-options'
+
+// Components
 import {
   SegmentedControl //
-} from '../../../shared/segmented_control/segmented_control'
+} from '../../shared/segmented_control/segmented_control'
 
-// components
+// Styled Components
+import { HeaderWrapper } from './explorer_web3_header.style'
 
 export const ExploreWeb3Header = () => {
   // render
-  return <SegmentedControl navOptions={ExploreNavOptions} />
+  return (
+    <HeaderWrapper>
+      <SegmentedControl
+        maxWidth='384px'
+        navOptions={ExploreNavOptions}
+      />
+    </HeaderWrapper>
+  )
 }

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -41,7 +41,7 @@ import { Column } from '../../../shared/style'
 // components
 import getWalletPageApiProxy from '../../../../page/wallet_page_api_proxy'
 import { WalletBanner } from '../../wallet-banner/index'
-import { ExploreWeb3Header } from '../explore_web3/explore_web3_header'
+import { ExploreWeb3Header } from '../../card-headers/explorer_web3_header'
 import {
   EditVisibleAssetsModal //
 } from '../../popup-modals/edit-visible-assets-modal/index'

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -217,7 +217,7 @@ export const AccountsAndTransactionsList = ({
           <Row padding='24px 0px'>
             <SegmentedControl
               navOptions={PortfolioAssetOptions}
-              width={'384px'}
+              maxWidth='384px'
             />
           </Row>
         )}
@@ -300,7 +300,7 @@ export const AccountsAndTransactionsList = ({
             <Row padding='24px 0px'>
               <SegmentedControl
                 navOptions={PortfolioAssetOptions}
-                width={'384px'}
+                maxWidth='384px'
               />
             </Row>
           )}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -590,7 +590,7 @@ export const PortfolioOverview = () => {
             {!hidePortfolioNFTsTab && (
               <SegmentedControl
                 navOptions={PortfolioNavOptions}
-                width={'384px'}
+                maxWidth='384px'
               />
             )}
           </ControlsRow>

--- a/components/brave_wallet_ui/components/shared/segmented_control/segmented_control.style.ts
+++ b/components/brave_wallet_ui/components/shared/segmented_control/segmented_control.style.ts
@@ -8,20 +8,29 @@ import LeoSegmentedControl, {
   SegmentedControlProps
 } from '@brave/leo/react/segmentedControl'
 
-export const StyledWrapper = styled.div<{ width?: string }>`
-  flex: 1;
+// Shared Styles
+import {
+  layoutPanelWidth,
+  layoutSmallWidth //
+} from '../../desktop/wallet-page-wrapper/wallet-page-wrapper.style'
+
+export const StyledWrapper = styled.div<{ maxWidth?: string }>`
   display: flex;
   flex-direction: row;
   align-items: center;
   justify-content: center;
   z-index: 0;
+  width: 100%;
+  max-width: ${(p) => p.maxWidth ?? 'unset'};
+  --leo-segmented-control-width: 100%;
+  @media screen and (max-width: ${layoutSmallWidth}px) {
+    max-width: unset;
+  }
 `
 
-export const SegmentedControl = styled(
-  LeoSegmentedControl
-)<SegmentedControlProps>`
-  margin: 24px 0 10px 0;
-`
+export const SegmentedControl = styled(LeoSegmentedControl).attrs({
+  size: window.innerWidth <= layoutPanelWidth ? 'small' : 'default'
+})<SegmentedControlProps>``
 
 export const ControlItemWrapper = styled.div`
   text-align: center;

--- a/components/brave_wallet_ui/components/shared/segmented_control/segmented_control.tsx
+++ b/components/brave_wallet_ui/components/shared/segmented_control/segmented_control.tsx
@@ -22,10 +22,10 @@ import {
 
 interface Props {
   navOptions: NavOption[]
-  width?: string
+  maxWidth?: string
 }
 
-export const SegmentedControl = ({ navOptions, width }: Props) => {
+export const SegmentedControl = ({ navOptions, maxWidth }: Props) => {
   // Routing
   const history = useHistory()
   const { pathname: walletLocation, hash } = useLocation()
@@ -40,7 +40,7 @@ export const SegmentedControl = ({ navOptions, width }: Props) => {
 
   // Render
   return (
-    <StyledWrapper width={width}>
+    <StyledWrapper maxWidth={maxWidth}>
       <StyledSegmentedControl
         value={selectedRoute}
         onChange={({ value }) => {


### PR DESCRIPTION
## Description 

Fixes the `Segmented Controls` sizing and padding in the `Wallet`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/40718>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. There should not be big vertical `Padding` on the `Segmented Controls` on the `Portfolio`, `Portfolio Asset`, `Edit Visible Asset`, `Explorer` and `Account Details` views.
2. The `Segmented Controls` should be smaller in the `Panel` on the `Portfolio`, `Portfolio Asset`, `Edit Visible Asset`, `Explorer` and `Account Details` views.

## Portfolio

#### Before:

![image](https://github.com/user-attachments/assets/46daf6de-5a4d-40fd-b2c4-15fcfed9fbf6) | ![image](https://github.com/user-attachments/assets/2b9fe8d0-cc37-4485-bd45-9bfad2c81d71)
-- | --

#### After:

![image](https://github.com/user-attachments/assets/9333b1e0-9386-44da-a77c-20fb1039f4dc) | ![image](https://github.com/user-attachments/assets/fd33564b-2e35-4872-9a90-372302e1dd99)
-- | --

## Portfolio Asset

#### Before:

![image](https://github.com/user-attachments/assets/6b854bf4-53d9-4660-b5cd-11605f9ad510) | ![image](https://github.com/user-attachments/assets/5c7b3259-c9e2-4302-a0dc-72f672fc9941)
-- | --

#### After:

![image](https://github.com/user-attachments/assets/c611af70-eab8-49d8-9226-81cd2c1b401c) | ![image](https://github.com/user-attachments/assets/c27ce7b0-44dd-4e3f-af21-87eca03c1086)
-- | --

## Edit Visible Assets

#### Before:

![image](https://github.com/user-attachments/assets/c5840faa-cd3a-4f71-a6c1-244c8bae3b44) | ![image](https://github.com/user-attachments/assets/f5000883-5b69-4a79-8d6d-00f809c7f247)
-- | --

#### After:

![image](https://github.com/user-attachments/assets/93a1f907-b396-4cee-bb47-6e8a84060931) | ![image](https://github.com/user-attachments/assets/46a812d0-68cb-41d0-9300-bd04da9ea696)
-- | --

## Explorer

#### Before:

![image](https://github.com/user-attachments/assets/ab267955-ec45-49f8-90bc-38b3646d5a19) | ![image](https://github.com/user-attachments/assets/56321010-a850-49a9-9137-b12f93bd151a)
-- | --

#### After:

![image](https://github.com/user-attachments/assets/0c431519-30a0-4da9-befc-542947018491) | ![image](https://github.com/user-attachments/assets/bf7bbde1-b7b5-480f-9303-327052f0fce5)
-- | --

## Account Details

#### Before:

![image](https://github.com/user-attachments/assets/1abb26e6-4ffa-4192-9408-c10e259bce79) | ![image](https://github.com/user-attachments/assets/4c2babbc-0836-46a6-8559-09df94633543)
-- | --

#### After:

![image](https://github.com/user-attachments/assets/14466a92-b2a3-4fd5-8700-6226e8137c31) | ![image](https://github.com/user-attachments/assets/ec6fd0d0-47aa-4efe-9a4d-383fe340ab7a)
-- | --
