### PR TITLE
[NTP] Don't hide NTP stats or widgets for "short" windows (uplift to 1.70.x)

### DIFF
--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -165,15 +165,15 @@ export const Page: React.FunctionComponent<React.PropsWithChildren<PageProps>> =
 
 export const GridItemStats = styled('section')`
   grid-column: 1 / span 2;
-  @media screen and (max-height: ${breakpointShortHeight}) {
-    display: none;
-  }
 `
 
 export const GridItemClock = styled('section')`
   grid-column: 3;
   justify-self: center;
   @media screen and (max-width: ${breakpointEveryBlock}) {
+    display: none;
+  }
+  @media screen and (max-height: ${breakpointShortHeight}) {
     display: none;
   }
 `
@@ -185,9 +185,6 @@ export const GridItemWidgetStack = styled('section')`
     max-width: 284px;
   }
   @media screen and (max-width: ${breakpointEveryBlock}) {
-    display: none;
-  }
-  @media screen and (max-height: ${breakpointShortHeight}) {
     display: none;
   }
 `


### PR DESCRIPTION
Uplift of #25429
Resolves https://github.com/brave/brave-browser/issues/39927

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.