### PR TITLE
Replace requests to `laptop-updates.brave.com` with requests to `usage-ping.brave.com` and `feedback.brave.com`

### DIFF
--- a/android/java/org/chromium/chrome/browser/rate/RateFeedbackUtils.java
+++ b/android/java/org/chromium/chrome/browser/rate/RateFeedbackUtils.java
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 
 public class RateFeedbackUtils {
     private static final String TAG = "Rate_Brave";
-    private static final String RATE_URL = "https://laptop-updates.brave.com/1/feedback";
+    private static final String RATE_URL = "https://feedback.brave.com/1/feedback";
 
     public interface RateFeedbackCallback {
         void rateFeedbackSubmitted();
@@ -69,8 +69,9 @@ public class RateFeedbackUtils {
 
     private static void sendRateFeedback(String userSelection, String userFeedback) {
         Context context = ContextUtils.getApplicationContext();
-        String appVersion = AboutChromeSettings.getApplicationVersion(
-                context, AboutSettingsBridge.getApplicationVersion());
+        String appVersion =
+                AboutChromeSettings.getApplicationVersion(
+                        context, AboutSettingsBridge.getApplicationVersion());
         StringBuilder sb = new StringBuilder();
 
         Profile mProfile = ProfileManager.getLastUsedRegularProfile();
@@ -80,8 +81,10 @@ public class RateFeedbackUtils {
         HttpURLConnection urlConnection = null;
         try {
             URL url = new URL(RATE_URL);
-            urlConnection = (HttpURLConnection) ChromiumNetworkAdapter.openConnection(
-                    url, NetworkTrafficAnnotationTag.MISSING_TRAFFIC_ANNOTATION);
+            urlConnection =
+                    (HttpURLConnection)
+                            ChromiumNetworkAdapter.openConnection(
+                                    url, NetworkTrafficAnnotationTag.MISSING_TRAFFIC_ANNOTATION);
             urlConnection.setDoOutput(true);
             urlConnection.setRequestMethod("POST");
             urlConnection.setUseCaches(false);

--- a/browser/brave_stats/BUILD.gn
+++ b/browser/brave_stats/BUILD.gn
@@ -3,15 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import("//brave/browser/brave_stats/buildflags.gni")
 import("//build/buildflag_header.gni")
-
-declare_args() {
-  brave_stats_updater_url = ""
-}
-
-if (is_official_build) {
-  assert(brave_stats_updater_url != "")
-}
 
 buildflag_header("buildflags") {
   header = "buildflags.h"

--- a/browser/brave_stats/brave_stats_updater_browsertest.cc
+++ b/browser/brave_stats/brave_stats_updater_browsertest.cc
@@ -45,7 +45,7 @@ std::unique_ptr<net::test_server::HttpResponse> HandleRequestForStats(
     const net::test_server::HttpRequest& request) {
   std::unique_ptr<net::test_server::BasicHttpResponse> http_response(
       new net::test_server::BasicHttpResponse());
-  if (request.relative_url == "/promo/initialize/nonua") {
+  if (request.relative_url == "//promo/initialize/nonua") {
     // We need a download id to make promo initialization happy
     http_response->set_code(net::HTTP_OK);
     http_response->set_content("{\"download_id\":\"keur123\"}");
@@ -98,8 +98,7 @@ class BraveStatsUpdaterBrowserTest : public PlatformBrowserTest {
   void SetBaseUpdateURLForTest() {
     std::unique_ptr<base::Environment> env(base::Environment::Create());
     env->SetVar("BRAVE_REFERRALS_SERVER",
-                embedded_test_server()->host_port_pair().ToString());
-    env->SetVar("BRAVE_REFERRALS_LOCAL", "1");  // use http for local testing
+                embedded_test_server()->base_url().spec());
   }
 
   GURL GetUpdateURL() const { return update_url_; }

--- a/browser/brave_stats/buildflags.gni
+++ b/browser/brave_stats/buildflags.gni
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  brave_stats_updater_url = ""
+}
+
+if (is_official_build) {
+  assert(brave_stats_updater_url != "")
+}

--- a/components/brave_referrals/browser/BUILD.gn
+++ b/components/brave_referrals/browser/BUILD.gn
@@ -20,6 +20,7 @@ static_library("browser") {
 
   deps = [
     "//base",
+    "//brave/brave_domains",
     "//brave/components/brave_stats/browser",
     "//brave/components/constants",
     "//brave/vendor/brave_base",

--- a/components/brave_referrals/browser/brave_referrals_service.cc
+++ b/components/brave_referrals/browser/brave_referrals_service.cc
@@ -19,6 +19,7 @@
 #include "base/strings/stringprintf.h"
 #include "base/task/thread_pool.h"
 #include "base/values.h"
+#include "brave/brave_domains/service_domains.h"
 #include "brave/components/brave_referrals/common/pref_names.h"
 #include "brave/components/constants/network_constants.h"
 #include "brave/components/constants/pref_names.h"
@@ -129,15 +130,14 @@ std::string ReadPromoCode(const base::FilePath& promo_code_file) {
 std::string BuildReferralEndpoint(const std::string& path) {
   std::unique_ptr<base::Environment> env(base::Environment::Create());
   std::string referral_server;
-  std::string proto = "https";
   env->GetVar("BRAVE_REFERRALS_SERVER", &referral_server);
-  if (referral_server.empty())
-    referral_server = kBraveReferralsServer;
-  if (env->HasVar("BRAVE_REFERRALS_LOCAL"))
-    proto = "http";
+  if (referral_server.empty()) {
+    auto referral_domain = brave_domains::GetServicesDomain("usage-ping");
+    referral_server = base::StrCat(
+        {url::kHttpsScheme, url::kStandardSchemeSeparator, referral_domain});
+  }
 
-  return base::StringPrintf("%s://%s%s", proto.c_str(), referral_server.c_str(),
-                            path.c_str());
+  return referral_server + path;
 }
 
 }  // namespace

--- a/components/constants/network_constants.h
+++ b/components/constants/network_constants.h
@@ -14,7 +14,6 @@ inline constexpr char kBraveSoftwareProxyPattern[] =
 
 inline constexpr char kBraveUsageStandardPath[] = "/1/usage/brave-core";
 
-inline constexpr char kBraveReferralsServer[] = "laptop-updates.brave.com";
 inline constexpr char kBraveReferralsInitPath[] = "/promo/initialize/nonua";
 inline constexpr char kBraveReferralsActivityPath[] = "/promo/activity";
 

--- a/ios/brave-ios/Sources/Growth/DAU.swift
+++ b/ios/brave-ios/Sources/Growth/DAU.swift
@@ -20,8 +20,8 @@ public class DAU {
     // TODO: Handle via brave-stats-updater-server switch and get URL from brave_stats_updater_url
     let domain =
       AppConstants.isOfficialBuild
-      ? "https://laptop-updates.brave.com/"
-      : "https://laptop-updates.bravesoftware.com/"
+      ? "https://usage-ping.brave.com/"
+      : "https://usage-ping.bravesoftware.com/"
 
     return "\(domain)\(apiVersion)/usage/ios?platform=ios"
   }

--- a/ios/brave-ios/Sources/Growth/URP/UserReferralProgram.swift
+++ b/ios/brave-ios/Sources/Growth/URP/UserReferralProgram.swift
@@ -18,8 +18,8 @@ public class UserReferralProgram {
   public static let shared = UserReferralProgram()
 
   struct HostUrl {
-    static let staging = "https://laptop-updates.bravesoftware.com"
-    static let prod = "https://laptop-updates.brave.com"
+    static let staging = "https://usage-ping.bravesoftware.com"
+    static let prod = "https://usage-ping.brave.com"
   }
 
   let adServicesURLString = "https://api-adservices.apple.com/api/v1/"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/16374

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Use a MITM proxy to ensure that usage pings are sent to `usage-ping.brave.com` and Android feedback is sent to `feedback.brave.com`. On Windows, rename the installer to `Brave-Browser-BRV002.exe`. Use the proxy to ensure a one-time request is sent to `https://usage-ping.brave.com/promo/initialize/nonua` with the refcode (BRV002) included in the body.