### PR TITLE
[Rewards 3.0] Fix mojo struct ptr access when querying creator info (uplift to 1.72.x)

### DIFF
--- a/browser/ui/webui/brave_rewards/rewards_page_data_source.cc
+++ b/browser/ui/webui/brave_rewards/rewards_page_data_source.cc
@@ -238,7 +238,7 @@ static constexpr webui::LocalizedString kStrings[] = {
      IDS_BRAVE_REWARDS_ONBOARDING_ERROR_HEADER_DISABLED},
     {"onboardingErrorText", IDS_BRAVE_REWARDS_ONBOARDING_ERROR_TEXT},
     {"onboardingErrorTitle", IDS_BRAVE_REWARDS_ONBOARDING_ERROR_HEADER},
-    {"onboardingLearnMoreLabel", IDS_REWARDS_LEARN_MORE},
+    {"onboardingLearnMoreLabel", IDS_REWARDS_WIDGET_HOW_DOES_IT_WORK},
     {"onboardingSuccessLearnMoreLabel",
      IDS_BRAVE_REWARDS_ONBOARDING_HOW_DOES_IT_WORK},
     {"onboardingSuccessText", IDS_BRAVE_REWARDS_ONBOARDING_GEO_SUCCESS_TEXT},

--- a/browser/ui/webui/brave_rewards/rewards_page_handler.cc
+++ b/browser/ui/webui/brave_rewards/rewards_page_handler.cc
@@ -338,7 +338,8 @@ void RewardsPageHandler::GetPublisherForActiveTab(
   auto get_publisher_callback = [](decltype(callback) callback,
                                    mojom::Result result,
                                    mojom::PublisherInfoPtr publisher_info) {
-    if (publisher_info->status == mojom::PublisherStatus::NOT_VERIFIED) {
+    if (publisher_info &&
+        publisher_info->status == mojom::PublisherStatus::NOT_VERIFIED) {
       publisher_info = nullptr;
     }
     std::move(callback).Run(std::move(publisher_info));


### PR DESCRIPTION
Uplift of #26118
Resolves https://github.com/brave/brave-browser/issues/41750
Resolves https://github.com/brave/brave-browser/issues/40041

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.