### PR TITLE
[iOS] Allow customizing the bookmarks button to a widget shortcut action

### DIFF
--- a/ios/brave-ios/Sources/Brave/Extensions/WidgetShortcutExtension.swift
+++ b/ios/brave-ios/Sources/Brave/Extensions/WidgetShortcutExtension.swift
@@ -1,0 +1,81 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveStrings
+import BraveWidgetsModels
+import DesignSystem
+import Foundation
+import Strings
+import UIKit
+
+extension WidgetShortcut {
+  static let eligibleButtonShortcuts: [WidgetShortcut] = [
+    .bookmarks,
+    .history,
+    .downloads,
+    .playlist,
+    .wallet,
+    .braveNews,
+    .braveLeo,
+  ]
+
+  var displayString: String {
+    switch self {
+    case .unknown:
+      return ""
+    case .bookmarks:
+      return Strings.bookmarksMenuItem
+    case .history:
+      return Strings.historyMenuItem
+    case .downloads:
+      return Strings.downloadsMenuItem
+    case .playlist:
+      return Strings.OptionsMenu.bravePlaylistItemTitle
+    case .wallet:
+      return Strings.Wallet.wallet
+    case .braveNews:
+      return Strings.OptionsMenu.braveNewsItemTitle
+    case .braveLeo:
+      return Strings.leoMenuItem
+    default:
+      return ""
+    }
+  }
+
+  var braveSystemImageName: String? {
+    switch self {
+    case .unknown:
+      return nil
+    case .newTab:
+      return "leo.plus.add"
+    case .newPrivateTab:
+      return "leo.product.private-window"
+    case .bookmarks:
+      return "leo.product.bookmarks"
+    case .history:
+      return "leo.history"
+    case .downloads:
+      return "leo.download"
+    case .playlist:
+      return "leo.product.playlist"
+    case .search:
+      return "leo.search"
+    case .wallet:
+      return "leo.product.brave-wallet"
+    case .scanQRCode:
+      return "leo.qr.code"
+    case .braveNews:
+      return "leo.product.brave-news"
+    case .braveLeo:
+      return "leo.product.brave-leo"
+    @unknown default:
+      return nil
+    }
+  }
+
+  var image: UIImage? {
+    return braveSystemImageName.flatMap { UIImage(braveSystemNamed: $0) }
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -10,6 +10,7 @@ import BraveShared
 import BraveStrings
 import BraveUI
 import BraveWallet
+import BraveWidgetsModels
 import CertificateUtilities
 import Data
 import Lottie
@@ -556,8 +557,13 @@ extension BrowserViewController: TopToolbarDelegate {
 
   // TODO: This logic should be fully abstracted away and share logic from current MenuViewController
   // See: https://github.com/brave/brave-ios/issues/1452
-  func topToolbarDidTapBookmarkButton(_ topToolbar: TopToolbarView) {
-    navigationHelper.openBookmarks()
+  func topToolbarDidTapShortcutButton(_ topToolbar: TopToolbarView) {
+    guard
+      let shortcut = Preferences.General.toolbarShortcutButton.value.flatMap(WidgetShortcut.init)
+    else {
+      return
+    }
+    NavigationPath.handleWidgetShortcut(shortcut, with: self)
   }
 
   func topToolbarDidTapBraveRewardsButton(_ topToolbar: TopToolbarView) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/NavigationRouter.swift
@@ -111,8 +111,7 @@ public enum NavigationPath: Equatable {
     )
   }
 
-  private static func handleWidgetShortcut(_ path: WidgetShortcut, with bvc: BrowserViewController)
-  {
+  static func handleWidgetShortcut(_ path: WidgetShortcut, with bvc: BrowserViewController) {
     switch path {
     case .unknown, .search:
       // Search

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -2,6 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import BraveWidgetsModels
 import Foundation
 import Preferences
 import Shared
@@ -74,9 +75,9 @@ extension Preferences {
       default: false
     )
     /// Specifies whether the bookmark button is present on toolbar
-    static let showBookmarkToolbarShortcut = Option<Bool>(
+    static let toolbarShortcutButton = Option<Int?>(
       key: "general.show-bookmark-toolbar-shortcut",
-      default: UIDevice.isIpad
+      default: UIDevice.isIpad ? WidgetShortcut.bookmarks.rawValue : nil
     )
     /// Controls whether or not media should continue playing in the background
     static let mediaAutoBackgrounding = Option<Bool>(

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShortcutButtonPickerView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShortcutButtonPickerView.swift
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveStrings
+import BraveWidgetsModels
+import DesignSystem
+import Preferences
+import Strings
+import SwiftUI
+
+struct ShortcutButtonPickerView: View {
+  @ObservedObject private var selectedShortcut = Preferences.General.toolbarShortcutButton
+  @Environment(\.dismiss) var dismiss
+
+  var body: some View {
+    Form {
+      Picker("", selection: $selectedShortcut.value) {
+        Label(Strings.ShortcutButton.hideButtonTitle, braveSystemImage: "leo.eye.off")
+          .tag(Int?.none)
+        ForEach(WidgetShortcut.eligibleButtonShortcuts, id: \.self) { shortcut in
+          Label(shortcut.displayString, braveSystemImage: shortcut.braveSystemImageName ?? "")
+            .tag(Int?.some(shortcut.rawValue))
+        }
+      }
+      .pickerStyle(.inline)
+      .tint(Color(braveSystemName: .iconDefault))
+      .foregroundStyle(Color(braveSystemName: .textPrimary))
+    }
+    .onChange(of: selectedShortcut.value) { newValue in
+      dismiss()
+    }
+    .navigationTitle(Strings.ShortcutButton.shortcutButtonTitle)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -700,10 +700,16 @@ class SettingsViewController: TableViewController {
     }
 
     display.rows.append(contentsOf: [
-      .boolRow(
-        title: Strings.showBookmarkButtonInTopToolbar,
-        option: Preferences.General.showBookmarkToolbarShortcut,
-        image: UIImage(braveSystemNamed: "leo.product.bookmarks")
+      Row(
+        text: Strings.ShortcutButton.shortcutButtonTitle,
+        selection: { [weak self] in
+          let controller = UIHostingController(rootView: ShortcutButtonPickerView())
+          controller.navigationItem.title = Strings.ShortcutButton.shortcutButtonTitle
+          self?.navigationController?.pushViewController(controller, animated: true)
+        },
+        image: UIImage(braveSystemNamed: "leo.launch"),
+        accessory: .disclosureIndicator,
+        cellClass: MultilineValue1Cell.self
       ),
       .boolRow(
         title: Strings.hideRewardsIcon,

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -4,6 +4,7 @@
 
 import BraveCore
 import BraveShields
+import BraveWidgetsModels
 import Data
 import Foundation
 import Growth
@@ -26,6 +27,7 @@ public class Migration {
     Preferences.migrateAdAndTrackingProtection()
     Preferences.migrateHTTPSUpgradeLevel()
     Preferences.migrateBackgroundSponsoredImages()
+    Preferences.migrateBookmarksButtonInToolbar()
 
     if Preferences.General.isFirstLaunch.value {
       if UIDevice.current.userInterfaceIdiom == .phone {
@@ -201,6 +203,12 @@ extension Preferences {
       key: "newtabpage.background-sponsored-images",
       default: true
     )
+
+    /// Specifies whether the bookmark button is present on toolbar
+    static let showBookmarkToolbarShortcut = Option<Bool>(
+      key: "general.show-bookmark-toolbar-shortcut",
+      default: UIDevice.isIpad
+    )
   }
 
   /// Migration preferences
@@ -245,6 +253,11 @@ extension Preferences {
 
     static let backgroundSponsoredImagesCompleted = Option<Bool>(
       key: "migration.newtabpage-background-sponsored-images",
+      default: false
+    )
+
+    static let migratedBookmarksButtonInToolbar = Option<Bool>(
+      key: "migration.bookmarks-button-in-toolbar",
       default: false
     )
   }
@@ -402,6 +415,17 @@ extension Preferences {
     }
 
     Migration.backgroundSponsoredImagesCompleted.value = true
+  }
+
+  fileprivate class func migrateBookmarksButtonInToolbar() {
+    guard !Migration.migratedBookmarksButtonInToolbar.value else { return }
+
+    DeprecatedPreferences.showBookmarkToolbarShortcut.migrate { isEnabled in
+      Preferences.General.toolbarShortcutButton.value =
+        isEnabled ? WidgetShortcut.bookmarks.rawValue : nil
+    }
+
+    Migration.migratedBookmarksButtonInToolbar.value = true
   }
 }
 

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -2581,14 +2581,6 @@ extension Strings {
     value: "Save Logins",
     comment: "Setting to enable the built-in password manager"
   )
-  public static let showBookmarkButtonInTopToolbar = NSLocalizedString(
-    "ShowBookmarkButtonInTopToolbar",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "Show Bookmarks Shortcut",
-    comment:
-      "Setting to show a bookmark button on the top level menu that triggers a panel of the user's bookmarks."
-  )
   public static let alwaysRequestDesktopSite = NSLocalizedString(
     "AlwaysRequestDesktopSite",
     tableName: "BraveShared",
@@ -9712,6 +9704,23 @@ extension Strings {
       bundle: .module,
       value: "Refresh your credentials",
       comment: "Button action text for refreshing credentials from brave site."
+    )
+  }
+}
+
+extension Strings {
+  public struct ShortcutButton {
+    public static let hideButtonTitle = NSLocalizedString(
+      "shortcutsButton.hideButtonTitle",
+      bundle: .module,
+      value: "Hide Shortcut Button",
+      comment: "An option in a list of shortcut actions that hides the button"
+    )
+    public static let shortcutButtonTitle = NSLocalizedString(
+      "shortcutsButton.shortcutButtonTitle",
+      bundle: .module,
+      value: "Shortcut Button",
+      comment: "A title shown when letting the user choose a button's purpose from a list of destinations"
     )
   }
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/41031

| Long Press | Settings | Settings | 
| --- | --- | --- |
| ![Simulator Screenshot - iPhone 16 Pro - 2024-09-13 at 15 02 00](https://github.com/user-attachments/assets/fd1bb7a1-4f56-467c-9b03-b3c678369367) | ![Simulator Screenshot - iPhone 16 Pro - 2024-09-13 at 15 02 09](https://github.com/user-attachments/assets/7bbfbbeb-b643-41a3-a229-fcd02f2f1fd7) | ![Simulator Screenshot - iPhone 16 Pro - 2024-09-13 at 15 02 12](https://github.com/user-attachments/assets/f8058c33-1b6c-4d31-9354-3444cbbf7328) |

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

