### PR TITLE
[CodeHealth] Remove empty param lists for lambdas

### DIFF
--- a/browser/ai_chat/page_content_fetcher_browsertest.cc
+++ b/browser/ai_chat/page_content_fetcher_browsertest.cc
@@ -191,7 +191,7 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContentPDF) {
   ASSERT_TRUE(chat_tab_helper);
   auto run_loop = std::make_unique<base::RunLoop>();
   chat_tab_helper->SetOnPDFA11yInfoLoadedCallbackForTesting(
-      base::BindLambdaForTesting([this, &run_loop, &kExpectedText]() {
+      base::BindLambdaForTesting([this, &run_loop, &kExpectedText] {
         FetchPageContent(FROM_HERE, kExpectedText, false, false);
         run_loop->Quit();
       }));
@@ -200,7 +200,7 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContentPDF) {
 
   run_loop = std::make_unique<base::RunLoop>();
   chat_tab_helper->SetOnPDFA11yInfoLoadedCallbackForTesting(
-      base::BindLambdaForTesting([this, &run_loop]() {
+      base::BindLambdaForTesting([this, &run_loop] {
         FetchPageContent(FROM_HERE, "", false, false);
         run_loop->Quit();
       }));
@@ -217,7 +217,7 @@ IN_PROC_BROWSER_TEST_F(PageContentFetcherBrowserTest, FetchPageContentPDF) {
   chat_tab_helper = ai_chat::AIChatTabHelper::FromWebContents(
       browser()->tab_strip_model()->GetWebContentsAt(1));
   chat_tab_helper->SetOnPDFA11yInfoLoadedCallbackForTesting(
-      base::BindLambdaForTesting([this, &run_loop, &kExpectedText]() {
+      base::BindLambdaForTesting([this, &run_loop, &kExpectedText] {
         FetchPageContent(FROM_HERE, kExpectedText, false, false);
         run_loop->Quit();
       }));

--- a/browser/greaselion/greaselion_browsertest.cc
+++ b/browser/greaselion/greaselion_browsertest.cc
@@ -516,7 +516,7 @@ IN_PROC_BROWSER_TEST_F(GreaselionServiceTest, FoldersAreRemovedOnUpdate) {
   auto io_runner = base::ThreadPool::CreateSequencedTaskRunner(
       {base::MayBlock(), base::TaskShutdownBehavior::BLOCK_SHUTDOWN});
 
-  auto count_folders_on_io_runner = [&io_runner]() {
+  auto count_folders_on_io_runner = [&io_runner] {
     base::RunLoop run_loop;
     size_t folder_count;
 

--- a/browser/importer/brave_external_process_importer_host_unittest.cc
+++ b/browser/importer/brave_external_process_importer_host_unittest.cc
@@ -134,7 +134,7 @@ class BraveExternalProcessImporterHostUnitTest : public testing::Test {
     external_process_host()->StartImportSettings(source_profile, GetProfile(),
                                                  importer::EXTENSIONS, nullptr);
     base::RunLoop loop;
-    ImportEndedObserver observer(base::BindLambdaForTesting([&loop, this]() {
+    ImportEndedObserver observer(base::BindLambdaForTesting([&loop, this] {
       external_process_host_ = nullptr;
       loop.Quit();
     }));

--- a/browser/onboarding/onboarding_unittest.cc
+++ b/browser/onboarding/onboarding_unittest.cc
@@ -108,7 +108,7 @@ TEST_F(OnboardingTest, HelperCreationTestForNonFirstRun) {
   TestingBrowserProcess::GetGlobal()->local_state()->SetTime(
       onboarding::prefs::kLastShieldsIconHighlightTime, base::Time());
   OnboardingTabHelper::MaybeCreateForWebContents(web_contents.get());
-  ASSERT_TRUE(base::test::RunUntil([&tab_helper, &web_contents]() {
+  ASSERT_TRUE(base::test::RunUntil([&tab_helper, &web_contents] {
     tab_helper = OnboardingTabHelper::FromWebContents(web_contents.get());
     return tab_helper;
   }));

--- a/browser/playlist/test/playlist_browsertest.cc
+++ b/browser/playlist/test/playlist_browsertest.cc
@@ -75,7 +75,7 @@ class PlaylistBrowserTest : public PlatformBrowserTest {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run()) {
                         run_loop_->Quit();
                       }

--- a/browser/playlist/test/playlist_service_unittest.cc
+++ b/browser/playlist/test/playlist_service_unittest.cc
@@ -93,7 +93,7 @@ class PlaylistServiceUnitTest : public testing::Test {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run()) {
                         run_loop_->Quit();
                       }

--- a/browser/ui/commander/commander_service_browsertest.cc
+++ b/browser/ui/commander/commander_service_browsertest.cc
@@ -42,7 +42,7 @@ class CommanderServiceBrowserTest : public InProcessBrowserTest {
   void TearDownOnMainThread() override {
     commander()->Hide();
     WaitUntil(base::BindLambdaForTesting(
-        [this]() { return !commander()->IsShowing(); }));
+        [this] { return !commander()->IsShowing(); }));
   }
 
  protected:
@@ -62,7 +62,7 @@ class CommanderServiceBrowserTest : public InProcessBrowserTest {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run()) {
                         run_loop_->Quit();
                       }

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -196,7 +196,7 @@ class SidebarBrowserTest : public InProcessBrowserTest {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run())
                         run_loop_->Quit();
                     }));

--- a/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
+++ b/browser/ui/tabs/test/shared_pinned_tab_service_browsertest.cc
@@ -56,7 +56,7 @@ void SharedPinnedTabServiceBrowserTest::WaitUntil(
 
   base::RepeatingTimer scheduler;
   scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                  base::BindLambdaForTesting([this, &condition]() {
+                  base::BindLambdaForTesting([this, &condition] {
                     if (condition.Run()) {
                       run_loop_->Quit();
                     }

--- a/browser/ui/text_recognition_browsertest.cc
+++ b/browser/ui/text_recognition_browsertest.cc
@@ -74,7 +74,7 @@ class TextRecognitionBrowserTest : public InProcessBrowserTest {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run())
                         run_loop_->Quit();
                     }));

--- a/browser/ui/views/brave_shields/cookie_list_opt_in_browsertest.cc
+++ b/browser/ui/views/brave_shields/cookie_list_opt_in_browsertest.cc
@@ -52,7 +52,7 @@ class CookieListFilterEnabledObserver {
   CookieListFilterEnabledObserver() {
     pref_observer_.Init(g_browser_process->local_state());
     pref_observer_.Add(prefs::kAdBlockRegionalFilters,
-                       base::BindLambdaForTesting([this]() {
+                       base::BindLambdaForTesting([this] {
                          if (IsCookieListFilterEnabled()) {
                            run_loop_.Quit();
                          }

--- a/browser/ui/views/brave_tooltips/brave_tooltips_unittest.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltips_unittest.cc
@@ -17,7 +17,7 @@
 class MockBraveTooltipDelegate : public brave_tooltips::BraveTooltipDelegate {
  public:
   MockBraveTooltipDelegate() {
-    ON_CALL(*this, OnTooltipWidgetDestroyed).WillByDefault([this]() {
+    ON_CALL(*this, OnTooltipWidgetDestroyed).WillByDefault([this] {
       run_loop_.Quit();
     });
   }

--- a/browser/ui/views/location_bar/brave_location_bar_view_browsertest.cc
+++ b/browser/ui/views/location_bar/brave_location_bar_view_browsertest.cc
@@ -74,7 +74,7 @@ class BraveLocationBarViewBrowserTest : public InProcessBrowserTest {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run()) {
                         run_loop_->Quit();
                       }

--- a/browser/ui/views/tabs/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/tab_drag_controller.cc
@@ -207,7 +207,7 @@ void TabDragController::DetachAndAttachToNewContext(
     return;
   }
 
-  auto get_region_view = [this]() {
+  auto get_region_view = [this] {
     auto* browser_view = static_cast<BraveBrowserView*>(
         BrowserView::GetBrowserViewForNativeWindow(
             GetAttachedBrowserWidget()->GetNativeWindow()));

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -192,7 +192,7 @@ class VerticalTabStripBrowserTest : public InProcessBrowserTest {
 
     base::RepeatingTimer scheduler;
     scheduler.Start(FROM_HERE, base::Milliseconds(100),
-                    base::BindLambdaForTesting([this, &condition]() {
+                    base::BindLambdaForTesting([this, &condition] {
                       if (condition.Run()) {
                         run_loop_->Quit();
                       }

--- a/components/brave_news/browser/background_history_querier_unittest.cc
+++ b/components/brave_news/browser/background_history_querier_unittest.cc
@@ -52,7 +52,7 @@ class BraveNewsBackgroundHistoryQuerierTest : public testing::Test {
             {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
              base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})) {
     querier_ = MakeHistoryQuerier(
-        history_service_.AsWeakPtr(), base::BindLambdaForTesting([this]() {
+        history_service_.AsWeakPtr(), base::BindLambdaForTesting([this] {
           return fake_destroyed_ ? nullptr : &tracker_;
         }));
   }

--- a/components/brave_news/browser/publishers_parsing.cc
+++ b/components/brave_news/browser/publishers_parsing.cc
@@ -38,7 +38,7 @@ std::optional<Publishers> ParseCombinedPublisherList(const base::Value& value) {
     }
     auto& entry = *parsed_publisher;
 
-    GURL site_url = [&entry]() {
+    GURL site_url = [&entry] {
       if (base::StartsWith(entry.site_url, "https://")) {
         return GURL(entry.site_url);
       } else {

--- a/components/brave_rewards/core/rewards_engine.cc
+++ b/components/brave_rewards/core/rewards_engine.cc
@@ -272,21 +272,21 @@ void RewardsEngine::RestorePublishers(RestorePublishersCallback callback) {
 }
 
 void RewardsEngine::SetPublisherMinVisitTime(int duration_in_seconds) {
-  WhenReady([this, duration_in_seconds]() {
+  WhenReady([this, duration_in_seconds] {
     state()->SetPublisherMinVisitTime(duration_in_seconds);
   });
 }
 
 void RewardsEngine::SetPublisherMinVisits(int visits) {
-  WhenReady([this, visits]() { state()->SetPublisherMinVisits(visits); });
+  WhenReady([this, visits] { state()->SetPublisherMinVisits(visits); });
 }
 
 void RewardsEngine::SetAutoContributionAmount(double amount) {
-  WhenReady([this, amount]() { state()->SetAutoContributionAmount(amount); });
+  WhenReady([this, amount] { state()->SetAutoContributionAmount(amount); });
 }
 
 void RewardsEngine::SetAutoContributeEnabled(bool enabled) {
-  WhenReady([this, enabled]() { state()->SetAutoContributeEnabled(enabled); });
+  WhenReady([this, enabled] { state()->SetAutoContributeEnabled(enabled); });
 }
 
 void RewardsEngine::GetBalanceReport(mojom::ActivityMonth month,
@@ -451,7 +451,7 @@ void RewardsEngine::RefreshPublisher(const std::string& publisher_key,
 }
 
 void RewardsEngine::StartContributionsForTesting() {
-  WhenReady([this]() {
+  WhenReady([this] {
     contribution()->StartContributionsForTesting();  // IN-TEST
   });
 }
@@ -460,7 +460,7 @@ void RewardsEngine::UpdateMediaDuration(uint64_t window_id,
                                             const std::string& publisher_key,
                                             uint64_t duration,
                                             bool first_visit) {
-  WhenReady([this, window_id, publisher_key, duration, first_visit]() {
+  WhenReady([this, window_id, publisher_key, duration, first_visit] {
     publisher()->UpdateMediaDuration(window_id, publisher_key, duration,
                                      first_visit);
   });

--- a/components/brave_rewards/core/test/rewards_engine_test.h
+++ b/components/brave_rewards/core/test/rewards_engine_test.h
@@ -48,7 +48,7 @@ class RewardsEngineTest : public testing::Test {
   template <typename F>
   void WaitFor(F fn) {
     base::RunLoop run_loop;
-    fn(base::BindLambdaForTesting([&run_loop]() { run_loop.Quit(); }));
+    fn(base::BindLambdaForTesting([&run_loop] { run_loop.Quit(); }));
     run_loop.Run();
   }
 

--- a/components/brave_wallet/browser/ens_resolver_task.cc
+++ b/components/brave_wallet/browser/ens_resolver_task.cc
@@ -289,7 +289,7 @@ void EnsResolverTask::FetchEnsResolver() {
 
 void EnsResolverTask::OnFetchEnsResolverDone(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     task_error_.emplace(MakeInternalError());
@@ -335,7 +335,7 @@ void EnsResolverTask::FetchEnsip10Support() {
 
 void EnsResolverTask::OnFetchEnsip10SupportDone(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     task_error_.emplace(MakeInternalError());
@@ -371,7 +371,7 @@ void EnsResolverTask::FetchEnsRecord() {
 
 void EnsResolverTask::OnFetchEnsRecordDone(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     task_error_.emplace(MakeInternalError());
@@ -422,7 +422,7 @@ void EnsResolverTask::FetchWithEnsip10Resolve() {
 
 void EnsResolverTask::OnFetchWithEnsip10ResolveDone(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     task_error_.emplace(MakeInternalError());
@@ -527,7 +527,7 @@ void EnsResolverTask::FetchOffchainData() {
 }
 
 void EnsResolverTask::OnFetchOffchainDone(APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     task_error_.emplace(MakeInternalError());
@@ -568,7 +568,7 @@ void EnsResolverTask::FetchOffchainCallback() {
 
 void EnsResolverTask::OnFetchOffchainCallbackDone(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     task_error_.emplace(MakeInternalError());

--- a/components/brave_wallet/browser/keyring_service_unittest.cc
+++ b/components/brave_wallet/browser/keyring_service_unittest.cc
@@ -935,7 +935,7 @@ TEST_F(KeyringServiceUnitTest, CreateAndRestoreWallet) {
   service.Reset();
 
   auto verify_restore_wallet = base::BindLambdaForTesting(
-      [&mnemonic_to_be_restored, &service, &address0]() {
+      [&mnemonic_to_be_restored, &service, &address0] {
         EXPECT_TRUE(
             RestoreWallet(&service, *mnemonic_to_be_restored, "brave1", false));
         {

--- a/components/brave_wallet/browser/sns_resolver_task.cc
+++ b/components/brave_wallet/browser/sns_resolver_task.cc
@@ -789,7 +789,7 @@ void SnsResolverTask::FetchNftSplMint() {
 }
 
 void SnsResolverTask::OnFetchNftSplMint(APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     SetError(MakeInternalError());
@@ -827,7 +827,7 @@ void SnsResolverTask::FetchNftTokenOwner() {
 
 void SnsResolverTask::OnFetchNftTokenOwner(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     SetError(MakeInternalError());
@@ -857,7 +857,7 @@ void SnsResolverTask::FetchDomainRegistryState() {
 
 void SnsResolverTask::OnFetchDomainRegistryState(
     APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     SetError(MakeInternalError());
@@ -896,7 +896,7 @@ void SnsResolverTask::FetchNextRecord() {
 }
 
 void SnsResolverTask::OnFetchNextRecord(APIRequestResult api_request_result) {
-  absl::Cleanup cleanup([this]() { this->WorkOnTask(); });
+  absl::Cleanup cleanup([this] { this->WorkOnTask(); });
 
   if (!api_request_result.Is2XXResponseCode()) {
     SetError(MakeInternalError());

--- a/components/de_amp/browser/test/de_amp_browsertest.cc
+++ b/components/de_amp/browser/test/de_amp_browsertest.cc
@@ -170,7 +170,7 @@ class DeAmpBrowserTest : public InProcessBrowserTest {
                       const std::string& content_type,
                       const net::test_server::HttpRequest& request)
         -> std::unique_ptr<net::test_server::HttpResponse> {
-      [&request]() {
+      [&request] {
         // This should never happen, abort test
         ASSERT_EQ(request.headers.find("X-Brave-De-AMP"),
                   request.headers.end());

--- a/components/tor/tor_control_unittest.cc
+++ b/components/tor/tor_control_unittest.cc
@@ -125,7 +125,7 @@ TEST(TorControlTest, ReadDone) {
       std::make_unique<TorControl>(delegate.AsWeakPtr(), io_task_runner);
   base::RunLoop run_loop;
   io_task_runner->PostTask(
-      FROM_HERE, base::BindLambdaForTesting([&run_loop, &control, &delegate]() {
+      FROM_HERE, base::BindLambdaForTesting([&run_loop, &control, &delegate] {
         constexpr char test_str[] =
             "250-SOCKSPORT=9050\r\n250 ORPORT=0\r\n250 OK";
         control->reading_ = true;


### PR DESCRIPTION
In cxx20 and higher, lambda function syntax can omit the empty param list in some cases. This change removes these occurrences to reduce code clutter.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41550

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

