### PR TITLE
Disable flaky BraveSwipeRefreshHandlerTest.allowRefreshForLeo test (uplift to 1.71.x)

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/BraveSwipeRefreshHandlerTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BraveSwipeRefreshHandlerTest.java
@@ -94,6 +94,7 @@ public class BraveSwipeRefreshHandlerTest {
 
     @Test
     @SmallTest
+    @DisabledTest(message = "https://github.com/brave/brave-browser/issues/40851")
     public void allowRefreshForNonLeo() throws Exception {
         boolean refreshed = loadUrlAttemptRefresh("https://brave.com", PageTransition.TYPED);
         Assert.assertTrue(refreshed);


### PR DESCRIPTION
Uplift of #25610
Resolves https://github.com/brave/brave-browser/issues/41108

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.