### PR TITLE
[ubsan] `SidebarContainerView` requires precocious downcast

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -283,7 +283,7 @@ BraveBrowserView::BraveBrowserView(std::unique_ptr<Browser> browser)
     auto original_side_panel = RemoveChildViewT(unified_side_panel_.get());
     sidebar_container_view_ =
         AddChildView(std::make_unique<SidebarContainerView>(
-            GetBraveBrowser(), browser_->GetFeatures().side_panel_coordinator(),
+            browser_.get(), browser_->GetFeatures().side_panel_coordinator(),
             std::move(original_side_panel)));
     unified_side_panel_ = sidebar_container_view_->side_panel();
 

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -114,7 +114,7 @@ class SidebarContainerView::BrowserWindowEventObserver
 };
 
 SidebarContainerView::SidebarContainerView(
-    BraveBrowser* browser,
+    Browser* browser,
     SidePanelCoordinator* side_panel_coordinator,
     std::unique_ptr<BraveSidePanel> side_panel)
     : views::AnimationDelegateViews(this),
@@ -134,7 +134,7 @@ SidebarContainerView::~SidebarContainerView() = default;
 void SidebarContainerView::Init() {
   initialized_ = true;
 
-  sidebar_model_ = browser_->sidebar_controller()->model();
+  sidebar_model_ = GetBraveBrowser()->sidebar_controller()->model();
   sidebar_model_observation_.Observe(sidebar_model_);
   browser_->tab_strip_model()->AddObserver(this);
 
@@ -157,7 +157,8 @@ void SidebarContainerView::Init() {
 
   AddChildViews();
   UpdateToolbarButtonVisibility();
-  SetSidebarShowOption(GetSidebarService(browser_)->GetSidebarShowOption());
+  SetSidebarShowOption(
+      GetSidebarService(GetBraveBrowser())->GetSidebarShowOption());
 }
 
 void SidebarContainerView::SetSidebarOnLeft(bool sidebar_on_left) {
@@ -275,8 +276,8 @@ void SidebarContainerView::UpdateBackground() {
 }
 
 void SidebarContainerView::AddChildViews() {
-  sidebar_control_view_ =
-      AddChildView(std::make_unique<SidebarControlView>(this, browser_));
+  sidebar_control_view_ = AddChildView(
+      std::make_unique<SidebarControlView>(this, GetBraveBrowser()));
   sidebar_control_view_->SetPaintToLayer();
 
   // To prevent showing layered-children while its bounds is invisible.
@@ -698,7 +699,7 @@ void SidebarContainerView::UpdateToolbarButtonVisibility() {
   // This is similar to how chromium's side_panel_coordinator View
   // also has some control on the toolbar button.
   auto has_panel_item =
-      GetSidebarService(browser_)->GetDefaultPanelItem().has_value();
+      GetSidebarService(GetBraveBrowser())->GetDefaultPanelItem().has_value();
   auto* browser_view = BrowserView::GetBrowserViewForBrowser(browser_);
   auto* brave_toolbar = static_cast<BraveToolbarView*>(browser_view->toolbar());
   if (brave_toolbar && brave_toolbar->side_panel_button()) {
@@ -728,7 +729,7 @@ void SidebarContainerView::OnEntryShown(SidePanelEntry* entry) {
   // as well as Sidebar as there are other ways than Sidebar for SidePanel
   // items to be shown and hidden, e.g. toolbar button.
   DVLOG(1) << "Panel shown: " << SidePanelEntryIdToString(entry->key().id());
-  auto* controller = browser_->sidebar_controller();
+  auto* controller = GetBraveBrowser()->sidebar_controller();
 
   // Handling if |entry| is managed one.
   for (const auto& item : sidebar_model_->GetAllSidebarItems()) {
@@ -760,7 +761,7 @@ void SidebarContainerView::OnEntryShown(SidePanelEntry* entry) {
 void SidebarContainerView::OnEntryHidden(SidePanelEntry* entry) {
   // Make sure item is deselected
   DVLOG(1) << "Panel hidden: " << SidePanelEntryIdToString(entry->key().id());
-  auto* controller = browser_->sidebar_controller();
+  auto* controller = GetBraveBrowser()->sidebar_controller();
 
   // Handling if |entry| is managed one.
   for (const auto& item : sidebar_model_->GetAllSidebarItems()) {
@@ -928,6 +929,10 @@ void SidebarContainerView::StartObservingContextualSidePanelRegistry(
       OnEntryShown(*active_entry);
     }
   }
+}
+
+BraveBrowser* SidebarContainerView::GetBraveBrowser() const {
+  return static_cast<BraveBrowser*>(browser_.get());
 }
 
 BEGIN_METADATA(SidebarContainerView)

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -61,7 +61,7 @@ class SidebarContainerView
       public TabStripModelObserver {
   METADATA_HEADER(SidebarContainerView, views::View)
  public:
-  SidebarContainerView(BraveBrowser* browser,
+  SidebarContainerView(Browser* browser,
                        SidePanelCoordinator* side_panel_coordinator,
                        std::unique_ptr<BraveSidePanel> side_panel);
   ~SidebarContainerView() override;
@@ -187,7 +187,11 @@ class SidebarContainerView
   void StopObservingContextualSidePanelRegistry(content::WebContents* contents);
   void StopObservingContextualSidePanelRegistry(SidePanelRegistry* registry);
 
-  raw_ptr<BraveBrowser> browser_ = nullptr;
+  // Casts |browser_| to BraveBrowser, as storing it as BraveBrowser would cause
+  // a precocious downcast.
+  BraveBrowser* GetBraveBrowser() const;
+
+  raw_ptr<Browser> browser_ = nullptr;
   raw_ptr<SidePanelCoordinator> side_panel_coordinator_ = nullptr;
   raw_ptr<BraveSidePanel> side_panel_ = nullptr;
   raw_ptr<sidebar::SidebarModel> sidebar_model_ = nullptr;


### PR DESCRIPTION
`SidebarContainerView` requires a `BraveBrowser` instance, when `Browser` is constructed but `BraveBrowser` is not fully constructed. This PR changes that to have a casting function doing to be used at a later stage whenever casting to `BraveBrowser` is necessary.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41537

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

