### PR TITLE
[Customize]: Update sidebar to be blurple and use Nala component

### DIFF
--- a/components/brave_new_tab_ui/components/default/settings/index.ts
+++ b/components/brave_new_tab_ui/components/default/settings/index.ts
@@ -45,7 +45,7 @@ const getTopSiteCustomizationImage = (dark: boolean, selected: boolean, favorite
   }
 }
 
-export const SettingsContent = styled('div') <{}>`
+export const SettingsContent = styled('div')`
   display: grid;
   grid-template-columns: auto 1fr;
   grid-gap: 20px;
@@ -55,7 +55,7 @@ export const SettingsContent = styled('div') <{}>`
   }
 `
 
-export const SettingsSidebar = styled('aside') <{}>`
+export const SettingsSidebar = styled('aside')`
   position: relative;
   /* normalize against SettingsMenu default padding */
   margin-inline-start: -24px;
@@ -167,14 +167,14 @@ export const SettingsSidebarButton = styled.button`
   }
 `
 
-export const SettingsFeatureBody = styled('section') <{}>`
+export const SettingsFeatureBody = styled('section')`
   padding: 10px 16px;
   height: 360px;
   overflow: auto;
   overscroll-behavior: contain;
 `
 
-export const SettingsTitle = styled('h1') <{}>`
+export const SettingsTitle = styled('h1')`
     margin: 0;
     margin-bottom: ${spacing.xl};
     font: ${font.heading.h3};
@@ -218,7 +218,7 @@ export const SettingsRow = styled('div') <SettingsRowProps>`
   }
 `
 
-export const SettingsText = styled('span') <{}>`
+export const SettingsText = styled('span')`
   display: flex;
   align-items: center;
   font-style: normal;
@@ -235,7 +235,7 @@ export const SettingsSectionTitle = styled('h3') <ControllableLayoutProps>`
   line-height: 24px;
 `
 
-export const SettingsWidget = styled('div') <{}>`
+export const SettingsWidget = styled('div')`
   width: calc(50% - var(--widget-gap));
   margin-top: calc(20px - var(--widget-gap));
   padding: 0px 1px;
@@ -253,41 +253,41 @@ export const StyledWidgetSettings = styled('div')`
   gap: var(--widget-gap);
 `
 
-export const FeaturedSettingsWidget = styled('div') <{}>`
+export const FeaturedSettingsWidget = styled('div')`
   width: 100%;
 `
 
-export const StyledBannerImage = styled('img') <{}>`
+export const StyledBannerImage = styled('img')`
   width: 100%;
   margin-bottom: 10px;
 `
 
-export const StyledSettingsInfo = styled('div') <{}>`
+export const StyledSettingsInfo = styled('div')`
   float: left;
   max-width: 250px;
   flex-grow: 1;
 `
 
-export const StyledSettingsTitle = styled('div') <{}>`
+export const StyledSettingsTitle = styled('div')`
   font-weight: 600;
   font-size: 14px;
   margin-bottom: 5px;
 `
 
-export const StyledSettingsCopy = styled('div') <{}>`
+export const StyledSettingsCopy = styled('div')`
   font-size: 13px;
   font-weight: 300;
   line-height: 17px;
 `
 
-export const StyledButtonIcon = styled('div') <{}>`
+export const StyledButtonIcon = styled('div')`
   display: inline-block;
   margin-right: 5px;
   width: 19px;
   height: 17px;
 `
 
-export const ToggleCardsWrapper = styled('div') <{}>`
+export const ToggleCardsWrapper = styled('div')`
   padding: 15px 15px 5px 15px;
   clear: both;
   border-radius: 10px;
@@ -295,21 +295,21 @@ export const ToggleCardsWrapper = styled('div') <{}>`
   color: ${p => isDarkTheme(p) ? '#FFF' : 'rgb(59, 62, 79)'};
 `
 
-export const ToggleCardsText = styled('div') <{}>`
+export const ToggleCardsText = styled('div')`
   text-align: left;
   max-width: 325px;
 `
 
