### PR TITLE
[ads] Send page land immediately for non-successful HTTP status codes

### DIFF
--- a/browser/brave_ads/device_id/device_id_impl_unittest.cc
+++ b/browser/brave_ads/device_id/device_id_impl_unittest.cc
@@ -14,9 +14,9 @@ namespace brave_ads {
 
 namespace {
 
-struct DisallwedMask {
+struct DisallowedMask {
   template <typename... Args>
-  constexpr DisallwedMask(Args... args)  // NOLINT(runtime/explicit)
+  constexpr DisallowedMask(Args... args)  // NOLINT(runtime/explicit)
       : address{static_cast<uint8_t>(args)...}, size(sizeof...(args)) {}
 
   base::span<const uint8_t> as_span() const {
@@ -27,7 +27,7 @@ struct DisallwedMask {
   size_t size;
 };
 
-void TestDisallowedRange(DisallwedMask mask) {
+void TestDisallowedRange(DisallowedMask mask) {
   std::array<uint8_t, 6u> address;
 
   // test the lower bound of the match

--- a/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
@@ -15,7 +15,6 @@
 #include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/functional/bind.h"
-#include "base/memory/raw_ptr.h"
 #include "base/notreached.h"
 #include "base/path_service.h"
 #include "base/run_loop.h"

--- a/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
+++ b/browser/brave_ads/tabs/ads_tab_helper_browsertest.cc
@@ -435,8 +435,7 @@ class BraveAdsTabHelperTest : public PlatformBrowserTest {
       }
     }
 
-    NOTREACHED_NORETURN()
-        << "Query key not found. Unable to handle the request.";
+    NOTREACHED() << "Query key not found. Unable to handle the request.";
   }
 
   std::vector<GURL> RedirectChainExpectation(

--- a/browser/brave_ads/tooltips/ads_tooltips_controller.h
+++ b/browser/brave_ads/tooltips/ads_tooltips_controller.h
@@ -8,7 +8,6 @@
 
 #include <string>
 
-#include "base/memory/raw_ptr.h"
 #include "brave/browser/ui/brave_tooltips/brave_tooltip_delegate.h"
 #include "brave/components/brave_ads/browser/tooltips/ads_tooltips_delegate.h"
 

--- a/components/brave_ads/browser/ads_service.h
+++ b/components/brave_ads/browser/ads_service.h
@@ -12,7 +12,6 @@
 #include <string>
 #include <vector>
 
-#include "base/memory/raw_ptr.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/browser/ads_service_callback.h"
 #include "brave/components/brave_ads/browser/ads_service_observer.h"

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -89,7 +89,7 @@ int ResourceBundleId(const std::string& name) {
     return IDR_ADS_CATALOG_SCHEMA;
   }
 
-  NOTREACHED_NORETURN();
+  NOTREACHED();
 }
 
 std::string URLMethodToRequestType(

--- a/components/brave_ads/browser/reminder/reminder_util.cc
+++ b/components/brave_ads/browser/reminder/reminder_util.cc
@@ -62,8 +62,8 @@ base::Value::Dict BuildReminder(const mojom::ReminderType mojom_reminder_type) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ReminderType: "
-                        << mojom_reminder_type;
+  NOTREACHED() << "Unexpected value for mojom::ReminderType: "
+               << mojom_reminder_type;
 }
 
 bool IsReminder(const std::string& placement_id) {

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler_unittest.cc
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler_unittest.cc
@@ -9,7 +9,6 @@
 #include <utility>
 
 #include "base/check.h"
-#include "base/strings/strcat.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/browser/ads_service_mock.h"
@@ -270,7 +269,7 @@ TEST_F(BraveAdsCreativeSearchResultAdHandlerTest,
             creative_search_result_ads =
                 ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
                     mojom_web_page->entities);
-        ASSERT_EQ(creative_search_result_ads.size(), 1u);
+        ASSERT_EQ(creative_search_result_ads.size(), 1U);
         ASSERT_EQ(creative_search_result_ads[0]->placement_id,
                   test::kCreativeAdPlacementId);
 
@@ -310,7 +309,7 @@ TEST_F(BraveAdsCreativeSearchResultAdHandlerTest,
             creative_search_result_ads =
                 ExtractCreativeSearchResultAdsFromMojomWebPageEntities(
                     mojom_web_page->entities);
-        ASSERT_EQ(creative_search_result_ads.size(), 1u);
+        ASSERT_EQ(creative_search_result_ads.size(), 1U);
         ASSERT_EQ(creative_search_result_ads[0]->placement_id,
                   test::kEscapedCreativeAdPlacementIdWithUnreservedCharacters);
 

--- a/components/brave_ads/core/internal/account/account_util.cc
+++ b/components/brave_ads/core/internal/account/account_util.cc
@@ -53,8 +53,8 @@ bool IsAllowedToDeposit(const mojom::AdType mojom_ad_type,
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::AdType: "
-                        << base::to_underlying(mojom_ad_type);
+  NOTREACHED() << "Unexpected value for mojom::AdType: "
+               << base::to_underlying(mojom_ad_type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/confirmations/confirmation_type.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmation_type.cc
@@ -76,8 +76,7 @@ mojom::ConfirmationType ToMojomConfirmationType(const std::string_view value) {
     return mojom_confirmation_type;
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ConfirmationType: "
-                        << value;
+  NOTREACHED() << "Unexpected value for mojom::ConfirmationType: " << value;
 }
 
 const char* ToString(const mojom::ConfirmationType mojom_confirmation_type) {
@@ -88,8 +87,8 @@ const char* ToString(const mojom::ConfirmationType mojom_confirmation_type) {
     return confirmation_type.data();
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ConfirmationType: "
-                        << base::to_underlying(mojom_confirmation_type);
+  NOTREACHED() << "Unexpected value for mojom::ConfirmationType: "
+               << base::to_underlying(mojom_confirmation_type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/deposits/deposits_factory.cc
+++ b/components/brave_ads/core/internal/account/deposits/deposits_factory.cc
@@ -48,8 +48,8 @@ std::unique_ptr<DepositInterface> DepositsFactory::Build(
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ConfirmationType: "
-                        << base::to_underlying(mojom_confirmation_type);
+  NOTREACHED() << "Unexpected value for mojom::ConfirmationType: "
+               << base::to_underlying(mojom_confirmation_type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/issuers/token_issuers/token_issuer_value_util.cc
+++ b/components/brave_ads/core/internal/account/issuers/token_issuers/token_issuer_value_util.cc
@@ -43,8 +43,8 @@ std::optional<std::string> ToString(const TokenIssuerType token_issuer_type) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for TokenIssuerType: "
-                        << base::to_underlying(token_issuer_type);
+  NOTREACHED() << "Unexpected value for TokenIssuerType: "
+               << base::to_underlying(token_issuer_type);
 }
 
 std::optional<TokenIssuerType> ParseTokenIssuerType(

--- a/components/brave_ads/core/internal/ad_units/ad_type.cc
+++ b/components/brave_ads/core/internal/ad_units/ad_type.cc
@@ -50,7 +50,7 @@ mojom::AdType ToMojomAdType(std::string_view value) {
     return mojom_ad_type;
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::AdType: " << value;
+  NOTREACHED() << "Unexpected value for mojom::AdType: " << value;
 }
 
 const char* ToString(mojom::AdType mojom_ad_type) {
@@ -60,8 +60,8 @@ const char* ToString(mojom::AdType mojom_ad_type) {
     return ad_type.data();
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::AdType: "
-                        << base::to_underlying(mojom_ad_type);
+  NOTREACHED() << "Unexpected value for mojom::AdType: "
+               << base::to_underlying(mojom_ad_type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/creative_ad_cache_unittest.cc
+++ b/components/brave_ads/core/internal/ad_units/creative_ad_cache_unittest.cc
@@ -10,6 +10,7 @@
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/search_result_ads/creative_search_result_ad_test_util.h"
+#include "net/http/http_status_code.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -34,7 +35,8 @@ TEST_F(BraveAdsCreativeAdCacheTest, AddCreativeAd) {
           /*should_generate_random_uuids=*/true);
 
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   // Act
   creative_ad_cache_->MaybeAdd(test::kPlacementId, mojom_creative_ad->Clone());
@@ -48,7 +50,8 @@ TEST_F(BraveAdsCreativeAdCacheTest, AddCreativeAd) {
 TEST_F(BraveAdsCreativeAdCacheTest, DoNotAddCreativeAd) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   // Act
   creative_ad_cache_->MaybeAdd(test::kPlacementId,
@@ -63,7 +66,8 @@ TEST_F(BraveAdsCreativeAdCacheTest, DoNotAddCreativeAd) {
 TEST_F(BraveAdsCreativeAdCacheTest, DoNotAddInvalidCreativeAd) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   CreativeAdVariant creative_ad_variant;
 
@@ -117,11 +121,13 @@ TEST_F(BraveAdsCreativeAdCacheTest, GetCreativeAdsAcrossMultipleTabs) {
 
   // Act
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
   creative_ad_cache_->MaybeAdd(test::kPlacementId, mojom_creative_ad->Clone());
 
   SimulateOpeningNewTab(/*tab_id=*/2,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
   creative_ad_cache_->MaybeAdd(test::kAnotherPlacementId,
                                mojom_creative_ad->Clone());
 
@@ -141,11 +147,13 @@ TEST_F(BraveAdsCreativeAdCacheTest, PurgePlacementsOnTabDidClose) {
           /*should_generate_random_uuids=*/true);
 
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
   creative_ad_cache_->MaybeAdd(test::kPlacementId, mojom_creative_ad->Clone());
 
   SimulateOpeningNewTab(/*tab_id=*/2,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
   creative_ad_cache_->MaybeAdd(test::kAnotherPlacementId,
                                mojom_creative_ad->Clone());
 

--- a/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_test.cc
@@ -33,7 +33,8 @@ class BraveAdsInlineContentAdIntegrationTest : public test::TestBase {
     test::TestBase::SetUp(/*is_integration_test=*/true);
 
     SimulateOpeningNewTab(/*tab_id=*/1,
-                          /*redirect_chain=*/{GURL("brave://newtab")});
+                          /*redirect_chain=*/{GURL("brave://newtab")},
+                          net::HTTP_OK);
   }
 
   void SetUpMocks() override {

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.cc
@@ -7,7 +7,6 @@
 
 #include "base/check_op.h"
 #include "base/containers/contains.h"
-#include "net/http/http_status_code.h"
 #include "url/gurl.h"
 
 namespace brave_ads {
@@ -177,19 +176,21 @@ void AdsClientNotifierForTesting::NotifyDidSolveAdaptiveCaptcha() {
 
 void AdsClientNotifierForTesting::SimulateOpeningNewTab(
     const int32_t tab_id,
-    const std::vector<GURL>& redirect_chain) {
+    const std::vector<GURL>& redirect_chain,
+    const int http_status_code) {
   CHECK(!base::Contains(redirect_chains_, tab_id)) << "Tab already open";
 
   redirect_chains_[tab_id] = redirect_chain;
 
   SimulateSelectTab(tab_id);
 
-  SimulateNavigateToURL(tab_id, redirect_chain);
+  SimulateNavigateToURL(tab_id, redirect_chain, http_status_code);
 }
 
 void AdsClientNotifierForTesting::SimulateNavigateToURL(
     const int32_t tab_id,
-    const std::vector<GURL>& redirect_chain) {
+    const std::vector<GURL>& redirect_chain,
+    const int http_status_code) {
   CHECK(base::Contains(redirect_chains_, tab_id)) << "Tab does not exist";
 
   redirect_chains_[tab_id] = redirect_chain;
@@ -198,7 +199,7 @@ void AdsClientNotifierForTesting::SimulateNavigateToURL(
 
   NotifyTabDidChange(tab_id, redirect_chain, /*is_new_navigation=*/true,
                      /*is_restoring=*/false, is_visible);
-  NotifyTabDidLoad(tab_id, net::HTTP_OK);
+  NotifyTabDidLoad(tab_id, http_status_code);
 }
 
 void AdsClientNotifierForTesting::SimulateSelectTab(const int32_t tab_id) {

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.h
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.h
@@ -94,9 +94,11 @@ class AdsClientNotifierForTesting : public AdsClientNotifier {
 
   // Simulate helper functions.
   void SimulateOpeningNewTab(int32_t tab_id,
-                             const std::vector<GURL>& redirect_chain);
+                             const std::vector<GURL>& redirect_chain,
+                             int http_status_code);
   void SimulateNavigateToURL(int32_t tab_id,
-                             const std::vector<GURL>& redirect_chain);
+                             const std::vector<GURL>& redirect_chain,
+                             int http_status_code);
   void SimulateSelectTab(int32_t tab_id);
   void SimulateClosingTab(int32_t tab_id);
 

--- a/components/brave_ads/core/internal/common/net/http/http_status_code_util.cc
+++ b/components/brave_ads/core/internal/common/net/http/http_status_code_util.cc
@@ -8,6 +8,7 @@
 #include "base/containers/fixed_flat_set.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
+#include "net/http/http_status_code.h"
 
 namespace brave_ads {
 
@@ -39,6 +40,11 @@ std::optional<std::string> HttpStatusCodeClassToString(
 }
 
 }  // namespace
+
+bool IsSuccessfulHttpStatusCode(const int http_status_code) {
+  return http_status_code >= /*200*/ net::HTTP_OK &&
+         http_status_code < /*400*/ net::HTTP_BAD_REQUEST;
+}
 
 std::optional<std::string> HttpStatusCodeToString(const int http_status_code) {
   const int http_status_code_class = http_status_code / 100;

--- a/components/brave_ads/core/internal/common/net/http/http_status_code_util.h
+++ b/components/brave_ads/core/internal/common/net/http/http_status_code_util.h
@@ -11,6 +11,8 @@
 
 namespace brave_ads {
 
+bool IsSuccessfulHttpStatusCode(int http_status_code);
+
 std::optional<std::string> HttpStatusCodeToString(int http_status_code);
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/common/net/http/http_status_code_util_unittest.cc
+++ b/components/brave_ads/core/internal/common/net/http/http_status_code_util_unittest.cc
@@ -15,6 +15,13 @@
 
 namespace brave_ads {
 
+TEST(BraveAdsHttpStatusCodeUtilTest, IsSuccessfulHttpStatusCode) {
+  // Act & Assert
+  for (int i = /*200*/ net::HTTP_OK; i < net::HTTP_STATUS_CODE_MAX; ++i) {
+    EXPECT_EQ(IsSuccessfulHttpStatusCode(i), i < /*400*/ net::HTTP_BAD_REQUEST);
+  }
+}
+
 TEST(BraveAdsHttpStatusCodeUtilTest, HttpStatusCodeToString) {
   // Arrange
   static constexpr auto kAllowedHttpStatusCodes = base::MakeFixedFlatSet<int>({

--- a/components/brave_ads/core/internal/common/net/http/http_status_code_util_unittest.cc
+++ b/components/brave_ads/core/internal/common/net/http/http_status_code_util_unittest.cc
@@ -5,8 +5,10 @@
 
 #include "brave/components/brave_ads/core/internal/common/net/http/http_status_code_util.h"
 
+#include "base/containers/fixed_flat_set.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/stringprintf.h"
+#include "net/http/http_status_code.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -14,8 +16,24 @@
 namespace brave_ads {
 
 TEST(BraveAdsHttpStatusCodeUtilTest, HttpStatusCodeToString) {
+  // Arrange
+  static constexpr auto kAllowedHttpStatusCodes = base::MakeFixedFlatSet<int>({
+      400,  // Bad Request.
+      401,  // Unauthorized.
+      403,  // Forbidden.
+      404,  // Not Found.
+      407,  // Proxy Authentication Required.
+      408,  // Request Timeout.
+      429,  // Too Many Requests.
+      451,  // Unavailable For Legal Reasons.
+      500,  // Internal Server Error.
+      502,  // Bad Gateway.
+      503,  // Service Unavailable.
+      504   // Gateway Timeout.
+  });
+
   // Act & Assert
-  for (int i = 0; i <= 1024; ++i) {
+  for (int i = 0; i <= net::HTTP_STATUS_CODE_MAX; ++i) {
     const std::optional<std::string> http_status_code =
         HttpStatusCodeToString(i);
     if (!http_status_code) {
@@ -23,19 +41,7 @@ TEST(BraveAdsHttpStatusCodeUtilTest, HttpStatusCodeToString) {
       continue;
     }
 
-    // Allowed HTTP status codes, other codes are mapped to their class.
-    if (i == 400 ||  // Bad Request.
-        i == 401 ||  // Unauthorized.
-        i == 403 ||  // Forbidden.
-        i == 404 ||  // Not Found.
-        i == 407 ||  // Proxy Authentication Required.
-        i == 408 ||  // Request Timeout.
-        i == 429 ||  // Too Many Requests.
-        i == 451 ||  // Unavailable For Legal Reasons.
-        i == 500 ||  // Internal Server Error.
-        i == 502 ||  // Bad Gateway.
-        i == 503 ||  // Service Unavailable.
-        i == 504) {  // Gateway Timeout.
+    if (kAllowedHttpStatusCodes.contains(i)) {
       EXPECT_EQ(base::NumberToString(i), http_status_code);
     } else {
       EXPECT_EQ(base::StringPrintf("%dxx", /*http_status_code_class*/ i / 100),

--- a/components/brave_ads/core/internal/common/test/internal/tag_parser_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/tag_parser_test_util_internal.cc
@@ -114,7 +114,7 @@ void ReplaceTagsForText(const std::vector<std::string>& tags,
       CHECK(time_tag_value) << "Invalid time tag value: " << value;
       value = *time_tag_value;
     } else {
-      NOTREACHED_NORETURN() << "Unsupported tag: " << tag;
+      NOTREACHED() << "Unsupported tag: " << tag;
     }
 
     const std::string enclosed_tag =

--- a/components/brave_ads/core/internal/common/test/internal/url_response_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/url_response_test_util_internal.cc
@@ -123,7 +123,7 @@ std::optional<mojom::UrlResponseInfo> GetNextUrlResponseForRequest(
     const base::FilePath path = UrlResponsesDataPath().AppendASCII(
         ParseFilenameFromResponseBody(response_body));
     if (!base::ReadFileToString(path, &response_body)) {
-      NOTREACHED_NORETURN() << path << " not found";
+      NOTREACHED() << path << " not found";
     }
 
     ParseAndReplaceTags(response_body);

--- a/components/brave_ads/core/internal/common/test/mock_test_util.cc
+++ b/components/brave_ads/core/internal/common/test/mock_test_util.cc
@@ -113,8 +113,8 @@ void MockBuildChannel(const BuildChannelType type) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for BuildChannelType: "
-                        << base::to_underlying(type);
+  NOTREACHED() << "Unexpected value for BuildChannelType: "
+               << base::to_underlying(type);
 }
 
 void MockIsNetworkConnectionAvailable(const AdsClientMock& ads_client_mock,

--- a/components/brave_ads/core/internal/common/url/request_builder/host/url_host_factory.cc
+++ b/components/brave_ads/core/internal/common/url/request_builder/host/url_host_factory.cc
@@ -41,8 +41,8 @@ std::unique_ptr<UrlHostInterface> UrlHostFactory::Build(
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for UrlHostType: "
-                        << base::to_underlying(type);
+  NOTREACHED() << "Unexpected value for UrlHostType: "
+               << base::to_underlying(type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/flags/environment/environment_command_line_switch_parser_util.cc
+++ b/components/brave_ads/core/internal/flags/environment/environment_command_line_switch_parser_util.cc
@@ -30,8 +30,8 @@ std::optional<mojom::EnvironmentType> ParseEnvironmentCommandLineSwitch() {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for Environment: "
-                        << base::to_underlying(*rewards_flags.environment);
+  NOTREACHED() << "Unexpected value for Environment: "
+               << base::to_underlying(*rewards_flags.environment);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ml/pipeline/linear_pipeline_util.cc
+++ b/components/brave_ads/core/internal/ml/pipeline/linear_pipeline_util.cc
@@ -79,7 +79,7 @@ std::optional<TransformationVector> LoadTransformations(
       }
       case linear_text_classification::flat::TransformationType::
           TransformationType_NONE: {
-        NOTREACHED_NORETURN();
+        NOTREACHED();
       }
     }
     if (!transformation_ptr) {

--- a/components/brave_ads/core/internal/ml/pipeline/neural_pipeline_util.cc
+++ b/components/brave_ads/core/internal/ml/pipeline/neural_pipeline_util.cc
@@ -71,7 +71,7 @@ std::optional<TransformationVector> LoadTransformations(
       }
       case neural_text_classification::flat::TransformationType::
           TransformationType_NONE: {
-        NOTREACHED_NORETURN();
+        NOTREACHED();
       }
     }
     if (!transformation_ptr) {

--- a/components/brave_ads/core/internal/serving/inline_content_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/inline_content_ad_serving_unittest.cc
@@ -20,6 +20,7 @@
 #include "brave/components/brave_ads/core/internal/targeting/behavioral/anti_targeting/resource/anti_targeting_resource.h"
 #include "brave/components/brave_ads/core/internal/targeting/geographical/subdivision/subdivision_targeting.h"
 #include "brave/components/brave_ads/core/public/ad_units/inline_content_ad/inline_content_ad_info.h"
+#include "net/http/http_status_code.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -30,7 +31,8 @@ class BraveAdsInlineContentAdServingTest : public test::TestBase {
   void MaybeServeAd(const std::string& dimensions,
                     MaybeServeInlineContentAdCallback callback) {
     SimulateOpeningNewTab(/*tab_id=*/1,
-                          /*redirect_chain=*/{GURL("brave://newtab")});
+                          /*redirect_chain=*/{GURL("brave://newtab")},
+                          net::HTTP_OK);
 
     SubdivisionTargeting subdivision_targeting;
     AntiTargetingResource anti_targeting_resource;

--- a/components/brave_ads/core/internal/serving/permission_rules/media_permission_rule_unittest.cc
+++ b/components/brave_ads/core/internal/serving/permission_rules/media_permission_rule_unittest.cc
@@ -8,6 +8,7 @@
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/serving/permission_rules/permission_rule_feature.h"
+#include "net/http/http_status_code.h"
 #include "url/gurl.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -25,7 +26,8 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
        ShouldAllowIfMediaIsStoppedForSingleTab) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 
@@ -39,7 +41,8 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
        ShouldAllowIfMediaIsStoppedOnMultipleTabs) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
   NotifyTabDidStartPlayingMedia(/*tab_id=*/2);
@@ -55,7 +58,8 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
        ShouldAllowIfMediaIsPlayingOnMultipleTabsButStoppedForVisibleTab) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
   NotifyTabDidStartPlayingMedia(/*tab_id=*/2);
@@ -70,7 +74,8 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
        ShouldNotAllowIfMediaIsPlayingOnVisibleTab) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 
@@ -88,7 +93,8 @@ TEST_F(
       {{"should_only_serve_ads_if_media_is_not_playing", "false"}});
 
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
 
@@ -100,7 +106,8 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
        ShouldNotAllowIfMediaIsPlayingOnMultipleTabs) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
   NotifyTabDidStartPlayingMedia(/*tab_id=*/2);
@@ -113,7 +120,8 @@ TEST_F(BraveAdsMediaPermissionRuleTest,
        ShouldNotAllowIfMediaIsPlayingOnMultipleTabsButStoppedForOccludedTab) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyTabDidStartPlayingMedia(/*tab_id=*/1);
   NotifyTabDidStartPlayingMedia(/*tab_id=*/2);

--- a/components/brave_ads/core/internal/serving/prediction/model_based/sampling/creative_ad_model_based_predictor_sampling.h
+++ b/components/brave_ads/core/internal/serving/prediction/model_based/sampling/creative_ad_model_based_predictor_sampling.h
@@ -57,7 +57,7 @@ std::optional<T> MaybeSampleCreativeAd(
     }
   }
 
-  NOTREACHED_NORETURN() << "Sum should always be less than probability";
+  NOTREACHED() << "Sum should always be less than probability";
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/prefs/internal/condition_matcher_pref_util_internal.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/prefs/internal/condition_matcher_pref_util_internal.cc
@@ -45,8 +45,8 @@ std::optional<std::string> ToString(const base::Value& value) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for base::Value::Type: "
-                        << base::to_underlying(value.type());
+  NOTREACHED() << "Unexpected value for base::Value::Type: "
+               << base::to_underlying(value.type());
 }
 
 std::optional<base::Value> MaybeGetRootPrefValue(

--- a/components/brave_ads/core/internal/user_engagement/conversions/actions/conversion_action_types_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/actions/conversion_action_types_util.cc
@@ -28,8 +28,8 @@ ConversionActionType ToConversionActionType(
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ConfirmationType: "
-                        << base::to_underlying(mojom_confirmation_type);
+  NOTREACHED() << "Unexpected value for mojom::ConfirmationType: "
+               << base::to_underlying(mojom_confirmation_type);
 }
 
 ConversionActionType ToConversionActionType(
@@ -42,7 +42,7 @@ ConversionActionType ToConversionActionType(
     return ConversionActionType::kClickThrough;
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for action_type: " << action_type;
+  NOTREACHED() << "Unexpected value for action_type: " << action_type;
 }
 
 std::string ToString(const ConversionActionType action_type) {
@@ -60,8 +60,8 @@ std::string ToString(const ConversionActionType action_type) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for ConversionActionType: "
-                        << base::to_underlying(action_type);
+  NOTREACHED() << "Unexpected value for ConversionActionType: "
+               << base::to_underlying(action_type);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_util.cc
@@ -59,8 +59,8 @@ bool IsAllowedToConvertAdEvent(const AdEventInfo& ad_event) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::AdType: "
-                        << base::to_underlying(ad_event.type);
+  NOTREACHED() << "Unexpected value for mojom::AdType: "
+               << base::to_underlying(ad_event.type);
 }
 
 bool DidAdEventOccurWithinObservationWindow(

--- a/components/brave_ads/core/internal/user_engagement/reactions/reactions_type_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/reactions/reactions_type_util.cc
@@ -25,8 +25,8 @@ mojom::ReactionType ToggleLikedReactionType(
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ReactionType: "
-                        << mojom_reaction_type;
+  NOTREACHED() << "Unexpected value for mojom::ReactionType: "
+               << mojom_reaction_type;
 }
 
 mojom::ReactionType ToggleDislikedReactionType(
@@ -44,8 +44,8 @@ mojom::ReactionType ToggleDislikedReactionType(
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::ReactionType: "
-                        << mojom_reaction_type;
+  NOTREACHED() << "Unexpected value for mojom::ReactionType: "
+               << mojom_reaction_type;
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit.cc
@@ -70,6 +70,11 @@ void SiteVisit::MaybeLandOnPage(const TabInfo& tab,
     return;
   }
 
+  if (!IsSuccessfulHttpStatusCode(http_status_code)) {
+    // If the page did not load successfully, immediately land on the page.
+    return LandedOnPage(tab.id, http_status_code, ad);
+  }
+
   // The page loaded successfully, so land on the page after a delay.
   MaybeLandOnPageAfter(tab, http_status_code, ad, kPageLandAfter.Get());
 }

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
@@ -590,8 +590,9 @@ TEST_F(BraveAdsSiteVisitTest,
   EXPECT_FALSE(HasPendingTasks());
 }
 
-TEST_F(BraveAdsSiteVisitTest,
-       LandOnPageIfTheTabIsVisibleAndTheRedirectChainMatchesTheLastClickedAd) {
+TEST_F(
+    BraveAdsSiteVisitTest,
+    LandOnPageIfTheTabIsVisibleAndTheRedirectChainMatchesTheLastClickedAdForHttpSuccessfulResponseStatusCode) {
   // Arrange
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
@@ -610,20 +611,40 @@ TEST_F(BraveAdsSiteVisitTest,
 
 TEST_F(
     BraveAdsSiteVisitTest,
-    LandOnPageIfTheTabIsVisibleAndTheRedirectChainMatchesTheLastClickedAdForHttpResponseStatusErrorPage) {
+    LandOnPageIfTheTabIsVisibleAndTheRedirectChainMatchesTheLastClickedAdForHttpClientErrorResponseStatusCode) {
   // Arrange
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   EXPECT_CALL(site_visit_observer_mock_,
-              OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
-  SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
-  ASSERT_EQ(1U, GetPendingTaskCount());
+              OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()))
+      .Times(0);
 
   // Act & Assert
-  EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage(
-                                             /*tab_id=*/1, net::HTTP_OK, ad));
-  FastForwardClockBy(kPageLandAfter.Get());
+  EXPECT_CALL(site_visit_observer_mock_,
+              OnDidLandOnPage(
+                  /*tab_id=*/1, net::HTTP_BAD_REQUEST, ad));
+  SimulateClickingAd(ad, /*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_BAD_REQUEST);
+}
+
+TEST_F(
+    BraveAdsSiteVisitTest,
+    LandOnPageIfTheTabIsVisibleAndTheRedirectChainMatchesTheLastClickedAdForHttpServerErrorResponseStatusCode) {
+  // Arrange
+  const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
+                                  /*should_generate_random_uuids=*/true);
+  EXPECT_CALL(site_visit_observer_mock_,
+              OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()))
+      .Times(0);
+
+  // Act & Assert
+  EXPECT_CALL(site_visit_observer_mock_,
+              OnDidLandOnPage(
+                  /*tab_id=*/1, net::HTTP_INTERNAL_SERVER_ERROR, ad));
+  SimulateClickingAd(ad, /*tab_id=*/1,
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_INTERNAL_SERVER_ERROR);
 }
 
 TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheTabIsOccluded) {

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_unittest.cc
@@ -45,10 +45,11 @@ class BraveAdsSiteVisitTest : public test::TestBase {
 
   void SimulateClickingAd(const AdInfo& ad,
                           const int32_t tab_id,
-                          const std::vector<GURL>& redirect_chain) {
+                          const std::vector<GURL>& redirect_chain,
+                          const int http_status_code) {
     site_visit_->set_last_clicked_ad(ad);
 
-    SimulateOpeningNewTab(tab_id, redirect_chain);
+    SimulateOpeningNewTab(tab_id, redirect_chain, http_status_code);
   }
 
   std::unique_ptr<SiteVisit> site_visit_;
@@ -62,7 +63,8 @@ TEST_F(BraveAdsSiteVisitTest, LandOnInlineContentAdPage) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kInlineContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_,
@@ -78,7 +80,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kInlineContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -93,7 +96,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kInlineContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_,
@@ -110,7 +114,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kInlineContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -122,7 +127,8 @@ TEST_F(BraveAdsSiteVisitTest, LandOnPromotedContentAdPage) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kPromotedContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_,
@@ -138,7 +144,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kPromotedContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -153,7 +160,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kPromotedContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_,
@@ -171,7 +179,8 @@ TEST_F(
   const AdInfo ad = test::BuildAd(mojom::AdType::kPromotedContentAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -183,7 +192,8 @@ TEST_F(BraveAdsSiteVisitTest, LandOnNewTabPageAdPage) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kNewTabPageAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_,
@@ -199,7 +209,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kNewTabPageAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -218,7 +229,8 @@ TEST_F(
   const AdInfo ad = test::BuildAd(mojom::AdType::kNewTabPageAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -234,7 +246,8 @@ TEST_F(
   const AdInfo ad = test::BuildAd(mojom::AdType::kNewTabPageAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -246,7 +259,8 @@ TEST_F(BraveAdsSiteVisitTest, LandOnNotificationAdPage) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_,
@@ -262,7 +276,8 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -276,7 +291,8 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnNotificationAdPageForNonRewardsUser) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -290,7 +306,8 @@ TEST_F(BraveAdsSiteVisitTest,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(
       ad, /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")});
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -304,10 +321,12 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheSameTabIsAlreadyLanding) {
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   SimulateNavigateToURL(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com/about")});
+                        /*redirect_chain=*/{GURL("https://brave.com/about")},
+                        net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Act & Assert
@@ -329,7 +348,8 @@ TEST_F(
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad_1, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad_1, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Tab 1 (Occluded/Suspend page landing)
@@ -345,7 +365,8 @@ TEST_F(
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad_2, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad_2, /*tab_id=*/2,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Tab 2 (Occluded/Suspend page landing)
@@ -394,7 +415,8 @@ TEST_F(
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Browser (Entered background/Suspend page landing)
@@ -431,7 +453,8 @@ TEST_F(
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Browser (Resign active/Suspend page landing)
@@ -471,7 +494,8 @@ TEST_F(BraveAdsSiteVisitTest, DoNotSuspendOrResumePageLand) {
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Browser (Resign active/Suspend page landing)
@@ -505,7 +529,8 @@ TEST_F(
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnMaybeLandOnPage).Times(0);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   EXPECT_EQ(0U, GetPendingTaskCount());
 }
 
@@ -517,7 +542,8 @@ TEST_F(BraveAdsSiteVisitTest,
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad_1, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad_1, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Tab 1 (Occluded/Suspend page landing)
@@ -531,7 +557,8 @@ TEST_F(BraveAdsSiteVisitTest,
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad_2, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad_2, /*tab_id=*/2,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Tab 2 (Occluded/Suspend page landing)
@@ -571,7 +598,8 @@ TEST_F(BraveAdsSiteVisitTest,
   EXPECT_CALL(site_visit_observer_mock_,
               OnMaybeLandOnPage(ad, /*after=*/kPageLandAfter.Get()));
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
   ASSERT_EQ(1U, GetPendingTaskCount());
 
   // Act & Assert
@@ -603,7 +631,8 @@ TEST_F(BraveAdsSiteVisitTest, DoNotLandOnPageIfTheTabIsOccluded) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -622,7 +651,8 @@ TEST_F(
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(
       ad, /*tab_id=*/1,
-      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")});
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnDidLandOnPage).Times(0);
@@ -635,12 +665,15 @@ TEST_F(BraveAdsSiteVisitTest,
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnCanceledPageLand(/*tab_id=*/1, ad));
-  SimulateNavigateToURL(/*tab_id=*/1, /*redirect_chain=*/{
-                            GURL("https://basicattentiontoken.org")});
+  SimulateNavigateToURL(
+      /*tab_id=*/1,
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      net::HTTP_OK);
   FastForwardClockBy(kPageLandAfter.Get());
 }
 
@@ -649,7 +682,8 @@ TEST_F(BraveAdsSiteVisitTest, CancelPageLandIfTheTabIsClosed) {
   const AdInfo ad = test::BuildAd(mojom::AdType::kNotificationAd,
                                   /*should_generate_random_uuids=*/true);
   SimulateClickingAd(ad, /*tab_id=*/1,
-                     /*redirect_chain=*/{GURL("https://brave.com")});
+                     /*redirect_chain=*/{GURL("https://brave.com")},
+                     net::HTTP_OK);
 
   // Act & Assert
   EXPECT_CALL(site_visit_observer_mock_, OnCanceledPageLand(/*tab_id=*/1, ad));

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.cc
@@ -7,6 +7,7 @@
 
 #include "base/notreached.h"
 #include "base/types/cxx23_to_underlying.h"
+#include "brave/components/brave_ads/core/internal/application_state/browser_manager.h"
 #include "brave/components/brave_ads/core/internal/common/url/url_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings.h"
 #include "brave/components/brave_ads/core/internal/tabs/tab_manager.h"
@@ -52,6 +53,12 @@ bool IsAllowedToLandOnPage(const mojom::AdType mojom_ad_type) {
 
   NOTREACHED_NORETURN() << "Unexpected value for mojom::AdType: "
                         << base::to_underlying(mojom_ad_type);
+}
+
+bool ShouldResumePageLand(const int32_t tab_id) {
+  return TabManager::GetInstance().IsVisible(tab_id) &&
+         BrowserManager::GetInstance().IsActive() &&
+         BrowserManager::GetInstance().IsInForeground();
 }
 
 bool DidLandOnPage(const int32_t tab_id, const GURL& url) {

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.cc
@@ -51,8 +51,8 @@ bool IsAllowedToLandOnPage(const mojom::AdType mojom_ad_type) {
     }
   }
 
-  NOTREACHED_NORETURN() << "Unexpected value for mojom::AdType: "
-                        << base::to_underlying(mojom_ad_type);
+  NOTREACHED() << "Unexpected value for mojom::AdType: "
+               << base::to_underlying(mojom_ad_type);
 }
 
 bool ShouldResumePageLand(const int32_t tab_id) {

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.h
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.h
@@ -16,6 +16,8 @@ namespace brave_ads {
 
 bool IsAllowedToLandOnPage(mojom::AdType mojom_ad_type);
 
+bool ShouldResumePageLand(int32_t tab_id);
+
 bool DidLandOnPage(int32_t tab_id, const GURL& url);
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
@@ -10,6 +10,7 @@
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ads_feature.h"
+#include "net/http/http_status_code.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -222,7 +223,8 @@ TEST_F(BraveAdsSiteVisitUtilTest,
 TEST_F(BraveAdsSiteVisitUtilTest, DidLandOnPage) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   // Act & Assert
   EXPECT_TRUE(DidLandOnPage(/*tab_id=*/1, GURL("https://brave.com")));
@@ -231,7 +233,8 @@ TEST_F(BraveAdsSiteVisitUtilTest, DidLandOnPage) {
 TEST_F(BraveAdsSiteVisitUtilTest, DoNotLandOnPageForClosedTab) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://brave.com")});
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
 
   NotifyDidCloseTab(/*tab_id=*/1);
 
@@ -242,7 +245,8 @@ TEST_F(BraveAdsSiteVisitUtilTest, DoNotLandOnPageForClosedTab) {
 TEST_F(BraveAdsSiteVisitUtilTest, DoNotLandOnPageForDomainOrHostMismatch) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,
-                        /*redirect_chain=*/{GURL("https://foo.com")});
+                        /*redirect_chain=*/{GURL("https://foo.com")},
+                        net::HTTP_OK);
 
   // Act & Assert
   EXPECT_FALSE(DidLandOnPage(/*tab_id=*/1, GURL("https://brave.com")));

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
@@ -162,6 +162,63 @@ TEST_F(
   EXPECT_FALSE(IsAllowedToLandOnPage(mojom::AdType::kSearchResultAd));
 }
 
+TEST_F(BraveAdsSiteVisitUtilTest, ShouldResumePageLand) {
+  // Arrange
+  NotifyBrowserDidBecomeActive();
+  NotifyBrowserDidEnterForeground();
+
+  SimulateOpeningNewTab(/*tab_id=*/1,
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
+
+  // Act & Assert
+  EXPECT_TRUE(ShouldResumePageLand(/*tab_id=*/1));
+}
+
+TEST_F(BraveAdsSiteVisitUtilTest, ShouldNotResumePageLandIfTabIsOccluded) {
+  // Arrange
+  NotifyBrowserDidBecomeActive();
+  NotifyBrowserDidEnterForeground();
+
+  SimulateOpeningNewTab(/*tab_id=*/1,
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
+  SimulateOpeningNewTab(
+      /*tab_id=*/2,
+      /*redirect_chain=*/{GURL("https://basicattentiontoken.org")},
+      net::HTTP_OK);
+
+  // Act & Assert
+  EXPECT_FALSE(ShouldResumePageLand(/*tab_id=*/1));
+}
+
+TEST_F(BraveAdsSiteVisitUtilTest, ShouldNotResumePageLandIfBrowserIsInactive) {
+  // Arrange
+  NotifyBrowserDidResignActive();
+  NotifyBrowserDidEnterForeground();
+
+  SimulateOpeningNewTab(/*tab_id=*/1,
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
+
+  // Act & Assert
+  EXPECT_FALSE(ShouldResumePageLand(/*tab_id=*/1));
+}
+
+TEST_F(BraveAdsSiteVisitUtilTest,
+       ShouldNotResumePageLandIfBrowserDidEnterBackground) {
+  // Arrange
+  NotifyBrowserDidBecomeActive();
+  NotifyBrowserDidEnterBackground();
+
+  SimulateOpeningNewTab(/*tab_id=*/1,
+                        /*redirect_chain=*/{GURL("https://brave.com")},
+                        net::HTTP_OK);
+
+  // Act & Assert
+  EXPECT_FALSE(ShouldResumePageLand(/*tab_id=*/1));
+}
+
 TEST_F(BraveAdsSiteVisitUtilTest, DidLandOnPage) {
   // Arrange
   SimulateOpeningNewTab(/*tab_id=*/1,


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42137

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For landing pages (site visits) returning HTTP status codes in the 4xx and 5xx ranges, redeem a `landed` confirmation token for Rewards users immediately without a 5-second delay. For status codes in the 2xx and 3xx ranges, apply a 5-second delay before redeeming the confirmation token.