### PR TITLE
[Android] Changes for unit tests

### DIFF
--- a/build/commands/lib/test.js
+++ b/build/commands/lib/test.js
@@ -20,9 +20,9 @@ const getTestsToRun = (config, suite) => {
   if (suite === 'brave_unit_tests') {
     if (config.targetOS !== 'android') {
       testsToRun.push('brave_installer_unittests')
-    } else {
-      testsToRun.push('bin/run_brave_public_test_apk')
     }
+  } else if (suite === 'brave_java_unit_tests') {
+    testsToRun = ['bin/run_brave_java_unit_tests']
   }
   return testsToRun
 }
@@ -71,14 +71,11 @@ const buildTests = async (suite, buildConfig = config.defaultBuildConfig, option
   let testSuites = [
     'brave_unit_tests',
     'brave_browser_tests',
+    'brave_java_unit_tests',
     'brave_network_audit_tests',
   ]
   if (testSuites.includes(suite)) {
     config.buildTargets = ['brave/test:' + suite]
-    if (suite === 'brave_unit_tests' && config.targetOS === 'android') {
-      // We need to build the APK for the java tests as well.
-      config.buildTargets.push('brave/test:brave_public_test_apk')
-    }
   } else {
     config.buildTargets = [suite]
   }
@@ -168,8 +165,8 @@ const runTests = (passthroughArgs, suite, buildConfig, options) => {
       }
       if (config.targetOS === 'android') {
         assert(
-            config.targetArch === 'x86' || options.manual_android_test_device,
-            'Only x86 build can be run automatically. For other builds please run test device manually and specify manual_android_test_device flag.')
+            config.targetArch === 'x86' || config.targetArch === 'x64' || options.manual_android_test_device,
+            'Only x86 and x64 builds can be run automatically. For other builds please run test device manually and specify manual_android_test_device flag.')
       }
       if (config.targetOS === 'android' && !options.manual_android_test_device) {
         // Specify emulator to run tests on

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -244,7 +244,7 @@ program
   .option('--target_environment <target_environment>', 'target environment (device, catalyst, simulator)')
   .option('--run_disabled_tests', 'run disabled tests')
   .option('--manual_android_test_device', 'indicates that Android test device is run manually')
-  .option('--android_test_emulator_name <emulator_name', 'set name of the Android emulator for tests', 'android_30_google_atd_x86')
+  .option('--android_test_emulator_name <emulator_name', 'set name of the Android emulator for tests', 'android_33_google_apis_x64')
   .option('--use_remoteexec [arg]', 'whether to use RBE for building', JSON.parse)
   .option('--offline', 'use offline mode for RBE')
   .arguments('[build_config]')

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -500,6 +500,7 @@ test("brave_unit_tests") {
       "//chrome/android:chrome_apk_paks",
       "//chrome/test/android:chrome_java_test_support_common",
       "//components/gcm_driver/instance_id/android:instance_id_driver_test_support_java",
+      "//components/sync/android:explicit_passphrase_platform_client_stub_java",
     ]
     if (enable_brave_vpn || enable_ai_chat) {
       deps += [ "//brave/components/brave_mobile_subscription/renderer/android:unit_tests" ]
@@ -1234,7 +1235,7 @@ if (is_android) {
     ]
   }
 
-  chrome_public_test_apk_tmpl("brave_public_test_apk") {
+  chrome_public_test_apk_tmpl("brave_java_unit_tests") {
     apk_name = "BravePublicTest"
     android_manifest = brave_public_test_apk_manifest
     android_manifest_dep = ":brave_public_test_apk_manifest"


### PR DESCRIPTION
Now we will have separate suite for java unit tests to run. In addition, tests will be run on x64 emulators like they started doing in the upstream.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40885

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

