### PR TITLE
Perf tests: move setup android step from devops

### DIFF
--- a/tools/perf/components/android_tools.py
+++ b/tools/perf/components/android_tools.py
@@ -6,8 +6,8 @@
 import os
 import re
 import logging
-
 import time
+
 from typing import List, Optional
 
 from components.perf_test_utils import GetProcessOutput
@@ -31,7 +31,7 @@ def SetupAndroidDevice() -> None:
   ],
                    check=True)
   if not RunFromRoot(f'sh {tmp_file}'):
-    raise RuntimeError('Failed to setup root on the device')
+    raise RuntimeError('Failed to setup the device: setup_android_device.sh')
   RunFromRoot('killall adbd')  # Restart adbd on the device to apply the changes
   time.sleep(2)
 

--- a/tools/perf/components/android_tools.py
+++ b/tools/perf/components/android_tools.py
@@ -14,7 +14,7 @@ from components.perf_test_utils import GetProcessOutput
 import components.path_util as path_util
 
 
-def RunFromRoot(cmd: str) -> bool:
+def RunAsRoot(cmd: str) -> bool:
   result, _ = GetProcessOutput(
       [path_util.GetAdbPath(), 'shell', 'su', '-c', '\'' + cmd + '\''])
   return result
@@ -30,15 +30,15 @@ def SetupAndroidDevice() -> None:
       tmp_file,
   ],
                    check=True)
-  if not RunFromRoot(f'sh {tmp_file}'):
+  if not RunAsRoot(f'sh {tmp_file}'):
     raise RuntimeError('Failed to setup the device: setup_android_device.sh')
-  RunFromRoot('killall adbd')  # Restart adbd on the device to apply the changes
+  RunAsRoot('killall adbd')  # Restart adbd on the device to apply the changes
   time.sleep(2)
 
 
 def RebootAndroid() -> None:
   logging.debug('Rebooting Android device')
-  RunFromRoot('reboot')
+  RunAsRoot('reboot')
   time.sleep(30)
 
 

--- a/tools/perf/components/common_options.py
+++ b/tools/perf/components/common_options.py
@@ -41,6 +41,7 @@ class CommonOptions:
   working_directory: str = ''
   target_os: str = PerfBenchmark.FixupTargetOS(sys.platform)
   target_arch: str = ''
+  reboot_android: bool = False
 
   do_report: bool = False
   upload: bool = True
@@ -94,6 +95,10 @@ class CommonOptions:
                         type=str,
                         choices=['windows', 'mac', 'linux', 'android'])
     parser.add_argument('--target-arch', type=str, choices=['x64', 'arm64'])
+    parser.add_argument(
+        '--reboot-android',
+        action='store_true',
+        help='Reboot the Android device before running the tests')
     parser.add_argument(
         '--local-run',
         action='store_true',
@@ -175,6 +180,8 @@ class CommonOptions:
         options.target_arch = 'arm64'
       else:
         options.target_arch = 'x64'
+
+    options.reboot_android = args.reboot_android or args.ci_mode
 
     options.report_on_failure = args.report_on_failure
     if args.targets is not None:

--- a/tools/perf/run_perftests.py
+++ b/tools/perf/run_perftests.py
@@ -23,6 +23,7 @@ import sys
 import os
 import tempfile
 
+import components.android_tools as android_tools
 import components.perf_config as perf_config
 import components.perf_test_runner as perf_test_runner
 import components.perf_test_utils as perf_test_utils
@@ -126,6 +127,11 @@ npm run perf_tests -- smoke-brave.json5 v1.58.45
 
   json_config = load_config(args.config, options)
   config = perf_config.PerfConfig(json_config)
+
+  if options.is_android:
+    if options.reboot_android:
+      android_tools.RebootAndroid()
+    android_tools.SetupAndroidDevice()
 
   if options.mode == PerfMode.RUN:
     if len(config.runners) != 1:

--- a/tools/perf/setup_android_device.sh
+++ b/tools/perf/setup_android_device.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# The script is used to setup the android device:
+# 1. Disable SELinux
+# 2. Enable adb root (adbd must be restarted after)
+# 3. Unlock the device screen
+
+setenforce 0 && \
+resetprop ro.debuggable 1 && \
+magiskpolicy --live "allow adbd adbd process setcurrent" && \
+magiskpolicy --live "allow adbd su process dyntransition" && \
+magiskpolicy --live "permissive { su }" && \
+input keyevent 82


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41880
The PR:
* move devops part to setup android device to b-c
* make a dedicated file to be pushed and launched instead of one-liner. If the script fails the build is considered as broken.
* add a step to unlock device after rebooting
* reboot the device by default of CI and optionally for a local run

Verified here: https://ci.brave.com/job/brave-browser-test-perf-android/1142/console

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

