### PR TITLE
[canary] Print JSON output for failed patches

### DIFF
--- a/build/commands/lib/applyPatches.js
+++ b/build/commands/lib/applyPatches.js
@@ -5,7 +5,7 @@ const applyPatches = (buildConfig = config.defaultBuildConfig, options = {}) => 
   async function RunCommand () {
     config.buildConfig = buildConfig
     config.update(options)
-    await util.applyPatches()
+    await util.applyPatches(options.printPatchFailuresInJson)
   }
 
   RunCommand().catch((err) => {

--- a/build/commands/lib/logging.js
+++ b/build/commands/lib/logging.js
@@ -124,6 +124,28 @@ function command (dir, cmd, args) {
   status(`${cmdArrowStyle('>')} ${cmdCmdStyle(cmd)} ${args.join(' ')}`, true)
 }
 
+function printFailedPatchesInJsonFormat(allPatchStatus, bravePath) {
+  const failedPatches = allPatchStatus.filter((patch) => patch.error)
+  if (!failedPatches.length) {
+    return;
+  }
+
+  const patchFailuresOutput = failedPatches.map(({path, patchPath}) => {
+    return {
+      // Trimming the patch path to be relative to the brave core repo. We skip
+      // the first character to avoid the trailing slash from the absolute
+      // path.
+      patchPath:
+        patchPath.replace(bravePath, '').substring(1),
+      path: path
+    }
+  })
+
+  console.log(chalk.red(`${failedPatches.length} Failed patches json breakdown:`))
+  console.log(JSON.stringify(patchFailuresOutput))
+  console.log(divider)
+}
+
 function allPatchStatus(allPatchStatus, patchGroupName) {
   if (!allPatchStatus.length) {
     console.log(chalk.bold.italic(`There were no ${patchGroupName} code patch updates to apply.`))
@@ -182,5 +204,6 @@ module.exports = {
   warn,
   command,
   updateStatus,
+  printFailedPatchesInJsonFormat,
   allPatchStatus
 }

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -24,7 +24,7 @@ const mergeWithDefault = (options) => {
   return Object.assign({}, config.defaultOptions, options)
 }
 
-async function applyPatches() {
+async function applyPatches(printPatchFailuresInJson) {
   const GitPatcher = require('./gitPatcher')
   Log.progressStart('apply patches')
   // Always detect if we need to apply patches, since user may have modified
@@ -62,7 +62,11 @@ async function applyPatches() {
   devtoolsFrontendPatchStatus.forEach(
     s => s.path = path.join('third_party', 'devtools-frontend', 'src', s.path))
   const allPatchStatus = [...chromiumPatchStatus, ...v8PatchStatus, ...catapultPatchStatus, ...devtoolsFrontendPatchStatus, ...ffmpegPatchStatus]
-  Log.allPatchStatus(allPatchStatus, 'Chromium')
+  if (printPatchFailuresInJson) {
+    Log.printFailedPatchesInJsonFormat(allPatchStatus, config.braveCoreDir)
+  } else {
+    Log.allPatchStatus(allPatchStatus, 'Chromium')
+  }
 
   const hasPatchError = allPatchStatus.some(p => p.error)
   // Exit on error in any patch
@@ -840,8 +844,8 @@ const util = {
     util.run('gclient', args, options)
   },
 
-  applyPatches: () => {
-    return applyPatches()
+  applyPatches: (printPatchFailuresInJson) => {
+    return applyPatches(printPatchFailuresInJson)
   },
 
   walkSync: (dir, filter = null, filelist = []) => {

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -68,10 +68,12 @@ program
   .arguments('[build_config]')
   .action(gnCheck)
 
-program
-  .command('apply_patches')
-  .arguments('[build_config]')
-  .action(applyPatches)
+program.command('apply_patches')
+    .option(
+        '--print-patch-failures-in-json',
+        'Emits a JSON structure with a list of patch files that failed to apply')
+    .arguments('[build_config]')
+    .action(applyPatches)
 
 program
   .command('update_symlink')


### PR DESCRIPTION
This change adds an argument a command line argument to `apply_patches`, namely `--print-patch-failures-in-json`, that allows the output of a JSON list of files that failed to apply. This will make it easier for us to read the output from this script when running `scritp/version_up.py`, and with this information we can further improve the automation of the daily canary build.

Sample output:

```nodejs
[
  {
    patchPath: 'patches/chrome-android-java-src-org-chromium-chrome-browser-sync-settings-ManageSyncSettings.java.patch',
    path: 'chrome/android/java/src/org/chromium/chrome/browser/sync/settings/ManageSyncSettings.java'
  },
  {
    patchPath: 'patches/chrome-browser-ui-views-toolbar-toolbar_view.cc.patch',
    path: 'chrome/browser/ui/views/toolbar/toolbar_view.cc'
  }
]
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41306

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

