### PR TITLE
Make vpn bubble start with server selection

### DIFF
--- a/browser/ui/brave_vpn/brave_vpn_controller.cc
+++ b/browser/ui/brave_vpn/brave_vpn_controller.cc
@@ -17,8 +17,8 @@ BraveVPNController::BraveVPNController(BrowserView* browser_view)
 
 BraveVPNController::~BraveVPNController() = default;
 
-void BraveVPNController::ShowBraveVPNBubble() {
-  GetBraveBrowserView()->ShowBraveVPNBubble();
+void BraveVPNController::ShowBraveVPNBubble(bool show_select) {
+  GetBraveBrowserView()->ShowBraveVPNBubble(show_select);
 }
 
 void BraveVPNController::OpenVPNAccountPage() {

--- a/browser/ui/brave_vpn/brave_vpn_controller.h
+++ b/browser/ui/brave_vpn/brave_vpn_controller.h
@@ -18,7 +18,7 @@ class BraveVPNController {
   BraveVPNController(const BraveVPNController&) = delete;
   BraveVPNController& operator=(const BraveVPNController&) = delete;
 
-  void ShowBraveVPNBubble();
+  void ShowBraveVPNBubble(bool show_select = false);
   void OpenVPNAccountPage();
 
  private:

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -602,9 +602,9 @@ void BraveBrowserView::ToggleSidebar() {
   browser_->GetFeatures().side_panel_ui()->Toggle();
 }
 
-void BraveBrowserView::ShowBraveVPNBubble() {
+void BraveBrowserView::ShowBraveVPNBubble(bool show_select) {
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
-  vpn_panel_controller_.ShowBraveVPNPanel();
+  vpn_panel_controller_.ShowBraveVPNPanel(show_select);
 #endif
 }
 

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -77,7 +77,7 @@ class BraveBrowserView : public BrowserView,
   void SetStarredState(bool is_starred) override;
   void ShowUpdateChromeDialog() override;
 
-  void ShowBraveVPNBubble();
+  void ShowBraveVPNBubble(bool show_select = false);
   void CreateWalletBubble();
   void CreateApproveWalletBubble();
   void CloseWalletBubble();

--- a/browser/ui/views/toolbar/brave_vpn_panel_controller.cc
+++ b/browser/ui/views/toolbar/brave_vpn_panel_controller.cc
@@ -5,6 +5,8 @@
 
 #include "brave/browser/ui/views/toolbar/brave_vpn_panel_controller.h"
 
+#include <string>
+
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "chrome/browser/profiles/profile.h"
@@ -20,15 +22,26 @@ BraveVPNPanelController::BraveVPNPanelController(BraveBrowserView* browser_view)
 
 BraveVPNPanelController::~BraveVPNPanelController() = default;
 
-void BraveVPNPanelController::ShowBraveVPNPanel() {
+void BraveVPNPanelController::ShowBraveVPNPanel(bool show_select) {
   auto* anchor_view = browser_view_->GetAnchorViewForBraveVPNPanel();
   if (!anchor_view)
     return;
 
+  if (show_select) {
+    // Reset previously launched bubble to make main panel start with
+    // server selection. Otherwise, bubble shows last position if it's
+    // not destroyed yet.
+    ResetBubbleManager();
+  }
+
+  std::string url = kVPNPanelURL;
+  if (show_select) {
+    url += "select";
+  }
   if (!webui_bubble_manager_) {
     auto* profile = browser_view_->browser()->profile();
     webui_bubble_manager_ = WebUIBubbleManager::Create<VPNPanelUI>(
-        anchor_view, profile, GURL(kVPNPanelURL), IDS_BRAVE_VPN_PANEL_NAME);
+        anchor_view, profile, GURL(url), IDS_BRAVE_VPN_PANEL_NAME);
   }
 
   if (webui_bubble_manager_->GetBubbleWidget()) {

--- a/browser/ui/views/toolbar/brave_vpn_panel_controller.h
+++ b/browser/ui/views/toolbar/brave_vpn_panel_controller.h
@@ -21,7 +21,9 @@ class BraveVPNPanelController {
   BraveVPNPanelController(const BraveVPNPanelController&) = delete;
   BraveVPNPanelController& operator=(const BraveVPNPanelController&) = delete;
 
-  void ShowBraveVPNPanel();
+  // Pass true to |show_select| when we want to show server selection
+  // in the main panel at startup.
+  void ShowBraveVPNPanel(bool show_select = false);
   // Manager should be reset to use different anchor view for bubble.
   void ResetBubbleManager();
 

--- a/components/brave_vpn/resources/panel/components/main-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/main-panel/index.tsx
@@ -109,6 +109,14 @@ function MainPanel() {
   const outOfCredentials = useSelector((state) => state.outOfCredentials)
   const regions = useSelector((state) => state.regions)
   const stateDescription = useSelector((state) => state.stateDescription)
+  const [showSelectedRegionOnce, setShowSelectedRegionOnce] =
+    React.useState(window.location.pathname === '/select')
+
+  if (showSelectedRegionOnce) {
+    setShowSelectedRegionOnce(false)
+    dispatch(Actions.toggleRegionSelector(true))
+    return <></>
+  }
 
   const onSelectRegionButtonClick = () => {
     dispatch(Actions.toggleRegionSelector(true))

--- a/components/brave_vpn/resources/panel/components/main-panel/index.tsx
+++ b/components/brave_vpn/resources/panel/components/main-panel/index.tsx
@@ -109,14 +109,6 @@ function MainPanel() {
   const outOfCredentials = useSelector((state) => state.outOfCredentials)
   const regions = useSelector((state) => state.regions)
   const stateDescription = useSelector((state) => state.stateDescription)
-  const [showSelectedRegionOnce, setShowSelectedRegionOnce] =
-    React.useState(window.location.pathname === '/select')
-
-  if (showSelectedRegionOnce) {
-    setShowSelectedRegionOnce(false)
-    dispatch(Actions.toggleRegionSelector(true))
-    return <></>
-  }
 
   const onSelectRegionButtonClick = () => {
     dispatch(Actions.toggleRegionSelector(true))

--- a/components/brave_vpn/resources/panel/state/reducer.ts
+++ b/components/brave_vpn/resources/panel/state/reducer.ts
@@ -24,7 +24,7 @@ type RootState = {
 
 const defaultState: RootState = {
   hasError: false,
-  isSelectingRegion: false,
+  isSelectingRegion: (window.location.pathname === '/select'),
   expired: false,
   outOfCredentials: false,
   connectionStatus: ConnectionState.DISCONNECTED,


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/41991

NTP VPN Widget card will use this.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Set purchased state
2. Load chrome-untrusted://vpn-panel.top-chrome/select at a tab
3. Check server selection is shown at first