### PR TITLE
Change default font in desktop settings to system fonts

### DIFF
--- a/browser/resources/settings/brave_overrides/settings_menu.ts
+++ b/browser/resources/settings/brave_overrides/settings_menu.ts
@@ -102,7 +102,7 @@ RegisterStyleOverride(
       }
 
       a[href] {
-        font-weight: 400 !important;
+        font-weight: 500 !important;
         margin: 0 20px 20px 0 !important;
         margin-inline-start: 0 !important;
         margin-inline-end: 0 !important;
@@ -120,7 +120,6 @@ RegisterStyleOverride(
 
       a[href].selected {
         color: #DB2F04;
-        font-weight: 400 !important;
       }
 
       a:hover, cr-icon:hover {

--- a/browser/resources/settings/brave_overrides/settings_menu.ts
+++ b/browser/resources/settings/brave_overrides/settings_menu.ts
@@ -64,7 +64,7 @@ RegisterStyleOverride(
         background-color: #fff;
         overflow-y: auto;
         padding: 24px !important;
-        box-shadow: 0px var(--Elevation-xxs, 1px) 0px 0px var(--Semantic-Elevation-Primary, rgba(0, 0, 0, 0.05)), 0px var(--Elevation-xxs, 1px) var(--Elevation-xs, 4px) 0px var(--Semantic-Elevation-Secondary, rgba(0, 0, 0, 0.10));
+        box-shadow: var(--leo-effect-elevation-01);
       }
 
       .cr-nav-menu-item {

--- a/browser/resources/settings/brave_overrides/settings_menu.ts
+++ b/browser/resources/settings/brave_overrides/settings_menu.ts
@@ -52,8 +52,8 @@ RegisterStyleOverride(
   html`
     <style>
       :host {
-        --brave-settings-menu-margin-v: 30px;
-        --brave-settings-menu-padding: 30px;
+        --brave-settings-menu-margin-v: 24px;
+        --brave-settings-menu-padding: 24px;
         --settings-nav-item-color: #424242 !important;
         position: sticky;
         top: var(--brave-settings-menu-margin-v);
@@ -63,7 +63,8 @@ RegisterStyleOverride(
         border-radius: 6px;
         background-color: #fff;
         overflow-y: auto;
-        padding: 30px !important;
+        padding: 24px !important;
+        box-shadow: 0px var(--Elevation-xxs, 1px) 0px 0px var(--Semantic-Elevation-Primary, rgba(0, 0, 0, 0.05)), 0px var(--Elevation-xxs, 1px) var(--Elevation-xs, 4px) 0px var(--Semantic-Elevation-Secondary, rgba(0, 0, 0, 0.10));
       }
 
       .cr-nav-menu-item {
@@ -73,8 +74,8 @@ RegisterStyleOverride(
         box-sizing: content-box !important;
         overflow: visible !important;
 
-        --iron-icon-width: 24px;
-        --iron-icon-height: 24px;
+        --iron-icon-width: 20px;
+        --iron-icon-height: 20px;
         --iron-icon-fill-color: currentColor;
       }
 
@@ -103,7 +104,7 @@ RegisterStyleOverride(
 
       a[href] {
         font-weight: 500 !important;
-        margin: 0 20px 20px 0 !important;
+        margin: 0 20px 24px 0 !important;
         margin-inline-start: 0 !important;
         margin-inline-end: 0 !important;
         padding-bottom: 0 !important;
@@ -128,8 +129,8 @@ RegisterStyleOverride(
 
       cr-icon, leo-icon {
         margin-inline-end: 14px !important;
-        width: 24px;
-        height: 24px;
+        width: 20px;
+        height: 20px;
       }
 
       a[href].selected::before {

--- a/browser/resources/settings/brave_overrides/settings_section.ts
+++ b/browser/resources/settings/brave_overrides/settings_section.ts
@@ -10,9 +10,9 @@ RegisterStyleOverride(
   'settings-section',
   html`
     <style include="settings-shared">
-    #header .title {
-    font-weight: 500 !important;
-    }
+      #header .title {
+        font-weight: 500 !important;
+      }
     </style>
   `
 )

--- a/browser/resources/settings/brave_overrides/settings_section.ts
+++ b/browser/resources/settings/brave_overrides/settings_section.ts
@@ -13,10 +13,9 @@ RegisterStyleOverride(
       #header .title {
         font-weight: 500 !important;
       }
-
       :host(:not(.expanded)) #card {
         box-shadow: var(--leo-effect-elevation-01) !important;
       }
-    </style>
+      </style>
   `
 )

--- a/browser/resources/settings/brave_overrides/settings_section.ts
+++ b/browser/resources/settings/brave_overrides/settings_section.ts
@@ -13,6 +13,10 @@ RegisterStyleOverride(
       #header .title {
         font-weight: 500 !important;
       }
+
+      :host(:not(.expanded)) #card {
+        box-shadow: 0px var(--Elevation-xxs, 1px) 0px 0px var(--Semantic-Elevation-Primary, rgba(0, 0, 0, 0.05)), 0px var(--Elevation-xxs, 1px) var(--Elevation-xs, 4px) 0px var(--Semantic-Elevation-Secondary, rgba(0, 0, 0, 0.10)) !important;
+      }
     </style>
   `
 )

--- a/browser/resources/settings/brave_overrides/settings_section.ts
+++ b/browser/resources/settings/brave_overrides/settings_section.ts
@@ -10,6 +10,9 @@ RegisterStyleOverride(
   'settings-section',
   html`
     <style include="settings-shared">
+    #header .title {
+    font-weight: 500 !important;
+    }
     </style>
   `
 )

--- a/browser/resources/settings/brave_overrides/settings_section.ts
+++ b/browser/resources/settings/brave_overrides/settings_section.ts
@@ -15,7 +15,7 @@ RegisterStyleOverride(
       }
 
       :host(:not(.expanded)) #card {
-        box-shadow: 0px var(--Elevation-xxs, 1px) 0px 0px var(--Semantic-Elevation-Primary, rgba(0, 0, 0, 0.05)), 0px var(--Elevation-xxs, 1px) var(--Elevation-xs, 4px) 0px var(--Semantic-Elevation-Secondary, rgba(0, 0, 0, 0.10)) !important;
+        box-shadow: var(--leo-effect-elevation-01) !important;
       }
     </style>
   `

