### PR TITLE
Do not crash while saving file using an extension.

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -152,7 +152,7 @@ void BraveBrowser::RunFileChooser(
     // something doesn't reach here. They show 'select file dialog' from
     // DownloadFilePicker::DownloadFilePicker directly.
     // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/choosers/file_chooser.mojom;l=27;drc=047c7dc4ee1ce908d7fea38ca063fa2f80f92c77
-
+    CHECK(render_frame_host);
     new_params->title = brave::GetFileSelectTitle(
         content::WebContents::FromRenderFrameHost(render_frame_host),
         render_frame_host->GetLastCommittedOrigin(),

--- a/browser/ui/brave_file_select_utils.cc
+++ b/browser/ui/brave_file_select_utils.cc
@@ -52,6 +52,7 @@ std::u16string GetFileSelectTitle(content::WebContents* web_contents,
   // TODO(sko) It's hard to test this behavior is in sync at this moment. Even
   // upstream tests aren't covering this. Need to figure out how we can test
   // extension and isolated web app case.
+  CHECK(web_contents);
   Profile* profile =
       Profile::FromBrowserContext(web_contents->GetBrowserContext());
 

--- a/chromium_src/chrome/browser/download/download_file_picker.cc
+++ b/chromium_src/chrome/browser/download/download_file_picker.cc
@@ -21,6 +21,9 @@ std::u16string GetTitle(content::RenderFrameHost* render_frame_host,
 #if BUILDFLAG(IS_ANDROID)
   return original_title;
 #else
+  if (!render_frame_host) {
+    return original_title;
+  }
   return brave::GetFileSelectTitle(
       content::WebContents::FromRenderFrameHost(render_frame_host),
       render_frame_host->GetLastCommittedOrigin(),


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/41179

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

