### PR TITLE
Hide redundant settings-secure-dns settings (uplift to 1.70.x)

### DIFF
--- a/patches/chrome-browser-resources-settings-privacy_page-security_page.html.patch
+++ b/patches/chrome-browser-resources-settings-privacy_page-security_page.html.patch
@@ -1,0 +1,26 @@
+diff --git a/chrome/browser/resources/settings/privacy_page/security_page.html b/chrome/browser/resources/settings/privacy_page/security_page.html
+index 7d79e5cb222645e3d789db363e5375ed6c86f7f3..354af4a6a000a6309c421f870a24724055647ef4 100644
+--- a/chrome/browser/resources/settings/privacy_page/security_page.html
++++ b/chrome/browser/resources/settings/privacy_page/security_page.html
+@@ -272,15 +272,17 @@
+           numeric-checked-value="[[httpsFirstModeSettingEnum_.ENABLED_FULL]]">
+       </settings-toggle-button>
+       <template is="dom-if" if="[[showSecureDnsSetting_]]">
+-        <settings-secure-dns prefs="{{prefs}}"></settings-secure-dns>
++        <settings-secure-dns prefs="{{prefs}}" id="secureDnsSettingOld">
++        </settings-secure-dns>
+       </template>
+     </template>
+-    <tempate is="dom-if" if="[[enableHttpsFirstModeNewSettings_]]" restamp>
++    <template is="dom-if" if="[[enableHttpsFirstModeNewSettings_]]" restamp>
+       <template is="dom-if" if="[[showSecureDnsSetting_]]">
+-        <settings-secure-dns prefs="{{prefs}}" class="no-hr">
++        <settings-secure-dns prefs="{{prefs}}" class="no-hr"
++            id="secureDnsSettingNew">
+         </settings-secure-dns>
+       </template>
+-    </tempate>
++    </template>
+ <if expr="is_chromeos">
+     <template is="dom-if" if="[[showSecureDnsSettingLink_]]">
+         <cr-link-row id="openChromeOSSecureDnsSettings"

--- a/patches/chrome-test-data-webui-settings-security_page_test.ts.patch
+++ b/patches/chrome-test-data-webui-settings-security_page_test.ts.patch
@@ -1,0 +1,46 @@
+diff --git a/chrome/test/data/webui/settings/security_page_test.ts b/chrome/test/data/webui/settings/security_page_test.ts
+index f14e2dd3bc1ef02adac14bf24688c7421d86e984..e644899a644c6667dfcfb4e113102b623670e2a8 100644
+--- a/chrome/test/data/webui/settings/security_page_test.ts
++++ b/chrome/test/data/webui/settings/security_page_test.ts
+@@ -228,6 +228,20 @@ suite('Main', function() {
+     flush();
+     assertEquals(lockedSubLabel, toggle.subLabel);
+   });
++
++  // Tests that only the new Secure DNS toggle is shown when the new
++  // HTTPS-First Mode Settings flag is enabled.
++  // Regression test for crbug.com/365884462
++  // TODO(crbug.com/349860796): Remove when Balanced Mode is fully launched.
++  // <if expr="not is_chromeos">
++  test('SecureDnsToggleNotDuplicated', function() {
++    // Check that the setting under the new element ID visible.
++    assertTrue(isChildVisible(page, '#secureDnsSettingNew'));
++
++    // Check that the setting under the old element ID is not visible.
++    assertFalse(isChildVisible(page, '#secureDnsSettingOld'));
++  });
++  // </if>
+ });
+ 
+ suite('SecurityPageHappinessTrackingSurveys', function() {
+@@ -465,6 +479,20 @@ suite('FlagsDisabled', function() {
+     assertEquals(lockedSubLabel, toggle.subLabel);
+   });
+ 
++  // Tests that only the old Secure DNS toggle is shown when the new
++  // HTTPS-First Mode Settings flag is disabled.
++  // Regression test for crbug.com/365884462
++  // TODO(crbug.com/349860796): Remove when Balanced Mode is fully launched.
++  // <if expr="not is_chromeos">
++  test('SecureDnsToggleNotDuplicated', function() {
++    // Check that the setting under the new element ID is not visible.
++    assertFalse(isChildVisible(page, '#secureDnsSettingNew'));
++
++    // Check that the setting under the old element ID is visible.
++    assertTrue(isChildVisible(page, '#secureDnsSettingOld'));
++  });
++  // </if>
++
+   // TODO(crbug.com/349439367): Remove the test once
+   // kExtendedReportingRemovePrefDependency is fully launched.
+   test('LogSafeBrowsingExtendedToggle', async function() {


### PR DESCRIPTION
Uplift of #25521
fix https://github.com/brave/brave-browser/issues/40989

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.