### PR TITLE
Add new `build_policy_templates` action

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -247,6 +247,15 @@ if (!is_ios) {
   }
 }
 
+if (!is_android && !is_ios) {
+  group("brave_group_policy_templates") {
+    # Currently, group policy resources are only generated on Windows.
+    if (is_win) {
+      deps = [ "//brave/components/policy:pack_policy_templates" ]
+    }
+  }
+}
+
 if (!is_ios) {
   brave_paks("packed_resources") {
     if (is_mac) {

--- a/components/policy/BUILD.gn
+++ b/components/policy/BUILD.gn
@@ -1,7 +1,20 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# See `components/policy/BUILD.gn` for more info about how these files
+# are generated. Also see:
+# `chromium_src/components/policy/tools/generate_policy_source.py`
+# for Brave specific group policy definitions.
+
 if (is_win) {
   action("pack_policy_templates") {
     chrome_pack_policy_templates = "//components/policy:pack_policy_templates"
-    deps = [ chrome_pack_policy_templates ]
+    deps = [
+      "//components/policy:policy_templates",
+      chrome_pack_policy_templates,
+    ]
     script = "pack_policy_templates.py"
     chrome_policy_templates_zip =
         get_label_info(chrome_pack_policy_templates, "root_out_dir") +

--- a/components/policy/pack_policy_templates.py
+++ b/components/policy/pack_policy_templates.py
@@ -4,6 +4,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+# Script that prepares a Brave-specific version of the policy_templates.zip
+# file that folks expect for administering Brave via group policy.
+#
+# For more info, see:
+# https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy
+# and
+# https://github.com/brave/brave-browser/issues/26502
 """
 Create a Zip file of Windows Group Policy templates similar to Chrome's.
 """
@@ -16,37 +23,38 @@ from tempfile import TemporaryDirectory
 from zipfile import ZipFile, ZIP_DEFLATED
 
 def main():
-  chrome_policy_zip, dest_zip = _get_args()
-  _pack_policy_templates(chrome_policy_zip, dest_zip)
+    chrome_policy_zip, dest_zip = _get_args()
+    _pack_policy_templates(chrome_policy_zip, dest_zip)
 
 def _get_args():
-  parser = argparse.ArgumentParser()
-  parser.add_argument('chrome_policy_zip',
-                      help="Path to Chrome's policy_templates.zip")
-  parser.add_argument('dest_zip',
-                      help="Path to the Zip file to be created")
-  args = parser.parse_args()
-  return args.chrome_policy_zip, args.dest_zip
+    parser = argparse.ArgumentParser()
+    parser.add_argument('chrome_policy_zip',
+                        help="Path to Chrome's policy_templates.zip")
+    parser.add_argument('dest_zip', help="Path to the Zip file to be created")
+    args = parser.parse_args()
+    return args.chrome_policy_zip, args.dest_zip
 
 def _pack_policy_templates(chrome_policy_zip, dest_zip):
-  with TemporaryDirectory() as tmp_dir:
-    with ZipFile(chrome_policy_zip) as src_zip:
-      src_zip.extract('VERSION', tmp_dir)
-      namelist = src_zip.namelist()
-      for dir_ in ('windows/adm/', 'windows/admx/', 'windows/examples/'):
-        src_zip.extractall(tmp_dir, (n for n in namelist if n.startswith(dir_)))
+    with TemporaryDirectory() as tmp_dir:
+        with ZipFile(chrome_policy_zip) as src_zip:
+            src_zip.extract('VERSION', tmp_dir)
+            namelist = src_zip.namelist()
+            for dir_ in ('windows/adm/', 'windows/admx/', 'windows/examples/'):
+                src_zip.extractall(tmp_dir,
+                                   (n for n in namelist if n.startswith(dir_)))
 
-    # Some sanity checks:
-    assert exists(join(tmp_dir, 'windows/adm/en-US/chrome.adm'))
-    assert exists(join(tmp_dir, 'windows/admx/chrome.admx'))
-    assert exists(join(tmp_dir, 'windows/admx/en-US/chrome.adml'))
+        # Some sanity checks:
+        assert exists(join(tmp_dir, 'windows/adm/en-US/chrome.adm'))
+        assert exists(join(tmp_dir, 'windows/admx/chrome.admx'))
+        assert exists(join(tmp_dir, 'windows/admx/en-US/chrome.adml'))
 
-    with ZipFile(dest_zip, 'w', ZIP_DEFLATED) as dest_zipfile:
-      for dirpath, _, filenames in os.walk(tmp_dir):
-        for filename in filenames:
-          filepath = join(dirpath, filename)
-          arcname = relpath(filepath, tmp_dir).replace('chrome', 'brave')
-          dest_zipfile.write(filepath, arcname=arcname)
+        with ZipFile(dest_zip, 'w', ZIP_DEFLATED) as dest_zipfile:
+            for dirpath, _, filenames in os.walk(tmp_dir):
+                for filename in filenames:
+                    filepath = join(dirpath, filename)
+                    arcname = relpath(filepath,
+                                      tmp_dir).replace('chrome', 'brave')
+                    dest_zipfile.write(filepath, arcname=arcname)
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "gen_env": "node ./build/commands/scripts/genEnv.js",
     "gen_gradle": "node ./build/commands/scripts/commands.js gen_gradle",
     "ios_pack_js": "webpack --config ios/brave-ios/webpack.config.js",
-    "ios_bootstrap": "node ./build/commands/scripts/iosCommands.js ios_bootstrap"
+    "ios_bootstrap": "node ./build/commands/scripts/iosCommands.js ios_bootstrap",
+    "build_policy_templates": "node ./build/commands/scripts/commands.js build --target=brave_group_policy_templates"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Currently, group policy is only generated during `create_dist`. This allows us to quickly create `policy_templates.zip` and the Brave specific version `brave_policy_templates.zip`.

Fixes https://github.com/brave/brave-browser/issues/41217

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Be on Windows
2. Inside the `src/brave` folder, run `npm run build_policy_templates`
3. Verify `src/out/Component/policy_templates.zip` and `src/out/Component/brave_policy_templates.zip` were generated
