### PR TITLE
[ads] Add search result ad right button click handling

### DIFF
--- a/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_tab_helper.h
+++ b/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_tab_helper.h
@@ -7,10 +7,10 @@
 #define BRAVE_BROWSER_BRAVE_ADS_CREATIVES_SEARCH_RESULT_AD_CREATIVE_SEARCH_RESULT_AD_TAB_HELPER_H_
 
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom-forward.h"
 #include "content/public/browser/web_contents_observer.h"
 #include "content/public/browser/web_contents_user_data.h"
 
@@ -39,8 +39,6 @@ class CreativeSearchResultAdTabHelper
 
   bool ShouldHandleCreativeAdEvents() const;
 
-  void MaybeTriggerCreativeAdClickedEvent(const GURL& url);
-
  private:
   friend class content::WebContentsUserData<CreativeSearchResultAdTabHelper>;
 
@@ -52,13 +50,17 @@ class CreativeSearchResultAdTabHelper
   void MaybeExtractCreativeAdPlacementIdsFromWebPageAndHandleViewedEvents();
 
   void MaybeHandleCreativeAdViewedEvents(
-      std::vector<std::string> placement_ids);
-  void MaybeHandleCreativeAdViewedEvent(const std::string& placement_id);
-  void MaybeHandleCreativeAdViewedEventCallback(const std::string& placement_id,
-                                                const base::Value value);
+      std::vector<mojom::CreativeSearchResultAdInfoPtr>
+          creative_search_result_ads);
+  void MaybeHandleCreativeAdViewedEvent(
+      mojom::CreativeSearchResultAdInfoPtr creative_search_result_ad);
+  void MaybeHandleCreativeAdViewedEventCallback(
+      mojom::CreativeSearchResultAdInfoPtr creative_search_result_ad,
+      const base::Value value);
 
