### PR TITLE
Removed usage of SidePanelViewStateObserver

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -778,10 +778,6 @@ WalletButton* BraveBrowserView::GetWalletButton() {
   return static_cast<BraveToolbarView*>(toolbar())->wallet_button();
 }
 
-void BraveBrowserView::WillShowSidePanel() {
-  sidebar_container_view_->WillShowSidePanel();
-}
-
 void BraveBrowserView::NotifyDialogPositionRequiresUpdate() {
   GetBrowserViewLayout()->NotifyDialogPositionRequiresUpdate();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -81,7 +81,6 @@ class BraveBrowserView : public BrowserView,
   void CloseWalletBubble();
   WalletButton* GetWalletButton();
   views::View* GetWalletButtonAnchorView();
-  void WillShowSidePanel();
 
   // Triggers layout of web modal dialogs
   void NotifyDialogPositionRequiresUpdate();
@@ -135,6 +134,10 @@ class BraveBrowserView : public BrowserView,
 
   views::WebView* secondary_contents_web_view() {
     return secondary_contents_web_view_.get();
+  }
+
+  SidebarContainerView* sidebar_container_view() {
+    return sidebar_container_view_;
   }
 
  private:

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -14,6 +14,7 @@
 #include "brave/browser/ui/sidebar/sidebar_service_factory.h"
 #include "brave/browser/ui/sidebar/sidebar_utils.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
+#include "brave/browser/ui/views/sidebar/sidebar_container_view.h"
 #include "brave/browser/ui/views/toolbar/brave_toolbar_view.h"
 #include "brave/browser/ui/views/toolbar/side_panel_button.h"
 #include "brave/components/sidebar/browser/sidebar_service.h"
@@ -94,6 +95,7 @@ void BraveSidePanelCoordinator::OnViewVisibilityChanged(
     views::View* starting_from) {
   UpdateToolbarButtonHighlight(observed_view->GetVisible());
   SidePanelCoordinator::OnViewVisibilityChanged(observed_view, starting_from);
+  GetBraveBrowserView()->sidebar_container_view()->UpdateActiveItemState();
 }
 
 std::optional<SidePanelEntry::Key>
@@ -150,9 +152,7 @@ void BraveSidePanelCoordinator::PopulateSidePanel(
 
   // Notify to give opportunity to observe another panel entries from
   // global or active tab's contextual registry.
-  auto* brave_browser_view = static_cast<BraveBrowserView*>(browser_view_);
-  CHECK(browser_view_->unified_side_panel()->children().size() == 1);
-  brave_browser_view->WillShowSidePanel();
+  GetBraveBrowserView()->sidebar_container_view()->WillShowSidePanel();
   SidePanelCoordinator::PopulateSidePanel(supress_animations, unique_key, entry,
                                           std::move(content_view));
 }
@@ -166,4 +166,8 @@ void BraveSidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange(
 
   SidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange(key,
                                                                  is_active);
+}
+
+BraveBrowserView* BraveSidePanelCoordinator::GetBraveBrowserView() {
+  return static_cast<BraveBrowserView*>(browser_view_);
 }

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.cc
@@ -94,8 +94,19 @@ void BraveSidePanelCoordinator::OnViewVisibilityChanged(
     views::View* observed_view,
     views::View* starting_from) {
   UpdateToolbarButtonHighlight(observed_view->GetVisible());
+
+  // See the comment of SidePanelCoordinator::OnViewVisibilityChanged()
+  // about this condition.
+  bool update_items_state = true;
+  if (observed_view->GetVisible() || !current_key_) {
+    update_items_state = false;
+  }
+
   SidePanelCoordinator::OnViewVisibilityChanged(observed_view, starting_from);
-  GetBraveBrowserView()->sidebar_container_view()->UpdateActiveItemState();
+
+  if (update_items_state) {
+    GetBraveBrowserView()->sidebar_container_view()->UpdateActiveItemState();
+  }
 }
 
 std::optional<SidePanelEntry::Key>

--- a/browser/ui/views/side_panel/brave_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/brave_side_panel_coordinator.h
@@ -11,6 +11,8 @@
 
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 
+class BraveBrowserView;
+
 class BraveSidePanelCoordinator : public SidePanelCoordinator {
  public:
   using SidePanelCoordinator::SidePanelCoordinator;
@@ -43,6 +45,7 @@ class BraveSidePanelCoordinator : public SidePanelCoordinator {
   // entry exists.
   std::optional<SidePanelEntry::Key> GetLastActiveEntryKey() const;
   void UpdateToolbarButtonHighlight(bool side_panel_visible);
+  BraveBrowserView* GetBraveBrowserView();
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_BRAVE_SIDE_PANEL_COORDINATOR_H_

--- a/browser/ui/views/sidebar/sidebar_container_view.cc
+++ b/browser/ui/views/sidebar/sidebar_container_view.cc
@@ -128,7 +128,6 @@ SidebarContainerView::SidebarContainerView(
 
   SetNotifyEnterExitOnChild(true);
   side_panel_ = AddChildView(std::move(side_panel));
-  side_panel_view_state_observation_.Observe(side_panel_coordinator_);
 }
 
 SidebarContainerView::~SidebarContainerView() = default;
@@ -831,15 +830,6 @@ void SidebarContainerView::UpdateActiveItemState() {
   controller->UpdateActiveItemState(current_type);
 }
 
-void SidebarContainerView::OnSidePanelDidClose() {
-  // As contextual registry is owned by TabFeatures,
-  // that registry is destroyed before coordinator notifies OnEntryHidden() when
-  // tab is closed. In this case, we should update sidebar ui(active item state)
-  // with this notification. If not, sidebar ui's active item state is not
-  // changed.
-  UpdateActiveItemState();
-}
-
 void SidebarContainerView::OnTabStripModelChanged(
     TabStripModel* tab_strip_model,
     const TabStripModelChange& change,
@@ -918,6 +908,9 @@ void SidebarContainerView::AddSidePanelEntryObservation(SidePanelEntry* entry) {
   if (entry->IsBeingObservedBy(this)) {
     return;
   }
+
+  DVLOG(1) << "Start observation: "
+           << SidePanelEntryIdToString(entry->key().id());
   entry->AddObserver(this);
 }
 
@@ -926,6 +919,9 @@ void SidebarContainerView::RemoveSidePanelEntryObservation(
   if (!entry->IsBeingObservedBy(this)) {
     return;
   }
+
+  DVLOG(1) << "Stop observation: "
+           << SidePanelEntryIdToString(entry->key().id());
   entry->RemoveObserver(this);
 }
 

--- a/browser/ui/views/sidebar/sidebar_container_view.h
+++ b/browser/ui/views/sidebar/sidebar_container_view.h
@@ -20,7 +20,6 @@
 #include "chrome/browser/ui/tabs/tab_strip_model_observer.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_entry_observer.h"
-#include "chrome/browser/ui/views/side_panel/side_panel_view_state_observer.h"
 #include "components/prefs/pref_member.h"
 #include "ui/events/event_observer.h"
 #include "ui/gfx/animation/slide_animation.h"
@@ -55,7 +54,6 @@ class SidebarContainerView
       public SidebarShowOptionsEventDetectWidget::Delegate,
       public sidebar::SidebarModel::Observer,
       public SidePanelEntryObserver,
-      public SidePanelViewStateObserver,
       public TabStripModelObserver {
   METADATA_HEADER(SidebarContainerView, views::View)
  public:
@@ -135,8 +133,7 @@ class SidebarContainerView
       const TabStripSelectionChange& selection) override;
   void OnTabWillBeRemoved(content::WebContents* contents, int index) override;
 
-  // SidePanelViewStateObserver:
-  void OnSidePanelDidClose() override;
+  void UpdateActiveItemState();
 
  private:
   friend class sidebar::SidebarBrowserTest;
@@ -187,7 +184,6 @@ class SidebarContainerView
   void StopBrowserWindowEventMonitoring();
 
   void StartObservingContextualSidePanelEntry(content::WebContents* contents);
-  void UpdateActiveItemState();
 
   // Casts |browser_| to BraveBrowser, as storing it as BraveBrowser would cause
   // a precocious downcast.
@@ -214,8 +210,6 @@ class SidebarContainerView
   std::unique_ptr<views::EventMonitor> browser_window_event_monitor_;
   std::unique_ptr<SidebarShowOptionsEventDetectWidget> show_options_widget_;
   BooleanPrefMember show_side_panel_button_;
-  base::ScopedObservation<SidePanelCoordinator, SidePanelViewStateObserver>
-      side_panel_view_state_observation_{this};
   base::ScopedObservation<sidebar::SidebarModel,
                           sidebar::SidebarModel::Observer>
       sidebar_model_observation_{this};


### PR DESCRIPTION
As cr132 deleted SidePanelViewStateObserver, we couldn't rely on it anymore.
As SidePanelViewStateObserver::OnSidePanelDidClose() is called from the SidePanelCoordinator::OnViewVisibilityChanged(),
we could send same msg to SidebarContainerView from there.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42015

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

n/a - no behavioral changes.