### PR TITLE
[ads] Fix NTP media type P3A metrics when modified from Rewards page

### DIFF
--- a/browser/profiles/profile_util.cc
+++ b/browser/profiles/profile_util.cc
@@ -15,6 +15,7 @@
 #include "brave/components/brave_shields/core/common/brave_shield_utils.h"
 #include "brave/components/constants/brave_constants.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
 #include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "brave/components/tor/buildflags/buildflags.h"
@@ -45,15 +46,6 @@ bool IsTorDisabledForProfile(Profile* profile) {
 #endif
 }
 
-void RecordSponsoredImagesEnabledP3A(Profile* profile) {
-  bool is_sponsored_image_enabled =
-      profile->GetPrefs()->GetBoolean(kNewTabPageShowBackgroundImage) &&
-      profile->GetPrefs()->GetBoolean(
-          kNewTabPageShowSponsoredImagesBackgroundImage);
-  UMA_HISTOGRAM_BOOLEAN("Brave.NTP.SponsoredMediaType",
-                        is_sponsored_image_enabled);
-}
-
 void RecordInitialP3AValues(Profile* profile) {
   // Preference is unregistered for some reason in profile_manager_unittest
   // TODO(bsclifton): create a proper testing profile
@@ -62,7 +54,7 @@ void RecordInitialP3AValues(Profile* profile) {
           kNewTabPageShowSponsoredImagesBackgroundImage)) {
     return;
   }
