### PR TITLE
Add group policy for sync service URL

### DIFF
--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -7,6 +7,7 @@
 #define BRAVE_BROWSER_POLICY_BRAVE_SIMPLE_POLICY_MAP_H_
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
+#include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -44,6 +45,10 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
     {policy::key::kBraveShieldsEnabledForUrls,
      kManagedBraveShieldsEnabledForUrls, base::Value::Type::LIST},
 #endif
+
+    {policy::key::kBraveSyncUrl, brave_sync::kCustomSyncServiceUrl,
+     base::Value::Type::STRING},
+
 #if BUILDFLAG(ENABLE_TOR)
     {policy::key::kTorDisabled, tor::prefs::kTorDisabled,
      base::Value::Type::BOOLEAN},

--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -7,7 +7,6 @@
 #define BRAVE_BROWSER_POLICY_BRAVE_SIMPLE_POLICY_MAP_H_
 
 #include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
-#include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -17,6 +16,7 @@
 
 #if BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
 #include "brave/components/brave_rewards/common/pref_names.h"
+#include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/brave_wallet/common/pref_names.h"
 #endif
 
@@ -44,10 +44,9 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
      kManagedBraveShieldsDisabledForUrls, base::Value::Type::LIST},
     {policy::key::kBraveShieldsEnabledForUrls,
      kManagedBraveShieldsEnabledForUrls, base::Value::Type::LIST},
-#endif
-
     {policy::key::kBraveSyncUrl, brave_sync::kCustomSyncServiceUrl,
      base::Value::Type::STRING},
+#endif
 
 #if BUILDFLAG(ENABLE_TOR)
     {policy::key::kTorDisabled, tor::prefs::kTorDisabled,

--- a/chromium_src/components/policy/tools/generate_policy_source.py
+++ b/chromium_src/components/policy/tools/generate_policy_source.py
@@ -166,6 +166,26 @@ def AddBravePolicies(template_file_contents):
             'desc': ('''This policy allows an admin to specify that Brave '''
                      '''AI Chat feature will be enabled.'''),
         },
+        {
+            'name': 'BraveSyncUrl',
+            'type': 'main',
+            'schema': {
+                'type': 'string'
+            },
+            'supported_on': ['chrome.*:129-'],
+            'features': {
+                'dynamic_refresh': False,
+                'per_profile': True,
+                'can_be_recommended': False,
+                'can_be_mandatory': True
+            },
+            'example_value': ['https://sync-v2.brave.com/v2'],
+            'id': 8,
+            'caption': '''Custom sync server URL.''',
+            'tags': [],
+            'desc': ('''This policy allows an admin to specify a custom '''
+                     '''sync server URL for Brave.'''),
+        },
     ]
 
     # Our new polices are added with highest id

--- a/chromium_src/components/sync/service/DEPS
+++ b/chromium_src/components/sync/service/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
+  "+brave/components/brave_sync",
   "+brave/components/sync/service",
 ]

--- a/chromium_src/components/sync/service/sync_service_impl.cc
+++ b/chromium_src/components/sync/service/sync_service_impl.cc
@@ -3,13 +3,51 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/components/brave_sync/brave_sync_prefs.h"
 #include "brave/components/sync/service/brave_sync_auth_manager.h"
 #include "brave/components/sync/service/brave_sync_stopped_reporter.h"
+#include "components/prefs/pref_service.h"
+#include "components/sync/base/sync_util.h"
+
+namespace syncer {
+
+GURL BraveGetSyncServiceURL(const base::CommandLine& command_line,
+                            version_info::Channel channel,
+                            PrefService* prefs) {
+  // Allow group policy to override sync service URL.
+  // This has a higher priority than the --sync-url command-line param.
+  // https://github.com/brave/brave-browser/issues/20431
+  if (prefs && prefs->IsManagedPreference(brave_sync::kCustomSyncServiceUrl)) {
+    std::string value(prefs->GetString(brave_sync::kCustomSyncServiceUrl));
+    if (!value.empty()) {
+      GURL custom_sync_url(value);
+      // Provided URL must be HTTPS.
+      if (custom_sync_url.is_valid() &&
+          custom_sync_url.SchemeIs(url::kHttpsScheme)) {
+        DVLOG(2) << "Sync URL specified via GPO: "
+                 << prefs->GetString(brave_sync::kCustomSyncServiceUrl);
+        return custom_sync_url;
+      } else {
+        LOG(WARNING) << "The following sync URL specified via GPO "
+                     << "is invalid: " << value;
+      }
+    }
+  }
+
+  // Default logic.
+  // See `GetSyncServiceURL` in `components/sync/base/sync_util.cc`
+  return GetSyncServiceURL(command_line, channel);
+}
+
+}  // namespace syncer
 
 #define SyncAuthManager BraveSyncAuthManager
 #define SyncStoppedReporter BraveSyncStoppedReporter
