### PR TITLE
Android Webcompat reporter has empty channel for release build follow up (correct the quotation marks) (uplift to 1.72.x)

### DIFF
--- a/components/version_info/android/BUILD.gn
+++ b/components/version_info/android/BUILD.gn
@@ -28,7 +28,7 @@ process_version("generate_brave_version_constants") {
   if (is_official_build && brave_channel == "") {
     extra_args += [
       "-e",
-      "BRAVE_CHANNEL=RELEASE",
+      "BRAVE_CHANNEL=\"RELEASE\"",
     ]
   } else {
     extra_args += [


### PR DESCRIPTION
Uplift of #26172
Resolves https://github.com/brave/brave-browser/issues/41823

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.