### PR TITLE
[iOS] Fix crash when cleaning up rewards internals sharables (uplift to 1.70.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/Rewards Internals/RewardsInternalsShareController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Debug/Rewards Internals/RewardsInternalsShareController.swift
@@ -130,7 +130,7 @@ class RewardsInternalsShareController: UITableViewController {
         self.progressIndiciator.progress = 0
       }
     }
-    Task {
+    Task { [dropDirectory, zipPath] in
       do {
         if await AsyncFileManager.default.fileExists(atPath: dropDirectory.path) {
           try await AsyncFileManager.default.removeItem(at: dropDirectory)


### PR DESCRIPTION
Uplift of #25467
Resolves https://github.com/brave/brave-browser/issues/40819

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.