### PR TITLE
[iOS] Handle non-passbook attachment downloads correctly

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -756,13 +756,14 @@ extension BrowserViewController: WKNavigationDelegate {
       return .download
     }
 
+    if response.mimeType == MIMEType.passbook {
+      return .download
+    }
+
     // Check if this response should be handed off to Passbook.
     if shouldDownloadNavigationResponse {
       shouldDownloadNavigationResponse = false
-
-      if response.mimeType == MIMEType.passbook {
-        return .download
-      }
+      return .download
     }
 
     // If the content type is not HTML, create a temporary document so it can be downloaded and

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadQueue.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/DownloadQueue.swift
@@ -38,7 +38,7 @@ class Download: NSObject {
   func pause() {}
   func resume() {}
 
-  fileprivate func uniqueDownloadPathForFilename(_ filename: String) async throws -> URL {
+  func uniqueDownloadPathForFilename(_ filename: String) async throws -> URL {
     let downloadsPath = try await AsyncFileManager.default.downloadsPath()
     let basePath = downloadsPath.appending(path: filename)
     let fileExtension = basePath.pathExtension


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/41073

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

From https://community.brave.com/t/downloaded-videos-on-ios/568738/4
- Copy an instagram link (e.g. `https://www.instagram.com/reel/DABSg8nJb4D/`)
- Visit `snapinsta.app` and submit the link to be downloaded
- Click "Download" when it appears