### PR TITLE
fix(privacy): Update Shred behaviour to clear all cache data

### DIFF
--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -93,6 +93,10 @@ BASE_FEATURE(kBraveReduceLanguage,
 BASE_FEATURE(kBraveShredFeature,
              "BraveShredFeature",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// When enabled, brave shred will clear all cache data when shredding.
+BASE_FEATURE(kBraveShredCacheData,
+             "BraveShredCacheData",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 // When enabled, show Strict (aggressive) fingerprinting mode in Brave Shields.
 BASE_FEATURE(kBraveShowStrictFingerprintingMode,
              "BraveShowStrictFingerprintingMode",

--- a/components/brave_shields/core/common/features.h
+++ b/components/brave_shields/core/common/features.h
@@ -32,6 +32,7 @@ BASE_DECLARE_FEATURE(kBraveExtensionNetworkBlocking);
 BASE_DECLARE_FEATURE(kBraveLocalhostAccessPermission);
 BASE_DECLARE_FEATURE(kBraveReduceLanguage);
 BASE_DECLARE_FEATURE(kBraveShredFeature);
+BASE_DECLARE_FEATURE(kBraveShredCacheData);
 BASE_DECLARE_FEATURE(kBraveShowStrictFingerprintingMode);
 BASE_DECLARE_FEATURE(kCosmeticFilteringExtraPerfMetrics);
 BASE_DECLARE_FEATURE(kCosmeticFilteringJsPerformance);

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -51,6 +51,7 @@ OBJC_EXPORT
 @property(class, nonatomic, readonly) Feature* kBraveReduceLanguage;
 @property(class, nonatomic, readonly) Feature* kBraveSearchDefaultAPIFeature;
 @property(class, nonatomic, readonly) Feature* kBraveShredFeature;
+@property(class, nonatomic, readonly) Feature* kBraveShredCacheData;
 @property(class, nonatomic, readonly)
     Feature* kBraveShowStrictFingerprintingMode;
 @property(class, nonatomic, readonly) Feature* kBraveSync;

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -202,6 +202,11 @@
       initWithFeature:&brave_shields::features::kBraveShredFeature];
 }
 
++ (Feature*)kBraveShredCacheData {
+  return [[Feature alloc]
+      initWithFeature:&brave_shields::features::kBraveShredCacheData];
+}
+
 + (Feature*)kBraveShowStrictFingerprintingMode {
   return
       [[Feature alloc] initWithFeature:&brave_shields::features::

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -75,33 +75,41 @@
                                  kBraveWalletTransactionSimulationsFeature),  \
       })
 
-#define BRAVE_SHIELDS_FEATURE_ENTRIES                                        \
-  EXPAND_FEATURE_ENTRIES(                                                    \
-      {                                                                      \
-          "brave-shred",                                                     \
-          "Enable Brave 'Shred' Feature",                                    \
-          "Enable the Brave ‘Shred’ feature which will allow a user to " \
-          "easily delete all site data on demand or automatically when "     \
-          "closing a site or terminating the application.",                  \
-          flags_ui::kOsIos,                                                  \
-          FEATURE_VALUE_TYPE(brave_shields::features::kBraveShredFeature),   \
-      },                                                                     \
-      {                                                                      \
-          "https-by-default",                                                \
-          "Use HTTPS by Default",                                            \
-          "Attempt to connect to all websites using HTTPS before falling "   \
-          "back to HTTP.",                                                   \
-          flags_ui::kOsIos,                                                  \
-          FEATURE_VALUE_TYPE(net::features::kBraveHttpsByDefault),           \
-      },                                                                     \
-      {                                                                      \
-          "https-only-mode",                                                 \
-          "Enable HTTPS By Default Strict Mode",                             \
-          "Connect to all websites using HTTPS and display an intersitital " \
-          "to fallback to HTTP",                                             \
-          flags_ui::kOsIos,                                                  \
-          FEATURE_VALUE_TYPE(                                                \
-              security_interstitials::features::kHttpsOnlyMode),             \
+#define BRAVE_SHIELDS_FEATURE_ENTRIES                                          \
+  EXPAND_FEATURE_ENTRIES(                                                      \
+      {                                                                        \
+          "brave-shred",                                                       \
+          "Enable Brave 'Shred' Feature",                                      \
+          "Enable the Brave ‘Shred’ feature which will allow a user to "   \
+          "easily delete all site data on demand or automatically when "       \
+          "closing a site or terminating the application.",                    \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_shields::features::kBraveShredFeature),     \
+      },                                                                       \
+      {                                                                        \
+          "brave-shred-cache-data",                                            \
+          "Shred Clears All Cache Data",                                       \
+          "Shred feature will also remove all cache data, in addition to the " \
+          "data associated with the site being shred.",                        \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_shields::features::kBraveShredCacheData),   \
+      },                                                                       \
+      {                                                                        \
+          "https-by-default",                                                  \
+          "Use HTTPS by Default",                                              \
+          "Attempt to connect to all websites using HTTPS before falling "     \
+          "back to HTTP.",                                                     \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(net::features::kBraveHttpsByDefault),             \
+      },                                                                       \
+      {                                                                        \
+          "https-only-mode",                                                   \
+          "Enable HTTPS By Default Strict Mode",                               \
+          "Connect to all websites using HTTPS and display an intersitital "   \
+          "to fallback to HTTP",                                               \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(                                                  \
+              security_interstitials::features::kHttpsOnlyMode),               \
       })
 
 #if BUILDFLAG(ENABLE_AI_CHAT)


### PR DESCRIPTION
- When using shred, clear all cache data. Wrapped in a feature flag so we can disable via Griffin.

Resolves https://github.com/brave/brave-browser/issues/41095

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable Shred (`#brave-shred`) & Shred Cache Data (`#brave-shred-cache-data`) feature flags, then restart the app.
2. Visit a site which stores 3rd-party cache (this can be checked in Settings -> Shields & Privacy -> Manage Website Data).
    - Ex. Visiting`https://google.ca` will show data from `google.ca`, `gstatic.com`, and `google.com`.
3. Visit Settings -> Shields & Privacy -> Manage Website Data to confirm there are entries with just `Cache` listed in the subtitle/description.
4. Tap & hold on the tab tray icon & tap 'Shred Site Data'.
    - Note: Shred on Tab Close has a delay before site is shredded. Shred on App Close will be resolved with https://github.com/brave/brave-browser/issues/40484


https://github.com/user-attachments/assets/f93106be-f74a-4fd3-b73a-2c4329be7c15