-  void MaybeHandleCreativeAdClickedEvent(
-      content::NavigationHandle* navigation_handle);
+  void MaybeHandleCreativeAdClickedEvent(const GURL& url);
+  void MaybeHandleCreativeAdClickedEventCallback(
+      mojom::CreativeSearchResultAdInfoPtr creative_search_result_ad);
 
   // content::WebContentsObserver:
   void DidStartNavigation(

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -173,6 +173,13 @@ class AdsService : public KeyedService {
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       TriggerAdEventCallback callback) = 0;
 
+  // Called to get the search result ad specified by `placement_id`. The
+  // callback takes one argument - `mojom::CreativeSearchResultAdInfoPtr`
+  // containing the info of the search result ad.
+  virtual void MaybeGetSearchResultAd(
+      const std::string& placement_id,
+      MaybeGetSearchResultAdCallback callback) = 0;
+
   // Called when a user views or interacts with a search result ad to trigger a
   // `mojom_ad_event_type` event for the ad specified in `mojom_creative_ad`.
   // The callback takes one argument - `bool` is set to `true` if successful

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/browser/ads_service_impl.h"
 
+#include <optional>
 #include <utility>
 
 #include "base/base64.h"
@@ -1281,6 +1282,17 @@ void AdsServiceImpl::TriggerPromotedContentAdEvent(
   bat_ads_associated_remote_->TriggerPromotedContentAdEvent(
       placement_id, creative_instance_id, mojom_ad_event_type,
       std::move(callback));
+}
+
+void AdsServiceImpl::MaybeGetSearchResultAd(
+    const std::string& placement_id,
+    MaybeGetSearchResultAdCallback callback) {
+  if (!bat_ads_associated_remote_.is_bound()) {
+    return std::move(callback).Run(/*mojom_creative_ad*/ {});
+  }
+
+  bat_ads_associated_remote_->MaybeGetSearchResultAd(placement_id,
+                                                     std::move(callback));
 }
 
 void AdsServiceImpl::TriggerSearchResultAdEvent(

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -262,6 +262,8 @@ class AdsServiceImpl final : public AdsService,
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       TriggerAdEventCallback callback) override;
 
+  void MaybeGetSearchResultAd(const std::string& placement_id,
+                              MaybeGetSearchResultAdCallback callback) override;
   void TriggerSearchResultAdEvent(
       mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
       mojom::SearchResultAdEventType mojom_ad_event_type,

--- a/components/brave_ads/browser/ads_service_mock.h
+++ b/components/brave_ads/browser/ads_service_mock.h
@@ -84,6 +84,9 @@ class AdsServiceMock : public AdsService {
                TriggerAdEventCallback));
 
   MOCK_METHOD(void,
+              MaybeGetSearchResultAd,
+              (const std::string&, MaybeGetSearchResultAdCallback));
+  MOCK_METHOD(void,
               TriggerSearchResultAdEvent,
               (mojom::CreativeSearchResultAdInfoPtr,
                const mojom::SearchResultAdEventType,

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler.h
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler.h
@@ -7,14 +7,13 @@
 #define BRAVE_COMPONENTS_BRAVE_ADS_CONTENT_BROWSER_CREATIVES_SEARCH_RESULT_AD_CREATIVE_SEARCH_RESULT_AD_HANDLER_H_
 
 #include <memory>
-#include <optional>
-#include <string>
 #include <vector>
 
 #include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "brave/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom-forward.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "third_party/blink/public/mojom/document_metadata/document_metadata.mojom-forward.h"
 
@@ -27,7 +26,8 @@ class RenderFrameHost;
 namespace brave_ads {
 
 using ExtractCreativeAdPlacementIdsFromWebPageCallback =
-    base::OnceCallback<void(std::vector<std::string> placement_ids)>;
+    base::OnceCallback<void(std::vector<mojom::CreativeSearchResultAdInfoPtr>
+                                creative_search_result_ads)>;
 
 class AdsService;
 
@@ -52,8 +52,8 @@ class CreativeSearchResultAdHandler final {
       content::RenderFrameHost* render_frame_host,
       ExtractCreativeAdPlacementIdsFromWebPageCallback callback);
 
-  void MaybeTriggerCreativeAdViewedEvent(const std::string& placement_id);
-  void MaybeTriggerCreativeAdClickedEvent(const GURL& url);
+  void MaybeTriggerCreativeAdViewedEvent(
+      mojom::CreativeSearchResultAdInfoPtr creative_search_result_ad);
 
  private:
   friend class BraveAdsCreativeSearchResultAdHandlerTest;
@@ -70,8 +70,6 @@ class CreativeSearchResultAdHandler final {
   const raw_ptr<AdsService> ads_service_;  // NOT OWNED
 
   const bool should_trigger_creative_ad_viewed_events_;
-
-  std::optional<CreativeSearchResultAdMap> creative_search_result_ads_;
 
   base::WeakPtrFactory<CreativeSearchResultAdHandler> weak_factory_{this};
 };

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor.h
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor.h
@@ -6,20 +6,14 @@
 #ifndef BRAVE_COMPONENTS_BRAVE_ADS_CONTENT_BROWSER_CREATIVES_SEARCH_RESULT_AD_CREATIVE_SEARCH_RESULT_AD_MOJOM_WEB_PAGE_ENTITIES_EXTRACTOR_H_
 #define BRAVE_COMPONENTS_BRAVE_ADS_CONTENT_BROWSER_CREATIVES_SEARCH_RESULT_AD_CREATIVE_SEARCH_RESULT_AD_MOJOM_WEB_PAGE_ENTITIES_EXTRACTOR_H_
 
-#include <string>
 #include <vector>
 
-#include "base/containers/flat_map.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom-forward.h"
 #include "components/schema_org/common/metadata.mojom-forward.h"
 
 namespace brave_ads {
 
-using CreativeSearchResultAdMap =
-    base::flat_map</*placement_id*/ std::string,
-                   mojom::CreativeSearchResultAdInfoPtr>;
-
-CreativeSearchResultAdMap
+std::vector<mojom::CreativeSearchResultAdInfoPtr>
 ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
     const std::vector<schema_org::mojom::EntityPtr>& mojom_entities);
 

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor_unittest.cc
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor_unittest.cc
@@ -57,14 +57,16 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest, Extract) {
       test::CreativeSearchResultAdMojomWebPageEntities(
           /*excluded_property_names=*/{});
 
-  const CreativeSearchResultAdMap creative_search_result_ads =
-      ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-          mojom_web_page_entities);
+  const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+      creative_search_result_ads =
+          ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+              mojom_web_page_entities);
   ASSERT_THAT(creative_search_result_ads, ::testing::SizeIs(1));
   const mojom::CreativeSearchResultAdInfoPtr& mojom_creative_ad =
-      creative_search_result_ads.at(test::kCreativeAdPlacementId);
+      creative_search_result_ads[0];
   ASSERT_TRUE(mojom_creative_ad);
   ASSERT_TRUE(mojom_creative_ad->creative_set_conversion);
+  EXPECT_EQ(test::kCreativeAdPlacementId, mojom_creative_ad->placement_id);
 
   VerifyRequiredMojomCreativeAdExpectations(mojom_creative_ad);
   VerifyRequiredMojomCreativeSetConversionExpectations(mojom_creative_ad);
@@ -82,9 +84,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
   const auto& mojom_entity = mojom_property->values->get_entity_values()[0];
   mojom_entity->type = "unsupported";
 
-  const CreativeSearchResultAdMap creative_search_result_ads =
-      ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-          mojom_web_page_entities);
+  const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+      creative_search_result_ads =
+          ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+              mojom_web_page_entities);
   EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
 }
 
@@ -93,9 +96,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
   {
     const std::vector<schema_org::mojom::EntityPtr> mojom_web_page_entities;
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -105,9 +109,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
             /*excluded_property_names=*/{});
     mojom_web_page_entities[0]->type = "unsupported";
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -117,9 +122,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
             /*excluded_property_names=*/{});
     mojom_web_page_entities[0]->properties.clear();
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -130,9 +136,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
     const auto& mojom_property = mojom_web_page_entities[0]->properties[0];
     mojom_property->name = "unsupported";
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -143,9 +150,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
     const auto& mojom_property = mojom_web_page_entities[0]->properties[0];
     mojom_property->values = schema_org::mojom::Values::NewEntityValues({});
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -157,9 +165,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
     mojom_property->values =
         schema_org::mojom::Values::NewStringValues({"unsupported"});
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 }
@@ -170,9 +179,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
       test::CreativeSearchResultAdMojomWebPageEntities(
           /*excluded_property_names=*/{"data-placement-id"});
 
