### PR TITLE
chore(wallet): Reading compressed NFT info from txInfo.

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -573,7 +573,6 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
       value = details.fromAmount
       fiat = details.fromFiat ?? ""
 
-      // TODO: Some UI updates for solana compressed NFT transfer brave-browser#40433
       if activeParsedTransaction.transaction.txType == .solanaCompressedNftTransfer {
         symbol = "SOL"
       }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -678,15 +678,12 @@ enum TransactionParser {
       else {
         return nil
       }
-      let fromToken: BraveWallet.BlockchainToken? =
-        transaction.txType == .solanaCompressedNftTransfer
-        ? nil
-        : token(
-          for: splTokenMintAddress,
-          network: txNetwork,
-          userAssets: userAssets,
-          allTokens: allTokens
-        )  // solana compressed NFT transfer might get it's NFT info after issue #40353
+      let fromToken: BraveWallet.BlockchainToken? = token(
+        for: splTokenMintAddress,
+        network: txNetwork,
+        userAssets: userAssets,
+        allTokens: allTokens
+      )
       let tokenNFTMetadata: BraveWallet.NftMetadata?
       if let fromToken {
         tokenNFTMetadata = nftMetadata[fromToken.id]
@@ -696,24 +693,22 @@ enum TransactionParser {
       let fromValue = "\(amount)"
       var fromValueFormatted = ""
       var fromFiat = "$0.00"
-      if transaction.txType == .solanaCompressedNftTransfer {
+      if let token = fromToken {
+        fromValueFormatted =
+          formatter.decimalString(for: fromValue, radix: .decimal, decimals: Int(token.decimals))?
+          .trimmingTrailingZeros ?? ""
+        if token.isNft {
+          fromFiat = ""  // don't show fiat for NFTs
+        } else {
+          fromFiat =
+            currencyFormatter.formatAsFiat(
+              assetRatios[token.assetRatioId.lowercased(), default: 0]
+              * (Double(fromValueFormatted) ?? 0)
+            ) ?? "$0.00"
+        }
+      } else {
         fromValueFormatted = "0"
         fromFiat = ""
-      } else {
-        if let token = fromToken {
-          fromValueFormatted =
-            formatter.decimalString(for: fromValue, radix: .decimal, decimals: Int(token.decimals))?
-            .trimmingTrailingZeros ?? ""
-          if token.isNft {
-            fromFiat = ""  // don't show fiat for NFTs
-          } else {
-            fromFiat =
-              currencyFormatter.formatAsFiat(
-                assetRatios[token.assetRatioId.lowercased(), default: 0]
-                  * (Double(fromValueFormatted) ?? 0)
-              ) ?? "$0.00"
-          }
-        }
       }
       // Example:
       // Send 0.1234 SMB

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transactions/TransactionParser.swift
@@ -703,7 +703,7 @@ enum TransactionParser {
           fromFiat =
             currencyFormatter.formatAsFiat(
               assetRatios[token.assetRatioId.lowercased(), default: 0]
-              * (Double(fromValueFormatted) ?? 0)
+                * (Double(fromValueFormatted) ?? 0)
             ) ?? "$0.00"
         }
       } else {


### PR DESCRIPTION
Before we are displaying empty token information since TxInfo does not have any token information if it is a compressed NFT transaction. But since https://github.com/brave/brave-browser/issues/40353 is resolved, we can now reading the compressed NFT information from the same place other transaction. 
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40433

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. try to make a compressed NFT transaction
2. In tx detail, you should see what NFT you just sent. 
