### PR TITLE
[iOS] HF translation for 1.70.1

### DIFF
--- a/ios/brave-ios/App/BraveWidgets/ca.lproj/BraveWidgets.strings
+++ b/ios/brave-ios/App/BraveWidgets/ca.lproj/BraveWidgets.strings
@@ -152,6 +152,9 @@
 "L1fziM-Y7TWy8" = "Hi ha ${count} opcions que coincideixen amb 'Cerca’.";
 
 /* (No Comment) */
+"M2Y1rg" = "#4";
+
+/* (No Comment) */
 "nthxSL" = "Descàrregues";
 
 /* (No Comment) */

--- a/ios/brave-ios/App/BraveWidgets/es.lproj/BraveWidgets.strings
+++ b/ios/brave-ios/App/BraveWidgets/es.lproj/BraveWidgets.strings
@@ -59,6 +59,9 @@
 "e13lS3-qKrzyX" = "Solo para confirmar: ¿querías decir \"Escanear código QR\"?";
 
 /* (No Comment) */
+"e13lS3-U0eRbw" = "Sólo para confirmar, ¿querías usar \"Leo AI\"?";
+
+/* (No Comment) */
 "e13lS3-VBH4G6" = "Solo para confirmar: ¿querías decir \"Historial\"?";
 
 /* (No Comment) */
@@ -90,6 +93,9 @@
 
 /* (No Comment) */
 "EvESs0-qKrzyX" = "Solo para confirmar: ¿querías decir \"Escanear código QR\"?";
+
+/* (No Comment) */
+"EvESs0-U0eRbw" = "Sólo para confirmar, ¿querías usar \"Leo AI\"?";
 
 /* (No Comment) */
 "EvESs0-VBH4G6" = "Solo para confirmar: ¿querías decir \"Historial\"?";
@@ -140,6 +146,9 @@
 "L1fziM-qKrzyX" = "Hay ${count} opciones que coinciden con \"Escanear código QR\".";
 
 /* (No Comment) */
+"L1fziM-U0eRbw" = "Hay ${count} opciones que coinciden con 'Leo AI'.";
+
+/* (No Comment) */
 "L1fziM-VBH4G6" = "Hay ${count} opciones que coinciden con \"Historial\".";
 
 /* (No Comment) */
@@ -150,6 +159,9 @@
 
 /* (No Comment) */
 "L1fziM-Y7TWy8" = "Hay ${count} opciones que coinciden con \"Búsqueda\".";
+
+/* (No Comment) */
+"M2Y1rg" = "#4";
 
 /* (No Comment) */
 "nthxSL" = "Descargas";
@@ -177,6 +189,9 @@
 
 /* (No Comment) */
 "r2EI05-qKrzyX" = "Solo para confirmar: ¿querías decir \"Escanear código QR\"?";
+
+/* (No Comment) */
+"r2EI05-U0eRbw" = "Sólo para confirmar, ¿querías usar \"Leo AI\"?";
 
 /* (No Comment) */
 "r2EI05-VBH4G6" = "Solo para confirmar: ¿querías decir \"Historial\"?";
@@ -218,6 +233,9 @@
 "tNCrcE-qKrzyX" = "Hay ${count} opciones que coinciden con \"Escanear código QR\".";
 
 /* (No Comment) */
+"tNCrcE-U0eRbw" = "Hay ${count} opciones que coinciden con 'Leo AI'.";
+
+/* (No Comment) */
 "tNCrcE-VBH4G6" = "Hay ${count} opciones que coinciden con \"Historial\".";
 
 /* (No Comment) */
@@ -249,6 +267,9 @@
 
 /* (No Comment) */
 "TxuMja-qKrzyX" = "Hay ${count} opciones que coinciden con \"Escanear código QR\".";
+
+/* (No Comment) */
+"TxuMja-U0eRbw" = "Hay ${count} opciones que coinciden con 'Leo AI'.";
 
 /* (No Comment) */
 "TxuMja-VBH4G6" = "Hay ${count} opciones que coinciden con \"Historial\".";
@@ -308,6 +329,9 @@
 "YQiQuz-qKrzyX" = "Solo para confirmar: ¿querías decir \"Escanear código QR\"?";
 
 /* (No Comment) */
+"YQiQuz-U0eRbw" = "Sólo para confirmar, ¿querías usar \"Leo AI\"?";
+
+/* (No Comment) */
 "YQiQuz-VBH4G6" = "Solo para confirmar: ¿querías decir \"Historial\"?";
 
 /* (No Comment) */
@@ -336,6 +360,9 @@
 
 /* (No Comment) */
 "z517nu-qKrzyX" = "Hay ${count} opciones que coinciden con \"Escanear código QR\".";
+
+/* (No Comment) */
+"z517nu-U0eRbw" = "Hay ${count} opciones que coinciden con 'Leo AI'.";
 
 /* (No Comment) */
 "z517nu-VBH4G6" = "Hay ${count} opciones que coinciden con \"Historial\".";

--- a/ios/brave-ios/App/BraveWidgets/nl.lproj/BraveWidgets.strings
+++ b/ios/brave-ios/App/BraveWidgets/nl.lproj/BraveWidgets.strings
@@ -59,6 +59,9 @@
 "e13lS3-qKrzyX" = "Even voor de zekerheid, je wilde 'Scan QR-code', toch?";
 
 /* (No Comment) */
+"e13lS3-U0eRbw" = "Even voor de zekerheid, je wilde 'Leo AI', toch?";
+
+/* (No Comment) */
 "e13lS3-VBH4G6" = "Even voor de zekerheid, je wilde 'Geschiedenis', toch?";
 
 /* (No Comment) */
@@ -90,6 +93,9 @@
 
 /* (No Comment) */
 "EvESs0-qKrzyX" = "Even voor de zekerheid, je wilde 'Scan QR-code', toch?";
+
+/* (No Comment) */
+"EvESs0-U0eRbw" = "Even voor de zekerheid, je wilde 'Leo AI', toch?";
 
 /* (No Comment) */
 "EvESs0-VBH4G6" = "Even voor de zekerheid, je wilde 'Geschiedenis', toch?";
@@ -140,6 +146,9 @@
 "L1fziM-qKrzyX" = "Er zijn ${count} opties voor ‘Scan QR-code’.";
 
 /* (No Comment) */
+"L1fziM-U0eRbw" = "Er zijn ${count} opties voor 'Leo AI'.";
+
+/* (No Comment) */
 "L1fziM-VBH4G6" = "Er zijn ${count} opties voor ‘Geschiedenis’.";
 
 /* (No Comment) */