-  const CreativeSearchResultAdMap creative_search_result_ads =
-      ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-          mojom_web_page_entities);
+  const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+      creative_search_result_ads =
+          ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+              mojom_web_page_entities);
   EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
 }
 
@@ -183,13 +193,13 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
           kCreativeAdPlacementIdPropertyName,
           test::kCreativeAdPlacementIdWithUnreservedCharacters);
 
-  const CreativeSearchResultAdMap creative_search_result_ads =
-      ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-          mojom_web_page_entities);
+  const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+      creative_search_result_ads =
+          ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+              mojom_web_page_entities);
   ASSERT_THAT(creative_search_result_ads, ::testing::SizeIs(1));
   const mojom::CreativeSearchResultAdInfoPtr& mojom_creative_ad =
-      creative_search_result_ads.at(
-          test::kEscapedCreativeAdPlacementIdWithUnreservedCharacters);
+      creative_search_result_ads[0];
   ASSERT_TRUE(mojom_creative_ad);
   EXPECT_EQ(test::kEscapedCreativeAdPlacementIdWithUnreservedCharacters,
             mojom_creative_ad->placement_id);
@@ -202,15 +212,17 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
           /*name=*/"foo",
           /*value=*/"bar");
 
-  const CreativeSearchResultAdMap creative_search_result_ads =
-      ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-          mojom_web_page_entities);
+  const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+      creative_search_result_ads =
+          ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+              mojom_web_page_entities);
   ASSERT_THAT(creative_search_result_ads, ::testing::SizeIs(1));
 
   const mojom::CreativeSearchResultAdInfoPtr& mojom_creative_ad =
-      creative_search_result_ads.at(test::kCreativeAdPlacementId);
+      creative_search_result_ads[0];
   ASSERT_TRUE(mojom_creative_ad);
   ASSERT_TRUE(mojom_creative_ad->creative_set_conversion);
+  EXPECT_EQ(test::kCreativeAdPlacementId, mojom_creative_ad->placement_id);
 
   VerifyRequiredMojomCreativeAdExpectations(mojom_creative_ad);
   VerifyRequiredMojomCreativeSetConversionExpectations(mojom_creative_ad);
@@ -235,9 +247,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
         test::CreativeSearchResultAdMojomWebPageEntities(
             /*excluded_property_names=*/{property_name});
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 }
@@ -250,9 +263,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
         test::CreativeSearchResultAdMojomWebPageEntitiesWithProperty(
             kCreativeAdLandingPagePropertyName, /*value=*/"http://brave.com");
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -262,9 +276,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
         test::CreativeSearchResultAdMojomWebPageEntitiesWithProperty(
             kCreativeAdRewardsValuePropertyName, /*value=*/"0-5");
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -274,9 +289,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
         test::CreativeSearchResultAdMojomWebPageEntitiesWithProperty(
             kCreativeSetConversionObservationWindowPropertyName, /*value=*/"1");
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 
@@ -292,9 +308,10 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
                                     kCreativeAdCreativeInstanceIdPropertyName,
                                     /*value=*/101);
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     EXPECT_THAT(creative_search_result_ads, ::testing::IsEmpty());
   }
 }
@@ -305,14 +322,16 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
       test::CreativeSearchResultAdMojomWebPageEntitiesWithProperty(
           kCreativeSetConversionAdvertiserPublicKeyPropertyName, /*value=*/"");
 
-  const CreativeSearchResultAdMap creative_search_result_ads =
-      ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-          mojom_web_page_entities);
+  const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+      creative_search_result_ads =
+          ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+              mojom_web_page_entities);
   ASSERT_THAT(creative_search_result_ads, ::testing::SizeIs(1));
   const mojom::CreativeSearchResultAdInfoPtr& mojom_creative_ad =
-      creative_search_result_ads.at(test::kCreativeAdPlacementId);
+      creative_search_result_ads[0];
   ASSERT_TRUE(mojom_creative_ad);
   ASSERT_TRUE(mojom_creative_ad->creative_set_conversion);
+  EXPECT_EQ(test::kCreativeAdPlacementId, mojom_creative_ad->placement_id);
 
   VerifyRequiredMojomCreativeAdExpectations(mojom_creative_ad);
   VerifyRequiredMojomCreativeSetConversionExpectations(mojom_creative_ad);
@@ -333,13 +352,15 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
         test::CreativeSearchResultAdMojomWebPageEntities(
             /*excluded_property_names=*/{property_name});
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     ASSERT_THAT(creative_search_result_ads, ::testing::SizeIs(1));
     const mojom::CreativeSearchResultAdInfoPtr& mojom_creative_ad =
