### PR TITLE
[Android] Select the highest priority threat from SafetyNetClient.loo…

### DIFF
--- a/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */

--- a/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java
@@ -1,0 +1,64 @@
+/* Copyright (c) 2023 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser;
+
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.test.BaseJUnit4ClassRunner;
+import org.chromium.base.test.util.Batch;
+import org.chromium.components.safe_browsing.BraveSafeBrowsingUtils;
+import org.chromium.components.safe_browsing.BraveSafeBrowsingUtils.SafetyNetJavaThreatType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+@Batch(Batch.PER_CLASS)
+@RunWith(BaseJUnit4ClassRunner.class)
+public class BraveSafetyNetThreatsPrioritiesTest {
+
+    @Test
+    @SmallTest
+    public void testPriorities() throws Exception {
+        // Fail safe option for empty input, consider it is safe
+        Assert.assertEquals(
+                BraveSafeBrowsingUtils.getMostPriorityThreat(new ArrayList<>()),
+                SafetyNetJavaThreatType.MAX_VALUE);
+
+        // Single input must return the same value
+        Assert.assertEquals(
+                BraveSafeBrowsingUtils.getMostPriorityThreat(
+                        Arrays.asList(new Integer[] {SafetyNetJavaThreatType.SOCIAL_ENGINEERING})),
+                SafetyNetJavaThreatType.SOCIAL_ENGINEERING);
+
+        // Several threats as input - return the most priority one
+        Assert.assertEquals(
+                BraveSafeBrowsingUtils.getMostPriorityThreat(
+                        Arrays.asList(
+                                new Integer[] {
+                                    SafetyNetJavaThreatType.UNWANTED_SOFTWARE,
+                                    SafetyNetJavaThreatType.SUBRESOURCE_FILTER,
+                                    SafetyNetJavaThreatType.SOCIAL_ENGINEERING,
+                                    SafetyNetJavaThreatType.BILLING,
+                                    SafetyNetJavaThreatType.POTENTIALLY_HARMFUL_APPLICATION,
+                                })),
+                SafetyNetJavaThreatType.SOCIAL_ENGINEERING);
+
+        Assert.assertEquals(
+                BraveSafeBrowsingUtils.getMostPriorityThreat(
+                        Arrays.asList(
+                                new Integer[] {
+                                    SafetyNetJavaThreatType.SUBRESOURCE_FILTER,
+                                    SafetyNetJavaThreatType.CSD_ALLOWLIST,
+                                    SafetyNetJavaThreatType.POTENTIALLY_HARMFUL_APPLICATION,
+                                    SafetyNetJavaThreatType.UNWANTED_SOFTWARE,
+                                })),
+                SafetyNetJavaThreatType.POTENTIALLY_HARMFUL_APPLICATION);
+    }
+}

--- a/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java
+++ b/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java
@@ -28,18 +28,18 @@ public class BraveSafetyNetThreatsPrioritiesTest {
     public void testPriorities() throws Exception {
         // Fail safe option for empty input, consider it is safe
         Assert.assertEquals(
-                BraveSafeBrowsingUtils.getMostPriorityThreat(new ArrayList<>()),
+                BraveSafeBrowsingUtils.getHighestPriorityThreat(new ArrayList<>()),
                 SafetyNetJavaThreatType.MAX_VALUE);
 
         // Single input must return the same value
         Assert.assertEquals(
-                BraveSafeBrowsingUtils.getMostPriorityThreat(
+                BraveSafeBrowsingUtils.getHighestPriorityThreat(
                         Arrays.asList(new Integer[] {SafetyNetJavaThreatType.SOCIAL_ENGINEERING})),
                 SafetyNetJavaThreatType.SOCIAL_ENGINEERING);
 
         // Several threats as input - return the most priority one
         Assert.assertEquals(
-                BraveSafeBrowsingUtils.getMostPriorityThreat(
+                BraveSafeBrowsingUtils.getHighestPriorityThreat(
                         Arrays.asList(
                                 new Integer[] {
                                     SafetyNetJavaThreatType.UNWANTED_SOFTWARE,
@@ -51,7 +51,7 @@ public class BraveSafetyNetThreatsPrioritiesTest {
                 SafetyNetJavaThreatType.SOCIAL_ENGINEERING);
 
         Assert.assertEquals(
-                BraveSafeBrowsingUtils.getMostPriorityThreat(
+                BraveSafeBrowsingUtils.getHighestPriorityThreat(
                         Arrays.asList(
                                 new Integer[] {
                                     SafetyNetJavaThreatType.SUBRESOURCE_FILTER,

--- a/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingApiHandler.java
+++ b/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingApiHandler.java
@@ -134,7 +134,7 @@ public class BraveSafeBrowsingApiHandler implements SafeBrowsingApiHandler {
                                         BraveSafeBrowsingUtils
                                                 .safetyNetToSafeBrowsingJavaThreatType(
                                                         BraveSafeBrowsingUtils
-                                                                .getMostPriorityThreat(threats)),
+                                                                .getHighestPriorityThreat(threats)),
                                         THREAT_ATTRIBUTES_STUB,
                                         SafeBrowsingJavaResponseStatus.SUCCESS_WITH_REAL_TIME,
                                         DEFAULT_CHECK_DELTA);

--- a/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingApiHandler.java
+++ b/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingApiHandler.java
@@ -11,8 +11,8 @@ import android.webkit.URLUtil;
 
 import com.google.android.gms.common.api.ApiException;
 import com.google.android.gms.common.api.CommonStatusCodes;
+import com.google.android.gms.safetynet.SafeBrowsingThreat;
 import com.google.android.gms.safetynet.SafetyNet;
-import com.google.android.gms.safetynet.SafetyNetApi.SafeBrowsingResponse;
 import com.google.android.gms.safetynet.SafetyNetStatusCodes;
 
 import org.chromium.base.ContextUtils;
@@ -20,6 +20,9 @@ import org.chromium.base.Log;
 import org.chromium.components.safe_browsing.BraveSafeBrowsingUtils.SafeBrowsingJavaResponseStatus;
 import org.chromium.components.safe_browsing.BraveSafeBrowsingUtils.SafeBrowsingJavaThreatType;
 import org.chromium.components.safe_browsing.SafeBrowsingApiHandler.LookupResult;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Brave implementation of SafeBrowsingApiHandler for Safe Browsing Under the bonnet it still uses
@@ -120,18 +123,18 @@ public class BraveSafeBrowsingApiHandler implements SafeBrowsingApiHandler {
                                         DEFAULT_CHECK_DELTA);
                                 return;
                             } else {
-                                warnWhenMoreThanOneThreat(sbResponse);
+                                List<Integer> threats =
+                                        sbResponse.getDetectedThreats().stream()
+                                                .map(SafeBrowsingThreat::getThreatType)
+                                                .collect(Collectors.toList());
 
-                                // Response only with the first code
                                 mObserver.onUrlCheckDone(
                                         callbackId,
                                         LookupResult.SUCCESS,
                                         BraveSafeBrowsingUtils
                                                 .safetyNetToSafeBrowsingJavaThreatType(
-                                                        sbResponse
-                                                                .getDetectedThreats()
-                                                                .get(0)
-                                                                .getThreatType()),
+                                                        BraveSafeBrowsingUtils
+                                                                .getMostPriorityThreat(threats)),
                                         THREAT_ATTRIBUTES_STUB,
                                         SafeBrowsingJavaResponseStatus.SUCCESS_WITH_REAL_TIME,
                                         DEFAULT_CHECK_DELTA);
@@ -199,18 +202,6 @@ public class BraveSafeBrowsingApiHandler implements SafeBrowsingApiHandler {
                             }
                             mTriesCount = 0;
                         });
-    }
-
-    private void warnWhenMoreThanOneThreat(SafeBrowsingResponse sbResponse) {
-        if (sbResponse.getDetectedThreats().size() != 1) {
-            Log.d(TAG, "Unexpected threats count: " + sbResponse.getDetectedThreats().size());
-            String threats = "";
-            for (int i = 0; i < sbResponse.getDetectedThreats().size(); i++) {
-                threats += sbResponse.getDetectedThreats().get(i).getThreatType();
-                threats += " ";
-            }
-            Log.d(TAG, "Threats: [" + threats + "]");
-        }
     }
 
     public void initSafeBrowsing() {

--- a/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingUtils.java
+++ b/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingUtils.java
@@ -153,7 +153,7 @@ public class BraveSafeBrowsingUtils {
     };
 
     @VisibleForTesting
-    public static int getMostPriorityThreat(List<Integer> threats) {
+    public static int getHighestPriorityThreat(List<Integer> threats) {
         if (threats.size() == 0) {
             return SafetyNetJavaThreatType.MAX_VALUE;
         }

--- a/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingUtils.java
+++ b/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingUtils.java
@@ -6,6 +6,7 @@
 package org.chromium.components.safe_browsing;
 
 import androidx.annotation.IntDef;
+import androidx.annotation.VisibleForTesting;
 
 import org.chromium.base.Log;
 
@@ -138,5 +139,36 @@ public class BraveSafeBrowsingUtils {
                                 + safetyNetThreatType);
                 return SafeBrowsingJavaThreatType.NO_THREAT;
         }
+    }
+
+    // Priorities from most high to low
+    private static final int SAFETY_NET_THREAT_PRIORITIES[] = {
+        SafetyNetJavaThreatType.SOCIAL_ENGINEERING,
+        SafetyNetJavaThreatType.BILLING,
+        SafetyNetJavaThreatType.POTENTIALLY_HARMFUL_APPLICATION,
+        SafetyNetJavaThreatType.UNWANTED_SOFTWARE,
+        SafetyNetJavaThreatType.SUBRESOURCE_FILTER,
+        SafetyNetJavaThreatType.CSD_ALLOWLIST,
+        SafetyNetJavaThreatType.MAX_VALUE
+    };
+
+    @VisibleForTesting
+    public static int getMostPriorityThreat(List<Integer> threats) {
+        if (threats.size() == 0) {
+            return SafetyNetJavaThreatType.MAX_VALUE;
+        }
+
+        if (threats.size() == 1) {
+            return threats.get(0);
+        }
+
+        for (int i = 0; i < SAFETY_NET_THREAT_PRIORITIES.length; ++i) {
+            if (threats.contains(SAFETY_NET_THREAT_PRIORITIES[i])) {
+                return SAFETY_NET_THREAT_PRIORITIES[i];
+            }
+        }
+
+        assert false : "Unexpected threat";
+        return SafetyNetJavaThreatType.MAX_VALUE;
     }
 }

--- a/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingUtils.java
+++ b/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingUtils.java
@@ -144,8 +144,8 @@ public class BraveSafeBrowsingUtils {
     // Priorities from most high to low
     private static final int SAFETY_NET_THREAT_PRIORITIES[] = {
         SafetyNetJavaThreatType.SOCIAL_ENGINEERING,
-        SafetyNetJavaThreatType.BILLING,
         SafetyNetJavaThreatType.POTENTIALLY_HARMFUL_APPLICATION,
+        SafetyNetJavaThreatType.BILLING,
         SafetyNetJavaThreatType.UNWANTED_SOFTWARE,
         SafetyNetJavaThreatType.SUBRESOURCE_FILTER,
         SafetyNetJavaThreatType.CSD_ALLOWLIST,

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1264,6 +1264,7 @@ if (is_android) {
     }
 
     sources = [
+      "//brave/android/javatests/org/chromium/chrome/browser/BraveSafetyNetThreatsPrioritiesTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/BraveSwipeRefreshHandlerTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/BytecodeTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/brave_wallet/BraveWalletUtilsTest.java",
@@ -1279,6 +1280,7 @@ if (is_android) {
       "//base:base_java_test_support",
       "//base:base_shared_preferences_java",
       "//brave/components/brave_wallet/common:mojom_java",
+      "//brave/components/safe_browsing/android:brave_safe_browsing_java",
       "//cc:cc_java",
       "//chrome/android/features/keyboard_accessory/public:public_java",
       "//chrome/browser/android/browserservices/intents:java",


### PR DESCRIPTION
This PR changes the way how BraveSafeBrowsingApiHandler handles the case when SafetyNet reports more than one threat.
Before: the first one was taken.
Now: the most prioritized is taken, threats are arranged by priorities at `SAFETY_NET_THREAT_PRIORITIES` array.

`SAFETY_NET_THREAT_PRIORITIES` can be changed after the review, the test must be updated accordingly then.

The codes returned from https://testsafebrowsing.appspot.com/ are:

- (1) `[A/W/M/L/C] Should show a phishing warning` - 5 - `SafetyNetJavaThreatType.SOCIAL_ENGINEERING`
- (2) `[A/W/M/L/C/D] Should show a malware warning` - 4 - `SafetyNetJavaThreatType.POTENTIALLY_HARMFUL_APPLICATION`
- (4) `[W/M/L/C] Should show a unwanted software warning` - 3 - `SafetyNetJavaThreatType.UNWANTED_SOFTWARE`
- (6) `[A/W/M/L/C] Should show a billing warning` - 15 - `SafetyNetJavaThreatType.BILLING`


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41581

This is a follow-up for https://github.com/brave/brave-core/pull/25842.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x]  I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
There is no a strict test plan, because I never saw the website which had more than one threat reported by SafetyNet.

The basic sanity check though is
1. Open https://testsafebrowsing.appspot.com/
2. For 1, 2, 4, 6 option the corresponding interstitial page with warning must be displayed.