+#define GetSyncServiceURL(...) \
+  BraveGetSyncServiceURL(__VA_ARGS__, sync_client_->GetPrefService())
 
 #include "src/components/sync/service/sync_service_impl.cc"
 
 #undef SyncAuthManager
 #undef SyncStoppedReporter
+#undef GetSyncServiceURL

--- a/components/brave_sync/brave_sync_prefs.cc
+++ b/components/brave_sync/brave_sync_prefs.cc
@@ -83,6 +83,7 @@ void Prefs::RegisterProfilePrefs(PrefRegistrySimple* registry) {
   registry->RegisterBooleanPref(kSyncFailedDecryptSeedNoticeDismissed, false);
   registry->RegisterBooleanPref(kSyncAccountDeletedNoticePending, false);
   registry->RegisterStringPref(kSyncLeaveChainDetails, std::string());
+  registry->RegisterStringPref(kCustomSyncServiceUrl, std::string());
 }
 
 // static

--- a/components/brave_sync/brave_sync_prefs.h
+++ b/components/brave_sync/brave_sync_prefs.h
@@ -23,6 +23,8 @@ class Time;
 
 namespace brave_sync {
 
+inline constexpr char kCustomSyncServiceUrl[] = "brave_sync.sync_service_url";
+
 class Prefs {
  public:
   explicit Prefs(PrefService* pref_service);


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/20431

Security review https://github.com/brave/reviews/issues/1744

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used GitHub [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Windows
#### Using regedit.exe
1. Open `regedit.exe`
2. Navigate to `HKEY_LOCAL_MACHINE\SOFTWARE\Policies\`
3. Create the key (folders) `BraveSoftware\Brave\` if they don't already exist
4. Create a new string value (`REG_SZ`) with the name `BraveSyncUrl` and the value `https://sync-v2.brave.com/v2`. 
5. Load Brave; verify it shows under brave://policy/
  
#### Adding using a `.reg` file (also on Windows)
1. Create a new empty file called `sync-policy.reg` 
2. Open it in Notepad and put this for the content:
```
Windows Registry Editor Version 5.00

[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\BraveSoftware\Brave]
"BraveSyncUrl"="https://sync-v2.brave.com/v2"
```
3. Save the file and close it
4. Double click the `sync-policy.reg` file to run it (you should get prompted)
5. Load Brave; verify it shows under brave://policy/

### macOS
You can set via the command line. 

- For Brave, you'd use a bundle ID of `com.brave.Browser`, `com.brave.Browser.beta`, or `com.brave.Browser.nightly` (depending on your channel. 
- The key name will be `BraveSyncUrl`
- The value would be the sync server. For example, `https://sync-v2.brave.com/v2`

Steps for Release channel (change bundle ID for other channels)

1. Run the following from command line:
    ```
    defaults write com.brave.Browser BraveSyncUrl -string https://sync-v2.brave.com/v2
    ```

2. Load Brave; verify it shows under brave://policy/



### Linux
You can set the options via `/etc/brave/policies/managed`

Basically, you will make a file with JSON matching the keys/values you'd like to set. Full overview here:
https://source.chromium.org/chromium/chromium/src/+/main:docs/website/site/administrators/linux-quick-start/index.md

### Example of how to set the sync URL
1. create a file 
    ```bash
    vim /etc/brave/policies/managed/sync_url_policy.json
    ```
2. paste in:
    ```json
    {
        "BraveSyncUrl": "https://sync-v2.brave.com/v2"
    }
    ```

3. Save the file and exit (escape; `:wq`, enter)
4. Load Brave; verify it shows under brave://policy/
5. Delete the file after testing is complete
