### PR TITLE
style(wallet): Portfolio Activity Tab Padding

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -643,6 +643,8 @@ export const PortfolioOverview = () => {
         >
           <ActivityWrapper
             fullWidth={true}
+            fullHeight={true}
+            justifyContent='flex-start'
             padding='0px 16px'
           >
             <TransactionsScreen />

--- a/components/brave_wallet_ui/page/screens/transactions/transaction-screen.styles.ts
+++ b/components/brave_wallet_ui/page/screens/transactions/transaction-screen.styles.ts
@@ -5,10 +5,28 @@
 
 import styled from 'styled-components'
 
+// Icons
+import {
+  NoTransactionsIconDark,
+  NoTransactionsIconLight
+} from '../../../assets/svg-icons/empty-state-icons'
+
 export const SearchAndFiltersRow = styled.div`
   display: flex;
   flex-direction: row;
   flex-wrap: wrap;
   width: 100%;
   gap: 14px;
+`
+
+export const EmptyTransactionsIcon = styled.div`
+  width: 100px;
+  height: 100px;
+  background-repeat: no-repeat;
+  background-size: 100%;
+  background-position: center;
+  background-image: url(${NoTransactionsIconLight});
+  @media (prefers-color-scheme: dark) {
+    background-image: url(${NoTransactionsIconDark});
+  }
 `

--- a/components/brave_wallet_ui/page/screens/transactions/transactions-screen.tsx
+++ b/components/brave_wallet_ui/page/screens/transactions/transactions-screen.tsx
@@ -63,6 +63,7 @@ import {
   LoadingSkeletonStyleProps,
   Skeleton
 } from '../../../components/shared/loading-skeleton/styles'
+import { EmptyTransactionsIcon } from './transaction-screen.styles'
 
 const txListItemSkeletonProps: LoadingSkeletonStyleProps = {
   width: '100%',
@@ -249,8 +250,9 @@ export const TransactionsScreen: React.FC = () => {
               <Column
                 fullHeight
                 gap={'24px'}
+                padding={isPanel ? '0px 0px 32px 0px' : '0px'}
               >
-                <VerticalSpacer space={14} />
+                <EmptyTransactionsIcon />
                 <Text
                   textSize='18px'
                   isBold
@@ -263,24 +265,29 @@ export const TransactionsScreen: React.FC = () => {
               </Column>
             )}
 
-            <Column
-              fullWidth={true}
-              fullHeight={true}
-              justifyContent='flex-start'
-            >
-              {filteredTransactions.map((tx, i) => (
-                <PortfolioTransactionItem
-                  key={tx.id}
-                  transaction={tx}
-                  onClick={onClickTransaction}
-                />
-              ))}
-            </Column>
+            {filteredTransactions.length !== 0 && (
+              <Column
+                fullWidth={true}
+                fullHeight={true}
+                justifyContent='flex-start'
+              >
+                {filteredTransactions.map((tx) => (
+                  <PortfolioTransactionItem
+                    key={tx.id}
+                    transaction={tx}
+                    onClick={onClickTransaction}
+                  />
+                ))}
+              </Column>
+            )}
 
             {txsForSelectedChain &&
               txsForSelectedChain.length !== 0 &&
               filteredTransactions.length === 0 && (
-                <Column fullHeight>
+                <Column
+                  fullHeight
+                  padding={isPanel ? '32px 0px 64px 0px' : '0px'}
+                >
                   <Text textSize='14px'>
                     {getLocale('braveWalletConnectHardwareSearchNothingFound')}
                   </Text>


### PR DESCRIPTION
## Description 

Fixes the `centering` and `padding` for `Portfolio Activity` tab's empty state.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/41786>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a new wallet
2. Open Panel and hide graph 
3. Click on Activity in segmented controller
4. The empty state text should be `Centered` and have `Padding`.

Before:

![Screenshot 36](https://github.com/user-attachments/assets/48d2243c-e17e-4299-bdbc-a6f66148a478)

After:

![Screenshot 37](https://github.com/user-attachments/assets/3f2f600b-a08b-4d45-8c13-7d63e563d172)
