### PR TITLE
SidePanel: fixes button pressed state.

### DIFF
--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -224,6 +224,18 @@ void SidebarController::AddItemWithCurrentTab() {
                           SidebarItem::BuiltInItemType::kNone, false));
 }
 
+void SidebarController::UpdateActiveItemState(
+    std::optional<SidebarItem::BuiltInItemType> active_panel_item) {
+  if (!active_panel_item) {
+    ActivateItemAt(std::nullopt);
+    return;
+  }
+
+  if (auto index = sidebar_model_->GetIndexOf(*active_panel_item)) {
+    ActivateItemAt(*index);
+  }
+}
+
 void SidebarController::SetSidebar(Sidebar* sidebar) {
   DCHECK(!sidebar_);
   // |sidebar| can be null in unit test.

--- a/browser/ui/sidebar/sidebar_controller.h
+++ b/browser/ui/sidebar/sidebar_controller.h
@@ -52,6 +52,8 @@ class SidebarController : public SidebarService::Observer {
       std::optional<size_t> index,
       WindowOpenDisposition disposition = WindowOpenDisposition::CURRENT_TAB);
   void AddItemWithCurrentTab();
+  void UpdateActiveItemState(std::optional<SidebarItem::BuiltInItemType>
+                                 active_panel_item = std::nullopt);
 
   // Ask panel item activation state change to SidePanelUI.
   void ActivatePanelItem(SidebarItem::BuiltInItemType panel_item);

--- a/browser/ui/sidebar/sidebar_utils.cc
+++ b/browser/ui/sidebar/sidebar_utils.cc
@@ -149,6 +149,24 @@ SidePanelEntryId SidePanelIdFromSideBarItemType(BuiltInItemType type) {
          "not have a panel Id.";
 }
 
+std::optional<BuiltInItemType> BuiltInItemTypeFromSidePanelId(
+    SidePanelEntryId id) {
+  switch (id) {
+    case SidePanelEntryId::kReadingList:
+      return BuiltInItemType::kReadingList;
+    case SidePanelEntryId::kBookmarks:
+      return BuiltInItemType::kBookmarks;
+    case SidePanelEntryId::kPlaylist:
+      return BuiltInItemType::kPlaylist;
+    case SidePanelEntryId::kChatUI:
+      return BuiltInItemType::kChatUI;
+    default:
+      break;
+  }
+
+  return std::nullopt;
+}
+
 SidePanelEntryId SidePanelIdFromSideBarItem(const SidebarItem& item) {
   CHECK(item.open_in_panel) << static_cast<int>(item.built_in_item_type);
   return SidePanelIdFromSideBarItemType(item.built_in_item_type);

--- a/browser/ui/sidebar/sidebar_utils.h
+++ b/browser/ui/sidebar/sidebar_utils.h
@@ -29,6 +29,8 @@ GURL ConvertURLToBuiltInItemURL(const GURL& url);
 SidePanelEntryId SidePanelIdFromSideBarItemType(
     SidebarItem::BuiltInItemType type);
 SidePanelEntryId SidePanelIdFromSideBarItem(const SidebarItem& item);
+std::optional<SidebarItem::BuiltInItemType> BuiltInItemTypeFromSidePanelId(
+    SidePanelEntryId id);
 void SetLastUsedSidePanel(PrefService* prefs,
                           std::optional<SidePanelEntryId> id);
 std::optional<SidePanelEntryId> GetLastUsedSidePanel(Browser* browser);

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -811,6 +811,16 @@ void SidebarContainerView::OnEntryWillDeregister(SidePanelRegistry* registry,
 void SidebarContainerView::OnRegistryDestroying(SidePanelRegistry* registry) {
   if (panel_registry_observations_.IsObservingSource(registry)) {
     StopObservingContextualSidePanelRegistry(registry);
+    // If this is the active tab being destroyed, then reset the active item.
+    // Note, that items persisted across tabs like reading list or bookmarks
+    // don't show as active_entry, in which case leave the active item as is.
+    if (registry == active_contextual_registry_) {
+      if (registry->active_entry()) {
+        auto* controller = browser_->sidebar_controller();
+        controller->ActivateItemAt(std::nullopt);
+      }
+      active_contextual_registry_ = nullptr;
+    }
   }
 }
 
@@ -844,17 +854,11 @@ void SidebarContainerView::OnTabStripModelChanged(
         }
       }
     }
-    return;
-  }
-
-  if (change.type() == TabStripModelChange::kInserted) {
+  } else if (change.type() == TabStripModelChange::kInserted) {
     for (const auto& contents : change.GetInsert()->contents) {
       StartObservingContextualSidePanelRegistry(contents.contents);
     }
-    return;
-  }
-
-  if (change.type() == TabStripModelChange::kRemoved) {
+  } else if (change.type() == TabStripModelChange::kRemoved) {
     bool removed_for_deletion =
         (change.GetRemove()->contents[0].remove_reason ==
          TabStripModelChange::RemoveReason::kDeleted);
@@ -865,7 +869,18 @@ void SidebarContainerView::OnTabStripModelChanged(
       for (const auto& contents : change.GetRemove()->contents) {
         StopObservingContextualSidePanelRegistry(contents.contents);
       }
-      return;
+    }
+  }
+
+  // Keep track of the active contextual registry
+  if (selection.active_tab_changed()) {
+    active_contextual_registry_ =
+        selection.new_contents
+            ? SidePanelRegistry::GetDeprecated(selection.new_contents)
+            : nullptr;
+    if (active_contextual_registry_) {
+      DCHECK(panel_registry_observations_.IsObservingSource(
+          active_contextual_registry_));
     }
   }
 }

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -127,6 +127,7 @@ SidebarContainerView::SidebarContainerView(
 
   SetNotifyEnterExitOnChild(true);
   side_panel_ = AddChildView(std::move(side_panel));
+  side_panel_view_state_observation_.Observe(side_panel_coordinator_);
 }
 
 SidebarContainerView::~SidebarContainerView() = default;
