### PR TITLE
[iOS] Fix button title colors to match new Nala colors

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncAddDevice/SyncAddDeviceDetailView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/SyncAddDevice/SyncAddDeviceDetailView.swift
@@ -216,7 +216,7 @@ class SyncAddDeviceActionView: UIStackView {
     $0.setTitle(Strings.done, for: .normal)
     $0.titleLabel?.font = .preferredFont(for: .subheadline, weight: .semibold)
     $0.addTarget(self, action: #selector(dismiss), for: .touchUpInside)
-    $0.setTitleColor(.white, for: .normal)
+    $0.setTitleColor(UIColor(braveSystemName: .schemesOnPrimary), for: .normal)
     $0.backgroundColor = UIColor(braveSystemName: .buttonBackground)
     $0.layer.cornerRadius = 12
     $0.layer.cornerCurve = .continuous

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusP3AScreenView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusP3AScreenView.swift
@@ -166,7 +166,7 @@ struct FocusP3AScreenView: View {
         label: {
           Text(Strings.FocusOnboarding.continueButtonTitle)
             .font(.body.weight(.semibold))
-            .foregroundColor(Color(.white))
+            .foregroundColor(Color(braveSystemName: .schemesOnPrimary))
             .dynamicTypeSize(dynamicTypeRange)
             .padding()
             .frame(maxWidth: .infinity)

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusStepsScreenView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusStepsScreenView.swift
@@ -155,7 +155,7 @@ struct FocusStepsView: View {
           label: {
             Text(Strings.FocusOnboarding.continueButtonTitle)
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.white))
+              .foregroundColor(Color(braveSystemName: .schemesOnPrimary))
               .dynamicTypeSize(dynamicTypeRange)
               .padding()
               .frame(maxWidth: .infinity)

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSystemSettingsView.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/FocusSystemSettingsView.swift
@@ -123,7 +123,7 @@ public struct FocusSystemSettingsView: View {
           label: {
             Text(Strings.FocusOnboarding.systemSettingsButtonTitle)
               .font(.body.weight(.semibold))
-              .foregroundColor(Color(.white))
+              .foregroundColor(Color(braveSystemName: .schemesOnPrimary))
               .dynamicTypeSize(dynamicTypeRange)
               .padding()
               .frame(maxWidth: .infinity)

--- a/ios/brave-ios/Sources/PlaylistUI/PopulateNewPlaylistView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PopulateNewPlaylistView.swift
@@ -89,7 +89,7 @@ struct PopulateNewPlaylistView: View {
           .containerShape(.rect(cornerRadius: 10, style: .continuous))
       }
       .padding()
-      .tint(Color.white)
+      .tint(Color(braveSystemName: .schemesOnPrimary))
       .background(
         LinearGradient(
           stops: [


### PR DESCRIPTION
Replaces a few places we hard-coded a white text color and used the `buttonBackground` Nala color which now in dark mode would look bad

Resolves https://github.com/brave/brave-browser/issues/41776

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

