### PR TITLE
Fixed contextual panel item is not activated after attaching to window

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -1242,6 +1242,21 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithAIChat,
   EXPECT_TRUE(model()->active_index().has_value());
   EXPECT_EQ(model()->active_index(),
             model()->GetIndexOf(SidebarItem::BuiltInItemType::kBookmarks));
+
+  // Check tab specific panel item is still activated after moving to another
+  // browser.
+  tab_model()->ActivateTabAt(1);
+  EXPECT_EQ(model()->active_index(), tab_specific_item_index);
+
+  auto* browser2 = CreateBrowser(browser()->profile());
+  auto* browser2_model =
+      static_cast<BraveBrowser*>(browser2)->sidebar_controller()->model();
+  auto* browser2_tab_model = browser2->tab_strip_model();
+
+  auto detached_tab = tab_model()->DetachTabAtForInsertion(1);
+  browser2_tab_model->AppendTab(std::move(detached_tab), /* foreground */ true);
+  EXPECT_EQ(browser2_model->active_index(),
+            browser2_model->GetIndexOf(SidebarItem::BuiltInItemType::kChatUI));
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTestWithAIChat,

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -42,11 +42,6 @@ void BraveSidePanelCoordinator::Show(
   sidebar::SetLastUsedSidePanel(browser_view_->GetProfile()->GetPrefs(),
                                 entry_key.id());
 
-  // Notify to give opportunity to observe another panel entries from
-  // global or active tab's contextual registry.
-  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
-  brave_browser_view->WillShowSidePanel();
-
   SidePanelCoordinator::Show(entry_key, open_trigger);
 }
 
@@ -91,13 +86,6 @@ void BraveSidePanelCoordinator::Toggle() {
 void BraveSidePanelCoordinator::Toggle(
     SidePanelEntryKey key,
     SidePanelUtil::SidePanelOpenTrigger open_trigger) {
-  // Notify to give opportunity to observe another panel entries from
-  // global or active tab's contextual registry.
-  if (!IsSidePanelShowing()) {
-    auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
-    brave_browser_view->WillShowSidePanel();
-  }
-
   SidePanelCoordinator::Toggle(key, open_trigger);
 }
 
@@ -160,6 +148,11 @@ void BraveSidePanelCoordinator::PopulateSidePanel(
     return;
   }
 
+  // Notify to give opportunity to observe another panel entries from
+  // global or active tab's contextual registry.
+  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
+  brave_browser_view->WillShowSidePanel();
+
   SidePanelCoordinator::PopulateSidePanel(supress_animations, unique_key, entry,
                                           std::move(content_view));
 }
@@ -167,11 +160,6 @@ void BraveSidePanelCoordinator::PopulateSidePanel(
 void BraveSidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange(
     SidePanelEntryKey key,
     bool is_active) {
-  // // Notify to give opportunity to observe another panel entries from
-  // // global or active tab's contextual registry.
-  // auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
-  // brave_browser_view->WillShowSidePanel();
-
   if (!browser_view_->toolbar()->pinned_toolbar_actions_container()) {
     return;
   }

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.h
@@ -9,7 +9,7 @@
 #include <memory>
 #include <optional>
 
-#include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"  // IWYU pragma: export
+#include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 
 class BraveSidePanelCoordinator : public SidePanelCoordinator {
  public:


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/41782

We called SidebarContainerView::WillShowSidePanel() to observe tab's contextual entry/global entry when panel starts to show from some places. But there was corner-case that WillShowSidePanel() is not called when panel is shown. It happened when tab is attached to another window. And realized that PopulateSidePanel() is always called whenever panel is shown in whatever situation. Fixed by calling WillShowSidePanel() from PopulateSidePanel().

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTestWithAIChat.TabSpecificPanelAndUnManagedPanel`

See the linked issue for manual test.