### PR TITLE
Disable TFLITE_USE_STD_ALIGNED_ALLOC on Android (uplift to 1.71.x)

### DIFF
--- a/build/commands/scripts/updatePatches.js
+++ b/build/commands/scripts/updatePatches.js
@@ -30,11 +30,13 @@ module.exports = function RunCommand (options) {
   const catapultDir = path.join(config.srcDir, 'third_party', 'catapult')
   const devtoolsFrontendDir = path.join(config.srcDir, 'third_party', 'devtools-frontend', 'src')
   const ffmpegDir = path.join(config.srcDir, 'third_party', 'ffmpeg')
+  const tfliteDir = path.join(config.srcDir, 'third_party', 'tflite', 'src')
   const patchDir = path.join(config.braveCoreDir, 'patches')
   const v8PatchDir = path.join(patchDir, 'v8')
   const catapultPatchDir = path.join(patchDir, 'third_party', 'catapult')
   const devtoolsFrontendPatchDir = path.join(patchDir, 'third_party', 'devtools-frontend', 'src')
   const ffmpegPatchDir = path.join(patchDir, 'third_party', 'ffmpeg')
+  const tflitePatchDir = path.join(patchDir, 'third_party', 'tflite', 'src')
 
   Promise.all([
     // chromium
@@ -47,6 +49,8 @@ module.exports = function RunCommand (options) {
     updatePatches(devtoolsFrontendDir, devtoolsFrontendPatchDir),
     // third_party/ffmpeg
     updatePatches(ffmpegDir, ffmpegPatchDir),
+    // third_party/tflite/src
+    updatePatches(tfliteDir, tflitePatchDir)
   ])
   .then(() => {
     console.log('Done.')

--- a/patches/third_party/tflite/src/tensorflow-lite-simple_memory_arena.cc.patch
+++ b/patches/third_party/tflite/src/tensorflow-lite-simple_memory_arena.cc.patch
@@ -1,0 +1,13 @@
+diff --git a/tensorflow/lite/simple_memory_arena.cc b/tensorflow/lite/simple_memory_arena.cc
+index f1299b56ac75027a683c421cb9d32c96d5fb1ed6..11e13e9d5a259496bb7090fcae038a217fc986b0 100644
+--- a/tensorflow/lite/simple_memory_arena.cc
++++ b/tensorflow/lite/simple_memory_arena.cc
+@@ -34,7 +34,7 @@ limitations under the License.
+ #if defined(__ANDROID__)
+ // Android has C11 aligned_alloc only with API 28 or newer, even with C++17 or
+ // C11 compilation (this is a non-standard behavior).
+-#define TF_LITE_HAS_ALIGNED_ALLOC (__ANDROID_API__ >= 28)
++#define TF_LITE_HAS_ALIGNED_ALLOC 0
+ #elif defined(__APPLE__)
+ // Apple does not provide aligned_alloc, even with C++17 or C11 compilation
+ // (this is a non-standard behavior).


### PR DESCRIPTION
Uplift of #26006
Resolves https://github.com/brave/brave-browser/issues/41481

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.