### PR TITLE
Bump Nightly (master) to 1.74.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brave-core",
-  "version": "1.73.79",
+  "version": "1.74.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "brave-core",
-      "version": "1.73.79",
+      "version": "1.74.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@brave/brave-ui": "0.40.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brave-core",
-  "version": "1.73.79",
+  "version": "1.74.0",
   "description": "Brave Core is a set of changes, APIs and scripts used for customizing Chromium to make Brave.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We had an incident on November 1st where 1.73.48 was pushed out for folks:
- on Windows
- who had Nightly installed
- who ran the auto-updater

Employees can see https://github.com/brave/devops/pull/12602 for the root cause fix.

These folks had 1.73.48 pushed to release channel. To correct this, we're making Beta (what used to be 1.72.x) into 1.73.x and then master (Nightly) will become 1.74.x after the next migration is ran.