-export const ToggleCardsTitle = styled('span') <{}>`
+export const ToggleCardsTitle = styled('span')`
   font-weight: bold;
 `
 
-export const ToggleCardsCopy = styled('p') <{}>`
+export const ToggleCardsCopy = styled('p')`
   line-height: 18px;
   font-weight: normal;
 `
 
-export const ToggleCardsSwitch = styled('div') <{}>`
+export const ToggleCardsSwitch = styled('div')`
   float: right;
   margin: -65px -10px 0 0;
 `
@@ -324,7 +324,7 @@ export const StyledTopSitesCustomizationSettings = styled('div')`
   gap: var(--widget-gap)
 `
 
-export const StyledTopSitesCustomizationSettingsOption = styled('button') <{}>`
+export const StyledTopSitesCustomizationSettingsOption = styled('button')`
   width: calc(50% - var(--widget-gap) / 2);
   display: flex;
   flex-direction: column;
@@ -357,7 +357,7 @@ export const StyledTopSitesCustomizationImage = styled('img') <CustomizationImag
   `}
 `
 
-export const StyledTopSitesCustomizationOptionTitle = styled('div') <{}>`
+export const StyledTopSitesCustomizationOptionTitle = styled('div')`
   font-weight: 500;
   font-size: 13px;
   line-height: 20px;
@@ -365,14 +365,14 @@ export const StyledTopSitesCustomizationOptionTitle = styled('div') <{}>`
   text-align: left;
 `
 
-export const StyledTopSitesCustomizationOptionDesc = styled('div') <{}>`
+export const StyledTopSitesCustomizationOptionDesc = styled('div')`
   font-weight: 400;
   font-size: 11px;
   line-height: 17px;
   text-align: left;
 `
 
-export const StyledCustomBackgroundSettings = styled('div') <{}>`
+export const StyledCustomBackgroundSettings = styled('div')`
   --option-gap: 10px;
   display: flex;
   flex-direction: row;
@@ -381,7 +381,7 @@ export const StyledCustomBackgroundSettings = styled('div') <{}>`
   gap: var(--option-gap)
 `
 
-export const StyledCustomBackgroundOption = styled('button') <{}>`
+export const StyledCustomBackgroundOption = styled('button')`
   width: calc(50% - var(--option-gap) / 2);
   display: flex;
   flex-direction: column;
@@ -474,14 +474,14 @@ export const StyledCustomBackgroundOptionColor = styled('div') <SelectionProps &
   background: ${p => p.colorValue};
 `
 
-export const StyledUploadLabel = styled('div') <{}>`
+export const StyledUploadLabel = styled('div')`
 font-style: normal;
 font-weight: 400;
 font-size: 11px;
 line-height: 17px;
 `
 
-export const StyledCustomBackgroundOptionLabel = styled('div') <{}>`
+export const StyledCustomBackgroundOptionLabel = styled('div')`
 font-style: normal;
 font-weight: 400;
 font-size: 14px;

--- a/components/brave_new_tab_ui/components/default/settings/index.ts
+++ b/components/brave_new_tab_ui/components/default/settings/index.ts
@@ -16,7 +16,7 @@ import frecencySelectedDark from './assets/frecency-selected-dark.svg'
 import frecencyUnselectedDark from './assets/frecency-unselected-dark.svg'
 
 import CheckedCircle from './assets/checked-circle.svg'
-import { color, effect, font, gradient, radius, spacing } from '@brave/leo/tokens/css/variables'
+import { color, effect, font, radius, spacing } from '@brave/leo/tokens/css/variables'
 
 // Reverse decisions to have the controls define their margin. This helps
 // fill the gap before we remove all margins from these types of controls.
@@ -55,117 +55,6 @@ export const SettingsContent = styled('div')`
   }
 `
 
