### PR TITLE
Disable TFLITE_USE_STD_ALIGNED_ALLOC on Android

### DIFF
--- a/build/commands/scripts/updatePatches.js
+++ b/build/commands/scripts/updatePatches.js
@@ -30,11 +30,13 @@ module.exports = function RunCommand (options) {
   const catapultDir = path.join(config.srcDir, 'third_party', 'catapult')
   const devtoolsFrontendDir = path.join(config.srcDir, 'third_party', 'devtools-frontend', 'src')
   const ffmpegDir = path.join(config.srcDir, 'third_party', 'ffmpeg')
+  const tfliteDir = path.join(config.srcDir, 'third_party', 'tflite', 'src')
   const patchDir = path.join(config.braveCoreDir, 'patches')
   const v8PatchDir = path.join(patchDir, 'v8')
   const catapultPatchDir = path.join(patchDir, 'third_party', 'catapult')
   const devtoolsFrontendPatchDir = path.join(patchDir, 'third_party', 'devtools-frontend', 'src')
   const ffmpegPatchDir = path.join(patchDir, 'third_party', 'ffmpeg')
+  const tflitePatchDir = path.join(patchDir, 'third_party', 'tflite', 'src')
 
   Promise.all([
     // chromium
@@ -47,6 +49,8 @@ module.exports = function RunCommand (options) {
     updatePatches(devtoolsFrontendDir, devtoolsFrontendPatchDir),
     // third_party/ffmpeg
     updatePatches(ffmpegDir, ffmpegPatchDir),
+    // third_party/tflite/src
+    updatePatches(tfliteDir, tflitePatchDir)
   ])
   .then(() => {
     console.log('Done.')

--- a/patches/third_party/tflite/src/tensorflow-lite-simple_memory_arena.cc.patch
+++ b/patches/third_party/tflite/src/tensorflow-lite-simple_memory_arena.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/tensorflow/lite/simple_memory_arena.cc b/tensorflow/lite/simple_memory_arena.cc
+index f1299b56ac75027a683c421cb9d32c96d5fb1ed6..11e13e9d5a259496bb7090fcae038a217fc986b0 100644
+--- a/tensorflow/lite/simple_memory_arena.cc
++++ b/tensorflow/lite/simple_memory_arena.cc
+@@ -34,7 +34,7 @@ limitations under the License.
+ #if defined(__ANDROID__)
+ // Android has C11 aligned_alloc only with API 28 or newer, even with C++17 or
+ // C11 compilation (this is a non-standard behavior).
+-#define TF_LITE_HAS_ALIGNED_ALLOC (__ANDROID_API__ >= 28)
++#define TF_LITE_HAS_ALIGNED_ALLOC 0
+ #elif defined(__APPLE__)
+ // Apple does not provide aligned_alloc, even with C++17 or C11 compilation
+ // (this is a non-standard behavior).


### PR DESCRIPTION
because aligned_alloc conflicts with chromium allocator shim

credit to @bridiver for narrowing down the root cause.

chromium override is not feasible because
if we do 

```
#include "src/third_party/tflite/src/tensorflow/lite/simple_memory_arena.cc"                                                                                                                                                                            
#if defined(__ANDROID__)                                                                                                                                                                                                                                
#undef TF_LITE_HAS_ALIGNED_ALLOC 
#define TF_LITE_HAS_ALIGNED_ALLOC 0 
#endif  
```
it would be too late because the preprocessor already expand the macro
but if we do
```
#if defined(__ANDROID__)                                                                                                                                                                                                                                
#undef TF_LITE_HAS_ALIGNED_ALLOC
#define TF_LITE_HAS_ALIGNED_ALLOC 0 
#endif                                                                                                                                                                                                                                                  
#include "src/third_party/tflite/src/tensorflow/lite/simple_memory_arena.cc"    
```
the compiler will complain redefinition of the macro in upstream file

And if would redefine `__ANDROID_API__` to be 0, it would be too risky if any include headers contains that.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41481

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable brave-ai-chat-page-content-refine flag
2. Visit https://www.brianbondy.com/blog/187/cocodona-2024
3. Open Leo and ask Who was the pacer?
4. Browser should not crash

