### PR TITLE
Fixed empty channel on release build for Android (uplift to 1.71.x)

### DIFF
--- a/components/version_info/android/BUILD.gn
+++ b/components/version_info/android/BUILD.gn
@@ -23,7 +23,17 @@ process_version("generate_brave_version_constants") {
     "BRAVE_BROWSER_VERSION=\"$brave_version\"",
     "-e",
     "BRAVE_CHROMIUM_VERSION=\"$chrome_version_string\"",
-    "-e",
-    "BRAVE_CHANNEL=str.upper('$brave_channel')",
   ]
+
+  if (is_official_build && brave_channel == "") {
+    extra_args += [
+      "-e",
+      "BRAVE_CHANNEL=RELEASE",
+    ]
+  } else {
+    extra_args += [
+      "-e",
+      "BRAVE_CHANNEL=str.upper('$brave_channel')",
+    ]
+  }
 }


### PR DESCRIPTION
Uplift of #26122
Resolves https://github.com/brave/brave-browser/issues/41719

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.