### PR TITLE
fix(privacy): Filter search case sensitivity on iOS (uplift to 1.70.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/FilterListsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/FilterLists/FilterListsView.swift
@@ -216,7 +216,7 @@ struct FilterListsView: View {
   }
 
   @ViewBuilder private var defaultFilterListRows: some View {
-    let searchText = searchText.lowercased()
+    let searchText = searchText
     #if DEBUG
     let allEnabled = Binding {
       filterListStorage.filterLists.allSatisfy({
@@ -385,13 +385,14 @@ struct FilterListsView_Previews: PreviewProvider {
 extension FilterList {
   fileprivate func satisfies(searchText: String) -> Bool {
     guard !searchText.isEmpty else { return true }
-    return entry.title.contains(searchText) || entry.desc.contains(searchText)
+    return entry.title.localizedCaseInsensitiveContains(searchText)
+      || entry.desc.localizedCaseInsensitiveContains(searchText)
   }
 }
 
 extension FilterListCustomURL {
   @MainActor fileprivate func satisfies(searchText: String) -> Bool {
     guard !searchText.isEmpty else { return true }
-    return setting.externalURL.absoluteString.contains(searchText)
+    return setting.externalURL.absoluteString.localizedCaseInsensitiveContains(searchText)
   }
 }


### PR DESCRIPTION
Uplift of #25675
Resolves https://github.com/brave/brave-browser/issues/41168

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.