### PR TITLE
[ubsan] Fix `SplitViewBrowserData` null deref

### DIFF
--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -147,13 +147,11 @@ void BraveBrowserCommandController::OnTabGroupChanged(
   UpdateCommandsForTabs();
 }
 
-void BraveBrowserCommandController::OnTileTabs(
-    const SplitViewBrowserData::Tile& tile) {
+void BraveBrowserCommandController::OnTileTabs(const TabTile& tile) {
   UpdateCommandForSplitView();
 }
 
-void BraveBrowserCommandController::OnWillBreakTile(
-    const SplitViewBrowserData::Tile& tile) {
+void BraveBrowserCommandController::OnWillBreakTile(const TabTile& tile) {
   UpdateCommandForSplitView();
 }
 

--- a/browser/ui/brave_browser_command_controller.h
+++ b/browser/ui/brave_browser_command_controller.h
@@ -73,8 +73,8 @@ class BraveBrowserCommandController : public chrome::BrowserCommandController,
   friend class ::BraveBrowserCommandControllerTest;
 
   // Overriden from SplitViewBrowserDataObserver:
-  void OnTileTabs(const SplitViewBrowserData::Tile& tile) override;
-  void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) override;
+  void OnTileTabs(const TabTile& tile) override;
+  void OnWillBreakTile(const TabTile& tile) override;
   void OnWillDeleteBrowserData() override;
 
   // Overriden from CommandUpdater:

--- a/browser/ui/tabs/split_view_browser_data_observer.h
+++ b/browser/ui/tabs/split_view_browser_data_observer.h
@@ -7,14 +7,15 @@
 #define BRAVE_BROWSER_UI_TABS_SPLIT_VIEW_BROWSER_DATA_OBSERVER_H_
 
 #include "base/observer_list_types.h"
-#include "brave/browser/ui/tabs/split_view_browser_data.h"
+
+struct TabTile;
 
 class SplitViewBrowserDataObserver : public base::CheckedObserver {
  public:
-  virtual void OnTileTabs(const SplitViewBrowserData::Tile& tile) {}
-  virtual void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) {}
-  virtual void OnDidBreakTile(const SplitViewBrowserData::Tile& tile) {}
-  virtual void OnSwapTabsInTile(const SplitViewBrowserData::Tile& tile) {}
+  virtual void OnTileTabs(const TabTile& tile) {}
+  virtual void OnWillBreakTile(const TabTile& tile) {}
+  virtual void OnDidBreakTile(const TabTile& tile) {}
+  virtual void OnSwapTabsInTile(const TabTile& tile) {}
   virtual void OnWillDeleteBrowserData() {}
 };
 

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.cc
@@ -27,9 +27,8 @@ SplitViewTabStripModelAdapter::SplitViewTabStripModelAdapter(
 
 SplitViewTabStripModelAdapter::~SplitViewTabStripModelAdapter() = default;
 
-void SplitViewTabStripModelAdapter::MakeTiledTabsAdjacent(
-    const SplitViewBrowserData::Tile& tile,
-    bool move_right_tab) {
+void SplitViewTabStripModelAdapter::MakeTiledTabsAdjacent(const TabTile& tile,
+                                                          bool move_right_tab) {
   auto tab1 = tile.first;
   auto tab2 = tile.second;
   auto index1 = model_->GetIndexOfTab(tab1);
@@ -56,7 +55,7 @@ void SplitViewTabStripModelAdapter::TabDragStarted() {
 }
 
 bool SplitViewTabStripModelAdapter::SynchronizeGroupedState(
-    const SplitViewBrowserData::Tile& tile,
+    const TabTile& tile,
     const tabs::TabHandle& source,
     std::optional<tab_groups::TabGroupId> group) {
   DCHECK(!is_in_synch_grouped_state_);
@@ -80,7 +79,7 @@ bool SplitViewTabStripModelAdapter::SynchronizeGroupedState(
 }
 
 bool SplitViewTabStripModelAdapter::SynchronizePinnedState(
-    const SplitViewBrowserData::Tile& tile,
+    const TabTile& tile,
     const tabs::TabHandle& source) {
   auto tab1 = tile.first;
   auto tab2 = tile.second;
@@ -104,7 +103,7 @@ bool SplitViewTabStripModelAdapter::SynchronizePinnedState(
 void SplitViewTabStripModelAdapter::TabDragEnded() {
   // Check if any tiles are separated after drag and drop session. Then break
   // the tiles.
-  std::vector<SplitViewBrowserData::Tile> tiles_to_break;
+  std::vector<TabTile> tiles_to_break;
   for (const auto& tile : split_view_browser_data_->tiles()) {
     auto tab1 = tile.first;
     auto tab2 = tile.second;
@@ -265,17 +264,16 @@ void SplitViewTabStripModelAdapter::TabPinnedStateChanged(
   DCHECK(tile->first == source_tab || tile->second == source_tab);
 
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE,
-      base::BindOnce(
-          [](base::WeakPtr<SplitViewTabStripModelAdapter> adapter,
-             SplitViewBrowserData::Tile tile, tabs::TabHandle source_tab) {
-            if (!adapter) {
-              return;
-            }
+      FROM_HERE, base::BindOnce(
+                     [](base::WeakPtr<SplitViewTabStripModelAdapter> adapter,
+                        TabTile tile, tabs::TabHandle source_tab) {
+                       if (!adapter) {
+                         return;
+                       }
 
-            adapter->SynchronizePinnedState(tile, source_tab);
-          },
-          weak_ptr_factory_.GetWeakPtr(), *tile, source_tab));
+                       adapter->SynchronizePinnedState(tile, source_tab);
+                     },
+                     weak_ptr_factory_.GetWeakPtr(), *tile, source_tab));
 }
 
 void SplitViewTabStripModelAdapter::TabGroupedStateChanged(
@@ -301,8 +299,8 @@ void SplitViewTabStripModelAdapter::TabGroupedStateChanged(
   base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
       FROM_HERE,
       base::BindOnce(
-          [](base::WeakPtr<SplitViewTabStripModelAdapter> adapter,
-             SplitViewBrowserData::Tile tile, const tabs::TabHandle& source,
+          [](base::WeakPtr<SplitViewTabStripModelAdapter> adapter, TabTile tile,
+             const tabs::TabHandle& source,
              std::optional<tab_groups::TabGroupId> group) {
             if (!adapter) {
               return;

--- a/browser/ui/tabs/split_view_tab_strip_model_adapter.h
+++ b/browser/ui/tabs/split_view_tab_strip_model_adapter.h
@@ -10,9 +10,11 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
-#include "brave/browser/ui/tabs/split_view_browser_data.h"
 #include "chrome/browser/ui/tabs/tab_model.h"
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+
+class SplitViewBrowserData;
+struct TabTile;
 
 // This class observes changes in tabs' index and make other tab that are paired
 // with the changed tab be synchronized.
@@ -22,17 +24,17 @@ class SplitViewTabStripModelAdapter : public TabStripModelObserver {
                                 TabStripModel* model);
   ~SplitViewTabStripModelAdapter() override;
 
-  void MakeTiledTabsAdjacent(const SplitViewBrowserData::Tile& tile,
-                             bool move_right_tab = true);
-  bool SynchronizeGroupedState(const SplitViewBrowserData::Tile& tile,
+  void MakeTiledTabsAdjacent(const TabTile& tile, bool move_right_tab = true);
+  bool SynchronizeGroupedState(const TabTile& tile,
                                const tabs::TabHandle& source,
                                std::optional<tab_groups::TabGroupId> group);
-  bool SynchronizePinnedState(const SplitViewBrowserData::Tile& tile,
+  bool SynchronizePinnedState(const TabTile& tile,
                               const tabs::TabHandle& source);
 
   void TabDragStarted();
   void TabDragEnded();
   bool is_in_tab_dragging() const { return is_in_tab_dragging_; }
+  TabStripModel& tab_strip_model() { return *model_; }
 
   // TabStripModelObserver:
   void OnTabStripModelChanged(

--- a/browser/ui/tabs/test/split_view_browser_data_browsertest.cc
+++ b/browser/ui/tabs/test/split_view_browser_data_browsertest.cc
@@ -24,18 +24,22 @@ class SplitViewBrowserDataBrowserTest : public InProcessBrowserTest {
 
   SplitViewBrowserData& data() { return *data_; }
 
-  tabs::TabModel CreateTabModel() {
+  tabs::TabModel* CreateTabModel() {
     content::WebContents::CreateParams params(browser()->profile());
     auto web_contents = content::WebContents::Create(params);
     CHECK(web_contents);
-    return tabs::TabModel(std::move(web_contents),
-                          browser()->tab_strip_model());
+    auto tab_model = std::make_unique<tabs::TabModel>(
+        std::move(web_contents), browser()->tab_strip_model());
+    auto* result = tab_model.get();
+    browser()->tab_strip_model()->AppendTab(std::move(tab_model),
+                                            /*foreground=*/true);
+    return result;
   }
 
   // InProcessBrowserTest:
   void SetUpOnMainThread() override {
-    data_.reset(new SplitViewBrowserData(nullptr));
-    data_->is_testing_ = true;
+    CHECK(browser());
+    data_.reset(new SplitViewBrowserData(browser()));
   }
 
  private:
@@ -44,61 +48,61 @@ class SplitViewBrowserDataBrowserTest : public InProcessBrowserTest {
 };
 
 IN_PROC_BROWSER_TEST_F(SplitViewBrowserDataBrowserTest, TileTabs_AddsTile) {
-  auto tab_1 = CreateTabModel();
-  auto tab_2 = CreateTabModel();
-  EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
-  EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
+  auto* tab_1 = CreateTabModel();
+  auto* tab_2 = CreateTabModel();
+  EXPECT_FALSE(data().IsTabTiled(tab_1->GetHandle()));
+  EXPECT_FALSE(data().IsTabTiled(tab_2->GetHandle()));
 
-  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
+  data().TileTabs({.first = tab_1->GetHandle(), .second = tab_2->GetHandle()});
 
-  EXPECT_TRUE(data().IsTabTiled(tab_1.GetHandle()));
-  EXPECT_TRUE(data().IsTabTiled(tab_2.GetHandle()));
+  EXPECT_TRUE(data().IsTabTiled(tab_1->GetHandle()));
+  EXPECT_TRUE(data().IsTabTiled(tab_2->GetHandle()));
 }
 
 IN_PROC_BROWSER_TEST_F(SplitViewBrowserDataBrowserTest, BreakTile_RemovesTile) {
-  auto tab_1 = CreateTabModel();
-  auto tab_2 = CreateTabModel();
-  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
+  auto* tab_1 = CreateTabModel();
+  auto* tab_2 = CreateTabModel();
+  data().TileTabs({.first = tab_1->GetHandle(), .second = tab_2->GetHandle()});
 
-  ASSERT_TRUE(data().IsTabTiled(tab_1.GetHandle()));
-  ASSERT_TRUE(data().IsTabTiled(tab_2.GetHandle()));
+  ASSERT_TRUE(data().IsTabTiled(tab_1->GetHandle()));
+  ASSERT_TRUE(data().IsTabTiled(tab_2->GetHandle()));
 
-  data().BreakTile(tab_1.GetHandle());
-  EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
-  EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
+  data().BreakTile(tab_1->GetHandle());
+  EXPECT_FALSE(data().IsTabTiled(tab_1->GetHandle()));
+  EXPECT_FALSE(data().IsTabTiled(tab_2->GetHandle()));
 
-  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
-  data().BreakTile(tab_2.GetHandle());
-  EXPECT_FALSE(data().IsTabTiled(tab_1.GetHandle()));
-  EXPECT_FALSE(data().IsTabTiled(tab_2.GetHandle()));
+  data().TileTabs({.first = tab_1->GetHandle(), .second = tab_2->GetHandle()});
+  data().BreakTile(tab_2->GetHandle());
+  EXPECT_FALSE(data().IsTabTiled(tab_1->GetHandle()));
+  EXPECT_FALSE(data().IsTabTiled(tab_2->GetHandle()));
 }
 
 IN_PROC_BROWSER_TEST_F(SplitViewBrowserDataBrowserTest, FindTile) {
-  auto tab_1 = CreateTabModel();
-  auto tab_2 = CreateTabModel();
-  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
+  auto* tab_1 = CreateTabModel();
+  auto* tab_2 = CreateTabModel();
+  data().TileTabs({.first = tab_1->GetHandle(), .second = tab_2->GetHandle()});
 
   EXPECT_EQ(0, std::distance(data().tiles_.begin(),
-                             data().FindTile(tab_1.GetHandle())));
+                             data().FindTile(tab_1->GetHandle())));
   EXPECT_EQ(0, std::distance(data().tiles_.begin(),
-                             data().FindTile(tab_2.GetHandle())));
+                             data().FindTile(tab_2->GetHandle())));
 
-  data().BreakTile(tab_2.GetHandle());
-  EXPECT_EQ(data().tiles_.end(), data().FindTile(tab_1.GetHandle()));
-  EXPECT_EQ(data().tiles_.end(), data().FindTile(tab_2.GetHandle()));
+  data().BreakTile(tab_2->GetHandle());
+  EXPECT_EQ(data().tiles_.end(), data().FindTile(tab_1->GetHandle()));
+  EXPECT_EQ(data().tiles_.end(), data().FindTile(tab_2->GetHandle()));
 
-  auto tab_3 = CreateTabModel();
-  auto tab_4 = CreateTabModel();
-  data().TileTabs({.first = tab_1.GetHandle(), .second = tab_2.GetHandle()});
-  data().TileTabs({.first = tab_3.GetHandle(), .second = tab_4.GetHandle()});
+  auto* tab_3 = CreateTabModel();
+  auto* tab_4 = CreateTabModel();
+  data().TileTabs({.first = tab_1->GetHandle(), .second = tab_2->GetHandle()});
+  data().TileTabs({.first = tab_3->GetHandle(), .second = tab_4->GetHandle()});
   EXPECT_EQ(1, std::distance(data().tiles_.begin(),
-                             data().FindTile(tab_3.GetHandle())));
+                             data().FindTile(tab_3->GetHandle())));
   EXPECT_EQ(1, std::distance(data().tiles_.begin(),
-                             data().FindTile(tab_4.GetHandle())));
+                             data().FindTile(tab_4->GetHandle())));
 
-  data().BreakTile(tab_1.GetHandle());
+  data().BreakTile(tab_1->GetHandle());
   EXPECT_EQ(0, std::distance(data().tiles_.begin(),
-                             data().FindTile(tab_3.GetHandle())));
+                             data().FindTile(tab_3->GetHandle())));
   EXPECT_EQ(0, std::distance(data().tiles_.begin(),
-                             data().FindTile(tab_4.GetHandle())));
+                             data().FindTile(tab_4->GetHandle())));
 }

--- a/browser/ui/tabs/test/split_view_tab_strip_model_adapter_browsertest.cc
+++ b/browser/ui/tabs/test/split_view_tab_strip_model_adapter_browsertest.cc
@@ -30,7 +30,9 @@ class SplitViewTabStripModelAdapterBrowserTest : public InProcessBrowserTest {
     return browser()->tab_strip_model();
   }
   SplitViewBrowserData& data() const { return *split_view_browser_data_; }
-  SplitViewTabStripModelAdapter& adapter() const { return *adapter_; }
+  SplitViewTabStripModelAdapter& adapter() const {
+    return split_view_browser_data_->tab_strip_model_adapter_;
+  }
 
   std::unique_ptr<content::WebContents> CreateWebContents() {
     content::WebContents::CreateParams params(browser()->profile());
@@ -43,21 +45,14 @@ class SplitViewTabStripModelAdapterBrowserTest : public InProcessBrowserTest {
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
 
-    split_view_browser_data_.reset(new SplitViewBrowserData(nullptr));
-    split_view_browser_data_->is_testing_ = true;
-    split_view_browser_data_->tab_strip_model_for_testing_ = tab_strip_model();
-    split_view_browser_data_->tab_strip_model_adapter_ =
-        std::make_unique<SplitViewTabStripModelAdapter>(
-            *split_view_browser_data_, tab_strip_model());
-
-    adapter_ = split_view_browser_data_->tab_strip_model_adapter_.get();
+    CHECK(browser());
+    split_view_browser_data_.reset(new SplitViewBrowserData(browser()));
   }
 
  private:
   base::test::ScopedFeatureList feature_list_;
 
   std::unique_ptr<SplitViewBrowserData> split_view_browser_data_;
-  raw_ptr<SplitViewTabStripModelAdapter> adapter_;
 };
 
 IN_PROC_BROWSER_TEST_F(SplitViewTabStripModelAdapterBrowserTest,

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -394,8 +394,7 @@ tabs::TabHandle BraveBrowserView::GetActiveTabHandle() {
       model->GetIndexOfWebContents(GetActiveWebContents()));
 }
 
-bool BraveBrowserView::IsActiveWebContentsTiled(
-    const SplitViewBrowserData::Tile& tile) {
+bool BraveBrowserView::IsActiveWebContentsTiled(const TabTile& tile) {
   CHECK(base::FeatureList::IsEnabled(tabs::features::kBraveSplitView));
 
   auto active_tab_handle = GetActiveTabHandle();
@@ -839,7 +838,7 @@ void BraveBrowserView::OnAcceleratorsChanged(
   }
 }
 
-void BraveBrowserView::OnTileTabs(const SplitViewBrowserData::Tile& tile) {
+void BraveBrowserView::OnTileTabs(const TabTile& tile) {
   if (!IsActiveWebContentsTiled(tile)) {
     return;
   }
@@ -847,7 +846,7 @@ void BraveBrowserView::OnTileTabs(const SplitViewBrowserData::Tile& tile) {
   UpdateContentsWebViewVisual();
 }
 
-void BraveBrowserView::OnWillBreakTile(const SplitViewBrowserData::Tile& tile) {
+void BraveBrowserView::OnWillBreakTile(const TabTile& tile) {
   if (!IsActiveWebContentsTiled(tile)) {
     return;
   }
@@ -857,8 +856,7 @@ void BraveBrowserView::OnWillBreakTile(const SplitViewBrowserData::Tile& tile) {
                                 weak_ptr_.GetWeakPtr()));
 }
 
-void BraveBrowserView::OnSwapTabsInTile(
-    const SplitViewBrowserData::Tile& tile) {
+void BraveBrowserView::OnSwapTabsInTile(const TabTile& tile) {
   if (!IsActiveWebContentsTiled(tile)) {
     return;
   }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -130,9 +130,9 @@ class BraveBrowserView : public BrowserView,
   void OnAcceleratorsChanged(const commands::Accelerators& changed) override;
 
   // SplitViewBrowserDataObserver:
-  void OnTileTabs(const SplitViewBrowserData::Tile& tile) override;
-  void OnWillBreakTile(const SplitViewBrowserData::Tile& tile) override;
-  void OnSwapTabsInTile(const SplitViewBrowserData::Tile& tile) override;
+  void OnTileTabs(const TabTile& tile) override;
+  void OnWillBreakTile(const TabTile& tile) override;
+  void OnSwapTabsInTile(const TabTile& tile) override;
 
   views::WebView* secondary_contents_web_view() {
     return secondary_contents_web_view_.get();
@@ -199,7 +199,7 @@ class BraveBrowserView : public BrowserView,
   void UpdateSideBarHorizontalAlignment();
 
   tabs::TabHandle GetActiveTabHandle();
-  bool IsActiveWebContentsTiled(const SplitViewBrowserData::Tile& tile);
+  bool IsActiveWebContentsTiled(const TabTile& tile);
   void UpdateSplitViewSizeDelta(content::WebContents* old_contents,
                                 content::WebContents* new_contents);
   void UpdateContentsWebViewVisual();

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -295,9 +295,8 @@ void BraveTabContainer::PaintBoundingBoxForTiles(
   });
 }
 
-void BraveTabContainer::PaintBoundingBoxForTile(
-    gfx::Canvas& canvas,
-    const SplitViewBrowserData::Tile& tile) {
+void BraveTabContainer::PaintBoundingBoxForTile(gfx::Canvas& canvas,
+                                                const TabTile& tile) {
   if (!GetTabCount()) {
     return;
   }
@@ -573,11 +572,11 @@ void BraveTabContainer::HandleDragExited() {
   SetDropArrow({});
 }
 
-void BraveTabContainer::OnTileTabs(const SplitViewBrowserData::Tile& tile) {
+void BraveTabContainer::OnTileTabs(const TabTile& tile) {
   SchedulePaint();
 }
 
-void BraveTabContainer::OnDidBreakTile(const SplitViewBrowserData::Tile& tile) {
+void BraveTabContainer::OnDidBreakTile(const TabTile& tile) {
   SchedulePaint();
 }
 

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -59,8 +59,8 @@ class BraveTabContainer : public TabContainerImpl,
   void HandleDragExited() override;
 
   // SplitViewBrowserDataObserver:
-  void OnTileTabs(const SplitViewBrowserData::Tile& tile) override;
-  void OnDidBreakTile(const SplitViewBrowserData::Tile& tile) override;
+  void OnTileTabs(const TabTile& tile) override;
+  void OnDidBreakTile(const TabTile& tile) override;
 
  private:
   class DropArrow : public views::WidgetObserver {
@@ -107,8 +107,7 @@ class BraveTabContainer : public TabContainerImpl,
 
   void PaintBoundingBoxForTiles(gfx::Canvas& canvas,
                                 const SplitViewBrowserData* split_view_data);
-  void PaintBoundingBoxForTile(gfx::Canvas& canvas,
-                               const SplitViewBrowserData::Tile& tile);
+  void PaintBoundingBoxForTile(gfx::Canvas& canvas, const TabTile& tile);
 
   static gfx::ImageSkia* GetDropArrowImage(
       BraveTabContainer::DropArrow::Position pos,

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -247,8 +247,7 @@ TabTiledState BraveTabStrip::GetTiledStateForTab(int index) const {
   return IsFirstTabInTile(tab) ? TabTiledState::kFirst : TabTiledState::kSecond;
 }
 
-std::optional<SplitViewBrowserData::Tile> BraveTabStrip::GetTileForTab(
-    const Tab* tab) const {
+std::optional<TabTile> BraveTabStrip::GetTileForTab(const Tab* tab) const {
   auto* browser = GetBrowser();
   auto* data = SplitViewBrowserData::FromBrowser(browser);
   if (!data) {

--- a/browser/ui/views/tabs/brave_tab_strip.h
+++ b/browser/ui/views/tabs/brave_tab_strip.h
@@ -44,7 +44,7 @@ class BraveTabStrip : public TabStrip {
   void UpdateTabContainer();
   bool ShouldShowVerticalTabs() const;
 
-  std::optional<SplitViewBrowserData::Tile> GetTileForTab(const Tab* tab) const;
+  std::optional<TabTile> GetTileForTab(const Tab* tab) const;
 
   TabContainer* GetTabContainerForTesting();
 


### PR DESCRIPTION
All browser tests for this type are incurring in a null deref, as `browser` was not being passed into the type. This fix corrects these cases.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41740

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

