### PR TITLE
[ads] Check for the NTP SI component updates after power is resumed

### DIFF
--- a/components/ntp_background_images/browser/ntp_background_images_service.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_service.cc
@@ -44,7 +44,7 @@ namespace ntp_background_images {
 
 namespace {
 
-constexpr int kSIComponentUpdateCheckIntervalMins = 15;
+constexpr base::TimeDelta kSIComponentUpdateCheckInterval = base::Minutes(15);
 constexpr char kNTPManifestFile[] = "photo.json";
 constexpr char kNTPSRMappingTableFile[] = "mapping-table.json";
 
@@ -157,7 +157,7 @@ void NTPBackgroundImagesService::CheckNTPSIComponentUpdateIfNeeded() {
 
   // If previous update check is missed, do update check now.
   if (base::Time::Now() - last_update_check_time_ >
-      base::Minutes(kSIComponentUpdateCheckIntervalMins)) {
+      kSIComponentUpdateCheckInterval) {
     si_update_check_callback_.Run();
   }
 }
@@ -167,6 +167,10 @@ void NTPBackgroundImagesService::CheckImagesComponentUpdate(
   DVLOG(2) << __func__ << ": Check NTP Images component update";
 
   last_update_check_time_ = base::Time::Now();
+  si_update_check_timer_.Start(
+      FROM_HERE, last_update_check_time_ + kSIComponentUpdateCheckInterval,
+      base::BindOnce(si_update_check_callback_));
+
   BraveOnDemandUpdater::GetInstance()->EnsureInstalled(component_id);
 }
 
@@ -215,8 +219,8 @@ void NTPBackgroundImagesService::RegisterSponsoredImagesComponent() {
 
   last_update_check_time_ = base::Time::Now();
   si_update_check_timer_.Start(
-      FROM_HERE, base::Minutes(kSIComponentUpdateCheckIntervalMins),
-      si_update_check_callback_);
+      FROM_HERE, last_update_check_time_ + kSIComponentUpdateCheckInterval,
+      base::BindOnce(si_update_check_callback_));
 }
 
 void NTPBackgroundImagesService::CheckSuperReferralComponent() {

--- a/components/ntp_background_images/browser/ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/ntp_background_images_service.h
@@ -9,14 +9,13 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include "base/files/file_path.h"
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/observer_list.h"
-#include "base/timer/timer.h"
+#include "base/timer/wall_clock_timer.h"
 #include "base/values.h"
 #include "components/prefs/pref_change_registrar.h"
 
@@ -154,7 +153,7 @@ class NTPBackgroundImagesService {
   virtual void MarkThisInstallIsNotSuperReferralForever();
 
   base::Time last_update_check_time_;
-  base::RepeatingTimer si_update_check_timer_;
+  base::WallClockTimer si_update_check_timer_;
   base::RepeatingClosure si_update_check_callback_;
   bool test_data_used_ = false;
   raw_ptr<component_updater::ComponentUpdateService> component_update_service_ =


### PR DESCRIPTION
This change helps users to get up-to-date NTP Sponsored Images when Laptop power resumed after more then 15 minutes power suspension. The problem is that power suspension freezes the update timer, so users are not checking for updates after power resume.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42125

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Start Brave on a laptop with command line: `--enable-logging=stderr --vmodule="*/ntp_background_images/*"=6`
* Check that NTP SI component is registered. There should be a log line:
   `RegisterBackgroundImagesComponent: Start NTP BI component`
* Wait for 15 minutes. 
   EXPECTATION: NTP SI component is trying to update in 15 minutes interval. There should be a log line:
   `CheckImagesComponentUpdate: Check NTP Images component update`
* Open brave://components page. 
   EXPECTATION: `NTP Sponsored Images` component from the list has no errors.
* Suspend the laptop for more then 15 minutes.
* Turn on laptop
   EXPECTATION: NTP SI component was tried to update right after power resumed. There should be a log line:
   `CheckImagesComponentUpdate: Check NTP Images component update`