### PR TITLE
fix(privacy): Fix :upward procedural filters on iOS

### DIFF
--- a/ios/brave-ios/Tests/ClientTests/Resources/html/index.html
+++ b/ios/brave-ios/Tests/ClientTests/Resources/html/index.html
@@ -87,6 +87,18 @@
       <div id="test-remove-class" class="test"></div>
       <div id="test-remove-attribute" test></div>
       <div id="test-style-element">Styled text</div>
+      <div id="test-upward-int">
+        <div>
+          <div id="test-upward-int-target"></div>
+        </div>
+      </div>
+      <div id="test-upward-selector">
+        <div>
+          <div>
+            <div id="test-upward-selector-target"></div>
+          </div>
+        </div>
+      </div>
     </div>
   </body>
 </html>

--- a/ios/brave-ios/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
+++ b/ios/brave-ios/Tests/ClientTests/Resources/scripts/cosmetic-filter-tests.js
@@ -19,7 +19,9 @@
       'removedClass': results.removedClass,
       'removedAttribute': results.removedAttribute,
       'removedElement': results.removedElement,
-      'styledElement': results.styledElement
+      'styledElement': results.styledElement,
+      'upwardInt': results.upwardInt,
+      'upwardSelector': results.upwardSelector
     })
   }
 
@@ -35,7 +37,9 @@
       removedElement: true,
       removedClass: false,
       removedAttribute: false,
-      styledElement: false
+      styledElement: false,
+      upwardInt: false,
+      upwardSelector: false
     }
 
     elements.forEach((node) => {
@@ -63,6 +67,14 @@
 
       if (node.id === 'test-style-element') {
         results.styledElement = window.getComputedStyle(node).backgroundColor === "rgb(255, 0, 0)"
+      }
+
+      if (node.id === 'test-upward-int') {
+        results.upwardInt = window.getComputedStyle(node).display === 'none'
+      }
+
+      if (node.id === 'test-upward-selector') {
+        results.upwardSelector = window.getComputedStyle(node).display === 'none'
       }
     })
 

--- a/ios/brave-ios/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/User Scripts/ScriptExecutionTests.swift
@@ -30,6 +30,8 @@ final class ScriptExecutionTests: XCTestCase {
     let removedClass: Bool
     let removedAttribute: Bool
     let styledElement: Bool
+    let upwardInt: Bool
+    let upwardSelector: Bool
   }
 
   @MainActor func testSiteStateListenerScript() async throws {
@@ -251,6 +253,8 @@ final class ScriptExecutionTests: XCTestCase {
         "brave.com###test-remove-class:remove-class(test)",
         "brave.com###test-remove-attribute:remove-attr(test)",
         "brave.com###test-style-element:style(background-color: red !important)",
+        "brave.com###test-upward-int-target:upward(2)",
+        "brave.com###test-upward-selector-target:upward(#test-upward-selector)",
       ].joined(separator: "\n")
     )
     let proceduralFilters = try engine.cosmeticFilterModel(
@@ -417,5 +421,7 @@ final class ScriptExecutionTests: XCTestCase {
     XCTAssertTrue(resultsAfterPump?.removedAttribute ?? false)
     XCTAssertTrue(resultsAfterPump?.removedClass ?? false)
     XCTAssertTrue(resultsAfterPump?.styledElement ?? false)
+    XCTAssertTrue(resultsAfterPump?.upwardInt ?? false)
+    XCTAssertTrue(resultsAfterPump?.upwardSelector ?? false)
   }
 }


### PR DESCRIPTION
- Resolves both `:upward` filter Testcase 20 & Testcase 21 on the procedural filters test site.
    - Updates `SelectorsPollerScript.js` to align the iOS `performAction` with desktop `performAction` function: https://github.com/brave/brave-core/blob/9a79082cd72877f8cd0d02742835a3997c319476/components/cosmetic_filters/resources/data/content_cosmetic.ts#L733-L741
- Merging into Procedural Filters PR: https://github.com/brave/brave-core/pull/24688 to match previous workflow.
    - All expected test cases in Procedural Filters PR should pass (expect Testcase 29 which will be resolves with https://github.com/brave/brave-browser/issues/40771)

Resolves https://github.com/brave/brave-browser/issues/40861

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Add to Custom Filters:
```
! Hide warning
antonok.com,testcases.agrd.dev,pages.dev###subscribe-to-test-extended-css-rules-filter
! Case 20
antonok.com,testcases.agrd.dev,pages.dev#?#.test-upward-selector:upward(#case20)
! Case 21
antonok.com,testcases.agrd.dev,pages.dev#?#.test-upward-number-case21:upward(4)
```
2. Visit https://antonok.com/tmp/procedural-filter-tests/index.html
3. Verify Testcase 20 & Testcase 21 pass