### PR TITLE
[ads] Fixes empty device id on Linux

### DIFF
--- a/browser/brave_ads/device_id/device_id_impl_linux.cc
+++ b/browser/brave_ads/device_id/device_id_impl_linux.cc
@@ -41,9 +41,29 @@ using DiskMap = std::map<base::FilePath, base::FilePath>;
 namespace {
 
 constexpr char kDiskByUuidDirectoryName[] = "/dev/disk/by-uuid";
-const char* const kDeviceNames[] = {"sda1", "hda1", "dm-0", "xvda1",
-                                    "sda2", "hda2", "dm-1", "xvda2"};
-const char* const kNetDeviceNamePrefixes[] = {
+constexpr const char* const kDeviceNames[] = {
+    "sda1",       // First partition of the first SATA, SCSI, or IDE drive.
+    "hda1",       // First partition of the first IDE/ATA drive.
+    "nvme0n1p1",  // First partition of the first NVMe device.
+    "md0p1",      // First partition of the first RAID array.
+    "mmcblk0p1",  // First partition of the first MMC/SD card.
+    "dm-0",       // First Device Mapper device.
+    "vda1",       // First partition of the first virtual drive in KVM or QEMU
+                  // virtualized environments.
+    "xvda1",  // First partition of the first virtual drive in Xen virtualized
+              // environments.
+    "sda2",   // Second partition of the first SATA, SCSI, or IDE drive.
+    "hda2",   // Second partition of the first IDE/ATA drive.
+    "nvme0n1p2",  // Second partition of the first NVMe device.
+    "md0p2",      // Second partition of the first RAID array.
+    "mmcblk0p2",  // Second partition of the first MMC/SD card.
+    "dm-1",       // Second Device Mapper device.
+    "vda2",       // Second partition of the first virtual drive in KVM or QEMU
+                  // virtualized environments.
+    "xvda2",  // Second partition of the first virtual drive in Xen virtualized
+              // environments.
+};
+constexpr const char* const kNetDeviceNamePrefixes[] = {
     // Fedora 15 uses biosdevname feature where Embedded ethernet uses the "em"
     // prefix and PCI cards use the p[0-9]c[0-9] format based on PCI slot and
     // card information.


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41693

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Start Brave browser on Linux
* Open brave://rewards-internals page
* Open `Ad diagnostics` tab on `Rewards internals` page

EXPECTATION:
*  `Device ID` field is not `Unknown` or empty 