@@ -150,6 +159,9 @@
 
 /* (No Comment) */
 "L1fziM-Y7TWy8" = "Er zijn ${count} opties voor ‘Search’.";
+
+/* (No Comment) */
+"M2Y1rg" = "#4";
 
 /* (No Comment) */
 "nthxSL" = "Downloads";
@@ -177,6 +189,9 @@
 
 /* (No Comment) */
 "r2EI05-qKrzyX" = "Even voor de zekerheid, je wilde 'Scan QR-code', toch?";
+
+/* (No Comment) */
+"r2EI05-U0eRbw" = "Even voor de zekerheid, je wilde 'Leo AI', toch?";
 
 /* (No Comment) */
 "r2EI05-VBH4G6" = "Even voor de zekerheid, je wilde 'Geschiedenis', toch?";
@@ -218,6 +233,9 @@
 "tNCrcE-qKrzyX" = "Er zijn ${count} opties voor ‘Scan QR-code’.";
 
 /* (No Comment) */
+"tNCrcE-U0eRbw" = "Er zijn ${count} opties voor 'Leo AI'.";
+
+/* (No Comment) */
 "tNCrcE-VBH4G6" = "Er zijn ${count} opties voor ‘Geschiedenis’.";
 
 /* (No Comment) */
@@ -251,6 +269,9 @@
 "TxuMja-qKrzyX" = "Er zijn ${count} opties voor ‘Scan QR-code’.";
 
 /* (No Comment) */
+"TxuMja-U0eRbw" = "Er zijn ${count} opties voor 'Leo AI'.";
+
+/* (No Comment) */
 "TxuMja-VBH4G6" = "Er zijn ${count} opties voor ‘Geschiedenis’.";
 
 /* (No Comment) */
@@ -264,6 +285,9 @@
 
 /* (No Comment) */
 "tYwiRd" = "Geschatte bespaarde tijd";
+
+/* (No Comment) */
+"U0eRbw" = "Leo AI";
 
 /* (No Comment) */
 "VBH4G6" = "Geschiedenis";
@@ -305,6 +329,9 @@
 "YQiQuz-qKrzyX" = "Even voor de zekerheid, je wilde 'Scan QR-code', toch?";
 
 /* (No Comment) */
+"YQiQuz-U0eRbw" = "Even voor de zekerheid, je wilde 'Leo AI', toch?";
+
+/* (No Comment) */
 "YQiQuz-VBH4G6" = "Even voor de zekerheid, je wilde 'Geschiedenis', toch?";
 
 /* (No Comment) */
@@ -333,6 +360,9 @@
 
 /* (No Comment) */
 "z517nu-qKrzyX" = "Er zijn ${count} opties voor ‘Scan QR-code’.";
+
+/* (No Comment) */
+"z517nu-U0eRbw" = "Er zijn ${count} opties voor 'Leo AI'.";
 
 /* (No Comment) */
 "z517nu-VBH4G6" = "Er zijn ${count} opties voor ‘Geschiedenis’.";

--- a/ios/brave-ios/App/BraveWidgets/nl.lproj/Localizable.strings
+++ b/ios/brave-ios/App/BraveWidgets/nl.lproj/Localizable.strings
@@ -2,6 +2,9 @@
 "widgets.BookmarksMenuItem" = "Bladwijzers";
 
 /* The name of the feature */
+"widgets.braveLeo" = "Leo AI";
+
+/* The name of the feature */
 "widgets.braveNews" = "Brave News";
 
 /* Title for downloads menu item */

--- a/ios/brave-ios/Sources/AIChat/Resources/es.lproj/BraveLeo.strings
+++ b/ios/brave-ios/Sources/AIChat/Resources/es.lproj/BraveLeo.strings
@@ -154,6 +154,12 @@
 /* The model intro message when you first enter the chat assistant -- %@ is a place-holder for the model name */
 "aichat.introMessageGenericMessageDescription" = "Hola, me llamo Leo. Soy asistente de IA de Brave, con la tecnología de %@. Pregúntame lo que quieras y haré todo lo posible por responderte.";
 
+/* The model intro message when you first enter the chat assistant */
+"aichat.introMessageLlamaMessageDescription" = "Hola, soy Leo. Soy un asistente de IA totalmente alojado por Brave. Estoy impulsado por Llama 3.1 8B, un modelo creado por Meta para ser eficiente y aplicable a muchos casos de uso.";
+
+/* The model and creator for intro message - Llama 3.1 8B is the model name -- Meta is the creator */
+"aichat.introMessageLlamaModelDescription" = "Llama 3.1 8B de Meta";
+
 /* The model's purpose - Describes what it can do best */
 "aichat.introMessageLlamaModelPurposeDescription" = "Chat de uso general";
 
@@ -330,6 +336,9 @@
 
 /* The title for disliking response to clipboard action */
 "aichat.responseContextMenuDislikeAnswerTitle" = "Dar \"No me gusta\" a la respuesta";
+
+/* The title for editing user prompt action from context menu */
+"aichat.responseContextMenuEditPromptTitle" = "Editar pregunta";
 
 /* The title for liking response to clipboard action */
 "aichat.responseContextMenuLikeAnswerTitle" = "Dar \"Me gusta\" a la respuesta";

--- a/ios/brave-ios/Sources/AIChat/Resources/nl.lproj/BraveLeo.strings
+++ b/ios/brave-ios/Sources/AIChat/Resources/nl.lproj/BraveLeo.strings
@@ -13,6 +13,9 @@
 /* The title for the settings to change default model for conversations */
 "aichat.advancedSettingsDefaultModelTitle" = "Standaardmodel";
 
+/* The title for the header for adjusting leo ai settings */
+"aichat.advancedSettingsHeaderTitle" = "Leo is een slimme assistent op AI, ingebouwd in de browser.";
+
 /* The subtitle for the button which links purchase to Brave Account */
 "aichat.advancedSettingsLinkPurchaseActionSubTitle" = "Koppel uw App Store-aankoop aan uw Brave-account om Leo op andere apparaten te gebruiken.";
 
@@ -67,6 +70,12 @@
 /* The title shown on limit reached error view, which is suggesting user to change default model */
 "aichat.contextLimitErrorTitle" = "Dit gesprek is te lang en kan niet worden verdergezet.\nMogelijk kan Leo met andere beschikbare modellen langere gesprekken voeren.";
 
