### PR TITLE
[ads] Fix intermittent crash on database call during shutdown

### DIFF
--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.h
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.h
@@ -50,16 +50,16 @@ class ConfirmationQueue final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const ConfirmationQueueItemList& confirmation_queue_items) const;
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const ConfirmationQueueItemList& confirmation_queue_items) const;
 
   int batch_size_;

--- a/components/brave_ads/core/internal/account/deposits/deposits_database_table.h
+++ b/components/brave_ads/core/internal/account/deposits/deposits_database_table.h
@@ -26,9 +26,9 @@ class Deposits final : public TableInterface {
  public:
   void Save(const DepositInfo& deposit, ResultCallback callback);
 
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeAdList& creative_ads);
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const DepositInfo& deposit);
 
   void GetForCreativeInstanceId(const std::string& creative_instance_id,
@@ -38,14 +38,14 @@ class Deposits final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const CreativeAdList& creative_ads) const;
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const DepositInfo& deposit) const;
 };
 

--- a/components/brave_ads/core/internal/account/transactions/transactions_database_table.h
+++ b/components/brave_ads/core/internal/account/transactions/transactions_database_table.h
@@ -39,15 +39,15 @@ class Transactions final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const TransactionList& transactions);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const TransactionList& transactions) const;
 };
 

--- a/components/brave_ads/core/internal/common/database/database_column_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_column_util.cc
@@ -92,7 +92,7 @@ void BindColumn(sql::Statement* const statement,
   }
 }
 
