### PR TITLE
Do not crash P3A scheduling if time is wrong. (uplift to 1.72.x)

### DIFF
--- a/components/p3a/rotation_scheduler.cc
+++ b/components/p3a/rotation_scheduler.cc
@@ -190,7 +190,6 @@ void RotationScheduler::UpdateJsonTimer(MetricLogType log_type) {
           : now + config_->json_rotation_intervals.at(log_type);
   if (now >= next_rotation) {
     // Should never happen, but let's stay on the safe side.
-    NOTREACHED_IN_MIGRATION();
     return;
   }
   json_rotation_timers_[log_type]->Start(


### PR DESCRIPTION
Uplift of #26192
Fixes https://github.com/brave/brave-browser/issues/41857

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.