### PR TITLE
style(wallet): Use Nala Alert for Wallet Banners

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -169,13 +169,6 @@ export const CryptoView = ({ sessionRoute }: Props) => {
         isMetaMaskInstalled)) &&
     !isDefaultWalletBannerDismissed
 
-  const noBannerPadding =
-    isPanel &&
-    (!showBanner ||
-      (!isCheckingWalletBackupStatus &&
-        !isWalletBackedUp &&
-        !isBackupWarningDismissed))
-
   // memos
   const banners = React.useMemo(
     () => (
@@ -199,7 +192,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
                 setDismissBackupWarning(true)
               }}
               onClick={onShowBackup}
-              bannerType='danger'
+              bannerType='error'
               buttonText={getLocale('braveWalletBackupButton')}
               description={getLocale('braveWalletBackupWarningText')}
             />
@@ -236,7 +229,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
             <StyledWrapper>
               <Column
                 fullWidth={true}
-                padding={noBannerPadding ? '0px' : '20px 20px 0px 20px'}
+                padding={isPanel ? '0px' : '20px 20px 0px 20px'}
               >
                 {banners}
               </Column>
@@ -281,7 +274,7 @@ export const CryptoView = ({ sessionRoute }: Props) => {
             <StyledWrapper>
               <Column
                 fullWidth={true}
-                padding={noBannerPadding ? '0px' : '20px 20px 0px 20px'}
+                padding={isPanel ? '0px' : '20px 20px 0px 20px'}
               >
                 {banners}
               </Column>

--- a/components/brave_wallet_ui/components/desktop/wallet-banner/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-banner/index.tsx
@@ -3,13 +3,19 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
-// Styled Components
-import { StyledWrapper, WarningText, BannerButton, ButtonRow } from './style'
+import Button from '@brave/leo/react/button'
+
+// Utils
 import { getLocale } from '../../../../common/locale'
+
+// Styled Components
+import { StyledWrapper, Alert, Icon } from './style'
+import { Row } from '../../shared/style'
+
 export interface Props {
   onClick: () => void
   onDismiss: () => void
-  bannerType: 'warning' | 'danger'
+  bannerType: 'warning' | 'error'
   description: string
   buttonText: string
 }
@@ -18,22 +24,41 @@ export const WalletBanner = (props: Props) => {
   const { onDismiss, onClick, bannerType, description, buttonText } = props
 
   return (
-    <StyledWrapper bannerType={bannerType}>
-      <WarningText>{description}</WarningText>
-      <ButtonRow>
-        <BannerButton
-          onClick={onClick}
-          buttonType='primary'
+    <StyledWrapper>
+      <Alert
+        type={bannerType}
+        mode='full'
+      >
+        <Icon
+          slot='icon'
+          name={
+            bannerType === 'warning'
+              ? 'warning-triangle-filled'
+              : 'warning-circle-filled'
+          }
+        />
+        {description}
+        <Row
+          alignItems='flex-start'
+          slot='actions'
+          width='unset'
         >
-          {buttonText}
-        </BannerButton>
-        <BannerButton
-          onClick={onDismiss}
-          buttonType='secondary'
-        >
-          {getLocale('braveWalletDismissButton')}
-        </BannerButton>
-      </ButtonRow>
+          <Button
+            kind='plain'
+            onClick={onClick}
+            size='tiny'
+          >
+            {buttonText}
+          </Button>
+          <Button
+            kind='plain-faint'
+            onClick={onDismiss}
+            size='tiny'
+          >
+            {getLocale('braveWalletDismissButton')}
+          </Button>
+        </Row>
+      </Alert>
     </StyledWrapper>
   )
 }

--- a/components/brave_wallet_ui/components/desktop/wallet-banner/style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-banner/style.ts
@@ -3,79 +3,30 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at https://mozilla.org/MPL/2.0/.
 import styled from 'styled-components'
-import { WalletButton } from '../../shared/style'
-interface StyleProps {
-  buttonType: 'primary' | 'secondary'
-  bannerType: 'warning' | 'danger'
-}
+import LeoAlert from '@brave/leo/react/alert'
+import LeoIcon from '@brave/leo/react/icon'
 
-export const StyledWrapper = styled.div<Partial<StyleProps>>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+// Shared Styles
+import {
+  layoutPanelWidth //
+} from '../wallet-page-wrapper/wallet-page-wrapper.style'
+import { Row } from '../../shared/style'
+
+export const StyledWrapper = styled(Row)`
+  overflow: hidden;
+  margin-bottom: 16px;
+  position: relative;
+  padding: 0px 12px;
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 0px 16px;
+  }
+`
+
+export const Alert = styled(LeoAlert)`
   width: 100%;
-  background-color: ${(p) =>
-    p.bannerType === 'warning'
-      ? p.theme.color.warningBackground
-      : p.theme.color.errorBackground};
-  border-radius: 4px;
-  border: 1px solid
-    ${(p) =>
-      p.bannerType === 'warning'
-        ? p.theme.color.warningBorder
-        : p.theme.color.errorBorder};
-  padding: 20px;
-  margin-bottom: 14px;
-  @media screen and (max-width: 1080px) {
-    flex-direction: column;
-    align-items: flex-start;
-  }
+  --leo-alert-padding: 16px;
 `
 
-export const WarningText = styled.span`
-  font-family: Poppins;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 18px;
-  color: ${(p) => p.theme.color.text01};
-  @media screen and (max-width: 1080px) {
-    margin-bottom: 12px;
-  }
-`
-
-export const ButtonRow = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-`
-
-export const BannerButton = styled(WalletButton)<Partial<StyleProps>>`
-  display: flex;
-  cursor: pointer;
-  outline: none;
-  border: none;
-  background: none;
-  padding: 0px;
-  margin: 0px;
-  font-family: Poppins;
-  font-size: 12px;
-  font-weight: 600;
-  color: ${(p) =>
-    p.buttonType === 'primary'
-      ? p.theme.color.interactive05
-      : p.theme.color.text02};
-  @media (prefers-color-scheme: dark) {
-    color: ${(p) =>
-      p.buttonType === 'primary'
-        ? p.theme.palette.white
-        : p.theme.color.text02};
-  }
-  letter-spacing: 0.01em;
-  margin-left: 20px;
-  @media screen and (max-width: 1080px) {
-    margin-left: 0px;
-    margin-right: 20px;
-  }
+export const Icon = styled(LeoIcon)`
+  --leo-icon-size: 20px;
 `


### PR DESCRIPTION
## Description 

Updates the `Wallet Banners` to now use the Nala `Alert` component

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/41036>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a new `Profile` and `Wallet`, but do not backup your `Wallet` yet.
2. Go to the `Portfolio` page and test the `Backup Wallet` alert, make sure all buttons work.
3. Go to brave://settings/web3 and set your default wallet to `Extensions (no fallback)`.
4. Go back to the `Portfolio` page and test the `Default Wallet` alert, make sure all buttons work. 

## Desktop View

#### Light Mode:

![image](https://github.com/user-attachments/assets/42ae9173-2823-47f2-96cf-fc3cf87d8381) | ![image](https://github.com/user-attachments/assets/ee61a2bc-4ddc-4c25-8ee6-04bdb89c2f42) | ![image](https://github.com/user-attachments/assets/0cc7abc6-58f3-421f-869f-34cec010d925)
--|--|--

#### Dark Mode:

![image](https://github.com/user-attachments/assets/cf8d331a-94b6-407d-ac5d-4f024ed14e78) | ![image](https://github.com/user-attachments/assets/7b0593ed-e332-489a-b045-624475194725) | ![image](https://github.com/user-attachments/assets/bbc51b26-5e00-46ce-aee7-044b337e1a43)
--|--|--

## Panel View

#### Light Mode:

![image](https://github.com/user-attachments/assets/2e55b633-27bf-43fd-a502-f5f84163cb00) | ![image](https://github.com/user-attachments/assets/95b679d3-63fc-4de0-a95f-4c5a801fded4) | ![image](https://github.com/user-attachments/assets/42b6e2d9-c4d3-4765-9f04-a4f156995f6f)
--|--|--

#### Dark Mode:

![image](https://github.com/user-attachments/assets/721b5b2e-4112-4d6e-ac5a-21e9090f9fda) | ![image](https://github.com/user-attachments/assets/0cc09f30-a8bc-4a87-88a6-01ec4880711a) | ![image](https://github.com/user-attachments/assets/2a6d8580-31db-4406-8252-bbc793b325ad)
--|--|--