### PR TITLE
Open Leo from search

### DIFF
--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -712,6 +712,17 @@
     Allowed to access localhost resources
   </message>
 
+  <!-- AI chat setting -->
+  <message name="IDS_SETTINGS_SITE_SETTINGS_BRAVE_OPEN_AI_CHAT" desc="Label for opening Leo AI chat site settings.">
+    Leo AI chat
+  </message>
+  <message name="IDS_SETTINGS_SITE_SETTINGS_BRAVE_OPEN_AI_CHAT_ASK" desc="Label for the enabled option of opening Leo AI chat site settings.">
+    Sites can ask to open Leo AI chat
+  </message>
+  <message name="IDS_SETTINGS_SITE_SETTINGS_BRAVE_OPEN_AI_CHAT_BLOCK" desc="Label for the disabled option of opening Leo AI chat site settings.">
+    Don't allow site to open Leo AI chat
+  </message>
+
   <!-- Settings / Privacy and security / Safety Check -->
   <message name="IDS_SETTINGS_BRAVE_SAFETY_CHECK_SAFE_BROWSING_ENABLED_STANDARD_AVAILABLE_ENHANCED" desc="This text points out that Safe Browsing is enabled as standard protection.">
     Standard protection is on.

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -361,44 +361,47 @@
 #endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
-#define BRAVE_AI_CHAT                                          \
-  EXPAND_FEATURE_ENTRIES({                                     \
-      "brave-ai-chat",                                         \
-      "Brave AI Chat",                                         \
-      "Summarize articles and engage in conversation with AI", \
-      kOsWin | kOsMac | kOsLinux | kOsAndroid,                 \
-      FEATURE_VALUE_TYPE(ai_chat::features::kAIChat),          \
-  })
-#define BRAVE_AI_CHAT_HISTORY                                \
-  EXPAND_FEATURE_ENTRIES({                                   \
-      "brave-ai-chat-history",                               \
-      "Brave AI Chat History",                               \
-      "Enables AI Chat History persistence and management",  \
-      kOsWin | kOsMac | kOsLinux,                            \
-      FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory), \
-  })
-#define BRAVE_AI_CHAT_CONTEXT_MENU_REWRITE_IN_PLACE                      \
-  EXPAND_FEATURE_ENTRIES({                                               \
-      "brave-ai-chat-context-menu-rewrite-in-place",                     \
-      "Brave AI Chat Rewrite In Place From Context Menu",                \
-      "Enables AI Chat rewrite in place feature from the context menu",  \
-      kOsDesktop,                                                        \
-      FEATURE_VALUE_TYPE(ai_chat::features::kContextMenuRewriteInPlace), \
-  })
-#define BRAVE_AI_CHAT_PAGE_CONTENT_REFINE                                   \
-  EXPAND_FEATURE_ENTRIES({                                                  \
-      "brave-ai-chat-page-content-refine",                                  \
-      "Brave AI Chat Page Content Refine",                                  \
-      "Enable local text embedding for long page content in order to find " \
-      "most relevant parts to the prompt within context limit.",            \
-      kOsDesktop | kOsAndroid,                                              \
-      FEATURE_VALUE_TYPE(ai_chat::features::kPageContentRefine),            \
-  })
+#define BRAVE_AI_CHAT_FEATURE_ENTRIES                                        \
+  EXPAND_FEATURE_ENTRIES(                                                    \
+      {                                                                      \
+          "brave-ai-chat",                                                   \
+          "Brave AI Chat",                                                   \
+          "Summarize articles and engage in conversation with AI",           \
+          kOsWin | kOsMac | kOsLinux | kOsAndroid,                           \
+          FEATURE_VALUE_TYPE(ai_chat::features::kAIChat),                    \
+      },                                                                     \
+      {                                                                      \
+          "brave-ai-chat-history",                                           \
+          "Brave AI Chat History",                                           \
+          "Enables AI Chat History persistence and management",              \
+          kOsWin | kOsMac | kOsLinux,                                        \
+          FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory),             \
+      },                                                                     \
+      {                                                                      \
+          "brave-ai-chat-context-menu-rewrite-in-place",                     \
+          "Brave AI Chat Rewrite In Place From Context Menu",                \
+          "Enables AI Chat rewrite in place feature from the context menu",  \
+          kOsDesktop,                                                        \
+          FEATURE_VALUE_TYPE(ai_chat::features::kContextMenuRewriteInPlace), \
+      },                                                                     \
+      {                                                                      \
+          "brave-ai-chat-page-content-refine",                               \
+          "Brave AI Chat Page Content Refine",                               \
+          "Enable local text embedding for long page content in order to "   \
+          "find "                                                            \
+          "most relevant parts to the prompt within context limit.",         \
+          kOsDesktop | kOsAndroid,                                           \
+          FEATURE_VALUE_TYPE(ai_chat::features::kPageContentRefine),         \
+      },                                                                     \
+      {                                                                      \
+          "brave-ai-chat-open-leo-from-brave-search",                        \
+          "Open Leo AI Chat from Brave Search",                              \
+          "Enables opening Leo AI Chat from Brave Search",                   \
+          kOsDesktop | kOsAndroid,                                           \
+          FEATURE_VALUE_TYPE(ai_chat::features::kOpenAIChatFromBraveSearch), \
+      })
 #else
-#define BRAVE_AI_CHAT
-#define BRAVE_AI_CHAT_HISTORY
-#define BRAVE_AI_CHAT_CONTEXT_MENU_REWRITE_IN_PLACE
-#define BRAVE_AI_CHAT_PAGE_CONTENT_REFINE
+#define BRAVE_AI_CHAT_FEATURE_ENTRIES
 #endif
 #if BUILDFLAG(ENABLE_AI_REWRITER)
 #define BRAVE_AI_REWRITER                                     \
@@ -980,10 +983,7 @@
   BRAVE_SAFE_BROWSING_ANDROID                                                  \
   BRAVE_CHANGE_ACTIVE_TAB_ON_SCROLL_EVENT_FEATURE_ENTRIES                      \
   BRAVE_TABS_FEATURE_ENTRIES                                                   \
-  BRAVE_AI_CHAT                                                                \
-  BRAVE_AI_CHAT_HISTORY                                                        \
-  BRAVE_AI_CHAT_CONTEXT_MENU_REWRITE_IN_PLACE                                  \
-  BRAVE_AI_CHAT_PAGE_CONTENT_REFINE                                            \
+  BRAVE_AI_CHAT_FEATURE_ENTRIES                                                \
   BRAVE_AI_REWRITER                                                            \
   BRAVE_OMNIBOX_FEATURES                                                       \
   BRAVE_MIDDLE_CLICK_AUTOSCROLL_FEATURE_ENTRY                                  \

--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -10,12 +10,12 @@ assert(enable_ai_chat)
 
 static_library("ai_chat") {
   sources = [
-    "//brave/browser/ai_chat/ai_chat_service_factory.cc",
-    "//brave/browser/ai_chat/ai_chat_service_factory.h",
-    "//brave/browser/ai_chat/ai_chat_settings_helper.cc",
-    "//brave/browser/ai_chat/ai_chat_settings_helper.h",
-    "//brave/browser/ai_chat/ai_chat_utils.cc",
-    "//brave/browser/ai_chat/ai_chat_utils.h",
+    "ai_chat_service_factory.cc",
+    "ai_chat_service_factory.h",
+    "ai_chat_settings_helper.cc",
+    "ai_chat_settings_helper.h",
+    "ai_chat_utils.cc",
+    "ai_chat_utils.h",
   ]
 
   deps = [
@@ -46,7 +46,10 @@ static_library("ai_chat") {
 
 source_set("unit_tests") {
   testonly = true
-  sources = [ "ai_chat_throttle_unittest.cc" ]
+  sources = [
+    "ai_chat_throttle_unittest.cc",
+    "brave_open_ai_chat_permission_context_unittest.cc",
+  ]
 
   deps = [
     "//base",
@@ -70,6 +73,7 @@ source_set("browser_tests") {
     sources = [
       "//chrome/browser/renderer_context_menu/render_view_context_menu_browsertest_util.cc",
       "//chrome/browser/renderer_context_menu/render_view_context_menu_browsertest_util.h",
+      "ai_chat_brave_search_throttle_browsertest.cc",
       "ai_chat_browsertests.cc",
       "ai_chat_metrics_browsertest.cc",
       "ai_chat_policy_browsertest.cc",

--- a/browser/ai_chat/ai_chat_brave_search_throttle_browsertest.cc
+++ b/browser/ai_chat/ai_chat_brave_search_throttle_browsertest.cc
@@ -1,0 +1,242 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h"
+
+#include <memory>
+#include <string>
+
+#include "base/files/file_path.h"
+#include "base/location.h"
+#include "base/path_service.h"
+#include "base/strings/string_util.h"
+#include "brave/browser/ui/brave_browser.h"
+#include "brave/browser/ui/sidebar/sidebar_controller.h"
+#include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "brave/components/constants/brave_paths.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/permissions/permission_request_manager.h"
+#include "components/permissions/test/mock_permission_prompt_factory.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
+#include "content/public/test/test_navigation_observer.h"
+#include "content/public/test/test_utils.h"
+#include "net/base/net_errors.h"
+#include "net/dns/mock_host_resolver.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+constexpr char kBraveSearchHost[] = "search.brave.com";
+constexpr char kLeoPath[] = "/leo";
+constexpr char kOpenAIChatButtonValidPath[] = "/open_ai_chat_button_valid.html";
+constexpr char kOpenAIChatButtonInvalidPath[] =
+    "/open_ai_chat_button_invalid.html";
+
+}  // namespace
+
+// TODO(jocelyn): This should be changed to PlatformBrowserTest when we support
+// Android. https://github.com/brave/brave-browser/issues/41905
+class AIChatBraveSearchThrottleBrowserTest : public InProcessBrowserTest {
+ public:
+  AIChatBraveSearchThrottleBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    host_resolver()->AddRule("*", "127.0.0.1");
+    content::SetupCrossSiteRedirector(&https_server_);
+
+    base::FilePath test_data_dir =
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA);
+    test_data_dir = test_data_dir.AppendASCII("leo");
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    ASSERT_TRUE(https_server_.Start());
+
+    permissions::PermissionRequestManager* manager =
+        permissions::PermissionRequestManager::FromWebContents(
+            GetActiveWebContents());
+    prompt_factory_ =
+        std::make_unique<permissions::MockPermissionPromptFactory>(manager);
+  }
+
+  void TearDownOnMainThread() override {
+    prompt_factory_.reset();
+    InProcessBrowserTest::TearDownOnMainThread();
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+  }
+
+  content::WebContents* GetActiveWebContents() {
+    return browser()->tab_strip_model()->GetActiveWebContents();
+  }
+
+  void ClickOpenAIChatButton() {
+    // Modify the href to have test server port and click it.
+    ASSERT_TRUE(content::ExecJs(GetActiveWebContents()->GetPrimaryMainFrame(),
+                                content::JsReplace(R"(
+            const link = document.getElementById('continue-with-leo')
+            const url = new URL(link.href)
+            url.port = $1
+            link.href = url.href
+            link.click())",
+                                                   https_server_.port())));
+  }
+
+  bool IsLeoOpened() {
+    sidebar::SidebarController* controller =
+        static_cast<BraveBrowser*>(browser())->sidebar_controller();
+    auto index = controller->model()->GetIndexOf(
+        sidebar::SidebarItem::BuiltInItemType::kChatUI);
+    return index.has_value() && controller->IsActiveIndex(index);
+  }
+
+  void CloseLeoPanel(const base::Location& location) {
+    SCOPED_TRACE(testing::Message() << location.ToString());
+    sidebar::SidebarController* controller =
+        static_cast<BraveBrowser*>(browser())->sidebar_controller();
+    controller->DeactivateCurrentPanel();
+    ASSERT_FALSE(IsLeoOpened());
+  }
+
+  void NavigateToTestPage(const base::Location& location,
+                          const std::string& host,
+                          const std::string& path,
+                          int expected_prompt_count) {
+    SCOPED_TRACE(testing::Message() << location.ToString());
+    ASSERT_TRUE(content::NavigateToURL(GetActiveWebContents(),
+                                       https_server_.GetURL(host, path)));
+    EXPECT_FALSE(IsLeoOpened());
+    EXPECT_EQ(expected_prompt_count, prompt_factory_->show_count());
+  }
+
+  void ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      const base::Location& location,
+      int expected_prompt_count,
+      bool expected_leo_opened,
+      const std::string& expected_last_committed_path =
+          kOpenAIChatButtonValidPath) {
+    SCOPED_TRACE(testing::Message() << location.ToString());
+    content::TestNavigationObserver observer(
+        GetActiveWebContents(), net::ERR_ABORTED,
+        content::MessageLoopRunner::QuitMode::IMMEDIATE,
+        false /* ignore_uncommitted_navigations */);
+    ClickOpenAIChatButton();
+    observer.Wait();
+
+    EXPECT_EQ(IsLeoOpened(), expected_leo_opened);
+    EXPECT_EQ(expected_prompt_count, prompt_factory_->show_count());
+    EXPECT_EQ(observer.last_navigation_url().path_piece(), kLeoPath);
+    EXPECT_EQ(GetActiveWebContents()->GetLastCommittedURL().path_piece(),
+              expected_last_committed_path);
+  }
+
+ protected:
+  net::test_server::EmbeddedTestServer https_server_;
+  std::unique_ptr<permissions::MockPermissionPromptFactory> prompt_factory_;
+
+ private:
+  content::ContentMockCertVerifier mock_cert_verifier_;
+};
+
+IN_PROC_BROWSER_TEST_F(AIChatBraveSearchThrottleBrowserTest,
+                       OpenAIChat_AskAndAccept) {
+  int cur_prompt_count = 0;
+  prompt_factory_->set_response_type(
+      permissions::PermissionRequestManager::ACCEPT_ALL);
+  NavigateToTestPage(FROM_HERE, kBraveSearchHost, kOpenAIChatButtonValidPath,
+                     cur_prompt_count);
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, ++cur_prompt_count,
+      /*expected_leo_opened=*/true);
+
+  CloseLeoPanel(FROM_HERE);
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, cur_prompt_count,
+      /*expected_leo_opened=*/true);
+}
+
+IN_PROC_BROWSER_TEST_F(AIChatBraveSearchThrottleBrowserTest,
+                       OpenAIChat_AskAndDeny) {
+  int cur_prompt_count = 0;
+  prompt_factory_->set_response_type(
+      permissions::PermissionRequestManager::DENY_ALL);
+  NavigateToTestPage(FROM_HERE, kBraveSearchHost, kOpenAIChatButtonValidPath,
+                     cur_prompt_count);
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, ++cur_prompt_count, /*expected_leo_opened=*/false);
+
+  // Clicking a button again to test no new permission prompt should be shown
+  // when the permission setting is denied.
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, cur_prompt_count,
+      /*expected_leo_opened=*/false);
+}
+
+IN_PROC_BROWSER_TEST_F(AIChatBraveSearchThrottleBrowserTest,
+                       OpenAIChat_AskAndDismiss) {
+  int cur_prompt_count = 0;
+  prompt_factory_->set_response_type(
+      permissions::PermissionRequestManager::DISMISS);
+  NavigateToTestPage(FROM_HERE, kBraveSearchHost, kOpenAIChatButtonValidPath,
+                     cur_prompt_count);
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, ++cur_prompt_count, /*expected_leo_opened=*/false);
+
+  // Click a button again after dismissing the permission, permission prompt
+  // should be shown again.
+  prompt_factory_->set_response_type(
+      permissions::PermissionRequestManager::ACCEPT_ALL);
+  NavigateToTestPage(FROM_HERE, kBraveSearchHost, kOpenAIChatButtonValidPath,
+                     cur_prompt_count);
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, ++cur_prompt_count,
+      /*expected_leo_opened=*/true);
+}
+
+IN_PROC_BROWSER_TEST_F(AIChatBraveSearchThrottleBrowserTest,
+                       OpenAIChat_MismatchedNonce) {
+  int cur_prompt_count = 0;
+  NavigateToTestPage(FROM_HERE, kBraveSearchHost, kOpenAIChatButtonInvalidPath,
+                     cur_prompt_count);
+  // No permission prompt should be shown.
+  ClickOpenAIChatAndCheckLeoOpenedAndNavigationCancelled(
+      FROM_HERE, cur_prompt_count, /*expected_leo_opened=*/false,
+      kOpenAIChatButtonInvalidPath);
+}
+
+IN_PROC_BROWSER_TEST_F(AIChatBraveSearchThrottleBrowserTest,
+                       OpenAIChat_NotBraveSearchURL) {
+  // The behavior should be the same as without the throttle.
+  NavigateToTestPage(FROM_HERE, "brave.com", kOpenAIChatButtonValidPath, 0);
+  content::TestNavigationObserver observer(GetActiveWebContents());
+  ClickOpenAIChatButton();
+  observer.Wait();
+
+  EXPECT_FALSE(IsLeoOpened());
+  EXPECT_EQ(0, prompt_factory_->show_count());
+  EXPECT_TRUE(observer.last_navigation_succeeded());
+  EXPECT_EQ(observer.last_navigation_url().path_piece(), kLeoPath);
+  EXPECT_EQ(GetActiveWebContents()->GetLastCommittedURL().path_piece(),
+            kLeoPath);
+}

