### PR TITLE
Update AdGuard's Mv2 extension ID (uplift to 1.70.x)

### DIFF
--- a/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.cc
+++ b/browser/ui/webui/settings/brave_extensions_manifest_v2_handler.cc
@@ -25,7 +25,7 @@ namespace {
 constexpr const char kNoScriptId[] = "doojmbjmlfjjnbmnoijecmcbfeoakpjm";
 constexpr const char kUBlockId[] = "cjpalhdlnbpafiamejdnhcphjbkeiagm";
 constexpr const char kUMatrixId[] = "ogfcmafjalglgifnmanfmnieipoejdcf";
-constexpr const char kAdGuardId[] = "bgnkhhnnamicmpeenaelnjfhikgbkllg";
+constexpr const char kAdGuardId[] = "gfggjaccafhcbfogfkogggoepomehbjl";
 }  // namespace
 
 BASE_FEATURE(kExtensionsManifestV2,


### PR DESCRIPTION
Uplift of #25798
Resolves https://github.com/brave/brave-browser/issues/41173

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.