+/* The title of the section where custom models are displayed as a list. */
+"aichat.customModelChatSectionTitle" = "Aangepaste modellen";
+
+/* The title for the custom models section in the menu */
+"aichat.customModelsMenuSectionTitle" = "Aangepaste modellen";
+
 /* The title of the section where chat models are displayed as a list. */
 "aichat.defaultModelChatSectionTitle" = "Chat";
 
@@ -75,6 +84,9 @@
 
 /* The title of the menu where user can change the default model */
 "aichat.defaultModelViewTitle" = "Standaardmodel";
+
+/* The text displayed under an edited user prompt/message beside a timestamp. */
+"aichat.editedMessageCaption" = "Bewerkt";
 
 /* The title for view which user type feedback */
 "aichat.feedbackInputViewTitle" = "Geef hier je feedback";
@@ -130,6 +142,9 @@
 /* The model's purpose - Describes what it can do best */
 "aichat.introMessageClaudeHaikuModelPurposeDescription" = "Razendsnelle chat";
 
+/* The model intro message when you first enter the chat assistant */
+"aichat.introMessageClaudeSonnetMessageDescription" = "Hallo, ik ben Leo. Ik word geproxied door Brave en aangedreven door Claude 3.5 Sonnet, een model gemaakt door Anthropic om conversatie- en tekst verwerkingstaken uit te voeren.";
+
 /* The model and creator for intro message - Claude Sonnet is the model -- Anthropic is the creator */
 "aichat.introMessageClaudeSonnetModelDescription" = "Claude Sonnet van Anthropic";
 
@@ -138,6 +153,12 @@
 
 /* The model intro message when you first enter the chat assistant -- %@ is a place-holder for the model name */
 "aichat.introMessageGenericMessageDescription" = "Hallo, ik ben Leo. Ik ben de AI-assistent van Brave, mogelijk gemaakt door %@. Je kunt me alles vragen en ik doe mijn best om je een antwoord te geven.";
+
+/* The model intro message when you first enter the chat assistant */
+"aichat.introMessageLlamaMessageDescription" = "Hallo, ik ben Leo. Ik ben een AI-assistent die volledig door Brave wordt gehost en die mogelijk is gemaakt door door Llama 3.1 8B, een krachtig en veelzijdig model gemaakt door Meta.";
+
+/* The model and creator for intro message - Llama 3.1 8B is the model name -- Meta is the creator */
+"aichat.introMessageLlamaModelDescription" = "Llama 3.1 8B van Meta";
 
 /* The model's purpose - Describes what it can do best */
 "aichat.introMessageLlamaModelPurposeDescription" = "Chat voor algemene taken";
@@ -156,6 +177,9 @@
 
 /* The name of the AI-Assistant that's responsing to the user */
 "aichat.leoAssistantNameTitle" = "Leo";
+
+/* The default title displayed above a code block when the language of the code is not known. */
+"aichat.leoCodeExampleDefaultTitle" = "Voorbeeld van code";
 
 /* The text displayed on the loading screen when searching for a user query */
 "aichat.leoImprovedAnswerBraveSearch" = "Zoeken naar betere antwoorden voor";
@@ -312,6 +336,9 @@
 
 /* The title for disliking response to clipboard action */
 "aichat.responseContextMenuDislikeAnswerTitle" = "Antwoord niet leuk";
+
+/* The title for editing user prompt action from context menu */
+"aichat.responseContextMenuEditPromptTitle" = "Wijzig prompt";
 
 /* The title for liking response to clipboard action */
 "aichat.responseContextMenuLikeAnswerTitle" = "Antwoord leuk";

--- a/ios/brave-ios/Sources/BraveShields/Resources/es.lproj/BraveShared.strings
+++ b/ios/brave-ios/Sources/BraveShields/Resources/es.lproj/BraveShared.strings
@@ -157,6 +157,9 @@
 /* The option the user can select to do strict https upgrading */
 "HttpsUpgradeLevelStrict" = "Estricto";
 
+/* This is a label on a button that updates filter lists which signifies that lists have been updated */
+"ListsUpdated" = "Listas actualizadas";
+
 /* A button title when confirming to shred website data */
 "ShredDataButtonTitle" = "Triturar datos";
 
@@ -189,6 +192,12 @@
 
 /* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
 "TrackersAndAdsBlocking" = "Bloqueo de rastreadores y anuncios";
+
+/* This is a label for a button which when pressed updates all the filter lists */
+"UpdateLists" = "Actualizar listas";
+
+/* This is a label on a button that updates filter lists which signifies that lista are being updated */
+"UpdatingLists" = "Actualizando listas";
 
 /* The option the user can select for the type of https upgrading */
 "UpgradeConnectionsToHTTPS" = "Actualizar las conexiones a HTTPS";

--- a/ios/brave-ios/Sources/BraveShields/Resources/nl.lproj/BraveShared.strings
+++ b/ios/brave-ios/Sources/BraveShields/Resources/nl.lproj/BraveShared.strings
@@ -25,6 +25,9 @@
 /* A title for a popup that tells the user we recommend turning shields off for this site. */
 "AntiAdBlockWarningTitle" = "Pas instellingen van advertentieblokkering aan voor deze site";
 
+/* A picker title for selecting a automatic shred setting option */
+"AutoShred" = "Automatische versnippering";
+
 /* The option the user can select to do aggressive ad and tracker blocking */
 "BlockAdsAndTrackingAggressive" = "Agressief";
 
@@ -148,11 +151,38 @@
 /* A description of what the forget me toggle does */
 "ForgetMeDescription" = "Verwijdert cookies en andere sitegegevens wanneer u een site afsluit";
 
+/* A toggle option that deletes website content when the site is closed */
+"ForgetMeLabel" = "Vergeet me als ik deze site sluit";
+
 /* The option the user can select to do strict https upgrading */
 "HttpsUpgradeLevelStrict" = "Streng";
 
+/* This is a label on a button that updates filter lists which signifies that lists have been updated */
+"ListsUpdated" = "Lijsten bijgewerkt";
+
+/* A button title when confirming to shred website data */
+"ShredDataButtonTitle" = "Versnipper gegevens";
+
 /* An option setting for never automatically shreding site data */
 "ShredNever" = "Nooit";
