### PR TITLE
[DanglingPtr] Cherry-pick upstream build failure fix

### DIFF
--- a/patches/base-allocator-partition_allocator-partition_alloc.gni.patch
+++ b/patches/base-allocator-partition_allocator-partition_alloc.gni.patch
@@ -1,0 +1,15 @@
+diff --git a/base/allocator/partition_allocator/partition_alloc.gni b/base/allocator/partition_allocator/partition_alloc.gni
+index 2b589ddd153214e237c1028f6be736351754a6f0..f320b815d1a500dffc299471140a21ff2e5d03c7 100644
+--- a/base/allocator/partition_allocator/partition_alloc.gni
++++ b/base/allocator/partition_allocator/partition_alloc.gni
+@@ -284,7 +284,9 @@ stack_scan_supported =
+ # - has_memory_tagging
+ if (!use_partition_alloc ||
+     (defined(toolchain_allows_use_partition_alloc_as_malloc) &&
+-     !toolchain_allows_use_partition_alloc_as_malloc)) {
++     !toolchain_allows_use_partition_alloc_as_malloc) ||
++    (defined(toolchain_for_rust_host_build_tools) &&
++     toolchain_for_rust_host_build_tools)) {
+   use_partition_alloc_as_malloc = false
+   glue_core_pools = false
+   enable_backup_ref_ptr_support = false


### PR DESCRIPTION
I had to spend some significant bysecting this and it turns out rust tools don't support sanitisers, which was breaking the experimental build with dangling pointers.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/b250fcef54d8631d6fc09d1936980fa81ccaf4d0

    commit b250fcef54d8631d6fc09d1936980fa81ccaf4d0
    Author: danakj <danakj@chromium.org>
    Date:   Tue Oct 1 17:57:51 2024 +0000

        Disable PA-based features in the Rust host tools toolchain (proc macros)

        If the user explicitly turns on ASAN and use_raw_ptr_asan_unowned_impl
        we don't want to use those in the host tools toolchain. Elsewhere we
        disable ASAN in the toolchain in build/config/sanitizers/sanitizers.gni:
        ```
        if (!is_a_target_toolchain || toolchain_for_rust_host_build_tools) {
          is_asan = false
        ```

        But that leaves use_raw_ptr_asan_unowned_impl on without ASAN which then
        causes GN assertions and badness.

        The rust host tools toolchain should just use default allocators anyway
        so that the proc macro DLLs use the same allocator as the compiler that
        dlopens them.

        Bug: 40212971

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

