### PR TITLE
fix(privacy): Crash on launch with Shred and keep private tabs enabled (uplift to 1.72.x)

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppState.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppState.swift
@@ -53,6 +53,7 @@ public class AppState {
           // initialization. This is because Database container may change. See bugs #3416, #3377.
           didBecomeActive = true
           DataController.shared.initializeOnce()
+          DataController.sharedInMemory.initializeOnce()
           Migration.migrateLostTabsActiveWindow()
         }
 


### PR DESCRIPTION
Uplift of #26139
Resolves https://github.com/brave/brave-browser/issues/41765

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.