### PR TITLE
[DanglingPtr] Fix UaFs with `SidePanelEntry` observations

### DIFF
--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -286,18 +286,6 @@ class SidebarBrowserTest : public InProcessBrowserTest {
     return std::distance(items.cbegin(), iter);
   }
 
-  bool SidebarContainerObserving(SidePanelEntryId id) {
-    auto* sidebar_container_view =
-        static_cast<SidebarContainerView*>(controller()->sidebar());
-    for (const auto& entry :
-         sidebar_container_view->panel_entry_observations_.sources()) {
-      if (entry->key().id() == id) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   raw_ptr<views::View, DanglingUntriaged> item_added_bubble_anchor_ = nullptr;
   std::unique_ptr<base::RunLoop> run_loop_;
   base::WeakPtrFactory<SidebarBrowserTest> weak_factory_{this};
@@ -931,10 +919,6 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, TabSpecificAndGlobalPanelsTest) {
   WaitUntil(base::BindLambdaForTesting([&]() {
     return panel_ui->GetCurrentEntryId() == SidePanelEntryId::kBookmarks;
   }));
-  // As previous customize panel per-url panel, it's closed by deregistering
-  // after loading another url. Then, sidebar container should stop observing
-  // its entry.
-  EXPECT_FALSE(SidebarContainerObserving(SidePanelEntryId::kCustomizeChrome));
 }
 
 IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -778,8 +778,8 @@ WalletButton* BraveBrowserView::GetWalletButton() {
   return static_cast<BraveToolbarView*>(toolbar())->wallet_button();
 }
 
-void BraveBrowserView::WillShowSidePanel(bool show_on_deregistered) {
-  sidebar_container_view_->WillShowSidePanel(show_on_deregistered);
+void BraveBrowserView::WillShowSidePanel() {
+  sidebar_container_view_->WillShowSidePanel();
 }
 
 void BraveBrowserView::NotifyDialogPositionRequiresUpdate() {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -81,7 +81,7 @@ class BraveBrowserView : public BrowserView,
   void CloseWalletBubble();
   WalletButton* GetWalletButton();
   views::View* GetWalletButtonAnchorView();
-  void WillShowSidePanel(bool show_on_deregistered);
+  void WillShowSidePanel();
 
   // Triggers layout of web modal dialogs
   void NotifyDialogPositionRequiresUpdate();

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -152,22 +152,7 @@ void BraveSidePanelCoordinator::PopulateSidePanel(
   // global or active tab's contextual registry.
   auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
   CHECK(browser_view_->unified_side_panel()->children().size() == 1);
-  const auto content_wrapper =
-      browser_view_->unified_side_panel()->children()[0];
-  bool show_on_deregistered = false;
-  // If current entry is not null and its content is already removed from
-  // wrapper when new panel is about to be shown, new panel is shown by
-  // deregistering current panel. See the comment of
-  // SidebarContainerView::WillShowSidePanel() about why |show_on_deregistered|
-  // is needed.
-  // Instead, we can override base class' Show(const UniqueKey& entry, ...)
-  // method as we can know whether it's shown by deregistering with
-  // |open_trigger| arg. However, need patching to make it virtual as base class
-  // already have overridden same name methods.
-  if (current_entry_.get() && content_wrapper->children().empty()) {
-    show_on_deregistered = true;
-  }
-  brave_browser_view->WillShowSidePanel(show_on_deregistered);
+  brave_browser_view->WillShowSidePanel();
   SidePanelCoordinator::PopulateSidePanel(supress_animations, unique_key, entry,
                                           std::move(content_view));
 }

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h
@@ -34,11 +34,9 @@
   virtual NotifyPinnedContainerOfActiveStateChange
 
 #define PopulateSidePanel virtual PopulateSidePanel
-#define OnEntryWillDeregister virtual OnEntryWillDeregister
 
 #include "src/chrome/browser/ui/views/side_panel/side_panel_coordinator.h"  // IWYU pragma: export
 
-#undef OnEntryWillDeregister
 #undef PopulateSidePanel
 #undef NotifyPinnedContainerOfActiveStateChange
 #undef CreateHeader

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
+
+#include "src/chrome/browser/ui/views/side_panel/side_panel_entry.cc"
+
+bool SidePanelEntry::IsBeingObservedBy(SidePanelEntryObserver* observer) {
+  return observers_.HasObserver(observer);
+}

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_ENTRY_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_ENTRY_H_
+
+#define SupportsNewTabButton(...)    \
+  SupportsNewTabButton(__VA_ARGS__); \
+  bool IsBeingObservedBy(SidePanelEntryObserver* observer)
+
+#include "src/chrome/browser/ui/views/side_panel/side_panel_entry.h"  // IWYU pragma: export
+
+#undef SupportsNewTabButton
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_ENTRY_H_


### PR DESCRIPTION
This change addresses the uaf cases we were having with the multisource
observation for `SidePanelEntry` on `SidebarContainerView`. The main
issue we were having is that we can't precisely be notified of when a
given `SidePanelEntry` is going out of scope, and in many cases the
instances would be destroyed before the end of the lifetime of
`SidebarContainerView`. In such cases, the observation would be kept
around in the multisource observer, and eventually would cause an UaF,
as the multisource observer was being destroyed and trying to remove the
outstanding observations that were dangling.

`SidePanelEntry` observations do dangle in upstream. That's the model
they have for the lifetimes: FeatureFoo is destroyed before
`SidePanelEntry`. There are exactly 2 ways for a `SidePanelEntry` to be
destroyed in chromium: FeatureFoo destroyes it via Deregister, or
`SidePanelRegistry` is destroyed before `FeatureFoo`.
`SidebarContainerView` cannot in a reliable way keep track of these
guarantees.

This change is predicated on the fact that `SidebarContainerView` will
always outlive all the use of events by any living `SidePanelEntry`
instance.

In this change we introduce a customisation point to `SidePanelEntry`
that allows us to check if a certain entry is being observed or not. If
it is we don't double-observe.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#39053
Resolves brave/brave-browser#41924

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

