### PR TITLE
Fix crash in AI Chat when conversation is unassociated from page content

### DIFF
--- a/components/ai_chat/core/browser/associated_content_driver.cc
+++ b/components/ai_chat/core/browser/associated_content_driver.cc
@@ -74,7 +74,7 @@ void AssociatedContentDriver::AddRelatedConversation(
   associated_conversations_.insert(conversation);
 }
 
-void AssociatedContentDriver::OnRelatedConversationDestroyed(
+void AssociatedContentDriver::OnRelatedConversationDisassociated(
     ConversationHandler* conversation) {
   associated_conversations_.erase(conversation);
 }

--- a/components/ai_chat/core/browser/associated_content_driver.h
+++ b/components/ai_chat/core/browser/associated_content_driver.h
@@ -10,6 +10,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
@@ -48,7 +49,7 @@ class AssociatedContentDriver
 
   // ConversationHandler::AssociatedContentDelegate
   void AddRelatedConversation(ConversationHandler* conversation) override;
-  void OnRelatedConversationDestroyed(
+  void OnRelatedConversationDisassociated(
       ConversationHandler* conversation) override;
   int GetContentId() const override;
   GURL GetURL() const override;

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -67,7 +67,7 @@ class ConversationHandler : public mojom::ConversationHandler,
     AssociatedContentDelegate();
     virtual ~AssociatedContentDelegate();
     virtual void AddRelatedConversation(ConversationHandler* conversation) {}
-    virtual void OnRelatedConversationDestroyed(
+    virtual void OnRelatedConversationDisassociated(
         ConversationHandler* conversation) {}
     // Unique ID for the content. For browser Tab content, this should be
     // a navigation ID that's re-used during back navigations.
@@ -299,6 +299,12 @@ class ConversationHandler : public mojom::ConversationHandler,
   void PerformQuestionGeneration(std::string page_content,
                                  bool is_video,
                                  std::string invalidation_token);
+
+  // Disassociate with the current associated content. Use this instead of
+  // settings associated_content_delegegate_ to nullptr to ensure that we
+  // inform the delegate, otherwise when this class instance is destroyed,
+  // the delegate will not be informed.
+  void DisassociateContentDelegate();
 
   void OnGetStagedEntriesFromContent(
       const std::optional<std::vector<SearchQuerySummary>>& entries);


### PR DESCRIPTION
The associated content wasn't notified in all cases that the conversation was no longer associated with it and would not be notified of destruction. It kept a reference to the conversation and used it after destruction.

Fix https://github.com/brave/brave-browser/issues/42091
Fix https://github.com/brave/brave-browser/issues/42092

Also removes a `NOTREACHED_IN_MIGRATION` from the same file.
Fix https://github.com/brave/brave-browser/issues/42089

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
STR in https://github.com/brave/brave-browser/issues/42092