-        creative_search_result_ads.at(test::kCreativeAdPlacementId);
+        creative_search_result_ads[0];
     ASSERT_TRUE(mojom_creative_ad);
+    EXPECT_EQ(test::kCreativeAdPlacementId, mojom_creative_ad->placement_id);
 
     VerifyRequiredMojomCreativeAdExpectations(mojom_creative_ad);
     EXPECT_FALSE(mojom_creative_ad->creative_set_conversion);
@@ -358,13 +379,15 @@ TEST(BraveAdsCreativeSearchResultAdMojomWebPageEntitiesExtractorTest,
         test::CreativeSearchResultAdMojomWebPageEntities(
             /*excluded_property_names=*/{property_name});
 
-    const CreativeSearchResultAdMap creative_search_result_ads =
-        ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
-            mojom_web_page_entities);
+    const std::vector<mojom::CreativeSearchResultAdInfoPtr>
+        creative_search_result_ads =
+            ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
+                mojom_web_page_entities);
     ASSERT_THAT(creative_search_result_ads, ::testing::SizeIs(1));
     const mojom::CreativeSearchResultAdInfoPtr& mojom_creative_ad =
-        creative_search_result_ads.at(test::kCreativeAdPlacementId);
+        creative_search_result_ads[0];
     ASSERT_TRUE(mojom_creative_ad);
+    EXPECT_EQ(test::kCreativeAdPlacementId, mojom_creative_ad->placement_id);
 
     VerifyRequiredMojomCreativeAdExpectations(mojom_creative_ad);
     VerifyRequiredMojomCreativeSetConversionExpectations(mojom_creative_ad);

--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -259,6 +259,8 @@ static_library("internal") {
     "ad_units/ad_handler.h",
     "ad_units/ad_info.cc",
     "ad_units/ad_type.cc",
+    "ad_units/creative_ad_cache.cc",
+    "ad_units/creative_ad_cache.h",
     "ad_units/inline_content_ad/inline_content_ad_feature.cc",
     "ad_units/inline_content_ad/inline_content_ad_feature.h",
     "ad_units/inline_content_ad/inline_content_ad_handler.cc",

--- a/components/brave_ads/core/internal/ad_units/ad_handler.cc
+++ b/components/brave_ads/core/internal/ad_units/ad_handler.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/ad_units/ad_handler.h"
 
+#include <optional>
 #include <utility>
 
 #include "brave/components/brave_ads/core/internal/account/user_data/fixed/conversion_user_data.h"
@@ -106,11 +107,23 @@ void AdHandler::TriggerInlineContentAdEvent(
                                           std::move(callback));
 }
 