-export const SettingsSidebar = styled('aside')`
-  position: relative;
-  /* normalize against SettingsMenu default padding */
-  margin-inline-start: -24px;
-  padding-inline-start: 24px;
-`
-
-interface SettingsSidebarActiveButtonSliderProps {
-  translateTo: number
-}
-
-export const SettingsSidebarActiveButtonSlider =
-  styled('div') <SettingsSidebarActiveButtonSliderProps>`
-  position: absolute;
-  top: 0;
-  inset-inline-start: 0;
-  height: 48px;
-  width: 4px;
-  background: linear-gradient(93.83deg, ${p => p.theme.color.brandBrave} -3.53%, ${p => p.theme.palette.magenta500} 110.11%);
-  border-radius: 0px 2px 2px 0px;
-  transform: translateY(${p => p.translateTo * 48}px);
-  transition-delay: 0.05s;
-  transition-duration: 0.3s;
-  transition-timing-function: ease-in;
-  transition-property: transform;
-`
-
-export const SettingsSidebarButtonText = styled.span`
-  margin-left: 16px;
-  font-weight: 500;
-  font-size: 13px;
-  font-family: ${p => p.theme.fontFamily.heading};
-  line-height: normal;
-  position: relative;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  text-transform: capitalize;
-
-  transition: opacity var(--sidebar-button-transition-timing) ease-in-out,
-              color var(--sidebar-button-transition-timing) ease-in-out,
-              font-weight var(--sidebar-button-transition-timing) ease-in-out;
-
-  [data-active] & {
-    font-weight: 600;
-  }
-
-  /* Active version (hidden until item is active).
-     This is a separate element so that we can:
-     1. fade it in (no transition for background gradient)
-     2. still show ellipsis for overflowing text (which doesn't show for
-     background-clip: text) */
-  &::after {
-    content: attr(data-text);
-    position: absolute;
-    opacity: var(--active-opacity);
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: ${p => p.theme.color.panelBackground};
-    background-size: 100%;
-    background-repeat: repeat;
-    -webkit-background-clip: text;
-    background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-image: ${gradient.hero};
-    overflow: hidden;
-    text-overflow: ellipsis;
-    transition: opacity var(--sidebar-button-transition-timing) ease-in-out,
-                font-weight var(--sidebar-button-transition-timing) ease-in-out;
-  }
-`
-
-export const SettingsSidebarButton = styled.button`
-  --leo-icon-color: ${color.icon.default};
-  --sidebar-button-transition-timing: .12s;
-  --active-opacity: 0;
-
-  appearance: none;
-  padding: 0;
-  margin: 0;
-  border: 0;
-  width: 220px;
-  height: 48px;
-  text-align: left;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  background: inherit;
-  color: ${color.text.secondary};
-
-  &:hover {
-    --leo-icon-color: ${color.text.interactive};
-    color: ${color.text.interactive};
-  }
-
-  &[data-active], &:active {
-    --active-opacity: 1;
-    --leo-icon-color: ${gradient.hero};
-    color: ${gradient.hero};
-  }
-
-  &:active,
-  &:focus {
-    outline: none;
-  }
-
-  &:focus-visible {
-    box-shadow: ${effect.focusState};
-  }
-`
 
 export const SettingsFeatureBody = styled('section')`
   padding: 10px 16px;

--- a/components/brave_new_tab_ui/components/default/settings/navigateBack.tsx
+++ b/components/brave_new_tab_ui/components/default/settings/navigateBack.tsx
@@ -4,54 +4,18 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import styled from 'styled-components'
-import { ArrowLeftIcon } from 'brave-ui/components/icons'
-import { getLocale } from '../../../../common/locale'
+import { getLocale } from '$web-common/locale'
+import Icon from '@brave/leo/react/icon'
+import Button from '@brave/leo/react/button'
 
 type Props = {
   onBack: () => any
   title?: string
 }
 
-const Back = styled('button')`
-  appearance: none;
-  margin: 0 0 14px 0;
-  padding: 0;
-  outline: none;
-  border: none;
-  background: none;
-  display: flex;
-  flex-direction: row;
-  gap: 10px;
-  cursor: pointer;
-  color: inherit;
-  font-weight: 800;
-
-  &:focus,
-  &:hover {
-    color: ${p => p.theme.color.brandBraveInteracting}
-  }
-  &:active {
-    color: ${p => p.theme.color.brandBraveActive}
-  }
-  &:focus-visible {
-    outline: solid 1px ${p => p.theme.color.brandBrave};
-  }
-`
-
-const Icon = styled('div')`
-  width: 16px;
-  height: 16px;
-`
-
-export default function NavigateBack (props: Props) {
-  const onClick = React.useCallback(() => {
-    props.onBack()
-  }, [props.onBack])
-  return (
-    <Back onClick={onClick}>
-      <Icon><ArrowLeftIcon /></Icon>
-      <span>{ props.title ? props.title : getLocale('settingsNavigateBack')}</span>
-    </Back>
-  )
+export default function NavigateBack(props: Props) {
+  return <Button onClick={props.onBack} kind='plain-faint' fab size='tiny'>
+    <Icon name='arrow-left' slot='icon-before' />
+    <span>{props.title ? props.title : getLocale('settingsNavigateBack')}</span>
+  </Button>
 }

--- a/components/brave_new_tab_ui/containers/newTab/settings.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/settings.tsx
@@ -8,15 +8,14 @@ import * as React from 'react'
 import {
   SettingsContent,
   SettingsFeatureBody,
-  SettingsSidebar,
-  SettingsSidebarActiveButtonSlider,
-  SettingsSidebarButton,
-  SettingsSidebarButtonText,
   SettingsTitle,
 } from '../../components/default'
 
+import Navigation from '@brave/leo/react/navigation'
+import NavigationItem from '@brave/leo/react/navigationItem'
+import NavigationMenu from '@brave/leo/react/navigationMenu'
+
 import { getLocale } from '$web-common/locale'
-import Icon from '@brave/leo/react/icon'
 import { useBraveNews } from '../../../brave_news/browser/resources/shared/Context'
 import { loadTimeData } from '$web-common/loadTimeData'
 import Dialog from '@brave/leo/react/dialog'
@@ -34,6 +33,15 @@ const SearchSettings = React.lazy(() => import('./settings/search'))
 export const SettingsDialog = styled(Dialog)`
   --leo-dialog-width: 720px;
   --leo-dialog-padding: 24px 24px 0 24px;
