### PR TITLE
[ubsan] Apply `CloseBubbleOnTabActivationHelper` observer fix

### DIFF
--- a/patches/chrome-browser-ui-views-bubble-webui_bubble_manager.cc.patch
+++ b/patches/chrome-browser-ui-views-bubble-webui_bubble_manager.cc.patch
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/ui/views/bubble/webui_bubble_manager.cc b/chrome/browser/ui/views/bubble/webui_bubble_manager.cc
+index 5c989ce1b3ab12442abf6edcc0d4d1bffc96ee80..e9915c42a1dbebc685261279421b6b050798d0f1 100644
+--- a/chrome/browser/ui/views/bubble/webui_bubble_manager.cc
++++ b/chrome/browser/ui/views/bubble/webui_bubble_manager.cc
+@@ -6,6 +6,7 @@
+ 
+ #include "base/notimplemented.h"
+ #include "base/timer/timer.h"
++#include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/browser_list.h"
+ #include "chrome/browser/ui/webui/top_chrome/webui_contents_warmup_level_recorder.h"
+ #include "chrome/browser/ui/webui/top_chrome/webui_url_utils.h"
+@@ -69,7 +70,8 @@ bool WebUIBubbleManager::ShowBubble(const std::optional<gfx::Rect>& anchor,
+   if ((!disable_close_bubble_helper_) &&
+       BrowserList::GetInstance()->GetLastActive()) {
+     close_bubble_helper_ = std::make_unique<CloseBubbleOnTabActivationHelper>(
+-        bubble_view_.get(), BrowserList::GetInstance()->GetLastActive());
++        bubble_view_.get(),
++        BrowserList::GetInstance()->GetLastActive()->tab_strip_model());
+   }
+ 
+   if (identifier)

--- a/patches/chrome-browser-ui-views-close_bubble_on_tab_activation_helper.cc.patch
+++ b/patches/chrome-browser-ui-views-close_bubble_on_tab_activation_helper.cc.patch
@@ -1,0 +1,41 @@
+diff --git a/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.cc b/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.cc
+index d6329b61ad7c6f383f87c51e33f09a824990788f..c837fc0a5eb0317d8e0f2d7e3e7964b68484cd4b 100644
+--- a/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.cc
++++ b/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.cc
+@@ -10,17 +10,16 @@
+ 
+ CloseBubbleOnTabActivationHelper::CloseBubbleOnTabActivationHelper(
+     views::BubbleDialogDelegateView* owner_bubble,
+-    Browser* browser)
+-    : owner_bubble_(owner_bubble), browser_(browser) {
+-  DCHECK(owner_bubble_);
+-  DCHECK(browser_);
+-  browser_->tab_strip_model()->AddObserver(this);
++    TabStripModel* tab_strip_model)
++    : owner_bubble_(owner_bubble) {
++  CHECK(owner_bubble_);
++  CHECK(tab_strip_model);
++  // `AddObserver` called asymmetrically, with no `RemoveObserver` call in this
++  // class as `TabStripModel` removes itself.
++  tab_strip_model->AddObserver(this);
+ }
+ 
+-CloseBubbleOnTabActivationHelper::~CloseBubbleOnTabActivationHelper() {
+-  if (browser_)
+-    browser_->tab_strip_model()->RemoveObserver(this);
+-}
++CloseBubbleOnTabActivationHelper::~CloseBubbleOnTabActivationHelper() = default;
+ 
+ void CloseBubbleOnTabActivationHelper::OnTabStripModelChanged(
+     TabStripModel* tab_strip_model,
+@@ -36,10 +35,3 @@ void CloseBubbleOnTabActivationHelper::OnTabStripModelChanged(
+     owner_bubble_ = nullptr;
+   }
+ }
+-
+-void CloseBubbleOnTabActivationHelper::OnTabStripModelDestroyed(
+-    TabStripModel* tab_strip_model) {
+-  DCHECK(browser_);
+-  browser_->tab_strip_model()->RemoveObserver(this);
+-  browser_ = nullptr;
+-}