@@ -811,17 +812,27 @@ void SidebarContainerView::OnEntryWillDeregister(SidePanelRegistry* registry,
 void SidebarContainerView::OnRegistryDestroying(SidePanelRegistry* registry) {
   if (panel_registry_observations_.IsObservingSource(registry)) {
     StopObservingContextualSidePanelRegistry(registry);
-    // If this is the active tab being destroyed, then reset the active item.
-    // Note, that items persisted across tabs like reading list or bookmarks
-    // don't show as active_entry, in which case leave the active item as is.
-    if (registry == active_contextual_registry_) {
-      if (registry->active_entry()) {
-        auto* controller = browser_->sidebar_controller();
-        controller->ActivateItemAt(std::nullopt);
-      }
-      active_contextual_registry_ = nullptr;
-    }
   }
+}
+
+void SidebarContainerView::UpdateActiveItemState() {
+  DVLOG(1) << "Update active item state";
+
+  auto* controller = GetBraveBrowser()->sidebar_controller();
+  std::optional<sidebar::SidebarItem::BuiltInItemType> current_type;
+  if (auto entry_id = side_panel_coordinator_->GetCurrentEntryId()) {
+    current_type = sidebar::BuiltInItemTypeFromSidePanelId(*entry_id);
+  }
+  controller->UpdateActiveItemState(current_type);
+}
+
+void SidebarContainerView::OnSidePanelDidClose() {
+  // As contextual registry is owned by TabFeatures,
+  // that registry is destroyed before coordinator notifies OnEntryHidden() when
+  // tab is closed. In this case, we should update sidebar ui(active item state)
+  // with this notification. If not, sidebar ui's active item state is not
+  // changed.
+  UpdateActiveItemState();
 }
 
 void SidebarContainerView::OnTabStripModelChanged(
@@ -854,11 +865,17 @@ void SidebarContainerView::OnTabStripModelChanged(
         }
       }
     }