-  RecordSponsoredImagesEnabledP3A(profile);
+  ntp_background_images::RecordSponsoredImagesEnabledP3A(profile->GetPrefs());
   if (profile->IsRegularProfile()) {
     brave_shields::MaybeRecordInitialShieldsSettings(
         profile->GetPrefs(),

--- a/browser/profiles/profile_util.h
+++ b/browser/profiles/profile_util.h
@@ -13,10 +13,6 @@ namespace brave {
 
 bool IsTorDisabledForProfile(Profile* profile);
 
-// Specifically used to record if sponsored images are enabled.
-// Called from BraveAppearanceHandler and BraveNewTabMessageHandler
-void RecordSponsoredImagesEnabledP3A(Profile* profile);
-
 // Records default values for some histograms.
 //
 // For profile agnostic values (ex: local_state) see

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -459,12 +459,6 @@ void BraveNewTabMessageHandler::HandleSaveNewTabPagePref(
     return;
   }
   prefs->SetBoolean(settingsKey, settingsValueBool);
-
-  // P3A can only be recorded after profile is updated
-  if (settingsKeyInput == "showBackgroundImage" ||
-      settingsKeyInput == "brandedWallpaperOptIn") {
-    brave::RecordSponsoredImagesEnabledP3A(profile_);
-  }
 }
 
 void BraveNewTabMessageHandler::HandleRegisterNewTabPageView(

--- a/browser/ui/webui/settings/brave_appearance_handler.cc
+++ b/browser/ui/webui/settings/brave_appearance_handler.cc
@@ -96,11 +96,6 @@ void BraveAppearanceHandler::OnBraveDarkModeChanged() {
   }
 }
 
-void BraveAppearanceHandler::OnBackgroundPreferenceChanged(
-    const std::string& pref_name) {
-  brave::RecordSponsoredImagesEnabledP3A(profile_);
-}
-
 void BraveAppearanceHandler::OnPreferenceChanged(const std::string& pref_name) {
   if (IsJavascriptAllowed()) {
     if (pref_name == kNewTabPageShowsOptions || pref_name == prefs::kHomePage ||

--- a/browser/ui/webui/settings/brave_appearance_handler.h
+++ b/browser/ui/webui/settings/brave_appearance_handler.h
@@ -29,7 +29,6 @@ class BraveAppearanceHandler : public settings::SettingsPageUIHandler {
   void OnJavascriptDisallowed() override {}
 
   void OnBraveDarkModeChanged();
-  void OnBackgroundPreferenceChanged(const std::string& pref_name);
   void OnPreferenceChanged(const std::string& pref_name);
   void SetBraveThemeType(const base::Value::List& args);
   void GetBraveThemeType(const base::Value::List& args);

--- a/components/ntp_background_images/browser/BUILD.gn
+++ b/components/ntp_background_images/browser/BUILD.gn
@@ -16,6 +16,8 @@ static_library("browser") {
     "ntp_background_images_service.cc",
     "ntp_background_images_service.h",
     "ntp_p3a_helper.h",
+    "ntp_p3a_util.cc",
+    "ntp_p3a_util.h",
     "ntp_sponsored_images_data.cc",
     "ntp_sponsored_images_data.h",
     "sponsored_images_component_data.cc",

--- a/components/ntp_background_images/browser/ntp_p3a_util.cc
+++ b/components/ntp_background_images/browser/ntp_p3a_util.cc
@@ -1,0 +1,24 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
+
+#include "base/metrics/histogram_macros.h"
+#include "brave/components/ntp_background_images/common/pref_names.h"
+#include "components/prefs/pref_service.h"
+
+namespace ntp_background_images {
+
+void RecordSponsoredImagesEnabledP3A(const PrefService* const prefs) {
+  CHECK(prefs);
+
+  const bool is_sponsored_image_enabled =
+      prefs->GetBoolean(prefs::kNewTabPageShowBackgroundImage) &&
+      prefs->GetBoolean(prefs::kNewTabPageShowSponsoredImagesBackgroundImage);
+  UMA_HISTOGRAM_BOOLEAN("Brave.NTP.SponsoredMediaType",
+                        is_sponsored_image_enabled);
+}
+
+}  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/ntp_p3a_util.h
+++ b/components/ntp_background_images/browser/ntp_p3a_util.h
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_P3A_UTIL_H_
+#define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_P3A_UTIL_H_
+
+class PrefService;
+
+namespace ntp_background_images {
+
+// Specifically used to record if sponsored images are enabled.
+void RecordSponsoredImagesEnabledP3A(const PrefService* prefs);
+
+}  // namespace ntp_background_images
+
+#endif  // BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_P3A_UTIL_H_

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -22,6 +22,7 @@
 #include "brave/components/ntp_background_images/browser/brave_ntp_custom_background_service.h"
 #include "brave/components/ntp_background_images/browser/ntp_background_images_data.h"
 #include "brave/components/ntp_background_images/browser/ntp_p3a_helper.h"
+#include "brave/components/ntp_background_images/browser/ntp_p3a_util.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_images_data.h"
 #include "brave/components/ntp_background_images/browser/url_constants.h"
 #include "brave/components/ntp_background_images/common/pref_names.h"
@@ -323,6 +324,11 @@ void ViewCounterService::OnPreferenceChanged(const std::string& pref_name) {
   if (pref_name == brave_rewards::prefs::kEnabled) {
     ResetNotificationState();
     return;
+  }
+
+  if (pref_name == prefs::kNewTabPageShowBackgroundImage ||
+      pref_name == prefs::kNewTabPageShowSponsoredImagesBackgroundImage) {
+    RecordSponsoredImagesEnabledP3A(prefs_);
   }
 
   // Reset model because SI and SR use different policy.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41026

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `1`
* Open tab with NTP
* Click `Customize` setting
* Turn off `Show Background Images`
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `0`
* Turn on `Show Background Images`
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `1`

### Test case 2
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `1`
* Open tab with NTP
* Click `Customize` setting
* Turn off `Show Sponsored Images`
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `0`
* Turn on `Show Sponsored Images`
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `1`

### Test case 3
* Enable rewards
* Open brave://rewards
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `1`
* Turn off `New tab page ads`
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `0`
* Turn on `New tab page ads`
* Open brave://local-state and search for SponsoredMediaType
* EXPECTATION: `Brave.NTP.SponsoredMediaType` is set to `1`
