### PR TITLE
Add `usage-ping.brave.com` to pinned TLS, HSTS and network audit lists (uplift to 1.71.x)

### DIFF
--- a/browser/net/brave_network_audit_allowed_lists.h
+++ b/browser/net/brave_network_audit_allowed_lists.h
@@ -23,8 +23,11 @@ inline constexpr const char* kAllowedUrlPrefixes[] = {
     "https://updates.bravesoftware.com/",
 
     // stats/referrals
+    // TODO(djandries): remove laptop-updates and laptop-updates-staging once
+    // https://github.com/brave/brave-browser/issues/16374 hits release
     "https://laptop-updates.brave.com/",
     "https://laptop-updates-staging.brave.com/",
+    "https://usage-ping.brave.com/",
 
     // needed for DoH on Mac build machines
     "https://dns.google/dns-query",

--- a/chromium_src/chrome/browser/net/profile_network_context_service.cc
+++ b/chromium_src/chrome/browser/net/profile_network_context_service.cc
@@ -4,9 +4,12 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 static const char* kBraveCTExcludedHosts[] = {
     // Critical endpoints that shouldn't require SCTs so they always work
+    // TODO(djandries): remove laptop-updates once
+    // https://github.com/brave/brave-browser/issues/16374 hits release
     "laptop-updates.brave.com",
     "updates.bravesoftware.com",
     "updates-cdn.bravesoftware.com",
+    "usage-ping.brave.com",
     // Test host for manual testing
     "sct-exempted.bravesoftware.com",
 };

--- a/chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc
+++ b/chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc
@@ -39,7 +39,6 @@ constexpr std::string_view kBravePinsJson = R"brave_pins_json({
     // Brave
     { "name": "adblock-data.s3.brave.com", "pins": "brave"},
     { "name": "ai-chat.bsg.brave.com", "pins": "brave"},
-    { "name": "feedback.brave.com", "pins": "brave"},
     { "name": "brave-core-ext.s3.brave.com", "pins": "brave"},
     { "name": "brave-today-cdn.brave.com", "pins": "brave"},
     { "name": "clients4.brave.com", "pins": "brave"},
@@ -48,6 +47,7 @@ constexpr std::string_view kBravePinsJson = R"brave_pins_json({
     { "name": "devtools.brave.com", "pins": "brave"},
     { "name": "dict.brave.com", "pins": "brave"},
     { "name": "extensionupdater.brave.com", "pins": "brave"},
+    { "name": "feedback.brave.com", "pins": "brave"},
     { "name": "gaia.brave.com", "pins": "brave"},
     { "name": "go-updater.brave.com", "pins": "brave"},
     { "name": "mobile-data.s3.brave.com", "pins": "brave"},
@@ -136,6 +136,8 @@ constexpr std::string_view kBraveHstsJson = R"brave_hsts_json({
   "entries": [
     // Critical endpoints that should remain unpinned so that they
     // always work.
+    // TODO(djandries): remove laptop-updates once
+    // https://github.com/brave/brave-browser/issues/16374 hits release
     {
       "name": "laptop-updates.brave.com",
       "mode": "force-https",
@@ -151,6 +153,11 @@ constexpr std::string_view kBraveHstsJson = R"brave_hsts_json({
       "mode": "force-https",
       "policy": "custom"
     },
+    {
+      "name": "usage-ping.brave.com",
+      "mode": "force-https",
+      "policy": "custom"
+    },
 
     // Brave
     {
@@ -160,11 +167,6 @@ constexpr std::string_view kBraveHstsJson = R"brave_hsts_json({
     },
     {
       "name": "ai-chat.bsg.brave.com",
-      "mode": "force-https",
-      "policy": "custom"
-    },
-    {
-      "name": "feedback.brave.com",
       "mode": "force-https",
       "policy": "custom"
     },
@@ -205,6 +207,11 @@ constexpr std::string_view kBraveHstsJson = R"brave_hsts_json({
     },
     {
       "name": "extensionupdater.brave.com",
+      "mode": "force-https",
+      "policy": "custom"
+    },
+    {
+      "name": "feedback.brave.com",
       "mode": "force-https",
       "policy": "custom"
     },


### PR DESCRIPTION
Uplift of #26023
Resolves https://github.com/brave/brave-browser/issues/41659

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.