### PR TITLE
Fix solana web3 module loading renderer crash (uplift to 1.70.x)

### DIFF
--- a/components/brave_wallet/renderer/js_solana_provider.cc
+++ b/components/brave_wallet/renderer/js_solana_provider.cc
@@ -1073,14 +1073,13 @@ bool JSSolanaProvider::LoadSolanaWeb3ModuleIfNeeded(v8::Isolate* isolate) {
       {"(function() {", LoadDataResource(IDR_BRAVE_WALLET_SOLANA_WEB3_JS),
        "return solanaWeb3; })()"});
 
-  solana_web3_module_.Reset(
-      isolate,
-      ExecuteScript(render_frame()->GetWebFrame(), solana_web3_module_str)
-          .ToLocalChecked());
+  v8::Local<v8::Value> solana_web3_module;
   // loading SolanaWeb3 module failed
-  if (solana_web3_module_.IsEmpty()) {
+  if (!ExecuteScript(render_frame()->GetWebFrame(), solana_web3_module_str)
+           .ToLocal(&solana_web3_module)) {
     return false;
   }
+  solana_web3_module_.Reset(isolate, solana_web3_module);
   return true;
 }
 


### PR DESCRIPTION
Uplift of #25788
Resolves https://github.com/brave/brave-browser/issues/40354

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.