### PR TITLE
Add new purchase state OUT_OF_CREDENTIALS for VPN service

### DIFF
--- a/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
+++ b/browser/ui/webui/brave_vpn/brave_vpn_localized_string_provider.cc
@@ -111,6 +111,8 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source) {
       {"braveVpnSettingsTooltip", IDS_BRAVE_VPN_MAIN_PANEL_VPN_SETTINGS_TITLE},
       {"braveVpnSessionExpiredContent",
        IDS_BRAVE_VPN_MAIN_PANEL_SESSION_EXPIRED_PART_CONTENT},
+      {"braveVpnOutOfCredentials",
+       IDS_BRAVE_VPN_MAIN_PANEL_OUT_OF_CREDENTIALS_TITLE},
   };
 
   for (const auto& str : kLocalizedStrings) {

--- a/components/brave_vpn/browser/brave_vpn_service_helper.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_helper.cc
@@ -86,6 +86,7 @@ void SetSkusCredential(PrefService* local_prefs,
                 base::TimeToValue(expiration_time));
   local_prefs->SetDict(prefs::kBraveVPNSubscriberCredential,
                        std::move(cred_dict));
+  local_prefs->SetTime(prefs::kBraveVPNLastCredentialExpiry, expiration_time);
 }
 
 void SetSkusCredentialFetchingRetried(PrefService* local_prefs, bool retried) {

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -43,6 +43,7 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterStringPref(prefs::kBraveVPNWireguardProfileCredentials, "");
   registry->RegisterDictionaryPref(prefs::kBraveVPNRootPref);
   registry->RegisterDictionaryPref(prefs::kBraveVPNSubscriberCredential);
+  registry->RegisterTimePref(prefs::kBraveVPNLastCredentialExpiry, {});
   registry->RegisterBooleanPref(prefs::kBraveVPNLocalStateMigrated, false);
   registry->RegisterTimePref(prefs::kBraveVPNSessionExpiredDate, {});
 #if BUILDFLAG(ENABLE_BRAVE_VPN_WIREGUARD)

--- a/components/brave_vpn/common/mojom/brave_vpn.mojom
+++ b/components/brave_vpn/common/mojom/brave_vpn.mojom
@@ -114,6 +114,8 @@ enum PurchasedState {
   LOADING,
   SESSION_EXPIRED,
   FAILED,
+  // Desktop only - person ran out of SKU credentials.
+  OUT_OF_CREDENTIALS,
 };
 
 struct PurchasedInfo {

--- a/components/brave_vpn/common/pref_names.h
+++ b/components/brave_vpn/common/pref_names.h
@@ -60,6 +60,10 @@ inline constexpr char kBraveVPNEnvironment[] = "brave.brave_vpn.env";
 // Dict that has subscriber credential its expiration date.
 inline constexpr char kBraveVPNSubscriberCredential[] =
     "brave.brave_vpn.subscriber_credential";
+// Set the expiry of the last redeemed credential.
+// Useful in case redemption fails and person uses all credentials.
+inline constexpr char kBraveVPNLastCredentialExpiry[] =
+    "brave.brave_vpn.last_credential_expiry";
 
 // Time that session expired occurs.
 inline constexpr char kBraveVPNSessionExpiredDate[] =

--- a/components/brave_vpn/resources/panel/components/main-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/main-panel/index.tsx
@@ -106,7 +106,9 @@ function MainPanel() {
   const isSelectingRegion = useSelector((state) => state.isSelectingRegion)
   const connectionStatus = useSelector((state) => state.connectionStatus)
   const expired = useSelector((state) => state.expired)
+  const outOfCredentials = useSelector((state) => state.outOfCredentials)
   const regions = useSelector((state) => state.regions)
+  const stateDescription = useSelector((state) => state.stateDescription)
 
   const onSelectRegionButtonClick = () => {
     dispatch(Actions.toggleRegionSelector(true))
@@ -184,6 +186,17 @@ function MainPanel() {
             <SessionExpiredContent />
           </S.StyledAlert>
         )}
+        {outOfCredentials && (
+          <S.StyledAlert
+            type='warning'
+            mode='full'
+            hideIcon
+          >
+            <div slot='title'>{getLocale('braveVpnOutOfCredentials')}</div>
+            <div>{stateDescription}</div>
+          </S.StyledAlert>
+        )}
+        {!outOfCredentials && (
         <S.RegionSelectorButton
           type='button'
           onClick={onSelectRegionButtonClick}
@@ -195,6 +208,7 @@ function MainPanel() {
           </RegionInfo>
           <S.StyledIcon name='carat-right' />
         </S.RegionSelectorButton>
+        )}
       </S.PanelContent>
     </PanelBox>
   )

--- a/components/brave_vpn/resources/panel/state/actions.ts
+++ b/components/brave_vpn/resources/panel/state/actions.ts
@@ -24,6 +24,8 @@ export type showMainViewPayload = {
   regions: Region[]
   connectionStatus: ConnectionState
   expired: boolean
+  outOfCredentials: boolean
+  stateDescription: string
 }
 
 export type initializedPayload = {
@@ -39,12 +41,17 @@ export type purchasedStatePayload = {
   stateDescription?: string
 }
 
+export type outOfCredentialsPayload = {
+  description?: string
+}
+
 export const connect = createAction('connect')
 export const disconnect = createAction('disconnect')
 export const connectionFailed = createAction('connectionFailed')
 export const initialize = createAction('initialize')
 export const purchaseConfirmed = createAction('purchaseConfirmed')
 export const purchaseExpired = createAction('purchaseExpired')
+export const outOfCredentials = createAction<outOfCredentialsPayload>('outOfCredentials')
 export const showSellView = createAction('showSellView')
 export const showLoadingView = createAction('showLoadingView')
 export const resetConnectionState = createAction('resetConnectionState')

--- a/components/brave_vpn/resources/panel/state/async.ts
+++ b/components/brave_vpn/resources/panel/state/async.ts
@@ -70,7 +70,9 @@ handler.on(Actions.purchaseConfirmed.getType(), async (store) => {
         state === ConnectionState.CONNECT_FAILED
           ? ConnectionState.DISCONNECTED
           : state /* Treat connection failure on startup as disconnected */,
-      expired: false
+      expired: false,
+      outOfCredentials: false,
+      stateDescription: ''
     })
   )
 })
@@ -86,7 +88,9 @@ handler.on(Actions.purchaseExpired.getType(), async (store) => {
       currentRegion,
       regions,
       connectionStatus: ConnectionState.DISCONNECTED,
-      expired: true
+      expired: true,
+      outOfCredentials: false,
+      stateDescription: ''
     })
   )
 })

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -13,6 +13,7 @@ type RootState = {
   hasError: boolean
   isSelectingRegion: boolean
   expired: boolean
+  outOfCredentials: boolean
   connectionStatus: ConnectionState
   regions: Region[]
   currentRegion: Region
@@ -25,6 +26,7 @@ const defaultState: RootState = {
   hasError: false,
   isSelectingRegion: false,
   expired: false,
+  outOfCredentials: false,
   connectionStatus: ConnectionState.DISCONNECTED,
   regions: [],
   currentRegion: new Region(),
@@ -126,6 +128,16 @@ reducer.on(Actions.showLoadingView, (state): RootState => {
   }
 })
 
+reducer.on(Actions.outOfCredentials, (state, payload): RootState => {
+  return {
+      ...state,
+      expired: false,
+      stateDescription: payload.description || '',
+      outOfCredentials: true,
+      currentView: ViewType.Main
+    }
+})
+
 reducer.on(Actions.initialized, (state, payload): RootState => {
   return {
     ...state,
@@ -148,9 +160,11 @@ reducer.on(Actions.showMainView, (state, payload): RootState => {
   return {
     ...state,
     expired: payload.expired,
+    outOfCredentials: payload.outOfCredentials,
     currentRegion: payload.currentRegion,
     regions: payload.regions,
     connectionStatus: payload.connectionStatus,
+    stateDescription: payload.stateDescription,
     currentView: ViewType.Main
   }
 })

--- a/components/brave_vpn/resources/panel/state/store.ts
+++ b/components/brave_vpn/resources/panel/state/store.ts
@@ -32,6 +32,9 @@ const observer = {
       case PurchasedState.SESSION_EXPIRED:
         store.dispatch(Actions.purchaseExpired())
         break
+      case PurchasedState.OUT_OF_CREDENTIALS:
+        store.dispatch(Actions.outOfCredentials({description}))
+        break
       case PurchasedState.FAILED:
         store.dispatch(Actions.purchaseFailed({
           state: PurchasedState.FAILED, stateDescription: description

--- a/components/resources/brave_vpn_strings.grdp
+++ b/components/resources/brave_vpn_strings.grdp
@@ -182,6 +182,10 @@
     Credentials expiry date elapsed.
   </message>
 
+  <message name="IDS_BRAVE_VPN_MAIN_PANEL_OUT_OF_CREDENTIALS_CONTENT" desc="Message to show when person is out of credentials and needs to wait for more">
+    Brave VPN is having trouble authenticating to the VPN server. Please contact support or try again later.
+  </message>
+
   <message name="IDS_BRAVE_VPN_PURCHASE_CREDENTIALS_FETCH_FAILED" desc="Message to show when credentials cannot be loaded">
     Unable to load credentials.
   </message>
@@ -366,6 +370,9 @@ Let's get you connected!
   </message>
   <message name="IDS_BRAVE_VPN_MAIN_PANEL_SESSION_EXPIRED_PART_TITLE" desc="Title text for session expired panel">
     Session expired
+  </message>
+  <message name="IDS_BRAVE_VPN_MAIN_PANEL_OUT_OF_CREDENTIALS_TITLE" desc="Title text for when user is out of credentials and they can't authenticate">
+    Can't authenticate to VPN
   </message>
   <message name="IDS_BRAVE_VPN_MAIN_PANEL_VPN_SETTINGS_TITLE" desc="Settings button tooltip">
     Settings


### PR DESCRIPTION
This handles the condition where the all the credentials for a given day are redeemed and there are none left. This shouldn't happen - but can happen if there are network issues. Specifically, when the client doesn't receive response from server after redeeming the credential.

Fixes https://github.com/brave/brave-browser/issues/33031

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Login to account.brave.com with an account with VPN *or* buy VPN
2. Use VPN - connect to a server, disconnect
3. Exit Brave
4. Open the `Local State` file in a text editor of your choosing
5. Search for the `sku` > `state` area
6. Next part is tricky - @bsclifton can help. But you'll need to find the credentials that were just used (you can search for `spent: true`). Find the second credential for that same day and change `spent: false` to `spent: true`. Now they should both be true - meaning you are out of credentials for the time window you're in (if code asks for new credentials).
7. Look for `brave_vpn` > `subscriber_credential` and set `credential` to empty string `""`. This will force the next launch to try to get new credentials.
8. Save the file
9. Reload Brave
10. Open VPN menu
11. You should see messaging like this:
    ![image](https://github.com/user-attachments/assets/34d7a8c0-e5f4-4365-8b94-70bcef5de149)
