### PR TITLE
Fixed wrong region list name mapping (uplift to 1.71.x)

### DIFF
--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_helper.cc
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_helper.cc
@@ -41,7 +41,11 @@ mojom::RegionPtr GetRegionPtrWithNameFromRegionList(
     }
   }
 
-  return nullptr;
+  // We should not reach here but if service(guardian) api give wrong list,
+  // it could be crashed if we return null.
+  // Instead, return first region in the list for safe.
+  CHECK(!region_list.empty());
+  return region_list[0].Clone();
 }
 
 base::Value::Dict GetValueFromRegionWithoutCity(

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -72,7 +72,7 @@ constexpr auto kV1ToV2Map =
          {"us-central", "na-usa"},  {"us-east", "na-usa"},
          {"us-mountain", "na-usa"}, {"us-north-west", "na-usa"},
          {"us-west", "na-usa"},     {"eu-ua", "eu-ua"},
-         {"eu-en", "en-en"}});
+         {"eu-en", "eu-en"}});
 
 #if !BUILDFLAG(IS_ANDROID)
 void MigrateFromV1ToV2(PrefService* local_prefs) {


### PR DESCRIPTION
Uplift of #25701
fix https://github.com/brave/brave-browser/issues/41227

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.