-  } else if (change.type() == TabStripModelChange::kInserted) {
+    return;
+  }
+
+  if (change.type() == TabStripModelChange::kInserted) {
     for (const auto& contents : change.GetInsert()->contents) {
       StartObservingContextualSidePanelRegistry(contents.contents);
     }
-  } else if (change.type() == TabStripModelChange::kRemoved) {
+    return;
+  }
+
+  if (change.type() == TabStripModelChange::kRemoved) {
     bool removed_for_deletion =
         (change.GetRemove()->contents[0].remove_reason ==
          TabStripModelChange::RemoveReason::kDeleted);
@@ -870,18 +887,7 @@ void SidebarContainerView::OnTabStripModelChanged(
         StopObservingContextualSidePanelRegistry(contents.contents);
       }
     }
-  }
-
-  // Keep track of the active contextual registry
-  if (selection.active_tab_changed()) {
-    active_contextual_registry_ =
-        selection.new_contents
-            ? SidePanelRegistry::GetDeprecated(selection.new_contents)
-            : nullptr;
-    if (active_contextual_registry_) {
-      DCHECK(panel_registry_observations_.IsObservingSource(
-          active_contextual_registry_));
-    }
+    return;
   }
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -23,6 +23,7 @@
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry_observer.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_registry_observer.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_view_state_observer.h"
 #include "components/prefs/pref_member.h"
 #include "ui/events/event_observer.h"
 #include "ui/gfx/animation/slide_animation.h"
@@ -58,6 +59,7 @@ class SidebarContainerView
       public sidebar::SidebarModel::Observer,
       public SidePanelEntryObserver,
       public SidePanelRegistryObserver,
+      public SidePanelViewStateObserver,
       public TabStripModelObserver {
   METADATA_HEADER(SidebarContainerView, views::View)
  public:
@@ -134,6 +136,9 @@ class SidebarContainerView
       const TabStripModelChange& change,
       const TabStripSelectionChange& selection) override;
 
+  // SidePanelViewStateObserver:
+  void OnSidePanelDidClose() override;
+
  private:
   friend class sidebar::SidebarBrowserTest;
 
@@ -186,6 +191,7 @@ class SidebarContainerView
       content::WebContents* contents);
   void StopObservingContextualSidePanelRegistry(content::WebContents* contents);
   void StopObservingContextualSidePanelRegistry(SidePanelRegistry* registry);
+  void UpdateActiveItemState();
 
   // Casts |browser_| to BraveBrowser, as storing it as BraveBrowser would cause
   // a precocious downcast.
@@ -196,7 +202,6 @@ class SidebarContainerView
   raw_ptr<BraveSidePanel> side_panel_ = nullptr;
   raw_ptr<sidebar::SidebarModel> sidebar_model_ = nullptr;
   raw_ptr<SidebarControlView> sidebar_control_view_ = nullptr;
-  raw_ptr<SidePanelRegistry> active_contextual_registry_ = nullptr;
   bool initialized_ = false;
   bool sidebar_on_left_ = true;
   bool operation_from_active_tab_change_ = false;
@@ -210,6 +215,8 @@ class SidebarContainerView
   std::unique_ptr<views::EventMonitor> browser_window_event_monitor_;
   std::unique_ptr<SidebarShowOptionsEventDetectWidget> show_options_widget_;
   BooleanPrefMember show_side_panel_button_;
+  base::ScopedObservation<SidePanelCoordinator, SidePanelViewStateObserver>
+      side_panel_view_state_observation_{this};
   base::ScopedObservation<sidebar::SidebarModel,
                           sidebar::SidebarModel::Observer>
       sidebar_model_observation_{this};

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -196,6 +196,7 @@ class SidebarContainerView
   raw_ptr<BraveSidePanel> side_panel_ = nullptr;
   raw_ptr<sidebar::SidebarModel> sidebar_model_ = nullptr;
   raw_ptr<SidebarControlView> sidebar_control_view_ = nullptr;
+  raw_ptr<SidePanelRegistry> active_contextual_registry_ = nullptr;
   bool initialized_ = false;
   bool sidebar_on_left_ = true;
   bool operation_from_active_tab_change_ = false;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41154

It's a regression that only `SidebarContainerView::OnRegistryDestroyig()` is called when active tab with ai chat is closed now. 
Instead, we could try to make sidebar controller refresh active item state whenever relavant event happens.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue for manual test.
`SidebarBrowserTestWithAIChat.TabSpecificPanel`