### PR TITLE
Fix flaky create_dist_zips on macOS

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -542,6 +542,7 @@ action("create_dist_zips") {
     if (is_mac) {
       dir_inputs += [ brave_exe ]
       rebase_base_dir = rebase_path(root_out_dir)
+      deps += [ "//brave/build/mac:finalize_app" ]
     } else {
       rebase_base_dir = rebase_path(brave_dist_dir, root_out_dir)
     }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/41085.
Replaces https://github.com/brave/brave-core/pull/25576.

At least, I'm 98% sure that it will. https://github.com/brave/brave-browser/issues/41085 behaves a lot like something is deleting files out from under `make_zip(...)`. `//brave/build/mac:universalize` seems a very likely candidate for doing this. If it runs at the same time as `create_dist_zips`, then it modifies the files that get used there. I suspect that the failing `zip` call first iterates over all files and remembers their inode number. By the time `zip` gets to adding the file to the archive, it has been replaced by `universalize` by a newer copy with a different inode.