### PR TITLE
[iOS] Fix crash when dismissing news opt-in on NTP

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageFlowLayout.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageFlowLayout.swift
@@ -64,6 +64,9 @@ class NewTabPageFlowLayout: UICollectionViewFlowLayout {
 
       lastSizedElementMinY = nil
       lastSizedElementPreferredHeight = nil
+    } else {
+      gapLength = 0
+      extraHeight = 0
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -772,26 +772,9 @@ class NewTabPageViewController: UIViewController {
         collectionView.deleteItems(at: [IndexPath(item: 0, section: section)])
       }
 
-      // We check if first item exists before scrolling up to it.
-      // This should never happen since first item is our shields stats view.
-      // However we saw it crashing in XCode logs, see #4202.
-      let firstItemIndexPath = IndexPath(item: 0, section: 0)
-      if let itemCount = collectionView.dataSource?.collectionView(
-        collectionView,
-        numberOfItemsInSection: 0
-      ),
-        itemCount > 0,  // Only scroll if the section has items, otherwise it will crash.
-        collectionView.dataSource?
-          .collectionView(collectionView, cellForItemAt: firstItemIndexPath) != nil
-      {
-        collectionView.scrollToItem(at: firstItemIndexPath, at: .top, animated: true)
-      } else {
-        // Cannot scorll to deleted item index.
-        // Collection-View datasource never changes or updates
-        // Therefore we need to scroll to offset 0.
-        // See: #4575.
-        collectionView.setContentOffset(.zero, animated: true)
-      }
+      // scroll to offset .zero to preserve padding above section
+      collectionView.setContentOffset(.zero, animated: true)
+      backgroundButtonsView.setNeedsLayout()
       collectionView.verticalScrollIndicatorInsets = .zero
       UIView.animate(withDuration: 0.25) {
         self.feedOverlayView.headerView.alpha = 0.0


### PR DESCRIPTION
- Fix crash on iOS 18+ by not dequeueing a cell when scrolling to top after dismissing news card
- Fix layout bug causing empty scroll space on new tab page after dismissing news card

Resolves https://github.com/brave/brave-browser/issues/41858

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Fresh install app on iOS 18+.
2. On New Tab Page, tap 'X' on news opt-in card.
3. Verify app does not crash.
4. Scroll down, verify no empty space where news card used to be.