### PR TITLE
[ads] Fixes search result ad landing page metrics are not reported on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -172,6 +172,8 @@ extension Tab {
     var textContent: String?
 
     if rewards.isEnabled {
+      // Only utilized for verifiable conversions, which requires the user to have
+      // joined Brave Rewards.
       group.enter()
       webView.evaluateSafeJavaScript(
         functionName: "new XMLSerializer().serializeToString",
@@ -183,6 +185,9 @@ extension Tab {
         group.leave()
       }
 
+      // Only utilized for text classification, which requires the user to have
+      // joined Brave Rewards. Desktop requires the user to have opted into
+      // notification ads, however we do not have access to that pref at this time.
       group.enter()
       webView.evaluateSafeJavaScript(
         functionName: "document?.body?.innerText",

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -997,6 +997,15 @@ extension BrowserViewController: WKNavigationDelegate {
 
     rewards.reportTabNavigation(tabId: tab.rewardsId)
 
+    // Notify of tab changes after navigation completes but before notifying that
+    // the tab has loaded, so that any listeners can process the tab changes
+    // before the tab is considered loaded.
+    rewards.maybeNotifyTabDidChange(
+      tab: tab,
+      isSelected: tabManager.selectedTab == tab
+    )
+    rewards.maybeNotifyTabDidLoad(tab: tab)
+
     // The toolbar and url bar changes can not be
     // on different tab than selected. Or the webview
     // previews and etc will effect the status

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -405,6 +405,10 @@ class TabManager: NSObject {
       if previousTab.displayFavicon == nil {
         adsRewardsLog.warning("No favicon found in \(previousTab) to report to rewards panel")
       }
+      rewards?.maybeNotifyTabDidChange(
+        tab: previousTab,
+        isSelected: false
+      )
       rewards?.reportTabUpdated(
         tab: previousTab,
         isSelected: false,
@@ -414,6 +418,10 @@ class TabManager: NSObject {
       if newSelectedTab.displayFavicon == nil && !newTabUrl.isLocal {
         adsRewardsLog.warning("No favicon found in \(newSelectedTab) to report to rewards panel")
       }
+      rewards?.maybeNotifyTabDidChange(
+        tab: newSelectedTab,
+        isSelected: true
+      )
       rewards?.reportTabUpdated(
         tab: newSelectedTab,
         isSelected: true,

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -332,11 +332,13 @@ constexpr NSString* kComponentUpdaterMetadataPrefKey =
 }
 
 - (void)applicationDidBecomeActive {
+  // Notify browser's active state changed.
   [self notifyBrowserDidEnterForeground];
   [self notifyBrowserDidBecomeActive];
 }
 
 - (void)applicationDidBackground {
+  // Notify browser's active state changed.
   [self notifyBrowserDidResignActive];
   [self notifyBrowserDidEnterBackground];
 }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41722

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test case 1
- Join Brave Rewards
- Open search.brave.software
- Search for giraffe
- Tap the [STAGING] Brave Ads search result ad
   EXPECTATION: Search result ad landing page metrics are reported. There should be a log:
      `[ads] Maybe land on page for https://brave.com/brave-ads/?no_key_param= in 5 s`
      `[ads] Landed on page for https://brave.com/brave-ads/?no_key_param= on tab id %%%`
     