### PR TITLE
`BraveAdblockUI`/`BraveAdblockInternalsUI` with `DefaultWebUIConfig`

### DIFF
--- a/browser/ui/webui/brave_adblock_internals_ui.cc
+++ b/browser/ui/webui/brave_adblock_internals_ui.cc
@@ -7,6 +7,7 @@
 
 #include <memory>
 #include <optional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -130,12 +131,11 @@ class BraveAdblockInternalsMessageHandler
 
 }  // namespace
 
-BraveAdblockInternalsUI::BraveAdblockInternalsUI(content::WebUI* web_ui,
-                                                 const std::string& name)
+BraveAdblockInternalsUI::BraveAdblockInternalsUI(content::WebUI* web_ui)
     : content::WebUIController(web_ui) {
-  CreateAndAddWebUIDataSource(web_ui, name, kBraveAdblockInternalsGenerated,
-                              kBraveAdblockInternalsGeneratedSize,
-                              IDR_BRAVE_ADBLOCK_INTERNALS_HTML);
+  CreateAndAddWebUIDataSource(
+      web_ui, kAdblockInternalsHost, kBraveAdblockInternalsGenerated,
+      kBraveAdblockInternalsGeneratedSize, IDR_BRAVE_ADBLOCK_INTERNALS_HTML);
 
   web_ui->AddMessageHandler(
       std::make_unique<BraveAdblockInternalsMessageHandler>());

--- a/browser/ui/webui/brave_adblock_internals_ui.h
+++ b/browser/ui/webui/brave_adblock_internals_ui.h
@@ -6,14 +6,24 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_BRAVE_ADBLOCK_INTERNALS_UI_H_
 #define BRAVE_BROWSER_UI_WEBUI_BRAVE_ADBLOCK_INTERNALS_UI_H_
 
-#include <string>
-
+#include "brave/components/constants/webui_url_constants.h"
 #include "content/public/browser/web_ui_controller.h"
+#include "content/public/browser/webui_config.h"
+#include "content/public/common/url_constants.h"
+
+class BraveAdblockInternalsUI;
+
+class BraveAdblockInternalsUIConfig
+    : public content::DefaultWebUIConfig<BraveAdblockInternalsUI> {
+ public:
+  BraveAdblockInternalsUIConfig()
+      : DefaultWebUIConfig(content::kChromeUIScheme, kAdblockInternalsHost) {}
+};
 
 // The WebUI for brave://adblock-internals
 class BraveAdblockInternalsUI : public content::WebUIController {
  public:
-  BraveAdblockInternalsUI(content::WebUI* web_ui, const std::string& name);
+  explicit BraveAdblockInternalsUI(content::WebUI* web_ui);
 
   BraveAdblockInternalsUI(const BraveAdblockInternalsUI&) = delete;
   BraveAdblockInternalsUI& operator=(const BraveAdblockInternalsUI&) = delete;

--- a/browser/ui/webui/brave_adblock_ui.cc
+++ b/browser/ui/webui/brave_adblock_ui.cc
@@ -6,6 +6,7 @@
 #include "brave/browser/ui/webui/brave_adblock_ui.h"
 
 #include <memory>
+#include <string>
 #include <utility>
 
 #include "base/scoped_observation.h"
@@ -318,9 +319,9 @@ void AdblockDOMHandler::RefreshSubscriptionsList() {
 
 }  // namespace
 
-BraveAdblockUI::BraveAdblockUI(content::WebUI* web_ui, const std::string& name)
+BraveAdblockUI::BraveAdblockUI(content::WebUI* web_ui)
     : WebUIController(web_ui) {
-  CreateAndAddWebUIDataSource(web_ui, name, kBraveAdblockGenerated,
+  CreateAndAddWebUIDataSource(web_ui, kAdblockHost, kBraveAdblockGenerated,
                               kBraveAdblockGeneratedSize,
                               IDR_BRAVE_ADBLOCK_HTML);
   web_ui->AddMessageHandler(std::make_unique<AdblockDOMHandler>());

--- a/browser/ui/webui/brave_adblock_ui.h
+++ b/browser/ui/webui/brave_adblock_ui.h
@@ -6,13 +6,23 @@
 #ifndef BRAVE_BROWSER_UI_WEBUI_BRAVE_ADBLOCK_UI_H_
 #define BRAVE_BROWSER_UI_WEBUI_BRAVE_ADBLOCK_UI_H_
 
-#include <string>
-
+#include "brave/components/constants/webui_url_constants.h"
 #include "content/public/browser/web_ui_controller.h"
+#include "content/public/browser/webui_config.h"
+#include "content/public/common/url_constants.h"
+
+class BraveAdblockUI;
+
+class BraveAdblockUIConfig
+    : public content::DefaultWebUIConfig<BraveAdblockUI> {
+ public:
+  BraveAdblockUIConfig()
+      : DefaultWebUIConfig(content::kChromeUIScheme, kAdblockHost) {}
+};
 
 class BraveAdblockUI : public content::WebUIController {
  public:
-  BraveAdblockUI(content::WebUI* web_ui, const std::string& host);
+  explicit BraveAdblockUI(content::WebUI* web_ui);
   ~BraveAdblockUI() override;
   BraveAdblockUI(const BraveAdblockUI&) = delete;
   BraveAdblockUI& operator=(const BraveAdblockUI&) = delete;

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -13,8 +13,6 @@
 #include "base/no_destructor.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
-#include "brave/browser/ui/webui/brave_adblock_internals_ui.h"
-#include "brave/browser/ui/webui/brave_adblock_ui.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_page_ui.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_web_ui_utils.h"
 #include "brave/browser/ui/webui/brave_rewards_internals_ui.h"
@@ -93,11 +91,7 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
   auto host = url.host_piece();
   Profile* profile = Profile::FromBrowserContext(
       web_ui->GetWebContents()->GetBrowserContext());
-  if (host == kAdblockHost) {
-    return new BraveAdblockUI(web_ui, url.host());
-  } else if (host == kAdblockInternalsHost) {
-    return new BraveAdblockInternalsUI(web_ui, url.host());
-  } else if (host == kSkusInternalsHost) {
+  if (host == kSkusInternalsHost) {
     return new SkusInternalsUI(web_ui, url.host());
 #if !BUILDFLAG(IS_ANDROID)
   } else if (host == kWebcompatReporterHost) {
@@ -186,9 +180,7 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
     return nullptr;
   }
 
-  if (url.host_piece() == kAdblockHost ||
-      url.host_piece() == kAdblockInternalsHost ||
-      url.host_piece() == kWebcompatReporterHost ||
+  if (url.host_piece() == kWebcompatReporterHost ||
       (url.host_piece() == kSkusInternalsHost &&
        base::FeatureList::IsEnabled(skus::features::kSkusFeature)) ||
 #if BUILDFLAG(IS_ANDROID)

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -21,12 +21,14 @@
 #include "brave/browser/ui/webui/brave_wallet/wallet_panel_ui.h"
 #include "brave/browser/ui/webui/speedreader/speedreader_toolbar_ui.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
+#include "brave/browser/ui/webui/brave_adblock_internals_ui.h"
+#include "brave/browser/ui/webui/brave_adblock_ui.h"
 
 void RegisterChromeWebUIConfigs() {
   RegisterChromeWebUIConfigs_ChromiumImpl();
 
-#if !BUILDFLAG(IS_ANDROID)
   auto& map = content::WebUIConfigMap::GetInstance();
+#if !BUILDFLAG(IS_ANDROID)
   map.AddWebUIConfig(std::make_unique<brave_rewards::RewardsPageTopUIConfig>());
   map.AddWebUIConfig(std::make_unique<brave_rewards::RewardsPanelUIConfig>());
   map.AddWebUIConfig(std::make_unique<brave_rewards::TipPanelUIConfig>());
@@ -35,4 +37,6 @@ void RegisterChromeWebUIConfigs() {
   map.AddWebUIConfig(std::make_unique<WalletPanelUIConfig>());
   map.AddWebUIConfig(std::make_unique<SpeedreaderToolbarUIConfig>());
 #endif  // !BUILDFLAG(IS_ANDROID)
+  map.AddWebUIConfig(std::make_unique<BraveAdblockUIConfig>());
+  map.AddWebUIConfig(std::make_unique<BraveAdblockInternalsUIConfig>());
 }


### PR DESCRIPTION
This change migrates `BraveAdblockUI`/`BraveAdblockInternalsUI` to be launched with the use of `DefaultWebUIConfig`, which moves page selection away from `BraveWebUIControllerFactory`, to `WebUIConfigMap`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41397

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

