### PR TITLE
[iOS] - Fix Tab-Bar plus icon not fitting (uplift to 1.69.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabBar/TabsBarViewController.swift
@@ -27,7 +27,6 @@ class TabsBarViewController: UIViewController {
   private lazy var plusButton: UIButton = {
     let button = UIButton()
     button.setImage(UIImage(braveSystemNamed: "leo.plus.add"), for: .normal)
-    button.imageEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
     button.tintColor = .braveLabel
     button.contentMode = .scaleAspectFit
     button.addTarget(self, action: #selector(addTabPressed), for: .touchUpInside)


### PR DESCRIPTION
Uplift of #25481
Resolves https://github.com/brave/brave-browser/issues/40500

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.