### PR TITLE
Fixed crash with BraveTabGroupUiCoordinator.initializeWithNative at stack

### DIFF
--- a/android/features/tab_ui/BUILD.gn
+++ b/android/features/tab_ui/BUILD.gn
@@ -20,6 +20,7 @@ android_library("java") {
     "//chrome/browser/data_sharing:tab_group_ui_java",
     "//chrome/browser/flags:java",
     "//chrome/browser/preferences:java",
+    "//chrome/browser/profiles/android:java",
     "//chrome/browser/tab_ui/android:java",
     "//chrome/browser/tabmodel:java",
     "//chrome/browser/ui/android/layouts:java",

--- a/android/features/tab_ui/BUILD.gn
+++ b/android/features/tab_ui/BUILD.gn
@@ -20,7 +20,6 @@ android_library("java") {
     "//chrome/browser/data_sharing:tab_group_ui_java",
     "//chrome/browser/flags:java",
     "//chrome/browser/preferences:java",
-    "//chrome/browser/profiles/android:java",
     "//chrome/browser/tab_ui/android:java",
     "//chrome/browser/tabmodel:java",
     "//chrome/browser/ui/android/layouts:java",

--- a/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
+++ b/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
@@ -18,8 +18,6 @@ import org.chromium.base.supplier.OneshotSupplier;
 import org.chromium.chrome.browser.browser_controls.BrowserControlsStateProvider;
 import org.chromium.chrome.browser.data_sharing.DataSharingTabManager;
 import org.chromium.chrome.browser.layouts.LayoutStateProvider;
-import org.chromium.chrome.browser.profiles.Profile;
-import org.chromium.chrome.browser.profiles.ProfileManager;
 import org.chromium.chrome.browser.tab_ui.TabContentManager;
 import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider;
 import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider.IncognitoStateObserver;
@@ -39,7 +37,6 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
     // Own members.
     private IncognitoStateProvider mIncognitoStateProvider;
     private IncognitoStateObserver mIncognitoStateObserver;
-    private ProfileManager.Observer mProfileManagerObserver;
 
     public BraveTabGroupUiCoordinator(
             @NonNull Activity activity,
@@ -94,41 +91,6 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
 
     @Override
     public void initializeWithNative(
-            Activity activity,
-            BottomControlsCoordinator.BottomControlsVisibilityController visibilityController,
-            Callback<Object> onModelTokenChange) {
-        // Fix for the null object crash at TabGroupSyncFeatures.isTabGroupSyncEnabled
-        // Stack:
-        // at TabGroupSyncFeatures.isTabGroupSyncEnabled (TabGroupSyncFeatures.java:18)
-        // at TabGroupUiMediator.<init> (TabGroupUiMediator.java:143)
-        // at TabGroupUiCoordinator.initializeWithNative (TabGroupUiCoordinator.java:238)
-        // at BraveTabGroupUiCoordinator.initializeWithNative (BraveTabGroupUiCoordinator.java:97)
-        // at BottomControlsCoordinator.lambda$new$1 (BottomControlsCoordinator.java:148)
-        //
-        // Profile at TabGroupUiCoordinator can be null.
-        // Upstream does not have this issue because they don't use BottomControlsCoordinator
-        if (ProfileManager.isInitialized()) {
-            callSuperInitializeWithNative(activity, visibilityController, onModelTokenChange);
-        } else {
-            // Profile is not yet ready, continue initialization when it will be ready
-            mProfileManagerObserver =
-                    new ProfileManager.Observer() {
-                        @Override
-                        public void onProfileAdded(Profile profile) {
-                            ProfileManager.removeObserver(mProfileManagerObserver);
-
-                            callSuperInitializeWithNative(
-                                    activity, visibilityController, onModelTokenChange);
-                        }
-
-                        @Override
-                        public void onProfileDestroyed(Profile profile) {}
-                    };
-            ProfileManager.addObserver(mProfileManagerObserver);
-        }
-    }
-
-    private void callSuperInitializeWithNative(
             Activity activity,
             BottomControlsCoordinator.BottomControlsVisibilityController visibilityController,
             Callback<Object> onModelTokenChange) {

--- a/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
+++ b/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
@@ -23,6 +23,7 @@ import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider;
 import org.chromium.chrome.browser.tabmodel.IncognitoStateProvider.IncognitoStateObserver;
 import org.chromium.chrome.browser.tabmodel.TabCreatorManager;
 import org.chromium.chrome.browser.tabmodel.TabModelSelector;
+import org.chromium.chrome.browser.tabmodel.TabModelSelectorObserver;
 import org.chromium.chrome.browser.toolbar.bottom.BottomControlsCoordinator;
 import org.chromium.chrome.tab_ui.R;
 import org.chromium.components.browser_ui.bottomsheet.BottomSheetController;
@@ -37,6 +38,7 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
     // Own members.
     private IncognitoStateProvider mIncognitoStateProvider;
     private IncognitoStateObserver mIncognitoStateObserver;
+    private TabModelSelector mTabModelSelector;
 
     public BraveTabGroupUiCoordinator(
             @NonNull Activity activity,
@@ -68,6 +70,7 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
                 modalDialogManager);
 
         mIncognitoStateProvider = incognitoStateProvider;
+        mTabModelSelector = tabModelSelector;
 
         assert mToolbarView != null : "Make sure mToolbarView is properly patched in bytecode.";
         ChromeImageView fadingEdgeStart =
@@ -91,6 +94,39 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
 
     @Override
     public void initializeWithNative(
+            Activity activity,
+            BottomControlsCoordinator.BottomControlsVisibilityController visibilityController,
+            Callback<Object> onModelTokenChange) {
+        // Fix for the null object crash at TabGroupSyncFeatures.isTabGroupSyncEnabled
+        // Stack:
+        // at TabGroupSyncFeatures.isTabGroupSyncEnabled (TabGroupSyncFeatures.java:18)
+        // at TabGroupUiMediator.<init> (TabGroupUiMediator.java:143)
+        // at TabGroupUiCoordinator.initializeWithNative (TabGroupUiCoordinator.java:238)
+        // at BraveTabGroupUiCoordinator.initializeWithNative (BraveTabGroupUiCoordinator.java:97)
+        // at BottomControlsCoordinator.lambda$new$1 (BottomControlsCoordinator.java:148)
+        //
+        // TabModelSelector.getModel returns EmptyTabModel with null profile when the model is not
+        // found.
+        // Upstream does not have this issue because they don't use BottomControlsCoordinator
+        if (mTabModelSelector.getModels().size() < 2) {
+            mTabModelSelector.addObserver(
+                    new TabModelSelectorObserver() {
+                        @Override
+                        public void onChange() {
+                            if (mTabModelSelector.getModels().size() >= 2) {
+                                callSuperInitializeWithNative(
+                                        activity, visibilityController, onModelTokenChange);
+
+                                mTabModelSelector.removeObserver(this);
+                            }
+                        }
+                    });
+        } else {
+            callSuperInitializeWithNative(activity, visibilityController, onModelTokenChange);
+        }
+    }
+
+    private void callSuperInitializeWithNative(
             Activity activity,
             BottomControlsCoordinator.BottomControlsVisibilityController visibilityController,
             Callback<Object> onModelTokenChange) {

--- a/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
+++ b/android/features/tab_ui/java/src/org/chromium/chrome/browser/tasks/tab_management/BraveTabGroupUiCoordinator.java
@@ -108,12 +108,14 @@ public class BraveTabGroupUiCoordinator extends TabGroupUiCoordinator {
         // TabModelSelector.getModel returns EmptyTabModel with null profile when the model is not
         // found.
         // Upstream does not have this issue because they don't use BottomControlsCoordinator
-        if (mTabModelSelector.getModels().size() < 2) {
+        if (mTabModelSelector.getModels().size() < 2
+                || mTabModelSelector.getModel(false).getProfile() == null) {
             mTabModelSelector.addObserver(
                     new TabModelSelectorObserver() {
                         @Override
                         public void onChange() {
-                            if (mTabModelSelector.getModels().size() >= 2) {
+                            if (mTabModelSelector.getModels().size() >= 2
+                                    && mTabModelSelector.getModel(false).getProfile() != null) {
                                 callSuperInitializeWithNative(
                                         activity, visibilityController, onModelTokenChange);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41922

This PR:
- reverts https://github.com/brave/brave-core/pull/26119 because according to new crash stack from GP console it didn't actually fixed;
- moves `BraveTabGroupUiCoordinator.initializeWithNative` into `TabModelSelectorObserver.onChange` to ensure all tab models are loaded

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
We don't have the exact STR and cannot reproduce it on any of my devices. According to the stack the crash happened during app start.

