### PR TITLE
Notify users about a pending update sooner

### DIFF
--- a/app/brave_main_delegate.cc
+++ b/app/brave_main_delegate.cc
@@ -54,6 +54,8 @@ constexpr char kBraveOriginTrialsPublicKey[] =
 
 constexpr char kDummyUrl[] = "https://no-thanks.invalid";
 
+constexpr char kPendingUpdatePollingIntervalSec[] = "900";
+
 std::string GetUpdateURLHost() {
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
@@ -168,6 +170,14 @@ void BraveMainDelegate::AppendCommandLineOptions() {
   if (!command_line->HasSwitch(syncer::kSyncServiceURL)) {
     command_line->AppendSwitchASCII(syncer::kSyncServiceURL,
                                     brave_sync_service_url.c_str());
+  }
+
+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kCheckForUpdateIntervalSec)) {
+    // We want to prompt the user to restart the browser within 15, not 120,
+    // minutes when a new version is available.
+    command_line->AppendSwitchASCII(switches::kCheckForUpdateIntervalSec,
+                                    kPendingUpdatePollingIntervalSec);
   }
 
   variations::AppendBraveCommandLineOptions(*command_line);

--- a/app/brave_main_delegate_browsertest.cc
+++ b/app/brave_main_delegate_browsertest.cc
@@ -42,3 +42,10 @@ IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest, OriginTrialsTest) {
             base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
                 embedder_support::kOriginTrialPublicKey));
 }
+
+IN_PROC_BROWSER_TEST_F(BraveMainDelegateBrowserTest,
+                       LowerDefaultCheckForUpdateIntervalSec) {
+  EXPECT_EQ(base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
+                switches::kCheckForUpdateIntervalSec),
+            "900");
+}

--- a/app/brave_main_delegate_unittest.cc
+++ b/app/brave_main_delegate_unittest.cc
@@ -10,6 +10,7 @@
 #include "base/command_line.h"
 #include "brave/components/brave_sync/buildflags.h"
 #include "brave/components/variations/buildflags.h"
+#include "chrome/common/chrome_switches.h"
 #include "components/embedder_support/switches.h"
 #include "components/sync/base/command_line_switches.h"
 #include "components/variations/variations_switches.h"
@@ -46,9 +47,12 @@ TEST(BraveMainDelegateUnitTest, OverrideSwitchFromCommandLine) {
   base::CommandLine& command_line = *base::CommandLine::ForCurrentProcess();
   const std::string override_sync_url = "https://sync.com";
   const std::string override_origin_trials_public_key = "public_key";
+  const std::string override_check_for_update_interval_sec = "12345";
   command_line.AppendSwitchASCII(syncer::kSyncServiceURL, override_sync_url);
   command_line.AppendSwitchASCII(embedder_support::kOriginTrialPublicKey,
                                  override_origin_trials_public_key);
+  command_line.AppendSwitchASCII(switches::kCheckForUpdateIntervalSec,
+                                 override_check_for_update_interval_sec);
 
   BraveMainDelegate::AppendCommandLineOptions();
 
@@ -58,5 +62,9 @@ TEST(BraveMainDelegateUnitTest, OverrideSwitchFromCommandLine) {
   ASSERT_STREQ(
       override_origin_trials_public_key.c_str(),
       command_line.GetSwitchValueASCII(embedder_support::kOriginTrialPublicKey)
+          .c_str());
+  ASSERT_STREQ(
+      override_check_for_update_interval_sec.c_str(),
+      command_line.GetSwitchValueASCII(switches::kCheckForUpdateIntervalSec)
           .c_str());
 }


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/41446

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

