### PR TITLE
Fetch staged entries from Brave Search before opt-in to Leo (uplift to 1.74.x)

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1047,8 +1047,7 @@ void ConversationHandler::MaybeFetchOrClearContentStagedConversation() {
   }
 
   const bool can_check_for_staged_conversation =
-      ai_chat_service_->HasUserOptedIn() && IsContentAssociationPossible() &&
-      should_send_page_contents_;
+      IsContentAssociationPossible() && should_send_page_contents_;
   if (!can_check_for_staged_conversation) {
     // Clear any staged conversation entries since user might have unassociated
     // content with this conversation
@@ -1071,7 +1070,7 @@ void ConversationHandler::OnGetStagedEntriesFromContent(
     const std::optional<std::vector<SearchQuerySummary>>& entries) {
   // Check if all requirements are still met.
   if (is_request_in_progress_ || !entries || !IsContentAssociationPossible() ||
-      !should_send_page_contents_ || !ai_chat_service_->HasUserOptedIn()) {
+      !should_send_page_contents_) {
     return;
   }
 

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -248,7 +248,7 @@ function Main() {
             <div className={styles.promptContainer}>
               <LongConversationInfo />
             </div>}
-          {!aiChatContext.hasAcceptedAgreement && <WelcomeGuide />}
+          {!aiChatContext.hasAcceptedAgreement && !conversationContext.conversationHistory.length && <WelcomeGuide />}
         </div>
       </div>
       <div className={styles.input}>


### PR DESCRIPTION
Uplift of #26424
Resolves https://github.com/brave/brave-browser/issues/42112

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.