+`
+
+const Sidebar = styled(Navigation)`
+  /* normalize against SettingsMenu default padding */
+  margin-inline-start: -24px;
+`
+
+const SidebarItem = styled(NavigationItem)`
+  text-transform: capitalize;
 `
 
 export interface Props {
@@ -137,31 +145,13 @@ export default function Settings(props: Props) {
       {getLocale('dashboardSettingsTitle')}
     </SettingsTitle>
     <SettingsContent id='settingsBody'>
-      <SettingsSidebar id='sidebar'>
-        <SettingsSidebarActiveButtonSlider
-          translateTo={allowedTabTypes.indexOf(activeTab)}
-        />
-        {
-          allowedTabTypes.map((tabType) => {
-            const titleKey = tabTranslationKeys[tabType]
-            const isActive = activeTab === tabType
-            return (
-              <SettingsSidebarButton
-                tabIndex={0}
-                key={tabType}
-                data-active={isActive ? '' : null}
-                onClick={() => changeTab(tabType)}
-              >
-                <Icon name={tabIcons[tabType]} />
-                <SettingsSidebarButtonText
-                  data-text={getLocale(titleKey)}>
-                  {getLocale(titleKey)}
-                </SettingsSidebarButtonText>
-              </SettingsSidebarButton>
-            )
-          })
-        }
-      </SettingsSidebar>
+      <Sidebar id="sidebar">
+        <NavigationMenu>
+          {allowedTabTypes.map(tabType => <SidebarItem key={tabType} icon={tabIcons[tabType]} isCurrent={activeTab === tabType} onClick={() => changeTab(tabType)}>
+            {getLocale(tabTranslationKeys[tabType])}
+          </SidebarItem>)}
+        </NavigationMenu>
+      </Sidebar>
       <SettingsFeatureBody id='content'>
         {/* Empty loading fallback is ok here since we are loading from local disk. */}
         <React.Suspense fallback={(<div />)}>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41131

As a side effect, this fixes the blurry text issue

See https://github.com/brave/leo/issues/847 for some related Nala issues

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See issue & additionally:
1. Open customize menu on NTP
2. The same menu items should be present
3. The menu items should be blurple when selected

**Known:** The indicator know longer animates - this is expected and will be fixed in Nala eventually but is okay for now
