### PR TITLE
[CR130] Task manager background color is red

### DIFF
--- a/chromium_src/ui/color/material_ui_color_mixer.cc
+++ b/chromium_src/ui/color/material_ui_color_mixer.cc
@@ -18,28 +18,24 @@ namespace ui {
 
 void AddMaterialUiColorMixer(ColorProvider* provider,
                              const ColorProviderKey& key) {
-  ui::ColorMixer& mixer = provider->AddMixer();
-  const bool is_dark = key.color_mode == ui::ColorProviderKey::ColorMode::kDark;
-  mixer[ui::kColorListItemUrlFaviconBackground] = {
-      is_dark ? gfx::kGoogleGrey800 : gfx::kGoogleGrey050};
-  mixer[ui::kColorListItemFolderIconBackground] = {
-      is_dark ? gfx::kGoogleGrey800 : gfx::kGoogleGrey050};
-  mixer[ui::kColorListItemFolderIconForeground] = {is_dark ? gfx::kGoogleGrey100
-                                                           : SK_ColorBLACK};
-  mixer[ui::kColorCheckboxCheck] = {ui::kColorSysOnPrimary};
-  mixer[ui::kColorCheckboxCheckDisabled] = {ui::kColorSysStateDisabled};
-  mixer[ui::kColorCheckboxContainer] = {ui::kColorSysPrimary};
-  mixer[ui::kColorCheckboxContainerDisabled] = {
-      ui::kColorSysStateDisabledContainer};
-  mixer[ui::kColorCheckboxOutline] = {ui::kColorSysOutline};
-  mixer[ui::kColorCheckboxOutlineDisabled] = {
-      ui::kColorSysStateDisabledContainer};
-  mixer[ui::kColorToggleButtonHover] = {is_dark
-                                            ? SkColorSetRGB(0x44, 0x36, 0xE1)
+  ColorMixer& mixer = provider->AddMixer();
+  const bool is_dark = key.color_mode == ColorProviderKey::ColorMode::kDark;
+  mixer[kColorListItemUrlFaviconBackground] = {is_dark ? gfx::kGoogleGrey800
+                                                       : gfx::kGoogleGrey050};
+  mixer[kColorListItemFolderIconBackground] = {is_dark ? gfx::kGoogleGrey800
+                                                       : gfx::kGoogleGrey050};
+  mixer[kColorListItemFolderIconForeground] = {is_dark ? gfx::kGoogleGrey100
+                                                       : SK_ColorBLACK};
+  mixer[kColorCheckboxCheck] = {kColorSysOnPrimary};
+  mixer[kColorCheckboxCheckDisabled] = {kColorSysStateDisabled};
+  mixer[kColorCheckboxContainer] = {kColorSysPrimary};
+  mixer[kColorCheckboxContainerDisabled] = {kColorSysStateDisabledContainer};
+  mixer[kColorCheckboxOutline] = {kColorSysOutline};
+  mixer[kColorCheckboxOutlineDisabled] = {kColorSysStateDisabledContainer};
+  mixer[kColorToggleButtonHover] = {is_dark ? SkColorSetRGB(0x44, 0x36, 0xE1)
                                             : SkColorSetRGB(0x4C, 0x54, 0xD2)};
-  mixer[ui::kColorComboboxInkDropHovered] = {ui::kColorSysStateHoverOnSubtle};
-  mixer[ui::kColorComboboxInkDropRipple] = {
-      ui::kColorSysStateRippleNeutralOnSubtle};
+  mixer[kColorComboboxInkDropHovered] = {kColorSysStateHoverOnSubtle};
+  mixer[kColorComboboxInkDropRipple] = {kColorSysStateRippleNeutralOnSubtle};
   mixer[kColorComboboxBackground] = {kColorSysSurface};
   mixer[kColorComboboxBackgroundDisabled] = {GetResultingPaintColor(
       {kColorSysStateDisabledContainer}, {kColorComboboxBackground})};
@@ -56,34 +52,32 @@ void AddMaterialUiColorMixer(ColorProvider* provider,
   mixer[kColorTableForegroundSelectedFocused] = {kColorTableForeground};
   mixer[kColorTableForegroundSelectedUnfocused] = {
       kColorTableForegroundSelectedFocused};
-  mixer[ui::kColorToolbarSearchFieldBackground] = {
-      ui::kColorSysBaseContainerElevated};
-  mixer[ui::kColorToolbarSearchFieldBackgroundHover] = {
-      is_dark ? SetAlpha({ui::kColorRefNeutral10}, 0x0F)
-              : SetAlpha({ui::kColorRefNeutral20}, 0x1F)};
-  mixer[ui::kColorToolbarSearchFieldBackgroundPressed] = {
-      ui::kColorSysStateRippleNeutralOnSubtle};
-  mixer[ui::kColorToolbarSearchFieldForeground] = {ui::kColorSysOnSurface};
-  mixer[ui::kColorToolbarSearchFieldForegroundPlaceholder] = {
-      ui::kColorSysOnSurfaceSubtle};
-  mixer[ui::kColorToolbarSearchFieldIcon] = {ui::kColorSysOnSurfaceSubtle};
-  mixer[ui::kColorToastBackground] = {is_dark ? gfx::kGoogleGrey800
-                                              : gfx::kGoogleGrey100};
-  mixer[ui::kColorToastButton] = {ui::kColorSysInversePrimary};
-  mixer[ui::kColorToastForeground] = {ui::kColorSysOnSurfaceSubtle};
-  mixer[ui::kColorToggleButtonHover] = {ui::kColorSysStateHover};
-  mixer[ui::kColorToggleButtonPressed] = {ui::kColorSysStatePressed};
-  mixer[ui::kColorToggleButtonShadow] = {ui::kColorSysOutline};
-  mixer[ui::kColorToggleButtonThumbOff] = {ui::kColorSysOutline};
-  mixer[ui::kColorToggleButtonThumbOffDisabled] = {ui::kColorSysStateDisabled};
-  mixer[ui::kColorToggleButtonThumbOn] = {ui::kColorSysOnPrimary};
-  mixer[ui::kColorToggleButtonThumbOnDisabled] = {ui::kColorSysSurface};
-  mixer[ui::kColorToggleButtonThumbOnHover] = {ui::kColorSysPrimaryContainer};
-  mixer[ui::kColorToggleButtonTrackOff] = {ui::kColorSysSurfaceVariant};
-  mixer[ui::kColorToggleButtonTrackOffDisabled] = {ui::kColorSysSurfaceVariant};
-  mixer[ui::kColorToggleButtonTrackOn] = {ui::kColorSysPrimary};
-  mixer[ui::kColorToggleButtonTrackOnDisabled] = {
-      ui::kColorSysStateDisabledContainer};
+  mixer[kColorToolbarSearchFieldBackground] = {kColorSysBaseContainerElevated};
+  mixer[kColorToolbarSearchFieldBackgroundHover] = {
+      is_dark ? SetAlpha({kColorRefNeutral10}, 0x0F)
+              : SetAlpha({kColorRefNeutral20}, 0x1F)};
+  mixer[kColorToolbarSearchFieldBackgroundPressed] = {
+      kColorSysStateRippleNeutralOnSubtle};
+  mixer[kColorToolbarSearchFieldForeground] = {kColorSysOnSurface};
+  mixer[kColorToolbarSearchFieldForegroundPlaceholder] = {
+      kColorSysOnSurfaceSubtle};
+  mixer[kColorToolbarSearchFieldIcon] = {kColorSysOnSurfaceSubtle};
+  mixer[kColorToastBackground] = {is_dark ? gfx::kGoogleGrey800
+                                          : gfx::kGoogleGrey100};
+  mixer[kColorToastButton] = {kColorSysInversePrimary};
+  mixer[kColorToastForeground] = {kColorSysOnSurfaceSubtle};
+  mixer[kColorToggleButtonHover] = {kColorSysStateHover};
+  mixer[kColorToggleButtonPressed] = {kColorSysStatePressed};
+  mixer[kColorToggleButtonShadow] = {kColorSysOutline};
+  mixer[kColorToggleButtonThumbOff] = {kColorSysOutline};
+  mixer[kColorToggleButtonThumbOffDisabled] = {kColorSysStateDisabled};
+  mixer[kColorToggleButtonThumbOn] = {kColorSysOnPrimary};
+  mixer[kColorToggleButtonThumbOnDisabled] = {kColorSysSurface};
+  mixer[kColorToggleButtonThumbOnHover] = {kColorSysPrimaryContainer};
+  mixer[kColorToggleButtonTrackOff] = {kColorSysSurfaceVariant};
+  mixer[kColorToggleButtonTrackOffDisabled] = {kColorSysSurfaceVariant};
+  mixer[kColorToggleButtonTrackOn] = {kColorSysPrimary};
+  mixer[kColorToggleButtonTrackOnDisabled] = {kColorSysStateDisabledContainer};
 
   mixer[kColorAppMenuRowBackgroundHovered] = {kColorSysStateHoverOnSubtle};
   mixer[kColorAppMenuUpgradeRowBackground] = {

--- a/chromium_src/ui/color/material_ui_color_mixer.cc
+++ b/chromium_src/ui/color/material_ui_color_mixer.cc
@@ -44,6 +44,18 @@ void AddMaterialUiColorMixer(ColorProvider* provider,
   mixer[kColorComboboxBackgroundDisabled] = {GetResultingPaintColor(
       {kColorSysStateDisabledContainer}, {kColorComboboxBackground})};
   mixer[kColorComboboxContainerOutline] = {kColorSysNeutralOutline};
+  mixer[kColorTabBorderSelected] = {kColorSysPrimary};
+  mixer[kColorTabForeground] = {kColorSecondaryForeground};
+  mixer[kColorTabForegroundSelected] = {kColorSysPrimary};
+  mixer[kColorTableBackground] = {kColorPrimaryBackground};
+  mixer[kColorTableBackgroundAlternate] = {kColorTableBackground};
+  mixer[kColorTableBackgroundSelectedFocused] = {kColorSysTonalContainer};
+  mixer[kColorTableBackgroundSelectedUnfocused] = {
+      kColorTableBackgroundSelectedFocused};
+  mixer[kColorTableForeground] = {kColorPrimaryForeground};
+  mixer[kColorTableForegroundSelectedFocused] = {kColorTableForeground};
+  mixer[kColorTableForegroundSelectedUnfocused] = {
+      kColorTableForegroundSelectedFocused};
   mixer[ui::kColorToolbarSearchFieldBackground] = {
       ui::kColorSysBaseContainerElevated};
   mixer[ui::kColorToolbarSearchFieldBackgroundHover] = {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41423

This is due to the following upstream change:
https://source.chromium.org/chromium/chromium/src/+/91e39ce5aa9a78bbcd9abff1521923377ca425eb

**Note**: Easier to review by commit, as first commit contains the actual fix and second commit makes a small code cleanup.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