--- a/browser/ai_chat/brave_open_ai_chat_permission_context_unittest.cc
+++ b/browser/ai_chat/brave_open_ai_chat_permission_context_unittest.cc
@@ -1,0 +1,115 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/permissions/contexts/brave_open_ai_chat_permission_context.h"
+
+#include <memory>
+
+#include "base/run_loop.h"
+#include "base/test/bind.h"
+#include "chrome/test/base/chrome_render_view_host_test_harness.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "components/permissions/permission_request_data.h"
+#include "components/permissions/permission_request_id.h"
+#include "components/permissions/permission_request_manager.h"
+#include "components/permissions/test/mock_permission_prompt_factory.h"
+#include "content/public/browser/permission_result.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace permissions {
+
+class BraveOpenAIChatPermissionContextTest
+    : public ChromeRenderViewHostTestHarness {
+ public:
+  BraveOpenAIChatPermissionContextTest() = default;
+  ~BraveOpenAIChatPermissionContextTest() override = default;
+
+  ContentSetting RequestPermission(
+      BraveOpenAIChatPermissionContext* permission_context,
+      const GURL& url) {
+    NavigateAndCommit(url);
+    prompt_factory_->DocumentOnLoadCompletedInPrimaryMainFrame();
+
+    const PermissionRequestID id(
+        web_contents()->GetPrimaryMainFrame()->GetGlobalId(),
+        PermissionRequestID::RequestLocalId());
+    ContentSetting setting = ContentSetting::CONTENT_SETTING_DEFAULT;
+    base::RunLoop run_loop;
+    permission_context->RequestPermission(
+        PermissionRequestData(permission_context, id, /*user_gesture=*/true,
+                              url),
+        base::BindLambdaForTesting([&](ContentSetting result) {
+          setting = result;
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+
+    return setting;
+  }
+
+ protected:
+  void SetUp() override {
+    ChromeRenderViewHostTestHarness::SetUp();
+    PermissionRequestManager::CreateForWebContents(web_contents());
+    PermissionRequestManager* manager =
+        PermissionRequestManager::FromWebContents(web_contents());
+    prompt_factory_ = std::make_unique<MockPermissionPromptFactory>(manager);
+  }
+
+  void TearDown() override {
+    prompt_factory_.reset();
+    ChromeRenderViewHostTestHarness::TearDown();
+  }
+
+  std::unique_ptr<MockPermissionPromptFactory> prompt_factory_;
+};
+
+TEST_F(BraveOpenAIChatPermissionContextTest, PromptForBraveSearch) {
+  GURL brave_search_url("https://search.brave.com");
+
+  prompt_factory_->set_response_type(PermissionRequestManager::ACCEPT_ALL);
+  BraveOpenAIChatPermissionContext context(browser_context());
+  EXPECT_EQ(ContentSetting::CONTENT_SETTING_ALLOW,
+            RequestPermission(&context, brave_search_url));
+  EXPECT_EQ(prompt_factory_->show_count(), 1);
+}
+
+TEST_F(BraveOpenAIChatPermissionContextTest, BlockForNonBraveSearch) {
+  GURL brave_url("https://brave.com");
+
+  prompt_factory_->set_response_type(PermissionRequestManager::ACCEPT_ALL);
+  BraveOpenAIChatPermissionContext context(browser_context());
+  EXPECT_EQ(ContentSetting::CONTENT_SETTING_BLOCK,
+            RequestPermission(&context, brave_url));
+  EXPECT_EQ(prompt_factory_->show_count(), 0);
+}
+
+TEST_F(BraveOpenAIChatPermissionContextTest, NotAllowedInInsecureOrigins) {
+  BraveOpenAIChatPermissionContext permission_context(browser_context());
+  GURL insecure_url("http://search.brave.com");
+  GURL secure_url("https://search.brave.com");
+
+  EXPECT_EQ(content::PermissionStatus::DENIED,
+            permission_context
+                .GetPermissionStatus(nullptr /* render_frame_host */,
+                                     insecure_url, insecure_url)
+                .status);
+
+  EXPECT_EQ(content::PermissionStatus::DENIED,
+            permission_context
+                .GetPermissionStatus(nullptr /* render_frame_host */,
+                                     insecure_url, secure_url)
+                .status);
+
+  EXPECT_EQ(content::PermissionStatus::ASK,
+            permission_context
+                .GetPermissionStatus(nullptr /* render_frame_host */,
+                                     secure_url, secure_url)
+                .status);
+}
+
+}  // namespace permissions

--- a/browser/brave_content_browser_client.cc
+++ b/browser/brave_content_browser_client.cc
@@ -156,7 +156,9 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 #endif
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/browser/ai_chat/ai_chat_service_factory.h"
 #include "brave/browser/ui/webui/ai_chat/ai_chat_ui.h"
+#include "brave/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
 #include "brave/components/ai_chat/content/browser/ai_chat_throttle.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
@@ -164,6 +166,9 @@ using extensions::ChromeContentBrowserClientExtensionsPart;
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
 #include "brave/components/ai_chat/core/common/mojom/settings_helper.mojom.h"
+#if !BUILDFLAG(IS_ANDROID)
+#include "brave/browser/ui/ai_chat/utils.h"
+#endif
 #if BUILDFLAG(IS_ANDROID)
 #include "brave/components/ai_chat/core/browser/android/ai_chat_iap_subscription_android.h"
 #endif
@@ -1268,6 +1273,16 @@ BraveContentBrowserClient::CreateThrottlesForNavigation(
       throttles.push_back(std::move(ai_chat_throttle));
     }
   }
+
+#if !BUILDFLAG(IS_ANDROID)
+  if (auto ai_chat_brave_search_throttle =
+          ai_chat::AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
+              base::BindOnce(&ai_chat::OpenAIChatForTab), handle,
+              ai_chat::AIChatServiceFactory::GetForBrowserContext(context),
+              user_prefs::UserPrefs::Get(context))) {
+    throttles.push_back(std::move(ai_chat_brave_search_throttle));
+  }
+#endif
 #endif  // ENABLE_AI_CHAT
 
   return throttles;