+std::optional<mojom::CreativeSearchResultAdInfoPtr>
+AdHandler::MaybeGetSearchResultAd(const std::string& placement_id) {
+  return creative_ad_cache_.MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+      placement_id);
+}
+
 void AdHandler::TriggerSearchResultAdEvent(
     mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
     const mojom::SearchResultAdEventType mojom_ad_event_type,
     TriggerAdEventCallback callback) {
   CHECK(mojom_creative_ad);
+
+  if (mojom_ad_event_type ==
+      mojom::SearchResultAdEventType::kViewedImpression) {
+    creative_ad_cache_.MaybeAdd(mojom_creative_ad->placement_id,
+                                mojom_creative_ad->Clone());
+  }
 
   search_result_ad_handler_.TriggerEvent(
       std::move(mojom_creative_ad), mojom_ad_event_type, std::move(callback));

--- a/components/brave_ads/core/internal/ad_units/ad_handler.h
+++ b/components/brave_ads/core/internal/ad_units/ad_handler.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <string>
 
+#include "brave/components/brave_ads/core/internal/ad_units/creative_ad_cache.h"
 #include "brave/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_handler.h"
 #include "brave/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_handler.h"
 #include "brave/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_handler.h"
@@ -73,6 +74,9 @@ class AdHandler final : public ConversionsObserver, SiteVisitObserver {
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       TriggerAdEventCallback callback);
 
+  std::optional<mojom::CreativeSearchResultAdInfoPtr> MaybeGetSearchResultAd(
+      const std::string& placement_id);
+
   void TriggerSearchResultAdEvent(
       mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
       mojom::SearchResultAdEventType mojom_ad_event_type,
@@ -95,6 +99,8 @@ class AdHandler final : public ConversionsObserver, SiteVisitObserver {
   void OnCanceledPageLand(int32_t tab_id, const AdInfo& ad) override;
 
   Catalog catalog_;
+
+  CreativeAdCache creative_ad_cache_;
 
   Conversions conversions_;
 

--- a/components/brave_ads/core/internal/ad_units/creative_ad_cache.cc
+++ b/components/brave_ads/core/internal/ad_units/creative_ad_cache.cc
@@ -1,0 +1,87 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/ad_units/creative_ad_cache.h"
+
+#include <optional>
+
+#include "base/containers/contains.h"
+#include "base/functional/overloaded.h"
+#include "brave/components/brave_ads/core/internal/tabs/tab_info.h"
+#include "brave/components/brave_ads/core/internal/tabs/tab_manager.h"
+
+namespace brave_ads {
+
+namespace {
+
+bool IsCreativeAdVariantValid(const CreativeAdVariant& creative_ad_variant) {
+  return absl::visit(
+      base::Overloaded{
+          [](const mojom::CreativeSearchResultAdInfoPtr& search_result_ad)
+              -> bool { return !!search_result_ad; }},
+      creative_ad_variant);
+}
+
+std::optional<CreativeAdVariant> CloneCreativeAdVariant(
+    const CreativeAdVariant& creative_ad_variant) {
+  return absl::visit(
+      base::Overloaded{
+          [](const mojom::CreativeSearchResultAdInfoPtr& search_result_ad)
+              -> std::optional<CreativeAdVariant> {
+            return search_result_ad.Clone();
+          }},
+      creative_ad_variant);
+}
+
+}  // namespace
+
+CreativeAdCache::CreativeAdCache() {
+  TabManager::GetInstance().AddObserver(this);
+}
+
+CreativeAdCache::~CreativeAdCache() {
+  TabManager::GetInstance().RemoveObserver(this);
+}
+
+void CreativeAdCache::MaybeAdd(const std::string& placement_id,
+                               CreativeAdVariant creative_ad_variant) {
+  if (!IsCreativeAdVariantValid(creative_ad_variant)) {
+    return;
+  }
+
+  if (const std::optional<TabInfo> tab =
+          TabManager::GetInstance().MaybeGetVisible()) {
+    creative_ad_variants_[placement_id] = std::move(creative_ad_variant);
+    placement_ids_[tab->id].push_back(placement_id);
+  }
+}
+
+std::optional<CreativeAdVariant> CreativeAdCache::MaybeGet(
+    const std::string& placement_id) {
+  const auto iter = creative_ad_variants_.find(placement_id);
+  if (iter == creative_ad_variants_.cend()) {
+    return std::nullopt;
+  }
+  const auto& creative_ad_variant = iter->second;
+
+  return CloneCreativeAdVariant(creative_ad_variant);
+}
+
+void CreativeAdCache::OnDidCloseTab(const int32_t tab_id) {
+  PurgePlacements(tab_id);
+}
+
+void CreativeAdCache::PurgePlacements(const int32_t tab_id) {
+  if (!base::Contains(placement_ids_, tab_id)) {
+    return;
+  }
+
+  for (const std::string& placement_id : placement_ids_[tab_id]) {
+    creative_ad_variants_.erase(placement_id);
+  }
+  placement_ids_.erase(tab_id);
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/creative_ad_cache.h
+++ b/components/brave_ads/core/internal/ad_units/creative_ad_cache.h
@@ -1,0 +1,71 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_AD_UNITS_CREATIVE_AD_CACHE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_AD_UNITS_CREATIVE_AD_CACHE_H_
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "brave/components/brave_ads/core/internal/tabs/tab_manager_observer.h"
+#include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
+#include "third_party/abseil-cpp/absl/types/variant.h"
+
+namespace brave_ads {
+
+using CreativeAdVariant = absl::variant<mojom::CreativeSearchResultAdInfoPtr>;
+using CreativeAdVariantMap =
+    std::map</*placement_id*/ std::string, CreativeAdVariant>;
+
+using PlacementIdList = std::vector<std::string>;
+using PlacementIdMap = std::map</*tab_id*/ int32_t, PlacementIdList>;
+
+class CreativeAdCache final : public TabManagerObserver {
+ public:
+  CreativeAdCache();
+
+  CreativeAdCache(const CreativeAdCache&) = delete;
+  const CreativeAdCache& operator=(const CreativeAdCache&) = delete;
+
+  CreativeAdCache(CreativeAdCache&&) = delete;
+  const CreativeAdCache& operator=(CreativeAdCache&&) = delete;
+
+  ~CreativeAdCache() override;
+
+  void MaybeAdd(const std::string& placement_id,
+                CreativeAdVariant creative_ad_variant);
+
+  template <typename T>
+  std::optional<T> MaybeGet(const std::string& placement_id) {
+    std::optional<CreativeAdVariant> creative_ad_variant =
+        MaybeGet(placement_id);
+    if (!creative_ad_variant) {
+      return std::nullopt;
+    }
+
+    if (!absl::holds_alternative<T>(*creative_ad_variant)) {
+      return std::nullopt;
+    }
+
+    return std::move(absl::get<T>(*creative_ad_variant));
+  }
+
+ private:
+  // TabManagerObserver:
+  void OnDidCloseTab(int32_t tab_id) override;
+
+  std::optional<CreativeAdVariant> MaybeGet(const std::string& placement_id);
+
+  void PurgePlacements(int32_t tab_id);
+
+  CreativeAdVariantMap creative_ad_variants_;
+  PlacementIdMap placement_ids_;
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_AD_UNITS_CREATIVE_AD_CACHE_H_

--- a/components/brave_ads/core/internal/ad_units/creative_ad_cache_unittest.cc
+++ b/components/brave_ads/core/internal/ad_units/creative_ad_cache_unittest.cc
@@ -1,0 +1,159 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/ad_units/creative_ad_cache.h"
+
+#include <memory>
+
+#include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
+#include "brave/components/brave_ads/core/internal/common/test/test_base.h"
+#include "brave/components/brave_ads/core/internal/creatives/search_result_ads/creative_search_result_ad_test_util.h"
+#include "brave/components/brave_ads/core/internal/tabs/tab_manager.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+constexpr char kAnotherPlacementId[] = "b1f50335-5b9f-4139-a8cd-dd3d16337096";
+
+class BraveAdsCreativeAdCacheTest : public test::TestBase {
+ protected:
+  void SetUp() override {
+    test::TestBase::SetUp();
+
+    cache_ = std::make_unique<CreativeAdCache>();
+  }
+
+  void SimulateOpenTab(const int32_t tab_id) {
+    NotifyTabDidChange(tab_id, /*redirect_chain=*/{GURL("https://brave.com")},
+                       /*is_new_navigation=*/true, /*is_restoring=*/false,
+                       /*is_visible=*/true);
+  }
+
+  void SimulateCloseTab(const int32_t tab_id) { NotifyDidCloseTab(tab_id); }
+
+  std::unique_ptr<CreativeAdCache> cache_;
+};
+
+TEST_F(BraveAdsCreativeAdCacheTest, AddCreativeAd) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr expected_mojom_creative_ad =
+      test::BuildCreativeSearchResultAdWithConversion(
+          /*should_generate_random_uuids=*/true);
+
+  SimulateOpenTab(/*tab_id=*/1);
+
+  // Act
+  cache_->MaybeAdd(test::kPlacementId, expected_mojom_creative_ad->Clone());
+
+  // Assert
+  EXPECT_EQ(expected_mojom_creative_ad,
+            cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+                test::kPlacementId));
+}
+
+TEST_F(BraveAdsCreativeAdCacheTest, DoNotAddCreativeAd) {
+  // Arrange
+  SimulateOpenTab(/*tab_id=*/1);
+
+  // Act
+  cache_->MaybeAdd(test::kPlacementId, mojom::CreativeSearchResultAdInfoPtr{});
+
+  // Assert
+  EXPECT_FALSE(cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+      test::kPlacementId));
+}
+
+TEST_F(BraveAdsCreativeAdCacheTest, DoNotAddInvalidCreativeAd) {
+  // Arrange
+  SimulateOpenTab(/*tab_id=*/1);
+
+  CreativeAdVariant creative_ad_variant;
+
+  // Act
+  cache_->MaybeAdd(test::kPlacementId, std::move(creative_ad_variant));
+
+  // Assert
+  EXPECT_FALSE(cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+      test::kPlacementId));
+}
+
+TEST_F(BraveAdsCreativeAdCacheTest, DoNotAddCreativeAdForOccludedTab) {
+  // Arrange
+  CreativeAdVariant creative_ad_variant(
+      test::BuildCreativeSearchResultAdWithConversion(
+          /*should_generate_random_uuids=*/true));
+
+  // Act
+  cache_->MaybeAdd(test::kPlacementId, std::move(creative_ad_variant));
+
+  // Assert
+  EXPECT_FALSE(cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+      test::kPlacementId));
+}
+
+TEST_F(BraveAdsCreativeAdCacheTest, DoNotGetCreativeAdForMissingPlacementId) {
+  // Arrange
+  CreativeAdVariant creative_ad_variant(
+      test::BuildCreativeSearchResultAdWithConversion(
+          /*should_generate_random_uuids=*/true));
+
+  // Act
+  cache_->MaybeAdd(test::kPlacementId, std::move(creative_ad_variant));
+
+  // Assert
+  EXPECT_FALSE(cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+      test::kMissingPlacementId));
+}
+
+TEST_F(BraveAdsCreativeAdCacheTest, GetCreativeAdsForMultipleTabs) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr expected_mojom_creative_ad =
+      test::BuildCreativeSearchResultAdWithConversion(
+          /*should_generate_random_uuids=*/true);
+
+  // Act
+  SimulateOpenTab(/*tab_id=*/1);
+  cache_->MaybeAdd(test::kPlacementId, expected_mojom_creative_ad->Clone());
+  SimulateOpenTab(/*tab_id=*/2);
+  cache_->MaybeAdd(kAnotherPlacementId, expected_mojom_creative_ad->Clone());
+
+  // Assert
+  EXPECT_EQ(expected_mojom_creative_ad,
+            cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+                test::kPlacementId));
+
+  EXPECT_EQ(expected_mojom_creative_ad,
+            cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+                kAnotherPlacementId));
+}
+
+TEST_F(BraveAdsCreativeAdCacheTest, PurgePlacementsOnTabDidClose) {
+  // Arrange
+  const mojom::CreativeSearchResultAdInfoPtr expected_mojom_creative_ad =
+      test::BuildCreativeSearchResultAdWithConversion(
+          /*should_generate_random_uuids=*/true);
+
+  SimulateOpenTab(/*tab_id=*/1);
+  cache_->MaybeAdd(test::kPlacementId, expected_mojom_creative_ad->Clone());
+
+  SimulateOpenTab(/*tab_id=*/2);
+  cache_->MaybeAdd(kAnotherPlacementId, expected_mojom_creative_ad->Clone());
+
+  // Act
+  SimulateCloseTab(/*tab_id=*/2);
+
+  // Assert
+  EXPECT_EQ(expected_mojom_creative_ad,
+            cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+                test::kPlacementId));
+
+  EXPECT_FALSE(cache_->MaybeGet<mojom::CreativeSearchResultAdInfoPtr>(
+      kAnotherPlacementId));
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/internal/ads_impl.h
+++ b/components/brave_ads/core/internal/ads_impl.h
@@ -85,6 +85,8 @@ class AdsImpl final : public Ads {
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       TriggerAdEventCallback callback) override;
 
