### PR TITLE
fix(privacy): Adjust iOS HTTPS upgrade error handling

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -659,26 +659,6 @@ extension BrowserViewController: WKNavigationDelegate {
     let response = navigationResponse.response
     let responseURL = response.url
     let tab = tab(for: webView)
-    let isInvalid: Bool
-    if let httpResponse = response as? HTTPURLResponse {
-      isInvalid = httpResponse.statusCode >= 400
-    } else {
-      isInvalid = true
-    }
-
-    // Handle invalid upgrade to https
-    if isInvalid,
-      navigationResponse.isForMainFrame,
-      let responseURL = responseURL,
-      let tab = tab,
-      let originalResponse = handleInvalidHTTPSUpgrade(
-        tab: tab,
-        responseURL: responseURL
-      )
-    {
-      tab.loadRequest(originalResponse)
-      return .cancel
-    }
 
     // Store the response in the tab
     if let responseURL = responseURL {


### PR DESCRIPTION
- Stop considering https upgrade with status code >= 400 as an upgrade failure to align with desktop: https://github.com/brave/brave-core/pull/25346
- This resolves cases where a site gives status code 503 after upgrading http to https (ex. with upgrade of `scrisc.com`)

Resolves https://github.com/brave/brave-browser/issues/40682

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. In shields settings, 'Upgrade Connections to HTTPS' to Standard mode
2. Open new tab
3. Visit `http://scrisc.com/`
4. Verify site is upgraded to `https://scrisc.com`
5. Force quit & relaunch the app (resets exception list). 
    - Not needed if https://github.com/brave/brave-core/pull/25454 has landed & this PR is rebased.
6. In shields settings, 'Upgrade Connections to HTTPS' to Strict mode
7. Open a new tab
8. Visit `http://scrisc.com/`
9. Verify site is upgraded to `https://scrisc.com` and interstitial is not shown 