### PR TITLE
Do not crash while saving file using an extension. (uplift to 1.70.x)

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -152,7 +152,7 @@ void BraveBrowser::RunFileChooser(
     // something doesn't reach here. They show 'select file dialog' from
     // DownloadFilePicker::DownloadFilePicker directly.
     // https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/public/mojom/choosers/file_chooser.mojom;l=27;drc=047c7dc4ee1ce908d7fea38ca063fa2f80f92c77
-
+    CHECK(render_frame_host);
     new_params->title = brave::GetFileSelectTitle(
         content::WebContents::FromRenderFrameHost(render_frame_host),
         render_frame_host->GetLastCommittedOrigin(),

--- a/browser/ui/brave_file_select_utils.cc
+++ b/browser/ui/brave_file_select_utils.cc
@@ -52,6 +52,7 @@ std::u16string GetFileSelectTitle(content::WebContents* web_contents,
   // TODO(sko) It's hard to test this behavior is in sync at this moment. Even
   // upstream tests aren't covering this. Need to figure out how we can test
   // extension and isolated web app case.
+  CHECK(web_contents);
   Profile* profile =
       Profile::FromBrowserContext(web_contents->GetBrowserContext());
 

--- a/chromium_src/chrome/browser/download/download_file_picker.cc
+++ b/chromium_src/chrome/browser/download/download_file_picker.cc
@@ -21,6 +21,9 @@ std::u16string GetTitle(content::RenderFrameHost* render_frame_host,
 #if BUILDFLAG(IS_ANDROID)
   return original_title;
 #else
+  if (!render_frame_host) {
+    return original_title;
+  }
   return brave::GetFileSelectTitle(
       content::WebContents::FromRenderFrameHost(render_frame_host),
       render_frame_host->GetLastCommittedOrigin(),


### PR DESCRIPTION
Uplift of #25702
Fixes https://github.com/brave/brave-browser/issues/41179

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.