### PR TITLE
Fixes call to `ShouldBlockPlaylistWebUI()`. (uplift to 1.74.x)

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -1321,6 +1321,10 @@ source_set("ui") {
     ]
   }
 
+  if (enable_playlist) {
+    deps += [ "//brave/components/playlist/common" ]
+  }
+
   if (enable_playlist_webui) {
     sources += [
       "playlist/playlist_browser_finder.cc",

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -63,6 +63,7 @@
 
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
 #include "brave/browser/ui/webui/playlist_ui.h"
+#include "brave/components/playlist/common/features.h"
 #endif
 
 #if BUILDFLAG(ENABLE_TOR)
@@ -244,8 +245,10 @@ WebUI::TypeID BraveWebUIControllerFactory::GetWebUIType(
   }
 #endif  // BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(ENABLE_PLAYLIST_WEBUI)
-  if (playlist::PlaylistUI::ShouldBlockPlaylistWebUI(browser_context, url)) {
-    return WebUI::kNoWebUI;
+  if (base::FeatureList::IsEnabled(playlist::features::kPlaylist)) {
+    if (playlist::PlaylistUI::ShouldBlockPlaylistWebUI(browser_context, url)) {
+      return WebUI::kNoWebUI;
+    }
   }
 #endif
 


### PR DESCRIPTION
Uplift of #26378
Resolves https://github.com/brave/brave-browser/issues/42096

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.