### PR TITLE
Fetch staged entries from Brave Search before opt-in to Leo (uplift to 1.73.x)

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1031,8 +1031,7 @@ void ConversationHandler::MaybeFetchOrClearContentStagedConversation() {
   }
 
   const bool can_check_for_staged_conversation =
-      ai_chat_service_->HasUserOptedIn() && IsContentAssociationPossible() &&
-      should_send_page_contents_;
+      IsContentAssociationPossible() && should_send_page_contents_;
   if (!can_check_for_staged_conversation) {
     // Clear any staged conversation entries since user might have unassociated
     // content with this conversation
@@ -1055,7 +1054,7 @@ void ConversationHandler::OnGetStagedEntriesFromContent(
     const std::optional<std::vector<SearchQuerySummary>>& entries) {
   // Check if all requirements are still met.
   if (is_request_in_progress_ || !entries || !IsContentAssociationPossible() ||
-      !should_send_page_contents_ || !ai_chat_service_->HasUserOptedIn()) {
+      !should_send_page_contents_) {
     return;
   }
 

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -1089,13 +1089,6 @@ TEST_F(ConversationHandlerUnitTest,
   conversation_handler_->OnGetStagedEntriesFromContent(entries);
   task_environment_.RunUntilIdle();
   EXPECT_EQ(conversation_handler_->GetConversationHistory().size(), 0u);
-
-  // No staged entries if user opt-out.
-  conversation_handler_->SetShouldSendPageContents(true);
-  EmulateUserOptedOut();
-  conversation_handler_->OnGetStagedEntriesFromContent(entries);
-  task_environment_.RunUntilIdle();
-  EXPECT_EQ(conversation_handler_->GetConversationHistory().size(), 0u);
 }
 
 TEST_F(ConversationHandlerUnitTest, OnGetStagedEntriesFromContent) {
@@ -1131,19 +1124,15 @@ TEST_F(ConversationHandlerUnitTest, OnGetStagedEntriesFromContent) {
   EXPECT_EQ(history[5]->text, "summary2");
 }
 
-TEST_F(ConversationHandlerUnitTest_OptedOut,
+TEST_F(ConversationHandlerUnitTest,
        MaybeFetchOrClearSearchQuerySummary_NotOptedIn) {
-  // Content will have staged entries, but we want to make sure that
-  // ConversationHandler won't ask for them when not opted-in yet.
+  // Staged entries could be retrieved before user opts in.
   SetAssociatedContentStagedEntries(/*empty=*/false);
-  EXPECT_CALL(*associated_content_, GetStagedEntriesFromContent).Times(0);
-  // Modifying whether page contents should be sent should trigger content
-  // staging.
+  EXPECT_CALL(*associated_content_, GetStagedEntriesFromContent).Times(1);
   // Don't get a false positive because no client is automatically connected.
+  // Connecting a client will trigger content staging.
   NiceMock<MockConversationHandlerClient> client(conversation_handler_.get());
   EXPECT_TRUE(conversation_handler_->IsAnyClientConnected());
-  conversation_handler_->SetShouldSendPageContents(false);
-  conversation_handler_->SetShouldSendPageContents(true);
   conversation_handler_->GetAssociatedContentInfo(base::BindLambdaForTesting(
       [&](mojom::SiteInfoPtr site_info, bool should_send_page_contents) {
         EXPECT_TRUE(should_send_page_contents);
@@ -1152,7 +1141,7 @@ TEST_F(ConversationHandlerUnitTest_OptedOut,
   task_environment_.RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(conversation_handler_.get());
 
-  EXPECT_TRUE(conversation_handler_->GetConversationHistory().empty());
+  EXPECT_FALSE(conversation_handler_->GetConversationHistory().empty());
 }
 
 TEST_F(ConversationHandlerUnitTest,

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -270,7 +270,7 @@ function Main() {
           <div className={styles.promptContainer}>
               <LongConversationInfo />
           </div>}
-          {!aiChatContext.hasAcceptedAgreement && <WelcomeGuide />}
+          {!aiChatContext.hasAcceptedAgreement && !conversationContext.conversationHistory.length && <WelcomeGuide />}
         </div>
       </div>
       <div className={styles.input}>


### PR DESCRIPTION
Uplift of #26424
Resolves https://github.com/brave/brave-browser/issues/42112

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.