### PR TITLE
Pass `base::TimeDelta` by value

### DIFF
--- a/browser/brave_shields/ad_block_service_browsertest.cc
+++ b/browser/brave_shields/ad_block_service_browsertest.cc
@@ -3077,7 +3077,7 @@ class AdBlockServiceTestJsPerformance : public AdBlockServiceTest {
         target, content::JsReplace(kTemplate, start_number, end_number)));
   }
 
-  void NonBlockingDelay(const base::TimeDelta& delay) {
+  void NonBlockingDelay(base::TimeDelta delay) {
     base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
         FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/browser/misc_metrics/doh_metrics.cc
+++ b/browser/misc_metrics/doh_metrics.cc
@@ -30,8 +30,8 @@ const int kAutoSecureRequestsBuckets[] = {0, 5, 50, 90};
 
 constexpr char kDohModeAutomatic[] = "automatic";
 constexpr char kDohModeSecure[] = "secure";
-const base::TimeDelta kAutoSecureInitDelay = base::Seconds(6);
-const base::TimeDelta kAutoSecureReportInterval = base::Seconds(20);
+constexpr base::TimeDelta kAutoSecureInitDelay = base::Seconds(6);
+constexpr base::TimeDelta kAutoSecureReportInterval = base::Seconds(20);
 
 const char* GetAutoSecureRequestsHistogramName() {
   std::string histogram_name = kAutoSecureRequestsHistogramName;

--- a/browser/sandbox/win/module_file_name_patch_browsertest.cc
+++ b/browser/sandbox/win/module_file_name_patch_browsertest.cc
@@ -19,7 +19,7 @@ using sandbox::policy::features::kModuleFileNamePatch;
 
 namespace {
 
-void NonBlockingDelay(const base::TimeDelta& delay) {
+void NonBlockingDelay(base::TimeDelta delay) {
   base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -168,7 +168,7 @@ class SpeedReaderBrowserTest : public InProcessBrowserTest {
         browser()->profile());
   }
 
-  void NonBlockingDelay(const base::TimeDelta& delay) {
+  void NonBlockingDelay(base::TimeDelta delay) {
     base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
         FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/browser/tor/test/brave_tor_browsertest.cc
+++ b/browser/tor/test/brave_tor_browsertest.cc
@@ -133,7 +133,7 @@ bool CheckComponentExists(const std::string& component_id) {
   return base::PathExists(user_data_dir.AppendASCII(component_id));
 }
 
-void NonBlockingDelay(const base::TimeDelta& delay) {
+void NonBlockingDelay(base::TimeDelta delay) {
   base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -393,19 +393,13 @@ void BraveTooltipPopup::CloseWidgetView() {
 
 void BraveTooltipPopup::FadeIn() {
   animation_state_ = AnimationState::kFadeIn;
-
-  const base::TimeDelta fade_duration = base::Milliseconds(fade_duration_);
-  animation_->SetDuration(fade_duration);
-
+  animation_->SetDuration(base::Milliseconds(fade_duration_));
   StartAnimation();
 }
 
 void BraveTooltipPopup::FadeOut() {
   animation_state_ = AnimationState::kFadeOut;
-
-  const base::TimeDelta fade_duration = base::Milliseconds(fade_duration_);
-  animation_->SetDuration(fade_duration);
-
+  animation_->SetDuration(base::Milliseconds(fade_duration_));
   StartAnimation();
 }
 

--- a/browser/ui/views/overlay/brave_video_overlay_window_views.cc
+++ b/browser/ui/views/overlay/brave_video_overlay_window_views.cc
@@ -32,7 +32,7 @@ namespace {
 
 constexpr int kTopControlIconSize = 20;
 
-std::u16string ToString(const base::TimeDelta& time) {
+std::u16string ToString(base::TimeDelta time) {
   const int time_in_seconds = time.InSecondsF();
   const int hours = time_in_seconds / 3600;
   const int minutes = (time_in_seconds % 3600) / 60;

--- a/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
+++ b/browser/ui/webui/brave_wallet/wallet_panel_ui_browsertest.cc
@@ -98,7 +98,7 @@ std::string Select(const std::string& selector1, const std::string& selector2) {
                             selector1.c_str(), selector2.c_str());
 }
 
-void NonBlockingDelay(const base::TimeDelta& delay) {
+void NonBlockingDelay(base::TimeDelta delay) {
   base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_browsertest.cc
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_browsertest.cc
@@ -45,7 +45,7 @@ bool IsExtensionToggleEnabled(content::WebContents* web_contents) {
       .value.GetBool();
 }
 
-void NonBlockingDelay(const base::TimeDelta& delay) {
+void NonBlockingDelay(base::TimeDelta delay) {
   base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/browser/url_sanitizer/url_sanitizer_browsertest.cc
+++ b/browser/url_sanitizer/url_sanitizer_browsertest.cc
@@ -117,7 +117,7 @@ class URLSanitizerTestBase : public InProcessBrowserTest {
     loop.Run();
   }
 
-  void NonBlockingDelay(const base::TimeDelta& delay) {
+  void NonBlockingDelay(base::TimeDelta delay) {
     base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
         FROM_HERE, run_loop.QuitWhenIdleClosure(), delay);

--- a/components/assist_ranker/ranker_model_loader_impl_unittest.cc
+++ b/components/assist_ranker/ranker_model_loader_impl_unittest.cc
@@ -49,7 +49,7 @@ class RankerModelLoaderImplTest : public ::testing::Test {
   // Helper method used by InitRemoteModels()
   void InitModel(const GURL& model_url,
                  const base::Time& last_modified,
-                 const base::TimeDelta& cache_duration,
+                 base::TimeDelta cache_duration,
                  RankerModel* model);
 
   // Implements RankerModelLoaderImpl's ValidateModelCallback interface.
@@ -108,7 +108,7 @@ void RankerModelLoaderImplTest::InitRemoteModels() {
 
 void RankerModelLoaderImplTest::InitModel(const GURL& model_url,
                                           const base::Time& last_modified,
-                                          const base::TimeDelta& cache_duration,
+                                          base::TimeDelta cache_duration,
                                           RankerModel* model) {
   ASSERT_TRUE(model != nullptr);
   model->mutable_proto()->Clear();

--- a/components/brave_shields/content/browser/ad_block_subscription_service_manager.cc
+++ b/components/brave_shields/content/browser/ad_block_subscription_service_manager.cc
@@ -41,6 +41,8 @@ base::TimeDelta* g_testing_subscription_retry_interval = nullptr;
 namespace {
 
 const uint16_t kSubscriptionMaxExpiresHours = 14 * 24;
+constexpr base::TimeDelta kListRetryInterval = base::Hours(1);
+constexpr base::TimeDelta kListCheckInitialDelay = base::Minutes(1);
 
 bool SkipGURLField(std::string_view value, GURL* field) {
   return true;
@@ -83,9 +85,6 @@ bool ParseExpiresWithFallback(const base::Value* value, uint16_t* field) {
     return true;
   }
 }
-
-const base::TimeDelta kListRetryInterval = base::Hours(1);
-const base::TimeDelta kListCheckInitialDelay = base::Minutes(1);
 
 SubscriptionInfo BuildInfoFromDict(const GURL& sub_url,
                                    const base::Value::Dict& dict) {

--- a/components/captive_portal/content/brave_captive_portal_service_unittest.cc
+++ b/components/captive_portal/content/brave_captive_portal_service_unittest.cc
@@ -199,7 +199,7 @@ class CaptivePortalServiceTest : public testing::Test,
 
   // Changes test time for the service and service's captive portal
   // detector.
-  void AdvanceTime(const base::TimeDelta& delta) {
+  void AdvanceTime(base::TimeDelta delta) {
     tick_clock_->Advance(delta);
     CaptivePortalDetectorTestBase::AdvanceTime(delta);
   }

--- a/components/misc_metrics/general_browser_usage.cc
+++ b/components/misc_metrics/general_browser_usage.cc
@@ -19,7 +19,7 @@ namespace misc_metrics {
 
 namespace {
 
-const base::TimeDelta kReportInterval = base::Minutes(10);
+constexpr base::TimeDelta kReportInterval = base::Minutes(10);
 
 #if !BUILDFLAG(IS_ANDROID)
 constexpr int kProfileCountBuckets[] = {0, 1, 2, 3, 5};

--- a/components/misc_metrics/privacy_hub_metrics.cc
+++ b/components/misc_metrics/privacy_hub_metrics.cc
@@ -15,7 +15,7 @@ namespace misc_metrics {
 
 namespace {
 const int kViewsMonthlyBucketValues[] = {1, 10, 20};
-const base::TimeDelta kReportUpdateInterval = base::Days(1);
+constexpr base::TimeDelta kReportUpdateInterval = base::Days(1);
 }  // namespace
 
 

--- a/components/misc_metrics/tab_metrics.cc
+++ b/components/misc_metrics/tab_metrics.cc
@@ -15,7 +15,7 @@ namespace misc_metrics {
 
 namespace {
 const int kPercentBucketValues[] = {25, 50, 75};
-const base::TimeDelta kReportUpdateInterval = base::Days(1);
+constexpr base::TimeDelta kReportUpdateInterval = base::Days(1);
 }  // namespace
 
 TabMetrics::TabMetrics(PrefService* local_state)


### PR DESCRIPTION
For trivially copyable types like `base::TimeDelta`, we should avoid passing them as reference, as the cost is exactly the same as passing by value.

This change also turns many of the non-scoped constants into `constexpr`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

