### PR TITLE
Fixed crash at Content Filtering

### DIFF
--- a/android/brave_java_sources.gni
+++ b/android/brave_java_sources.gni
@@ -361,6 +361,7 @@ brave_java_sources = [
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSearchEngineUtils.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSearchEnginesPreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsActivity.java",
+  "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsIntentUtil.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSettingsLauncherImpl.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveStatsPreferences.java",
   "../../brave/android/java/org/chromium/chrome/browser/settings/BraveSyncCodeCountdownFragment.java",

--- a/android/java/apk_for_test.flags
+++ b/android/java/apk_for_test.flags
@@ -897,3 +897,7 @@
 }
 
 -keep class org.chromium.chrome.browser.tabbed_mode.BraveTabbedNavigationBarColorControllerBase
+
+-keep class org.chromium.chrome.browser.settings.SettingsIntentUtil {
+    *** createIntent(...);
+}

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsIntentUtil.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsIntentUtil.java
@@ -1,0 +1,25 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.settings;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class BraveSettingsIntentUtil {
+
+    public static Intent createIntent(
+            @NonNull Context context,
+            @Nullable String fragmentName,
+            @Nullable Bundle fragmentArgs) {
+        Intent intent = SettingsIntentUtil.createIntent(context, fragmentName, fragmentArgs);
+        intent.setClass(context, BraveSettingsActivity.class);
+        return intent;
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BytecodeTest.java
@@ -353,6 +353,8 @@ public class BytecodeTest {
         Assert.assertTrue(
                 classExists(
                         "org/chromium/chrome/browser/notifications/NotificationPlatformBridge"));
+
+        Assert.assertTrue(classExists("org/chromium/chrome/browser/settings/SettingsIntentUtil"));
     }
 
     @Test
@@ -855,6 +857,16 @@ public class BytecodeTest {
                         boolean.class,
                         boolean.class,
                         BraveNotificationPlatformBridge.getActionInfoArrayClass()));
+        Assert.assertTrue(
+                methodExists(
+                        "org/chromium/chrome/browser/settings/SettingsIntentUtil",
+                        "createIntent",
+                        MethodModifier.STATIC,
+                        true,
+                        Intent.class,
+                        Context.class,
+                        String.class,
+                        Bundle.class));
     }
 
     @Test

--- a/build/android/bytecode/BUILD.gn
+++ b/build/android/bytecode/BUILD.gn
@@ -92,6 +92,7 @@ java_binary("java_bytecode_rewriter") {
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveReturnToChromeUtilClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSearchEngineAdapterClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSearchEnginePreferenceClassAdapter.java",
+    "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSettingsIntentUtilClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSettingsLauncherImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveShareDelegateImplClassAdapter.java",
     "//brave/build/android/bytecode/java/org/brave/bytecode/BraveSingleCategorySettingsClassAdapter.java",

--- a/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveClassAdapter.java
@@ -91,6 +91,7 @@ public class BraveClassAdapter {
         chain = new BraveReturnToChromeUtilClassAdapter(chain);
         chain = new BraveSearchEngineAdapterClassAdapter(chain);
         chain = new BraveSearchEnginePreferenceClassAdapter(chain);
+        chain = new BraveSettingsIntentUtilClassAdapter(chain);
         chain = new BraveSettingsLauncherImplClassAdapter(chain);
         chain = new BraveShareDelegateImplClassAdapter(chain);
         chain = new BraveSingleCategorySettingsClassAdapter(chain);

--- a/build/android/bytecode/java/org/brave/bytecode/BraveSettingsIntentUtilClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BraveSettingsIntentUtilClassAdapter.java
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.brave.bytecode;
+
+import org.objectweb.asm.ClassVisitor;
+
+public class BraveSettingsIntentUtilClassAdapter extends BraveClassVisitor {
+    static String sSettingsIntentUtilClassName =
+            "org/chromium/chrome/browser/settings/SettingsIntentUtil";
+
+    static String sBraveSettingsIntentUtilClassName =
+            "org/chromium/chrome/browser/settings/BraveSettingsIntentUtil";
+
+    public BraveSettingsIntentUtilClassAdapter(ClassVisitor visitor) {
+        super(visitor);
+        changeMethodOwner(
+                sSettingsIntentUtilClassName, "createIntent", sBraveSettingsIntentUtilClassName);
+    }
+}


### PR DESCRIPTION
Crash happened at app menu => Settings => Brave Shields & privacy => Content Filtering.

Must be uplifted along with `cr130` https://github.com/brave/brave-browser/issues/40694 

Tombstone
```
java.lang.ClassCastException: org.chromium.chrome.browser.settings.SettingsActivity cannot be cast to org.chromium.chrome.browser.settings.BraveSettingsActivity
at org.chromium.chrome.browser.shields.ContentFilteringFragment.onAttach(ContentFilteringFragment.java:86)
```

Upstream had added a new place to create Intent for Settings activity.

Related Chromium change:
https://source.chromium.org/chromium/chromium/src/+/d4af6a2c4ccc6427aa7df0f2beacf61793459e66

	[Settings] Introduce a central place to construct intents

	SettingsIntentUtil becomes the central place to construct intents
	launching the settings activity.

	Bug: b/356743945
	Change-Id: Id6988af4a182fe6603bb02c9dae8b2ac48f80fed
	Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5832868

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41402, https://github.com/brave/brave-browser/issues/41404

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
Open app menu => Settings => Brave Shields & privacy => Content Filtering. Must not crash.