-void BindColumnInt(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnInt(const mojom::DBActionInfoPtr& mojom_db_action,
                    const int32_t index,
                    const int32_t value) {
   CHECK(mojom_db_action);
@@ -106,7 +106,7 @@ void BindColumnInt(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-int ColumnInt(const mojom::DBRowInfo* const mojom_db_row, const size_t column) {
+int ColumnInt(const mojom::DBRowInfoPtr& mojom_db_row, const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());
   CHECK_EQ(mojom::DBColumnValueUnion::Tag::kIntValue,
@@ -115,7 +115,7 @@ int ColumnInt(const mojom::DBRowInfo* const mojom_db_row, const size_t column) {
   return mojom_db_row->column_values_union.at(column)->get_int_value();
 }
 
-void BindColumnInt64(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnInt64(const mojom::DBActionInfoPtr& mojom_db_action,
                      const int32_t index,
                      const int64_t value) {
   CHECK(mojom_db_action);
@@ -129,7 +129,7 @@ void BindColumnInt64(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-int64_t ColumnInt64(const mojom::DBRowInfo* const mojom_db_row,
+int64_t ColumnInt64(const mojom::DBRowInfoPtr& mojom_db_row,
                     const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());
@@ -139,7 +139,7 @@ int64_t ColumnInt64(const mojom::DBRowInfo* const mojom_db_row,
   return mojom_db_row->column_values_union.at(column)->get_int64_value();
 }
 
-void BindColumnDouble(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnDouble(const mojom::DBActionInfoPtr& mojom_db_action,
                       const int32_t index,
                       const double value) {
   CHECK(mojom_db_action);
@@ -153,7 +153,7 @@ void BindColumnDouble(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-double ColumnDouble(const mojom::DBRowInfo* const mojom_db_row,
+double ColumnDouble(const mojom::DBRowInfoPtr& mojom_db_row,
                     const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());
@@ -163,7 +163,7 @@ double ColumnDouble(const mojom::DBRowInfo* const mojom_db_row,
   return mojom_db_row->column_values_union.at(column)->get_double_value();
 }
 
-void BindColumnBool(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnBool(const mojom::DBActionInfoPtr& mojom_db_action,
                     const int32_t index,
                     const bool value) {
   CHECK(mojom_db_action);
@@ -177,8 +177,7 @@ void BindColumnBool(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-bool ColumnBool(const mojom::DBRowInfo* const mojom_db_row,
-                const size_t column) {
+bool ColumnBool(const mojom::DBRowInfoPtr& mojom_db_row, const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());
   CHECK_EQ(mojom::DBColumnValueUnion::Tag::kBoolValue,
@@ -187,7 +186,7 @@ bool ColumnBool(const mojom::DBRowInfo* const mojom_db_row,
   return mojom_db_row->column_values_union.at(column)->get_bool_value();
 }
 
-void BindColumnString(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnString(const mojom::DBActionInfoPtr& mojom_db_action,
                       const int32_t index,
                       const std::string& value) {
   CHECK(mojom_db_action);
@@ -201,7 +200,7 @@ void BindColumnString(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-std::string ColumnString(const mojom::DBRowInfo* const mojom_db_row,
+std::string ColumnString(const mojom::DBRowInfoPtr& mojom_db_row,
                          const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());
@@ -211,7 +210,7 @@ std::string ColumnString(const mojom::DBRowInfo* const mojom_db_row,
   return mojom_db_row->column_values_union.at(column)->get_string_value();
 }
 
-void BindColumnTime(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnTime(const mojom::DBActionInfoPtr& mojom_db_action,
                     const int32_t index,
                     const base::Time value) {
   CHECK(mojom_db_action);
@@ -225,7 +224,7 @@ void BindColumnTime(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-base::Time ColumnTime(const mojom::DBRowInfo* const mojom_db_row,
+base::Time ColumnTime(const mojom::DBRowInfoPtr& mojom_db_row,
                       const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());
@@ -235,7 +234,7 @@ base::Time ColumnTime(const mojom::DBRowInfo* const mojom_db_row,
   return mojom_db_row->column_values_union.at(column)->get_time_value();
 }
 
-void BindColumnTimeDelta(mojom::DBActionInfo* const mojom_db_action,
+void BindColumnTimeDelta(const mojom::DBActionInfoPtr& mojom_db_action,
                          const int32_t index,
                          const base::TimeDelta value) {
   CHECK(mojom_db_action);
@@ -249,7 +248,7 @@ void BindColumnTimeDelta(mojom::DBActionInfo* const mojom_db_action,
   mojom_db_action->bind_columns.push_back(std::move(mojom_db_bind_column));
 }
 
-base::TimeDelta ColumnTimeDelta(const mojom::DBRowInfo* const mojom_db_row,
+base::TimeDelta ColumnTimeDelta(const mojom::DBRowInfoPtr& mojom_db_row,
                                 const size_t column) {
   CHECK(mojom_db_row);
   CHECK_LT(column, mojom_db_row->column_values_union.size());

--- a/components/brave_ads/core/internal/common/database/database_column_util.h
+++ b/components/brave_ads/core/internal/common/database/database_column_util.h
@@ -21,47 +21,47 @@ std::string BuildBindColumnPlaceholders(size_t column_count, size_t row_count);
 void BindColumn(sql::Statement* statement,
                 const mojom::DBBindColumnInfo& mojom_db_bind_column);
 
-void BindColumnInt(mojom::DBActionInfo* mojom_db_action,
+void BindColumnInt(const mojom::DBActionInfoPtr& mojom_db_action,
                    int32_t index,
                    int32_t value);
-[[nodiscard]] int ColumnInt(const mojom::DBRowInfo* mojom_db_row,
+[[nodiscard]] int ColumnInt(const mojom::DBRowInfoPtr& mojom_db_row,
                             size_t column);
 
-void BindColumnInt64(mojom::DBActionInfo* mojom_db_action,
+void BindColumnInt64(const mojom::DBActionInfoPtr& mojom_db_action,
                      int32_t index,
                      int64_t value);
-[[nodiscard]] int64_t ColumnInt64(const mojom::DBRowInfo* mojom_db_row,
+[[nodiscard]] int64_t ColumnInt64(const mojom::DBRowInfoPtr& mojom_db_row,
                                   size_t column);
 
-void BindColumnDouble(mojom::DBActionInfo* mojom_db_action,
+void BindColumnDouble(const mojom::DBActionInfoPtr& mojom_db_action,
                       int32_t index,
                       double value);
-[[nodiscard]] double ColumnDouble(const mojom::DBRowInfo* mojom_db_row,
+[[nodiscard]] double ColumnDouble(const mojom::DBRowInfoPtr& mojom_db_row,
                                   size_t column);
 
-void BindColumnBool(mojom::DBActionInfo* mojom_db_action,
+void BindColumnBool(const mojom::DBActionInfoPtr& mojom_db_action,
                     int32_t index,
                     bool value);
-[[nodiscard]] bool ColumnBool(const mojom::DBRowInfo* mojom_db_row,
+[[nodiscard]] bool ColumnBool(const mojom::DBRowInfoPtr& mojom_db_row,
                               size_t column);
 
-void BindColumnString(mojom::DBActionInfo* mojom_db_action,
+void BindColumnString(const mojom::DBActionInfoPtr& mojom_db_action,
                       int32_t index,
                       const std::string& value);
-[[nodiscard]] std::string ColumnString(const mojom::DBRowInfo* mojom_db_row,
+[[nodiscard]] std::string ColumnString(const mojom::DBRowInfoPtr& mojom_db_row,
                                        size_t column);
 
-void BindColumnTime(mojom::DBActionInfo* mojom_db_action,
+void BindColumnTime(const mojom::DBActionInfoPtr& mojom_db_action,
                     int32_t index,
                     base::Time value);
-[[nodiscard]] base::Time ColumnTime(const mojom::DBRowInfo* mojom_db_row,
+[[nodiscard]] base::Time ColumnTime(const mojom::DBRowInfoPtr& mojom_db_row,
                                     size_t column);
 
-void BindColumnTimeDelta(mojom::DBActionInfo* mojom_db_action,
+void BindColumnTimeDelta(const mojom::DBActionInfoPtr& mojom_db_action,
                          int32_t index,
                          base::TimeDelta value);
 [[nodiscard]] base::TimeDelta ColumnTimeDelta(
-    const mojom::DBRowInfo* mojom_db_row,
+    const mojom::DBRowInfoPtr& mojom_db_row,
     size_t column);
 
 }  // namespace brave_ads::database

--- a/components/brave_ads/core/internal/common/database/database_table_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_table_util.cc
@@ -12,7 +12,7 @@
 
 namespace brave_ads::database {
 
-void CreateTableIndex(mojom::DBTransactionInfo* const mojom_db_transaction,
+void CreateTableIndex(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const std::string& table_name,
                       const std::vector<std::string>& columns) {
   CHECK(mojom_db_transaction);
@@ -26,7 +26,7 @@ void CreateTableIndex(mojom::DBTransactionInfo* const mojom_db_transaction,
            base::JoinString(columns, ", ")});
 }
 
-void DropTableIndex(mojom::DBTransactionInfo* const mojom_db_transaction,
+void DropTableIndex(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                     const std::string& index_name) {
   CHECK(mojom_db_transaction);
   CHECK(!index_name.empty());
@@ -36,7 +36,7 @@ void DropTableIndex(mojom::DBTransactionInfo* const mojom_db_transaction,
         ad_events_created_at_index;)");
 }
 
-void DropTable(mojom::DBTransactionInfo* const mojom_db_transaction,
+void DropTable(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                const std::string& table_name) {
   CHECK(mojom_db_transaction);
   CHECK(!table_name.empty());
@@ -47,7 +47,7 @@ void DropTable(mojom::DBTransactionInfo* const mojom_db_transaction,
           {table_name});
 }
 
-void DeleteTable(mojom::DBTransactionInfo* const mojom_db_transaction,
+void DeleteTable(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                  const std::string& table_name) {
   CHECK(mojom_db_transaction);
   CHECK(!table_name.empty());
@@ -58,7 +58,7 @@ void DeleteTable(mojom::DBTransactionInfo* const mojom_db_transaction,
           {table_name});
 }
 
-void CopyTableColumns(mojom::DBTransactionInfo* const mojom_db_transaction,
+void CopyTableColumns(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const std::string& from,
                       const std::string& to,
                       const std::vector<std::string>& from_columns,
@@ -88,7 +88,7 @@ void CopyTableColumns(mojom::DBTransactionInfo* const mojom_db_transaction,
   }
 }
 
-void CopyTableColumns(mojom::DBTransactionInfo* const mojom_db_transaction,
+void CopyTableColumns(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const std::string& from,
                       const std::string& to,
                       const std::vector<std::string>& columns,
@@ -97,7 +97,7 @@ void CopyTableColumns(mojom::DBTransactionInfo* const mojom_db_transaction,
                           should_drop);
 }
 
-void RenameTable(mojom::DBTransactionInfo* const mojom_db_transaction,
+void RenameTable(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                  const std::string& from,
                  const std::string& to) {
   CHECK(mojom_db_transaction);

--- a/components/brave_ads/core/internal/common/database/database_table_util.h
+++ b/components/brave_ads/core/internal/common/database/database_table_util.h
@@ -13,33 +13,33 @@
 
 namespace brave_ads::database {
 
-void CreateTableIndex(mojom::DBTransactionInfo* mojom_db_transaction,
+void CreateTableIndex(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const std::string& table_name,
                       const std::vector<std::string>& columns);
 
-void DropTableIndex(mojom::DBTransactionInfo* mojom_db_transaction,
+void DropTableIndex(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                     const std::string& index_name);
 
-void DropTable(mojom::DBTransactionInfo* mojom_db_transaction,
+void DropTable(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                const std::string& table_name);
 
-void DeleteTable(mojom::DBTransactionInfo* mojom_db_transaction,
+void DeleteTable(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                  const std::string& table_name);
 
-void CopyTableColumns(mojom::DBTransactionInfo* mojom_db_transaction,
+void CopyTableColumns(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const std::string& from,
                       const std::string& to,
                       const std::vector<std::string>& from_columns,
                       const std::vector<std::string>& to_columns,
                       bool should_drop);
 
-void CopyTableColumns(mojom::DBTransactionInfo* mojom_db_transaction,
+void CopyTableColumns(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const std::string& from,
                       const std::string& to,
                       const std::vector<std::string>& columns,
                       bool should_drop);
 
-void RenameTable(mojom::DBTransactionInfo* mojom_db_transaction,
+void RenameTable(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                  const std::string& from,
                  const std::string& to);
 

--- a/components/brave_ads/core/internal/common/database/database_transaction_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_transaction_util.cc
@@ -20,7 +20,7 @@ namespace {
 void RunDBTransactionCallback(
     ResultCallback callback,
     mojom::DBTransactionResultInfoPtr mojom_db_transaction_result) {
-  if (IsError(&*mojom_db_transaction_result)) {
+  if (IsError(mojom_db_transaction_result)) {
     return std::move(callback).Run(/*success=*/false);
   }
 
@@ -30,15 +30,15 @@ void RunDBTransactionCallback(
 }  // namespace
 
 bool IsSuccess(
-    const mojom::DBTransactionResultInfo* const mojom_db_transaction_result) {
-  return mojom_db_transaction_result != nullptr &&
+    const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result) {
+  return mojom_db_transaction_result &&
          mojom_db_transaction_result->status_code ==
              mojom::DBTransactionResultInfo::StatusCode::kSuccess;
 }
 
 bool IsError(
-    const mojom::DBTransactionResultInfo* const mojom_db_transaction_result) {
-  return mojom_db_transaction_result == nullptr ||
+    const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result) {
+  return !mojom_db_transaction_result ||
          mojom_db_transaction_result->status_code !=
              mojom::DBTransactionResultInfo::StatusCode::kSuccess;
 }
@@ -50,13 +50,13 @@ void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
       base::BindOnce(&RunDBTransactionCallback, std::move(callback)));
 }
 
-void Raze(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void Raze(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   mojom_db_transaction->should_raze = true;
 }
 
-void Execute(mojom::DBTransactionInfo* const mojom_db_transaction,
+void Execute(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
              const std::string& sql) {
   CHECK(mojom_db_transaction);
 
@@ -66,7 +66,7 @@ void Execute(mojom::DBTransactionInfo* const mojom_db_transaction,
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
-void Execute(mojom::DBTransactionInfo* const mojom_db_transaction,
+void Execute(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
              const std::string& sql,
              const std::vector<std::string>& subst) {
   CHECK(mojom_db_transaction);
@@ -77,7 +77,7 @@ void Execute(mojom::DBTransactionInfo* const mojom_db_transaction,
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
-void Vacuum(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void Vacuum(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   mojom_db_transaction->should_vacuum = true;

--- a/components/brave_ads/core/internal/common/database/database_transaction_util.h
+++ b/components/brave_ads/core/internal/common/database/database_transaction_util.h
@@ -16,10 +16,11 @@ namespace brave_ads::database {
 
 // Returns true if the transaction result is a success.
 bool IsSuccess(
-    const mojom::DBTransactionResultInfo* mojom_db_transaction_result);
+    const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result);
 
 // Returns true if the transaction result is an error.
-bool IsError(const mojom::DBTransactionResultInfo* mojom_db_transaction_result);
+bool IsError(
+    const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result);
 
 // Run a database transaction.
 void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
@@ -27,19 +28,19 @@ void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
 
 // Raze the database. This must be done before any other actions are run. All
 // tables must be recreated after the raze operation is completed.
-void Raze(mojom::DBTransactionInfo* mojom_db_transaction);
+void Raze(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
 // Execute a SQL statement.
-void Execute(mojom::DBTransactionInfo* mojom_db_transaction,
+void Execute(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
              const std::string& sql);
 
 // Execute a SQL statement with placeholders.
-void Execute(mojom::DBTransactionInfo* mojom_db_transaction,
+void Execute(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
              const std::string& sql,
              const std::vector<std::string>& subst);
 
 // Vacuum the database. This must be done after any other actions are run.
-void Vacuum(mojom::DBTransactionInfo* mojom_db_transaction);
+void Vacuum(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
 }  // namespace brave_ads::database
 

--- a/components/brave_ads/core/internal/creatives/campaigns_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/campaigns_database_table.cc
@@ -23,7 +23,7 @@ namespace {
 
 constexpr char kTableName[] = "campaigns";
 
-size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
+size_t BindColumns(const mojom::DBActionInfoPtr& mojom_db_action,
                    const CreativeAdList& creative_ads) {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
@@ -52,12 +52,12 @@ void Campaigns::Delete(ResultCallback callback) const {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
 
-  DeleteTable(&*mojom_db_transaction, GetTableName());
+  DeleteTable(mojom_db_transaction, GetTableName());
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }
 
-void Campaigns::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+void Campaigns::Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                        const CreativeAdList& creative_ads) {
   CHECK(mojom_db_transaction);
 
@@ -67,7 +67,7 @@ void Campaigns::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
 
   mojom::DBActionInfoPtr mojom_db_action = mojom::DBActionInfo::New();
   mojom_db_action->type = mojom::DBActionInfo::Type::kRunStatement;
-  mojom_db_action->sql = BuildInsertSql(&*mojom_db_action, creative_ads);
+  mojom_db_action->sql = BuildInsertSql(mojom_db_action, creative_ads);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
@@ -75,7 +75,8 @@ std::string Campaigns::GetTableName() const {
   return kTableName;
 }
 
-void Campaigns::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void Campaigns::Create(
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   Execute(mojom_db_transaction, R"(
@@ -90,7 +91,7 @@ void Campaigns::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
       );)");
 }
 
-void Campaigns::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+void Campaigns::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                         const int to_version) {
   CHECK(mojom_db_transaction);
 
@@ -105,7 +106,7 @@ void Campaigns::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
 ///////////////////////////////////////////////////////////////////////////////
 
 void Campaigns::MigrateToV43(
-    mojom::DBTransactionInfo* const mojom_db_transaction) {
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   // We can safely recreate the table because it will be repopulated after
@@ -115,7 +116,7 @@ void Campaigns::MigrateToV43(
 }
 
 std::string Campaigns::BuildInsertSql(
-    mojom::DBActionInfo* mojom_db_action,
+    const mojom::DBActionInfoPtr& mojom_db_action,
     const CreativeAdList& creative_ads) const {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());

--- a/components/brave_ads/core/internal/creatives/campaigns_database_table.h
+++ b/components/brave_ads/core/internal/creatives/campaigns_database_table.h
@@ -17,21 +17,21 @@ namespace brave_ads::database::table {
 
 class Campaigns final : public TableInterface {
  public:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeAdList& creative_ads);
 
   void Delete(ResultCallback callback) const;
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const CreativeAdList& creative_ads) const;
 };
 

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.h
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.h
@@ -31,16 +31,16 @@ class CreativeSetConversions final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeSetConversionList& creative_set_conversions);
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const CreativeSetConversionList& creative_set_conversions) const;
 };
 

--- a/components/brave_ads/core/internal/creatives/creative_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/creative_ads_database_table.h
@@ -23,7 +23,7 @@ using GetCreativeAdCallback =
 
 class CreativeAds final : public TableInterface {
  public:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeAdList& creative_ads);
 
   void Delete(ResultCallback callback) const;
@@ -33,14 +33,14 @@ class CreativeAds final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const CreativeAdList& creative_ads) const;
 };
 

--- a/components/brave_ads/core/internal/creatives/dayparts_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/dayparts_database_table.cc
@@ -21,7 +21,7 @@ namespace {
 
 constexpr char kTableName[] = "dayparts";
 
-size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
+size_t BindColumns(const mojom::DBActionInfoPtr& mojom_db_action,
                    const CreativeAdList& creative_ads) {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
@@ -45,7 +45,7 @@ size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
 
 }  // namespace
 
-void Dayparts::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+void Dayparts::Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const CreativeAdList& creative_ads) {
   CHECK(mojom_db_transaction);
 
@@ -55,7 +55,7 @@ void Dayparts::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
 
   mojom::DBActionInfoPtr mojom_db_action = mojom::DBActionInfo::New();
   mojom_db_action->type = mojom::DBActionInfo::Type::kRunStatement;
-  mojom_db_action->sql = BuildInsertSql(&*mojom_db_action, creative_ads);
+  mojom_db_action->sql = BuildInsertSql(mojom_db_action, creative_ads);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
@@ -63,7 +63,7 @@ void Dayparts::Delete(ResultCallback callback) const {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
 
-  DeleteTable(&*mojom_db_transaction, GetTableName());
+  DeleteTable(mojom_db_transaction, GetTableName());
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }
@@ -72,7 +72,7 @@ std::string Dayparts::GetTableName() const {
   return kTableName;
 }
 
-void Dayparts::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void Dayparts::Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   Execute(mojom_db_transaction, R"(
@@ -90,7 +90,7 @@ void Dayparts::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
       );)");
 }
 
-void Dayparts::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+void Dayparts::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                        const int to_version) {
   CHECK(mojom_db_transaction);
 
@@ -105,7 +105,7 @@ void Dayparts::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
 ///////////////////////////////////////////////////////////////////////////////
 
 void Dayparts::MigrateToV43(
-    mojom::DBTransactionInfo* const mojom_db_transaction) {
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   // We can safely recreate the table because it will be repopulated after
@@ -114,8 +114,9 @@ void Dayparts::MigrateToV43(
   Create(mojom_db_transaction);
 }
 
-std::string Dayparts::BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
-                                     const CreativeAdList& creative_ads) const {
+std::string Dayparts::BuildInsertSql(
+    const mojom::DBActionInfoPtr& mojom_db_action,
+    const CreativeAdList& creative_ads) const {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
 

--- a/components/brave_ads/core/internal/creatives/dayparts_database_table.h
+++ b/components/brave_ads/core/internal/creatives/dayparts_database_table.h
@@ -17,21 +17,21 @@ namespace brave_ads::database::table {
 
 class Dayparts final : public TableInterface {
  public:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeAdList& creative_ads);
 
   void Delete(ResultCallback callback) const;
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const CreativeAdList& creative_ads) const;
 };
 

--- a/components/brave_ads/core/internal/creatives/geo_targets_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/geo_targets_database_table.cc
@@ -21,7 +21,7 @@ namespace {
 
 constexpr char kTableName[] = "geo_targets";
 
-size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
+size_t BindColumns(const mojom::DBActionInfoPtr& mojom_db_action,
                    const CreativeAdList& creative_ads) {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
@@ -43,7 +43,7 @@ size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
 
 }  // namespace
 
-void GeoTargets::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+void GeoTargets::Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                         const CreativeAdList& creative_ads) {
   CHECK(mojom_db_transaction);
 
@@ -53,7 +53,7 @@ void GeoTargets::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
 
   mojom::DBActionInfoPtr mojom_db_action = mojom::DBActionInfo::New();
   mojom_db_action->type = mojom::DBActionInfo::Type::kRunStatement;
-  mojom_db_action->sql = BuildInsertSql(&*mojom_db_action, creative_ads);
+  mojom_db_action->sql = BuildInsertSql(mojom_db_action, creative_ads);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
@@ -61,7 +61,7 @@ void GeoTargets::Delete(ResultCallback callback) const {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
 
-  DeleteTable(&*mojom_db_transaction, GetTableName());
+  DeleteTable(mojom_db_transaction, GetTableName());
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }
@@ -70,7 +70,8 @@ std::string GeoTargets::GetTableName() const {
   return kTableName;
 }
 
-void GeoTargets::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void GeoTargets::Create(
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   Execute(mojom_db_transaction, R"(
@@ -84,8 +85,9 @@ void GeoTargets::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
       );)");
 }
 
-void GeoTargets::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
-                         const int to_version) {
+void GeoTargets::Migrate(
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction,
+    const int to_version) {
   CHECK(mojom_db_transaction);
 
   switch (to_version) {
@@ -99,7 +101,7 @@ void GeoTargets::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
 ///////////////////////////////////////////////////////////////////////////////
 
 void GeoTargets::MigrateToV43(
-    mojom::DBTransactionInfo* const mojom_db_transaction) {
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   // We can safely recreate the table because it will be repopulated after
@@ -109,7 +111,7 @@ void GeoTargets::MigrateToV43(
 }
 
 std::string GeoTargets::BuildInsertSql(
-    mojom::DBActionInfo* mojom_db_action,
+    const mojom::DBActionInfoPtr& mojom_db_action,
     const CreativeAdList& creative_ads) const {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());

--- a/components/brave_ads/core/internal/creatives/geo_targets_database_table.h
+++ b/components/brave_ads/core/internal/creatives/geo_targets_database_table.h
@@ -17,21 +17,21 @@ namespace brave_ads::database::table {
 
 class GeoTargets final : public TableInterface {
  public:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeAdList& creative_ads);
 
   void Delete(ResultCallback callback) const;
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const CreativeAdList& creative_ads) const;
 };
 

--- a/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table.h
@@ -80,18 +80,18 @@ class CreativeInlineContentAds final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeInlineContentAdList& creative_ads);
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const CreativeInlineContentAdList& creative_ads) const;
 
   int batch_size_;

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_wallpapers_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_wallpapers_database_table.cc
@@ -23,7 +23,7 @@ namespace {
 
 constexpr char kTableName[] = "creative_new_tab_page_ad_wallpapers";
 
-size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
+size_t BindColumns(const mojom::DBActionInfoPtr& mojom_db_action,
                    const CreativeNewTabPageAdList& creative_ads) {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
@@ -49,7 +49,7 @@ size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
 }  // namespace
 
 void CreativeNewTabPageAdWallpapers::Insert(
-    mojom::DBTransactionInfo* mojom_db_transaction,
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction,
     const CreativeNewTabPageAdList& creative_ads) {
   CHECK(mojom_db_transaction);
 
@@ -65,8 +65,7 @@ void CreativeNewTabPageAdWallpapers::Insert(
 
   mojom::DBActionInfoPtr mojom_db_action = mojom::DBActionInfo::New();
   mojom_db_action->type = mojom::DBActionInfo::Type::kRunStatement;
-  mojom_db_action->sql =
-      BuildInsertSql(&*mojom_db_action, filtered_creative_ads);
+  mojom_db_action->sql = BuildInsertSql(mojom_db_action, filtered_creative_ads);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
@@ -74,7 +73,7 @@ void CreativeNewTabPageAdWallpapers::Delete(ResultCallback callback) const {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
 
-  DeleteTable(&*mojom_db_transaction, GetTableName());
+  DeleteTable(mojom_db_transaction, GetTableName());
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }
@@ -84,7 +83,7 @@ std::string CreativeNewTabPageAdWallpapers::GetTableName() const {
 }
 
 void CreativeNewTabPageAdWallpapers::Create(
-    mojom::DBTransactionInfo* const mojom_db_transaction) {
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   Execute(mojom_db_transaction, R"(
@@ -103,7 +102,7 @@ void CreativeNewTabPageAdWallpapers::Create(
 }
 
 void CreativeNewTabPageAdWallpapers::Migrate(
-    mojom::DBTransactionInfo* mojom_db_transaction,
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction,
     const int to_version) {
   CHECK(mojom_db_transaction);
 
@@ -118,7 +117,7 @@ void CreativeNewTabPageAdWallpapers::Migrate(
 ///////////////////////////////////////////////////////////////////////////////
 
 void CreativeNewTabPageAdWallpapers::MigrateToV43(
-    mojom::DBTransactionInfo* const mojom_db_transaction) {
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   // We can safely recreate the table because it will be repopulated after
@@ -128,7 +127,7 @@ void CreativeNewTabPageAdWallpapers::MigrateToV43(
 }
 
 std::string CreativeNewTabPageAdWallpapers::BuildInsertSql(
-    mojom::DBActionInfo* mojom_db_action,
+    const mojom::DBActionInfoPtr& mojom_db_action,
     const CreativeNewTabPageAdList& creative_ads) const {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_wallpapers_database_table.h
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ad_wallpapers_database_table.h
@@ -17,22 +17,22 @@ namespace brave_ads::database::table {
 
 class CreativeNewTabPageAdWallpapers final : public TableInterface {
  public:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeNewTabPageAdList& creative_ads);
 
   void Delete(ResultCallback callback) const;
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const CreativeNewTabPageAdList& creative_ads) const;
 };
 

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h
@@ -69,18 +69,18 @@ class CreativeNewTabPageAds final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeNewTabPageAdList& creative_ads);
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const CreativeNewTabPageAdList& creative_ads) const;
 
   int batch_size_;

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h
@@ -60,19 +60,20 @@ class CreativeNotificationAds final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  static void MigrateToV37(mojom::DBTransactionInfo* mojom_db_transaction);
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  static void MigrateToV37(
+      const mojom::DBTransactionInfoPtr& mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeNotificationAdList& creative_ads);
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const CreativeNotificationAdList& creative_ads) const;
 
   int batch_size_;

--- a/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table.h
+++ b/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table.h
@@ -72,18 +72,18 @@ class CreativePromotedContentAds final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativePromotedContentAdList& creative_ads);
 
   std::string BuildInsertSql(
-      mojom::DBActionInfo* mojom_db_action,
+      const mojom::DBActionInfoPtr& mojom_db_action,
       const CreativePromotedContentAdList& creative_ads) const;
 
   int batch_size_;

--- a/components/brave_ads/core/internal/creatives/segments_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/segments_database_table.cc
@@ -21,7 +21,7 @@ namespace {
 
 constexpr char kTableName[] = "segments";
 
-size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
+size_t BindColumns(const mojom::DBActionInfoPtr& mojom_db_action,
                    const CreativeAdList& creative_ads) {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
@@ -41,7 +41,7 @@ size_t BindColumns(mojom::DBActionInfo* mojom_db_action,
 
 }  // namespace
 
-void Segments::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+void Segments::Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const CreativeAdList& creative_ads) {
   CHECK(mojom_db_transaction);
 
@@ -51,7 +51,7 @@ void Segments::Insert(mojom::DBTransactionInfo* mojom_db_transaction,
 
   mojom::DBActionInfoPtr mojom_db_action = mojom::DBActionInfo::New();
   mojom_db_action->type = mojom::DBActionInfo::Type::kRunStatement;
-  mojom_db_action->sql = BuildInsertSql(&*mojom_db_action, creative_ads);
+  mojom_db_action->sql = BuildInsertSql(mojom_db_action, creative_ads);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 }
 
@@ -59,7 +59,7 @@ void Segments::Delete(ResultCallback callback) const {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
 
-  DeleteTable(&*mojom_db_transaction, GetTableName());
+  DeleteTable(mojom_db_transaction, GetTableName());
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }
@@ -68,7 +68,7 @@ std::string Segments::GetTableName() const {
   return kTableName;
 }
 
-void Segments::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void Segments::Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   Execute(mojom_db_transaction, R"(
@@ -82,7 +82,7 @@ void Segments::Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
       );)");
 }
 
-void Segments::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+void Segments::Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                        const int to_version) {
   CHECK(mojom_db_transaction);
 
@@ -97,7 +97,7 @@ void Segments::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
 ///////////////////////////////////////////////////////////////////////////////
 
 void Segments::MigrateToV43(
-    mojom::DBTransactionInfo* const mojom_db_transaction) {
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   // We can safely recreate the table because it will be repopulated after
@@ -106,8 +106,9 @@ void Segments::MigrateToV43(
   Create(mojom_db_transaction);
 }
 
-std::string Segments::BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
-                                     const CreativeAdList& creative_ads) const {
+std::string Segments::BuildInsertSql(
+    const mojom::DBActionInfoPtr& mojom_db_action,
+    const CreativeAdList& creative_ads) const {
   CHECK(mojom_db_action);
   CHECK(!creative_ads.empty());
 

--- a/components/brave_ads/core/internal/creatives/segments_database_table.h
+++ b/components/brave_ads/core/internal/creatives/segments_database_table.h
@@ -17,21 +17,21 @@ namespace brave_ads::database::table {
 
 class Segments final : public TableInterface {
  public:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const CreativeAdList& creative_ads);
 
   void Delete(ResultCallback callback) const;
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void MigrateToV43(mojom::DBTransactionInfo* mojom_db_transaction);
+  void MigrateToV43(const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const CreativeAdList& creative_ads) const;
 };
 

--- a/components/brave_ads/core/internal/database/database_manager.cc
+++ b/components/brave_ads/core/internal/database/database_manager.cc
@@ -64,7 +64,7 @@ void DatabaseManager::CreateOrOpen(ResultCallback callback) {
 void DatabaseManager::CreateOrOpenCallback(
     ResultCallback callback,
     mojom::DBTransactionResultInfoPtr mojom_db_transaction_result) {
-  if (database::IsError(&*mojom_db_transaction_result)) {
+  if (database::IsError(mojom_db_transaction_result)) {
     BLOG(0, "Failed to create or open database");
 
     NotifyFailedToCreateOrOpenDatabase();

--- a/components/brave_ads/core/internal/database/database_table_interface.cc
+++ b/components/brave_ads/core/internal/database/database_table_interface.cc
@@ -7,11 +7,13 @@
 
 #include "base/check.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_constants.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 
 namespace brave_ads::database {
 
-void TableInterface::Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
-                             const int to_version) {
+void TableInterface::Migrate(
+    const mojom::DBTransactionInfoPtr& mojom_db_transaction,
+    const int to_version) {
   CHECK(mojom_db_transaction);
 
   if (to_version == kVersionNumber) {

--- a/components/brave_ads/core/internal/database/database_table_interface.h
+++ b/components/brave_ads/core/internal/database/database_table_interface.h
@@ -18,8 +18,9 @@ class TableInterface {
 
   virtual std::string GetTableName() const = 0;
 
-  virtual void Create(mojom::DBTransactionInfo* mojom_db_transaction) = 0;
-  virtual void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  virtual void Create(
+      const mojom::DBTransactionInfoPtr& mojom_db_transaction) = 0;
+  virtual void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                        int to_version);
 };
 

--- a/components/brave_ads/core/internal/history/ad_history_database_table.h
+++ b/components/brave_ads/core/internal/history/ad_history_database_table.h
@@ -43,15 +43,15 @@ class AdHistory final : public TableInterface {
 
   std::string GetTableName() const override;
 
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const AdHistoryList& ad_history) const;
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const AdHistoryList& ad_history) const;
 
   int batch_size_;

--- a/components/brave_ads/core/internal/legacy_migration/database/database_creation.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_creation.cc
@@ -31,7 +31,7 @@ namespace brave_ads::database {
 
 namespace {
 
-void Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   Execute(mojom_db_transaction, "PRAGMA auto_vacuum = FULL;");
@@ -93,7 +93,7 @@ void Create(mojom::DBTransactionInfo* const mojom_db_transaction) {
 void Create(ResultCallback callback) {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
-  Create(&*mojom_db_transaction);
+  Create(mojom_db_transaction);
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }

--- a/components/brave_ads/core/internal/legacy_migration/database/database_migration.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_migration.cc
@@ -32,7 +32,7 @@ namespace brave_ads::database {
 
 namespace {
 
-void MigrateToV44(mojom::DBTransactionInfo* const mojom_db_transaction) {
+void MigrateToV44(const mojom::DBTransactionInfoPtr& mojom_db_transaction) {
   CHECK(mojom_db_transaction);
 
   // Normally, whether or not the database supports `auto_vacuum` must be
@@ -45,7 +45,7 @@ void MigrateToV44(mojom::DBTransactionInfo* const mojom_db_transaction) {
   Vacuum(mojom_db_transaction);
 }
 
-void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
              const int to_version) {
   CHECK(mojom_db_transaction);
 
@@ -57,7 +57,7 @@ void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
   }
 }
 
-void MigrateToVersion(mojom::DBTransactionInfo* mojom_db_transaction,
+void MigrateToVersion(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                       const int to_version) {
   CHECK(mojom_db_transaction);
 
@@ -129,7 +129,7 @@ void MigrateFromVersion(const int from_version, ResultCallback callback) {
       mojom::DBTransactionInfo::New();
 
   for (int i = from_version + 1; i <= kVersionNumber; ++i) {
-    MigrateToVersion(&*mojom_db_transaction, i);
+    MigrateToVersion(mojom_db_transaction, i);
   }
 
   mojom::DBActionInfoPtr mojom_db_action = mojom::DBActionInfo::New();

--- a/components/brave_ads/core/internal/legacy_migration/database/database_raze.cc
+++ b/components/brave_ads/core/internal/legacy_migration/database/database_raze.cc
@@ -15,7 +15,7 @@ namespace brave_ads::database {
 void Raze(ResultCallback callback) {
   mojom::DBTransactionInfoPtr mojom_db_transaction =
       mojom::DBTransactionInfo::New();
-  database::Raze(&*mojom_db_transaction);
+  database::Raze(mojom_db_transaction);
 
   RunDBTransaction(std::move(mojom_db_transaction), std::move(callback));
 }

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.h
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.h
@@ -39,15 +39,15 @@ class AdEvents final : public TableInterface {
   void PurgeAllOrphaned(ResultCallback callback) const;
 
   std::string GetTableName() const override;
-  void Create(mojom::DBTransactionInfo* mojom_db_transaction) override;
-  void Migrate(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Create(const mojom::DBTransactionInfoPtr& mojom_db_transaction) override;
+  void Migrate(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
                int to_version) override;
 
  private:
-  void Insert(mojom::DBTransactionInfo* mojom_db_transaction,
+  void Insert(const mojom::DBTransactionInfoPtr& mojom_db_transaction,
               const AdEventList& ad_event);
 
-  std::string BuildInsertSql(mojom::DBActionInfo* mojom_db_action,
+  std::string BuildInsertSql(const mojom::DBActionInfoPtr& mojom_db_action,
                              const AdEventList& ad_events) const;
 };
 

--- a/components/brave_ads/core/public/database/database.h
+++ b/components/brave_ads/core/public/database/database.h
@@ -37,31 +37,31 @@ class ADS_EXPORT Database final {
  private:
   mojom::DBTransactionResultInfo::StatusCode RunDBActions(
       const mojom::DBTransactionInfoPtr& mojom_db_transaction,
-      mojom::DBTransactionResultInfo* mojom_db_transaction_result);
+      const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result);
 
   mojom::DBTransactionResultInfo::StatusCode MaybeRaze(
-      const mojom::DBTransactionInfo* mojom_db_transaction);
+      const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
   bool InitializeMetaTable();
 
   bool ShouldCreateTables();
   mojom::DBTransactionResultInfo::StatusCode Initialize(
-      mojom::DBTransactionResultInfo* mojom_db_transaction_result);
+      const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result);
 
   mojom::DBTransactionResultInfo::StatusCode Execute(
-      const mojom::DBActionInfo* mojom_db_action);
+      const mojom::DBActionInfoPtr& mojom_db_action);
 
   mojom::DBTransactionResultInfo::StatusCode RunStatement(
-      const mojom::DBActionInfo* mojom_db_action);
+      const mojom::DBActionInfoPtr& mojom_db_action);
 
   mojom::DBTransactionResultInfo::StatusCode StepStatement(
-      const mojom::DBActionInfo* mojom_db_action,
-      mojom::DBTransactionResultInfo* mojom_db_transaction_result);
+      const mojom::DBActionInfoPtr& mojom_db_action,
+      const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result);
 
   mojom::DBTransactionResultInfo::StatusCode Migrate();
 
   mojom::DBTransactionResultInfo::StatusCode MaybeVacuum(
-      const mojom::DBTransactionInfo* mojom_db_transaction);
+      const mojom::DBTransactionInfoPtr& mojom_db_transaction);
 
   void ErrorCallback(int error, sql::Statement* statement);
 


### PR DESCRIPTION
This is a fix of intermittent crash happening during browser shutdown, which is hard to reproduce. Crash happens only for version 1.71.x.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40791

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This is a fix of intermittent crash happening during browser shutdown, which is hard to reproduce. No manual testing is required.