+  void MaybeGetSearchResultAd(const std::string& placement_id,
+                              MaybeGetSearchResultAdCallback callback) override;
   void TriggerSearchResultAdEvent(
       mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
       mojom::SearchResultAdEventType mojom_ad_event_type,

--- a/components/brave_ads/core/public/ads.h
+++ b/components/brave_ads/core/public/ads.h
@@ -142,6 +142,13 @@ class ADS_EXPORT Ads {
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       TriggerAdEventCallback callback) = 0;
 
+  // Called to get the search result ad specified by `placement_id`. The
+  // callback takes one argument - `mojom::CreativeSearchResultAdInfoPtr`
+  // containing the info of the search result ad.
+  virtual void MaybeGetSearchResultAd(
+      const std::string& placement_id,
+      MaybeGetSearchResultAdCallback callback) = 0;
+
   // Called when a user views or interacts with a search result ad to trigger a
   // `mojom_ad_event_type` event for the ad specified in `mojom_creative_ad`.
   // The callback takes one argument - `bool` is set to `true` if successful

--- a/components/brave_ads/core/public/ads_callback.h
+++ b/components/brave_ads/core/public/ads_callback.h
@@ -38,6 +38,9 @@ using MaybeServeInlineContentAdCallback =
 using MaybeGetNotificationAdCallback =
     base::OnceCallback<void(const std::optional<NotificationAdInfo>& ad)>;
 
+using MaybeGetSearchResultAdCallback = base::OnceCallback<void(
+    mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad)>;
+
 using TriggerAdEventCallback = base::OnceCallback<void(bool success)>;
 
 using PurgeOrphanedAdEventsForTypeCallback =

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -159,6 +159,7 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h",
     "//brave/components/brave_ads/core/internal/ad_units/ad_test_util.cc",
     "//brave/components/brave_ads/core/internal/ad_units/ad_test_util.h",
+    "//brave/components/brave_ads/core/internal/ad_units/creative_ad_cache_unittest.cc",
     "//brave/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_feature_unittest.cc",
     "//brave/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_info_unittest.cc",
     "//brave/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_test.cc",

--- a/components/services/bat_ads/bat_ads_impl.cc
+++ b/components/services/bat_ads/bat_ads_impl.cc
@@ -196,6 +196,12 @@ void BatAdsImpl::TriggerInlineContentAdEvent(
                                         std::move(callback));
 }
 