+
+/* An option setting for automatically shredding only when the app is closed */
+"ShredOnAppClose" = "App gesloten";
+
+/* An option setting for automatically shredding when the site is closed */
+"ShredOnSiteTabsClosed" = "Tabbladen van site gesloten";
+
+/* A list row label for accessing the shred settings screen */
+"ShredSiteData" = "Versnipper sitegegevens";
+
+/* A message for a confirmation window that appears when a user clicks on 'Shred Data'. */
+"ShredSiteDataConfirmationMessage" = "Door de versnippering worden alle tabbladen van deze site gesloten en worden alle sitegegevens verwijderd. Deze actie kun je niet ongedaan maken.";
+
+/* A title for a confirmation window that appears when a user clicks on 'Shred Data' */
+"ShredSiteDataConfirmationTitle" = "Sitegegevens versnipperen?";
+
+/* A button title that shreds site data immediately */
+"ShredSiteDataNow" = "Versnipper sitegegevens nu";
 
 /* A page title for the warning page that appears when http was blocked */
 "SiteIsNotSecure" = "Site is niet veilig";
@@ -162,6 +192,12 @@
 
 /* A label for a shield option that allows you to switch between different blocking levels for tracker and ads blocking. Options include disabled, standard and aggressive. */
 "TrackersAndAdsBlocking" = "Blokkeer trackers en advertenties";
+
+/* This is a label for a button which when pressed updates all the filter lists */
+"UpdateLists" = "Werk lijsten bij";
+
+/* This is a label on a button that updates filter lists which signifies that lista are being updated */
+"UpdatingLists" = "Lijsten bijwerken";
 
 /* The option the user can select for the type of https upgrading */
 "UpgradeConnectionsToHTTPS" = "Upgrade verbindingen naar HTTPS";

--- a/ios/brave-ios/Sources/BraveStrings/Resources/es.lproj/BraveShared.strings
+++ b/ios/brave-ios/Sources/BraveStrings/Resources/es.lproj/BraveShared.strings
@@ -28,6 +28,9 @@
 /* Title for the button to add a new website bookmark. */
 "AddToMenuItem" = "Añadir marcador";
 
+/* Text for the toggle switch to clear 'Brave Ads' data in settings */
+"ads.braveAdsDataToggleOption" = "Datos de Anuncios de Brave";
+
 /* individual blocking statistic title */
 "AdsAndTrackers" = "Anuncios y rastreadores";
 
@@ -1078,8 +1081,17 @@
 /* A setting to enable or disable the device's keyboard from opening automatically when creating a new tab. */
 "ntp.settingsAutoOpenKeyboard" = "Abrir teclado automáticamente";
 
+/* A setting to enable or disable background on the NTP screen. */
+"ntp.settingsBackgroundImages" = "Fondo";
+
+/* A button that leads to a 'more' menu, letting users configure additional settings. */
+"ntp.settingsBackgroundImageSubMenu" = "Tipo de medio";
+
 /* A selection to let the users only see a set of predefined, default images on the background of the app. */
 "ntp.settingsDefaultImagesOnly" = "Imágenes predeterminadas";
+
+/* A selection to let the users see sponsored image and video backgrounds when opening a new tab. */
+"ntp.settingsSponsoredImagesAndVideosSelection" = "Imágenes y vídeos patrocinados";
 
 /* A selection to let the users see sponsored image backgrounds when opening a new tab. */
 "ntp.settingsSponsoredImagesSelection" = "Imágenes de patrocinadores";
@@ -1404,6 +1416,9 @@
 
 /* The title for the setting that will allow a user to toggle sending privacy preserving analytics to Brave. */
 "p3a.settingTitle" = "Permitir estadísticas del producto con preservación de la privacidad (P3A)";
+
+/* No comment provided by engineer. */
+"p3aCalloutCloseAccessibilityLabel" = "Cerrar llamada de producto que preserva la privacidad";
 
 /* No comment provided by engineer. */
 "pageSecurityView.pageNotFullySecureTitle" = "Tu conexión a este sitio no es completamente segura.";
@@ -2248,11 +2263,29 @@
 /* Title for Brave Talk rewards opt-in screen */
 "rewards.braveTalkRewardsOptInTitle" = "Para iniciar una llamada gratuita, activa Brave Rewards";
 
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Iniciar para ayudar a Brave y a la comunidad BAT.";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "El uso de Recompensas de Brave ayuda a Brave y a la comunidad BAT.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Estás ayudando a Brave y a la comunidad BAT.";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Gracias por ayudar a Brave y a la comunidad BAT.";
+
 /* The placeholders say 'Terms of Service' and 'Privacy Policy'. So full sentence goes like: 'By clicking, you agree to the Terms of Service and Privacy Policy...' */
 "rewards.optInDisclaimer" = "Al hacer clic, aceptas las %1$@ y la %2$@. Puedes deshabilitar esta opción en cualquier momento en Ajustes.";
 
 /* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Ayuda a apoyar a Brave y a la comunidad BAT activando las Recompensas de Brave y viendo los Anuncios de Brave.";
+
+/* No comment provided by engineer. */
 "rewards.settingsToggleTitle" = "Habilitar Recompensas de Brave";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Este creador de contenido está verificado con Creadores de Brave";
 
 /* Displayed next to a number representing the total number of publishers supported */
 "rewards.totalSupportedCount" = "Número de creadores de contenido a los que ayudas a apoyar este mes.";
@@ -3021,6 +3054,9 @@
 
 /* Header for device choosing screen. */
 "SyncChooseDeviceHeader" = "Elige el tipo de dispositivo con el que te gustaría realizar la sincronización.";
+
+/* Error title explaining the sync code is expired and it must be genrated all over again. */
+"SyncCodeExpirationTitleLabel" = "Código caducado. Genera uno nuevo pulsando el botón de abajo.";
 
 /* Title explaining how loing the sync code can be used. It will be used like Ex: This temporary code is valid for the next 17 hours 33 minutes 1 second */
 "SyncCodeTimeRemainingTitleLabel" = "Este código temporal solo tiene validez durante las próximas %@";

--- a/ios/brave-ios/Sources/BraveStrings/Resources/nl.lproj/BraveShared.strings
+++ b/ios/brave-ios/Sources/BraveStrings/Resources/nl.lproj/BraveShared.strings
@@ -28,6 +28,9 @@
 /* Title for the button to add a new website bookmark. */
 "AddToMenuItem" = "Voeg bladwijzer toe";
 
+/* Text for the toggle switch to clear 'Brave Ads' data in settings */
+"ads.braveAdsDataToggleOption" = "Brave Ads-gegevens";
+
 /* individual blocking statistic title */
 "AdsAndTrackers" = "Advertenties en trackers";
 
@@ -157,6 +160,9 @@
 /* Brave Rewards title */
 "BraveRewardsTitle" = "Brave Rewards";
 
