### PR TITLE
fix(privacy): Add logic to record initial AdBlockSetting & FingerprintBlockSetting values

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3283,12 +3283,16 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reloadSelectedTab()
     case Preferences.General.enablePullToRefresh.key:
       tabManager.selectedTab?.updatePullToRefreshVisibility()
-    case ShieldPreferences.blockAdsAndTrackingLevelRaw.key,
-      Preferences.Shields.blockScripts.key,
+    case Preferences.Shields.blockScripts.key,
       Preferences.Shields.blockImages.key,
-      Preferences.Shields.fingerprintingProtection.key,
       Preferences.Shields.useRegionAdBlock.key:
       tabManager.reloadSelectedTab()
+    case ShieldPreferences.blockAdsAndTrackingLevelRaw.key:
+      tabManager.reloadSelectedTab()
+      recordGlobalAdBlockShieldsP3A()
+    case Preferences.Shields.fingerprintingProtection.key:
+      tabManager.reloadSelectedTab()
+      recordGlobalFingerprintingShieldsP3A()
     case Preferences.General.defaultPageZoomLevel.key:
       tabManager.allTabs.forEach({
         guard let url = $0.webView?.url else { return }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -65,9 +65,6 @@ import os
   @Published var adBlockAndTrackingPreventionLevel: ShieldLevel {
     didSet {
       ShieldPreferences.blockAdsAndTrackingLevel = adBlockAndTrackingPreventionLevel
-      if adBlockAndTrackingPreventionLevel != oldValue {
-        recordGlobalAdBlockShieldsP3A()
-      }
     }
   }
   @Published var httpsUpgradeLevel: HTTPSUpgradeLevel {
@@ -278,43 +275,5 @@ import os
         }
       }
       .store(in: &subscriptions)
-
-    Preferences.Shields.fingerprintingProtection.$value
-      .sink { [weak self] _ in
-        self?.recordGlobalFingerprintingShieldsP3A()
-      }
-      .store(in: &subscriptions)
-  }
-
-  // MARK: - P3A
-
-  private func recordGlobalAdBlockShieldsP3A() {
-    // Q46 What is the global ad blocking shields setting?
-    enum Answer: Int, CaseIterable {
-      case disabled = 0
-      case standard = 1
-      case aggressive = 2
-    }
-
-    let answer = { () -> Answer in
-      switch ShieldPreferences.blockAdsAndTrackingLevel {
-      case .disabled: return .disabled
-      case .standard: return .standard
-      case .aggressive: return .aggressive
-      }
-    }()
-
-    UmaHistogramEnumeration("Brave.Shields.AdBlockSetting", sample: answer)
-  }
-
-  private func recordGlobalFingerprintingShieldsP3A() {
-    // Q47 What is the global fingerprinting shields setting?
-    enum Answer: Int, CaseIterable {
-      case disabled = 0
-      case standard = 1
-      case aggressive = 2
-    }
-    let answer: Answer = Preferences.Shields.fingerprintingProtection.value ? .standard : .disabled
-    UmaHistogramEnumeration("Brave.Shields.FingerprintBlockSetting", sample: answer)
   }
 }

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -83,9 +83,9 @@ extension Preferences {
       default: false
     )
     /// Whether or not we've reported the initial state of shields for p3a
-    public static let initialP3AStateReported = Option<Bool>(
-      key: "shields.initial-p3a-state-reported",
-      default: false
+    public static let initialP3AStateReportedRevision = Option<Int>(
+      key: "shields.initial-p3a-state-reported-revision",
+      default: 0
     )
   }
 


### PR DESCRIPTION
- Updated initial shields P3A value recordings to record 2 questions not reporting their initial value.
    - `Brave.Shields.AdBlockSetting` was only being recorded when the value changed, not recording the initial value.
    - `Brave.Shields.FingerprintBlockSetting` was only being recorded when Shields settings was opened which may have missed initial value if user never opened shields settings.
- Additionally updated initial value function to add a `kCurrentReportRevision` to align with [desktop logic](https://github.com/brave/brave-core/blob/69c80cde8669df5f681382fa8e161ed95b30c0dd/components/brave_shields/content/browser/brave_shields_p3a.cc#L252-L255), instead of existing boolean for easier updates later (increase `kCurrentReportRevision` by 1 to re-record initial shields values).

Resolves https://github.com/brave/brave-browser/issues/41054

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Verify `AdBlockSetting` & `FingerprintBlockSetting` are both recorded at first launch
2. Verify both are updated when value changes