### PR TITLE
Fix Leo yearly subscription ID on nightly (Uplift to 1.71.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
+++ b/ios/brave-ios/Sources/BraveStore/Subscription/SDK/BraveStoreSDK.swift
@@ -138,7 +138,12 @@ public enum BraveStoreProduct: String, AppStoreProduct, CaseIterable {
 
     switch self {
     case .vpnMonthly, .leoMonthly: return "\(prefix)\(productId).monthly"
-    case .vpnYearly, .leoYearly: return "\(prefix)\(productId).yearly"
+    case .vpnYearly: return "\(prefix)\(productId).yearly"
+    case .leoYearly:
+      if BraveSkusEnvironment.current == .release {
+        return "\(prefix)\(productId).yearly.2"
+      }
+      return "\(prefix)\(productId).yearly"
     }
   }
 }


### PR DESCRIPTION
Uplift of #26268
Resolves https://github.com/brave/brave-browser/issues/41931

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.