### PR TITLE
fix(wallet): BTC and ZEC Buy Quotes from Route

### DIFF
--- a/components/brave_wallet_ui/page/screens/fund-wallet/hooks/useBuy.ts
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/hooks/useBuy.ts
@@ -60,7 +60,7 @@ export type BuyParamOverrides = {
   sourceCurrencyCode?: string
   destinationCurrencyCode?: string
   amount?: string
-  account?: string
+  receiveAddress?: string
 }
 
 const DEFAULT_ASSET: MeldCryptoCurrency = {
@@ -257,15 +257,11 @@ export const useBuy = () => {
         destinationCurrencyCode:
           overrides.destinationCurrencyCode ?? selectedAsset?.currencyCode,
         amount: overrides.amount ?? amount,
-        account: overrides.account ?? selectedAccount.address,
+        receiveAddress: overrides.receiveAddress ?? receiveAddress,
         paymentMethod: overrides.paymentMethod ?? selectedPaymentMethod
       }
 
-      if (
-        !params.sourceCurrencyCode ||
-        !params.destinationCurrencyCode ||
-        !params.account
-      ) {
+      if (!params.sourceCurrencyCode || !params.destinationCurrencyCode) {
         return
       }
 
@@ -287,7 +283,7 @@ export const useBuy = () => {
       let quoteResponse
       try {
         quoteResponse = await generateQuotes({
-          account: selectedAccount.address,
+          account: params.receiveAddress,
           amount: amountWrapped.toNumber(),
           country: params.country || 'US',
           sourceCurrencyCode: params.sourceCurrencyCode,
@@ -322,10 +318,10 @@ export const useBuy = () => {
       amount,
       selectedCountryCode,
       generateQuotes,
-      selectedAccount?.address,
       selectedAsset?.currencyCode,
       selectedCurrency?.currencyCode,
-      selectedPaymentMethod
+      selectedPaymentMethod,
+      receiveAddress
     ]
   )
 


### PR DESCRIPTION
## Description 

Fixes a bug where Buy `quotes` were not being fetched for `BTC` and `ZEC` when clicking buy from the `Portfolio` page.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42083>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Portfolio` screen
2. Open the more menu for `BTC` or `ZEC` and click `Buy`
3. After being routed to the `Buy` screen Buy `Quotes` should be fetch.

Before:

https://github.com/user-attachments/assets/6ca35e17-777e-4dd7-bfb7-441ff54e7048

After:

https://github.com/user-attachments/assets/c9b7511d-e618-4b77-b099-8a4c57d5566d
