### PR TITLE
[Android] Fix for crash in Password settings

### DIFF
--- a/android/java/org/chromium/chrome/browser/password_manager/settings/BravePasswordSettingsBase.java
+++ b/android/java/org/chromium/chrome/browser/password_manager/settings/BravePasswordSettingsBase.java
@@ -5,32 +5,10 @@
 
 package org.chromium.chrome.browser.password_manager.settings;
 
-import android.view.Menu;
-
 import org.chromium.chrome.browser.settings.BravePreferenceFragment;
 
 public abstract class BravePasswordSettingsBase extends BravePreferenceFragment {
-    /*
-     * This variable will be used instead of upstream's `PasswordSettings#mMenu`.
-     */
-    protected Menu mMenu;
-
     public void createCheckPasswords() {
         // Do nothing here as we don't have check passwords option in Brave.
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-
-        /*
-         * In `PasswordSettings` class `passwordListAvailable` method gets called before `onCreateOptionsMenu`.
-         * Now on pressing `back`, Seetings activity is not finished, but just returns 1 fragment back.
-         * This causes null pointer crash on returning to the password settings page, since `mMenu` is already not null,
-         * but not inflated yet by the time we call `passwordListAvailable` and we try to access `export_passwords`.
-         * This issue is not happening in the upstream since they use different password settings page that utilizes OS level password manager.
-         * So here we make sure `mMenu` is null every time we leave password settings page.
-         */
-        mMenu = null;
     }
 }

--- a/android/java/org/chromium/chrome/browser/settings/BraveSettingsIntentUtil.java
+++ b/android/java/org/chromium/chrome/browser/settings/BraveSettingsIntentUtil.java
@@ -12,7 +12,13 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+
 public class BraveSettingsIntentUtil {
+    private static String PASSWORD_SETTINGS_FRAGMENT =
+            "org.chromium.chrome.browser.password_manager.settings.PasswordSettings";
+    private static String CREDENTIAL_EDIT_FRAGMENT =
+            "org.chromium.chrome.browser.password_entry_edit.CredentialEditFragmentView";
 
     public static Intent createIntent(
             @NonNull Context context,
@@ -20,6 +26,19 @@ public class BraveSettingsIntentUtil {
             @Nullable Bundle fragmentArgs) {
         Intent intent = SettingsIntentUtil.createIntent(context, fragmentName, fragmentArgs);
         intent.setClass(context, BraveSettingsActivity.class);
+        /*
+         * Password settings and credential edit fragments are not used in the upstream anymore and
+         * thus not adjusted to be used within single Settings activity. For now we just open them
+         * with a separate activity as it used to be.
+         * Going forward we should adjust them to be used within the single Settings activity
+         * https://github.com/brave/brave-browser/issues/41977
+         */
+        if (ChromeFeatureList.sSettingsSingleActivity.isEnabled()
+                && fragmentName != null
+                && (fragmentName.equals(PASSWORD_SETTINGS_FRAGMENT)
+                        || fragmentName.equals(CREDENTIAL_EDIT_FRAGMENT))) {
+            intent.removeFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+        }
         return intent;
     }
 }

--- a/build/android/bytecode/java/org/brave/bytecode/BravePasswordSettingsBaseClassAdapter.java
+++ b/build/android/bytecode/java/org/brave/bytecode/BravePasswordSettingsBaseClassAdapter.java
@@ -23,7 +23,5 @@ public class BravePasswordSettingsBaseClassAdapter extends BraveClassVisitor {
                 "createCheckPasswords",
                 sBravePasswordSettingsBaseClassName);
         deleteMethod(sPasswordSettingsClassName, "createCheckPasswords");
-
-        deleteField(sPasswordSettingsClassName, "mMenu");
     }
 }


### PR DESCRIPTION
Chromium change:
https://source.chromium.org/chromium/chromium/src/+/df77cbacb9476b0b6d3e75cc34b5d127985e79c3

[Settings] Enable the single-activity mode by default

Bug: b/356743945

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41976

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

