### PR TITLE
fix(privacy): Filter search case sensitivity on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/FilterListsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/FilterListsView.swift
@@ -216,7 +216,7 @@ struct FilterListsView: View {
   }
 
   @ViewBuilder private var defaultFilterListRows: some View {
-    let searchText = searchText.lowercased()
+    let searchText = searchText
     #if DEBUG
     let allEnabled = Binding {
       filterListStorage.filterLists.allSatisfy({
@@ -385,13 +385,14 @@ struct FilterListsView_Previews: PreviewProvider {
 extension FilterList {
   fileprivate func satisfies(searchText: String) -> Bool {
     guard !searchText.isEmpty else { return true }
-    return entry.title.contains(searchText) || entry.desc.contains(searchText)
+    return entry.title.localizedCaseInsensitiveContains(searchText)
+      || entry.desc.localizedCaseInsensitiveContains(searchText)
   }
 }
 
 extension FilterListCustomURL {
   @MainActor fileprivate func satisfies(searchText: String) -> Bool {
     guard !searchText.isEmpty else { return true }
-    return setting.externalURL.absoluteString.contains(searchText)
+    return setting.externalURL.absoluteString.localizedCaseInsensitiveContains(searchText)
   }
 }


### PR DESCRIPTION
- We were lowercasing the user-entered search text, but then performing a case-sensitive search on the title & description of the filters.

Resolves https://github.com/brave/brave-browser/issues/41168

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open app Settings -> Brave Shields & Privacy -> Content Filtering
2. Scroll down slightly to reveal search bar
3. Enter `You` as search text
4. Verify all filters with `You` are visible
5. Change search text to `YoUtUbE`
6. Verify all filters with `YouTube` are visible
7. Change search text to `easylist`
8. Verify all filters with `EasyList` are visible

You | YoUtUbE | easylist
--|--|--
![You](https://github.com/user-attachments/assets/d27d8b9d-c39c-4486-935f-fde17586c51c) | ![YoUtUbE](https://github.com/user-attachments/assets/5c319305-cbac-44ab-89f6-9d82c121ce80) | ![easylist](https://github.com/user-attachments/assets/540dad10-cb95-46ce-aa04-39ad1d8e189e)
