### PR TITLE
Backport an upstream fix for geolocation crash. (uplift to 1.71.x)

### DIFF
--- a/patches/third_party-blink-renderer-modules-geolocation-geolocation.cc.patch
+++ b/patches/third_party-blink-renderer-modules-geolocation-geolocation.cc.patch
@@ -1,0 +1,21 @@
+diff --git a/third_party/blink/renderer/modules/geolocation/geolocation.cc b/third_party/blink/renderer/modules/geolocation/geolocation.cc
+index 223049e27395830a64f80ac67ccf435793e3f1e3..c7d247a700167f8215648bcb4fd43836f8507b40 100644
+--- a/third_party/blink/renderer/modules/geolocation/geolocation.cc
++++ b/third_party/blink/renderer/modules/geolocation/geolocation.cc
+@@ -90,10 +90,12 @@ GeolocationPositionError* CreatePositionError(
+       error_code = GeolocationPositionError::kPositionUnavailable;
+       break;
+     default:
+-      // On Blink side, it should only handles W3C defined error codes.
+-      // If it reaches here that means an unexpected error type being propagated
+-      // to Blink. This should never happen.
+-      NOTREACHED_NORETURN();
++      // On the Blink side, it should only handle W3C-defined error codes. If it
++      // reaches here, that means a platform-specific error type is being
++      // propagated to Blink. We will now just use kPositionUnavailable until
++      // more explicit error codes are defined in the W3C spec.
++      error_code = GeolocationPositionError::kPositionUnavailable;
++      break;
+   }
+   return MakeGarbageCollected<GeolocationPositionError>(error_code,
+                                                         error.error_message);


### PR DESCRIPTION
Backport of https://chromium-review.googlesource.com/c/chromium/src/+/5840695

Fixes https://github.com/brave/brave-browser/issues/41859

Pre-approval checklist:
- [x] You have tested your change on Nightly.
- [ ] This contains text which needs to be translated.
    - [ ] There are more than 7 days before the release.
    - [ ] I've notified folks in #l10n on Slack that translations are needed.
- [x] The PR milestones match the branch they are landing to.

Pre-merge checklist:
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.

Post-merge checklist:
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.

