### PR TITLE
Refactor SidebarContainerView

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -905,6 +905,18 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, TabSpecificAndGlobalPanelsTest) {
   WaitUntil(base::BindLambdaForTesting([&]() {
     return panel_ui->GetCurrentEntryId() == SidePanelEntryId::kBookmarks;
   }));
+
+  // Check per-url contextual panel close.
+  // If current tab load another url, customize panel should be hidden.
+  tab_model()->ActivateTabAt(0);
+  WaitUntil(base::BindLambdaForTesting([&]() {
+    return panel_ui->GetCurrentEntryId() == SidePanelEntryId::kCustomizeChrome;
+  }));
+
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("brave://newtab/")));
+  WaitUntil(base::BindLambdaForTesting([&]() {
+    return panel_ui->GetCurrentEntryId() == SidePanelEntryId::kBookmarks;
+  }));
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -779,6 +779,14 @@ WalletButton* BraveBrowserView::GetWalletButton() {
   return static_cast<BraveToolbarView*>(toolbar())->wallet_button();
 }
 
+void BraveBrowserView::WillShowSidePanel() {
+  sidebar_container_view_->WillShowSidePanel();
+}
+
+void BraveBrowserView::WillDeregisterSidePanelEntry(SidePanelEntry* entry) {
+  sidebar_container_view_->WillDeregisterSidePanelEntry(entry);
+}
+
 void BraveBrowserView::NotifyDialogPositionRequiresUpdate() {
   GetBrowserViewLayout()->NotifyDialogPositionRequiresUpdate();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -57,6 +57,7 @@ class BraveBrowser;
 class BraveHelpBubbleHostView;
 class ContentsLayoutManager;
 class SidebarContainerView;
+class SidePanelEntry;
 class SplitViewLocationBar;
 class SplitViewSeparator;
 class VerticalTabStripWidgetDelegateView;
@@ -80,6 +81,8 @@ class BraveBrowserView : public BrowserView,
   void CloseWalletBubble();
   WalletButton* GetWalletButton();
   views::View* GetWalletButtonAnchorView();
+  void WillShowSidePanel();
+  void WillDeregisterSidePanelEntry(SidePanelEntry* entry);
 
   // Triggers layout of web modal dialogs
   void NotifyDialogPositionRequiresUpdate();

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -42,6 +42,11 @@ void BraveSidePanelCoordinator::Show(
   sidebar::SetLastUsedSidePanel(browser_view_->GetProfile()->GetPrefs(),
                                 entry_key.id());
 
+  // Notify to give opportunity to observe another panel entries from
+  // global or active tab's contextual registry.
+  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+  brave_browser_view->WillShowSidePanel();
+
   SidePanelCoordinator::Show(entry_key, open_trigger);
 }
 
@@ -86,6 +91,11 @@ void BraveSidePanelCoordinator::Toggle() {
 void BraveSidePanelCoordinator::Toggle(
     SidePanelEntryKey key,
     SidePanelUtil::SidePanelOpenTrigger open_trigger) {
+  // Notify to give opportunity to observe another panel entries from
+  // global or active tab's contextual registry.
+  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+  brave_browser_view->WillShowSidePanel();
+
   SidePanelCoordinator::Toggle(key, open_trigger);
 }
 
@@ -161,4 +171,15 @@ void BraveSidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange(
 
   SidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange(key,
                                                                  is_active);
+}
+
+void BraveSidePanelCoordinator::OnEntryWillDeregister(
+    SidePanelRegistry* registry,
+    SidePanelEntry* entry) {
+  SidePanelCoordinator::OnEntryWillDeregister(registry, entry);
+
+  // This could give the opportunity to stop observing from |entry| if
+  // this deregister happens while tab is still live.
+  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+  brave_browser_view->WillDeregisterSidePanelEntry(entry);
 }

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -93,8 +93,10 @@ void BraveSidePanelCoordinator::Toggle(
     SidePanelUtil::SidePanelOpenTrigger open_trigger) {
   // Notify to give opportunity to observe another panel entries from
   // global or active tab's contextual registry.
-  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
-  brave_browser_view->WillShowSidePanel();
+  if (!IsSidePanelShowing()) {
+    auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+    brave_browser_view->WillShowSidePanel();
+  }
 
   SidePanelCoordinator::Toggle(key, open_trigger);
 }
@@ -165,6 +167,11 @@ void BraveSidePanelCoordinator::PopulateSidePanel(
 void BraveSidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange(
     SidePanelEntryKey key,
     bool is_active) {
+  // // Notify to give opportunity to observe another panel entries from
+  // // global or active tab's contextual registry.
+  // auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+  // brave_browser_view->WillShowSidePanel();
+
   if (!browser_view_->toolbar()->pinned_toolbar_actions_container()) {
     return;
   }

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.h
@@ -35,6 +35,8 @@ class BraveSidePanelCoordinator : public SidePanelCoordinator {
       const UniqueKey& unique_key,
       SidePanelEntry* entry,
       std::optional<std::unique_ptr<views::View>> content_view) override;
+  void OnEntryWillDeregister(SidePanelRegistry* registry,
+                             SidePanelEntry* entry) override;
 
   void NotifyPinnedContainerOfActiveStateChange(SidePanelEntryKey key,
                                                 bool is_active) override;

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -38,6 +38,7 @@
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
 #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/exclusive_access/fullscreen_within_tab_helper.h"
+#include "chrome/browser/ui/tabs/public/tab_features.h"
 #include "chrome/browser/ui/tabs/tab_strip_model.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
@@ -139,18 +140,6 @@ void SidebarContainerView::Init() {
   sidebar_model_observation_.Observe(sidebar_model_);
   browser_->tab_strip_model()->AddObserver(this);
 
-  auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
-  DCHECK(browser_view);
-
-  auto* global_registry = side_panel_coordinator_->GetWindowRegistry();
-  panel_registry_observations_.AddObservation(global_registry);
-
-  for (const auto& entry : global_registry->entries()) {
-    DVLOG(1) << "Observing panel entry in ctor: "
-             << SidePanelEntryIdToString(entry->key().id());
-    panel_entry_observations_.AddObservation(entry.get());
-  }
-
   show_side_panel_button_.Init(
       kShowSidePanelButton, browser_->profile()->GetPrefs(),
       base::BindRepeating(&SidebarContainerView::UpdateToolbarButtonVisibility,
@@ -184,6 +173,29 @@ void SidebarContainerView::SetSidebarOnLeft(bool sidebar_on_left) {
 
 bool SidebarContainerView::IsSidebarVisible() const {
   return sidebar_control_view_ && sidebar_control_view_->GetVisible();
+}
+
+void SidebarContainerView::WillShowSidePanel() {
+  // It's good timing to start observing any panel entries
+  // from global and contextual if not yet observed.
+  auto* tab_model = browser_->tab_strip_model();
+  auto* active_web_contents = tab_model->GetActiveWebContents();
+  if (!active_web_contents) {
+    return;
+  }
+  StartObservingContextualSidePanelEntry(active_web_contents);
+
+  auto* global_registry = side_panel_coordinator_->GetWindowRegistry();
+  for (const auto& entry : global_registry->entries()) {
+    StartObservingForEntry(entry.get());
+  }
+}
+
+void SidebarContainerView::WillDeregisterSidePanelEntry(SidePanelEntry* entry) {
+  // If entry's life cycle is tied with tab, we stop observing from
+  // OnTabWillBeRemoved(). However, some entry could be deregistered while tab
+  // is live. In that case, we need to stop observing here explicitely.
+  StopObservingForEntry(entry);
 }
 
 bool SidebarContainerView::IsFullscreenForCurrentEntry() const {
@@ -797,26 +809,10 @@ void SidebarContainerView::OnEntryHidden(SidePanelEntry* entry) {
   }
 }
 
-void SidebarContainerView::OnEntryRegistered(SidePanelRegistry* registry,
-                                             SidePanelEntry* entry) {
-  // Observe when it's shown or hidden
-  DVLOG(1) << "Observing panel entry in registry observer: "
-           << SidePanelEntryIdToString(entry->key().id());
-  panel_entry_observations_.AddObservation(entry);
-}
-
-void SidebarContainerView::OnEntryWillDeregister(SidePanelRegistry* registry,
-                                                 SidePanelEntry* entry) {
-  // Stop observing
-  DVLOG(1) << "Unobserving panel entry in registry observer: "
-           << SidePanelEntryIdToString(entry->key().id());
-  panel_entry_observations_.RemoveObservation(entry);
-}
-
-void SidebarContainerView::OnRegistryDestroying(SidePanelRegistry* registry) {
-  if (panel_registry_observations_.IsObservingSource(registry)) {
-    StopObservingContextualSidePanelRegistry(registry);
-  }
+void SidebarContainerView::OnTabWillBeRemoved(content::WebContents* contents,
+                                              int index) {
+  // At this time, we can stop observing as TabFeatures is available.
+  StopObservingContextualSidePanelEntry(contents);
 }
 
 void SidebarContainerView::UpdateActiveItemState() {
@@ -839,102 +835,37 @@ void SidebarContainerView::OnSidePanelDidClose() {
   UpdateActiveItemState();
 }
 
-void SidebarContainerView::OnTabStripModelChanged(
-    TabStripModel* tab_strip_model,
-    const TabStripModelChange& change,
-    const TabStripSelectionChange& selection) {
-  if ((change.type() == TabStripModelChange::kReplaced)) {
-    // Pre-cr129's change
-    // https://chromium.googlesource.com/chromium/src/+/2fd6b53ce, we would
-    // handle shared pinned tab moving from one window to another here by
-    // starting to observe the new contents registry and stoping observing the
-    // old contents registry. But since the registry is no longer associated
-    // with the contents and is now associated with the tab instead we don't
-    // need to do the swap here. However, we may need to take some action here
-    // to fix https://github.com/brave/brave-browser/issues/40681.
-
-    // For AI Chat, if the contents got replaced then the AI Chat UI associated
-    // with that contetnts will no longer work, so just close it.
-    auto* replace = change.GetReplace();
-    // old_contents is already removed from the tab, so use the new_contents to
-    // get the registry.
-    auto* registry = SidePanelRegistry::GetDeprecated(replace->new_contents);
-    if (registry) {
-      if (auto* entry = registry->GetEntryForKey(
-              SidePanelEntry::Key(SidePanelEntryId::kChatUI))) {
-        if (side_panel_coordinator_->IsSidePanelEntryShowing(entry->key())) {
-          side_panel_coordinator_->Close();
-        } else {
-          entry->ClearCachedView();
-        }
-      }
-    }
-    return;
-  }
-
-  if (change.type() == TabStripModelChange::kInserted) {
-    for (const auto& contents : change.GetInsert()->contents) {
-      StartObservingContextualSidePanelRegistry(contents.contents);
-    }
-    return;
-  }
-
-  if (change.type() == TabStripModelChange::kRemoved) {
-    bool removed_for_deletion =
-        (change.GetRemove()->contents[0].remove_reason ==
-         TabStripModelChange::RemoveReason::kDeleted);
-    // If the tab is removed for deletion the side panel registry has already
-    // been destroyed. We stop observing that registry in
-    // SidePanelRegistryObserver::OnRegistryDestroying override above.
-    if (!removed_for_deletion) {
-      for (const auto& contents : change.GetRemove()->contents) {
-        StopObservingContextualSidePanelRegistry(contents.contents);
-      }
-    }
-    return;
-  }
-}
-
-void SidebarContainerView::StopObservingContextualSidePanelRegistry(
+void SidebarContainerView::StopObservingContextualSidePanelEntry(
     content::WebContents* contents) {
-  auto* registry = SidePanelRegistry::GetDeprecated(contents);
-  StopObservingContextualSidePanelRegistry(registry);
-}
+  auto* tab = tabs::TabInterface::GetFromContents(contents);
+  if (!tab->GetTabFeatures()) {
+    return;
+  }
 
-void SidebarContainerView::StopObservingContextualSidePanelRegistry(
-    SidePanelRegistry* registry) {
+  auto* registry = tab->GetTabFeatures()->side_panel_registry();
   if (!registry) {
     return;
   }
 
-  panel_registry_observations_.RemoveObservation(registry);
-
   for (const auto& entry : registry->entries()) {
-    if (panel_entry_observations_.IsObservingSource(entry.get())) {
-      DVLOG(1) << "Removing panel entry observation from removed contextual "
-                  "registry : "
-               << SidePanelEntryIdToString(entry->key().id());
-      panel_entry_observations_.RemoveObservation(entry.get());
-    }
+    StopObservingForEntry(entry.get());
   }
 }
 
-void SidebarContainerView::StartObservingContextualSidePanelRegistry(
+void SidebarContainerView::StartObservingContextualSidePanelEntry(
     content::WebContents* contents) {
-  auto* registry = SidePanelRegistry::GetDeprecated(contents);
+  auto* tab = tabs::TabInterface::GetFromContents(contents);
+  if (!tab->GetTabFeatures()) {
+    return;
+  }
+
+  auto* registry = tab->GetTabFeatures()->side_panel_registry();
   if (!registry) {
     return;
   }
 
-  panel_registry_observations_.AddObservation(registry);
-
   for (const auto& entry : registry->entries()) {
-    if (!panel_entry_observations_.IsObservingSource(entry.get())) {
-      DVLOG(1) << "Observing existing panel entry from newly added contextual "
-                  "registry : "
-               << SidePanelEntryIdToString(entry->key().id());
-      panel_entry_observations_.AddObservation(entry.get());
-    }
+    StartObservingForEntry(entry.get());
   }
 
   SharedPinnedTabService* shared_pinned_tab_service =
@@ -953,6 +884,22 @@ void SidebarContainerView::StartObservingContextualSidePanelRegistry(
     if (auto active_entry = registry->active_entry()) {
       OnEntryShown(*active_entry);
     }
+  }
+}
+
+void SidebarContainerView::StartObservingForEntry(SidePanelEntry* entry) {
+  if (!panel_entry_observations_.IsObservingSource(entry)) {
+    DVLOG(1) << "Observing panel entry: "
+             << SidePanelEntryIdToString(entry->key().id());
+    panel_entry_observations_.AddObservation(entry);
+  }
+}
+
+void SidebarContainerView::StopObservingForEntry(SidePanelEntry* entry) {
+  if (panel_entry_observations_.IsObservingSource(entry)) {
+    DVLOG(1) << "Removing panel entry observation: "
+             << SidePanelEntryIdToString(entry->key().id());
+    panel_entry_observations_.RemoveObservation(entry);
   }
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -124,6 +124,10 @@ class SidebarContainerView
   void OnEntryHidden(SidePanelEntry* entry) override;
 
   // TabStripModelObserver:
+  void OnTabStripModelChanged(
+      TabStripModel* tab_strip_model,
+      const TabStripModelChange& change,
+      const TabStripSelectionChange& selection) override;
   void OnTabWillBeRemoved(content::WebContents* contents, int index) override;
 
   // SidePanelViewStateObserver:

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
@@ -18,7 +18,6 @@
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_registry.h"
-#include "chrome/browser/ui/views/side_panel/side_panel_registry_observer.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_ui.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_util.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_view_state_observer.h"


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/41342

As upstream deleted SidebarRegistryObserver in ToT,
SidebarContainerView also should not rely on.
Instead, SidePanelCoordinator notifies directly to SidebarContainerView
when we can start/stop panel entry observing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This PR doesn't change current behavior but logic is changed.
So, want to get test from QA.
It would be good to check overall sidebar functionality.