### PR TITLE
Support `.env` in GN scripts directly.

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -64,12 +64,6 @@ hooks = [
     'action': ['python3', 'script/ios_bootstrap.py']
   },
   {
-    # The .env file is used by `gn gen`. Create it if it doesn't exist.
-    'name': 'ensure_env_config',
-    'pattern': '.',
-    'action': ['python3', 'build/env_config.py', 'create_if_not_found', '.env'],
-  },
-  {
     # Download hermetic xcode for goma
     'name': 'download_hermetic_xcode',
     'pattern': '.',

--- a/DEPS
+++ b/DEPS
@@ -64,6 +64,12 @@ hooks = [
     'action': ['python3', 'script/ios_bootstrap.py']
   },
   {
+    # The .env file is used by `gn gen`. Create it if it doesn't exist.
+    'name': 'ensure_env_config',
+    'pattern': '.',
+    'action': ['python3', 'build/env_config.py', 'create_if_not_found', '.env'],
+  },
+  {
     # Download hermetic xcode for goma
     'name': 'download_hermetic_xcode',
     'pattern': '.',

--- a/build/PRESUBMIT.py
+++ b/build/PRESUBMIT.py
@@ -44,5 +44,11 @@ def CheckCIFeatures(input_api, output_api):
 
     return [
         output_api.PresubmitError(
-            f'build/.ci_features lines don\'t match regex {expected_re}', items)
+            f'build/.ci_features lines don\'t match regex {expected_re}',
+            items)
     ]
+
+
+def CheckUnitTests(input_api, output_api):
+    return input_api.canned_checks.RunUnitTestsInDirectory(
+        input_api, output_api, '.', files_to_check=[r'.+_test.py$'])

--- a/build/buildflag_header_with_env_config.gni
+++ b/build/buildflag_header_with_env_config.gni
@@ -6,32 +6,35 @@
 import("//brave/build/env_config.gni")
 import("//build/buildflag_header.gni")
 
-# Prevent empty .env flags in official builds, but allow this to be configurable
-# for development.
-if (defined(env_config.allow_empty_env_config_flags)) {
-  allow_empty_env_config_flags = env_config.allow_empty_env_config_flags
-} else {
-  allow_empty_env_config_flags = !is_official_build
-}
-
-# Similar to buildflag_header(), but supports flags defined in .env file.
+# Similar to buildflag_header(), but supports flags defined in a .env file.
 #
-# For example, "sample_secret_key=iamsecret" in the .env file can be generated
-# into a buildflag header as `SAMPLE_SECRET_KEY=\"iamsecret\"` using the
+# For example, `sample_secret_key=iamsecret` in the .env file can be generated
+# as a buildflag_header() flag `SAMPLE_SECRET_KEY=\"iamsecret\"` using the
 # following format:
 #
-#   env_config_flags = [ "SAMPLE_SECRET_KEY" ]
+#     env_config_flags = [ "SAMPLE_SECRET_KEY" ]
 #
-# If the value is not set, it will default to an empty string. A custom default
+# If the flag is not found, it will default to an empty string. A custom default
 # value can be provided using the following format:
 #
-#   env_config_flags = [ "SAMPLE_SECRET_KEY=\"iamdefault\"" ]
-#   env_config_flags = [ "SAMPLE_BOOLEAN_PARAM=false" ]
-#   env_config_flags = [ "SAMPLE_INTEGER_PARAM=0" ]
+#     env_config_flags = [ "SAMPLE_SECRET_KEY=\"iamdefault\"" ]
+#     env_config_flags = [ "SAMPLE_BOOLEAN_KEY=false" ]
+#     env_config_flags = [ "SAMPLE_INTEGER_KEY=0" ]
 #
-# The generator will match the lowercase version of the flag name in the .env
-# file. If the flag is not found in the .env file, it will be generated as an
-# empty string if this is allowed in the current configuration.
+# Values parsed from the .env file are stringified as JSON, meaning strings will
+# be quoted and have all unusual symbols escaped. Numbers and booleans will not
+# be escaped, allowing these values to be used in the header as is. This enables
+# the correct definition of multiline strings, booleans, and integers in the
+# generated header.
+
+# Prevent unset .env flags in official builds, but allow this to be configurable
+# for development.
+if (defined(env_config.allow_unset_env_config_flags)) {
+  allow_unset_env_config_flags = env_config.allow_unset_env_config_flags
+} else {
+  allow_unset_env_config_flags = !is_official_build
+}
+
 template("buildflag_header_with_env_config") {
   buildflag_header(target_name) {
     forward_variables_from(invoker, "*", [ "env_config_flags" ])
@@ -41,29 +44,33 @@ template("buildflag_header_with_env_config") {
         flags = []
       }
 
-      foreach(name, invoker.env_config_flags) {
+      foreach(_env_config_flag, invoker.env_config_flags) {
         _name_and_default_value = []
-        _name_and_default_value = string_split(name, "=")
-        if (_name_and_default_value[0] == name) {
-          # No default value provided.
-          _default_value = "\"\""
+        _name_and_default_value = string_split(_env_config_flag, "=")
+        if (_name_and_default_value[0] == _env_config_flag) {
+          # Default to empty string.
+          _env_config_flag_name = _env_config_flag
+          _env_config_flag_value = "\"\""
         } else {
-          # Default value provided.
-          name = _name_and_default_value[0]
-          _default_value = _name_and_default_value[1]
+          # Default to the provided value.
+          _env_config_flag_name = _name_and_default_value[0]
+          _env_config_flag_value = _name_and_default_value[1]
         }
 
-        _escaped_name = name + "_escaped"
-        if (defined(env_config[_escaped_name])) {
-          _env_config_flag_value = env_config[_escaped_name]
-          not_needed([ "_default_value" ])
+        # Lookup the escaped flag in the env_config and use its value if it
+        # exists.
+        _escaped_env_config_flag_name = _env_config_flag_name + "_escaped"
+        if (defined(env_config[_escaped_env_config_flag_name])) {
+          _env_config_flag_value = env_config[_escaped_env_config_flag_name]
         } else {
-          assert(allow_empty_env_config_flags,
-                 "$name (or lowercase variant) is not set in " +
+          # If the flag is not found in .env, make sure this is allowed in the
+          # current configuration.
+          assert(allow_unset_env_config_flags,
+                 _env_config_flag_name +
+                     " (or its lowercase variant) is not found in: " +
                      string_join(" or ", env_config_files))
-          _env_config_flag_value = _default_value
         }
-        flags += [ "$name=$_env_config_flag_value" ]
+        flags += [ "$_env_config_flag_name=$_env_config_flag_value" ]
       }
     }
   }

--- a/build/buildflag_header_with_env_config.gni
+++ b/build/buildflag_header_with_env_config.gni
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/build/env_config.gni")
+import("//build/buildflag_header.gni")
+
+# Prevent empty .env flags in official builds, but allow this to be configurable
+# for development.
+if (defined(env_config.allow_empty_env_config_flags)) {
+  allow_empty_env_config_flags = env_config.allow_empty_env_config_flags
+} else {
+  allow_empty_env_config_flags = !is_official_build
+}
+
+# Similar to buildflag_header(), but supports flags defined in .env file.
+#
+# For example, "sample_secret_key=iamsecret" in the .env file can be generated
+# into a buildflag header as `SAMPLE_SECRET_KEY="iamsecret"` using the
+# following:
+#
+#   env_config_flags = [ "SAMPLE_SECRET_KEY" ]
+#
+# The generator will match the lowercase version of the flag name in the .env
+# file. If the flag is not found in the .env file, it will be generated as an
+# empty string if this is allowed in the current configuration.
+template("buildflag_header_with_env_config") {
+  buildflag_header(target_name) {
+    forward_variables_from(invoker, "*", [ "env_config_flags" ])
+
+    if (defined(invoker.env_config_flags)) {
+      _extracted_env_config_flags = []
+
+      foreach(name, invoker.env_config_flags) {
+        if (defined(env_config[name])) {
+          _extracted_env_config_flags += [ "$name=\"${env_config[name]}\"" ]
+        } else {
+          assert(allow_empty_env_config_flags,
+                 "$name (or lowercase variant) is not set in " +
+                     string_join(" or ", env_config_files))
+          _extracted_env_config_flags += [ "$name=\"\"" ]
+        }
+      }
+
+      if (defined(flags)) {
+        flags += _extracted_env_config_flags
+      } else {
+        flags = _extracted_env_config_flags
+      }
+    }
+  }
+}

--- a/build/buildflag_header_with_env_config.gni
+++ b/build/buildflag_header_with_env_config.gni
@@ -17,10 +17,17 @@ if (defined(env_config.allow_empty_env_config_flags)) {
 # Similar to buildflag_header(), but supports flags defined in .env file.
 #
 # For example, "sample_secret_key=iamsecret" in the .env file can be generated
-# into a buildflag header as `SAMPLE_SECRET_KEY="iamsecret"` using the
-# following:
+# into a buildflag header as `SAMPLE_SECRET_KEY=\"iamsecret\"` using the
+# following format:
 #
 #   env_config_flags = [ "SAMPLE_SECRET_KEY" ]
+#
+# If the value is not set, it will default to an empty string. A custom default
+# value can be provided using the following format:
+#
+#   env_config_flags = [ "SAMPLE_SECRET_KEY=\"iamdefault\"" ]
+#   env_config_flags = [ "SAMPLE_BOOLEAN_PARAM=false" ]
+#   env_config_flags = [ "SAMPLE_INTEGER_PARAM=0" ]
 #
 # The generator will match the lowercase version of the flag name in the .env
 # file. If the flag is not found in the .env file, it will be generated as an
@@ -30,23 +37,33 @@ template("buildflag_header_with_env_config") {
     forward_variables_from(invoker, "*", [ "env_config_flags" ])
 
     if (defined(invoker.env_config_flags)) {
-      _extracted_env_config_flags = []
+      if (!defined(flags)) {
+        flags = []
+      }
 
       foreach(name, invoker.env_config_flags) {
-        if (defined(env_config[name])) {
-          _extracted_env_config_flags += [ "$name=\"${env_config[name]}\"" ]
+        _name_and_default_value = []
+        _name_and_default_value = string_split(name, "=")
+        if (_name_and_default_value[0] == name) {
+          # No default value provided.
+          _default_value = "\"\""
+        } else {
+          # Default value provided.
+          name = _name_and_default_value[0]
+          _default_value = _name_and_default_value[1]
+        }
+
+        _escaped_name = name + "_escaped"
+        if (defined(env_config[_escaped_name])) {
+          _env_config_flag_value = env_config[_escaped_name]
+          not_needed([ "_default_value" ])
         } else {
           assert(allow_empty_env_config_flags,
                  "$name (or lowercase variant) is not set in " +
                      string_join(" or ", env_config_files))
-          _extracted_env_config_flags += [ "$name=\"\"" ]
+          _env_config_flag_value = _default_value
         }
-      }
-
-      if (defined(flags)) {
-        flags += _extracted_env_config_flags
-      } else {
-        flags = _extracted_env_config_flags
+        flags += [ "$name=$_env_config_flag_value" ]
       }
     }
   }

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -45,9 +45,14 @@ const getEnvConfig = (key, default_value = undefined) => {
 
     // Parse src/brave/.env with all included env files.
     let envConfigPath = path.join(braveCoreDir, '.env')
-    // It's okay to not have the initial `.env` file.
     if (fs.existsSync(envConfigPath)) {
       dotenvPopulateWithIncludes(envConfig, envConfigPath)
+    } else {
+      // The .env file is used by `gn gen`. Create it if it doesn't exist.
+      const defaultEnvConfigContent =
+        '# This is an .env config file for the build system.\n' +
+        '# See https://github.com/brave/brave-browser/wiki/Build-configuration\n'
+      fs.writeFileSync(envConfigPath, defaultEnvConfigContent)
     }
 
     // Convert 'true' and 'false' strings into booleans.

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -50,8 +50,8 @@ const getEnvConfig = (key, default_value = undefined) => {
     } else {
       // The .env file is used by `gn gen`. Create it if it doesn't exist.
       const defaultEnvConfigContent =
-        '# This is an .env config file for the build system.\n' +
-        '# See https://github.com/brave/brave-browser/wiki/Build-configuration\n'
+        '# This is a placeholder .env config file for the build system.\n' +
+        '# See for details: https://github.com/brave/brave-browser/wiki/Build-configuration\n'
       fs.writeFileSync(envConfigPath, defaultEnvConfigContent)
     }
 

--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -147,7 +147,6 @@ const Config = function () {
   this.braveServicesProductionDomain = getEnvConfig(['brave_services_production_domain']) || ''
   this.braveServicesStagingDomain = getEnvConfig(['brave_services_staging_domain']) || ''
   this.braveServicesDevDomain = getEnvConfig(['brave_services_dev_domain']) || ''
-  this.braveServicesKey = getEnvConfig(['brave_services_key']) || ''
   this.braveGoogleApiKey = getEnvConfig(['brave_google_api_key']) || 'AIzaSyAREPLACEWITHYOUROWNGOOGLEAPIKEY2Q'
   this.googleApiEndpoint = getEnvConfig(['brave_google_api_endpoint']) || 'https://www.googleapis.com/geolocation/v1/geolocate?key='
   this.googleDefaultClientId = getEnvConfig(['google_default_client_id']) || ''
@@ -331,7 +330,6 @@ Config.prototype.buildArgs = function () {
     v8_enable_verify_heap: this.isAsan(),
     disable_fieldtrial_testing_config: true,
     safe_browsing_mode: 1,
-    brave_services_key: this.braveServicesKey,
     root_extra_deps: ["//brave"],
     clang_unsafe_buffers_paths: "//brave/build/config/unsafe_buffers_paths.txt",
     // TODO: Re-enable when chromium_src overrides work for files in relative

--- a/build/dotfile_settings.gni
+++ b/build/dotfile_settings.gni
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_build_dotfile_settings = {
+  exec_script_whitelist = [ "//brave/build/env_config.gni" ]
+}

--- a/build/dotfile_settings.gni
+++ b/build/dotfile_settings.gni
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-brave_build_dotfile_settings = {
-  exec_script_whitelist = [ "//brave/build/env_config.gni" ]
-}
+brave_exec_script_whitelist = [
+  # //brave/.env parser.
+  "//brave/build/env_config.gni",
+]

--- a/build/env_config.gni
+++ b/build/env_config.gni
@@ -17,10 +17,13 @@ env_config = exec_script("env_config.py",
 # A list of .env files that were used to generate the env_config.
 env_config_files = [ rebase_path(env_config_file) ]
 
+# If there were any extra .env files included, add GN dependencies on them so
+# that GN is re-run if they change.
 if (defined(env_config.include_env) && env_config.include_env != []) {
-  # This no-op command adds GN dependencies on the extra .env files so that GN
-  # is re-run if they change.
-  exec_script("//build/noop.py", [], "", env_config.include_env)
+  foreach(env_file, env_config.include_env) {
+    # Read the file to register it as a gen-time dependency.
+    read_file(env_file, "")
+  }
 
   # Add the extra .env files to the list.
   env_config_files += rebase_path(env_config.include_env)

--- a/build/env_config.gni
+++ b/build/env_config.gni
@@ -21,12 +21,9 @@ env_config = exec_script("env_config.py",
 env_config_files = [ rebase_path(env_config_file) ]
 
 if (defined(env_config.include_env) && env_config.include_env != []) {
-  # This command is a no-op, but it adds GN dependencies on the extra .env files
-  # so that GN is re-run if they change.
-  exec_script("env_config.py",
-              [ "include_env_noop" ],
-              "",
-              env_config.include_env)
+  # This no-op command adds GN dependencies on the extra .env files so that GN
+  # is re-run if they change.
+  exec_script("//build/noop.py", [], "", env_config.include_env)
 
   # Add the extra .env files to the list.
   env_config_files += rebase_path(env_config.include_env)

--- a/build/env_config.gni
+++ b/build/env_config.gni
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  # Path to .env file that contains variables to be used in the build.
+  env_config_file = "//brave/.env"
+}
+
+# Parsed .env as a GN scope.
+env_config = exec_script("env_config.py",
+                         [
+                           "convert_to_json",
+                           rebase_path(env_config_file),
+                         ],
+                         "json",
+                         [ env_config_file ])
+
+# A list of .env files that were used to generate the env_config.
+env_config_files = [ rebase_path(env_config_file) ]
+
+if (defined(env_config.include_env) && env_config.include_env != []) {
+  # This command is a no-op, but it adds GN dependencies on the extra .env files
+  # so that GN is re-run if they change.
+  exec_script("env_config.py",
+              [ "include_env_noop" ],
+              "",
+              env_config.include_env)
+
+  # Add the extra .env files to the list.
+  env_config_files += rebase_path(env_config.include_env)
+}

--- a/build/env_config.gni
+++ b/build/env_config.gni
@@ -10,10 +10,7 @@ declare_args() {
 
 # Parsed .env as a GN scope.
 env_config = exec_script("env_config.py",
-                         [
-                           "convert_to_json",
-                           rebase_path(env_config_file),
-                         ],
+                         [ rebase_path(env_config_file) ],
                          "json",
                          [ env_config_file ])
 

--- a/build/env_config.py
+++ b/build/env_config.py
@@ -5,34 +5,21 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import argparse
-import inspect
 import json
 import os
 import re
 import sys
 
-ENV_CONFIG_SAMPLE = inspect.cleandoc('''
-# This is a sample .env config file for the build system.
-# See https://github.com/brave/brave-browser/wiki/Build-configuration
-''')
-
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('command',
-                        choices=['create_if_not_found', 'convert_to_json'])
-    parser.add_argument('filename', nargs='?')
+    parser.add_argument('filename')
 
     args = parser.parse_args()
 
-    if args.command == 'create_if_not_found':
-        if not os.path.exists(args.filename):
-            with open(args.filename, 'w', newline='\n') as file:
-                file.write(ENV_CONFIG_SAMPLE + '\n')
-    elif args.command == 'convert_to_json':
-        json.dump(read_env_config_as_dict(args.filename),
-                  sort_keys=True,
-                  fp=sys.stdout)
+    json.dump(read_env_config_as_dict(args.filename),
+              sort_keys=True,
+              fp=sys.stdout)
 
 
 # Regex to define an env config line with GN restrictions.

--- a/build/env_config.py
+++ b/build/env_config.py
@@ -19,9 +19,8 @@ ENV_CONFIG_SAMPLE = inspect.cleandoc('''
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        'command',
-        choices=['create_if_not_found', 'convert_to_json', 'include_env_noop'])
+    parser.add_argument('command',
+                        choices=['create_if_not_found', 'convert_to_json'])
     parser.add_argument('filename', nargs='?')
 
     args = parser.parse_args()
@@ -34,10 +33,6 @@ def main():
         json.dump(read_env_config_as_dict(args.filename),
                   sort_keys=True,
                   fp=sys.stdout)
-    elif args.command == 'include_env_noop':
-        # A no-op command used in GN to add extra dependencies on the files
-        # declared by include_env.
-        pass
 
 
 def read_env_config_as_dict(file_path, result_dict=None):

--- a/build/env_config.py
+++ b/build/env_config.py
@@ -98,6 +98,11 @@ def read_env_config_as_dict(file_path, result_dict=None):
                 # strings to uppercase.
                 result_dict[key.upper()] = value
 
+                # Store JSON-escaped variants to be used in a buildflag header.
+                escaped_value = json.dumps(value)
+                result_dict[key + '_escaped'] = escaped_value
+                result_dict[key.upper() + '_escaped'] = escaped_value
+
     return result_dict
 
 

--- a/build/env_config.py
+++ b/build/env_config.py
@@ -11,13 +11,16 @@ import re
 import sys
 
 
+# This script reads a .env configuration file and converts it into a JSON
+# object, which is then printed to the standard output. It is used as part of
+# `gn gen` to access .env variables directly from `.gn/.gni` files.
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('filename')
+    parser.add_argument('file_path')
 
     args = parser.parse_args()
 
-    json.dump(read_env_config_as_dict(args.filename),
+    json.dump(read_env_config_as_dict(args.file_path),
               sort_keys=True,
               fp=sys.stdout)
 
@@ -58,13 +61,15 @@ def read_env_config_as_dict(file_path, result_dict=None):
             maybe_quote = value[0] if value else ''
 
             # Remove surrounding quotes
-            value = re.sub(r'^(\")([\s\S]*)\1$', r'\2', value)
+            value = re.sub(r"^(['\"`])([\s\S]*)\1$", r'\2', value)
 
             # Expand newlines if double quoted
             if maybe_quote == '"':
                 value = value.replace('\\n', '\n')
 
             try:
+                # Try to parse the value as JSON to represent numbers and
+                # booleans correctly.
                 value = json.loads(value)
             except json.JSONDecodeError:
                 # Keep the value as a string if it's not a valid JSON.

--- a/build/env_config.py
+++ b/build/env_config.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import argparse
+import inspect
+import json
+import os
+import re
+import sys
+
+ENV_CONFIG_SAMPLE = inspect.cleandoc('''
+# This is a sample .env config file for the build system.
+# See https://github.com/brave/brave-browser/wiki/Build-configuration
+''')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'command',
+        choices=['create_if_not_found', 'convert_to_json', 'include_env_noop'])
+    parser.add_argument('filename', nargs='?')
+
+    args = parser.parse_args()
+
+    if args.command == 'create_if_not_found':
+        if not os.path.exists(args.filename):
+            with open(args.filename, 'w', newline='\n') as file:
+                file.write(ENV_CONFIG_SAMPLE + '\n')
+    elif args.command == 'convert_to_json':
+        json.dump(read_env_config_as_dict(args.filename),
+                  sort_keys=True,
+                  fp=sys.stdout)
+    elif args.command == 'include_env_noop':
+        # A no-op command used in GN to add extra dependencies on the files
+        # declared by include_env.
+        pass
+
+
+def read_env_config_as_dict(file_path, result_dict=None):
+    if result_dict is None:
+        result_dict = {}
+
+    # PowerShell saves files with BOM, to support this we use utf-8-sig.
+    with open(file_path, 'r', encoding='utf-8-sig') as file:
+        for line in file:
+            # Remove comments at the end of the line
+            line = re.sub(r'#.*$', '', line).strip()
+
+            splitted_line = line.split('=', 1)
+            if len(splitted_line) != 2:
+                continue
+
+            key, value = map(str.strip, splitted_line)
+
+            # Skip invalid keys.
+            if not re.match(r'[a-zA-Z_]+[a-zA-Z0-9_]*', key):
+                continue
+
+            try:
+                value = json.loads(value)
+            except json.JSONDecodeError:
+                # Keep the value as a string if it's not a valid JSON.
+                pass
+
+            if key == 'include_env':
+                include_path = value
+                if not os.path.isabs(include_path):
+                    include_path = os.path.abspath(
+                        os.path.join(os.path.dirname(file_path), include_path))
+                result_dict.setdefault('include_env', []).append(
+                    include_path.replace("\\", "/"))
+                read_env_config_as_dict(include_path, result_dict)
+            else:
+                result_dict[key] = value
+                # Additionaly store the key in uppercase to be able to access it
+                # during BUILDFLAG generation. GN doesn't have a way to convert
+                # strings to uppercase.
+                result_dict[key.upper()] = value
+
+    return result_dict
+
+
+if __name__ == '__main__':
+    main()

--- a/build/env_config.py
+++ b/build/env_config.py
@@ -25,12 +25,12 @@ def main():
               fp=sys.stdout)
 
 
-# Regex to define an env config line with GN restrictions.
+# Regex to define a .env config line with C++/GN restrictions.
 ENV_CONFIG_LINE = re.compile(
     r"""
     (?:^|\n)                # Start of line or newline
     \s*                     # Optional leading whitespace
-    ([a-zA-Z_]+\w*)         # Key: a valid C++/GN identifier
+    ([a-zA-Z_]\w*)          # Key: a valid C++/GN identifier
     (?:\s*=\s*)             # Assignment operator: '=' with optional whitespace
     (                       # Start of value capturing group
         \s*'(?:\\'|[^'])*'  # Single-quoted value

--- a/build/env_config_test.py
+++ b/build/env_config_test.py
@@ -128,6 +128,19 @@ class TestReadEnvConfigAsDict(unittest.TestCase):
         result = read_env_config_as_dict(file_path)
         self.assert_env_config_value(result, 'MULTILINE_KEY', 'line1\nline2')
 
+    def test_invalid_keys(self):
+        content = """
+        1key=sample_value
+        key-two=sample_value
+        key.three=sample_value
+        _KEY_VALID=valid_key
+        """
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, '_KEY_VALID', 'valid_key')
+        # Expect only _KEY4 and _KEY4_escaped in the result.
+        self.assertEqual(len(result), 2)
+
     def test_utf_8_with_bom(self):
         content = "SAMPLE_KEY=sample_value"
         file_path = self.create_temp_file(content, encoding="utf-8-sig")

--- a/build/env_config_test.py
+++ b/build/env_config_test.py
@@ -138,7 +138,7 @@ class TestReadEnvConfigAsDict(unittest.TestCase):
         file_path = self.create_temp_file(content)
         result = read_env_config_as_dict(file_path)
         self.assert_env_config_value(result, '_KEY_VALID', 'valid_key')
-        # Expect only _KEY4 and _KEY4_escaped in the result.
+        # Expect only _KEY_VALID and _KEY_VALID_escaped in the result.
         self.assertEqual(len(result), 2)
 
     def test_utf_8_with_bom(self):

--- a/build/env_config_test.py
+++ b/build/env_config_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+import tempfile
+import os
+import json
+
+from env_config import read_env_config_as_dict
+
+
+class TestReadEnvConfigAsDict(unittest.TestCase):
+
+    def setUp(self):
+        # Create a temporary directory to store test files
+        self.test_dir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        # Clean up the temporary directory
+        self.test_dir.cleanup()
+
+    def create_temp_file(self, content, filename="test.env", encoding="utf-8"):
+        # Helper function to create a temporary file with the given content
+        file_path = os.path.join(self.test_dir.name, filename)
+        with open(file_path, 'w', encoding=encoding) as f:
+            f.write(content)
+        return file_path
+
+    def assert_env_config_value(self, result, key, value):
+        self.assertEqual(result[key], value)
+        self.assertEqual(result[key + '_escaped'], json.dumps(value))
+
+    def test_env_config(self):
+        content = """
+        SAMPLE_KEY=sample_value
+        ANOTHER_KEY="another value"
+        ONE_MORE_KEY = test
+        UNQUOTED_VAL_WITH_SPACES = value with spaces
+        """
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'SAMPLE_KEY', 'sample_value')
+        self.assert_env_config_value(result, 'ANOTHER_KEY', 'another value')
+        self.assert_env_config_value(result, 'ONE_MORE_KEY', 'test')
+        self.assert_env_config_value(result, 'UNQUOTED_VAL_WITH_SPACES',
+                                     'value with spaces')
+
+    def test_key_is_uppercased(self):
+        content = "sample_key=sample_value"
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'sample_key', 'sample_value')
+        self.assert_env_config_value(result, 'SAMPLE_KEY', 'sample_value')
+
+    def test_quoted_strings(self):
+        for quote in ['`', '"', "'"]:
+            content = f"SAMPLE_KEY={quote}sample_value{quote}"
+            file_path = self.create_temp_file(content)
+            result = read_env_config_as_dict(file_path)
+            self.assert_env_config_value(result, 'SAMPLE_KEY', 'sample_value')
+
+    def test_comments(self):
+        content = """
+        # A comment
+        SAMPLE_KEY=sample_value # another comment
+        """
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'SAMPLE_KEY', 'sample_value')
+
+    def test_include_env(self):
+        main_content = """
+        VAR1=val1
+        VAR2=val2
+        include_env=include.env
+        """
+        include_content = """
+        INCLUDED_KEY=included_value
+        VAR2=val2_override
+        """
+        main_file_path = self.create_temp_file(main_content, "main.env")
+        include_file_path = self.create_temp_file(include_content,
+                                                  "include.env")
+        result = read_env_config_as_dict(main_file_path)
+        self.assert_env_config_value(result, 'VAR1', 'val1')
+        self.assert_env_config_value(result, 'VAR2', 'val2_override')
+        self.assert_env_config_value(result, 'INCLUDED_KEY', 'included_value')
+        self.assertIn(include_file_path.replace("\\", "/"),
+                      result['include_env'])
+
+    def test_json_value(self):
+        content = 'JSON_KEY={"key": "value"}'
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'JSON_KEY', {"key": "value"})
+
+    def test_bool_value(self):
+        content = 'BOOL_KEY=true'
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'BOOL_KEY', True)
+
+    def test_number_value(self):
+        content = 'NUMBER_KEY=10'
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'NUMBER_KEY', 10)
+
+    def test_invalid_json_value(self):
+        content = 'INVALID_JSON_KEY={key: value}'
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'INVALID_JSON_KEY',
+                                     '{key: value}')
+
+    def test_multiline_string(self):
+        content = 'MULTILINE_KEY="line1\\nline2"'
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'MULTILINE_KEY', 'line1\nline2')
+
+    def test_multiline_string2(self):
+        content = 'MULTILINE_KEY="line1\nline2"'
+        file_path = self.create_temp_file(content)
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'MULTILINE_KEY', 'line1\nline2')
+
+    def test_utf_8_with_bom(self):
+        content = "SAMPLE_KEY=sample_value"
+        file_path = self.create_temp_file(content, encoding="utf-8-sig")
+        result = read_env_config_as_dict(file_path)
+        self.assert_env_config_value(result, 'SAMPLE_KEY', 'sample_value')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/components/constants/BUILD.gn
+++ b/components/constants/BUILD.gn
@@ -3,25 +3,17 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import("//brave/build/buildflag_header_with_env_config.gni")
 import("//brave/build/config.gni")
-import("//build/buildflag_header.gni")
 import("//build/util/branding.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 
-declare_args() {
-  brave_services_key = ""
-}
-
-if (is_official_build) {
-  assert(brave_services_key != "")
-}
-
-buildflag_header("brave_services_key") {
+buildflag_header_with_env_config("brave_services_key") {
   # Please use //brave/components/constants instead.
   visibility = [ ":*" ]
 
   header = "brave_services_key.h"
-  flags = [ "BRAVE_SERVICES_KEY=\"$brave_services_key\"" ]
+  env_config_flags = [ "BRAVE_SERVICES_KEY" ]
 }
 
 source_set("constants") {

--- a/patches/build-dotfile_settings.gni.patch
+++ b/patches/build-dotfile_settings.gni.patch
@@ -1,0 +1,9 @@
+diff --git a/build/dotfile_settings.gni b/build/dotfile_settings.gni
+index bd7f4553e89ebde76214178b9dd2e8e10af916de..12176fa3f1c6c064a43452e5d18fa33837230ba7 100644
+--- a/build/dotfile_settings.gni
++++ b/build/dotfile_settings.gni
+@@ -41,3 +41,4 @@ build_dotfile_settings = {
+     "//build/util/branding.gni",
+   ]
+ }
++import("//brave/build/dotfile_settings.gni") build_dotfile_settings.exec_script_whitelist += brave_build_dotfile_settings.exec_script_whitelist

--- a/patches/build-dotfile_settings.gni.patch
+++ b/patches/build-dotfile_settings.gni.patch
@@ -1,9 +1,9 @@
 diff --git a/build/dotfile_settings.gni b/build/dotfile_settings.gni
-index bd7f4553e89ebde76214178b9dd2e8e10af916de..12176fa3f1c6c064a43452e5d18fa33837230ba7 100644
+index bd7f4553e89ebde76214178b9dd2e8e10af916de..40918c48054ed11829b9757f7093f7df01b8e0d0 100644
 --- a/build/dotfile_settings.gni
 +++ b/build/dotfile_settings.gni
 @@ -41,3 +41,4 @@ build_dotfile_settings = {
      "//build/util/branding.gni",
    ]
  }
-+import("//brave/build/dotfile_settings.gni") build_dotfile_settings.exec_script_whitelist += brave_build_dotfile_settings.exec_script_whitelist
++import("//brave/build/dotfile_settings.gni") build_dotfile_settings.exec_script_whitelist += brave_exec_script_whitelist


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Add support for accessing `.env` vars directly in GN scripts.

Resolves https://github.com/brave/brave-browser/issues/40783

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

