### PR TITLE
Add NTT reach metrics

### DIFF
--- a/browser/ntp_background/android/ntp_background_images_bridge.cc
+++ b/browser/ntp_background/android/ntp_background_images_bridge.cc
@@ -173,12 +173,14 @@ NTPBackgroundImagesBridge::CreateBrandedWallpaper(
       data.FindBool(ntp_background_images::kIsSponsoredKey).value_or(false);
   auto* creative_instance_id =
       data.FindString(ntp_background_images::kCreativeInstanceIDKey);
+  auto* campaign_id = data.FindString(ntp_background_images::kCampaignIdKey);
   const std::string* wallpaper_id =
       data.FindString(ntp_background_images::kWallpaperIDKey);
 
   view_counter_service_->BrandedWallpaperWillBeDisplayed(
       wallpaper_id ? *wallpaper_id : "",
-      creative_instance_id ? *creative_instance_id : "");
+      creative_instance_id ? *creative_instance_id : "",
+      campaign_id ? *campaign_id : "");
 
   return Java_NTPBackgroundImagesBridge_createBrandedWallpaper(
       env, ConvertUTF8ToJavaString(env, *image_path), focal_point_x,

--- a/browser/ntp_background/ntp_p3a_helper_impl.h
+++ b/browser/ntp_background/ntp_p3a_helper_impl.h
@@ -10,7 +10,9 @@
 #include <string>
 
 #include "base/callback_list.h"
+#include "base/scoped_observation.h"
 #include "base/timer/timer.h"
+#include "brave/components/ntp_background_images/browser/ntp_background_images_service.h"
 #include "brave/components/ntp_background_images/browser/ntp_p3a_helper.h"
 
 class PrefRegistrySimple;
@@ -23,22 +25,28 @@ enum class MetricLogType;
 
 namespace ntp_background_images {
 
-class NTPP3AHelperImpl : public NTPP3AHelper {
+class NTPP3AHelperImpl : public NTPP3AHelper,
+                         public NTPBackgroundImagesService::Observer {
  public:
   NTPP3AHelperImpl(PrefService* local_state,
                    p3a::P3AService* p3a_service,
+                   ntp_background_images::NTPBackgroundImagesService*
+                       ntp_background_images_service,
                    PrefService* prefs,
                    bool use_uma_for_testing = false);
   ~NTPP3AHelperImpl() override;
 
   static void RegisterLocalStatePrefs(PrefRegistrySimple* registry);
 
-  void RecordView(const std::string& creative_instance_id) override;
+  void RecordView(const std::string& creative_instance_id,
+                  const std::string& campaign_id) override;
 
   void RecordClickAndMaybeLand(
       const std::string& creative_instance_id) override;
 
   void SetLastTabURL(const GURL& url) override;
+
+  void CheckLoadedCampaigns(const NTPSponsoredImagesData& data);
 
   // See BraveP3AService::RegisterDynamicMetric and
   // BraveP3AService::RegisterMetricCycledCallback header comments for more
@@ -48,24 +56,30 @@ class NTPP3AHelperImpl : public NTPP3AHelper {
                          bool is_constellation);
 
  private:
-  std::string BuildHistogramName(const std::string& creative_instance_id,
-                                 const std::string& event_type);
-
-  void RecordMetric(const std::string& histogram_name,
-                    int count,
-                    bool is_constellation);
+  void RecordCreativeMetric(const std::string& histogram_name,
+                            int count,
+                            bool is_constellation);
   void RemoveMetricIfInstanceDoesNotExist(
       const std::string& histogram_name,
       const std::string& event_type,
       const std::string& creative_instance_id);
+  void CleanOldCampaignsAndCreatives();
 
   void UpdateMetricCount(const std::string& creative_instance_id,
                          const std::string& event_type);
+
+  void UpdateCampaignMetric(const std::string& campaign_id,
+                            const std::string& event_type);
 
   void OnLandingStartCheck(const std::string& creative_instance_id);
 
   void OnLandingEndCheck(const std::string& creative_instance_id,
                          const std::string& expected_hostname);
+
+  // NTPBackgroundImagesService::Observer:
+  void OnUpdated(NTPBackgroundImagesData* data) override;
+  void OnUpdated(NTPSponsoredImagesData* data) override;
+  void OnSuperReferralEnded() override;
 
   raw_ptr<PrefService> local_state_;
   raw_ptr<p3a::P3AService> p3a_service_;
@@ -78,6 +92,11 @@ class NTPP3AHelperImpl : public NTPP3AHelper {
   base::CallbackListSubscription metric_sent_subscription_;
   base::CallbackListSubscription rotation_subscription_;
 
+  base::ScopedObservation<NTPBackgroundImagesService,
+                          NTPBackgroundImagesService::Observer>
+      ntp_background_images_service_observation_{this};
+
+  const bool is_json_deprecated_;
   bool use_uma_for_testing_;
 };
 

--- a/browser/ntp_background/view_counter_service_factory.cc
+++ b/browser/ntp_background/view_counter_service_factory.cc
@@ -84,7 +84,9 @@ ViewCounterServiceFactory::BuildServiceInstanceForBrowserContext(
     if (g_brave_browser_process->p3a_service() != nullptr) {
       ntp_p3a_helper = std::make_unique<NTPP3AHelperImpl>(
           g_browser_process->local_state(),
-          g_brave_browser_process->p3a_service(), profile->GetPrefs());
+          g_brave_browser_process->p3a_service(),
+          g_brave_browser_process->ntp_background_images_service(),
+          profile->GetPrefs());
     }
 
     return std::make_unique<ViewCounterService>(

--- a/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_message_handler.cc
@@ -554,9 +554,12 @@ void BraveNewTabMessageHandler::HandleGetWallpaperData(
       data->FindString(ntp_background_images::kCreativeInstanceIDKey);
   const std::string* wallpaper_id =
       data->FindString(ntp_background_images::kWallpaperIDKey);
+  const std::string* campaign_id =
+      data->FindString(ntp_background_images::kCampaignIdKey);
   service->BrandedWallpaperWillBeDisplayed(
       wallpaper_id ? *wallpaper_id : "",
-      creative_instance_id ? *creative_instance_id : "");
+      creative_instance_id ? *creative_instance_id : "",
+      campaign_id ? *campaign_id : "");
 
   constexpr char kBrandedWallpaperKey[] = "brandedWallpaper";
   wallpaper.Set(kBrandedWallpaperKey, std::move(*data));

--- a/components/ntp_background_images/browser/ntp_p3a_helper.h
+++ b/components/ntp_background_images/browser/ntp_p3a_helper.h
@@ -16,7 +16,8 @@ class NTPP3AHelper {
  public:
   virtual ~NTPP3AHelper() {}
 
-  virtual void RecordView(const std::string& creative_instance_id) = 0;
+  virtual void RecordView(const std::string& creative_instance_id,
+                          const std::string& campaign_id) = 0;
 
   virtual void RecordClickAndMaybeLand(
       const std::string& creative_instance_id) = 0;

--- a/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_images_data.cc
@@ -372,6 +372,7 @@ std::optional<base::Value::Dict> NTPSponsoredImagesData::GetBackgroundAt(
   }
   data.Set(kWallpaperConditionMatchersKey, std::move(condition_matchers));
 
+  data.Set(kCampaignIdKey, campaign.campaign_id);
   data.Set(kCreativeInstanceIDKey,
            campaign.backgrounds[background_index].creative_instance_id);
 

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -143,7 +143,8 @@ ViewCounterService::~ViewCounterService() = default;
 
 void ViewCounterService::BrandedWallpaperWillBeDisplayed(
     const std::string& wallpaper_id,
-    const std::string& creative_instance_id) {
+    const std::string& creative_instance_id,
+    const std::string& campaign_id) {
   if (ads_service_) {
     ads_service_->TriggerNewTabPageAdEvent(
         wallpaper_id, creative_instance_id,
@@ -152,7 +153,7 @@ void ViewCounterService::BrandedWallpaperWillBeDisplayed(
 
     if (ntp_p3a_helper_) {
       // Should only report to P3A if rewards is disabled, as required by spec.
-      ntp_p3a_helper_->RecordView(creative_instance_id);
+      ntp_p3a_helper_->RecordView(creative_instance_id, campaign_id);
     }
   }
 

--- a/components/ntp_background_images/browser/view_counter_service.h
+++ b/components/ntp_background_images/browser/view_counter_service.h
@@ -97,7 +97,8 @@ class ViewCounterService : public KeyedService,
   std::string GetSuperReferralCode() const;
 
   void BrandedWallpaperWillBeDisplayed(const std::string& wallpaper_id,
-                                       const std::string& creative_instance_id);
+                                       const std::string& creative_instance_id,
+                                       const std::string& campaign_id);
 
   NTPBackgroundImagesData* GetCurrentWallpaperData() const;
   // Gets the current data for branded wallpaper, if there

--- a/components/p3a/metric_log_store.cc
+++ b/components/p3a/metric_log_store.cc
@@ -15,6 +15,7 @@
 #include "base/rand_util.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
+#include "brave/components/p3a/metric_log_type.h"
 #include "brave/components/p3a/uploader.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
@@ -53,7 +54,8 @@ bool IsMetricP2A(const std::string& histogram_name) {
 }
 
 bool IsMetricCreative(const std::string& histogram_name) {
-  return histogram_name.starts_with(kCreativeMetricPrefix);
+  return histogram_name.starts_with(kCreativeMetricPrefix) ||
+         histogram_name.starts_with(kCampaignMetricPrefix);
 }
 
 }  // namespace

--- a/components/p3a/metric_log_type.h
+++ b/components/p3a/metric_log_type.h
@@ -13,6 +13,7 @@
 namespace p3a {
 
 inline constexpr char kCreativeMetricPrefix[] = "creativeInstanceId.";
+inline constexpr char kCampaignMetricPrefix[] = "campaignId.";
 
 enum class MetricLogType {
   // Slow metrics are currently sent once per month.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41680

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Only evaluate the `logs_express` P3A pref.

0. Start with fresh profile using the following flags: `--disable-features="BraveP3AOtherJSONDeprecation,BraveP3ATypicalJSONDeprecation" --use-dev-goupdater-url`
1. Wait 20 seconds, access local state. Ensure one or more 'aware' metrics exist in `logs_express`.
2. Wait until the metrics are marked as sent. Close browser and advance system time by 1 day.
3. Open browser, ensure metrics no longer exist.
4. Open a new tab page, refresh until you see a sponsored image.
5. Ensure a 'viewed' metric now exists.
6. Wait until the metric is marked as sent, close the new tab, close the browser and advance system time by 1 day.
7. Open browser, ensure metric no longer exists. Ensure `creativeInstanceId.<creative id>.views` does exist.