### PR TITLE
[iOS] Fix crash if internal pages are stopped prior to fully loading (uplift to 1.73.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Interstitial Pages/InternalSchemeHandler.swift
@@ -127,6 +127,11 @@ public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
 
     let path = url.path.starts(with: "/") ? String(url.path.dropFirst()) : url.path
 
+    if activeTasks.object(forKey: urlSchemeTask) != nil {
+      // Already a task ongoing, technically this shouldn't happen.
+      return
+    }
+
     let task = Task {
       // For non-main doc URL, try load it as a resource
       if !urlSchemeTask.request.isPrivileged,
@@ -168,5 +173,7 @@ public class InternalSchemeHandler: NSObject, WKURLSchemeHandler {
     activeTasks.setObject(TaskHolder(task: task), forKey: urlSchemeTask)
   }
 
-  public func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+  public func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+    activeTasks.removeObject(forKey: urlSchemeTask)
+  }
 }


### PR DESCRIPTION
Uplift of #26434
Resolves https://github.com/brave/brave-browser/issues/42162

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.