### PR TITLE
style(wallet): Remove Divider in Page Headers

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -488,7 +488,6 @@ export const Account = () => {
   return (
     <WalletPageWrapper
       wrapContentInBox
-      hideDivider={true}
       noCardPadding={true}
       useCardInPanel={true}
       cardHeader={

--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -233,7 +233,6 @@ export const CryptoView = ({ sessionRoute }: Props) => {
             cardHeader={<PortfolioOverviewHeader />}
             useDarkBackground={isPanel}
             isPortfolio={true}
-            hideDivider={true}
           >
             <StyledWrapper>
               <Column
@@ -278,7 +277,6 @@ export const CryptoView = ({ sessionRoute }: Props) => {
             cardHeader={<PortfolioOverviewHeader />}
             useDarkBackground={isPanel}
             isPortfolio={true}
-            hideDivider={isPanel}
           >
             <StyledWrapper>
               <Column

--- a/components/brave_wallet_ui/components/desktop/views/market/market_asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/market/market_asset.tsx
@@ -387,7 +387,6 @@ export const MarketAsset = () => {
     <WalletPageWrapper
       wrapContentInBox={true}
       noCardPadding={true}
-      hideDivider={true}
       useCardInPanel={true}
       cardHeader={
         <AssetDetailsHeader

--- a/components/brave_wallet_ui/components/desktop/views/nfts/components/nft_collection.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/nfts/components/nft_collection.tsx
@@ -363,7 +363,6 @@ export const NftCollection = ({ networks, accounts }: Props) => {
     <WalletPageWrapper
       wrapContentInBox={true}
       noCardPadding={false}
-      hideDivider={false}
       cardHeader={
         <NftAssetHeader
           onBack={history.goBack}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-fungible-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-fungible-asset.tsx
@@ -454,7 +454,6 @@ export const PortfolioFungibleAsset = () => {
     <WalletPageWrapper
       wrapContentInBox={true}
       noCardPadding={true}
-      hideDivider={true}
       useCardInPanel={true}
       cardHeader={
         <AssetDetailsHeader

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-nft-asset.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-nft-asset.tsx
@@ -143,7 +143,6 @@ export const PortfolioNftAsset = () => {
     <WalletPageWrapper
       wrapContentInBox={true}
       noCardPadding={false}
-      hideDivider={false}
       cardHeader={
         <NftAssetHeader
           onBack={history.goBack}

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.style.ts
@@ -219,18 +219,7 @@ export const CardHeaderShadow = styled(CardHeader)<{
   box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.07);
 `
 
-export const CardHeaderContentWrapper = styled(Row)<{
-  dividerOpacity?: number
-  hideDivider?: boolean
-}>`
-  --divider-opacity: ${(p) =>
-    p.dividerOpacity !== undefined ? p.dividerOpacity : 1};
-  --divider-color: rgba(232, 233, 238, var(--divider-opacity));
-  @media (prefers-color-scheme: dark) {
-    --divider-color: rgba(43, 46, 59, var(--divider-opacity));
-  }
-  border-bottom: ${(p) =>
-    p.hideDivider ? 'none' : '1px solid var(--divider-color)'};
+export const CardHeaderContentWrapper = styled(Row)`
   height: 100%;
 `
 

--- a/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-page-wrapper/wallet-page-wrapper.tsx
@@ -50,7 +50,6 @@ export interface Props {
   hideNav?: boolean
   hideHeader?: boolean
   hideHeaderMenu?: boolean
-  hideDivider?: boolean
   cardHeader?: JSX.Element | undefined | null
   noMinCardHeight?: boolean
   noBorderRadius?: boolean
@@ -71,7 +70,6 @@ export const WalletPageWrapper = (props: Props) => {
     hideNav,
     hideHeader,
     hideHeaderMenu,
-    hideDivider,
     noMinCardHeight,
     noBorderRadius,
     useDarkBackground,
@@ -90,8 +88,6 @@ export const WalletPageWrapper = (props: Props) => {
   // State
   const [headerShadowOpacity, setHeaderShadowOpacity] =
     React.useState<number>(0)
-  const [headerDividerOpacity, setHeaderDividerOpacity] =
-    React.useState<number>(1)
   const [headerBackgroundOpacity, setHeaderBackgroundOpacity] =
     React.useState<number>(0)
   const [headerHeight, setHeaderHeight] = React.useState<number>(0)
@@ -121,7 +117,6 @@ export const WalletPageWrapper = (props: Props) => {
       // may not get calculated when scrolling fast.
       if (scrollTop === 0) {
         setHeaderShadowOpacity(0)
-        setHeaderDividerOpacity(1)
         setHeaderBackgroundOpacity(0)
         return
       }
@@ -134,12 +129,6 @@ export const WalletPageWrapper = (props: Props) => {
         // example: 0.00125 * 64 = 0.08
         setHeaderShadowOpacity((scrollTop / 8) * 0.01)
 
-        // Decreases dividerOpacity by 0.015625 until it reaches
-        // desired opacity of 0, or will increase dividerOpacity by
-        // 0.015625 until it reaches desired opacity of 1.
-        // example: 0.015625 * 64 = 1
-        setHeaderDividerOpacity((100 - (100 / 64) * scrollTop) * 0.01)
-
         // Increases backgroundOpacity by 0.015625 until it reaches
         // desired opacity of 1, or will decrease backgroundOpacity by
         // 0.015625 until it reaches desired opacity of 0.
@@ -148,11 +137,10 @@ export const WalletPageWrapper = (props: Props) => {
         return
       }
 
-      // Assures that shadowOpacity, dividerOpacity and backgroundOpacity are
+      // Assures that shadowOpacity and backgroundOpacity are
       // the expected values when scrollTop is greater than 64,
       // since some values may not get calculated when scrolling fast.
       setHeaderShadowOpacity(0.08)
-      setHeaderDividerOpacity(0)
       setHeaderBackgroundOpacity(1)
     }
   }, [scrollRef])
@@ -222,10 +210,7 @@ export const WalletPageWrapper = (props: Props) => {
                   useDarkBackground={useDarkBackground || shouldUsePanelCard}
                   backgroundOpacity={headerBackgroundOpacity}
                 >
-                  <CardHeaderContentWrapper
-                    dividerOpacity={headerDividerOpacity}
-                    hideDivider={shouldUsePanelCard || hideDivider}
-                  >
+                  <CardHeaderContentWrapper>
                     {cardHeader}
                   </CardHeaderContentWrapper>
                 </CardHeader>

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -481,7 +481,6 @@ export const SendScreen = React.memo((props: Props) => {
         noCardPadding={true}
         hideNav={isAndroid || isPanel}
         hideHeader={isAndroid}
-        hideDivider={true}
         cardHeader={
           isPanel ? (
             <PanelActionHeader

--- a/components/brave_wallet_ui/page/screens/swap/swap.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/swap.tsx
@@ -133,7 +133,6 @@ export const Swap = () => {
         wrapContentInBox={true}
         noCardPadding={true}
         noMinCardHeight={true}
-        hideDivider={true}
         hideNav={isPanel}
         cardHeader={
           isPanel ? (


### PR DESCRIPTION
## Description 

Removes the `Divider` in all Wallet Page `Headers` to match updated `Figma` designs.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/41458>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to all different `Screens`
2. There should no longer be a `divider` line in any of the Page `Headers`

Before:

![image](https://github.com/user-attachments/assets/c79cbd2f-634e-453a-ab04-b8ca8f7c2237) | ![image](https://github.com/user-attachments/assets/867003db-78fc-4760-b01d-3017fc956aeb) | ![image](https://github.com/user-attachments/assets/105b4e06-edaa-4516-b2ab-32518a4e1a57)
--|--|--

After:

![image](https://github.com/user-attachments/assets/87f71200-58d2-49a3-973c-369dd691f556) | ![image](https://github.com/user-attachments/assets/40706351-838d-41bf-832a-1797ffdcba85) | ![image](https://github.com/user-attachments/assets/9ef6d105-97c6-4031-8f4d-0947022091c9)
--|--|--
