### PR TITLE
[CodeHealth] Avoid unwanted copies with `base::flat_{tree,set,map}<>`

### DIFF
--- a/browser/brave_shields/brave_shields_web_contents_observer.h
+++ b/browser/brave_shields/brave_shields_web_contents_observer.h
@@ -80,10 +80,6 @@ class BraveShieldsWebContentsObserver
   friend class content::WebContentsUserData<BraveShieldsWebContentsObserver>;
   friend class BraveShieldsWebContentsObserverBrowserTest;
 
-  using BraveShieldsRemotesMap = base::flat_map<
-      content::RenderFrameHost*,
-      mojo::AssociatedRemote<brave_shields::mojom::BraveShields>>;
-
   // Allows indicating a implementor of brave_shields::mojom::BraveShieldsHost
   // other than this own class, for testing purposes only.
   static void SetReceiverImplForTesting(BraveShieldsWebContentsObserver* impl);

--- a/browser/brave_wallet/brave_wallet_tab_helper.cc
+++ b/browser/brave_wallet/brave_wallet_tab_helper.cc
@@ -37,33 +37,25 @@ BraveWalletTabHelper::~BraveWalletTabHelper() {
 void BraveWalletTabHelper::AddSolanaConnectedAccount(
     const content::GlobalRenderFrameHostId& id,
     const std::string& account) {
-  base::flat_set<std::string> connection_set;
-  if (solana_connected_accounts_.contains(id)) {
-    connection_set = solana_connected_accounts_.at(id);
-  }
-  connection_set.insert(account);
-  solana_connected_accounts_[id] = std::move(connection_set);
+  solana_connected_accounts_[id].insert(account);
 }
 
 void BraveWalletTabHelper::RemoveSolanaConnectedAccount(
     const content::GlobalRenderFrameHostId& id,
     const std::string& account) {
-  if (!solana_connected_accounts_.contains(id)) {
+  auto it = solana_connected_accounts_.find(id);
+  if (it == solana_connected_accounts_.end()) {
     return;
   }
-  auto connection_set = solana_connected_accounts_.at(id);
-  connection_set.erase(account);
-  solana_connected_accounts_[id] = std::move(connection_set);
+  it->second.erase(account);
 }
 
 bool BraveWalletTabHelper::IsSolanaAccountConnected(
     const content::GlobalRenderFrameHostId& id,
     const std::string& account) {
-  if (!solana_connected_accounts_.contains(id)) {
-    return false;
-  }
-  auto connection_set = solana_connected_accounts_.at(id);
-  return connection_set.contains(account);
+  auto it = solana_connected_accounts_.find(id);
+  return it == solana_connected_accounts_.end() ? false
+                                                : it->second.contains(account);
 }
 
 void BraveWalletTabHelper::ClearSolanaConnectedAccounts(

--- a/browser/ui/commands/accelerator_service.cc
+++ b/browser/ui/commands/accelerator_service.cc
@@ -83,7 +83,7 @@ AcceleratorService::AcceleratorService(
     base::flat_set<ui::Accelerator> system_managed)
     : pref_manager_(pref_service, commands::GetCommands()),
       default_accelerators_(std::move(default_accelerators)),
-      system_managed_(system_managed) {
+      system_managed_(std::move(system_managed)) {
   Initialize();
 }
 

--- a/browser/ui/commands/accelerator_service_factory.cc
+++ b/browser/ui/commands/accelerator_service_factory.cc
@@ -54,8 +54,8 @@ KeyedService* AcceleratorServiceFactory::BuildServiceInstanceFor(
   DCHECK(profile);
 
   auto [accelerators, system_managed] = GetDefaultAccelerators();
-  return new AcceleratorService(profile->GetPrefs(), accelerators,
-                                system_managed);
+  return new AcceleratorService(profile->GetPrefs(), std::move(accelerators),
+                                std::move(system_managed));
 }
 
 }  // namespace commands

--- a/browser/ui/views/commands/default_accelerators_views.cc
+++ b/browser/ui/views/commands/default_accelerators_views.cc
@@ -4,11 +4,11 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include <utility>
+
 #include "base/containers/flat_set.h"
 #include "base/ranges/algorithm.h"
-#include "brave/browser/ui/commands/default_accelerators.h"
-
 #include "brave/browser/ui/commands/accelerator_service.h"
+#include "brave/browser/ui/commands/default_accelerators.h"
 #include "chrome/browser/ui/views/accelerator_table.h"
 #include "ui/base/accelerators/accelerator.h"
 
@@ -20,8 +20,8 @@ namespace commands {
 
 std::pair<Accelerators, base::flat_set<ui::Accelerator>>
 GetDefaultAccelerators() {
-  Accelerators defaults;
-  base::flat_set<ui::Accelerator> system_commands;
+  std::pair<Accelerators, base::flat_set<ui::Accelerator>> result;
+  auto& [defaults, system_commands] = result;
 
   auto add_to_accelerators = [&defaults](const AcceleratorMapping& mapping) {
     defaults[mapping.command_id].push_back(
@@ -39,7 +39,7 @@ GetDefaultAccelerators() {
                                mapping.keycode, mapping.modifiers));
                          });
 #endif  // BUILDFLAG(IS_MAC)
-  return std::tie(defaults, system_commands);
+  return result;
 }
 
 }  // namespace commands

--- a/build/ios/mojom/cpp_transformations.h
+++ b/build/ios/mojom/cpp_transformations.h
@@ -69,7 +69,7 @@ NS_INLINE NSArray<NSNumber*>* NSArrayFromVector(std::vector<T> v) {
   typedef NSNumber* (*NSNumberCall)(id, SEL, T);
   NSNumberCall call = (NSNumberCall)method_getImplementation(method);
 
-  for (auto t : v) {
+  for (const auto& t : v) {
     NSNumber* number =
         reinterpret_cast<NSNumber*>(call(NSNumber.class, selector, t));
     [a addObject:number];
@@ -102,7 +102,7 @@ NS_INLINE std::vector<T> VectorFromNSArray(NSArray<NSNumber*>* a) {
 /// Convert a vector storing strings to an array of NSString's
 NS_INLINE NSArray<NSString*>* NSArrayFromVector(std::vector<std::string> v) {
   const auto a = [NSMutableArray new];
-  for (auto s : v) {
+  for (const auto& s : v) {
     [a addObject:[NSString stringWithCString:s.c_str()
                                     encoding:NSUTF8StringEncoding]];
   }
@@ -175,12 +175,12 @@ NS_INLINE NSNumber* NumberFromPrimitive(T t) {
 /// NSNumber *>
 template <typename T>
 NS_INLINE NSDictionary<NSString*, NSNumber*>* NSDictionaryFromMap(
-    std::map<std::string, T> m) {
+    const std::map<std::string, T>& m) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[[NSString stringWithCString:item.first.c_str()
                          encoding:NSUTF8StringEncoding]] =
         NumberFromPrimitive(item.second);
@@ -192,12 +192,12 @@ NS_INLINE NSDictionary<NSString*, NSNumber*>* NSDictionaryFromMap(
 /// NSNumber *>
 template <typename T>
 NS_INLINE NSDictionary<NSString*, NSNumber*>* NSDictionaryFromMap(
-    base::flat_map<std::string, T> m) {
+    const base::flat_map<std::string, T>& m) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[[NSString stringWithCString:item.first.c_str()
                          encoding:NSUTF8StringEncoding]] =
         NumberFromPrimitive(item.second);
@@ -207,12 +207,12 @@ NS_INLINE NSDictionary<NSString*, NSNumber*>* NSDictionaryFromMap(
 
 /// Convert a String to String mapping to an NSDictionary
 NS_INLINE NSDictionary<NSString*, NSString*>* NSDictionaryFromMap(
-    std::map<std::string, std::string> m) {
+    const std::map<std::string, std::string>& m) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[[NSString stringWithCString:item.first.c_str()
                          encoding:NSUTF8StringEncoding]] =
         [NSString stringWithCString:item.second.c_str()
@@ -223,12 +223,12 @@ NS_INLINE NSDictionary<NSString*, NSString*>* NSDictionaryFromMap(
 
 /// Convert a String to String mapping to an NSDictionary
 NS_INLINE NSDictionary<NSString*, NSString*>* NSDictionaryFromMap(
-    base::flat_map<std::string, std::string> m) {
+    const base::flat_map<std::string, std::string>& m) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[[NSString stringWithCString:item.first.c_str()
                          encoding:NSUTF8StringEncoding]] =
         [NSString stringWithCString:item.second.c_str()
@@ -241,13 +241,13 @@ NS_INLINE NSDictionary<NSString*, NSString*>* NSDictionaryFromMap(
 /// objects
 template <typename V, typename ObjCObj>
 NS_INLINE NSDictionary<NSString*, ObjCObj>* NSDictionaryFromMap(
-    std::map<std::string, V> m,
+    const std::map<std::string, V>& m,
     ObjCObj (^transformValue)(V)) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[[NSString stringWithCString:item.first.c_str()
                          encoding:NSUTF8StringEncoding]] =
         transformValue(item.second);
@@ -259,13 +259,13 @@ NS_INLINE NSDictionary<NSString*, ObjCObj>* NSDictionaryFromMap(
 /// objects
 template <typename V, typename ObjCObj>
 NS_INLINE NSDictionary<NSString*, ObjCObj>* NSDictionaryFromMap(
-    base::flat_map<std::string, V> m,
+    const base::flat_map<std::string, V>& m,
     ObjCObj (^transformValue)(V)) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[[NSString stringWithCString:item.first.c_str()
                          encoding:NSUTF8StringEncoding]] =
         transformValue(item.second);
@@ -277,14 +277,14 @@ NS_INLINE NSDictionary<NSString*, ObjCObj>* NSDictionaryFromMap(
 /// the key and the value types to Obj-C types
 template <typename K, typename KObjC, typename V, typename VObjC>
 NS_INLINE NSDictionary<KObjC, VObjC>* NSDictionaryFromMap(
-    std::map<K, V> m,
+    const std::map<K, V>& m,
     KObjC (^transformKey)(K),
     VObjC (^transformValue)(V)) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[transformKey(item.first)] = transformValue(item.second);
   }
   return d;
@@ -294,14 +294,14 @@ NS_INLINE NSDictionary<KObjC, VObjC>* NSDictionaryFromMap(
 /// the key and the value types to Obj-C types
 template <typename K, typename KObjC, typename V, typename VObjC>
 NS_INLINE NSDictionary<KObjC, VObjC>* NSDictionaryFromMap(
-    base::flat_map<K, V> m,
+    const base::flat_map<K, V>& m,
     KObjC (^transformKey)(K),
     VObjC (^transformValue)(V)) {
   const auto d = [NSMutableDictionary new];
   if (m.empty()) {
     return @{};
   }
-  for (auto item : m) {
+  for (const auto& item : m) {
     d[transformKey(item.first)] = transformValue(item.second);
   }
   return d;

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -290,7 +290,6 @@ class PageContentFetcherInternal {
       std::string invalidation_token,
       std::unique_ptr<std::string> response_body) {
     auto response_code = -1;
-    base::flat_map<std::string, std::string> headers;
     if (loader->ResponseInfo()) {
       auto headers_list = loader->ResponseInfo()->headers;
       if (headers_list) {
@@ -328,7 +327,6 @@ class PageContentFetcherInternal {
                             std::unique_ptr<network::SimpleURLLoader> loader,
                             std::unique_ptr<std::string> response_body) {
     auto response_code = -1;
-    base::flat_map<std::string, std::string> headers;
     if (loader->ResponseInfo()) {
       auto headers_list = loader->ResponseInfo()->headers;
       if (headers_list) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
@@ -167,8 +167,8 @@ EngineConsumerClaudeRemote::EngineConsumerClaudeRemote(
   base::flat_set<std::string_view> stop_sequences(kStopSequences.begin(),
                                                   kStopSequences.end());
   api_ = std::make_unique<RemoteCompletionClient>(
-      model_options.name, stop_sequences, url_loader_factory,
-      credential_manager);
+      model_options.name, std::move(stop_sequences),
+      std::move(url_loader_factory), credential_manager);
 
   max_page_content_length_ = model_options.max_page_content_length;
 }
@@ -222,7 +222,7 @@ void EngineConsumerClaudeRemote::GenerateQuestionSuggestions(
   stop_sequences.push_back("</response>");
 
   api_->QueryPrompt(
-      prompt, stop_sequences,
+      prompt, std::move(stop_sequences),
       base::BindOnce(
           &EngineConsumerClaudeRemote::OnGenerateQuestionSuggestionsResponse,
           weak_ptr_factory_.GetWeakPtr(), std::move(callback)));

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.cc
@@ -330,8 +330,8 @@ EngineConsumerLlamaRemote::EngineConsumerLlamaRemote(
   base::flat_set<std::string_view> stop_sequences(kStopSequences.begin(),
                                                   kStopSequences.end());
   api_ = std::make_unique<RemoteCompletionClient>(
-      model_options.name, stop_sequences, url_loader_factory,
-      credential_manager);
+      model_options.name, std::move(stop_sequences),
+      std::move(url_loader_factory), credential_manager);
 
   max_page_content_length_ = model_options.max_page_content_length;
 
@@ -374,7 +374,7 @@ void EngineConsumerLlamaRemote::GenerateQuestionSuggestions(
   stop_sequences.push_back("</ul>");
   DCHECK(api_);
   api_->QueryPrompt(
-      prompt, stop_sequences,
+      prompt, std::move(stop_sequences),
       base::BindOnce(
           &EngineConsumerLlamaRemote::OnGenerateQuestionSuggestionsResponse,
           weak_ptr_factory_.GetWeakPtr(), std::move(callback)));

--- a/components/ai_chat/core/browser/engine/mock_remote_completion_client.h
+++ b/components/ai_chat/core/browser/engine/mock_remote_completion_client.h
@@ -22,7 +22,7 @@ class MockRemoteCompletionClient : public RemoteCompletionClient {
   MOCK_METHOD(void,
               QueryPrompt,
               (const std::string&,
-               const std::vector<std::string>&,
+               std::vector<std::string>,
                GenerationCompletedCallback,
                GenerationDataCallback),
               (override));

--- a/components/ai_chat/core/browser/engine/remote_completion_client.cc
+++ b/components/ai_chat/core/browser/engine/remote_completion_client.cc
@@ -120,25 +120,26 @@ GURL GetEndpointUrl(bool premium, const std::string& path) {
 
 RemoteCompletionClient::RemoteCompletionClient(
     const std::string& model_name,
-    const base::flat_set<std::string_view>& stop_sequences,
+    base::flat_set<std::string_view> stop_sequences,
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager)
     : model_name_(model_name),
-      stop_sequences_(stop_sequences),
-      api_request_helper_(GetNetworkTrafficAnnotationTag(), url_loader_factory),
+      stop_sequences_(std::move(stop_sequences)),
+      api_request_helper_(GetNetworkTrafficAnnotationTag(),
+                          std::move(url_loader_factory)),
       credential_manager_(credential_manager) {}
 
 RemoteCompletionClient::~RemoteCompletionClient() = default;
 
 void RemoteCompletionClient::QueryPrompt(
     const std::string& prompt,
-    const std::vector<std::string>& extra_stop_sequences,
+    std::vector<std::string> extra_stop_sequences,
     GenerationCompletedCallback data_completed_callback,
     GenerationDataCallback
         data_received_callback /* = base::NullCallback() */) {
   auto callback = base::BindOnce(
       &RemoteCompletionClient::OnFetchPremiumCredential,
-      weak_ptr_factory_.GetWeakPtr(), prompt, extra_stop_sequences,
+      weak_ptr_factory_.GetWeakPtr(), prompt, std::move(extra_stop_sequences),
       std::move(data_completed_callback), std::move(data_received_callback));
   credential_manager_->FetchPremiumCredential(std::move(callback));
 }

--- a/components/ai_chat/core/browser/engine/remote_completion_client.h
+++ b/components/ai_chat/core/browser/engine/remote_completion_client.h
@@ -38,7 +38,7 @@ class RemoteCompletionClient {
 
   RemoteCompletionClient(
       const std::string& model_name,
-      const base::flat_set<std::string_view>& stop_sequences,
+      base::flat_set<std::string_view> stop_sequences,
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       AIChatCredentialManager* credential_manager);
 
@@ -50,7 +50,7 @@ class RemoteCompletionClient {
   // In non-SSE cases, only the data_completed_callback will be triggered.
   virtual void QueryPrompt(
       const std::string& prompt,
-      const std::vector<std::string>& stop_sequences,
+      std::vector<std::string> stop_sequences,
       GenerationCompletedCallback data_completed_callback,
       GenerationDataCallback data_received_callback = base::NullCallback());
   // Clears all in-progress requests

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1016,7 +1016,7 @@ void AdsServiceImpl::URLRequestCallback(
   mojom_url_response->url = url_loader->GetFinalURL();
   mojom_url_response->status_code = response_code;
   mojom_url_response->body = response_body ? *response_body : "";
-  mojom_url_response->headers = headers;
+  mojom_url_response->headers = std::move(headers);
 
   std::move(callback).Run(std::move(mojom_url_response));
 }

--- a/components/brave_news/browser/peeking_card.cc
+++ b/components/brave_news/browser/peeking_card.cc
@@ -64,7 +64,7 @@ base::flat_set<std::string> GetTopStoryUrls(
 
 std::optional<size_t> PickPeekingCardWithMax(
     SubscriptionsSnapshot subscriptions,
-    base::flat_set<std::string> top_story_urls,
+    const base::flat_set<std::string>& top_story_urls,
     const ArticleInfos& articles,
     size_t max_candidates) {
   // Store now, so it's consistent for everything.
@@ -217,11 +217,10 @@ std::optional<size_t> PickPeekingCardWithMax(
 
 std::optional<size_t> PickPeekingCard(
     SubscriptionsSnapshot subscriptions,
-    base::flat_set<std::string> top_story_urls,
+    const base::flat_set<std::string>& top_story_urls,
     const ArticleInfos& articles) {
-  return PickPeekingCardWithMax(std::move(subscriptions),
-                                std::move(top_story_urls), articles,
-                                kMaxPeekingCardCandidates);
+  return PickPeekingCardWithMax(std::move(subscriptions), top_story_urls,
+                                articles, kMaxPeekingCardCandidates);
 }
 
 }  // namespace brave_news

--- a/components/brave_news/browser/peeking_card.h
+++ b/components/brave_news/browser/peeking_card.h
@@ -21,13 +21,13 @@ base::flat_set<std::string> GetTopStoryUrls(
 
 std::optional<size_t> PickPeekingCardWithMax(
     SubscriptionsSnapshot subscriptions,
-    base::flat_set<std::string> top_story_urls,
+    const base::flat_set<std::string>& top_story_urls,
     const ArticleInfos& articles,
     size_t max_candidates);
 
 std::optional<size_t> PickPeekingCard(
     SubscriptionsSnapshot subscriptions,
-    base::flat_set<std::string> top_story_urls,
+    const base::flat_set<std::string>& top_story_urls,
     const ArticleInfos& articles);
 
 }  // namespace brave_news

--- a/components/brave_news/browser/suggestions_controller.cc
+++ b/components/brave_news/browser/suggestions_controller.cc
@@ -48,14 +48,7 @@ double ProjectToRange(double value, double min, double max) {
 }
 
 base::flat_map<std::string, double> GetVisitWeightings(
-    const Publishers& publishers,
     const history::QueryResults& history) {
-  // Get a flat list of hostnames from publishers
-  base::flat_set<std::string> publisher_hosts;
-  for (const auto& [_, publisher] : publishers) {
-    publisher_hosts.insert(publisher->site_url.host());
-  }
-
   // Score hostnames from browsing history by how many times they appear
   base::flat_map<std::string, double> weightings;
   for (const auto& entry : history) {
@@ -80,8 +73,9 @@ base::flat_map<std::string, double> GetVisitWeightings(
 }
 
 // Get score for having visited a source.
-double GetVisitWeighting(const mojom::PublisherPtr& publisher,
-                         base::flat_map<std::string, double> visit_weightings) {
+double GetVisitWeighting(
+    const mojom::PublisherPtr& publisher,
+    const base::flat_map<std::string, double>& visit_weightings) {
   const auto host_name = publisher->site_url.host();
   auto it = visit_weightings.find(host_name);
   if (it == visit_weightings.end()) {
@@ -188,7 +182,7 @@ std::vector<std::string>
 SuggestionsController::GetSuggestedPublisherIdsWithHistory(
     const Publishers& publishers,
     const history::QueryResults& history) {
-  const auto visit_weightings = GetVisitWeightings(publishers, history);
+  const auto visit_weightings = GetVisitWeightings(history);
   base::flat_map<std::string, double> scores;
 
   for (const auto& [publisher_id, publisher] : publishers) {

--- a/components/brave_news/common/locales_helper.cc
+++ b/components/brave_news/common/locales_helper.cc
@@ -93,11 +93,10 @@ base::flat_set<std::string> GetPublisherLocales(const Publishers& publishers) {
 }
 
 base::flat_set<std::string> GetMinimalLocalesSet(
-    const base::flat_set<std::string>& channel_locales,
+    base::flat_set<std::string> channel_locales,
     const Publishers& publishers) {
   // All channel locales are part of the minimal set - we need to include all of
   // them.
-  base::flat_set<std::string> result = channel_locales;
 
   std::vector<mojom::Publisher*> subscribed_publishers;
   for (const auto& [id, publisher] : publishers) {
@@ -115,11 +114,11 @@ base::flat_set<std::string> GetMinimalLocalesSet(
   // locale and recalculate what's missing.
   std::optional<std::string> best_missing_locale;
   while ((best_missing_locale =
-              GetBestMissingLocale(result, subscribed_publishers))) {
-    result.insert(best_missing_locale.value());
+              GetBestMissingLocale(channel_locales, subscribed_publishers))) {
+    channel_locales.insert(best_missing_locale.value());
   }
 
-  return result;
+  return channel_locales;
 }
 
 bool IsUserInDefaultEnabledLocale() {

--- a/components/brave_news/common/locales_helper.h
+++ b/components/brave_news/common/locales_helper.h
@@ -28,7 +28,7 @@ base::flat_set<std::string> GetPublisherLocales(const Publishers& publishers);
 // should work well enough for our purposes.
 // Complexity is O(subscribed_publishers * subscribed_locales).
 base::flat_set<std::string> GetMinimalLocalesSet(
-    const base::flat_set<std::string>& channel_locales,
+    base::flat_set<std::string> channel_locales,
     const Publishers& publishers);
 
 // Calculate if Brave News should be enabled on the NTP by checking the

--- a/components/brave_news/common/subscriptions_snapshot.h
+++ b/components/brave_news/common/subscriptions_snapshot.h
@@ -92,7 +92,8 @@ class SubscriptionsSnapshot {
 
   // A map of |locale ==> channels[]| representing the channels subscribed to in
   // different locales.
-  const base::flat_map<std::string, std::vector<std::string>> channels() const {
+  const base::flat_map<std::string, std::vector<std::string>>& channels()
+      const {
     return channels_;
   }
 

--- a/components/brave_perf_predictor/browser/named_third_party_registry.h
+++ b/components/brave_perf_predictor/browser/named_third_party_registry.h
@@ -9,7 +9,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <tuple>
+#include <utility>
 
 #include "base/containers/flat_map.h"
 #include "base/memory/weak_ptr.h"
@@ -41,8 +41,8 @@ class NamedThirdPartyRegistry : public KeyedService {
   bool IsInitialized() const { return initialized_; }
   void MarkInitialized(bool initialized) { initialized_ = initialized; }
   void UpdateMappings(
-      std::tuple<base::flat_map<std::string, std::string>,
-                 base::flat_map<std::string, std::string>> entity_mappings);
+      std::pair<base::flat_map<std::string, std::string>,
+                base::flat_map<std::string, std::string>> entity_mappings);
 
   bool initialized_ = false;
   base::flat_map<std::string, std::string> entity_by_domain_;

--- a/components/brave_rewards/browser/rewards_service_impl.cc
+++ b/components/brave_rewards/browser/rewards_service_impl.cc
@@ -964,7 +964,7 @@ void RewardsServiceImpl::LoadURL(mojom::UrlRequestPtr request,
     response->url = request->url;
     response->status_code = response_status_code;
     response->body = test_response;
-    response->headers = test_headers;
+    response->headers = std::move(test_headers);
     std::move(callback).Run(std::move(response));
     return;
   }

--- a/components/brave_rewards/core/publisher/media/youtube.cc
+++ b/components/brave_rewards/core/publisher/media/youtube.cc
@@ -53,8 +53,7 @@ YouTube::~YouTube() = default;
 std::string YouTube::GetMediaIdFromParts(
     const base::flat_map<std::string, std::string>& parts) {
   std::string result;
-  base::flat_map<std::string, std::string>::const_iterator iter =
-      parts.find("docid");
+  auto iter = parts.find("docid");
   if (iter != parts.end()) {
     result = iter->second;
   }
@@ -67,10 +66,8 @@ uint64_t YouTube::GetMediaDurationFromParts(
     const base::flat_map<std::string, std::string>& data,
     const std::string& media_key) {
   uint64_t duration = 0;
-  base::flat_map<std::string, std::string>::const_iterator iter_st =
-      data.find("st");
-  base::flat_map<std::string, std::string>::const_iterator iter_et =
-      data.find("et");
+  auto iter_st = data.find("st");
+  auto iter_et = data.find("et");
   if (iter_st != data.end() && iter_et != data.end()) {
     const auto start_time = base::SplitString(
         iter_st->second, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);

--- a/components/brave_wallet/browser/meld_integration_service.cc
+++ b/components/brave_wallet/browser/meld_integration_service.cc
@@ -84,11 +84,9 @@ std::optional<std::string> SanitizeJson(const std::string& json) {
 GURL AppendFilterParams(
     GURL url,
     const brave_wallet::mojom::MeldFilterPtr& filter,
-    std::optional<base::flat_map<std::string, std::string>> def_params) {
-  if (def_params) {
-    for (const auto& [key, val] : *def_params) {
-      url = net::AppendQueryParameter(url, key, val);
-    }
+    const base::flat_map<std::string, std::string>& def_params) {
+  for (const auto& [key, val] : def_params) {
+    url = net::AppendQueryParameter(url, key, val);
   }
 
   url = net::AppendQueryParameter(

--- a/components/playlist/browser/media_detector_component_manager.cc
+++ b/components/playlist/browser/media_detector_component_manager.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/playlist/browser/media_detector_component_manager.h"
 
+#include <utility>
+
 #include "base/containers/flat_set.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
@@ -67,7 +69,7 @@ std::string ReadScript(const base::FilePath& path) {
 }
 
 base::flat_map<ScriptName, std::string> ReadScriptsFromComponent(
-    base::flat_set<base::FilePath> files) {
+    const base::flat_set<base::FilePath>& files) {
   base::flat_map<ScriptName, std::string> script_map;
   for (const auto& path : files) {
     if (auto script = ReadScript(path); !script.empty()) {
@@ -130,7 +132,7 @@ void MediaDetectorComponentManager::OnComponentReady(
 
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, base::MayBlock(),
-      base::BindOnce(&ReadScriptsFromComponent, files),
+      base::BindOnce(&ReadScriptsFromComponent, std::move(files)),
       base::BindOnce(&MediaDetectorComponentManager::OnGetScripts,
                      weak_factory_.GetWeakPtr()));
 }

--- a/components/request_otr/browser/request_otr_service.cc
+++ b/components/request_otr/browser/request_otr_service.cc
@@ -43,7 +43,7 @@ void RequestOTRService::OnRulesReady(const std::string& json_content) {
   rules_.clear();
   host_cache_.clear();
   rules_ = std::move(parsed_rules.value().first);
-  host_cache_ = parsed_rules.value().second;
+  host_cache_ = std::move(parsed_rules).value().second;
   DVLOG(1) << host_cache_.size() << " unique hosts, " << rules_.size()
            << " rules parsed from " << kRequestOTRConfigFile;
 }

--- a/ios/browser/api/brave_rewards/brave_rewards_api.mm
+++ b/ios/browser/api/brave_rewards/brave_rewards_api.mm
@@ -769,7 +769,7 @@ static NSString* const kTransferFeesPrefKey = @"transfer_fees";
             : "";
 
     engine->OnXHRLoad(tabId, base::SysNSStringToUTF8(url.absoluteString),
-                      partsMap, fpu, ref, std::move(visit));
+                      std::move(partsMap), fpu, ref, std::move(visit));
   }];
 }
 


### PR DESCRIPTION
Applies one or more of the following:
-- std::move(argument) where possible.
-- remove stray 'const' where not helpful.
-- pass by const ref where helpful.
-- initalise in place to select for NRVO.

This CL was uploaded by git cl split.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41358

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

