### PR TITLE
Add IPFS Component build flag, some other review suggestions follow up

### DIFF
--- a/browser/brave_browser_main_parts.cc
+++ b/browser/brave_browser_main_parts.cc
@@ -18,6 +18,7 @@
 #include "brave/components/brave_sync/features.h"
 #include "brave/components/constants/brave_constants.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "build/build_config.h"
@@ -56,7 +57,6 @@
 #include "brave/browser/infobars/brave_confirm_p3a_infobar_delegate.h"
 #include "brave/browser/infobars/brave_sync_account_deleted_infobar_delegate.h"
 #include "brave/browser/infobars/sync_cannot_run_infobar_delegate.h"
-#include "brave/components/ipfs/ipfs_component_cleaner.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_finder.h"
 #include "components/infobars/content/content_infobar_manager.h"
@@ -69,6 +69,10 @@
 #include "chrome/browser/extensions/extension_service.h"
 #include "extensions/browser/extension_system.h"
 #endif
+
+#if BUILDFLAG(DEPRECATE_IPFS)
+#include "brave/components/ipfs/ipfs_component_cleaner.h"
+#endif  // BUILDFLAG(DEPRECATE_IPFS)
 
 ChromeBrowserMainParts::ChromeBrowserMainParts(bool is_integration_test,
                                                StartupData* startup_data)
@@ -163,10 +167,10 @@ void ChromeBrowserMainParts::PostBrowserStart() {
   }
 #endif  // !BUILDFLAG(IS_ANDROID)
 
-#if !BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(DEPRECATE_IPFS)
   ipfs::CleanupIpfsComponent(
       base::PathService::CheckedGet(chrome::DIR_USER_DATA));
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(DEPRECATE_IPFS)
 }
 
 void ChromeBrowserMainParts::PreShutdown() {

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -190,6 +190,7 @@ brave_chrome_browser_deps = [
   "//brave/components/greaselion/browser/buildflags",
   "//brave/components/https_upgrade_exceptions/browser",
   "//brave/components/ipfs",
+  "//brave/components/ipfs/buildflags",
   "//brave/components/l10n/common",
   "//brave/components/localhost_permission",
   "//brave/components/ntp_background_images/browser",

--- a/components/ipfs/BUILD.gn
+++ b/components/ipfs/BUILD.gn
@@ -3,6 +3,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/ipfs/buildflags/buildflags.gni")
+
 static_library("ipfs") {
   sources = [
     "ipfs_prefs.cc",
@@ -11,7 +13,16 @@ static_library("ipfs") {
     "ipfs_utils.h",
   ]
 
+  if (deprecate_ipfs) {
+    sources += [
+      "ipfs_common.h",
+      "ipfs_component_cleaner.cc",
+      "ipfs_component_cleaner.h",
+    ]
+  }
+
   deps = [
+    "buildflags",
     "//base",
     "//brave/components/filecoin/rs:rust_lib",
     "//components/base32",
@@ -19,12 +30,4 @@ static_library("ipfs") {
     "//net",
     "//url",
   ]
-
-  if (!is_android && !is_ios) {
-    sources += [
-      "ipfs_common.h",
-      "ipfs_component_cleaner.cc",
-      "ipfs_component_cleaner.h",
-    ]
-  }
 }

--- a/components/ipfs/buildflags/BUILD.gn
+++ b/components/ipfs/buildflags/BUILD.gn
@@ -1,0 +1,12 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import("//brave/components/ipfs/buildflags/buildflags.gni")
+import("//build/buildflag_header.gni")
+
+buildflag_header("buildflags") {
+  header = "buildflags.h"
+  flags = [ "DEPRECATE_IPFS=$deprecate_ipfs" ]
+}

--- a/components/ipfs/buildflags/buildflags.gni
+++ b/components/ipfs/buildflags/buildflags.gni
@@ -1,0 +1,8 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+declare_args() {
+  deprecate_ipfs = !is_android && !is_ios
+}

--- a/components/ipfs/test/BUILD.gn
+++ b/components/ipfs/test/BUILD.gn
@@ -3,19 +3,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#import("//brave/build/config.gni")
-#import("//brave/components/ipfs/buildflags/buildflags.gni")
+import("//brave/components/ipfs/buildflags/buildflags.gni")
 import("//testing/test.gni")
 source_set("brave_ipfs_unit_tests") {
   testonly = true
 
   sources = [ "//brave/components/ipfs/ipfs_utils_unittest.cc" ]
 
-  if (!is_android && !is_ios) {
-    sources += [
-      "//brave/components/ipfs/ipfs_component_cleaner.cc",
-      "//brave/components/ipfs/ipfs_component_cleaner_unittest.cc",
-    ]
+  if (deprecate_ipfs) {
+    sources += [ "//brave/components/ipfs/ipfs_component_cleaner_unittest.cc" ]
   }
 
   deps = [


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41626

Created build flag: `deprecate_ipfs`, if enabled, we include special ipfs local node cleaner, which removes the ipfs local node and related files

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