+/* Brave Search Banner Promotion description content in Search Suggestions */
+"braveSearchPromotion.bannerDescription" = "Brave Search maakt geen profiel van jou.";
+
 /* Brave Search Banner Promotion title for maybe later button to activate promotion later in Search Suggestions */
 "braveSearchPromotion.bannerMaybeLaterButtonTitle" = "Misschien later";
 
@@ -267,6 +273,9 @@
 
 /* Title for p3a (Privacy Preserving Analytics) Full Screen Callout */
 "callout.p3aCalloutTitle" = "Help ons Brave beter te maken.";
+
+/* Title for toggle for enabling p3a (Privacy Preserving Analytics) Full Screen Callout */
+"callout.p3aCalloutToggleTitle" = "Deel privé- en anonieme productinzichten.";
 
 /* Subtitle - Description for Privacy Everywhere Full Screen Callout */
 "callout.privacyEverywhereCalloutDescription" = "Gebruik Brave Privacy op je computer of tablet en synchroniseer bladwijzers en extensies tussen je apparaten.";
@@ -1072,8 +1081,20 @@
 /* A setting to enable or disable the device's keyboard from opening automatically when creating a new tab. */
 "ntp.settingsAutoOpenKeyboard" = "Open toetsenbord automatisch";
 
+/* A setting to enable or disable background on the NTP screen. */
+"ntp.settingsBackgroundImages" = "Achtergrond";
+
+/* A button that leads to a 'more' menu, letting users configure additional settings. */
+"ntp.settingsBackgroundImageSubMenu" = "Mediatype";
+
 /* A selection to let the users only see a set of predefined, default images on the background of the app. */
 "ntp.settingsDefaultImagesOnly" = "Standaardafbeeldingen";
+
+/* A selection to let the users see sponsored image and video backgrounds when opening a new tab. */
+"ntp.settingsSponsoredImagesAndVideosSelection" = "Gesponsorde afbeeldingen en video's";
+
+/* A selection to let the users see sponsored image backgrounds when opening a new tab. */
+"ntp.settingsSponsoredImagesSelection" = "Gesponsorde afbeeldingen";
 
 /* Title on settings page to adjust the primary home screen functionality. */
 "ntp.settingsTitle" = "Nieuw tabblad";
@@ -1397,6 +1418,9 @@
 "p3a.settingTitle" = "Sta privacybeschermende productanalyse (P3A) toe";
 
 /* No comment provided by engineer. */
+"p3aCalloutCloseAccessibilityLabel" = "Sluit call-out van privacybeschermend product";
+
+/* No comment provided by engineer. */
 "pageSecurityView.pageNotFullySecureTitle" = "Je verbinding met deze site is niet volledig beveiligd.";
 
 /* No comment provided by engineer. */
@@ -1410,6 +1434,9 @@
 
 /* No comment provided by engineer. */
 "pageSecurityView.pageUnknownStatusWarning" = "Uw verbinding met deze site kan niet volledig worden geverifieerd. U kunt doorgaan of proberen de pagina opnieuw te laden om een veilige verbinding tot stand te brengen.";
+
+/* No comment provided by engineer. */
+"pageSecurityView.signIntoWebsiteURLBarTitle" = "Log in bij website";
 
 /* No comment provided by engineer. */
 "pageSecurityView.viewCertificateButtonTitle" = "Bekijk certificaat";
@@ -2236,11 +2263,29 @@
 /* Title for Brave Talk rewards opt-in screen */
 "rewards.braveTalkRewardsOptInTitle" = "Zet Brave Rewards aan om een gratis gesprek te starten";
 
+/* Displayed when Brave Rewards is disabled */
+"rewards.disabledBody" = "Zet deze functie aan om Brave en de BAT Community te steunen.";
+
+/* Displayed in the status container when rewards is disabled */
+"rewards.disabledStatusBody" = "Door Brave Rewards te gebruiken, steun je Brave en de BAT Community.";
+
+/* Displayed when Brave Rewards is enabled */
+"rewards.enabledBody" = "Je steunt Brave en de BAT Community.";
+
+/* Displayed in the status container when rewards is enabled but you're not currently supporting any publishers (0 AC count) */
+"rewards.enabledStatusBody" = "Bedankt voor het steunen van Brave en de BAT Community!";
+
 /* The placeholders say 'Terms of Service' and 'Privacy Policy'. So full sentence goes like: 'By clicking, you agree to the Terms of Service and Privacy Policy...' */
 "rewards.optInDisclaimer" = "Als je klikt, ga je akkoord met de %1$@ en het %2$@. Je kunt dit altijd uitschakelen in Instellingen.";
 
 /* No comment provided by engineer. */
+"rewards.settingsToggleMessage" = "Steun Brave en de BAT Community door Brave Rewards in te schakelen en advertenties in Brave te zien.";
+
+/* No comment provided by engineer. */
 "rewards.settingsToggleTitle" = "Schakel Brave Rewards in";
+
+/* Displayed under verified publishers */
+"rewards.supportingPublisher" = "Deze contentcreator is geverifieerd met Brave Creators";
 
 /* Displayed next to a number representing the total number of publishers supported */
 "rewards.totalSupportedCount" = "Aantal contentcreators die je deze maand hebt gesteund.";
@@ -3009,6 +3054,9 @@
 
 /* Header for device choosing screen. */
 "SyncChooseDeviceHeader" = "Kies het type apparaat dat je wilt synchroniseren.";
+
+/* Error title explaining the sync code is expired and it must be genrated all over again. */
+"SyncCodeExpirationTitleLabel" = "Code is verlopen. Maak een nieuwe aan door op de knop hieronder te tikken.";
 
 /* Title explaining how loing the sync code can be used. It will be used like Ex: This temporary code is valid for the next 17 hours 33 minutes 1 second */
 "SyncCodeTimeRemainingTitleLabel" = "Deze tijdelijke code is geldig voor de komende %@";

--- a/ios/brave-ios/Sources/BraveVPN/Resources/ca.lproj/Localizable.strings
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/ca.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Text for toggle which indicating the toggle action is for selecting region in automatic */
 "vpn.automaticServerSelectionToggleTitle" = "Automàtic";
 
+/* Title on top the list of available servers */
+"vpn.availableServerTitle" = "SERVIDORS DISPONIBLES";
+
 /* Button text to buy Brave VPN */
 "vpn.buyButton" = "Compra";
 
@@ -24,6 +27,9 @@
 
 /* Text for a checkbox to present the user benefits for using Brave VPN */
 "vpn.checkboxSpeedFast" = "Extremadament ràpid, fins a 100 Mbps";
