### PR TITLE
Use `base::StringPrintf` in `constexrp` contexts

### DIFF
--- a/browser/net/brave_network_audit_allowed_lists.h
+++ b/browser/net/brave_network_audit_allowed_lists.h
@@ -79,13 +79,6 @@ inline constexpr const char* kAllowedUrlPrefixes[] = {
     "https://static1.brave.com/",
 };
 
-inline constexpr const char* kAllowedBraveSearchTemplates[] = {
-    // Brave search
-    // The test simulation has a pattern https://search.brave.com:<port>
-    // port is changed dynamically
-    "https://search.brave.com:%s/",
-};
-
 // Before adding to this list, get approval from the security team.
 inline constexpr const char* kAllowedUrlPatterns[] = {
     // allowed because it's url for fetching super referral's mapping table

--- a/browser/net/brave_network_audit_search_ad_browsertest.cc
+++ b/browser/net/brave_network_audit_search_ad_browsertest.cc
@@ -14,7 +14,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"
-#include "base/strings/stringprintf.h"
+#include "base/strings/strcat.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/test/bind.h"
 #include "base/test/scoped_feature_list.h"
@@ -119,9 +119,13 @@ class BraveNetworkAuditSearchAdTest : public InProcessBrowserTest {
     std::string port =
         base::NumberToString(https_server()->host_port_pair().port());
     std::vector<std::string> allowed_prefixes;
-    for (const char* prefix : kAllowedBraveSearchTemplates) {
-      allowed_prefixes.push_back(base::StringPrintf(prefix, port.c_str()));
-    }
+
+    // Brave search
+    // The test simulation has a pattern https://search.brave.com:<port>
+    // port is changed dynamically
+    const char kAllowedBraveSearchTemplate[] = "https://search.brave.com:%s/";
+    allowed_prefixes.push_back(
+        base::StringPrintf(kAllowedBraveSearchTemplate, port.c_str()));
     VerifyNetworkAuditLog(net_log_path_, audit_results_path_, allowed_prefixes);
   }
 

--- a/components/brave_rewards/core/endpoints/brave/get_wallet.cc
+++ b/components/brave_rewards/core/endpoints/brave/get_wallet.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/json/json_reader.h"
+#include "base/strings/strcat.h"
 #include "brave/components/brave_rewards/core/common/environment_config.h"
 #include "brave/components/brave_rewards/core/common/request_signer.h"
 #include "brave/components/brave_rewards/core/common/url_helpers.h"
@@ -22,6 +23,8 @@ using Error = GetWallet::Error;
 using Result = GetWallet::Result;
 
 namespace {
+
+constexpr char kPath[] = "/v4/wallets/";
 
 Result ParseBody(RewardsEngine& engine, const std::string& body) {
   auto value = base::JSONReader::Read(body);
@@ -92,10 +95,6 @@ GetWallet::GetWallet(RewardsEngine& engine) : RequestBuilder(engine) {}
 
 GetWallet::~GetWallet() = default;
 
-std::string GetWallet::Path() const {
-  return "/v4/wallets/";
-}
-
 std::optional<std::string> GetWallet::Url() const {
   const auto wallet = engine_->wallet()->GetWallet();
   if (!wallet) {
@@ -105,7 +104,7 @@ std::optional<std::string> GetWallet::Url() const {
 
   auto url =
       URLHelpers::Resolve(engine_->Get<EnvironmentConfig>().rewards_grant_url(),
-                          {Path(), wallet->payment_id});
+                          {kPath, wallet->payment_id});
 
   return url.spec();
 }
@@ -131,8 +130,8 @@ std::optional<std::vector<std::string>> GetWallet::Headers(
     return std::nullopt;
   }
 
-  return signer->GetSignedHeaders("get " + Path() + wallet->payment_id,
-                                  content);
+  return signer->GetSignedHeaders(
+      base::StrCat({"get ", kPath, wallet->payment_id}), content);
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/endpoints/brave/get_wallet.h
+++ b/components/brave_rewards/core/endpoints/brave/get_wallet.h
@@ -79,8 +79,6 @@ class GetWallet final : public RequestBuilder,
   ~GetWallet() override;
 
  private:
-  std::string Path() const;
-
   std::optional<std::string> Url() const override;
   mojom::UrlMethod Method() const override;
   std::optional<std::vector<std::string>> Headers(

--- a/components/brave_rewards/core/endpoints/brave/patch_wallets.cc
+++ b/components/brave_rewards/core/endpoints/brave/patch_wallets.cc
@@ -10,7 +10,7 @@
 
 #include "base/json/json_reader.h"
 #include "base/json/json_writer.h"
-#include "base/strings/stringprintf.h"
+#include "base/strings/strcat.h"
 #include "brave/components/brave_rewards/core/common/environment_config.h"
 #include "brave/components/brave_rewards/core/common/request_signer.h"
 #include "brave/components/brave_rewards/core/rewards_engine.h"
@@ -22,6 +22,8 @@ using Error = PatchWallets::Error;
 using Result = PatchWallets::Result;
 
 namespace {
+
+constexpr char kPatchWalletsPathPrefix[] = "/v4/wallets/";
 
 Result ParseBody(RewardsEngine& engine, const std::string& body) {
   const auto value = base::JSONReader::Read(body);
@@ -87,10 +89,6 @@ PatchWallets::PatchWallets(RewardsEngine& engine, std::string&& geo_country)
 
 PatchWallets::~PatchWallets() = default;
 
-const char* PatchWallets::Path() const {
-  return "/v4/wallets/%s";
-}
-
 std::optional<std::string> PatchWallets::Url() const {
   const auto wallet = engine_->wallet()->GetWallet();
   if (!wallet) {
@@ -102,7 +100,7 @@ std::optional<std::string> PatchWallets::Url() const {
 
   return engine_->Get<EnvironmentConfig>()
       .rewards_grant_url()
-      .Resolve(base::StringPrintf(Path(), wallet->payment_id.c_str()))
+      .Resolve(base::StrCat({kPatchWalletsPathPrefix, wallet->payment_id}))
       .spec();
 }
 
@@ -128,7 +126,7 @@ std::optional<std::vector<std::string>> PatchWallets::Headers(
   }
 
   return signer->GetSignedHeaders(
-      "patch " + base::StringPrintf(Path(), wallet->payment_id.c_str()),
+      base::StrCat({"patch ", kPatchWalletsPathPrefix, wallet->payment_id}),
       content);
 }
 

--- a/components/brave_rewards/core/endpoints/brave/patch_wallets.h
+++ b/components/brave_rewards/core/endpoints/brave/patch_wallets.h
@@ -48,8 +48,6 @@ class PatchWallets final : public RequestBuilder,
   ~PatchWallets() override;
 
  private:
-  const char* Path() const;
-
   std::optional<std::string> Url() const override;
   mojom::UrlMethod Method() const override;
   std::optional<std::vector<std::string>> Headers(

--- a/components/brave_rewards/core/endpoints/brave/post_connect_bitflyer.cc
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_bitflyer.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/json/json_writer.h"
+#include "base/strings/stringprintf.h"
 #include "brave/components/brave_rewards/core/rewards_engine.h"
 
 namespace brave_rewards::internal::endpoints {
@@ -37,8 +38,8 @@ std::optional<std::string> PostConnectBitflyer::Content() const {
   return json;
 }
 
-const char* PostConnectBitflyer::Path() const {
-  return "/v3/wallet/bitflyer/%s/claim";
+std::string PostConnectBitflyer::Path(base::cstring_view payment_id) const {
+  return base::StringPrintf("/v3/wallet/bitflyer/%s/claim", payment_id.c_str());
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/endpoints/brave/post_connect_bitflyer.h
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_bitflyer.h
@@ -38,7 +38,7 @@ class PostConnectBitflyer final : public PostConnect {
  private:
   std::optional<std::string> Content() const override;
 
-  const char* Path() const override;
+  std::string Path(base::cstring_view payment_id) const override;
 
   std::string linking_info_;
 };

--- a/components/brave_rewards/core/endpoints/brave/post_connect_gemini.cc
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_gemini.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/json/json_writer.h"
+#include "base/strings/stringprintf.h"
 #include "brave/components/brave_rewards/core/rewards_engine.h"
 
 namespace brave_rewards::internal::endpoints {
@@ -46,8 +47,8 @@ std::optional<std::string> PostConnectGemini::Content() const {
   return json;
 }
 
-const char* PostConnectGemini::Path() const {
-  return "/v3/wallet/gemini/%s/claim";
+std::string PostConnectGemini::Path(base::cstring_view payment_id) const {
+  return base::StringPrintf("/v3/wallet/gemini/%s/claim", payment_id.c_str());
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/endpoints/brave/post_connect_gemini.h
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_gemini.h
@@ -41,7 +41,7 @@ class PostConnectGemini final : public PostConnect {
  private:
   std::optional<std::string> Content() const override;
 
-  const char* Path() const override;
+  std::string Path(base::cstring_view payment_id) const override;
 
   std::string linking_info_;
   std::string recipient_id_;

--- a/components/brave_rewards/core/endpoints/brave/post_connect_uphold.cc
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_uphold.cc
@@ -10,6 +10,7 @@
 
 #include "base/base64.h"
 #include "base/json/json_writer.h"
+#include "base/strings/stringprintf.h"
 #include "brave/components/brave_rewards/core/common/request_signer.h"
 #include "brave/components/brave_rewards/core/rewards_engine.h"
 #include "brave/components/brave_rewards/core/wallet/wallet.h"
@@ -102,8 +103,8 @@ std::optional<std::vector<std::string>> PostConnectUphold::Headers(
   return std::vector<std::string>{};
 }
 
-const char* PostConnectUphold::Path() const {
-  return "/v3/wallet/uphold/%s/claim";
+std::string PostConnectUphold::Path(base::cstring_view payment_id) const {
+  return base::StringPrintf("/v3/wallet/uphold/%s/claim", payment_id.c_str());
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/endpoints/brave/post_connect_uphold.h
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_uphold.h
@@ -58,7 +58,7 @@ class PostConnectUphold final : public PostConnect {
   std::optional<std::vector<std::string>> Headers(
       const std::string& content) const override;
 
-  const char* Path() const override;
+  std::string Path(base::cstring_view payment_id) const override;
 
   std::string address_;
 };

--- a/components/brave_rewards/core/endpoints/brave/post_connect_zebpay.cc
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_zebpay.cc
@@ -9,6 +9,7 @@
 #include <utility>
 
 #include "base/json/json_writer.h"
+#include "base/strings/stringprintf.h"
 #include "brave/components/brave_rewards/core/rewards_engine.h"
 
 namespace brave_rewards::internal::endpoints {
@@ -37,8 +38,8 @@ std::optional<std::string> PostConnectZebPay::Content() const {
   return json;
 }
 
-const char* PostConnectZebPay::Path() const {
-  return "/v3/wallet/zebpay/%s/claim";
+std::string PostConnectZebPay::Path(base::cstring_view payment_id) const {
+  return base::StringPrintf("/v3/wallet/zebpay/%s/claim", payment_id.c_str());
 }
 
 }  // namespace brave_rewards::internal::endpoints

--- a/components/brave_rewards/core/endpoints/brave/post_connect_zebpay.h
+++ b/components/brave_rewards/core/endpoints/brave/post_connect_zebpay.h
@@ -38,7 +38,7 @@ class PostConnectZebPay final : public PostConnect {
  private:
   std::optional<std::string> Content() const override;
 
-  const char* Path() const override;
+  std::string Path(base::cstring_view payment_id) const override;
 
   std::string linking_info_;
 };

--- a/components/brave_rewards/core/endpoints/common/post_connect.cc
+++ b/components/brave_rewards/core/endpoints/common/post_connect.cc
@@ -182,7 +182,7 @@ std::optional<std::string> PostConnect::Url() const {
 
   return engine_->Get<EnvironmentConfig>()
       .rewards_grant_url()
-      .Resolve(base::StringPrintf(Path(), wallet->payment_id.c_str()))
+      .Resolve(Path(wallet->payment_id))
       .spec();
 }
 
@@ -203,9 +203,7 @@ std::optional<std::vector<std::string>> PostConnect::Headers(
     return std::nullopt;
   }
 
-  return signer->GetSignedHeaders(
-      "post " + base::StringPrintf(Path(), wallet->payment_id.c_str()),
-      content);
+  return signer->GetSignedHeaders("post " + Path(wallet->payment_id), content);
 }
 
 std::string PostConnect::ContentType() const {

--- a/components/brave_rewards/core/endpoints/common/post_connect.h
+++ b/components/brave_rewards/core/endpoints/common/post_connect.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <vector>
 
+#include "base/strings/cstring_view.h"
 #include "brave/components/brave_rewards/common/mojom/rewards.mojom.h"
 #include "brave/components/brave_rewards/common/mojom/rewards_core.mojom.h"
 #include "brave/components/brave_rewards/core/endpoints/request_builder.h"
@@ -40,7 +41,7 @@ class PostConnect : public RequestBuilder, public ResponseHandler<PostConnect> {
   ~PostConnect() override;
 
  protected:
-  virtual const char* Path() const = 0;
+  virtual std::string Path(base::cstring_view payment_id) const = 0;
 
  private:
   std::optional<std::string> Url() const override;

--- a/components/brave_rewards/core/endpoints/common/post_connect_unittest.cc
+++ b/components/brave_rewards/core/endpoints/common/post_connect_unittest.cc
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <utility>
 
+#include "base/strings/stringprintf.h"
 #include "brave/components/brave_rewards/core/common/environment_config.h"
 #include "brave/components/brave_rewards/core/endpoints/request_for.h"
 #include "brave/components/brave_rewards/core/state/state_keys.h"
@@ -31,7 +32,9 @@ class PostConnectMock final : public endpoints::PostConnect {
   ~PostConnectMock() override = default;
 
  private:
-  const char* Path() const override { return "/v3/wallet/mock/%s/claim"; }
+  std::string Path(base::cstring_view payment_id) const override {
+    return base::StringPrintf("/v3/wallet/mock/%s/claim", payment_id.c_str());
+  }
 };
 
 using PostConnectParamType = std::tuple<

--- a/components/brave_wallet/browser/simulation_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/simulation_response_parser_unittest.cc
@@ -917,7 +917,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmBuyErc1155TokenWithEth) {
 
 // Example from https://docs.blowfish.xyz/reference/scan-transactions-evm
 TEST(SimulationResponseParserUnitTest, ParseEvmErc1155ApprovalForAll) {
-  std::string json(R"(
+  constexpr char kJson[] = R"(
     {
       "requestId":"e8cd35ce-f743-4ef2-8e94-f26857744db7",
       "action":"WARN",
@@ -968,10 +968,9 @@ TEST(SimulationResponseParserUnitTest, ParseEvmErc1155ApprovalForAll) {
         }
       }
     }
-  )");
+  )";
 
-  auto json_with_token_name =
-      base::StringPrintf(json.c_str(), "\"Sandbox ASSET\"");
+  auto json_with_token_name = base::StringPrintf(kJson, "\"Sandbox ASSET\"");
 
   auto simulation_response = evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
@@ -1022,22 +1021,22 @@ TEST(SimulationResponseParserUnitTest, ParseEvmErc1155ApprovalForAll) {
   EXPECT_EQ(state_change_raw_info->asset->price->dollar_value_per_token,
             "232.43");
 
-  json_with_token_name = base::StringPrintf(json.c_str(), "null");
+  json_with_token_name = base::StringPrintf(kJson, "null");
   EXPECT_TRUE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
 
-  json_with_token_name = base::StringPrintf(json.c_str(), "[]");
+  json_with_token_name = base::StringPrintf(kJson, "[]");
   EXPECT_FALSE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
 
-  json_with_token_name = base::StringPrintf(json.c_str(), "{}");
+  json_with_token_name = base::StringPrintf(kJson, "{}");
   EXPECT_FALSE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
 
-  json_with_token_name = base::StringPrintf(json.c_str(), "false");
+  json_with_token_name = base::StringPrintf(kJson, "false");
   EXPECT_FALSE(evm::ParseSimulationResponse(
       ParseJson(json_with_token_name),
       "0xd8da6bf26964af9d7eed9e03e53415d37aa96045"));
@@ -1202,7 +1201,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmUnknownWarnings) {
 }
 
 TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
-  std::string json_fmt(R"(
+  constexpr char kJson[] = R"(
     {
       "requestId":"e8cd35ce-f743-4ef2-8e94-f26857744db7",
       "action":"NONE",
@@ -1243,11 +1242,10 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
         }
       }
     }
-  )");
+  )";
 
   {
-    auto json =
-        base::StringPrintf(json_fmt.c_str(), "null", "null", "null", "null");
+    auto json = base::StringPrintf(kJson, "null", "null", "null", "null");
     auto simulation_response = evm::ParseSimulationResponse(
         ParseJson(json), "0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
 
@@ -1292,8 +1290,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   }
 
   {
-    auto json =
-        base::StringPrintf(json_fmt.c_str(), "null", "null", "true", "null");
+    auto json = base::StringPrintf(kJson, "null", "null", "true", "null");
     // OK: invalid values for nullable field asset->imageUrl are treated as
     // null.
     auto simulation_response = evm::ParseSimulationResponse(
@@ -1307,8 +1304,7 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   }
 
   {
-    auto json =
-        base::StringPrintf(json_fmt.c_str(), "null", "null", "null", "true");
+    auto json = base::StringPrintf(kJson, "null", "null", "null", "true");
     // OK: invalid values for nullable field asset->price are treated as
     // null.
     auto simulation_response = evm::ParseSimulationResponse(
@@ -1322,8 +1318,8 @@ TEST(SimulationResponseParserUnitTest, ParseEvmNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(json_fmt.c_str(), "null", "null", "null",
-                                   "{\"foo\": 1}");
+    auto json =
+        base::StringPrintf(kJson, "null", "null", "null", "{\"foo\": 1}");
     // OK: invalid dict for nullable field asset->price is treated as null.
     auto simulation_response = evm::ParseSimulationResponse(
         ParseJson(json), "0xd8da6bf26964af9d7eed9e03e53415d37aa96045");
@@ -1785,7 +1781,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaWarnings) {
 }
 
 TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
-  std::string json_fmt(R"(
+  constexpr char kJson[] = R"(
     {
       "aggregated": {
         "action": "NONE",
@@ -1805,7 +1801,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
                     "decimals": "6",
                     "supply": "1000000000",
                     "metaplexTokenStandard": "unknown",
-                    "price": null,
+                    "price": %s,
                     "imageUrl": "https://usdt.png"
                   },
                   "diff": {
@@ -1821,10 +1817,10 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
         "error": null,
       }
     }
-  )");
+  )";
 
   {
-    auto json = base::StringPrintf(json_fmt.c_str(), "null");
+    auto json = base::StringPrintf(kJson, "null");
     auto simulation_response = solana::ParseSimulationResponse(
         ParseJson(json), "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT");
 
@@ -1841,7 +1837,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(json_fmt.c_str(), "true");
+    auto json = base::StringPrintf(kJson, "true");
     auto simulation_response = solana::ParseSimulationResponse(
         ParseJson(json), "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT");
 
@@ -1859,7 +1855,7 @@ TEST(SimulationResponseParserUnitTest, ParseSolanaNullableFields) {
   }
 
   {
-    auto json = base::StringPrintf(json_fmt.c_str(), "{\"foo\": 1}");
+    auto json = base::StringPrintf(kJson, "{\"foo\": 1}");
     auto simulation_response = solana::ParseSimulationResponse(
         ParseJson(json), "8eekKfUAGSJbq3CdA2TmHb8tKuyzd5gtEas3MYAtXzrT");
 

--- a/components/brave_wallet/browser/solana_requests_unittest.cc
+++ b/components/brave_wallet/browser/solana_requests_unittest.cc
@@ -110,7 +110,7 @@ TEST(SolanaRequestsUnitTest, getBlockHeight) {
 }
 
 TEST(SolanaRequestsUnitTest, getTokenAccountsByOwner) {
-  std::string expected_json_string_fmt = R"(
+  constexpr char kExpectedJsonStringFormat[] = R"(
     {
       "id":1,
       "jsonrpc":"2.0",
@@ -128,18 +128,18 @@ TEST(SolanaRequestsUnitTest, getTokenAccountsByOwner) {
   )";
   ASSERT_EQ(base::test::ParseJsonDict(
                 getTokenAccountsByOwner("pubkey", "base64", "program")),
-            base::test::ParseJsonDict(base::StringPrintf(
-                expected_json_string_fmt.c_str(), "base64")));
+            base::test::ParseJsonDict(
+                base::StringPrintf(kExpectedJsonStringFormat, "base64")));
 
   ASSERT_EQ(base::test::ParseJsonDict(
                 getTokenAccountsByOwner("pubkey", "base58", "program")),
-            base::test::ParseJsonDict(base::StringPrintf(
-                expected_json_string_fmt.c_str(), "base58")));
+            base::test::ParseJsonDict(
+                base::StringPrintf(kExpectedJsonStringFormat, "base58")));
 
   ASSERT_EQ(base::test::ParseJsonDict(
                 getTokenAccountsByOwner("pubkey", "jsonParsed", "program")),
-            base::test::ParseJsonDict(base::StringPrintf(
-                expected_json_string_fmt.c_str(), "jsonParsed")));
+            base::test::ParseJsonDict(
+                base::StringPrintf(kExpectedJsonStringFormat, "jsonParsed")));
 
   EXPECT_CHECK_DEATH(
       getTokenAccountsByOwner("pubkey", "invalid encoding", "program"));

--- a/components/brave_wallet/browser/solana_response_parser_unittest.cc
+++ b/components/brave_wallet/browser/solana_response_parser_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 #include <string>
+#include <utility>
 
 #include "base/strings/stringprintf.h"
 #include "base/test/gtest_util.h"
@@ -80,7 +81,7 @@ TEST(SolanaResponseParserUnitTest, ParseGetTokenAccountBalance) {
 }
 
 TEST(SolanaResponseParserUnitTest, ParseGetSPLTokenBalances) {
-  std::string json_fmt(R"(
+  constexpr char kJsonFmt[] = R"(
     {
       "jsonrpc": "2.0",
       "result": {
@@ -177,10 +178,10 @@ TEST(SolanaResponseParserUnitTest, ParseGetSPLTokenBalances) {
       },
       "id": 1
     }
-  )");
+  )";
 
   // OK: well-formed json
-  auto json = base::StringPrintf(json_fmt.c_str(), "9");
+  auto json = base::StringPrintf(kJsonFmt, "9");
   auto result = ParseGetSPLTokenBalances(ParseJson(json));
   ASSERT_TRUE(result.has_value());
   ASSERT_EQ(result->size(), 2UL);
@@ -198,15 +199,15 @@ TEST(SolanaResponseParserUnitTest, ParseGetSPLTokenBalances) {
   EXPECT_EQ(result->at(1)->decimals, 6);
 
   // KO: decimals uint8_t overflow
-  json = base::StringPrintf(json_fmt.c_str(), "256");
+  json = base::StringPrintf(kJsonFmt, "256");
   EXPECT_FALSE(ParseGetSPLTokenBalances(ParseJson(json)));
 
   // KO: decimals uint8_t underflow
-  json = base::StringPrintf(json_fmt.c_str(), "-1");
+  json = base::StringPrintf(kJsonFmt, "-1");
   EXPECT_FALSE(ParseGetSPLTokenBalances(ParseJson(json)));
 
   // KO: decimals type mismatch
-  json = base::StringPrintf(json_fmt.c_str(), "\"not a decimal\"");
+  json = base::StringPrintf(kJsonFmt, "\"not a decimal\"");
   EXPECT_FALSE(ParseGetSPLTokenBalances(ParseJson(json)));
 }
 

--- a/components/brave_wallet/browser/swap_request_helper_unittest.cc
+++ b/components/brave_wallet/browser/swap_request_helper_unittest.cc
@@ -23,8 +23,7 @@ namespace brave_wallet {
 
 namespace {
 
-const char* GetJupiterQuoteTemplate() {
-  return R"(
+constexpr char kJupiterQuoteTemplate[] = R"(
     {
       "inputMint": "So11111111111111111111111111111111111111112",
       "inAmount": "100000000",
@@ -67,10 +66,8 @@ const char* GetJupiterQuoteTemplate() {
         }
       ]
     })";
-}
 
-const char* GetLiFiQuoteTemplate() {
-  return R"(
+constexpr char kLiFiQuoteTemplate[] = R"(
     {
       "routes": [
         {
@@ -367,10 +364,8 @@ const char* GetLiFiQuoteTemplate() {
       }
     }
   )";
-}
 
-const char* GetLiFiEvmToSolQuoteTemplate() {
-  return R"(
+constexpr char kLiFiEvmToSolQuoteTemplate[] = R"(
     {
       "routes": [
         {
@@ -602,10 +597,8 @@ const char* GetLiFiEvmToSolQuoteTemplate() {
       }
     }
   )";
-}
 
-const char* GetLiFiEvmToSolQuoteTemplate2() {
-  return R"(
+constexpr char kLiFiEvmToSolQuoteTemplate2[] = R"(
     {
       "routes": [
         {
@@ -833,14 +826,13 @@ const char* GetLiFiEvmToSolQuoteTemplate2() {
       }
     }
   )";
-}
 
 }  // namespace
 
 TEST(SwapRequestHelperUnitTest, EncodeJupiterTransactionParams) {
-  auto* json_template = GetJupiterQuoteTemplate();
   std::string json = base::StringPrintf(
-      json_template, "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");  // USDC
+      kJupiterQuoteTemplate,
+      "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");  // USDC
   mojom::JupiterQuotePtr swap_quote =
       jupiter::ParseQuoteResponse(ParseJson(json));
   ASSERT_TRUE(swap_quote);
@@ -1010,7 +1002,7 @@ TEST(SwapRequestHelperUnitTest, EncodeLiFiQuoteParams) {
 TEST(SwapRequestHelperUnitTest, EncodeLiFiTransactionParams) {
   // OK: EVM -> EVM bridge quotes are correctly handled
   mojom::LiFiQuotePtr quote =
-      lifi::ParseQuoteResponse(ParseJson(GetLiFiQuoteTemplate()));
+      lifi::ParseQuoteResponse(ParseJson(kLiFiQuoteTemplate));
   ASSERT_TRUE(quote);
   ASSERT_EQ(quote->routes.size(), 1UL);
   ASSERT_EQ(quote->routes[0]->steps.size(), 1UL);
@@ -1241,7 +1233,7 @@ TEST(SwapRequestHelperUnitTest, EncodeLiFiTransactionParams) {
   EXPECT_EQ(ParseJson(*params), ParseJson(expected_params));
 
   // OK: EVM -> SOL bridge quotes are correctly handled
-  quote = lifi::ParseQuoteResponse(ParseJson(GetLiFiEvmToSolQuoteTemplate()));
+  quote = lifi::ParseQuoteResponse(ParseJson(kLiFiEvmToSolQuoteTemplate));
   ASSERT_TRUE(quote);
   ASSERT_EQ(quote->routes.size(), 1UL);
   ASSERT_EQ(quote->routes[0]->steps.size(), 1UL);
@@ -1413,7 +1405,7 @@ TEST(SwapRequestHelperUnitTest, EncodeLiFiTransactionParams) {
   EXPECT_EQ(ParseJson(*params), ParseJson(expected_params));
 
   // OK: EVM to native SOL bridge quotes are correctly handled
-  quote = lifi::ParseQuoteResponse(ParseJson(GetLiFiEvmToSolQuoteTemplate2()));
+  quote = lifi::ParseQuoteResponse(ParseJson(kLiFiEvmToSolQuoteTemplate2));
   ASSERT_TRUE(quote);
   ASSERT_EQ(quote->routes.size(), 1UL);
   ASSERT_EQ(quote->routes[0]->steps.size(), 1UL);

--- a/components/brave_wallet/common/eth_request_helper_unittest.cc
+++ b/components/brave_wallet/common/eth_request_helper_unittest.cc
@@ -690,7 +690,7 @@ TEST(EthResponseHelperUnitTest, ParseSwitchEthereumChainParams) {
 }
 
 TEST(EthRequestHelperUnitTest, ParseEthSignTypedDataParams) {
-  const std::string json_tmpl = R"({
+  constexpr char kJson[] = R"({
     "params": [
       "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
       "{
@@ -723,7 +723,7 @@ TEST(EthRequestHelperUnitTest, ParseEthSignTypedDataParams) {
     ]
   })";
 
-  std::string json = base::StringPrintf(json_tmpl.c_str(), R"({
+  std::string json = base::StringPrintf(kJson, R"({
     \"from\": {
       \"name\":\"Cow\",
       \"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"
@@ -787,7 +787,7 @@ TEST(EthRequestHelperUnitTest, ParseEthSignTypedDataParams) {
   EXPECT_FALSE(meta);
 
   // Test with extra fields in the message.
-  json = base::StringPrintf(json_tmpl.c_str(), R"({
+  json = base::StringPrintf(kJson, R"({
     \"from\": {
       \"name\":\"Cow\",
       \"wallet\":\"0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826\"


### PR DESCRIPTION
Upstream has made this function constexpr, in order to force callers to change its call sites to use a constexpr string, in order to be able to validate at compile time the format string. There is an alternative `base::StringPrintfNonConstexpr`, but obviously this unsafe variant should be avoided whenever possible.

This change goes over the different places where the `constexpr` constrained was being violated, and corrects each callsite. This has also revealed a buggy test in `SimulationResponseParserUnitTest`, where the formatting string wasn't correct.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/8bf39fbefcd2963b3647c24f2b27dfb5c40875c4

    commit 8bf39fbefcd2963b3647c24f2b27dfb5c40875c4
    Author: Peter Kasting <pkasting@chromium.org>
    Date:   Fri Sep 13 19:07:33 2024 +0000

        Disallow StringPrintf() with non-constexpr format strings.

        Bug: 365705855

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41137

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

