### PR TITLE
fix(privacy: Shred button spacing in private tabs

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -95,6 +95,8 @@ class TabTrayController: AuthenticationController {
 
       privateModeButton.isSelected = privateMode
       tabTypeSelector.isHidden = privateMode
+      tabTypeSelectorContainerView.isHidden =
+        privateMode && !BraveCore.FeatureList.kBraveShredFeature.enabled
     }
   }
 
@@ -120,6 +122,7 @@ class TabTrayController: AuthenticationController {
 
   private let tabContentView = UIView()
 
+  private let tabTypeSelectorContainerView = UIView()
   private var tabTypeSelectorItems = [UIImage]()
   private lazy var tabTypeSelector: UISegmentedControl = {
     let segmentedControl = UISegmentedControl(items: tabTypeSelectorItems).then {
@@ -397,18 +400,25 @@ class TabTrayController: AuthenticationController {
       $0.isLayoutMarginsRelativeArrangement = true
     }
 
-    contentStackView.addArrangedSubview(tabTypeSelector)
-    contentStackView.setCustomSpacing(UX.segmentedControlTopInset, after: tabTypeSelector)
+    tabTypeSelectorContainerView.addSubview(tabTypeSelector)
+    contentStackView.addArrangedSubview(tabTypeSelectorContainerView)
+    contentStackView.setCustomSpacing(
+      UX.segmentedControlTopInset,
+      after: tabTypeSelectorContainerView
+    )
     contentStackView.addArrangedSubview(tabContentView)
 
     containerView.addSubview(contentStackView)
 
     if FeatureList.kBraveShredFeature.enabled {
-      containerView.addSubview(shredButton)
+      tabTypeSelectorContainerView.addSubview(shredButton)
 
-      shredButton.snp.makeConstraints { make in
-        make.trailing.equalTo(containerView.readableContentGuide)
-        make.centerY.equalTo(tabTypeSelector)
+      shredButton.snp.makeConstraints {
+        $0.leading.greaterThanOrEqualTo(tabTypeSelector.snp.trailing)
+        $0.trailing.equalTo(tabTypeSelectorContainerView.snp.trailing)
+        $0.centerY.equalTo(tabTypeSelectorContainerView)
+        $0.top.greaterThanOrEqualTo(tabTypeSelectorContainerView.snp.top)
+        $0.bottom.lessThanOrEqualTo(tabTypeSelectorContainerView.snp.bottom)
       }
     }
 
@@ -416,8 +426,16 @@ class TabTrayController: AuthenticationController {
       $0.edges.equalTo(containerView.safeAreaLayoutGuide)
     }
 
+    tabTypeSelectorContainerView.snp.makeConstraints {
+      $0.width.equalTo(containerView.layoutMarginsGuide.snp.width)
+    }
+
     tabTypeSelector.snp.makeConstraints {
       $0.width.equalTo(contentStackView.snp.width).dividedBy(2)
+      $0.centerX.equalTo(tabTypeSelectorContainerView.snp.centerX)
+      $0.centerY.equalTo(tabTypeSelectorContainerView.snp.centerY)
+      $0.top.equalTo(tabTypeSelectorContainerView.snp.top)
+      $0.bottom.equalTo(tabTypeSelectorContainerView.snp.bottom)
     }
 
     tabContentView.addSubview(tabTrayView)
@@ -824,6 +842,8 @@ class TabTrayController: AuthenticationController {
     }
 
     tabTypeSelector.isHidden = privateMode
+    tabTypeSelectorContainerView.isHidden =
+      privateMode && !BraveCore.FeatureList.kBraveShredFeature.enabled
   }
 
   func remove(tab: Tab) {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -432,10 +432,7 @@ class TabTrayController: AuthenticationController {
 
     tabTypeSelector.snp.makeConstraints {
       $0.width.equalTo(contentStackView.snp.width).dividedBy(2)
-      $0.centerX.equalTo(tabTypeSelectorContainerView.snp.centerX)
-      $0.centerY.equalTo(tabTypeSelectorContainerView.snp.centerY)
-      $0.top.equalTo(tabTypeSelectorContainerView.snp.top)
-      $0.bottom.equalTo(tabTypeSelectorContainerView.snp.bottom)
+      $0.center.top.bottom.equalTo(tabTypeSelectorContainerView)
     }
 
     tabContentView.addSubview(tabTrayView)


### PR DESCRIPTION
- Fix spacing of shred button in private mode
- Fix alignment of shred button on iPad (align to right edge)

Resolves https://github.com/brave/brave-browser/issues/41520

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable Shred feature flag & restart browser
2. Open tab tray
3. Tap private
4. Open at least 2 tabs
5. Verify shred button is not cut off & visible