### PR TITLE
Send selected_language for ratings / feedback

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_feedback_api.cc
+++ b/components/ai_chat/core/browser/ai_chat_feedback_api.cc
@@ -83,6 +83,7 @@ void AIChatFeedbackAPI::SendRating(
     bool is_premium,
     const base::span<const mojom::ConversationTurnPtr>& history,
     const std::string& model_name,
+    const std::string& selected_language,
     api_request_helper::APIRequestHelper::ResultCallback on_complete_callback) {
   base::Value::Dict payload;
 
@@ -106,6 +107,7 @@ void AIChatFeedbackAPI::SendRating(
   payload.Set("locale",
               base::StrCat({brave_l10n::GetDefaultISOLanguageCodeString(), "_",
                             brave_l10n::GetDefaultISOCountryCodeString()}));
+  payload.Set("selected_language", selected_language);
   payload.Set("rating", static_cast<int>(is_liked));
   payload.Set("channel", channel_name_);
   payload.Set("platform", brave_stats::GetPlatformIdentifier());
@@ -126,6 +128,7 @@ void AIChatFeedbackAPI::SendFeedback(
     const std::string& feedback,
     const std::string& rating_id,
     const std::optional<std::string>& hostname,
+    const std::string& selected_language,
     api_request_helper::APIRequestHelper::ResultCallback on_complete_callback) {
   base::Value::Dict dict;
 
@@ -136,6 +139,7 @@ void AIChatFeedbackAPI::SendFeedback(
   dict.Set("locale",
            base::StrCat({brave_l10n::GetDefaultISOLanguageCodeString(), "_",
                          brave_l10n::GetDefaultISOCountryCodeString()}));
+  dict.Set("selected_language", selected_language);
 
   if (hostname.has_value()) {
     dict.Set("domain", hostname.value());

--- a/components/ai_chat/core/browser/ai_chat_feedback_api.h
+++ b/components/ai_chat/core/browser/ai_chat_feedback_api.h
@@ -38,6 +38,7 @@ class AIChatFeedbackAPI {
                   bool is_premium,
                   const base::span<const mojom::ConversationTurnPtr>& history,
                   const std::string& model_name,
+                  const std::string& selected_language,
                   api_request_helper::APIRequestHelper::ResultCallback
                       on_complete_callback);
 
@@ -45,6 +46,7 @@ class AIChatFeedbackAPI {
                     const std::string& feedback,
                     const std::string& rating_id,
                     const std::optional<std::string>& hostname,
+                    const std::string& selected_language,
                     api_request_helper::APIRequestHelper::ResultCallback
                         on_complete_callback);
 

--- a/components/ai_chat/core/browser/constants.cc
+++ b/components/ai_chat/core/browser/constants.cc
@@ -87,6 +87,8 @@ base::span<const webui::LocalizedString> GetLocalizedStrings() {
        {"copyButtonLabel", IDS_CHAT_UI_COPY_BUTTON_LABEL},
        {"likeAnswerButtonLabel", IDS_CHAT_UI_LIKE_ANSWER_BUTTON_LABEL},
        {"dislikeAnswerButtonLabel", IDS_CHAT_UI_DISLIKE_ANSWER_BUTTON_LABEL},
+       {"likeDislikeAnswerButtonTitle",
+        IDS_CHAT_UI_LIKE_DISLIKE_ANSWER_BUTTON_TITLE},
        {"provideFeedbackTitle", IDS_CHAT_UI_PROVIDE_FEEDBACK_TITLE},
        {"selectFeedbackTopic", IDS_CHAT_UI_SELECT_FEEDBACK_TOPIC},
        {"feedbackCategoryLabel", IDS_CHAT_UI_FEEDBACK_CATEGORY_LABEL},

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -519,7 +519,7 @@ void ConversationHandler::RateMessage(bool is_liked,
 
     feedback_api_->SendRating(
         is_liked, ai_chat_service_->IsPremiumStatus(), history_slice,
-        model.options->get_leo_model_options()->name,
+        model.options->get_leo_model_options()->name, selected_language_,
         base::BindOnce(
             [](RateMessageCallback callback, APIRequestResult result) {
               if (result.Is2XXResponseCode() && result.value_body().is_dict()) {
@@ -565,7 +565,7 @@ void ConversationHandler::SendFeedback(const std::string& category,
                               (send_hostname && page_url.SchemeIsHTTPOrHTTPS())
                                   ? std::optional<std::string>(page_url.host())
                                   : std::nullopt,
-                              std::move(on_complete));
+                              selected_language_, std::move(on_complete));
 }
 
 void ConversationHandler::GetConversationUuid(

--- a/components/ai_chat/resources/page/components/context_menu_assistant/index.tsx
+++ b/components/ai_chat/resources/page/components/context_menu_assistant/index.tsx
@@ -166,6 +166,7 @@ function ContextMenuAssistant_(
             [styles.liked]: currentRatingStatus === RatingStatus.Liked
           })}
           onClick={handleLikeAnswer}
+          title={getLocale('likeDislikeAnswerButtonTitle')}
         >
           <Icon name='thumb-up' />
           <span>{getLocale('likeAnswerButtonLabel')}</span>
@@ -175,6 +176,7 @@ function ContextMenuAssistant_(
             [styles.disliked]: currentRatingStatus === RatingStatus.Disliked
           })}
           onClick={handleDislikeAnswer}
+          title={getLocale('likeDislikeAnswerButtonTitle')}
         >
           <Icon name='thumb-down' />
           <span>{getLocale('dislikeAnswerButtonLabel')}</span>

--- a/components/ai_chat/resources/page/stories/locale.ts
+++ b/components/ai_chat/resources/page/stories/locale.ts
@@ -53,6 +53,7 @@ provideStrings({
   copyButtonLabel: 'Copy',
   likeAnswerButtonLabel: 'Like answer',
   dislikeAnswerButtonLabel: 'Dislike answer',
+  likeDislikeAnswerButtonTitle: 'Sends rating, conversation, model, language, version, and premium status',
   provideFeedbackTitle: 'Provide Brave AI Feedback',
   selectFeedbackTopic: 'Select your feedback topic',
   feedbackCategoryLabel: 'Whats your feedback about?',

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -177,6 +177,9 @@
   <message name="IDS_CHAT_UI_DISLIKE_ANSWER_BUTTON_LABEL" desc="Button label to dislike an answer">
     Dislike answer
   </message>
+  <message name="IDS_CHAT_UI_LIKE_DISLIKE_ANSWER_BUTTON_TITLE" desc="Button title for like and dislike menu items">
+    Sends rating, conversation, model, language, version, and premium status
+  </message>
   <message name="IDS_CHAT_UI_PROVIDE_FEEDBACK_TITLE" desc="Title for feedback provision section">
     Provide Brave AI Feedback
   </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41982
Security review: https://github.com/brave/reviews/issues/1790

When ratings and feedback are submitted by users, this will help us figure out if there are problems related to the determined language which is known as the `selected_language`.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