--- a/patches/chrome-browser-ui-views-close_bubble_on_tab_activation_helper.h.patch
+++ b/patches/chrome-browser-ui-views-close_bubble_on_tab_activation_helper.h.patch
@@ -1,0 +1,41 @@
+diff --git a/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.h b/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.h
+index f1f3fdd58bf7b7502edd52bcc39a73ea71b6a14f..57a0bd6d6c2f66b9936625641131471de3e91794 100644
+--- a/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.h
++++ b/chrome/browser/ui/views/close_bubble_on_tab_activation_helper.h
+@@ -8,8 +8,6 @@
+ #include "base/memory/raw_ptr.h"
+ #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
+ 
+-class Browser;
+-
+ namespace views {
+ class BubbleDialogDelegateView;
+ }
+@@ -19,11 +17,12 @@ class BubbleDialogDelegateView;
+ // add, close or change the active tab.
+ class CloseBubbleOnTabActivationHelper : public TabStripModelObserver {
+  public:
+-  // It is the expectation of this class that |bubble| and |browser| should
+-  // outlive it. The recommended usage is for |bubble| to own |this|.
++  // It is the expectation of this class that `owner_bubble` and
++  // `tab_strip_model` should outlive it. The recommended usage is for `bubble`
++  // to own `this`.
+   CloseBubbleOnTabActivationHelper(
+       views::BubbleDialogDelegateView* owner_bubble,
+-      Browser* browser);
++      TabStripModel* tab_strip_model);
+ 
+   CloseBubbleOnTabActivationHelper(const CloseBubbleOnTabActivationHelper&) =
+       delete;
+@@ -37,11 +36,9 @@ class CloseBubbleOnTabActivationHelper : public TabStripModelObserver {
+       TabStripModel* tab_strip_model,
+       const TabStripModelChange& change,
+       const TabStripSelectionChange& selection) override;
+-  void OnTabStripModelDestroyed(TabStripModel* tab_strip_model) override;
+ 
+  private:
+   raw_ptr<views::BubbleDialogDelegateView> owner_bubble_;  // weak, owns me.
+-  raw_ptr<Browser> browser_;
+ };
+ 
+ #endif  // CHROME_BROWSER_UI_VIEWS_CLOSE_BUBBLE_ON_TAB_ACTIVATION_HELPER_H_

--- a/patches/chrome-browser-ui-views-profiles-profile_menu_view_base.cc.patch
+++ b/patches/chrome-browser-ui-views-profiles-profile_menu_view_base.cc.patch
@@ -1,7 +1,16 @@
 diff --git a/chrome/browser/ui/views/profiles/profile_menu_view_base.cc b/chrome/browser/ui/views/profiles/profile_menu_view_base.cc
-index 06d73cdced8d99fe3a174438de737f07a37f4b19..cc51817df5bfe1a1005cefcc6267026250bd9245 100644
+index 06d73cdced8d99fe3a174438de737f07a37f4b19..472f7ce393479bda1a1c6175f93c20009fc11401 100644
 --- a/chrome/browser/ui/views/profiles/profile_menu_view_base.cc
 +++ b/chrome/browser/ui/views/profiles/profile_menu_view_base.cc
+@@ -530,7 +530,7 @@ ProfileMenuViewBase::ProfileMenuViewBase(views::Button* anchor_button,
+     : BubbleDialogDelegateView(anchor_button, views::BubbleBorder::TOP_RIGHT),
+       browser_(browser),
+       anchor_button_(anchor_button),
+-      close_bubble_helper_(this, browser) {
++      close_bubble_helper_(this, browser->tab_strip_model()) {
+   SetButtons(static_cast<int>(ui::mojom::DialogButton::kNone));
+   // TODO(tluk): Remove when fixing https://crbug.com/822075
+   // The sign in webview will be clipped on the bottom corners without these
 @@ -589,6 +589,7 @@ void ProfileMenuViewBase::BuildProfileBackgroundContainer(
      identity_info_color_callback_ = base::BindRepeating(
          &ProfileMenuViewBase::BuildIdentityInfoColorCallback,


### PR DESCRIPTION
This is an upstream bug that has been fixed now, and it is affecting our ubsan runs.

Chromium change
https://chromium.googlesource.com/chromium/src/+/9cf6656bfc059af94c57957db356785ffa18dceb

```
commit 9cf6656bfc059af94c57957db356785ffa18dceb
Author: Claudio DeSouza <cdesouza@chromium.org>
Date:   Tue Oct 22 18:07:53 2024 +0000

    `CloseBubbleOnTabActivationHelper` double deregistering

    This came with ubsan recently, where `OnTabStripModelDestroyed` get
    called for `CloseBubbleOnTabActivationHelper`, and it tries to
    deregister using the member `tab_strip_model()`, and in some cases,
    `Browser::tab_strip_model()` is already gone.

    This CL undoes the local `RemoveObserver` call, that has been added
    by mistake to `CloseBubbleOnTabActivationHelper`, as this call is
    supposed to be handled by the base class. Furthermore, this CL reverts
    https://crrev.com/c/3753347, as that particular CL was addressing UaF
    failures caused by the introduction of `RemoveObserver` to this class.

    Bug: 40248746
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41828

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