+
+/* Text indicating how many cities is used for that country used as Ex: '1 City' */
+"vpn.cityCountTitle" = "%ld Ciutat";
 
 /* Text showing the vpn region is connected */
 "vpn.connectedRegionDescription" = "Connectat";
@@ -136,6 +142,12 @@
 /* No comment provided by engineer. */
 "vpn.monthlySubTitle" = "Subscripció mensual";
 
+/* Text indicating how many cities is used for that region used as Ex: '2 Cities' */
+"vpn.multipleCityCountTitle" = "%ld Ciutats";
+
+/* Text indicating how many server is used for that region used as Ex: '2 Servers' */
+"vpn.multipleServerCountTitle" = "%ld Servidors";
+
 /* Text to show user when their vpn plan has expired */
 "vpn.planExpired" = "Caducat";
 
@@ -187,8 +199,14 @@
 /* No comment provided by engineer. */
 "vpn.restorePurchases" = "Restaura";
 
+/* Title showing which country serves list showing. Ex: 'Brazil Server */
+"vpn.serverNameTitle" = "%@ Servidor";
+
 /* Text for description of toggle that auto selcets the server according to time zone. */
 "vpn.serverRegionAutoSelectDescription" = "Selecciona automàticament la regió del servidor VPN més propera en funció de la teva zona horària. Aquesta opció es recomana per maximitzar la velocitat d'Internet.";
+
+/* Text indicating how many server is used for that region used as Ex: '1 Server' */
+"vpn.serverTitle" = "%ld Servidor";
 
 /* VPN Banner Description */
 "vpn.settingHeaderBody" = "Actualitza a una VPN per protegir la connexió i bloquejar arreu els rastrejadors invasius.";

--- a/ios/brave-ios/Sources/BraveVPN/Resources/es.lproj/Localizable.strings
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/es.lproj/Localizable.strings
@@ -298,6 +298,9 @@
 /* Title for a button for enabling the Redeem Code flow */
 "vpn.vpnRedeemCodeButtonActionTitle" = "Canjear código";
 
+/* The alert title showing vpn region is changed */
+"vpn.vpnRegionChangedTitle" = "Región de VPN modificada";
+
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Se restablecerá la configuración del firewall + VPN de Brave y se corregirán todos los errores. El proceso puede tardar un minuto.";
 

--- a/ios/brave-ios/Sources/BraveVPN/Resources/nl.lproj/Localizable.strings
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/nl.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Text for toggle which indicating the toggle action is for selecting region in automatic */
 "vpn.automaticServerSelectionToggleTitle" = "Automatisch";
 
+/* Title on top the list of available servers */
+"vpn.availableServerTitle" = "BESCHIKBARE SERVERS";
+
 /* Button text to buy Brave VPN */
 "vpn.buyButton" = "Koop";
 
@@ -24,6 +27,9 @@
 
 /* Text for a checkbox to present the user benefits for using Brave VPN */
 "vpn.checkboxSpeedFast" = "Razendsnel, tot 100 Mbps";
+
+/* Text indicating how many cities is used for that country used as Ex: '1 City' */
+"vpn.cityCountTitle" = "%ld stad";
 
 /* Text showing the vpn region is connected */
 "vpn.connectedRegionDescription" = "Verbonden";
@@ -136,6 +142,12 @@
 /* No comment provided by engineer. */
 "vpn.monthlySubTitle" = "Maandabonnement";
 
+/* Text indicating how many cities is used for that region used as Ex: '2 Cities' */
+"vpn.multipleCityCountTitle" = "%ld steden";
+
+/* Text indicating how many server is used for that region used as Ex: '2 Servers' */
+"vpn.multipleServerCountTitle" = "%ld servers";
+
 /* Text to show user when their vpn plan has expired */
 "vpn.planExpired" = "Verlopen";
 
@@ -186,6 +198,15 @@
 
 /* No comment provided by engineer. */
 "vpn.restorePurchases" = "Herstel";
+
+/* Title showing which country serves list showing. Ex: 'Brazil Server */
+"vpn.serverNameTitle" = "Server in %@";
+
+/* Text for description of toggle that auto selcets the server according to time zone. */
+"vpn.serverRegionAutoSelectDescription" = "Selecteer automatisch de dichtstbijzijnde regio voor de VPN-server op basis van je tijdzone. Deze optie wordt aanbevolen voor een maximale browsesnelheid.";
+
+/* Text indicating how many server is used for that region used as Ex: '1 Server' */
+"vpn.serverTitle" = "%ld server";
 
 /* VPN Banner Description */
 "vpn.settingHeaderBody" = "Upgrade naar een VPN om je verbinding te beschermen en invasieve trackers overal te blokkeren.";
@@ -244,6 +265,9 @@
 /* Notification title to tell user that the vpn is turned on even in background */
 "vpn.vpnBackgroundNotificationTitle" = "Brave Firewall + VPN staat AAN";
 
+/* Text for description of list item which chooses the optimal server for the country region */
+"vpn.vpnCityRegionOptimalDescription" = "Gebruik de beste beschikbare server";
+
 /* Text for title of list item which chooses the optimal server for the country region */
 "vpn.vpnCityRegionOptimalTitle" = "Optimaal";
 
@@ -273,6 +297,9 @@
 
 /* Title for a button for enabling the Redeem Code flow */
 "vpn.vpnRedeemCodeButtonActionTitle" = "Wissel code in";
+
+/* The alert title showing vpn region is changed */
+"vpn.vpnRegionChangedTitle" = "VPN-regio gewijzigd";
 
 /* Message for alert to reset vpn configuration */
 "vpn.vpnResetAlertBody" = "Hiermee stel je de configuratie van Brave Firewall + VPN opnieuw in en los je eventuele fouten op. Dit proces duurt maar even.";

