### PR TITLE
Add command line key to diagnose Sync Passwords switch issue

### DIFF
--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -16,6 +16,7 @@ import androidx.annotation.VisibleForTesting;
 import androidx.fragment.app.FragmentManager;
 import androidx.preference.Preference;
 
+import org.chromium.base.CommandLine;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
 import org.chromium.chrome.R;
@@ -44,11 +45,25 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
 
     private Timer mPasswordsSummaryUpdater;
     private static final int RECHECK_VALID_AUTHENTICATION_INTERVAL_MILLIS = 10 * 1000;
+    private Boolean mVerboseSyncPasswordsPref = false;
+    private static final String VERBOSE_SYNC_PASSWORDS_PREF_COMMAND_LINE_KEY =
+            "verbose_sync_passwords_pref";
+
+    private void verboseIfEnabled(String message) {
+        if (!mVerboseSyncPasswordsPref) {
+            return;
+        }
+        Log.v(TAG, message);
+    }
 
     @VisibleForTesting
     @Override
     public void onCreatePreferences(@Nullable Bundle savedInstanceState, String rootKey) {
         super.onCreatePreferences(savedInstanceState, rootKey);
+
+        if (CommandLine.getInstance().hasSwitch(VERBOSE_SYNC_PASSWORDS_PREF_COMMAND_LINE_KEY)) {
+            mVerboseSyncPasswordsPref = true;
+        }
 
         Preference reviewSyncData = findPreference(PREF_SYNC_REVIEW_DATA);
         assert reviewSyncData != null : "Something has changed in the upstream!";
@@ -112,50 +127,91 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
         Preference.OnPreferenceChangeListener origSyncListner =
                 control.getOnPreferenceChangeListener();
 
-        control.setOnPreferenceChangeListener((Preference preference, Object newValue) -> {
-            assert newValue instanceof Boolean;
-            if ((Boolean) newValue) {
-                if (!ReauthenticationManager.isScreenLockSetUp(
-                            ContextUtils.getApplicationContext())) {
-                    showScreenLockToast();
-                } else {
-                    try {
-                        FragmentManager fragmentManager = this.getParentFragmentManager();
+        control.setOnPreferenceChangeListener(
+                (Preference preference, Object newValue) -> {
+                    assert newValue instanceof Boolean;
+                    if ((Boolean) newValue) {
+                        verboseIfEnabled("OnPreferenceChange: newValue is true");
+                        if (!ReauthenticationManager.isScreenLockSetUp(
+                                ContextUtils.getApplicationContext())) {
+                            verboseIfEnabled("OnPreferenceChange: no screenlock set up");
+                            showScreenLockToast();
+                        } else {
+                            verboseIfEnabled("OnPreferenceChange: screenlock is set up");
+                            try {
+                                FragmentManager fragmentManager = this.getParentFragmentManager();
 
-                        if (mReauthenticationHelper == null) {
-                            mReauthenticationHelper = new BravePasswordAccessReauthenticationHelper(
-                                    ContextUtils.getApplicationContext(), fragmentManager);
+                                if (mReauthenticationHelper == null) {
+                                    verboseIfEnabled(
+                                            "OnPreferenceChange: screenlock creating auth helper");
+                                    mReauthenticationHelper =
+                                            new BravePasswordAccessReauthenticationHelper(
+                                                    ContextUtils.getApplicationContext(),
+                                                    fragmentManager);
+                                }
+
+                                verboseIfEnabled("OnPreferenceChange: screenlock invoke reauth");
+                                mReauthenticationHelper.reauthenticateWithDescription(
+                                        R.string.enabling_password_sync_auth_message,
+                                        success -> {
+                                            verboseIfEnabled(
+                                                    "OnPreferenceChange: screenlock reauth response"
+                                                            + " success="
+                                                            + success);
+                                            if (success) {
+                                                verboseIfEnabled(
+                                                        "OnPreferenceChange: call original"
+                                                                + " onPreferenceChange");
+                                                Boolean originalOnPreferenceChangeResult =
+                                                        origSyncListner.onPreferenceChange(
+                                                                preference, true);
+                                                verboseIfEnabled(
+                                                        "OnPreferenceChange: original"
+                                                                + " onPreferenceChange result="
+                                                                + originalOnPreferenceChangeResult);
+                                                verboseIfEnabled(
+                                                        "OnPreferenceChange: call setChecked(true)"
+                                                                + " for control");
+                                                control.setChecked(true);
+
+                                                // Authentication will be valid for
+                                                // ReauthenticationManager.
+                                                // VALID_REAUTHENTICATION_TIME_INTERVAL_MILLIS,
+                                                // So schedule re-check operation.
+                                                verboseIfEnabled(
+                                                        "OnPreferenceChange: call schedule check"
+                                                                + " for valid");
+                                                scheduleCheckForStillValidAuth();
+                                            }
+                                        });
+                            } catch (java.lang.IllegalStateException ex) {
+                                Log.e(TAG, "BraveManageSyncSettings.OnPreferenceChange ex=", ex);
+                            } catch (Exception ex) {
+                                verboseIfEnabled("OnPreferenceChange: general exception=" + ex);
+                            }
                         }
-
-                        mReauthenticationHelper.reauthenticateWithDescription(
-                                R.string.enabling_password_sync_auth_message, success -> {
-                                    if (success) {
-                                        origSyncListner.onPreferenceChange(preference, true);
-                                        control.setChecked(true);
-
-                                        // Authentication will be valid for
-                                        // ReauthenticationManager.
-                                        // VALID_REAUTHENTICATION_TIME_INTERVAL_MILLIS,
-                                        // So schedule re-check operation.
-                                        scheduleCheckForStillValidAuth();
-                                    }
-                                });
-                    } catch (java.lang.IllegalStateException ex) {
-                        Log.e(TAG, "BraveManageSyncSettings.OnPreferenceChange ex=", ex);
+                        return false;
+                    } else {
+                        verboseIfEnabled("OnPreferenceChange: newValue is false");
+                        verboseIfEnabled("OnPreferenceChange: call updateSyncPasswordsSummary()");
+                        updateSyncPasswordsSummary();
+                        Boolean originalOnPreferenceChangeResult =
+                                origSyncListner.onPreferenceChange(preference, newValue);
+                        verboseIfEnabled(
+                                "OnPreferenceChange: original onPreferenceChange result="
+                                        + originalOnPreferenceChangeResult);
+                        return originalOnPreferenceChangeResult;
                     }
-                }
-                return false;
-            } else {
-                updateSyncPasswordsSummary();
-                return origSyncListner.onPreferenceChange(preference, newValue);
-            }
-        });
+                });
     }
 
     // See CredentialEditCoordinator.onResumeFragment
     public void onResumeFragment() {
         if (mReauthenticationHelper != null) {
+            verboseIfEnabled("onResumeFragment: call onReauthenticationMaybeHappened");
             mReauthenticationHelper.onReauthenticationMaybeHappened();
+        } else {
+            verboseIfEnabled("onResumeFragment: cannot call onReauthenticationMaybeHappened");
         }
     }
 
@@ -178,13 +234,17 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
 
     private void updateSyncPasswordsSummary() {
         if (ReauthenticationManager.isScreenLockSetUp(ContextUtils.getApplicationContext())) {
+            verboseIfEnabled("updateSyncPasswordsSummary: screen lock is set up");
             if (ReauthenticationManager.authenticationStillValid(
-                        ReauthenticationManager.ReauthScope.ONE_AT_A_TIME)) {
+                    ReauthenticationManager.ReauthScope.ONE_AT_A_TIME)) {
+                verboseIfEnabled("updateSyncPasswordsSummary: auth is still valid");
                 mPrefSyncPasswords.setSummaryOff("");
             } else {
+                verboseIfEnabled("updateSyncPasswordsSummary: auth is not valid anymore");
                 setRedPasswordsSummaryOff(R.string.sync_password_require_auth_summary);
             }
         } else {
+            verboseIfEnabled("updateSyncPasswordsSummary: screen lock is not set up");
             setRedPasswordsSummaryOff(R.string.device_require_auth_to_sync_passwords_summary);
         }
     }
@@ -198,6 +258,7 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
     }
 
     private void scheduleCheckForStillValidAuth() {
+        verboseIfEnabled("scheduleCheckForStillValidAuth");
         // Cancel old timer before creating new. Otherwise when we turn on/off passwords sync for
         // several times, we will have several timer procedures at the same time.
         cleanupPasswordsSummaryUpdater();
@@ -229,6 +290,7 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
     }
 
     private void cleanupPasswordsSummaryUpdater() {
+        verboseIfEnabled("cleanupPasswordsSummaryUpdater");
         if (mPasswordsSummaryUpdater != null) {
             mPasswordsSummaryUpdater.cancel();
             mPasswordsSummaryUpdater.purge();

--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -188,7 +188,7 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
                                 Log.e(
                                         TAG,
                                         "BraveManageSyncSettings.OnPreferenceChange"
-                                            + " IllegalStateException ex=",
+                                                + " IllegalStateException ex=",
                                         ex);
                             } catch (Exception ex) {
                                 Log.e(TAG, "BraveManageSyncSettings.OnPreferenceChange ex=", ex);

--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -53,7 +53,7 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
         if (!mVerboseSyncPasswordsPref) {
             return;
         }
-        Log.v(TAG, message);
+        Log.i(TAG, message);
     }
 
     @VisibleForTesting
@@ -185,9 +185,13 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
                                             }
                                         });
                             } catch (java.lang.IllegalStateException ex) {
-                                Log.e(TAG, "BraveManageSyncSettings.OnPreferenceChange ex=", ex);
+                                Log.e(
+                                        TAG,
+                                        "BraveManageSyncSettings.OnPreferenceChange"
+                                            + " IllegalStateException ex=",
+                                        ex);
                             } catch (Exception ex) {
-                                verboseIfEnabled("OnPreferenceChange: general exception=" + ex);
+                                Log.e(TAG, "BraveManageSyncSettings.OnPreferenceChange ex=", ex);
                             }
                         }
                         return false;


### PR DESCRIPTION
This PR
- puts additional diagnostics around the suspected code;
- adds a command line switch to enable it.

To see additional diagnostic output, add `--verbose_sync_passwords_pref` through QA Preferences/Command line

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41974

Related issue is also https://github.com/brave/brave-browser/issues/41974.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. add `--verbose_sync_passwords_pref` through QA Preferences/Command line
2. change sync password preference
3. expected to see advanced output in the logcat