--- a/browser/resources/settings/default_brave_shields_page/brave_adblock_subpage.html
+++ b/browser/resources/settings/default_brave_shields_page/brave_adblock_subpage.html
@@ -4,7 +4,6 @@
     --table-header-background-color: #E9E9F4;
     --tinted-color: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #FFFFFF 97.4%);
     --text02: #495057;
-    font-family: Poppins;
   }
 
   @media (prefers-color-scheme: dark) {

--- a/browser/resources/settings/default_brave_shields_page/brave_adblock_subpage.html
+++ b/browser/resources/settings/default_brave_shields_page/brave_adblock_subpage.html
@@ -22,6 +22,7 @@
 
   .label.shields-primary-title {
     font-size: 16px;
+    font-family: Poppins,sans-serif;
     font-weight: 500;
     margin: 24px 0 8px 0;
   }

--- a/ui/webui/resources/css/text_defaults_md.css
+++ b/ui/webui/resources/css/text_defaults_md.css
@@ -19,7 +19,7 @@ html {
 }
 
 body {
-  font-family: Poppins, $i18nRaw{fontfamily};
+  font-family: $i18nRaw{fontfamily};
   font-size: 81.25%;
 }
 
@@ -28,7 +28,6 @@ h2,
 h3,
 h4,
 h5,
-h6,
-button {
+h6 {
   font-family: Poppins, $i18nRaw{fontfamily};
 }


### PR DESCRIPTION
Removing Poppins as the font for the settings pages in favor of using the users' default system font. This will make the pages feel a bit more native and modern since we're moving away from Poppins for texts

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41559

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Font should match the System font on the chrome://settings page