### PR TITLE
[iOS] Fix playback speed + repeat mode buttons in Playlist fullscreen

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
@@ -146,7 +146,22 @@ extension PlayerView {
     var body: some View {
       VStack {
         HStack(spacing: 16) {
-          PlaybackSpeedPicker(playbackSpeed: $model.playbackSpeed)
+          if #available(iOS 18.0, *) {
+            // iOS 18 breaks simultaneous gestures on `Menu`, so we'll swap in a the old Button
+            // instead for those users for the time being...
+            Button {
+              model.playbackSpeed.cycle()
+            } label: {
+              Label(
+                Strings.Playlist.accessibilityPlaybackSpeed,
+                braveSystemImage: model.playbackSpeed.braveSystemName
+              )
+              .transition(.opacity.animation(.linear(duration: 0.1)))
+              .contentShape(.rect)
+            }
+          } else {
+            PlaybackSpeedPicker(playbackSpeed: $model.playbackSpeed)
+          }
           Spacer()
           Toggle(isOn: $model.isShuffleEnabled) {
             if model.isShuffleEnabled {
@@ -164,8 +179,39 @@ extension PlayerView {
             }
           }
           .toggleStyle(.button)
-          RepeatModePicker(repeatMode: $model.repeatMode)
-            .disabled(model.duration.isIndefinite)
+          Group {
+            if #available(iOS 18.0, *) {
+              // iOS 18 breaks simultaneous gestures on `Menu`, so we'll swap in a the old Button
+              // instead for those users for the time being...
+              Button {
+                model.repeatMode.cycle()
+              } label: {
+                Group {
+                  switch model.repeatMode {
+                  case .none:
+                    Label(
+                      Strings.Playlist.accessibilityRepeatModeOff,
+                      braveSystemImage: "leo.loop.off"
+                    )
+                  case .one:
+                    Label(
+                      Strings.Playlist.accessibilityRepeatModeOne,
+                      braveSystemImage: "leo.loop.1"
+                    )
+                  case .all:
+                    Label(
+                      Strings.Playlist.accessibilityRepeatModeAll,
+                      braveSystemImage: "leo.loop.all"
+                    )
+                  }
+                }
+                .transition(.opacity.animation(.linear(duration: 0.1)))
+              }
+            } else {
+              RepeatModePicker(repeatMode: $model.repeatMode)
+            }
+          }
+          .disabled(model.duration.isIndefinite)
           Button {
             Task {
               await model.playNextItem()


### PR DESCRIPTION
There is unfortunately a SwiftUI regression in iOS 18 which causes `simultaneousGesture` to break the primary tap gesture on `Menu(_:label:primaryAction:)` views. This change swaps the fullscreen buttons that used to have a long-press gesture back to standard Button's that cycle but have no long-press ability to choose an explicit speed/repeat mode.

Resolves https://github.com/brave/brave-browser/issues/41892

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

