### PR TITLE
[SERP->Leo] Support multiple query-answer pairs and fix key extraction

### DIFF
--- a/browser/ai_chat/ai_chat_ui_browsertest.cc
+++ b/browser/ai_chat/ai_chat_ui_browsertest.cc
@@ -66,6 +66,16 @@ std::unique_ptr<net::test_server::HttpResponse> HandleSearchQuerySummaryRequest(
         R"({"conversation": [{"query": "test query",
                                 "answer": [{"text": "test summary"}]}]})");
     return response;
+  } else if (query == "key=multi") {
+    auto response = std::make_unique<net::test_server::BasicHttpResponse>();
+    response->set_code(net::HTTP_OK);
+    response->set_content_type("application/json");
+    response->set_content(
+        R"({"conversation": [{"query": "test query",
+                                "answer": [{"text": "test summary"}]},
+                              {"query": "test query 2",
+                                "answer": [{"text": "test summary 2"}]}]})");
+    return response;
   }
 
   return nullptr;
@@ -167,15 +177,16 @@ class AIChatUIBrowserTest : public InProcessBrowserTest {
     run_loop.Run();
   }
 
-  void FetchSearchQuerySummary(const base::Location& location,
-                               const std::optional<ai_chat::SearchQuerySummary>&
-                                   expected_search_query_summary) {
+  void FetchSearchQuerySummary(
+      const base::Location& location,
+      const std::optional<std::vector<ai_chat::SearchQuerySummary>>&
+          expected_search_query_summary) {
     SCOPED_TRACE(testing::Message() << location.ToString());
 
     base::RunLoop run_loop;
     chat_tab_helper_->MaybeFetchOrClearSearchQuerySummary(
         base::BindLambdaForTesting(
-            [&](const std::optional<ai_chat::SearchQuerySummary>&
+            [&](const std::optional<std::vector<ai_chat::SearchQuerySummary>>&
                     search_query_summary) {
               EXPECT_EQ(search_query_summary, expected_search_query_summary);
               run_loop.Quit();
@@ -339,7 +350,7 @@ IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest,
 }
 
 IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest,
-                       FetchSearchQuerySummary_DynamicMetaTag) {
+                       FetchSearchQuerySummary_DynamicMetaTag_SingleQuery) {
   // Test when summarizer-key meta tag is dynamically inserted, should return
   // the search query summary from the mock response.
   NavigateURL(https_server_.GetURL("search.brave.com", "/search?q=query"));
@@ -348,6 +359,26 @@ IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest,
                               "meta.name = 'summarizer-key';"
                               "meta.content = '{test_key}';"
                               "document.head.appendChild(meta);");
-  FetchSearchQuerySummary(
-      FROM_HERE, ai_chat::SearchQuerySummary("test query", "test summary"));
+  FetchSearchQuerySummary(FROM_HERE, std::vector<ai_chat::SearchQuerySummary>(
+                                         {{"test query", "test summary"}}));
+
+  content::ExecuteScriptAsync(GetActiveWebContents()->GetPrimaryMainFrame(),
+                              "document.querySelector('meta[name=summarizer-"
+                              "key').content = 'multi';");
+}
+
+IN_PROC_BROWSER_TEST_F(AIChatUIBrowserTest,
+                       FetchSearchQuerySummary_DynamicMetaTag_MultiQuery) {
+  // Test when summarizer-key meta tag is dynamically inserted, should return
+  // the search query summary from the mock response.
+  NavigateURL(https_server_.GetURL("search.brave.com", "/search?q=query"));
+  content::ExecuteScriptAsync(GetActiveWebContents()->GetPrimaryMainFrame(),
+                              "var meta = document.createElement('meta');"
+                              "meta.name = 'summarizer-key';"
+                              "meta.content = 'multi';"
+                              "document.head.appendChild(meta);");
+
+  FetchSearchQuerySummary(FROM_HERE, std::vector<ai_chat::SearchQuerySummary>(
+                                         {{"test query", "test summary"},
+                                          {"test query 2", "test summary 2"}}));
 }

--- a/browser/ai_chat/page_content_fetcher_browsertest.cc
+++ b/browser/ai_chat/page_content_fetcher_browsertest.cc
@@ -260,9 +260,17 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, GetSearchSummarizerKey) {
 
   // Test meta with empty key.
   remove_first_summarizer_key();
-  GetSearchSummarizerKey(FROM_HERE, std::nullopt);
+  GetSearchSummarizerKey(FROM_HERE, "");
 
   // Test meta with empty key and other atribute.
+  remove_first_summarizer_key();
+  GetSearchSummarizerKey(FROM_HERE, "");
+
+  // Test meta with plain string key.
+  remove_first_summarizer_key();
+  GetSearchSummarizerKey(FROM_HERE, "plainstring123");
+
+  // Test no summarizer-key meta.
   remove_first_summarizer_key();
   GetSearchSummarizerKey(FROM_HERE, std::nullopt);
 }

--- a/components/ai_chat/core/browser/conversation_driver.h
+++ b/components/ai_chat/core/browser/conversation_driver.h
@@ -209,7 +209,7 @@ class ConversationDriver : public ModelService::Observer {
       mojom::PageContentExtractor::GetSearchSummarizerKeyCallback callback);
 
   using FetchSearchQuerySummaryCallback = base::OnceCallback<void(
-      const std::optional<SearchQuerySummary>& search_query_summary)>;
+      const std::optional<std::vector<SearchQuerySummary>>& entries)>;
 
   // Fetch search query and summary from Brave Search SERP and add them to the
   // conversation history or clear the existing staged search query and summary
@@ -273,6 +273,8 @@ class ConversationDriver : public ModelService::Observer {
       ConversationDriverUnitTest,
       MaybeFetchOrClearSearchQuerySummary_OnConversationActiveChanged);
   FRIEND_TEST_ALL_PREFIXES(ConversationDriverUnitTest,
+                           MaybeFetchOrClearSearchQuerySummary_MultiQuery);
+  FRIEND_TEST_ALL_PREFIXES(ConversationDriverUnitTest,
                            ParseSearchQuerySummaryResponse);
 
   void InitEngine();
@@ -289,8 +291,8 @@ class ConversationDriver : public ModelService::Observer {
 
   void ClearSearchQuerySummary();
   bool ShouldFetchSearchQuerySummary();
-  static std::optional<SearchQuerySummary> ParseSearchQuerySummaryResponse(
-      const base::Value& value);
+  static std::optional<std::vector<SearchQuerySummary>>
+  ParseSearchQuerySummaryResponse(const base::Value& value);
 
   void PerformAssistantGeneration(const std::string& input,
                                   int64_t current_navigation_id,

--- a/components/ai_chat/core/browser/types.h
+++ b/components/ai_chat/core/browser/types.h
@@ -14,12 +14,7 @@ struct SearchQuerySummary {
   std::string query;
   std::string summary;
 
-  SearchQuerySummary(const std::string& query, const std::string& summary)
-      : query(query), summary(summary) {}
-
-  bool operator==(const SearchQuerySummary& other) const {
-    return query == other.query && summary == other.summary;
-  }
+  bool operator==(const SearchQuerySummary& other) const = default;
 };
 
 }  // namespace ai_chat

--- a/components/ai_chat/renderer/BUILD.gn
+++ b/components/ai_chat/renderer/BUILD.gn
@@ -31,7 +31,6 @@ static_library("renderer") {
     "//third_party/blink/public:blink",
     "//third_party/blink/public/common",
     "//third_party/blink/public/strings",
-    "//third_party/re2",
     "//v8",
   ]
 

--- a/components/ai_chat/renderer/DEPS
+++ b/components/ai_chat/renderer/DEPS
@@ -7,7 +7,6 @@ include_rules = [
   "+content/public/renderer",
   "+third_party/abseil-cpp/absl",
   "+third_party/blink/public",
-  "+third_party/re2",
   "+v8/include",
   "+ui/accessibility",
 ]

--- a/test/data/leo/summarizer_key_meta.html
+++ b/test/data/leo/summarizer_key_meta.html
@@ -8,6 +8,7 @@
   <meta id="other_attr" name="summarizer-key" content="&#123;&quot;test&quot;&#125;" other="&#123;&quot;tt&quot;&#125;"></meta>
   <meta id="empty" name="summarizer-key" content=""></meta>
   <meta id="empty_with_other_attr" name="summarizer-key" content="" other="&#123;&quot;tt&quot;&#125;"></meta>
+  <meta id="plain_string_key" name="summarizer-key" content="plainstring123" other="test"></meta>
 </head>
 <body>
   <p>hello</p>


### PR DESCRIPTION
- Support multiple query-answer pairs to support conversation mode (still in development under flag) in Brave SERP
- Move from AXTree to blink APIs for key extraction to support both JSON format and plain string keys (used when conversation mode is enabled in Brave Search), remove the complexity of parsing HTML using regex.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40944

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable `Summarizer chat mode` in Brave Search Experimental features
2. Query `why is spotify losing money` and when the box of follow-up questions shows up, type a follow-up question like `summarize in one sentence`.
3. After answer is generated, open Leo panel
4. Should see both the original and follow-up queries and answers in Leo.
5. Disable the feature
6. Refresh the page, after the answer is generated on Brave SERP, open Leo, should see the query and the summary from Brave SERP.