--- a/browser/resources/settings/brave_overrides/privacy_page.ts
+++ b/browser/resources/settings/brave_overrides/privacy_page.ts
@@ -181,6 +181,36 @@ function InsertShieldsSubpage (pages: Element)
     `)
 }
 
+function InsertBraveOpenAIChatSubpage (pages: Element)
+{
+  pages.appendChild(
+    html`
+      <template is="dom-if" route-path="/content/braveOpenAIChat" no-search>
+        <settings-subpage
+          associated-control="[[$$('#braveAIChat')]]"
+          page-title="${loadTimeData.getString('siteSettingsBraveOpenAIChat')}">
+          <settings-category-default-radio-group
+              id="braveAIChatDefault"
+              category="[[contentSettingsTypesEnum_.BRAVE_OPEN_AI_CHAT]]"
+              block-option-label=
+                "${loadTimeData.getString('siteSettingsBraveOpenAIChatBlock')}"
+              allow-option-label=
+                "${loadTimeData.getString('siteSettingsBraveOpenAIChatAsk')}"
+              allow-option-icon="user"
+              block-option-icon="user-off">
+          </settings-category-default-radio-group>
+          <category-setting-exceptions
+            id="braveAIChatExceptions"
+            category="[[contentSettingsTypesEnum_.BRAVE_OPEN_AI_CHAT]]"
+            block-header="${loadTimeData.getString('siteSettingsBlock')}"
+            allow-header="${loadTimeData.getString('siteSettingsAllow')}"
+            read-only-list>
+          </category-setting-exceptions>
+        </settings-subpage>
+      </template>
+    `)
+}
+
 RegisterPolymerTemplateModifications({
   'settings-privacy-page': (templateContent) => {
     const pages = templateContent.getElementById('pages')
@@ -207,6 +237,11 @@ RegisterPolymerTemplateModifications({
         loadTimeData.getBoolean('isLocalhostAccessFeatureEnabled')
       if (isLocalhostAccessFeatureEnabled) {
         InsertLocalhostAccessSubpage(pages)
+      }
+      const isOpenAIChatFromBraveSearchEnabled =
+        loadTimeData.getBoolean('isOpenAIChatFromBraveSearchEnabled')
+      if (isOpenAIChatFromBraveSearchEnabled) {
+        InsertBraveOpenAIChatSubpage(pages)
       }
       InsertAutoplaySubpage(pages)
       const isNativeBraveWalletEnabled =

--- a/browser/resources/settings/brave_overrides/site_details.ts
+++ b/browser/resources/settings/brave_overrides/site_details.ts
@@ -99,6 +99,32 @@ RegisterPolymerTemplateModifications({
         }
         curChild++
       }
+      // AI Chat feature
+      const isOpenLeoFromBraveSearchFeatureEnabled =
+        loadTimeData.getBoolean('isOpenLeoFromBraveSearchFeatureEnabled')
+      const isOpenAIChatFromBraveSearchEnabled =
+        loadTimeData.getBoolean('isOpenAIChatFromBraveSearchEnabled')
+      if (isOpenAIChatFromBraveSearchEnabled && isOpenLeoFromBraveSearchFeatureEnabled) {
+        firstPermissionItem.insertAdjacentHTML(
+          'beforebegin',
+          getTrustedHTML`
+            <site-details-permission
+              category="[[contentSettingsTypesEnum_.BRAVE_OPEN_AI_CHAT]]"
+              icon="user">
+            </site-details-permission>
+          `)
+        const braveAIChatSettings = templateContent.
+          querySelector(`div.list-frame > site-details-permission:nth-child(${curChild})`)
+        if (!braveAIChatSettings) {
+          console.error(
+            '[Brave Settings Overrides] Couldn\'t find Brave AI chat settings')
+        }
+        else {
+          braveAIChatSettings.setAttribute(
+            'label', loadTimeData.getString('siteSettingsBraveOpenAIChat'))
+        }
+        curChild++
+      }
       const isNativeBraveWalletEnabled = loadTimeData.getBoolean('isNativeBraveWalletFeatureEnabled')
       if (isNativeBraveWalletEnabled) {
         firstPermissionItem.insertAdjacentHTML(

--- a/browser/resources/settings/brave_overrides/site_settings_page.ts
+++ b/browser/resources/settings/brave_overrides/site_settings_page.ts
@@ -137,6 +137,21 @@ RegisterPolymerComponentReplacement(
               lists_.permissionsAdvanced.splice(currentIndex, 0,
                 localhostAccessItem)
             }
+            const isOpenAIChatFromBraveSearchEnabled =
+              loadTimeData.getBoolean('isOpenAIChatFromBraveSearchEnabled')
+            if (isOpenAIChatFromBraveSearchEnabled) {
+              currentIndex++
+              const AIChatItem = {
+                route: routes.SITE_SETTINGS_BRAVE_OPEN_AI_CHAT,
+                id: 'braveOpenAIChat',
+                label: 'siteSettingsBraveOpenAIChat',
+                icon: 'product-brave-leo',
+                enabledLabel: 'siteSettingsBraveOpenAIChatAsk',
+                disabledLabel: 'siteSettingsBraveOpenAIChatBlock'
+              }
+              lists_.permissionsAdvanced.splice(currentIndex, 0,
+                AIChatItem)
+            }
             const isNativeBraveWalletEnabled = loadTimeData.getBoolean('isNativeBraveWalletFeatureEnabled')
             if (isNativeBraveWalletEnabled) {
               currentIndex++

--- a/browser/resources/settings/brave_routes.ts
+++ b/browser/resources/settings/brave_routes.ts
@@ -75,6 +75,10 @@ export default function addBraveRoutes(r: Partial<SettingsRoutes>) {
       r.SITE_SETTINGS_LOCALHOST_ACCESS = r.SITE_SETTINGS
         .createChild('localhostAccess')
     }
+    const isOpenAIChatFromBraveSearchEnabled = loadTimeData.getBoolean('isOpenAIChatFromBraveSearchEnabled')
+    if (isOpenAIChatFromBraveSearchEnabled) {
+      r.SITE_SETTINGS_BRAVE_OPEN_AI_CHAT = r.SITE_SETTINGS.createChild('braveOpenAIChat')
+    }
     const isNativeBraveWalletFeatureEnabled = loadTimeData.getBoolean('isNativeBraveWalletFeatureEnabled')
     if (isNativeBraveWalletFeatureEnabled) {
       r.SITE_SETTINGS_ETHEREUM = r.SITE_SETTINGS.createChild('ethereum')

--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -348,6 +348,10 @@ if (enable_ai_chat) {
     "//brave/components/ai_chat/core/common/mojom",
   ]
 
+  if (!is_android) {
+    brave_chrome_browser_deps += [ "//brave/browser/ui/ai_chat" ]
+  }
+
   if (is_android) {
     brave_chrome_browser_sources += brave_browser_ai_chat_android_sources
     brave_chrome_browser_deps += brave_browser_ai_chat_android_deps

--- a/browser/ui/ai_chat/BUILD.gn
+++ b/browser/ui/ai_chat/BUILD.gn
@@ -3,6 +3,24 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//brave/components/ai_chat/core/common/buildflags/buildflags.gni")
+assert(enable_ai_chat)
+
+if (!is_android) {
+  source_set("ai_chat") {
+    sources = [
+      "utils.cc",
+      "utils.h",
+    ]
+
+    deps = [
+      "//chrome/browser/ui/browser_window",
+      "//chrome/browser/ui/tabs",
+      "//chrome/browser/ui/views/side_panel",
+    ]
+  }
+}
+
 source_set("unit_tests") {
   testonly = true
   sources = [ "ai_chat_tab_helper_unittest.cc" ]

--- a/browser/ui/ai_chat/ai_chat_tab_helper_unittest.cc
+++ b/browser/ui/ai_chat/ai_chat_tab_helper_unittest.cc
@@ -51,6 +51,10 @@ class MockPageContentFetcher
               GetSearchSummarizerKey,
               (mojom::PageContentExtractor::GetSearchSummarizerKeyCallback),
               (override));
+  MOCK_METHOD(void,
+              GetOpenAIChatButtonNonce,
+              (mojom::PageContentExtractor::GetOpenAIChatButtonNonceCallback),
+              (override));
 };
 
 class MockAssociatedContentObserver : public AssociatedContentDriver::Observer {

--- a/browser/ui/ai_chat/utils.cc
+++ b/browser/ui/ai_chat/utils.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/ai_chat/utils.h"
+
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/tabs/public/tab_interface.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_entry_id.h"
+
+namespace ai_chat {
+
+void OpenAIChatForTab(content::WebContents* web_contents) {
+  if (!web_contents) {
+    return;
+  }
+
+  auto* tab = tabs::TabInterface::GetFromContents(web_contents);
+  auto* coordinator =
+      tab->GetBrowserWindowInterface()->GetFeatures().side_panel_coordinator();
+  CHECK(coordinator);
+  coordinator->Show(SidePanelEntryId::kChatUI);
+}
+
+}  // namespace ai_chat

--- a/browser/ui/ai_chat/utils.h
+++ b/browser/ui/ai_chat/utils.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_AI_CHAT_UTILS_H_
+#define BRAVE_BROWSER_UI_AI_CHAT_UTILS_H_
+
+namespace content {
+class WebContents;
+}
+
+namespace ai_chat {
+
+void OpenAIChatForTab(content::WebContents* web_contents);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_BROWSER_UI_AI_CHAT_UTILS_H_

--- a/browser/ui/webui/settings/brave_privacy_handler.cc
+++ b/browser/ui/webui/settings/brave_privacy_handler.cc
@@ -7,6 +7,7 @@
 
 #include "base/functional/bind.h"
 #include "base/values.h"
+#include "brave/components/ai_chat/core/common/buildflags/buildflags.h"
 #include "brave/components/brave_shields/core/common/features.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/de_amp/common/features.h"
@@ -21,6 +22,11 @@
 #include "content/public/browser/web_ui.h"
 #include "content/public/browser/web_ui_data_source.h"
 #include "third_party/blink/public/common/peerconnection/webrtc_ip_handling_policy.h"
+
+#if BUILDFLAG(ENABLE_AI_CHAT)
+#include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#endif
 
 #if BUILDFLAG(ENABLE_REQUEST_OTR)
 #include "brave/components/request_otr/common/features.h"
@@ -96,6 +102,14 @@ void BravePrivacyHandler::AddLoadTimeData(content::WebUIDataSource* data_source,
       "isLocalhostAccessFeatureEnabled",
       base::FeatureList::IsEnabled(
           brave_shields::features::kBraveLocalhostAccessPermission));
+  data_source->AddBoolean(
+      "isOpenAIChatFromBraveSearchEnabled",
+#if BUILDFLAG(ENABLE_AI_CHAT)
+      ai_chat::IsAIChatEnabled(profile->GetPrefs()) &&
+          ai_chat::features::IsOpenAIChatFromBraveSearchEnabled());
+#else
+      false);
+#endif
 }
 
 void BravePrivacyHandler::SetLocalStateBooleanEnabled(

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -105,6 +105,13 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       {"siteSettingsGoogleSignInAllowExceptions",
        IDS_SETTINGS_SITE_SETTINGS_GOOGLE_SIGN_IN_ALLOW_EXCEPTIONS},
 
+      {"siteSettingsBraveOpenAIChat",
+       IDS_SETTINGS_SITE_SETTINGS_BRAVE_OPEN_AI_CHAT},
+      {"siteSettingsBraveOpenAIChatAsk",
+       IDS_SETTINGS_SITE_SETTINGS_BRAVE_OPEN_AI_CHAT_ASK},
+      {"siteSettingsBraveOpenAIChatBlock",
+       IDS_SETTINGS_SITE_SETTINGS_BRAVE_OPEN_AI_CHAT_BLOCK},
+
       {"siteSettingsLocalhostAccess",
        IDS_SETTINGS_SITE_SETTINGS_LOCALHOST_ACCESS},
       {"siteSettingsCategoryLocalhostAccess",

--- a/chromium_src/android_webview/browser/aw_permission_manager.cc
+++ b/chromium_src/android_webview/browser/aw_permission_manager.cc
@@ -20,6 +20,7 @@
   case PermissionType::BRAVE_SOLANA:                    \
   case PermissionType::BRAVE_GOOGLE_SIGN_IN:            \
   case PermissionType::BRAVE_LOCALHOST_ACCESS:          \
+  case PermissionType::BRAVE_OPEN_AI_CHAT:              \
   case PermissionType::NUM
 
 #include "src/android_webview/browser/aw_permission_manager.cc"

--- a/chromium_src/chrome/browser/permissions/permission_manager_factory.cc
+++ b/chromium_src/chrome/browser/permissions/permission_manager_factory.cc
@@ -10,6 +10,7 @@
 #include "brave/components/permissions/brave_permission_manager.h"
 #include "brave/components/permissions/contexts/brave_google_sign_in_permission_context.h"
 #include "brave/components/permissions/contexts/brave_localhost_permission_context.h"
+#include "brave/components/permissions/contexts/brave_open_ai_chat_permission_context.h"
 #include "brave/components/permissions/contexts/brave_wallet_permission_context.h"
 #include "brave/components/permissions/permission_lifetime_manager.h"
 #include "components/permissions/features.h"
@@ -42,6 +43,8 @@ PermissionManagerFactory::BuildServiceInstanceForBrowserContext(
           profile);
   permission_contexts[ContentSettingsType::BRAVE_LOCALHOST_ACCESS] =
       std::make_unique<permissions::BraveLocalhostPermissionContext>(profile);
+  permission_contexts[ContentSettingsType::BRAVE_OPEN_AI_CHAT] =
+      std::make_unique<permissions::BraveOpenAIChatPermissionContext>(profile);
 
   if (base::FeatureList::IsEnabled(
           permissions::features::kPermissionLifetime)) {

--- a/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
+++ b/chromium_src/chrome/browser/ui/webui/settings/site_settings_helper.cc
@@ -31,6 +31,7 @@
   {ContentSettingsType::BRAVE_HTTPS_UPGRADE, nullptr},                \
   {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, nullptr},          \
   {ContentSettingsType::BRAVE_LOCALHOST_ACCESS, "localhostAccess"},   \
+  {ContentSettingsType::BRAVE_OPEN_AI_CHAT, "braveOpenAIChat"},       \
   {ContentSettingsType::BRAVE_WEBCOMPAT_NONE, nullptr}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_AUDIO, nullptr}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_CANVAS, nullptr}, \
@@ -87,19 +88,24 @@
 namespace site_settings {
 
 bool HasRegisteredGroupName(ContentSettingsType type) {
-  if (type == ContentSettingsType::AUTOPLAY)
+  if (type == ContentSettingsType::AUTOPLAY) {
     return true;
-  if (type == ContentSettingsType::BRAVE_GOOGLE_SIGN_IN)
+  }
+  if (type == ContentSettingsType::BRAVE_GOOGLE_SIGN_IN) {
     return true;
+  }
   if (type == ContentSettingsType::BRAVE_LOCALHOST_ACCESS) {
     return true;
   }
-  if (type == ContentSettingsType::BRAVE_ETHEREUM)
+  if (type == ContentSettingsType::BRAVE_ETHEREUM) {
     return true;
-  if (type == ContentSettingsType::BRAVE_SOLANA)
+  }
+  if (type == ContentSettingsType::BRAVE_SOLANA) {
     return true;
-  if (type == ContentSettingsType::BRAVE_SHIELDS)
+  }
+  if (type == ContentSettingsType::BRAVE_SHIELDS) {
     return true;
+  }
   return HasRegisteredGroupName_ChromiumImpl(type);
 }
 
@@ -112,6 +118,7 @@ std::vector<ContentSettingsType> GetVisiblePermissionCategories(
       ContentSettingsType::BRAVE_SOLANA,
       ContentSettingsType::BRAVE_GOOGLE_SIGN_IN,
       ContentSettingsType::BRAVE_LOCALHOST_ACCESS,
+      ContentSettingsType::BRAVE_OPEN_AI_CHAT,
   };
 
   auto types = GetVisiblePermissionCategories_ChromiumImpl(origin, profile);

--- a/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_registry.cc
@@ -228,6 +228,18 @@ void ContentSettingsRegistry::BraveInit() {
            ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE,
            ContentSettingsInfo::EXCEPTIONS_ON_SECURE_AND_INSECURE_ORIGINS);
 
+  // Register AI chat permission default value as Ask.
+  Register(ContentSettingsType::BRAVE_OPEN_AI_CHAT, "brave_open_ai_chat",
+           CONTENT_SETTING_ASK, WebsiteSettingsInfo::UNSYNCABLE,
+           /*allowlisted_schemes=*/{},
+           /*valid_settings=*/
+           {CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK, CONTENT_SETTING_ASK},
+           WebsiteSettingsInfo::TOP_ORIGIN_ONLY_SCOPE,
+           WebsiteSettingsRegistry::DESKTOP |
+               WebsiteSettingsRegistry::PLATFORM_ANDROID,
+           ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE,
+           ContentSettingsInfo::EXCEPTIONS_ON_SECURE_ORIGINS_ONLY);
+
   // Disable background sync by default (brave/brave-browser#4709)
   content_settings_info_.erase(ContentSettingsType::BACKGROUND_SYNC);
   website_settings_registry_->UnRegister(ContentSettingsType::BACKGROUND_SYNC);

--- a/chromium_src/components/content_settings/core/browser/content_settings_uma_util.cc
+++ b/chromium_src/components/content_settings/core/browser/content_settings_uma_util.cc
@@ -44,6 +44,7 @@ static_assert(static_cast<int>(ContentSettingsType::kMaxValue) <
   {ContentSettingsType::BRAVE_HTTPS_UPGRADE, brave_value(12)},            \
   {ContentSettingsType::BRAVE_REMEMBER_1P_STORAGE, brave_value(13)},      \
   {ContentSettingsType::BRAVE_LOCALHOST_ACCESS, brave_value(14)},         \
+  {ContentSettingsType::BRAVE_OPEN_AI_CHAT, brave_value(15)},             \
   /* Begin webcompat items */                                                \
   {ContentSettingsType::BRAVE_WEBCOMPAT_NONE, brave_value(50)}, \
   {ContentSettingsType::BRAVE_WEBCOMPAT_AUDIO, brave_value(51)}, \

--- a/chromium_src/components/content_settings/core/common/content_settings_types.mojom
+++ b/chromium_src/components/content_settings/core/common/content_settings_types.mojom
@@ -24,6 +24,9 @@ enum ContentSettingsType {
   BRAVE_HTTPS_UPGRADE,
   BRAVE_REMEMBER_1P_STORAGE,
   BRAVE_LOCALHOST_ACCESS,
+  // Allow a site to open AI Chat (in side panel on Desktop).
+  // This is limited to Brave Search only.
+  BRAVE_OPEN_AI_CHAT,
 
   BRAVE_WEBCOMPAT_NONE,
   BRAVE_WEBCOMPAT_AUDIO,

--- a/chromium_src/components/permissions/permission_request.cc
+++ b/chromium_src/components/permissions/permission_request.cc
@@ -3,13 +3,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "components/permissions/permission_request.h"
+
 #include <optional>
 #include <vector>
 
 #include "base/containers/contains.h"
 #include "build/build_config.h"
 #include "components/grit/brave_components_strings.h"
-#include "components/permissions/permission_request.h"
 #include "components/strings/grit/components_strings.h"
 #include "third_party/widevine/cdm/buildflags.h"
 
@@ -49,6 +50,9 @@
     break;                                                 \
   case RequestType::kBraveLocalhostAccessPermission:       \
     message_id = IDS_LOCALHOST_ACCESS_PERMISSION_FRAGMENT; \
+    break;                                                 \
+  case RequestType::kBraveOpenAIChat:                      \
+    message_id = IDS_OPEN_AI_CHAT_PERMISSION_FRAGMENT;     \
     break;
 
 #define BRAVE_ENUM_ITEMS_FOR_SWITCH_ANDROID          \
@@ -58,6 +62,9 @@
     break;                                           \
   case RequestType::kBraveLocalhostAccessPermission: \
     message_id = IDS_LOCALHOST_ACCESS_INFOBAR_TEXT;  \
+    break;                                           \
+  case RequestType::kBraveOpenAIChat:                \
+    message_id = IDS_OPEN_AI_CHAT_INFOBAR_TEXT;      \
     break;
 
 namespace {
@@ -154,16 +161,15 @@ PermissionRequest::GetDialogAnnotatedMessageText(
 #endif
 
 bool PermissionRequest::SupportsLifetime() const {
-  const RequestType kExcludedTypes[] = {
-    RequestType::kDiskQuota,
-    RequestType::kMultipleDownloads,
+  const RequestType kExcludedTypes[] = {RequestType::kDiskQuota,
+                                        RequestType::kMultipleDownloads,
 #if BUILDFLAG(IS_ANDROID)
-    RequestType::kProtectedMediaIdentifier,
+                                        RequestType::kProtectedMediaIdentifier,
 #else
     RequestType::kRegisterProtocolHandler,
 #endif  // BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(ENABLE_WIDEVINE)
-    RequestType::kWidevine
+                                        RequestType::kWidevine
 #endif  // BUILDFLAG(ENABLE_WIDEVINE)
   };
   return !base::Contains(kExcludedTypes, request_type());

--- a/chromium_src/components/permissions/permission_request_data.cc
+++ b/chromium_src/components/permissions/permission_request_data.cc
@@ -3,10 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "components/permissions/permission_request_data.h"
+
 #include <optional>
 
 #include "components/permissions/permission_context_base.h"
-#include "components/permissions/permission_request_data.h"
 
 namespace permissions {
 
@@ -21,6 +22,8 @@ std::optional<RequestType> ContentSettingsTypeToRequestTypeIfExists_BraveImpl(
       return RequestType::kBraveGoogleSignInPermission;
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
       return RequestType::kBraveLocalhostAccessPermission;
+    case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
+      return RequestType::kBraveOpenAIChat;
     default:
       return ContentSettingsTypeToRequestTypeIfExists(content_settings_type);
   }

--- a/chromium_src/components/permissions/permission_uma_util.cc
+++ b/chromium_src/components/permissions/permission_uma_util.cc
@@ -14,15 +14,16 @@
   case RequestType::kBraveSolana:                    \
   case RequestType::kBraveGoogleSignInPermission:    \
   case RequestType::kBraveLocalhostAccessPermission: \
+  case RequestType::kBraveOpenAIChat:                \
     return RequestTypeForUma::PERMISSION_VR;
 
 // These requests may be batched together, so we must handle them explicitly as
 // GetUmaValueForRequests expects only a few specific request types to be
 // batched
-#define BRAVE_GET_UMA_VALUE_FOR_REQUESTS                              \
-  if (request_type >= RequestType::kWidevine &&                       \
-      request_type <= RequestType::kBraveLocalhostAccessPermission) { \
-    return GetUmaValueForRequestType(request_type);                   \
+#define BRAVE_GET_UMA_VALUE_FOR_REQUESTS             \
+  if (request_type >= RequestType::kBraveMinValue && \
+      request_type <= RequestType::kBraveMaxValue) { \
+    return GetUmaValueForRequestType(request_type);  \
   }
 
 // We do not record permissions UKM and this can save us from patching

--- a/chromium_src/components/permissions/permission_util.cc
+++ b/chromium_src/components/permissions/permission_util.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "components/permissions/permission_util.h"
+
 #include "components/permissions/permission_uma_util.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
 
@@ -35,7 +36,9 @@
   case PermissionType::BRAVE_GOOGLE_SIGN_IN:                     \
     return ContentSettingsType::BRAVE_GOOGLE_SIGN_IN;            \
   case PermissionType::BRAVE_LOCALHOST_ACCESS:                   \
-    return ContentSettingsType::BRAVE_LOCALHOST_ACCESS;
+    return ContentSettingsType::BRAVE_LOCALHOST_ACCESS;          \
+  case PermissionType::BRAVE_OPEN_AI_CHAT:                       \
+    return ContentSettingsType::BRAVE_OPEN_AI_CHAT;
 
 #include "src/components/permissions/permission_util.cc"
 #undef PermissionUtil
@@ -55,6 +58,8 @@ std::string PermissionUtil::GetPermissionString(
       return "BraveGoogleSignInPermission";
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
       return "BraveLocalhostAccessPermission";
+    case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
+      return "BraveOpenAIChatPermission";
     default:
       return PermissionUtil_ChromiumImpl::GetPermissionString(content_type);
   }
@@ -76,6 +81,10 @@ bool PermissionUtil::GetPermissionType(ContentSettingsType type,
     *out = PermissionType::BRAVE_LOCALHOST_ACCESS;
     return true;
   }
+  if (type == ContentSettingsType::BRAVE_OPEN_AI_CHAT) {
+    *out = PermissionType::BRAVE_OPEN_AI_CHAT;
+    return true;
+  }
 
   return PermissionUtil_ChromiumImpl::GetPermissionType(type, out);
 }
@@ -87,6 +96,7 @@ bool PermissionUtil::IsPermission(ContentSettingsType type) {
     case ContentSettingsType::BRAVE_SOLANA:
     case ContentSettingsType::BRAVE_GOOGLE_SIGN_IN:
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
+    case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
       return true;
     default:
       return PermissionUtil_ChromiumImpl::IsPermission(type);
@@ -122,6 +132,8 @@ PermissionType PermissionUtil::ContentSettingTypeToPermissionType(
       return PermissionType::BRAVE_GOOGLE_SIGN_IN;
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
       return PermissionType::BRAVE_LOCALHOST_ACCESS;
+    case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
+      return PermissionType::BRAVE_OPEN_AI_CHAT;
     default:
       return PermissionUtil_ChromiumImpl::ContentSettingTypeToPermissionType(
           permission);
@@ -133,8 +145,9 @@ GURL PermissionUtil::GetCanonicalOrigin(ContentSettingsType permission,
                                         const GURL& embedding_origin) {
   // Use requesting_origin which will have ethereum or solana address info.
   if (permission == ContentSettingsType::BRAVE_ETHEREUM ||
-      permission == ContentSettingsType::BRAVE_SOLANA)
+      permission == ContentSettingsType::BRAVE_SOLANA) {
     return requesting_origin;
+  }
 
   return PermissionUtil_ChromiumImpl::GetCanonicalOrigin(
       permission, requesting_origin, embedding_origin);

--- a/chromium_src/components/permissions/request_type.cc
+++ b/chromium_src/components/permissions/request_type.cc
@@ -3,10 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "components/permissions/request_type.h"
+
 #include <optional>
 
 #include "build/build_config.h"
-#include "components/permissions/request_type.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "components/resources/android/theme_resources.h"
@@ -31,6 +32,7 @@ constexpr auto kAndroidStorageAccess = IDR_ANDROID_STORAGE_ACCESS;
   case RequestType::kBraveSolana:                    \
   case RequestType::kBraveGoogleSignInPermission:    \
   case RequestType::kBraveLocalhostAccessPermission: \
+  case RequestType::kBraveOpenAIChat:                \
     return IDR_ANDROID_INFOBAR_PERMISSION_COOKIE
 
 // Add Brave cases into GetIconIdDesktop.
@@ -41,6 +43,7 @@ constexpr auto kAndroidStorageAccess = IDR_ANDROID_STORAGE_ACCESS;
   case RequestType::kBraveSolana:                    \
   case RequestType::kBraveGoogleSignInPermission:    \
   case RequestType::kBraveLocalhostAccessPermission: \
+  case RequestType::kBraveOpenAIChat:                \
     return vector_icons::kExtensionIcon
 
 #define BRAVE_PERMISSION_KEY_FOR_REQUEST_TYPE                     \
@@ -53,7 +56,9 @@ constexpr auto kAndroidStorageAccess = IDR_ANDROID_STORAGE_ACCESS;
   case permissions::RequestType::kBraveGoogleSignInPermission:    \
     return "brave_google_sign_in";                                \
   case permissions::RequestType::kBraveLocalhostAccessPermission: \
-    return "brave_localhost_access";
+    return "brave_localhost_access";                              \
+  case permissions::RequestType::kBraveOpenAIChat:                \
+    return "brave_ai_chat";
 
 #define ContentSettingsTypeToRequestType \
   ContentSettingsTypeToRequestType_ChromiumImpl
@@ -85,6 +90,8 @@ RequestType ContentSettingsTypeToRequestType(
       return RequestType::kBraveGoogleSignInPermission;
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
       return RequestType::kBraveLocalhostAccessPermission;
+    case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
+      return RequestType::kBraveOpenAIChat;
     case ContentSettingsType::DEFAULT:
       // Currently we have only one DEFAULT type that is
       // not mapped, which is Widevine, it's used for
@@ -107,6 +114,8 @@ std::optional<ContentSettingsType> RequestTypeToContentSettingsType(
       return ContentSettingsType::BRAVE_ETHEREUM;
     case RequestType::kBraveSolana:
       return ContentSettingsType::BRAVE_SOLANA;
+    case RequestType::kBraveOpenAIChat:
+      return ContentSettingsType::BRAVE_OPEN_AI_CHAT;
     default:
       return RequestTypeToContentSettingsType_ChromiumImpl(request_type);
   }
@@ -118,6 +127,7 @@ bool IsRequestablePermissionType(ContentSettingsType content_settings_type) {
     case ContentSettingsType::BRAVE_LOCALHOST_ACCESS:
     case ContentSettingsType::BRAVE_ETHEREUM:
     case ContentSettingsType::BRAVE_SOLANA:
+    case ContentSettingsType::BRAVE_OPEN_AI_CHAT:
       return true;
     default:
       return IsRequestablePermissionType_ChromiumImpl(content_settings_type);

--- a/chromium_src/components/permissions/request_type.h
+++ b/chromium_src/components/permissions/request_type.h
@@ -6,9 +6,11 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_PERMISSIONS_REQUEST_TYPE_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_PERMISSIONS_REQUEST_TYPE_H_
 
-#define kStorageAccess                                     \
-  kStorageAccess, kWidevine, kBraveEthereum, kBraveSolana, \
-      kBraveGoogleSignInPermission, kBraveLocalhostAccessPermission
+#define kStorageAccess                                                       \
+  kStorageAccess, kWidevine, kBraveEthereum, kBraveSolana, kBraveOpenAIChat, \
+      kBraveGoogleSignInPermission, kBraveLocalhostAccessPermission,         \
+      kBraveMinValue = kWidevine,                                            \
+      kBraveMaxValue = kBraveLocalhostAccessPermission
 
 #define ContentSettingsTypeToRequestType \
   ContentSettingsTypeToRequestType_ChromiumImpl

--- a/chromium_src/content/browser/permissions/permission_controller_impl.cc
+++ b/chromium_src/content/browser/permissions/permission_controller_impl.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "content/browser/permissions/permission_controller_impl.h"
+
 #include "content/browser/permissions/permission_util.h"
 #include "third_party/blink/public/common/permissions/permission_utils.h"
 
@@ -21,6 +22,7 @@
   case PermissionType::BRAVE_SOLANA:                    \
   case PermissionType::BRAVE_GOOGLE_SIGN_IN:            \
   case PermissionType::BRAVE_LOCALHOST_ACCESS:          \
+  case PermissionType::BRAVE_OPEN_AI_CHAT:              \
   case PermissionType::NUM
 
 #include "src/content/browser/permissions/permission_controller_impl.cc"

--- a/chromium_src/content/shell/browser/shell_permission_manager.cc
+++ b/chromium_src/content/shell/browser/shell_permission_manager.cc
@@ -20,6 +20,7 @@
   case PermissionType::BRAVE_SOLANA:                    \
   case PermissionType::BRAVE_GOOGLE_SIGN_IN:            \
   case PermissionType::BRAVE_LOCALHOST_ACCESS:          \
+  case PermissionType::BRAVE_OPEN_AI_CHAT:              \
   case PermissionType::NUM
 
 #include "src/content/shell/browser/shell_permission_manager.cc"

--- a/chromium_src/third_party/blink/common/permissions/permission_utils.cc
+++ b/chromium_src/third_party/blink/common/permissions/permission_utils.cc
@@ -30,6 +30,8 @@
     return "BraveGoogleSignInPermission";               \
   case PermissionType::BRAVE_LOCALHOST_ACCESS:          \
     return "BraveLocalhostAccessPermission";            \
+  case PermissionType::BRAVE_OPEN_AI_CHAT:              \
+    return "BraveOpenAIChatPermission";                 \
   case PermissionType::BRAVE_ETHEREUM:                  \
     return "BraveEthereum";                             \
   case PermissionType::BRAVE_SOLANA:                    \
@@ -52,6 +54,7 @@
   case PermissionType::BRAVE_SPEEDREADER:               \
   case PermissionType::BRAVE_GOOGLE_SIGN_IN:            \
   case PermissionType::BRAVE_LOCALHOST_ACCESS:          \
+  case PermissionType::BRAVE_OPEN_AI_CHAT:              \
     return std::nullopt
 
 #include "src/third_party/blink/common/permissions/permission_utils.cc"

--- a/chromium_src/third_party/blink/public/common/permissions/permission_utils.h
+++ b/chromium_src/third_party/blink/public/common/permissions/permission_utils.h
@@ -20,7 +20,8 @@
   BRAVE_ETHEREUM,                   \
   BRAVE_SOLANA,                     \
   BRAVE_GOOGLE_SIGN_IN,             \
-  BRAVE_LOCALHOST_ACCESS,             \
+  BRAVE_LOCALHOST_ACCESS,           \
+  BRAVE_OPEN_AI_CHAT,               \
   NUM
 // clang-format on
 

--- a/components/ai_chat/content/browser/BUILD.gn
+++ b/components/ai_chat/content/browser/BUILD.gn
@@ -10,6 +10,8 @@ assert(enable_ai_chat)
 
 static_library("browser") {
   sources = [
+    "ai_chat_brave_search_throttle.cc",
+    "ai_chat_brave_search_throttle.h",
     "ai_chat_tab_helper.cc",
     "ai_chat_tab_helper.h",
     "ai_chat_throttle.cc",

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.cc
@@ -1,0 +1,147 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "brave/components/ai_chat/content/browser/ai_chat_tab_helper.h"
+#include "brave/components/ai_chat/content/browser/page_content_fetcher.h"
+#include "brave/components/ai_chat/core/browser/conversation_handler.h"
+#include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/core/common/utils.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/navigation_handle.h"
+#include "content/public/browser/permission_controller.h"
+#include "content/public/browser/permission_request_description.h"
+#include "content/public/browser/web_contents.h"
+
+namespace ai_chat {
+
+// static
+std::unique_ptr<AIChatBraveSearchThrottle>
+AIChatBraveSearchThrottle::MaybeCreateThrottleFor(
+    base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
+    content::NavigationHandle* navigation_handle,
+    AIChatService* ai_chat_service,
+    PrefService* pref_service) {
+  auto* web_contents = navigation_handle->GetWebContents();
+  if (!web_contents) {
+    return nullptr;
+  }
+
+  if (!open_leo_delegate || !ai_chat_service ||
+      !IsAIChatEnabled(pref_service) ||
+      !features::IsOpenAIChatFromBraveSearchEnabled() ||
+      !IsOpenAIChatButtonFromBraveSearchURL(navigation_handle->GetURL())) {
+    return nullptr;
+  }
+
+  return std::make_unique<AIChatBraveSearchThrottle>(
+      std::move(open_leo_delegate), navigation_handle, ai_chat_service);
+}
+
+AIChatBraveSearchThrottle::AIChatBraveSearchThrottle(
+    base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
+    content::NavigationHandle* handle,
+    AIChatService* ai_chat_service)
+    : content::NavigationThrottle(handle),
+      open_ai_chat_delegate_(std::move(open_leo_delegate)),
+      ai_chat_service_(ai_chat_service) {
+  CHECK(open_ai_chat_delegate_);
+  CHECK(ai_chat_service_);
+}
+
+AIChatBraveSearchThrottle::~AIChatBraveSearchThrottle() = default;
+
+AIChatBraveSearchThrottle::ThrottleCheckResult
+AIChatBraveSearchThrottle::WillStartRequest() {
+  content::WebContents* web_contents = navigation_handle()->GetWebContents();
+  if (!web_contents || !navigation_handle()->IsInPrimaryMainFrame() ||
+      !IsOpenAIChatButtonFromBraveSearchURL(navigation_handle()->GetURL()) ||
+      !IsBraveSearchURL(web_contents->GetLastCommittedURL())) {
+    // Uninterested navigation for this throttle.
+    return content::NavigationThrottle::PROCEED;
+  }
+
+  // Check if nonce in HTML tag matches the one in the URL.
+  AIChatTabHelper::FromWebContents(web_contents)
+      ->GetOpenAIChatButtonNonce(
+          base::BindOnce(&AIChatBraveSearchThrottle::OnGetOpenAIChatButtonNonce,
+                         weak_factory_.GetWeakPtr()));
+  return content::NavigationThrottle::DEFER;
+}
+
+void AIChatBraveSearchThrottle::OpenAIChatWithStagedEntries() {
+  content::WebContents* web_contents = navigation_handle()->GetWebContents();
+  if (!web_contents) {
+    return;
+  }
+
+  ai_chat_service_->OpenConversationWithStagedEntries(
+      AIChatTabHelper::FromWebContents(web_contents)->GetWeakPtr(),
+      base::BindOnce(&AIChatBraveSearchThrottle::OnOpenAIChat,
+                     weak_factory_.GetWeakPtr()));
+}
+
+void AIChatBraveSearchThrottle::OnOpenAIChat() {
+  std::move(open_ai_chat_delegate_).Run(navigation_handle()->GetWebContents());
+}
+
+void AIChatBraveSearchThrottle::OnGetOpenAIChatButtonNonce(
+    const std::optional<std::string>& nonce) {
+  if (!nonce || nonce->empty() ||
+      *nonce != navigation_handle()->GetURL().ref()) {
+    CancelDeferredNavigation(content::NavigationThrottle::CANCEL);
+    return;
+  }
+
+  // Check if the user has granted permission to open AI Chat.
+  content::WebContents* web_contents = navigation_handle()->GetWebContents();
+  if (!web_contents) {
+    CancelDeferredNavigation(content::NavigationThrottle::CANCEL);
+    return;
+  }
+
+  content::RenderFrameHost* rfh = web_contents->GetPrimaryMainFrame();
+  content::PermissionController* permission_controller =
+      web_contents->GetBrowserContext()->GetPermissionController();
+  content::PermissionResult permission_status =
+      permission_controller->GetPermissionResultForCurrentDocument(
+          blink::PermissionType::BRAVE_OPEN_AI_CHAT, rfh);
+
+  if (permission_status.status == content::PermissionStatus::DENIED) {
+    CancelDeferredNavigation(content::NavigationThrottle::CANCEL);
+  } else if (permission_status.status == content::PermissionStatus::GRANTED) {
+    OpenAIChatWithStagedEntries();
+    CancelDeferredNavigation(content::NavigationThrottle::CANCEL);
+  } else {  // ask
+    permission_controller->RequestPermissionFromCurrentDocument(
+        rfh,
+        content::PermissionRequestDescription(
+            blink::PermissionType::BRAVE_OPEN_AI_CHAT, /*user_gesture=*/true),
+        base::BindOnce(&AIChatBraveSearchThrottle::OnPermissionPromptResult,
+                       weak_factory_.GetWeakPtr()));
+  }
+}
+
+void AIChatBraveSearchThrottle::OnPermissionPromptResult(
+    content::PermissionStatus status) {
+  if (status == content::PermissionStatus::GRANTED) {
+    OpenAIChatWithStagedEntries();
+  }
+
+  CancelDeferredNavigation(content::NavigationThrottle::CANCEL);
+}
+
+const char* AIChatBraveSearchThrottle::GetNameForLogging() {
+  return "AIChatBraveSearchThrottle";
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
+++ b/components/ai_chat/content/browser/ai_chat_brave_search_throttle.h
@@ -1,0 +1,71 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_BRAVE_SEARCH_THROTTLE_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_BRAVE_SEARCH_THROTTLE_H_
+
+#include <memory>
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/weak_ptr.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_service.h"
+#include "content/public/browser/navigation_throttle.h"
+#include "content/public/browser/permission_result.h"
+
+namespace content {
+class WebContents;
+}
+
+class PrefService;
+
+namespace ai_chat {
+
+// A network throttle which intercepts Brave Search requests.
+// Currently the only use case is to intercept requests to open Leo AI chat, so
+// it is only created when navigating to open Leo button URL from Brave Search.
+// It could be extended to other Brave Search URLs in the future.
+//
+// For Open Leo feature, we check:
+// 1) If AI chat is enabled.
+// 2) If the request is from Brave Search and is trying to navigate to open Leo
+// button URL.
+// 3) If the nonce property in the a tag element is equal to the one in url ref.
+// 4) If the user has granted permission to open Leo.
+// The navigation to the specific Open Leo URL will be cancelled, and Leo AI
+// chat will be opened only if all the above conditions are met.
+class AIChatBraveSearchThrottle : public content::NavigationThrottle {
+ public:
+  AIChatBraveSearchThrottle(
+      base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
+      content::NavigationHandle* handle,
+      AIChatService* ai_chat_service);
+  ~AIChatBraveSearchThrottle() override;
+
+  static std::unique_ptr<AIChatBraveSearchThrottle> MaybeCreateThrottleFor(
+      base::OnceCallback<void(content::WebContents*)> open_leo_delegate,
+      content::NavigationHandle* navigation_handle,
+      AIChatService* ai_chat_service,
+      PrefService* pref_service);
+
+  ThrottleCheckResult WillStartRequest() override;
+  const char* GetNameForLogging() override;
+
+ private:
+  void OnGetOpenAIChatButtonNonce(const std::optional<std::string>& nonce);
+  void OnPermissionPromptResult(blink::mojom::PermissionStatus status);
+  void OnOpenAIChat();
+
+  void OpenAIChatWithStagedEntries();
+
+  base::OnceCallback<void(content::WebContents*)> open_ai_chat_delegate_;
+  const raw_ptr<AIChatService> ai_chat_service_ = nullptr;
+
+  base::WeakPtrFactory<AIChatBraveSearchThrottle> weak_factory_{this};
+};
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_BRAVE_SEARCH_THROTTLE_H_

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -27,6 +27,9 @@
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/navigation_details.h"
 #include "content/public/browser/navigation_entry.h"
+#include "content/public/browser/permission_controller.h"
+#include "content/public/browser/permission_request_description.h"
+#include "content/public/browser/permission_result.h"
 #include "content/public/browser/scoped_accessibility_mode.h"
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
@@ -412,6 +415,21 @@ void AIChatTabHelper::GetSearchSummarizerKey(
   }
 
   page_content_fetcher_delegate_->GetSearchSummarizerKey(std::move(callback));
+}
+
+void AIChatTabHelper::GetOpenAIChatButtonNonce(
+    mojom::PageContentExtractor::GetOpenAIChatButtonNonceCallback callback) {
+  page_content_fetcher_delegate_->GetOpenAIChatButtonNonce(std::move(callback));
+}
+
+bool AIChatTabHelper::HasOpenAIChatPermission() const {
+  content::RenderFrameHost* rfh = web_contents()->GetPrimaryMainFrame();
+  content::PermissionController* permission_controller =
+      web_contents()->GetBrowserContext()->GetPermissionController();
+  content::PermissionResult permission_status =
+      permission_controller->GetPermissionResultForCurrentDocument(
+          blink::PermissionType::BRAVE_OPEN_AI_CHAT, rfh);
+  return permission_status.status == content::PermissionStatus::GRANTED;
 }
 
 WEB_CONTENTS_USER_DATA_KEY_IMPL(AIChatTabHelper);

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -7,8 +7,8 @@
 #define BRAVE_COMPONENTS_AI_CHAT_CONTENT_BROWSER_AI_CHAT_TAB_HELPER_H_
 
 #include <memory>
-#include <optional>
 #include <string>
+#include <utility>
 
 #include "base/functional/callback_forward.h"
 #include "base/memory/raw_ptr.h"
@@ -74,6 +74,12 @@ class AIChatTabHelper : public content::WebContentsObserver,
     // Attempts to find a search summarizer key for the page.
     virtual void GetSearchSummarizerKey(
         GetSearchSummarizerKeyCallback callback) = 0;
+
+    // Fetches the nonce for the OpenLeo button from the page HTML and validate
+    // if it matches the href URL and the passed in nonce.
+    virtual void GetOpenAIChatButtonNonce(
+        mojom::PageContentExtractor::GetOpenAIChatButtonNonceCallback
+            callback) = 0;
   };
 
   AIChatTabHelper(const AIChatTabHelper&) = delete;
@@ -96,6 +102,9 @@ class AIChatTabHelper : public content::WebContentsObserver,
 
   // mojom::PageContentExtractorHost
   void OnInterceptedPageContentChanged() override;
+
+  void GetOpenAIChatButtonNonce(
+      mojom::PageContentExtractor::GetOpenAIChatButtonNonceCallback callback);
 
  private:
   friend class content::WebContentsUserData<AIChatTabHelper>;
@@ -156,6 +165,8 @@ class AIChatTabHelper : public content::WebContentsObserver,
   void MaybeSameDocumentIsNewPage();
 
   void GetSearchSummarizerKey(GetSearchSummarizerKeyCallback callback) override;
+
+  bool HasOpenAIChatPermission() const override;
 
   void OnFetchPageContentComplete(GetPageContentCallback callback,
                                   std::string content,

--- a/components/ai_chat/content/browser/page_content_fetcher.h
+++ b/components/ai_chat/content/browser/page_content_fetcher.h
@@ -39,6 +39,10 @@ class PageContentFetcher : public AIChatTabHelper::PageContentFetcherDelegate {
       mojom::PageContentExtractor::GetSearchSummarizerKeyCallback callback)
       override;
 
+  void GetOpenAIChatButtonNonce(
+      mojom::PageContentExtractor::GetOpenAIChatButtonNonceCallback callback)
+      override;
+
   void SetURLLoaderFactoryForTesting(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory) {
     url_loader_factory_ = url_loader_factory;

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -414,4 +414,21 @@ void AIChatService::OnConversationListChanged() {
   }
 }
 
+void AIChatService::OpenConversationWithStagedEntries(
+    base::WeakPtr<ConversationHandler::AssociatedContentDelegate>
+        associated_content,
+    base::OnceClosure open_ai_chat) {
+  if (!associated_content || !associated_content->HasOpenAIChatPermission()) {
+    return;
+  }
+
+  ConversationHandler* conversation = GetOrCreateConversationHandlerForContent(
+      associated_content->GetContentId(), associated_content);
+  CHECK(conversation);
+
+  // Open AI Chat and trigger a fetch of staged conversations from Brave Search.
+  std::move(open_ai_chat).Run();
+  conversation->MaybeFetchOrClearContentStagedConversation();
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -87,6 +87,11 @@ class AIChatService : public KeyedService,
       base::WeakPtr<ConversationHandler::AssociatedContentDelegate>
           associated_content);
 
+  void OpenConversationWithStagedEntries(
+      base::WeakPtr<ConversationHandler::AssociatedContentDelegate>
+          associated_content,
+      base::OnceClosure open_ai_chat);
+
   // mojom::Service
   void MarkAgreementAccepted() override;
   void GetVisibleConversations(

--- a/components/ai_chat/core/browser/associated_content_driver.cc
+++ b/components/ai_chat/core/browser/associated_content_driver.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 #include <utility>
+#include <vector>
 
 #include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
@@ -19,9 +20,9 @@
 #include "base/strings/string_util.h"
 #include "brave/brave_domains/service_domains.h"
 #include "brave/components/ai_chat/core/browser/brave_search_responses.h"
-#include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/browser/conversation_handler.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "net/base/url_util.h"
 #include "net/traffic_annotation/network_traffic_annotation.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -36,8 +36,6 @@ constexpr float kMaxContentLengthThreshold = 0.6f;
 constexpr size_t kReservedTokensForPrompt = 300;
 constexpr size_t kReservedTokensForMaxNewTokens = 400;
 
-inline constexpr char kBraveSearchURLPrefix[] = "search";
-
 }  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_CONSTANTS_H_

--- a/components/ai_chat/core/browser/utils.cc
+++ b/components/ai_chat/core/browser/utils.cc
@@ -5,6 +5,10 @@
 
 #include "brave/components/ai_chat/core/browser/utils.h"
 
+#include <string>
+#include <utility>
+#include <vector>
+
 #include "base/containers/fixed_flat_set.h"
 #include "base/functional/bind.h"
 #include "base/no_destructor.h"
@@ -14,6 +18,7 @@
 #include "base/time/time.h"
 #include "brave/brave_domains/service_domains.h"
 #include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"

--- a/components/ai_chat/core/common/BUILD.gn
+++ b/components/ai_chat/core/common/BUILD.gn
@@ -12,23 +12,31 @@ component("common") {
   defines = [ "IS_AI_CHAT_COMMON_IMPL" ]
 
   sources = [
+    "constants.h",
     "features.cc",
     "features.h",
     "pref_names.cc",
     "pref_names.h",
+    "utils.cc",
+    "utils.h",
   ]
 
   deps = [
     "//base",
+    "//brave/brave_domains",
     "//brave/components/ai_chat/core/common/buildflags:buildflags",
     "//components/prefs",
+    "//url",
   ]
 }
 
 if (!is_ios) {
   source_set("unit_tests") {
     testonly = true
-    sources = [ "pref_names_unittest.cc" ]
+    sources = [
+      "pref_names_unittest.cc",
+      "utils_unittest.cc",
+    ]
 
     deps = [
       "//base/test:test_support",

--- a/components/ai_chat/core/common/constants.h
+++ b/components/ai_chat/core/common/constants.h
@@ -1,0 +1,15 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_CONSTANTS_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_CONSTANTS_H_
+
+namespace ai_chat {
+
+inline constexpr char kBraveSearchURLPrefix[] = "search";
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_CONSTANTS_H_

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -60,4 +60,16 @@ bool IsPageContentRefineEnabled() {
   return base::FeatureList::IsEnabled(features::kPageContentRefine);
 }
 
+BASE_FEATURE(kOpenAIChatFromBraveSearch,
+             "OpenAIChatFromBraveSearch",
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+             base::FEATURE_ENABLED_BY_DEFAULT);
+#else
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif
+
+bool IsOpenAIChatFromBraveSearchEnabled() {
+  return base::FeatureList::IsEnabled(features::kOpenAIChatFromBraveSearch);
+}
+
 }  // namespace ai_chat::features

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -45,6 +45,10 @@ COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsContextMenuRewriteInPlaceEnabled();
 COMPONENT_EXPORT(AI_CHAT_COMMON) BASE_DECLARE_FEATURE(kPageContentRefine);
 COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsPageContentRefineEnabled();
 
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+BASE_DECLARE_FEATURE(kOpenAIChatFromBraveSearch);
+COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsOpenAIChatFromBraveSearchEnabled();
+
 }  // namespace ai_chat::features
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_FEATURES_H_

--- a/components/ai_chat/core/common/mojom/page_content_extractor.mojom
+++ b/components/ai_chat/core/common/mojom/page_content_extractor.mojom
@@ -32,6 +32,11 @@ interface PageContentExtractor {
   // Get summarizer-key meta tag from Brave Search SERP if it exists.
   // This should only be called when the last commited URL is Brave Search SERP.
   GetSearchSummarizerKey() => (string? key);
+
+  // Get the nonce in the href URL and the nonce attribute value in the
+  // continue-with-leo HTML anchor element (open Leo button). These two
+  // nonces value must be the same, otherwise nullopt will be returned.
+  GetOpenAIChatButtonNonce() => (string? nonce);
 };
 
 // Allows the renderer to notify the browser process of meaningful changes to

--- a/components/ai_chat/core/common/utils.cc
+++ b/components/ai_chat/core/common/utils.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/core/common/utils.h"
+
+#include "brave/brave_domains/service_domains.h"
+#include "brave/components/ai_chat/core/common/constants.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+namespace ai_chat {
+
+bool IsBraveSearchURL(const GURL& url) {
+  return url.is_valid() && url.SchemeIs(url::kHttpsScheme) &&
+         url.host_piece() ==
+             brave_domains::GetServicesDomain(kBraveSearchURLPrefix);
+}
+
+bool IsOpenAIChatButtonFromBraveSearchURL(const GURL& url) {
+  // Use search.brave.com in all cases because href on search site is
+  // hardcoded to search.brave.com for all environments.
+  return url.is_valid() && url.SchemeIs(url::kHttpsScheme) &&
+         url.host_piece() == "search.brave.com" && url.path_piece() == "/leo" &&
+         !url.ref_piece().empty();
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/core/common/utils.h
+++ b/components/ai_chat/core/common/utils.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_UTILS_H_
+#define BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_UTILS_H_
+
+#include "base/component_export.h"
+
+class GURL;
+
+namespace ai_chat {
+
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+bool IsBraveSearchURL(const GURL& url);
+
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+bool IsOpenAIChatButtonFromBraveSearchURL(const GURL& url);
+
+}  // namespace ai_chat
+
+#endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_UTILS_H_

--- a/components/ai_chat/core/common/utils_unittest.cc
+++ b/components/ai_chat/core/common/utils_unittest.cc
@@ -1,0 +1,35 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ai_chat/core/common/utils.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace ai_chat {
+
+TEST(AIChatCommonUtilsUnitTest, IsBraveSearchURL) {
+  EXPECT_TRUE(IsBraveSearchURL(GURL("https://search.brave.com")));
+  EXPECT_FALSE(IsBraveSearchURL(GURL("http://search.brave.com")));
+  EXPECT_FALSE(IsBraveSearchURL(GURL("https://test.brave.com/")));
+  EXPECT_FALSE(IsBraveSearchURL(GURL("https://brave.com/")));
+  EXPECT_FALSE(IsBraveSearchURL(GURL()));
+}
+
+TEST(AIChatCommonUtilsUnitTest, IsOpenAIChatButtonFromBraveSearchURL) {
+  EXPECT_TRUE(IsOpenAIChatButtonFromBraveSearchURL(
+      GURL("https://search.brave.com/leo#5566")));
+  EXPECT_FALSE(IsOpenAIChatButtonFromBraveSearchURL(GURL()));
+  EXPECT_FALSE(
+      IsOpenAIChatButtonFromBraveSearchURL(GURL("https://search.brave.com")));
+  EXPECT_FALSE(IsOpenAIChatButtonFromBraveSearchURL(
+      GURL("https://search.brave.com/leo")));
+  EXPECT_FALSE(IsOpenAIChatButtonFromBraveSearchURL(
+      GURL("https://search.brave.com/leo#")));
+  EXPECT_FALSE(
+      IsOpenAIChatButtonFromBraveSearchURL(GURL("https://brave.com/leo#5566")));
+}
+
+}  // namespace ai_chat

--- a/components/ai_chat/renderer/BUILD.gn
+++ b/components/ai_chat/renderer/BUILD.gn
@@ -22,6 +22,7 @@ static_library("renderer") {
 
   deps = [
     "//base",
+    "//brave/components/ai_chat/core/common",
     "//brave/components/ai_chat/core/common/mojom",
     "//content/public/renderer",
     "//gin",

--- a/components/ai_chat/renderer/page_content_extractor.h
+++ b/components/ai_chat/renderer/page_content_extractor.h
@@ -59,6 +59,9 @@ class PageContentExtractor
   void GetSearchSummarizerKey(
       mojom::PageContentExtractor::GetSearchSummarizerKeyCallback callback)
       override;
+  void GetOpenAIChatButtonNonce(
+      mojom::PageContentExtractor::GetOpenAIChatButtonNonceCallback callback)
+      override;
 
   // AIChatResourceSnifferThrottleDelegate
   void OnInterceptedPageContentChanged(

--- a/components/permissions/contexts/brave_open_ai_chat_permission_context.cc
+++ b/components/permissions/contexts/brave_open_ai_chat_permission_context.cc
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/permissions/contexts/brave_open_ai_chat_permission_context.h"
+
+#include <utility>
+
+#include "brave/brave_domains/service_domains.h"
+#include "components/content_settings/core/common/content_settings.h"
+#include "components/content_settings/core/common/content_settings_types.h"
+#include "components/permissions/permission_request_data.h"
+#include "third_party/blink/public/mojom/permissions_policy/permissions_policy_feature.mojom-shared.h"
+#include "url/gurl.h"
+#include "url/url_constants.h"
+
+namespace permissions {
+
+BraveOpenAIChatPermissionContext::BraveOpenAIChatPermissionContext(
+    content::BrowserContext* browser_context)
+    : PermissionContextBase(browser_context,
+                            ContentSettingsType::BRAVE_OPEN_AI_CHAT,
+                            blink::mojom::PermissionsPolicyFeature::kNotFound) {
+}
+
+BraveOpenAIChatPermissionContext::~BraveOpenAIChatPermissionContext() = default;
+
+ContentSetting BraveOpenAIChatPermissionContext::GetPermissionStatusInternal(
+    content::RenderFrameHost* render_frame_host,
+    const GURL& requesting_origin,
+    const GURL& embedding_origin) const {
+  // Check if origin is https://search.brave.com.
+  if (!requesting_origin.SchemeIs(url::kHttpsScheme) ||
+      requesting_origin.host_piece() !=
+          brave_domains::GetServicesDomain("search")) {
+    return ContentSetting::CONTENT_SETTING_BLOCK;
+  }
+
+  return PermissionContextBase::GetPermissionStatusInternal(
+      render_frame_host, requesting_origin, embedding_origin);
+}
+
+bool BraveOpenAIChatPermissionContext::IsRestrictedToSecureOrigins() const {
+  return true;
+}
+
+}  // namespace permissions

--- a/components/permissions/contexts/brave_open_ai_chat_permission_context.h
+++ b/components/permissions/contexts/brave_open_ai_chat_permission_context.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_PERMISSIONS_CONTEXTS_BRAVE_OPEN_AI_CHAT_PERMISSION_CONTEXT_H_
+#define BRAVE_COMPONENTS_PERMISSIONS_CONTEXTS_BRAVE_OPEN_AI_CHAT_PERMISSION_CONTEXT_H_
+
+#include "components/permissions/permission_context_base.h"
+#include "content/public/browser/browser_context.h"
+
+namespace permissions {
+
+class BraveOpenAIChatPermissionContext : public PermissionContextBase {
+ public:
+  explicit BraveOpenAIChatPermissionContext(
+      content::BrowserContext* browser_context);
+  ~BraveOpenAIChatPermissionContext() override;
+
+  BraveOpenAIChatPermissionContext(const BraveOpenAIChatPermissionContext&) =
+      delete;
+  BraveOpenAIChatPermissionContext& operator=(
+      const BraveOpenAIChatPermissionContext&) = delete;
+
+ private:
+  // PermissionContextBase:
+  ContentSetting GetPermissionStatusInternal(
+      content::RenderFrameHost* render_frame_host,
+      const GURL& requesting_origin,
+      const GURL& embedding_origin) const override;
+  bool IsRestrictedToSecureOrigins() const override;
+};
+
+}  // namespace permissions
+
+#endif  // BRAVE_COMPONENTS_PERMISSIONS_CONTEXTS_BRAVE_OPEN_AI_CHAT_PERMISSION_CONTEXT_H_

--- a/components/permissions/sources.gni
+++ b/components/permissions/sources.gni
@@ -12,6 +12,8 @@ brave_components_permissions_sources = [
   "//brave/components/permissions/contexts/brave_google_sign_in_permission_context.h",
   "//brave/components/permissions/contexts/brave_localhost_permission_context.cc",
   "//brave/components/permissions/contexts/brave_localhost_permission_context.h",
+  "//brave/components/permissions/contexts/brave_open_ai_chat_permission_context.cc",
+  "//brave/components/permissions/contexts/brave_open_ai_chat_permission_context.h",
   "//brave/components/permissions/contexts/brave_wallet_permission_context.cc",
   "//brave/components/permissions/contexts/brave_wallet_permission_context.h",
   "//brave/components/permissions/permission_expiration_key.cc",
@@ -39,6 +41,7 @@ if (enable_widevine) {
 
 brave_components_permissions_deps = [
   "//base",
+  "//brave/brave_domains",
   "//brave/components/brave_wallet/browser:permission_utils",
   "//brave/components/brave_wallet/common:mojom",
   "//brave/components/constants:constants",

--- a/components/resources/permissions_strings.grdp
+++ b/components/resources/permissions_strings.grdp
@@ -21,4 +21,10 @@
   <message name="IDS_PERMISSIONS_BUBBLE_SITE_PERMISSION_LINK" desc="Site permission link in the footnote description.">
     site permission
   </message>
+  <message name="IDS_OPEN_AI_CHAT_PERMISSION_FRAGMENT" desc="Label for Leo AI chat permission prompt.">
+    Allow opening Leo AI conversations in Brave?
+  </message>
+  <message name="IDS_OPEN_AI_CHAT_INFOBAR_TEXT" desc="Label for Leo AI chat permission prompt (Android).">
+    Allow <ph name="URL">$1<ex>search.brave.com</ex></ph> to open Leo AI conversations in Brave?
+  </message>
 </grit-part>

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -113,35 +113,33 @@
       })
 
 #if BUILDFLAG(ENABLE_AI_CHAT)
-#define BRAVE_AI_CHAT                                          \
-  EXPAND_FEATURE_ENTRIES({                                     \
-      "brave-ai-chat",                                         \
-      "Brave AI Chat",                                         \
-      "Summarize articles and engage in conversation with AI", \
-      flags_ui::kOsIos,                                        \
-      FEATURE_VALUE_TYPE(ai_chat::features::kAIChat),          \
-  })
-#define BRAVE_AI_CHAT_HISTORY                                \
-  EXPAND_FEATURE_ENTRIES({                                   \
-      "brave-ai-chat-history",                               \
-      "Brave AI Chat History",                               \
-      "Enables AI Chat History persistence and management",  \
-      flags_ui::kOsIos,                                      \
-      FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory), \
-  })
-#define BRAVE_AI_CHAT_PAGE_CONTENT_REFINE                                   \
-  EXPAND_FEATURE_ENTRIES({                                                  \
-      "brave-ai-chat-page-content-refine",                                  \
-      "Brave AI Chat Page Content Refine",                                  \
-      "Enable local text embedding for long page content in order to find " \
-      "most relevant parts to the prompt within context limit.",            \
-      flags_ui::kOsIos,                                                     \
-      FEATURE_VALUE_TYPE(ai_chat::features::kPageContentRefine),            \
-  })
+#define BRAVE_AI_CHAT_FEATURE_ENTRIES                                      \
+  EXPAND_FEATURE_ENTRIES(                                                  \
+      {                                                                    \
+          "brave-ai-chat",                                                 \
+          "Brave AI Chat",                                                 \
+          "Summarize articles and engage in conversation with AI",         \
+          flags_ui::kOsIos,                                                \
+          FEATURE_VALUE_TYPE(ai_chat::features::kAIChat),                  \
+      },                                                                   \
+      {                                                                    \
+          "brave-ai-chat-history",                                         \
+          "Brave AI Chat History",                                         \
+          "Enables AI Chat History persistence and management",            \
+          flags_ui::kOsIos,                                                \
+          FEATURE_VALUE_TYPE(ai_chat::features::kAIChatHistory),           \
+      },                                                                   \
+      {                                                                    \
+          "brave-ai-chat-page-content-refine",                             \
+          "Brave AI Chat Page Content Refine",                             \
+          "Enable local text embedding for long page content in order to " \
+          "find "                                                          \
+          "most relevant parts to the prompt within context limit.",       \
+          flags_ui::kOsIos,                                                \
+          FEATURE_VALUE_TYPE(ai_chat::features::kPageContentRefine),       \
+      })
 #else
-#define BRAVE_AI_CHAT
-#define BRAVE_AI_CHAT_HISTORY
-#define BRAVE_AI_CHAT_PAGE_CONTENT_REFINE
+#define BRAVE_AI_CHAT_FEATURE_ENTRIES
 #endif
 
 #define BRAVE_PLAYLIST_FEATURE_ENTRIES                        \
@@ -242,8 +240,6 @@
   BRAVE_SHIELDS_FEATURE_ENTRIES                                                \
   BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \
   BRAVE_SKU_SDK_FEATURE_ENTRIES                                                \
-  BRAVE_AI_CHAT                                                                \
-  BRAVE_AI_CHAT_HISTORY                                                        \
-  BRAVE_AI_CHAT_PAGE_CONTENT_REFINE                                            \
+  BRAVE_AI_CHAT_FEATURE_ENTRIES                                                \
   BRAVE_PLAYLIST_FEATURE_ENTRIES                                               \
   LAST_BRAVE_FEATURE_ENTRIES_ITEM  // Keep it as the last item.

--- a/patches/chrome-browser-resources-settings-site_settings-constants.ts.patch
+++ b/patches/chrome-browser-resources-settings-site_settings-constants.ts.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/resources/settings/site_settings/constants.ts b/chrome/browser/resources/settings/site_settings/constants.ts
-index 4ed920a8aabf9a853713935ffaa6653a8e1360b0..0c9e64bc05960754cdbcbc7bdcf118e292586b01 100644
+index 4ed920a8aabf9a853713935ffaa6653a8e1360b0..05d12ce52618e2b42f4d4c0fe59691bbffe297b3 100644
 --- a/chrome/browser/resources/settings/site_settings/constants.ts
 +++ b/chrome/browser/resources/settings/site_settings/constants.ts
 @@ -67,6 +67,7 @@ export enum ContentSettingsTypes {
    PDF_DOCUMENTS = 'pdfDocuments',
    SITE_DATA = 'site-data',
    OFFER_WRITING_HELP = 'offer-writing-help',
-+  AUTOPLAY = 'autoplay', ETHEREUM = 'ethereum', SOLANA = 'solana', BRAVE_SHIELDS = 'braveShields', GOOGLE_SIGN_IN = 'googleSignIn', LOCALHOST_ACCESS = 'localhostAccess',
++  AUTOPLAY = 'autoplay', ETHEREUM = 'ethereum', SOLANA = 'solana', BRAVE_SHIELDS = 'braveShields', GOOGLE_SIGN_IN = 'googleSignIn', LOCALHOST_ACCESS = 'localhostAccess', BRAVE_OPEN_AI_CHAT = 'braveOpenAIChat'
  }
  
  /**

--- a/patches/chrome-browser-resources-settings-site_settings-settings_category_default_radio_group.ts.patch
+++ b/patches/chrome-browser-resources-settings-site_settings-settings_category_default_radio_group.ts.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/resources/settings/site_settings/settings_category_default_radio_group.ts b/chrome/browser/resources/settings/site_settings/settings_category_default_radio_group.ts
-index f41407671c3aa79854cbf4c4adf5359278ea5f60..fa73ea59476b32d9feefe73c728f69c80669e848 100644
+index f41407671c3aa79854cbf4c4adf5359278ea5f60..fe1fe5d9527400c5a59143fafb3f17cc23a76ae8 100644
 --- a/chrome/browser/resources/settings/site_settings/settings_category_default_radio_group.ts
 +++ b/chrome/browser/resources/settings/site_settings/settings_category_default_radio_group.ts
 @@ -171,6 +171,7 @@ export class SettingsCategoryDefaultRadioGroupElement extends
        case ContentSettingsTypes.WEB_PRINTING:
          // "Ask" vs "Blocked".
          return ContentSetting.ASK;
-+      case ContentSettingsTypes.ETHEREUM: case ContentSettingsTypes.SOLANA: case ContentSettingsTypes.GOOGLE_SIGN_IN: case ContentSettingsTypes.LOCALHOST_ACCESS: return ContentSetting.ASK; case ContentSettingsTypes.AUTOPLAY: return ContentSetting.ALLOW;
++      case ContentSettingsTypes.ETHEREUM: case ContentSettingsTypes.SOLANA: case ContentSettingsTypes.GOOGLE_SIGN_IN: case ContentSettingsTypes.LOCALHOST_ACCESS: case ContentSettingsTypes.BRAVE_OPEN_AI_CHAT: return ContentSetting.ASK; case ContentSettingsTypes.AUTOPLAY: return ContentSetting.ALLOW;
        default:
          assertNotReached('Invalid category: ' + this.category);
      }

--- a/test/data/leo/leo
+++ b/test/data/leo/leo
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leo test</title>
+</head>
+<body>
+    <div style='font: 30px Arial'>I have spoken</div>
+</body>
+</html>

--- a/test/data/leo/open_ai_chat_button.html
+++ b/test/data/leo/open_ai_chat_button.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leo test</title>
+</head>
+<body>
+  <a id="valid" href="https://search.brave.com/leo#5566" data-nonce="5566">Open Leo</a>
+  <a id="invalid" href="https://search.brave.com/leo#1234" data-nonce="5566">Open Leo</a>
+  <div id="not-a-tag"></div>
+  <a id="no-href" data-nonce="5566">Open Leo</a>
+  <a id="no-nonce" href="https://search.brave.com/leo#5566">Open Leo</a>
+  <a id="empty-nonce" href="https://search.brave.com/leo#5566" data-nonce="">Open Leo</a>
+  <a id="empty-nonce2" href="https://search.brave.com/leo#" data-nonce="5566">Open Leo</a>
+  <a id="empty-nonce3" href="https://search.brave.com/leo" data-nonce="5566">Open Leo</a>
+  <a id="empty-nonce4" href="https://search.brave.com/leo#">Open Leo</a>
+  <a id="empty-nonce5" href="https://search.brave.com/leo" data-nonce="">Open Leo</a>
+  <a id="empty-nonce6" href="https://search.brave.com/leo">Open Leo</a>
+  <a id="not-https-url" href="http://search.brave.com/leo#5566" data-nonce="5566">Open Leo</a>
+  <a id="not-search-url" href="https://brave.com/leo#5566" data-nonce="5566">Open Leo</a>
+  <a id="not-open-leo-url" href="https://search.brave.com/test#5566" data-nonce="5566">Open Leo</a>
+</body>
+</html>

--- a/test/data/leo/open_ai_chat_button_invalid.html
+++ b/test/data/leo/open_ai_chat_button_invalid.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leo test</title>
+</head>
+<body>
+    <a id="continue-with-leo" href="https://search.brave.com/leo#1234" data-nonce="5566">Open Leo</a>
+</body>
+</html>

--- a/test/data/leo/open_ai_chat_button_valid.html
+++ b/test/data/leo/open_ai_chat_button_valid.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Leo test</title>
+</head>
+<body>
+  <a id="continue-with-leo" href="https://search.brave.com/leo#5566" data-nonce="5566">Open Leo</a>
+</body>
+</html>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41711

https://github.com/user-attachments/assets/bbfce0c6-3cc5-4aac-b301-e8e887fd7bdb

UI was updated on search side after the above demo video was recorded, it now looks like this, with a "Save chat in Brave Leo" at upper-right corner:
<img width="1608" alt="Screenshot 2024-10-30 at 4 13 46 PM" src="https://github.com/user-attachments/assets/e7f42d3d-87da-4cf8-bfd5-581727cad181">

- Add a new permission for opening Leo from Brave Search
- Add a navigation throttle to intercept the request for opening Leo from Brave Search (specifically, https://search.brave.com/leo#noncevalue). If the request is from Brave Search (last committed URL) and nonce is valid (identical between the one in URL and the one in nonce property), a permission prompt will be shown by default and Leo side panel would be opened with entries from Brave Search conversations staged in Leo side panel.
- A side change which removes the limitation of only have staged entries at the beginning of the conversation to accommodate that user could choose to click continue with Leo button in search UI multiple times and not only when there's empty Leo chat history. When need to remove staged entries, for example, when page context is unlinked, all staged entries will be cleared instead of whole chat history.

See Requirements `#2` and `#3` in https://docs.google.com/document/d/1idelFPpUEcKDNcyKYf3M5yw91tuIddjrlYfpaWEJjNk/edit?tab=t.0 for reference. 

S&P review: https://github.com/brave/reviews/issues/1776

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to search.brave.com with experimental flags enabled.
2. Type a query and click `Answer with AI`
3. Type a follow-up question in search conversation mode UI
4. Once answer is generated, click "Save chat in Brave Leo" at the upper-right corner.
5. Check permission prompt is shown, and Leo side panel should be opened when permission is allowed, entries from search.brave.com should be staged in Leo.
6. Visit brave://settings/content -> Additional permissions -> Leo AI chat, search.brave.com should be in the allow list.
7. Remove the allow entry in settings UI. 
8. Open a new tab and repeat step 1 to 4.
9. Permission prompt should be shown again, reject the prompt, Leo panel should not be opened.

Test opt-out case:
Try the feature in a profile that hasn't opted-in to Leo, when the continue with Leo button is clicked, accept the permission prompt, Leo should be opened with opt-in screen with disclaimer, search entries should appear after opt-in.

Test private window:
Try the feature in private window, shouldn't have any actions such as opening Leo or permission prompt.