### PR TITLE
fix(wallet): remove duplication nft_id when fetching nft metadata (uplift to 1.72.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Extensions/RpcServiceExtensions.swift
@@ -440,7 +440,13 @@ extension BraveWalletJsonRpcService {
       guard let self = self else { return [:] }
       for (coin, tokensPerCoin) in tokenCoinMap {
         group.addTask {
-          let nftIdentifiers = tokensPerCoin.map {
+          var uniqueTokensPerCoin: [BraveWallet.BlockchainToken] = []
+          for token in tokensPerCoin {
+            if !uniqueTokensPerCoin.contains(token) {
+              uniqueTokensPerCoin.append(token)
+            }
+          }
+          let nftIdentifiers = uniqueTokensPerCoin.map {
             BraveWallet.NftIdentifier(
               chainId: $0.chainId,
               contractAddress: $0.contractAddress,


### PR DESCRIPTION
Uplift of #26174
Resolves https://github.com/brave/brave-browser/issues/41839

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.