### PR TITLE
[CodeHealth] Use `string_view` with l10n utils

### DIFF
--- a/components/l10n/common/locale_subtag_parser_util.cc
+++ b/components/l10n/common/locale_subtag_parser_util.cc
@@ -22,7 +22,7 @@ constexpr char kUnderscoreSeparator = '_';
 constexpr char kCodeSetSeparator = '.';
 constexpr char kVariantSeparator = '@';
 
-std::string NormalizeLocale(const std::string& locale) {
+std::string NormalizeLocale(std::string_view locale) {
   // Calculate length of locale excluding charset and variant.
   const std::string::size_type pos = locale.find_first_of(base::StrCat(
       {std::string{kCodeSetSeparator}, std::string{kVariantSeparator}}));
@@ -53,7 +53,7 @@ std::string& LastLocale() {
 
 }  // namespace
 
-LocaleSubtagInfo ParseLocaleSubtags(const std::string& locale) {
+LocaleSubtagInfo ParseLocaleSubtags(std::string_view locale) {
   if (CachedLocaleSubtag() && LastLocale() == locale) {
     return *CachedLocaleSubtag();
   }

--- a/components/l10n/common/locale_subtag_parser_util.h
+++ b/components/l10n/common/locale_subtag_parser_util.h
@@ -13,7 +13,7 @@ namespace brave_l10n {
 struct LocaleSubtagInfo;
 
 // Parses the given |locale| and returns |LocaleSubtagInfo|.
-LocaleSubtagInfo ParseLocaleSubtags(const std::string& locale);
+LocaleSubtagInfo ParseLocaleSubtags(std::string_view locale);
 
 }  // namespace brave_l10n
 

--- a/components/l10n/common/locale_util.cc
+++ b/components/l10n/common/locale_util.cc
@@ -24,7 +24,7 @@ const std::string& GetDefaultLocaleString() {
   return DefaultLocaleString();
 }
 
-std::string GetISOLanguageCode(const std::string& locale) {
+std::string GetISOLanguageCode(std::string_view locale) {
   std::string language = ParseLocaleSubtags(locale).language;
   if (language.empty()) {
     return kFallbackLanguageCode;
@@ -37,7 +37,7 @@ std::string GetDefaultISOLanguageCodeString() {
   return GetISOLanguageCode(GetDefaultLocaleString());
 }
 
-std::optional<std::string> GetISOScriptCode(const std::string& locale) {
+std::optional<std::string> GetISOScriptCode(std::string_view locale) {
   std::string script = ParseLocaleSubtags(locale).script;
   if (script.empty()) {
     return std::nullopt;
@@ -50,7 +50,7 @@ std::optional<std::string> GetDefaultISOScriptCodeString() {
   return GetISOScriptCode(GetDefaultLocaleString());
 }
 
-std::string GetISOCountryCode(const std::string& locale) {
+std::string GetISOCountryCode(std::string_view locale) {
   std::string country = ParseLocaleSubtags(locale).country;
   if (country.empty()) {
     return kFallbackCountryCode;
@@ -63,7 +63,7 @@ std::string GetDefaultISOCountryCodeString() {
   return GetISOCountryCode(GetDefaultLocaleString());
 }
 
-std::optional<std::string> GetCharSet(const std::string& locale) {
+std::optional<std::string> GetCharSet(std::string_view locale) {
   std::string charset = ParseLocaleSubtags(locale).charset;
   if (charset.empty()) {
     return std::nullopt;
@@ -76,7 +76,7 @@ std::optional<std::string> GetDefaultCharSetString() {
   return GetCharSet(GetDefaultLocaleString());
 }
 
-std::optional<std::string> GetVariant(const std::string& locale) {
+std::optional<std::string> GetVariant(std::string_view locale) {
   std::string variant_code = ParseLocaleSubtags(locale).variant;
   if (variant_code.empty()) {
     return std::nullopt;

--- a/components/l10n/common/locale_util.h
+++ b/components/l10n/common/locale_util.h
@@ -23,7 +23,7 @@ const std::string& GetDefaultLocaleString();
 // Returns a lowercase two-letter ISO 639-1 language code for the given locale,
 // falling back to "en" if the locale does not contain a language code. See
 // https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes.
-std::string GetISOLanguageCode(const std::string& locale);
+std::string GetISOLanguageCode(std::string_view locale);
 
 // Returns a lowercase two-letter ISO 639-1 language code for the current
 // default locale of the device as a string, falling back to "en" if the locale
@@ -33,7 +33,7 @@ std::string GetDefaultISOLanguageCodeString();
 
 // Returns an optional sentence case four-letter ISO 15924 script code for the
 // given locale. See https://en.wikipedia.org/wiki/ISO_15924.
-std::optional<std::string> GetISOScriptCode(const std::string& locale);
+std::optional<std::string> GetISOScriptCode(std::string_view locale);
 
 // Returns an optional sentence case four-letter ISO 15924 script code for the
 // current default locale of the device as a string. See
@@ -45,7 +45,7 @@ std::optional<std::string> GetDefaultISOScriptCodeString();
 // contain a country code. See
 // https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 or
 // https://en.wikipedia.org/wiki/UN_M49.
-std::string GetISOCountryCode(const std::string& locale);
+std::string GetISOCountryCode(std::string_view locale);
 
 // Returns an uppercase two-letter ISO 3166-1 alpha-2 country code or UN M.49
 // code for the current default locale of the device as a string, falling back
@@ -55,7 +55,7 @@ std::string GetISOCountryCode(const std::string& locale);
 std::string GetDefaultISOCountryCodeString();
 
 // Returns an optional charset specifier for the given locale.
-std::optional<std::string> GetCharSet(const std::string& locale);
+std::optional<std::string> GetCharSet(std::string_view locale);
 
 // Returns an optional charset for the current default locale of the device as a
 // string.
@@ -63,7 +63,7 @@ std::optional<std::string> GetDefaultCharSetString();
 
 // Returns optional well-recognized variations that define a language or its
 // dialects for the given locale.
-std::optional<std::string> GetVariant(const std::string& locale);
+std::optional<std::string> GetVariant(std::string_view locale);
 
 // Returns optional well-recognized variations that define a language or its
 // dialects for the current default locale of the device as a string.


### PR DESCRIPTION
In general, for functions that merely string values, it is better to pass them as `string_view` rather than `const string&` as this allows caller to use `string_view` too. It also avoids `string` instantiations for literals.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

