### PR TITLE
[CodeHealth] Avoid `NoDestructor` where a static array suffices

### DIFF
--- a/browser/prefs/brave_pref_service_incognito_allowlist.cc
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.cc
@@ -5,7 +5,10 @@
 
 #include "brave/browser/prefs/brave_pref_service_incognito_allowlist.h"
 
-#include "base/no_destructor.h"
+#include <array>
+
+#include "base/containers/span.h"
+#include "base/strings/cstring_view.h"
 #include "brave/browser/ui/bookmark/brave_bookmark_prefs.h"
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/brave_wallet/browser/pref_names.h"
@@ -23,8 +26,8 @@
 
 namespace brave {
 
-const std::vector<const char*>& GetBravePersistentPrefNames() {
-  static base::NoDestructor<std::vector<const char*>> brave_allowlist({
+base::span<const base::cstring_view> GetBravePersistentPrefNames() {
+  static constexpr auto kAllowlist = std::to_array<base::cstring_view>({
       kBraveAutofillPrivateWindows,
 #if !BUILDFLAG(IS_ANDROID)
       kShowWalletIconOnToolbar,
@@ -47,7 +50,7 @@ const std::vector<const char*>& GetBravePersistentPrefNames() {
       brave::bookmarks::prefs::kShowAllBookmarksButton,
   });
 
-  return *brave_allowlist;
+  return kAllowlist;
 }
 
 }  // namespace brave

--- a/browser/prefs/brave_pref_service_incognito_allowlist.h
+++ b/browser/prefs/brave_pref_service_incognito_allowlist.h
@@ -6,13 +6,14 @@
 #ifndef BRAVE_BROWSER_PREFS_BRAVE_PREF_SERVICE_INCOGNITO_ALLOWLIST_H_
 #define BRAVE_BROWSER_PREFS_BRAVE_PREF_SERVICE_INCOGNITO_ALLOWLIST_H_
 
-#include <vector>
+#include "base/containers/span.h"
+#include "base/strings/cstring_view.h"
 
 namespace brave {
 
 // Returns names of preferences that should be persistent on incognito profile.
 // This list should be preferred over GetOriginalProfile().
-const std::vector<const char*>& GetBravePersistentPrefNames();
+base::span<const base::cstring_view> GetBravePersistentPrefNames();
 
 }  // namespace brave
 

--- a/chromium_src/chrome/browser/prefs/pref_service_incognito_allowlist.cc
+++ b/chromium_src/chrome/browser/prefs/pref_service_incognito_allowlist.cc
@@ -20,9 +20,9 @@ namespace prefs {
 std::vector<const char*> GetIncognitoPersistentPrefsAllowlist() {
   std::vector<const char*> allowlist =
       GetIncognitoPersistentPrefsAllowlist_ChromiumImpl();
-  allowlist.insert(allowlist.end(),
-                   brave::GetBravePersistentPrefNames().begin(),
-                   brave::GetBravePersistentPrefNames().end());
+  for (auto pref : brave::GetBravePersistentPrefNames()) {
+    allowlist.push_back(pref.data());
+  }
   return allowlist;
 }
 

--- a/chromium_src/components/crx_file/crx_verifier.cc
+++ b/chromium_src/components/crx_file/crx_verifier.cc
@@ -8,7 +8,7 @@
 #include <utility>
 #include <vector>
 
-#include "base/no_destructor.h"
+#include "base/containers/span.h"
 
 namespace {
 
@@ -21,14 +21,13 @@ constexpr uint8_t kBravePublisherKeyHash[] = {
     0xc0, 0x55, 0xea, 0xf2, 0x6e, 0x10, 0x7,  0x45, 0x6,  0xb9, 0xd5,
     0x35, 0xc8, 0x35, 0x8,  0x28, 0x97, 0x5f, 0x7a, 0xc1, 0x97};
 
-std::vector<uint8_t>& GetBravePublisherKeyHash() {
-  static base::NoDestructor<std::vector<uint8_t>> brave_publisher_key(
-      std::begin(kBravePublisherKeyHash), std::end(kBravePublisherKeyHash));
-  return *brave_publisher_key;
+auto GetBravePublisherKeyHash() {
+  static auto brave_publisher_key = std::to_array(kBravePublisherKeyHash);
+  return base::span(brave_publisher_key);
 }
 
 // Used in the patch in crx_verifier.cc.
-bool IsBravePublisher(const std::vector<uint8_t>& key_hash) {
+bool IsBravePublisher(base::span<const uint8_t> key_hash) {
   return GetBravePublisherKeyHash() == key_hash;
 }
 
@@ -36,8 +35,8 @@ bool IsBravePublisher(const std::vector<uint8_t>& key_hash) {
 
 namespace crx_file {
 
-void SetBravePublisherKeyHashForTesting(const std::vector<uint8_t>& test_key) {
-  GetBravePublisherKeyHash() = test_key;
+void SetBravePublisherKeyHashForTesting(base::span<const uint8_t> test_key) {
+  GetBravePublisherKeyHash().copy_from(test_key);
 }
 
 }  // namespace crx_file

--- a/chromium_src/components/crx_file/crx_verifier.h
+++ b/chromium_src/components/crx_file/crx_verifier.h
@@ -6,11 +6,13 @@
 #ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_CRX_FILE_CRX_VERIFIER_H_
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_CRX_FILE_CRX_VERIFIER_H_
 
+#include "base/containers/span.h"
+
 #include "src/components/crx_file/crx_verifier.h"  // IWYU pragma: export
 
 namespace crx_file {
 
-void SetBravePublisherKeyHashForTesting(const std::vector<uint8_t>& test_key);
+void SetBravePublisherKeyHashForTesting(base::span<const uint8_t> test_key);
 
 }  // namespace crx_file
 

--- a/components/brave_wallet/browser/android_page_appearing_browsertest.cc
+++ b/components/brave_wallet/browser/android_page_appearing_browsertest.cc
@@ -3,11 +3,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include <array>
 #include <optional>
 #include <string_view>
 
 #include "base/files/scoped_temp_dir.h"
-#include "base/no_destructor.h"
 #include "base/strings/pattern.h"
 #include "base/strings/strcat.h"
 #include "base/strings/utf_string_conversions.h"
@@ -342,10 +342,10 @@ class AndroidPageAppearingBrowserTest : public PlatformBrowserTest {
                                 ignore_patterns);
   }
 
-  const std::vector<std::string>& GetWebUISchemes() {
-    static base::NoDestructor<std::vector<std::string>> kWebUISchemes(
-        {"chrome://", "brave://"});
-    return *kWebUISchemes;
+  base::span<const std::string_view> GetWebUISchemes() {
+    static auto constexpr kWebUISchemes =
+        std::to_array<std::string_view>({"chrome://", "brave://"});
+    return kWebUISchemes;
   }
 
   base::ScopedTempDir temp_dir_;
@@ -366,7 +366,7 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestWalletPageRoute) {
       GURL("chrome://wallet/crypto/portfolio/assets");
   const GURL expected_virtual_url =
       GURL("brave://wallet/crypto/portfolio/assets");
-  for (const std::string& scheme : GetWebUISchemes()) {
+  for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/"}));
 
     auto* web_contents = GetActiveWebContents();
@@ -382,7 +382,7 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestWalletPageRoute) {
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
                        TestPortfolioPageAppearing) {
   const GURL expected_url = GURL("brave://wallet/crypto/portfolio/assets");
-  for (const std::string& scheme : GetWebUISchemes()) {
+  for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/crypto/portfolio/assets"}));
     const std::vector<std::string> ignore_patterns = {
         "TypeError: Cannot read properties of undefined (reading "
@@ -395,7 +395,7 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSwapPageAppearing) {
   const GURL expected_url = GURL("brave://wallet/swap");
-  for (const std::string& scheme : GetWebUISchemes()) {
+  for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/swap"}));
     const std::vector<std::string> ignore_patterns = {
         "TypeError: Cannot read properties of undefined (reading 'forEach')",
@@ -410,7 +410,7 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSwapPageAppearing) {
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSendPageAppearing) {
   const GURL expected_url = GURL("brave://wallet/send");
-  for (const std::string& scheme : GetWebUISchemes()) {
+  for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/send"}));
     const std::vector<std::string> ignore_patterns = {
         "TypeError: Cannot read properties of undefined (reading 'forEach')",
@@ -422,7 +422,7 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestSendPageAppearing) {
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
                        TestDepositPageAppearing) {
   const GURL expected_url = GURL("brave://wallet/crypto/deposit-funds");
-  for (const std::string& scheme : GetWebUISchemes()) {
+  for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/crypto/deposit-funds"}));
     const std::vector<std::string> ignore_patterns = {
         "TypeError: Cannot read properties of undefined (reading 'forEach')",
@@ -433,7 +433,7 @@ IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(AndroidPageAppearingBrowserTest, TestBuyPageAppearing) {
   const GURL expected_url = GURL("brave://wallet/crypto/fund-wallet");
-  for (const std::string& scheme : GetWebUISchemes()) {
+  for (auto scheme : GetWebUISchemes()) {
     GURL url = GURL(base::StrCat({scheme, "wallet/crypto/fund-wallet"}));
     const std::vector<std::string> ignore_patterns = {
         "TypeError: Cannot read properties of undefined (reading 'forEach')",


### PR DESCRIPTION
This PR removes some of the uses of `NoDestructor` for cases where `std::vector` was being used to store static data. This is safe, as the storage of the data is static.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