--- a/ios/brave-ios/Sources/BraveWallet/Resources/ar.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/ar.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "معاملة";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "ستؤدي هذه المعاملة إلى إعادة تعيين ملكية الحساب إلى برنامج جديد. هذا الإجراء لا رجعة فيه وقد يؤدي إلى خسارة الأموال.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "تم طلب تغيير ملكية الحساب";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "حساب الرمز المرتبط غير موجود حتى الآن. سينفق مبلغ صغير من SOL لإنشائه وتمويله.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/bs.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/bs.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transakcija";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Ova će transakcija prenijeti vlasništvo nad računom na novi program. Ova radnja je nepovratna i može dovesti do gubitka sredstava.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Zatražena je promjena vlasništva računa";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Povezani račun tokena još ne postoji. Troši se manja količina SOL-a za njegovo stvaranje i financiranje.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/cs.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/cs.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transakce";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Touto transakcí se vlastnictví účtu převede na nový program. Tato akce je nevratná a může vést ke ztrátě finančních prostředků.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Požadovaná změna vlastnictví účtu";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Přidružený účet tokenu zatím neexistuje. Na jeho vytvoření a financování bude vynaložena malá částka SOL.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/da.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/da.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaktion";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Denne transaktion vil omfordele ejerskabet af kontoen til et nyt program. Denne handling er irreversibel og kan resultere i tab af midler.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Anmodning om ændring af kontoejerskab";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Den tilknyttede token-konto findes ikke endnu. En lille mængde SOL vil blive brugt på at skabe og finansiere den.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/de.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/de.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaktion";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Bei dieser Transaktion wird das Konto einem neuen Programm zugewiesen. Dieser Vorgang ist unumkehrbar und kann zum Verlust von Geldern führen.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Änderung der Kontoinhaberschaft beantragt";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Das verbundene Token-Konto existiert noch nicht. Ein kleiner SOL-Betrag wird ausgegeben, um es zu erstellen und zu finanzieren.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/el.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/el.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Συναλλαγή";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Αυτή η συναλλαγή θα εκχωρήσει εκ νέου την κυριότητα του λογαριασμού σε ένα νέο πρόγραμμα. Η ενέργεια αυτή είναι μη αναστρέψιμη και μπορεί να οδηγήσει σε απώλεια κεφαλαίων.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Ζητείται αλλαγή ιδιοκτησίας λογαριασμού";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Ο συσχετισμένος λογαριασμός token δεν υπάρχει ακόμα. Ένα μικρό ποσό SOL θα δαπανηθεί για τη δημιουργία και τη χρηματοδότησή του.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/es.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/es.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transacción";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Esta transacción reasignará la propiedad de cuenta a un nuevo programa. Esta acción es irreversible y puede provocar la pérdida de fondos.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Se ha solicitado el cambio de titularidad de la cuenta";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "La cuenta de token asociada aún no existe. Se gastará una pequeña cantidad de SOL para crearla y añadirle fondos.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/fi.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/fi.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Maksutapahtuma";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Tämä tapahtuma siirtää tilin omistusoikeuden uudelle ohjelmalle. Tämä toimenpide on peruuttamaton ja voi johtaa varojen menetykseen.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Tilin omistajuuden muutosta pyydetty";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Liittyvää token-tiliä ei vielä ole olemassa. Pieni määrä SOLia käytetään sen luomiseen ja rahoittamiseen.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/fr.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/fr.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaction";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Cette transaction réattribuera la propriété du site compte à un nouveau programme. Cette action est irréversible et peut entraîner une perte de fonds.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Le changement de propriétaire du compte a été demandé";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Le compte du jeton associé n'existe pas encore. Une petite quantité de SOL sera dépensée pour le créer et le financer.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/gsw.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/gsw.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaktion";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Bei dieser Transaktion wird das Konto einem neuen Programm zugewiesen. Dieser Vorgang ist unumkehrbar und kann zum Verlust von Geldern führen.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Änderung der Kontoinhaberschaft beantragt";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Das verbundene Token-Konto existiert noch nicht. Ein kleiner SOL-Betrag wird ausgegeben, um es zu erstellen und zu finanzieren.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/hr.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/hr.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transakcija";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Ova će transakcija prenijeti vlasništvo nad računom na novi program. Ova radnja je nepovratna i može dovesti do gubitka sredstava.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Zatražena je promjena vlasništva računa";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Povezani račun tokena još ne postoji. Troši se manja količina SOL-a za njegovo stvaranje i financiranje.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/hu.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/hu.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Tranzakció";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Ez a tranzakció a számla tulajdonjogát egy új programra ruházza át. Ez a művelet visszafordíthatatlan, és a pénzeszközök elvesztését eredményezheti.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Számlatulajdonosi változás kérése";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "A kapcsolódó tokenszámla még nem létezik. Ennek létrehozására és fenntartására egy kisebb SOL összeg lesz felhasználva.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/id-ID.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/id-ID.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaksi";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Transaksi ini akan mengalihkan kepemilikan akun ke program baru. Tindakan ini tidak dapat dibatalkan dan dapat mengakibatkan hilangnya dana.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Perubahan kepemilikan akun yang diminta";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Akun token terkait belum tersedia. SOL dalam jumlah kecil akan digunakan untuk membuat dan mendanainya.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/it.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/it.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transazione";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Questa transazione riassegnerà la proprietà del sito account a un nuovo programma. Questa azione è irreversibile e può comportare la perdita di fondi.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Account richiesta di cambio di proprietà";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "L’account associato al token non esiste ancora. Una piccola quantità di SOL sarà utilizzata per creare e finanziare l’account.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/ja.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/ja.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "トランザクション";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "このトランザクションは、アカウントの所有権を新しいプログラムに再割り当てします。この操作は不可逆的であり、資金が失われる可能性があります。";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "アカウント所有者の変更を要請";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "関連するトークンアカウントはまだ存在しません。作成と資金調達のために少量のSOLを消費します。";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/ko-KR.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/ko-KR.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "트랜잭션";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "이 거래는 계정의 소유권을 새 프로그램으로 재할당합니다. 이 작업은 되돌릴 수 없으며 자금 손실이 발생할 수 있습니다.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "계정 소유권 변경 요청";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "아직 연결된 토큰 계정이 존재하지 않습니다. 계정을 만들고 자금을 입금하는 데 소액의 SOL가 지출됩니다.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/ms.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/ms.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaksi";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Urus niaga ini akan menetapkan semula pemilikan akaun kepada program baharu. Tindakan ini tidak dapat dipulihkan dan boleh mengakibatkan kehilangan dana.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Perubahan pemilikan akaun telah diminta";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Akaun token berkaitan belum wujud lagi. Jumlah kecil SOL akan dibelanjakan untuk membuat akaun dan memberikan dana.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/nb.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/nb.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaksjon";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Denne transaksjonen vil tildele eierskapet til kontoen til et nytt program. Denne handlingen er irreversibel og kan føre til tap av midler.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Anmodning om endring av kontoeierskap";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Den tilknyttede token-kontoen er ikke opprettet ennå. Et lite SOL-beløp brukes på å opprette og finansiere den.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/nl.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/nl.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transactie";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Op deze transactie wordt het eigendom van de account opnieuw toegewezen aan een nieuw programma. Deze actie is onomkeerbaar en kan leiden tot verlies van fondsen.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "account eigendomswijziging aangevraagd";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Het bijbehorende tokenaccount bestaat nog niet. Er wordt een kleine hoeveelheid SOL uitgegeven om het aan te maken en te financieren.";
 
