### PR TITLE
Migrate webcompat form to `ChromeWebUIConfigs`

### DIFF
--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -44,7 +44,6 @@
 #include "brave/browser/ui/webui/brave_wallet/wallet_page_ui.h"
 #include "brave/browser/ui/webui/new_tab_page/brave_new_tab_ui.h"
 #include "brave/browser/ui/webui/private_new_tab_page/brave_private_new_tab_ui.h"
-#include "brave/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.h"
 #include "brave/browser/ui/webui/welcome_page/brave_welcome_ui.h"
 #include "brave/components/brave_news/common/features.h"
 #include "brave/components/brave_wallet/browser/brave_wallet_utils.h"
@@ -93,10 +92,6 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
       web_ui->GetWebContents()->GetBrowserContext());
   if (host == kSkusInternalsHost) {
     return new SkusInternalsUI(web_ui, url.host());
-#if !BUILDFLAG(IS_ANDROID)
-  } else if (host == kWebcompatReporterHost) {
-    return new webcompat_reporter::WebcompatReporterUI(web_ui, url.host());
-#endif  // !BUILDFLAG(IS_ANDROID)
 #if !BUILDFLAG(IS_ANDROID)
   } else if (host == kWalletPageHost &&
              brave_wallet::IsAllowedForContext(profile)) {
@@ -180,8 +175,7 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
     return nullptr;
   }
 
-  if (url.host_piece() == kWebcompatReporterHost ||
-      (url.host_piece() == kSkusInternalsHost &&
+  if ((url.host_piece() == kSkusInternalsHost &&
        base::FeatureList::IsEnabled(skus::features::kSkusFeature)) ||
 #if BUILDFLAG(IS_ANDROID)
       (url.is_valid() && url.host_piece() == kWalletPageHost) ||

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.cc
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.cc
@@ -261,12 +261,11 @@ void WebcompatReporterDOMHandler::HandleSubmitReport(
   uploader_->SubmitReport(pending_report_);
 }
 
-WebcompatReporterUI::WebcompatReporterUI(content::WebUI* web_ui,
-                                         const std::string& name)
+WebcompatReporterUI::WebcompatReporterUI(content::WebUI* web_ui)
     : ConstrainedWebDialogUI(web_ui) {
-  CreateAndAddWebUIDataSource(web_ui, name, kWebcompatReporterGenerated,
-                              kWebcompatReporterGeneratedSize,
-                              IDR_WEBCOMPAT_REPORTER_HTML);
+  CreateAndAddWebUIDataSource(
+      web_ui, kWebcompatReporterHost, kWebcompatReporterGenerated,
+      kWebcompatReporterGeneratedSize, IDR_WEBCOMPAT_REPORTER_HTML);
   Profile* profile = Profile::FromWebUI(web_ui);
 
   web_ui->AddMessageHandler(

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.h
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.h
@@ -12,10 +12,13 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/task/sequenced_task_runner.h"
+#include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/webcompat_reporter/browser/webcompat_report_uploader.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/webui/constrained_web_dialog_ui.h"
 #include "content/public/browser/web_ui_message_handler.h"
+#include "content/public/browser/webui_config.h"
+#include "content/public/common/url_constants.h"
 
 namespace content {
 class RenderWidgetHostView;
@@ -23,6 +26,15 @@ class WebUI;
 }
 
 namespace webcompat_reporter {
+
+class WebcompatReporterUI;
+
+class WebcompatReporterUIConfig
+    : public content::DefaultWebUIConfig<WebcompatReporterUI> {
+ public:
+  WebcompatReporterUIConfig()
+      : DefaultWebUIConfig(content::kChromeUIScheme, kWebcompatReporterHost) {}
+};
 
 class WebcompatReporterDOMHandler : public content::WebUIMessageHandler {
  public:
@@ -60,7 +72,7 @@ class WebcompatReporterDOMHandler : public content::WebUIMessageHandler {
 
 class WebcompatReporterUI : public ConstrainedWebDialogUI {
  public:
-  WebcompatReporterUI(content::WebUI* web_ui, const std::string& host);
+  explicit WebcompatReporterUI(content::WebUI* web_ui);
   WebcompatReporterUI(const WebcompatReporterUI&) = delete;
   WebcompatReporterUI& operator=(const WebcompatReporterUI&) = delete;
   ~WebcompatReporterUI() override;

--- a/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/chromium_src/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -20,6 +20,7 @@
 #include "brave/browser/ui/webui/brave_shields/shields_panel_ui.h"
 #include "brave/browser/ui/webui/brave_wallet/wallet_panel_ui.h"
 #include "brave/browser/ui/webui/speedreader/speedreader_toolbar_ui.h"
+#include "brave/browser/ui/webui/webcompat_reporter/webcompat_reporter_ui.h"
 #endif  // !BUILDFLAG(IS_ANDROID)
 #include "brave/browser/ui/webui/brave_adblock_internals_ui.h"
 #include "brave/browser/ui/webui/brave_adblock_ui.h"
@@ -34,8 +35,10 @@ void RegisterChromeWebUIConfigs() {
   map.AddWebUIConfig(std::make_unique<brave_rewards::TipPanelUIConfig>());
   map.AddWebUIConfig(std::make_unique<CookieListOptInUIConfig>());
   map.AddWebUIConfig(std::make_unique<ShieldsPanelUIConfig>());
-  map.AddWebUIConfig(std::make_unique<WalletPanelUIConfig>());
   map.AddWebUIConfig(std::make_unique<SpeedreaderToolbarUIConfig>());
+  map.AddWebUIConfig(std::make_unique<WalletPanelUIConfig>());
+  map.AddWebUIConfig(
+      std::make_unique<webcompat_reporter::WebcompatReporterUIConfig>());
 #endif  // !BUILDFLAG(IS_ANDROID)
   map.AddWebUIConfig(std::make_unique<BraveAdblockUIConfig>());
   map.AddWebUIConfig(std::make_unique<BraveAdblockInternalsUIConfig>());


### PR DESCRIPTION
A similar rework is taking place upstream. The intent is to eventually abandon the use of `BraveWebUIControllerFactory`, and rely on `RegisterChromeWebUIConfigs()` for this type of routing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

