### PR TITLE
feat(wallet): Shield ZCash Account Modal

### DIFF
--- a/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
+++ b/browser/ui/webui/brave_wallet/common_handler/wallet_handler.cc
@@ -39,7 +39,8 @@ void WalletHandler::GetWalletInfo(GetWalletInfoCallback callback) {
       keyring_service->IsWalletCreatedSync(), keyring_service->IsLockedSync(),
       keyring_service->IsWalletBackedUpSync(), IsBitcoinEnabled(),
       IsBitcoinImportEnabled(), IsBitcoinLedgerEnabled(), IsZCashEnabled(),
-      IsAnkrBalancesEnabled(), IsTransactionSimulationsEnabled()));
+      IsAnkrBalancesEnabled(), IsTransactionSimulationsEnabled(),
+      IsZCashShieldedTransactionsEnabled()));
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1606,7 +1606,15 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletFilters", IDS_BRAVE_WALLET_FILTERS},
     {"braveWalletClearFilters", IDS_BRAVE_WALLET_CLEAR_FILTERS},
     {"braveWalletShowMore", IDS_BRAVE_WALLET_SHOW_MORE},
-    {"braveWalletDetails", IDS_BRAVE_WALLET_DETAILS}};
+    {"braveWalletDetails", IDS_BRAVE_WALLET_DETAILS},
+    {"braveWalletSwitchToShieldedAccount",
+     IDS_BRAVE_WALLET_SWITCH_TO_SHIELDED_ACCOUNT},
+    {"braveWalletShieldAccount", IDS_BRAVE_WALLET_SHIELD_ACCOUNT},
+    {"braveWalletAccountNotShieldedDescription",
+     IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION},
+    {"braveWalletAccountShieldedDescription",
+     IDS_BRAVE_WALLET_ACCOUNT_SHIELDED_DESCRIPTION},
+    {"braveWalletShielded", IDS_BRAVE_WALLET_SHIELDED}};
 
 // 0x swap constants
 inline constexpr char kZeroExSepoliaBaseAPIURL[] =

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -981,6 +981,7 @@ struct WalletInfo {
   bool is_z_cash_enabled;
   bool is_ankr_balances_feature_enabled;
   bool is_transaction_simulations_feature_enabled;
+  bool is_z_cash_shielded_transactions_enabled;
 };
 
 // Browser-side handler for common panel / page things

--- a/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
+++ b/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
@@ -1313,7 +1313,8 @@ export class MockedWalletApiProxy {
           isWalletCreated: true,
           isWalletLocked: false,
           isAnkrBalancesFeatureEnabled: false,
-          isTransactionSimulationsFeatureEnabled: true
+          isTransactionSimulationsFeatureEnabled: true,
+          isZCashShieldedTransactionsEnabled: false
         }
       }
     }

--- a/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
+++ b/components/brave_wallet_ui/common/selectors/wallet-selectors.ts
@@ -24,6 +24,8 @@ export const isAnkrBalancesFeatureEnabled = ({ wallet }: State) =>
   wallet.isAnkrBalancesFeatureEnabled
 export const isRefreshingNetworksAndTokens = ({ wallet }: State) =>
   wallet.isRefreshingNetworksAndTokens
+export const isZCashShieldedTransactionsEnabled = ({ wallet }: State) =>
+  wallet.isZCashShieldedTransactionsEnabled
 
 // unsafe selectors (will cause re-render if not strictly equal "===") (objects
 // and lists)

--- a/components/brave_wallet_ui/common/slices/api-base.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api-base.slice.ts
@@ -83,7 +83,8 @@ export function createWalletApiBase() {
       'MeldServiceProviders',
       'MeldCryptoQuotes',
       'MeldPaymentMethods',
-      'MeldWidget'
+      'MeldWidget',
+      'ZCashAccountInfo'
     ],
     endpoints: ({ mutation, query }) => ({})
   })

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -50,6 +50,7 @@ import { encryptionEndpoints } from './endpoints/encryption.endpoints'
 import { signingEndpoints } from './endpoints/signing.endpoints'
 import { dappRadarEndpoints } from './endpoints/dapp_radar.endpoints'
 import { meldIntegrationEndpoints } from './endpoints/meld_integration.endpoints'
