### PR TITLE
[VerticalTabs] Show context menu in empty spaces of vertical tabs container.

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -1414,12 +1414,16 @@ views::LabelButton& VerticalTabStripRegionView::GetToggleButtonForTesting() {
   return *header_view_->toggle_button();
 }
 
+bool VerticalTabStripRegionView::IsMenuShowing() const {
+  return menu_runner_ && menu_runner_->IsRunning();
+}
+
 // Show context menu in unobscured area.
 void VerticalTabStripRegionView::ShowContextMenuForViewImpl(
     views::View* source,
     const gfx::Point& p,
     ui::MenuSourceType source_type) {
-  if (menu_runner_ && menu_runner_->IsRunning()) {
+  if (IsMenuShowing()) {
     return;
   }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -92,6 +92,7 @@ class VerticalTabStripRegionView : public views::View,
   }
 
   void ResetExpandedWidth();
+  bool IsMenuShowing() const;
 
   // views::View:
   gfx::Size CalculatePreferredSize(

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -37,10 +37,10 @@ class VerticalTabStripRegionView : public views::View,
                                    public views::AnimationDelegateViews,
                                    public views::WidgetObserver,
                                    public FullscreenObserver,
-                                   public BrowserListObserver {
+                                   public BrowserListObserver,
+                                   public views::ContextMenuController {
   METADATA_HEADER(VerticalTabStripRegionView, views::View)
  public:
-
   // We have a state machine which cycles like:
   //
   //               <hovered>          <pressed button>
@@ -122,6 +122,11 @@ class VerticalTabStripRegionView : public views::View,
   // FullscreenObserver:
   void OnFullscreenStateChanged() override;
 
+  // views::ContextMenuController:
+  void ShowContextMenuForViewImpl(views::View* source,
+                                  const gfx::Point& p,
+                                  ui::MenuSourceType source_type) override;
+
   class HeaderView;
   class MouseWatcher;
 
@@ -176,8 +181,11 @@ class VerticalTabStripRegionView : public views::View,
 
   std::u16string GetShortcutTextForNewTabButton(BrowserView* browser_view);
 
+  void OnMenuClosed();
+
   views::LabelButton& GetToggleButtonForTesting();
 
+  raw_ptr<BrowserView> browser_view_ = nullptr;
   raw_ptr<Browser> browser_ = nullptr;
 
   raw_ptr<views::View> original_parent_of_region_view_ = nullptr;
@@ -229,6 +237,8 @@ class VerticalTabStripRegionView : public views::View,
       fullscreen_observation_{this};
 
   BooleanPrefMember vertical_tab_on_right_;
+
+  std::unique_ptr<views::MenuRunner> menu_runner_;
 
   base::WeakPtrFactory<VerticalTabStripRegionView> weak_factory_{this};
 };

--- a/browser/ui/views/frame/vertical_tab_strip_root_view_browsertest.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_root_view_browsertest.cc
@@ -3,10 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "brave/browser/ui/views/frame/vertical_tab_strip_root_view.h"
+
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
-#include "brave/browser/ui/views/frame/vertical_tab_strip_root_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "chrome/browser/ui/views/frame/browser_non_client_frame_view.h"
@@ -14,11 +15,11 @@
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
 #include "chrome/test/base/in_process_browser_test.h"
 #include "content/public/test/browser_test.h"
+#include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/dragdrop/drag_drop_types.h"
 #include "ui/base/dragdrop/drop_target_event.h"
 #include "ui/base/dragdrop/mojom/drag_drop_types.mojom.h"
 #include "ui/base/dragdrop/os_exchange_data.h"
-#include "ui/compositor/layer_tree_owner.h"
 
 class VerticalTabStripRootViewBrowserTest : public InProcessBrowserTest {
  public:
@@ -150,4 +151,21 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest, DragOnCurrentTab) {
                   ->GetWebContentsAt(0)
                   ->GetURL()
                   .EqualsIgnoringRef(url));
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripRootViewBrowserTest,
+                       ContextMenuInUnobscuredRegion) {
+  ToggleVerticalTabStrip();
+
+  ASSERT_TRUE(tabs::utils::ShouldShowVerticalTabs(browser()));
+
+  auto* vtab_strip_root_view =
+      vtab_tab_strip_widget_delegate_view()->vertical_tab_strip_region_view();
+
+  EXPECT_FALSE(vtab_strip_root_view->IsMenuShowing());
+
+  vtab_strip_root_view->ShowContextMenuForView(
+      vtab_strip_root_view, gfx::Point(), ui::MENU_SOURCE_MOUSE);
+
+  EXPECT_TRUE(vtab_strip_root_view->IsMenuShowing());
 }


### PR DESCRIPTION
- Show context menu similar to tabstrip in empty spaces of vertical tabs container.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41825

# OutCome
[brave_vertical_tabs_context_menu.webm](https://github.com/user-attachments/assets/69a1a887-c55f-40ef-9c60-7418e885c157)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable vertical tab via settings page or from tab's context menu.
2. Right click on empty spaces in vertical tab
3. Now Context menu should be shown
