### PR TITLE
[iOS] - Fix Session Restore URL Display (uplift to 1.72.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -450,24 +450,23 @@ class TabLocationView: UIView {
   }
 
   private func updateURLBarWithText() {
-    guard let url = url else {
-      urlDisplayLabel.text = ""
-      return
-    }
-
-    if let internalURL = InternalURL(url), internalURL.isBasicAuthURL {
+    if let url = url, let internalURL = InternalURL(url), internalURL.isBasicAuthURL {
       urlDisplayLabel.text = Strings.PageSecurityView.signIntoWebsiteURLBarTitle
     } else {
       // Matches LocationBarModelImpl::GetFormattedURL in Chromium (except for omitHTTP)
       // components/omnibox/browser/location_bar_model_impl.cc
       // TODO: Export omnibox related APIs and use directly
-      urlDisplayLabel.text = URLFormatter.formatURL(
-        url.scheme == "blob" ? URLOrigin(url: url).url?.absoluteString ?? "" : url.absoluteString,
-        formatTypes: [
-          .trimAfterHost, .omitHTTP, .omitHTTPS, .omitTrivialSubdomains, .omitDefaults,
-        ],
-        unescapeOptions: .normal
-      )
+      if let url = url {
+        urlDisplayLabel.text = URLFormatter.formatURL(
+          url.scheme == "blob" ? URLOrigin(url: url).url?.absoluteString ?? "" : url.absoluteString,
+          formatTypes: [
+            .trimAfterHost, .omitHTTP, .omitHTTPS, .omitTrivialSubdomains, .omitDefaults,
+          ],
+          unescapeOptions: .normal
+        )
+      } else {
+        urlDisplayLabel.text = ""
+      }
     }
 
     reloadButton.isHidden = url == nil


### PR DESCRIPTION
Uplift of #26099
Resolves https://github.com/brave/brave-browser/issues/41716

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.