+import { zcashEndpoints } from './endpoints/zcash.endpoints'
 
 export function createWalletApi() {
   // base to add endpoints to
@@ -160,6 +161,8 @@ export function createWalletApi() {
       .injectEndpoints({ endpoints: dappRadarEndpoints })
       // meld integration endpoints
       .injectEndpoints({ endpoints: meldIntegrationEndpoints })
+      // zcash endpoints
+      .injectEndpoints({ endpoints: zcashEndpoints })
   )
 }
 
@@ -256,6 +259,7 @@ export const {
   useGetTransactionsQuery,
   useGetUserTokensRegistryQuery,
   useGetWalletsToImportQuery,
+  useGetZCashAccountInfoQuery,
   useHideNetworksMutation,
   useImportAccountFromJsonMutation,
   useImportAccountMutation,
@@ -293,7 +297,9 @@ export const {
   useLazyGetTokensRegistryQuery,
   useLazyGetTransactionsQuery,
   useLazyGetUserTokensRegistryQuery,
+  useLazyGetZCashAccountInfoQuery,
   useLockWalletMutation,
+  useMakeAccountShieldedMutation,
   useNewUnapprovedTxAddedMutation,
   useOpenPanelUIMutation,
   usePrefetch,

--- a/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Types
+import { BraveWallet } from '../../../constants/types'
+
+// Utils
+import { handleEndpointError } from '../../../utils/api-utils'
+import { WalletApiEndpointBuilderParams } from '../api-base.slice'
+
+export const zcashEndpoints = ({
+  query,
+  mutation
+}: WalletApiEndpointBuilderParams) => {
+  return {
+    makeAccountShielded: mutation<true, BraveWallet.AccountId>({
+      queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {
+        try {
+          const { zcashWalletService } = baseQuery(undefined).data
+
+          const { errorMessage } = await zcashWalletService.makeAccountShielded(
+            args
+          )
+
+          if (errorMessage) {
+            return handleEndpointError(
+              endpoint,
+              'Error making account shielded: ',
+              errorMessage
+            )
+          }
+
+          return {
+            data: true
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Error making account shielded: ',
+            error
+          )
+        }
+      },
+      invalidatesTags: ['ZCashAccountInfo']
+    }),
+    getZCashAccountInfo: query<
+      BraveWallet.ZCashAccountInfo | null,
+      BraveWallet.AccountId
+    >({
+      queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {
+        try {
+          const { zcashWalletService } = baseQuery(undefined).data
+
+          const { accountInfo } = await zcashWalletService.getZCashAccountInfo(
+            args
+          )
+
+          return {
+            data: accountInfo
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Error getting ZCash account info: ',
+            error
+          )
+        }
+      },
+      providesTags: ['ZCashAccountInfo']
+    })
+  }
+}

--- a/components/brave_wallet_ui/common/slices/wallet.slice.ts
+++ b/components/brave_wallet_ui/common/slices/wallet.slice.ts
@@ -33,7 +33,8 @@ const defaultState: WalletState = {
   passwordAttempts: 0,
   assetAutoDiscoveryCompleted: true,
   isAnkrBalancesFeatureEnabled: false,
-  isRefreshingNetworksAndTokens: false
+  isRefreshingNetworksAndTokens: false,
+  isZCashShieldedTransactionsEnabled: false
 }
 
 // async actions
@@ -81,6 +82,8 @@ export const createWalletSlice = (initialState: WalletState = defaultState) => {
         state.isWalletLocked = payload.walletInfo.isWalletLocked
         state.isAnkrBalancesFeatureEnabled =
           payload.walletInfo.isAnkrBalancesFeatureEnabled
+        state.isZCashShieldedTransactionsEnabled =
+          payload.walletInfo.isZCashShieldedTransactionsEnabled
       },
 
       setAssetAutoDiscoveryCompleted(

--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.stories.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.stories.tsx
@@ -1,0 +1,29 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+
+import {
+  WalletPageStory //
+} from '../../../../stories/wrappers/wallet-page-story-wrapper'
+import { ShieldZCashAccountModal } from './shield_zcash_account'
+import { mockAccount } from '../../../../common/constants/mocks'
+
+export const _ShieldZCashAccountModal = {
+  render: () => {
+    return (
+      <WalletPageStory>
+        <ShieldZCashAccountModal
+          account={mockAccount}
+          onClose={() => alert('close')}
+        />
+      </WalletPageStory>
+    )
+  }
+}
+
+export default {
+  component: ShieldZCashAccountModal
+}

--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.style.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import styled from 'styled-components'
+import * as leo from '@brave/leo/tokens/css/variables'
+import Icon from '@brave/leo/react/icon'
+
+// Shared Styled
+import { Column, Row } from '../../../shared/style'
+
+export const StyledWrapper = styled(Column)`
+  overflow: hidden;
+`
+
+export const AccountRow = styled(Row)`
+  border-radius: ${leo.radius.xl};
+  background-color: ${leo.color.container.highlight};
+`
+
+export const ShieldIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 100%;
+  background-color: ${leo.color.systemfeedback.successBackground};
+  position: absolute;
+  left: -20px;
+`
+
+export const ShieldIcon = styled(Icon).attrs({
+  name: 'shield-done-filled'
+})`
+  --leo-icon-size: 24px;
+  color: ${leo.color.systemfeedback.successIcon};
+`

--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+import * as React from 'react'
+
+// Slices
+import { useMakeAccountShieldedMutation } from '../../../../common/slices/api.slice'
+
+// Types
+import { BraveWallet } from '../../../../constants/types'
+
+// Utils
+import { getLocale } from '../../../../../common/locale'
+
+// Components
+import { PopupModal } from '../../popup-modals/index'
+import {
+  CreateAccountIcon //
+} from '../../../shared/create-account-icon/create-account-icon'
+
+// Styles
+import {
+  AccountRow,
+  ShieldIconWrapper,
+  ShieldIcon
+} from './shield_zcash_account.style'
+import { Column, Text, Row, LeoSquaredButton } from '../../../shared/style'
+
+interface Props {
+  account: BraveWallet.AccountInfo
+  onClose: () => void
+}
+
+export const ShieldZCashAccountModal = (props: Props) => {
+  const { account, onClose } = props
+
+  // State
+  const [isShielding, setIsShielding] = React.useState<boolean>(false)
+
+  // mutations
+  const [shieldAccount] = useMakeAccountShieldedMutation()
+
+  const onShieldAccount = React.useCallback(async () => {
+    if (!account.accountId) {
+      return
+    }
+    setIsShielding(true)
+    await shieldAccount(account.accountId)
+    setIsShielding(false)
+    onClose()
+  }, [shieldAccount, account, onClose])
+
+  return (
+    <PopupModal
+      title={getLocale('braveWalletSwitchToShieldedAccount')}
+      onClose={onClose}
+      width='520px'
+      headerPaddingHorizontal='32px'
+      headerPaddingVertical='32px'
+    >
+      <Column
+        gap='24px'
+        padding='8px 32px'
+      >
+        <AccountRow
+          width='unset'
+          padding='8px 30px 8px 8px'
+        >
+          <ShieldIconWrapper>
+            <ShieldIcon />
+          </ShieldIconWrapper>
+          <CreateAccountIcon
+            account={account}
+            size='huge'
+            marginRight={16}
+          />
+          <Column alignItems='flex-start'>
+            <Text
+              textSize='14px'
+              isBold={true}
+              textColor='primary'
+              textAlign='left'
+            >
+              {account.name}
+            </Text>
+            <Text
+              textSize='12px'
+              isBold={false}
+              textColor='secondary'
+              textAlign='left'
+            >
+              ZCash
+            </Text>
+          </Column>
+        </AccountRow>
+        <Text
+          textSize='14px'
+          isBold={false}
+          textColor='primary'
+          textAlign='left'
+        >
+          {getLocale('braveWalletAccountNotShieldedDescription')}
+        </Text>
+        <Text
+          textSize='14px'
+          isBold={true}
+          textColor='primary'
+          textAlign='left'
+        >
+          {getLocale('braveWalletAccountShieldedDescription')}
+        </Text>
+      </Column>
+      <Row
+        gap='16px'
+        padding='32px'
+      >
+        <LeoSquaredButton
+          onClick={onClose}
+          kind='outline'
+        >
+          {getLocale('braveWalletButtonCancel')}
+        </LeoSquaredButton>
+        <LeoSquaredButton
+          onClick={onShieldAccount}
+          disabled={isShielding}
+        >
+          {getLocale('braveWalletShieldAccount')}
+        </LeoSquaredButton>
+      </Row>
+    </PopupModal>
+  )
+}

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/account-actions-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/account-actions-menu.tsx
@@ -31,14 +31,23 @@ export interface Props {
 export const AccountActionsMenu = (props: Props) => {
   const { options, onClick } = props
 
+  // Computed
+  const minButtonWidth = options.some((option) => option.id === 'shield')
+    ? 260
+    : undefined
+
   return (
     <StyledWrapper yPosition={26}>
       {options.slice(0, 2).map((option) => (
         <PopupButton
           key={option.id}
           onClick={() => onClick(option.id)}
+          minWidth={minButtonWidth}
         >
-          <ButtonIcon name={option.icon} />
+          <ButtonIcon
+            name={option.icon}
+            id={option.id}
+          />
           <PopupButtonText>{getLocale(option.name)}</PopupButtonText>
         </PopupButton>
       ))}
@@ -48,8 +57,12 @@ export const AccountActionsMenu = (props: Props) => {
         <PopupButton
           key={option.id}
           onClick={() => onClick(option.id)}
+          minWidth={minButtonWidth}
         >
-          <ButtonIcon name={option.icon} />
+          <ButtonIcon
+            name={option.icon}
+            id={option.id}
+          />
           <PopupButtonText>{getLocale(option.name)}</PopupButtonText>
         </PopupButton>
       ))}

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wellet-menus.style.ts
@@ -6,6 +6,11 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 import Icon from '@brave/leo/react/icon'
+
+// Types
+import { AccountModalTypes } from '../../../constants/types'
+
+// Shared Styles
 import { WalletButton, Row } from '../../shared/style'
 import {
   layoutPanelWidth,
@@ -64,9 +69,12 @@ export const PopupButtonText = styled.span`
   color: ${leo.color.text.primary};
 `
 
-export const ButtonIcon = styled(Icon)`
+export const ButtonIcon = styled(Icon)<{ id?: AccountModalTypes }>`
   --leo-icon-size: 18px;
-  color: ${leo.color.icon.default};
+  color: ${(p) =>
+    p.id === 'shield'
+      ? leo.color.systemfeedback.successIcon
+      : leo.color.icon.default};
   margin-right: 16px;
 `
 

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -213,6 +213,7 @@ export interface WalletState {
   assetAutoDiscoveryCompleted: boolean
   isAnkrBalancesFeatureEnabled: boolean
   isRefreshingNetworksAndTokens: boolean
+  isZCashShieldedTransactionsEnabled: boolean
 }
 
 export interface PanelState {
@@ -857,6 +858,7 @@ export type AccountModalTypes =
   | 'remove'
   | 'buy'
   | 'explorer'
+  | 'shield'
 
 export interface AccountButtonOptionsObjectType {
   name: string

--- a/components/brave_wallet_ui/options/account-list-button-options.ts
+++ b/components/brave_wallet_ui/options/account-list-button-options.ts
@@ -39,5 +39,10 @@ export const AccountButtonOptions: AccountButtonOptionsObjectType[] = [
     id: 'remove',
     name: 'braveWalletAccountsRemove',
     icon: 'trash'
+  },
+  {
+    id: 'shield',
+    name: 'braveWalletSwitchToShieldedAccount',
+    icon: 'shield-done'
   }
 ]

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1513,5 +1513,14 @@ provideStrings({
   braveWalletFilters: 'Filters',
   braveWalletClearFilters: 'Clear filters',
   braveWalletShowMore: 'Show more',
-  braveWalletDetails: 'Details'
+  braveWalletDetails: 'Details',
+
+  // ZCash
+  braveWalletSwitchToShieldedAccount: 'Switch to a shielded account',
+  braveWalletShieldAccount: 'Shield account',
+  braveWalletAccountNotShieldedDescription:
+    'Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.',
+  braveWalletAccountShieldedDescription:
+    'Upgrading to a shielded account means that these transactions hide the sender, receiver and amount details.',
+  braveWalletShielded: 'Shielded'
 })

--- a/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
+++ b/components/brave_wallet_ui/stories/mock-data/mock-wallet-state.ts
@@ -55,5 +55,6 @@ export const mockWalletState: WalletState = {
   isWalletLocked: false,
   passwordAttempts: 0,
   assetAutoDiscoveryCompleted: false,
-  isRefreshingNetworksAndTokens: false
+  isRefreshingNetworksAndTokens: false,
+  isZCashShieldedTransactionsEnabled: false
 }

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1145,6 +1145,11 @@
   <message name="IDS_BRAVE_WALLET_CLEAR_FILTERS" desc="Clear filters label">Clear filters</message>
   <message name="IDS_BRAVE_WALLET_SHOW_MORE" desc="Show more label">Show more</message>
   <message name="IDS_BRAVE_WALLET_DETAILS" desc="Details label">Details</message>
+  <message name="IDS_BRAVE_WALLET_SWITCH_TO_SHIELDED_ACCOUNT" desc="Switch to a shielded account button text">Switch to a shielded account</message>
+  <message name="IDS_BRAVE_WALLET_SHIELD_ACCOUNT" desc="Shield account button text">Shield account</message>
+  <message name="IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION" desc="ZCash account not shielded description.">Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.</message>
+  <message name="IDS_BRAVE_WALLET_ACCOUNT_SHIELDED_DESCRIPTION" desc="ZCash account shielded description">Upgrading to a shielded account means that these transactions hide the sender, receiver and amount details.</message>
+  <message name="IDS_BRAVE_WALLET_SHIELDED" desc="Shielded label">Shielded</message>
   <message name="IDS_BRAVE_WALLET_BUTTON_RETRY" desc="Retry an action">Retry</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_PREVIEW_FAILED" desc="Explaination that simulation of a transaction has failed">Transaction preview failed.</message>
   <message name="IDS_BRAVE_WALLET_ESTIMATED_BALANCE_CHANGE" desc="Grouping header for estimated balance changes">Estimated balance change</message>


### PR DESCRIPTION
## Description 

Introduces the ability to `Shield` a ZCash Account on the `Accounts` page.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/41780>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Make sure that ZCash Shielded Transactions` is enabled
2. Open the `Wallet` and navigate to the `Accounts` tab
3. Click on the `More Menu` for you ZCash Account
4. Click on `Switch to shielded account`
5. Now click `Shield account`
6. If successful you should now see a `Shielded` label next to your `Account Name`.

https://github.com/user-attachments/assets/2e190a06-9e08-4a2c-8b13-9f50b2525ff1
