### PR TITLE
fix(privacy): Add logic to record initial AdBlockSetting & FingerprintBlockSetting values (uplift to 1.71.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3283,12 +3283,16 @@ extension BrowserViewController: PreferencesObserver {
       tabManager.reloadSelectedTab()
     case Preferences.General.enablePullToRefresh.key:
       tabManager.selectedTab?.updatePullToRefreshVisibility()
-    case ShieldPreferences.blockAdsAndTrackingLevelRaw.key,
-      Preferences.Shields.blockScripts.key,
+    case Preferences.Shields.blockScripts.key,
       Preferences.Shields.blockImages.key,
-      Preferences.Shields.fingerprintingProtection.key,
       Preferences.Shields.useRegionAdBlock.key:
       tabManager.reloadSelectedTab()
+    case ShieldPreferences.blockAdsAndTrackingLevelRaw.key:
+      tabManager.reloadSelectedTab()
+      recordGlobalAdBlockShieldsP3A()
+    case Preferences.Shields.fingerprintingProtection.key:
+      tabManager.reloadSelectedTab()
+      recordGlobalFingerprintingShieldsP3A()
     case Preferences.General.defaultPageZoomLevel.key:
       tabManager.allTabs.forEach({
         guard let url = $0.webView?.url else { return }

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdvancedShieldSettings.swift
@@ -65,9 +65,6 @@ import os
   @Published var adBlockAndTrackingPreventionLevel: ShieldLevel {
     didSet {
       ShieldPreferences.blockAdsAndTrackingLevel = adBlockAndTrackingPreventionLevel
-      if adBlockAndTrackingPreventionLevel != oldValue {
-        recordGlobalAdBlockShieldsP3A()
-      }
     }
   }
   @Published var httpsUpgradeLevel: HTTPSUpgradeLevel {
@@ -278,43 +275,5 @@ import os
         }
       }
       .store(in: &subscriptions)
-
-    Preferences.Shields.fingerprintingProtection.$value
-      .sink { [weak self] _ in
-        self?.recordGlobalFingerprintingShieldsP3A()
-      }
-      .store(in: &subscriptions)
-  }
-
-  // MARK: - P3A
-
-  private func recordGlobalAdBlockShieldsP3A() {
-    // Q46 What is the global ad blocking shields setting?
-    enum Answer: Int, CaseIterable {
-      case disabled = 0
-      case standard = 1
-      case aggressive = 2
-    }
-
-    let answer = { () -> Answer in
-      switch ShieldPreferences.blockAdsAndTrackingLevel {
-      case .disabled: return .disabled
-      case .standard: return .standard
-      case .aggressive: return .aggressive
-      }
-    }()
-
-    UmaHistogramEnumeration("Brave.Shields.AdBlockSetting", sample: answer)
-  }
-
-  private func recordGlobalFingerprintingShieldsP3A() {
-    // Q47 What is the global fingerprinting shields setting?
-    enum Answer: Int, CaseIterable {
-      case disabled = 0
-      case standard = 1
-      case aggressive = 2
-    }
-    let answer: Answer = Preferences.Shields.fingerprintingProtection.value ? .standard : .disabled
-    UmaHistogramEnumeration("Brave.Shields.FingerprintBlockSetting", sample: answer)
   }
 }

--- a/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
+++ b/ios/brave-ios/Sources/Preferences/GlobalPreferences.swift
@@ -83,9 +83,9 @@ extension Preferences {
       default: false
     )
     /// Whether or not we've reported the initial state of shields for p3a
-    public static let initialP3AStateReported = Option<Bool>(
-      key: "shields.initial-p3a-state-reported",
-      default: false
+    public static let initialP3AStateReportedRevision = Option<Int>(
+      key: "shields.initial-p3a-state-reported-revision",
+      default: 0
     )
   }
 


### PR DESCRIPTION
Uplift of #25582
Resolves https://github.com/brave/brave-browser/issues/41054

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.