### PR TITLE
Remove `CalculatePreferredSize` from `BraveVPNStatusLabel` (uplift to 1.71.x)

### DIFF
--- a/browser/ui/views/toolbar/brave_vpn_status_label.cc
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.cc
@@ -76,21 +76,6 @@ void BraveVPNStatusLabel::OnConnectionStateChanged(ConnectionState state) {
   UpdateState();
 }
 
-gfx::Size BraveVPNStatusLabel::CalculatePreferredSize(
-    const views::SizeBounds& available_size) const {
-  auto size = views::Label::CalculatePreferredSize(available_size);
-  if (longest_state_string_id_ == -1)
-    return size;
-  auto text =
-      brave_l10n::GetLocalizedResourceUTF16String(longest_state_string_id_);
-  if (text == GetText())
-    return size;
-  size.set_width(font_list().GetExpectedTextWidth(text.length()) +
-                 GetInsets().width());
-  size.set_height(GetHeightForWidth(size.width()));
-  return size;
-}
-
 void BraveVPNStatusLabel::UpdateState() {
   const auto state = service_->GetConnectionState();
 

--- a/browser/ui/views/toolbar/brave_vpn_status_label.h
+++ b/browser/ui/views/toolbar/brave_vpn_status_label.h
@@ -27,9 +27,6 @@ class BraveVPNStatusLabel : public views::Label,
   BraveVPNStatusLabel(const BraveVPNStatusLabel&) = delete;
   BraveVPNStatusLabel& operator=(const BraveVPNStatusLabel&) = delete;
 
-  gfx::Size CalculatePreferredSize(
-      const views::SizeBounds& available_size) const override;
-
  private:
   // brave_vpn::BraveVPNServiceObserver overrides:
   void OnConnectionStateChanged(


### PR DESCRIPTION
Uplift of #25595
Fixes https://github.com/brave/brave-browser/issues/41084

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.