### PR TITLE
Fix interstitial not showing deceptive site warning. Fix URLBar Eliding

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1986,8 +1986,9 @@ public class BrowserViewController: UIViewController {
         tabsBar.updateSelectedTabTitle()
 
         if let url = webView.url,
-          webView.responds(to: Selector(("_safeBrowsingWarning")))
-            && webView.value(forKey: "_safeBrowsingWarning") != nil
+          webView.configuration.preferences.isFraudulentWebsiteWarningEnabled,
+          webView.responds(to: Selector(("_safeBrowsingWarning"))),
+          webView.value(forKey: "_safeBrowsingWarning") != nil
         {
           tab.url = url  // We can update the URL whenever showing an interstitial warning
           updateToolbarCurrentURL(url.displayURL)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1984,6 +1984,15 @@ public class BrowserViewController: UIViewController {
       if !title.isEmpty && title != tab.lastTitle {
         navigateInTab(tab: tab)
         tabsBar.updateSelectedTabTitle()
+
+        if let url = webView.url,
+          webView.responds(to: Selector(("_safeBrowsingWarning")))
+            && webView.value(forKey: "_safeBrowsingWarning") != nil
+        {
+          tab.url = url  // We can update the URL whenever showing an interstitial warning
+          updateToolbarCurrentURL(url.displayURL)
+          updateInContentHomePanel(url)
+        }
       }
     case .canGoBack, .canGoForward:
       guard tab === tabManager.selectedTab else {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1565,7 +1565,6 @@ extension TabManager: WKNavigationDelegate {
   }
 
   func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-    print("HERE!!!")
   }
 
   /// Called when the WKWebView's content process has gone away. If this happens for the currently selected tab

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1565,6 +1565,7 @@ extension TabManager: WKNavigationDelegate {
   }
 
   func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    print("HERE!!!")
   }
 
   /// Called when the WKWebView's content process has gone away. If this happens for the currently selected tab

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -106,14 +106,13 @@ class CollapsedURLBarView: UIView {
       urlLabel.text = currentURL.map {
         if let internalURL = InternalURL($0), internalURL.isBasicAuthURL {
           Strings.PageSecurityView.signIntoWebsiteURLBarTitle
+        } else if URLOrigin(url: $0).url != nil || URIFixup.getURL($0.absoluteString) != nil {
+          URLFormatter.formatURLOrigin(
+            forDisplayOmitSchemePathAndTrivialSubdomains: URLOrigin(url: $0).url?.absoluteString
+              ?? $0.absoluteString
+          )
         } else {
-          if URLOrigin(url: $0).url == nil && URIFixup.getURL($0.absoluteString) == nil {
-          } else {
-            URLFormatter.formatURLOrigin(
-              forDisplayOmitSchemePathAndTrivialSubdomains: URLOrigin(url: $0).url?.absoluteString
-                ?? $0.absoluteString
-            )
-          }
+          String()
         }
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -108,7 +108,9 @@ class CollapsedURLBarView: UIView {
           Strings.PageSecurityView.signIntoWebsiteURLBarTitle
         } else {
           URLFormatter.formatURLOrigin(
-            forDisplayOmitSchemePathAndTrivialSubdomains: $0.absoluteString
+            forDisplayOmitSchemePathAndTrivialSubdomains: $0.scheme != "http"
+              || $0.scheme != "https"
+              ? URLOrigin(url: $0).url?.absoluteString ?? $0.absoluteString : $0.absoluteString
           )
         }
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -107,11 +107,13 @@ class CollapsedURLBarView: UIView {
         if let internalURL = InternalURL($0), internalURL.isBasicAuthURL {
           Strings.PageSecurityView.signIntoWebsiteURLBarTitle
         } else {
-          URLFormatter.formatURLOrigin(
-            forDisplayOmitSchemePathAndTrivialSubdomains: $0.scheme != "http"
-              || $0.scheme != "https"
-              ? URLOrigin(url: $0).url?.absoluteString ?? $0.absoluteString : $0.absoluteString
-          )
+          if URLOrigin(url: $0).url == nil && URIFixup.getURL($0.absoluteString) == nil {
+          } else {
+            URLFormatter.formatURLOrigin(
+              forDisplayOmitSchemePathAndTrivialSubdomains: URLOrigin(url: $0).url?.absoluteString
+                ?? $0.absoluteString
+            )
+          }
         }
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -557,15 +557,15 @@ private class DisplayURLLabel: UILabel {
     didSet {
       clippingFade.isHidden = true
       if oldValue != text {
-        updateText()
-        updateTextSize()
-        detectLanguageForNaturalDirectionClipping()
-
         if let text = text {
           isWebScheme = ["http", "https"].contains(URL(string: text)?.scheme ?? "")
         } else {
           isWebScheme = false
         }
+
+        updateText()
+        updateTextSize()
+        detectLanguageForNaturalDirectionClipping()
       }
       setNeedsDisplay()
     }
@@ -612,8 +612,8 @@ private class DisplayURLLabel: UILabel {
       isRightToLeft = false
     }
     // Update clipping fade direction
-    clippingFade.gradientLayer.startPoint = .init(x: isRightToLeft && isWebScheme ? 1 : 0, y: 0.5)
-    clippingFade.gradientLayer.endPoint = .init(x: isRightToLeft && isWebScheme ? 0 : 1, y: 0.5)
+    clippingFade.gradientLayer.startPoint = .init(x: isRightToLeft || !isWebScheme ? 1 : 0, y: 0.5)
+    clippingFade.gradientLayer.endPoint = .init(x: isRightToLeft || !isWebScheme ? 0 : 1, y: 0.5)
   }
 
   @available(*, unavailable)
@@ -634,7 +634,7 @@ private class DisplayURLLabel: UILabel {
     super.layoutSubviews()
 
     clippingFade.frame = .init(
-      x: isRightToLeft && isWebScheme ? bounds.width - 20 : 0,
+      x: isRightToLeft || !isWebScheme ? bounds.width - 20 : 0,
       y: 0,
       width: 20,
       height: bounds.height
@@ -648,7 +648,7 @@ private class DisplayURLLabel: UILabel {
     var rect = rect
     if textSize.width > bounds.width {
       let delta = (textSize.width - bounds.width)
-      if !isRightToLeft && isWebScheme {
+      if !isRightToLeft && !isWebScheme {
         rect.origin.x -= delta
         rect.size.width += delta
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -463,10 +463,14 @@ class TabLocationView: UIView {
           url.scheme != "http" || url.scheme != "https"
             ? URLOrigin(url: url).url?.absoluteString ?? "" : url.absoluteString,
           formatTypes: [
-            .trimAfterHost, .omitHTTP, .omitHTTPS, .omitTrivialSubdomains, .omitDefaults,
+            .trimAfterHost, .omitHTTPS, .omitTrivialSubdomains, .omitDefaults,
           ],
           unescapeOptions: .normal
         )
+        
+        if urlDisplayLabel.text?.isEmpty == true {
+          print("HERE")
+        }
       }
     } else {
       urlDisplayLabel.text = ""

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -75,6 +75,8 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
   init(privateBrowsingManager: PrivateBrowsingManager) {
     self.privateBrowsingManager = privateBrowsingManager
     super.init(frame: .zero)
+    self.semanticContentAttribute = .forceLeftToRight
+    self.textAlignment = .left
 
     super.delegate = self
     super.addTarget(


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/internal/issues/1210

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

