### PR TITLE
Fix flaky create_dist_zips on macOS (uplift to 1.70.x)

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -542,6 +542,7 @@ action("create_dist_zips") {
     if (is_mac) {
       dir_inputs += [ brave_exe ]
       rebase_base_dir = rebase_path(root_out_dir)
+      deps += [ "//brave/build/mac:finalize_app" ]
     } else {
       rebase_base_dir = rebase_path(brave_dist_dir, root_out_dir)
     }


### PR DESCRIPTION
Uplift of #25581
Resolves https://github.com/brave/brave-browser/issues/41085

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.