### PR TITLE
[Android] Moved back simplified view prompt for regular tabs

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -318,6 +318,7 @@ public abstract class BraveActivity extends ChromeActivity
     private MiscAndroidMetricsConnectionErrorHandler mMiscAndroidMetricsConnectionErrorHandler;
     private AppUpdateManager mAppUpdateManager;
     private boolean mWalletBadgeVisible;
+    private boolean mSpoofCustomTab;
 
     /** Serves as a general exception for failed attempts to get BraveActivity. */
     public static class BraveActivityNotFoundException extends Exception {
@@ -2493,5 +2494,22 @@ public abstract class BraveActivity extends ChromeActivity
                         .create();
         alertDialog.getDelegate().setHandleNativeActionModesEnabled(false);
         alertDialog.show();
+    }
+
+    /*
+     * Whether we want to pretend to be a custom tab. May be usefull to avoid certain patches,
+     * when we want to have the same behaviour as in custom tabs.
+     */
+    public void spoofCustomTab(boolean spoof) {
+        mSpoofCustomTab = spoof;
+    }
+
+    @Override
+    public boolean isCustomTab() {
+        if (mSpoofCustomTab) {
+            return true;
+        }
+
+        return super.isCustomTab();
     }
 }

--- a/android/java/org/chromium/chrome/browser/dom_distiller/BraveReaderModeManager.java
+++ b/android/java/org/chromium/chrome/browser/dom_distiller/BraveReaderModeManager.java
@@ -40,7 +40,7 @@ public class BraveReaderModeManager extends ReaderModeManager {
 
         super.tryShowingPrompt();
 
-        //There is no need to spoof custom tab after showing the prompt.
+        // There is no need to spoof custom tab after showing the prompt.
         spoofCustomTab(false);
     }
 

--- a/android/java/org/chromium/chrome/browser/dom_distiller/BraveReaderModeManager.java
+++ b/android/java/org/chromium/chrome/browser/dom_distiller/BraveReaderModeManager.java
@@ -5,12 +5,16 @@
 
 package org.chromium.chrome.browser.dom_distiller;
 
+import android.app.Activity;
+
 import androidx.annotation.VisibleForTesting;
 
 import org.chromium.base.supplier.Supplier;
+import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.preferences.Pref;
 import org.chromium.chrome.browser.profiles.Profile;
 import org.chromium.chrome.browser.tab.Tab;
+import org.chromium.chrome.browser.tab.TabUtils;
 import org.chromium.components.messages.MessageDispatcher;
 import org.chromium.components.user_prefs.UserPrefs;
 
@@ -31,6 +35,24 @@ public class BraveReaderModeManager extends ReaderModeManager {
         if (profile == null || !UserPrefs.get(profile).getBoolean(Pref.READER_FOR_ACCESSIBILITY))
             return;
 
+        // If it is regular tab, we pretend to be a custom tab to show the prompt if applicable.
+        spoofCustomTab(!mTab.isCustomTab() && !mTab.isIncognito());
+
         super.tryShowingPrompt();
+
+        //There is no need to spoof custom tab after showing the prompt.
+        spoofCustomTab(false);
+    }
+
+    /*
+     * Whether we want to pretend to be a custom tab. Used here to avoid patch in the middle of `ReaderModeManager#tryShowingPrompt`.
+     */
+    void spoofCustomTab(boolean spoof) {
+        Activity activity = TabUtils.getActivity(mTab);
+        BraveActivity braveActivity =
+                activity instanceof BraveActivity ? (BraveActivity) activity : null;
+        if (braveActivity != null) {
+            braveActivity.spoofCustomTab(spoof);
+        }
     }
 }


### PR DESCRIPTION
This is regression from this chromium change:
https://chromium.googlesource.com/chromium/src/+/c20ba57087f147b22a78a0fd916fdc4b887c2946

Cleanup Reader mode contextual page action

This CL cleans up ContextualPageActionReaderMode feature. There are some details after the cleanup which can be summarized as :
1. Reader mode message UI is now only shown in CCT and incognito.
2. Finch param reader_mode_session_rate_limiting is set to false. Hence it was removed in this CL.
3. CPA alternative color is also unused, but there are some feature teams such as shopping who are interested in a similar experiment in future. Hence it was kept as is.
4. There is also some code related to muting certain sites if the user didn't take action. These are still needed for the message UI that is shown for CCT and incognito.

Bug: 356237338

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42087

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

