### PR TITLE
fix(wallet): Cancel and Retry Transaction Navigation

### DIFF
--- a/components/brave_wallet_ui/components/extension/post-confirmation/cancel_transaction/cancel_transaction.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/cancel_transaction/cancel_transaction.tsx
@@ -3,6 +3,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
+import { useDispatch } from 'react-redux'
+
+// Actions
+import * as WalletPanelActions from '../../../../panel/actions/wallet_panel_actions'
 
 // Types
 import { SerializableTransactionInfo } from '../../../../constants/types'
@@ -37,6 +41,7 @@ export const CancelTransaction = (props: Props) => {
 
   // Hooks
   const [cancelTx] = useCancelTransactionMutation()
+  const dispatch = useDispatch()
 
   // Methods
   const onClickCancelTransaction = () => {
@@ -45,6 +50,7 @@ export const CancelTransaction = (props: Props) => {
       chainId: transaction.chainId,
       transactionId: transaction.id
     })
+    dispatch(WalletPanelActions.setSelectedTransactionId(undefined))
   }
 
   return (

--- a/components/brave_wallet_ui/components/extension/post-confirmation/failed_or_canceled/failed_or_canceled.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/failed_or_canceled/failed_or_canceled.tsx
@@ -4,6 +4,10 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
 import LeoButton from '@brave/leo/react/button'
+import { useDispatch } from 'react-redux'
+
+// Actions
+import * as WalletPanelActions from '../../../../panel/actions/wallet_panel_actions'
 
 // Hooks
 import {
@@ -61,7 +65,8 @@ export const TransactionFailedOrCanceled = (props: Props) => {
 
   // Hooks
   const [retryTx] = useRetryTransactionMutation()
-
+  const dispatch = useDispatch()
+  
   // Computed
   const txCoinType = getCoinFromTxDataUnion(transaction.txDataUnion)
   const isBridge = isBridgeTransaction(transaction)
@@ -96,6 +101,7 @@ export const TransactionFailedOrCanceled = (props: Props) => {
       chainId: transaction.chainId,
       transactionId: transaction.id
     })
+    dispatch(WalletPanelActions.setSelectedTransactionId(undefined))
   }
 
   return (


### PR DESCRIPTION
## Description 

Fixes a bug where `Cancel` and `Retry` transaction was not navigating away to the new `Pending Transaction`.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42146>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and create/submit a new transaction.
2. When the `Transaction Status` panel appears, click `Cancel transaction`
3. The `Panel` should navigate to the new `Pending Transaction` for canceling
4. Create a failed transaction
5. When the `Failed Transaction Status` panel appears, click `Retry transaction`
6. The `Panel` should navigate to the new `Pending Transaction` to retry