@@ -456,6 +462,9 @@
 
 /* The error message for the input field when users input an invalid address for a custom network in Custom Network Details Screen. */
 "wallet.customNetworkInvalidAddressErrMsg" = "Ongeldig adres.";
+
+/* The error message for the input field when users input an unsecure address for a custom network in Custom Network Details Screen. */
+"wallet.customNetworkNotSecureErrMsg" = "Niet veilig.";
 
 /* The title above the input fields for users to input network rpc urls in Custom Network Details Screen. */
 "wallet.customNetworkRpcUrlsTitle" = "RPC-URL's";

--- a/ios/brave-ios/Sources/BraveWallet/Resources/pl.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/pl.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transakcja";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Ta transakcja spowoduje ponowne przypisanie własności konta do nowego programu. Działanie to jest nieodwracalne i może spowodować utratę środków.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Żądanie zmiany właściciela konta";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Powiązane konto tokenowe jeszcze nie istnieje. Na jego utworzenie i dodanie do niego funduszy wydana zostanie niewielka kwota w SOL.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/pt-BR.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/pt-BR.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transação";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Essa transação reatribuirá a propriedade da conta a um novo programa. Essa ação é irreversível e pode resultar em perda de fundos.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Solicitação de mudança de titularidade da conta";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "A conta de tokens associada ainda não existe. Será gasta uma pequena quantia de SOL para criá-la e financiá-la.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/pt-PT.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/pt-PT.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transação";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Esta transação irá reatribuir a propriedade da conta a um novo programa. Esta ação é irreversível e pode resultar na perda de fundos.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Pedido de alteração da titularidade da conta";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "A conta de tokens associada ainda não existe. Será gasta uma pequena quantia de SOL para a criar e financiar.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/ro.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/ro.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Tranzacție";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Acest tranzacție va transfera proprietatea cont către un nou program. Această acțiune este ireversibilă și poate duce la pierderea de fonduri.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Cont schimbare de proprietate solicitată";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Contul de token asociat nu există încă. O sumă mică de SOL va fi cheltuită pentru a-l crea și finanța.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/ru.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/ru.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Транзакция";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Эта операция переводит право собственности на счет на новую программу. Это действие необратимо и может привести к потере средств.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Запрос на изменение владельца аккаунта";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Счет с соответствующим видом токенов еще не создан. Чтобы открыть его и пополнить, будет списана небольшая сумма SOL.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/sk.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/sk.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transakcia";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Touto transakciou sa vlastníctvo účtu opätovne pridelí novému programu. Táto akcia je nezvratná a môže viesť k strate finančných prostriedkov.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Žiadosť o zmenu vlastníctva účtu";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Príslušný tokenový účet zatiaľ neexistuje. Na jeho vytvorenie a financovanie sa vynaloží malé množstvo SOL.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/sv.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/sv.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Transaktion";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Denna transaktion kommer att omfördela äganderätten till kontot till ett nytt program. Denna åtgärd är oåterkallelig och kan leda till förlust av medel.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Begäran om ändring av kontoinnehav";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Det tillhörande tokenkontot  finns inte ännu. Ett litet antal SOL kommer att spenderas för att skapa och finansiera det.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/tr.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/tr.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "İşlem";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Bu işlem, hesabın sahipliğini yeni bir programa yeniden atayacaktır. Bu işlem geri alınamaz ve fon kaybına neden olabilir.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Hesap sahipliği değişikliği talep edildi";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "İlişkili token hesabı henüz mevcut değil. Küçük miktarda SOL, hesabı oluşturmak ve fonlamak için harcanacaktır.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/uk.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/uk.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "Транзакція";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "Ця транзакція перепризначить право власності на рахунок новій програмі. Ця дія є незворотною і може призвести до втрати коштів.";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "Запитується зміна власника облікового запису";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "Облікового запису, пов’язаного із цим токеном, ще немає. Невелика кількість SOL буде витрачена на створення й наповнення його.";
 

--- a/ios/brave-ios/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
+++ b/ios/brave-ios/Sources/BraveWallet/Resources/zh-TW.lproj/BraveWallet.strings
@@ -355,6 +355,12 @@
 /* One of the picker options while confirming a transaction. When selected it displays a summary of the transaction such as value, gas fee, and totals */
 "wallet.confirmationViewModeTransaction" = "交易";
 
+/* The warning shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarning" = "此交易将把账户所有权重新分配给一个新的程序。此操作不可逆转，并可能导致资金损失。";
+
+/* The warning title shown on transaction confirmation for an Solana Dapp request that will reassign ownership of the account to a new program. */
+"wallet.confirmationViewSolAccountOwnershipChangeWarningTitle" = "请求更改账户所有权";
+
 /* The warning shown on transaction confirmation for an Solana SPL token transaction that has not yet created an associated token account. */
 "wallet.confirmationViewSolSplTokenAccountCreationWarning" = "尚未與任何代幣帳戶建立關聯。您需使用小額 SOL 建立帳戶及存入資金。";
 

--- a/ios/brave-ios/Sources/Onboarding/Resources/nl.lproj/FocusOnboarding.strings
+++ b/ios/brave-ios/Sources/Onboarding/Resources/nl.lproj/FocusOnboarding.strings
@@ -31,6 +31,9 @@
 /* The title of the toggle for enable / disable privacy preserving analytics. */
 "focusOnboarding.p3aToggleDescription" = "U kunt dit op elk gewenst moment veranderen in uw Brave-instellingen onder 'Brave Shields en Privacy'.";
 
+/* The title of the toggle for enable / disable the privacy preserving analytics. */
+"focusOnboarding.p3aToggleTitle" = "Deel privé- en anonieme productinzichten.";
+
 /* The title of the button that finishes the onboarding without setting default */
 "focusOnboarding.startBrowseActionButtonTitle" = "Browsen maar";
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41879

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Change your device to a language other than english
2. open Brave and navigate to https://admirable-blini-a16ea7.netlify.app/
3. connect your Brave Wallet to the Dapp
4. Click Send transaction (mainnet) fromt he Dapp
5. Observe the pending transaction screen shows up and there will be a new warning message and the message should be localized. 