+void BatAdsImpl::MaybeGetSearchResultAd(
+    const std::string& placement_id,
+    MaybeGetSearchResultAdCallback callback) {
+  GetAds()->MaybeGetSearchResultAd(placement_id, std::move(callback));
+}
+
 void BatAdsImpl::TriggerSearchResultAdEvent(
     brave_ads::mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
     const brave_ads::mojom::SearchResultAdEventType mojom_ad_event_type,

--- a/components/services/bat_ads/bat_ads_impl.h
+++ b/components/services/bat_ads/bat_ads_impl.h
@@ -84,6 +84,8 @@ class BatAdsImpl : public mojom::BatAds {
       brave_ads::mojom::PromotedContentAdEventType mojom_ad_event_type,
       TriggerPromotedContentAdEventCallback callback) override;
 
+  void MaybeGetSearchResultAd(const std::string& placement_id,
+                              MaybeGetSearchResultAdCallback callback) override;
   void TriggerSearchResultAdEvent(
       brave_ads::mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
       brave_ads::mojom::SearchResultAdEventType mojom_ad_event_type,

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -196,6 +196,8 @@ interface BatAds {
       brave_ads.mojom.PromotedContentAdEventType mojom_ad_event_type) =>
           (bool success);
 
+  MaybeGetSearchResultAd(string placement_id) =>
+      (brave_ads.mojom.CreativeSearchResultAdInfo? search_result_ad);
   TriggerSearchResultAdEvent(
       brave_ads.mojom.CreativeSearchResultAdInfo mojom_creative_ad,
       brave_ads.mojom.SearchResultAdEventType mojom_ad_event_type) =>

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -127,6 +127,9 @@ OBJC_EXPORT
                                 (BraveAdsPromotedContentAdEventType)eventType
                            completion:(void (^)(BOOL success))completion;
 
+- (void)triggerSearchResultAdClickedEvent:(NSString*)placementId
+                               completion:(void (^)(BOOL success))completion;
+
 - (void)triggerSearchResultAdEvent:
             (BraveAdsCreativeSearchResultAdInfo*)searchResultAd
                          eventType:(BraveAdsSearchResultAdEventType)eventType


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/40785

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
* Start the Browser
* Do not join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is NOT triggered. There should be Brave Ads log:
     `Search result ad: Not allowed to fire event`
     `Failed to fire search result ad kServedImpression event for placement_id %%% and creative instance id %%%`
* Click on the search result ad
   - EXPECTATION: Search result ad clicked event is triggered. There should be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
      `Successfully saved creative set conversions`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad click conversion event is triggered. There should be Brave Ads log:
      `Converted click conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`


### Test case 2
* Start the Browser
* Do not join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is NOT triggered. There should be Brave Ads log:
     `Search result ad: Not allowed to fire event`
     `Failed to fire search result ad kServedImpression event for placement_id %%% and creative instance id %%%`
* Do a `CMD+RIGHT` click to the search result ad to open it in a new tab in a background
   - EXPECTATION: Search result ad clicked event is triggered. There should be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad click conversion event is triggered. There should be Brave Ads log:
      `Converted click conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`

### Test case 3
* Start the Browser
* Do not join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is NOT triggered. There should be Brave Ads log:
     `Search result ad: Not allowed to fire event`
     `Failed to fire search result ad kServedImpression event for placement_id %%% and creative instance id %%%`
* Open the search result ad in a new window (`Open Link in New Window` from context menu)
   - EXPECTATION: Search result ad clicked event is triggered. There should be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad click conversion event is triggered. There should be Brave Ads log:
      `Converted click conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`

### Test case 4
* Start the Browser
* Join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is triggered. There should be Brave Ads log:
     `Viewed search result ad impression with placement id %%% and creative instance id %%%`
* Click on the search result ad
   - EXPECTATION: Search result ad clicked and landed events are triggered. There should be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
      `Successfully saved creative set conversions`
      `Maybe land on page for https://brave.com/brave-ads/?no_key_param= in 5 s`
      `Landed on page for https://brave.com/brave-ads/?no_key_param= on tab id %%%`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad click conversion event is triggered. There should be Brave Ads log:
      `Converted click conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`

### Test case 5
* Start the Browser
* Join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is triggered. There should be Brave Ads log:
     `Viewed search result ad impression with placement id %%% and creative instance id %%%`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad view conversion event is triggered. There should be Brave Ads log:
      `Converted view conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`

### Test case 6
* Start the Browser
* Join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is triggered. There should be Brave Ads log:
     `Viewed search result ad impression with placement id %%% and creative instance id %%%`
* Do a `CMD+RIGHT` click to the search result ad to open it in a new tab in a background
   - EXPECTATION: Search result ad clicked event is triggered. There should be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
      `Successfully saved creative set conversions`
      `Maybe land on page for https://brave.com/brave-ads/?no_key_param= in 5 s`
      `Suspended page landing on tab id 511936837 with 5 s remaining`
* Switch to the opened tab with ad
   - EXPECTATION: Search result ad landed event is triggered. There should be Brave Ads log:
      `Landed on page for https://brave.com/brave-ads/?no_key_param= on tab id %%%`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad click conversion event is triggered. There should be Brave Ads log:
      `Converted click conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`

### Test case 7
* Start the Browser
* Join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
   - EXPECTATION: Search result ad viewed event is triggered. There should be Brave Ads log:
     `Viewed search result ad impression with placement id %%% and creative instance id %%%`
* Open the search result ad in a new window (`Open Link in New Window` from context menu)
   - EXPECTATION: Search result ad clicked and landed event is triggered. There should be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
      `Successfully saved creative set conversions`
      `Maybe land on page for https://brave.com/brave-ads/?no_key_param= in 5 s`
      `Landed on page for https://brave.com/brave-ads/?no_key_param= on tab id %%%`
* Open conversion URL https://brave.com/vertical-tabs/ in a new tab:
   - EXPECTATION: Search result ad click conversion event is triggered. There should be Brave Ads log:
      `Converted click conversion for kSearchResultAd with creative instance id %%%, creative set id d81220f2-b7c6-4f3e-b3fa-5e0f579407a5, campaign id %%% and advertiser id %%%`

### Test case 8
* Start the Browser
* Do not join Brave Rewards
* Open search.brave.software
* Search with `giraffe` keyword
* Make sure that search result ad was shown
* Open the search result ad in a new Private window (`Open Link in Private Window` from context menu)
   - EXPECTATION: Search result ad clicked event NOT triggered. There should NOT be Brave Ads log:
      `Clicked search result ad with placement id %%% and creative instance id %%%`
