### PR TITLE
[CodeHealth] Apply `performance-move-const-arg`

### DIFF
--- a/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
@@ -80,7 +80,7 @@ void AdBlockFiltersProviderManager::LoadFilterSetForEngine(
   auto& filters_providers = is_for_default_engine
                                 ? default_engine_filters_providers_
                                 : additional_engine_filters_providers_;
-  const auto collect_and_merge = base::BarrierCallback<
+  auto collect_and_merge = base::BarrierCallback<
       base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>>(
       filters_providers.size(),
       base::BindOnce(&AdBlockFiltersProviderManager::FinishCombinating,
@@ -89,7 +89,7 @@ void AdBlockFiltersProviderManager::LoadFilterSetForEngine(
     task_tracker_.PostTask(
         base::SequencedTaskRunner::GetCurrentDefault().get(), FROM_HERE,
         base::BindOnce(&AdBlockFiltersProvider::LoadFilterSet,
-                       provider->AsWeakPtr(), std::move(collect_and_merge)));
+                       provider->AsWeakPtr(), collect_and_merge));
   }
 }
 

--- a/components/debounce/core/browser/debounce_rule.cc
+++ b/components/debounce/core/browser/debounce_rule.cc
@@ -201,8 +201,7 @@ DebounceRule::ParseRules(const std::string& contents) {
     }
     for (const URLPattern& pattern : rule->include_pattern_set()) {
       if (!pattern.host().empty()) {
-        const std::string etldp1 =
-            DebounceRule::GetETLDForDebounce(pattern.host());
+        std::string etldp1 = DebounceRule::GetETLDForDebounce(pattern.host());
         if (!etldp1.empty()) {
           hosts.insert(std::move(etldp1));
         }

--- a/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.cc
+++ b/components/https_upgrade_exceptions/browser/https_upgrade_exceptions_service.cc
@@ -51,7 +51,7 @@ void HttpsUpgradeExceptionsService::OnDATFileDataReady(
   }
   std::vector<std::string> lines = base::SplitString(
       contents, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-  for (const auto& line : lines) {
+  for (auto&& line : lines) {
     exceptional_domains_.insert(std::move(line));
   }
   is_ready_ = true;

--- a/components/localhost_permission/localhost_permission_component.cc
+++ b/components/localhost_permission/localhost_permission_component.cc
@@ -72,7 +72,7 @@ void LocalhostPermissionComponent::OnDATFileDataReady(
       continue;
     }
     // Construct a GURL from the line, and store the eTLD+1.
-    const auto url = GURL("https://" + std::move(line));
+    const auto url = GURL("https://" + line);
     if (url.is_valid()) {
       allowed_domains_.insert(GetDomain(url));
     }

--- a/components/p3a/p3a_config.cc
+++ b/components/p3a/p3a_config.cc
@@ -133,7 +133,7 @@ P3AConfig P3AConfig::LoadFromCommandLine() {
 
   config.average_upload_interval = MaybeOverrideTimeDeltaFromCommandLine(
       cmdline, switches::kP3AUploadIntervalSeconds,
-      std::move(config.average_upload_interval));
+      config.average_upload_interval);
 
   config.randomize_upload_interval =
       !cmdline->HasSwitch(switches::kP3ADoNotRandomizeUploadInterval);
@@ -141,15 +141,15 @@ P3AConfig P3AConfig::LoadFromCommandLine() {
   config.json_rotation_intervals[MetricLogType::kSlow] =
       MaybeOverrideTimeDeltaFromCommandLine(
           cmdline, switches::kP3ASlowRotationIntervalSeconds,
-          std::move(config.json_rotation_intervals[MetricLogType::kSlow]));
+          config.json_rotation_intervals[MetricLogType::kSlow]);
   config.json_rotation_intervals[MetricLogType::kTypical] =
       MaybeOverrideTimeDeltaFromCommandLine(
           cmdline, switches::kP3ATypicalRotationIntervalSeconds,
-          std::move(config.json_rotation_intervals[MetricLogType::kTypical]));
+          config.json_rotation_intervals[MetricLogType::kTypical]);
   config.json_rotation_intervals[MetricLogType::kExpress] =
       MaybeOverrideTimeDeltaFromCommandLine(
           cmdline, switches::kP3AExpressRotationIntervalSeconds,
-          std::move(config.json_rotation_intervals[MetricLogType::kExpress]));
+          config.json_rotation_intervals[MetricLogType::kExpress]);
 
   config.fake_star_epochs[MetricLogType::kSlow] =
       MaybeSetUint8FromCommandLine(cmdline, switches::kP3AFakeSlowStarEpoch);

--- a/components/permissions/permission_lifetime_options.cc
+++ b/components/permissions/permission_lifetime_options.cc
@@ -13,7 +13,7 @@ namespace permissions {
 PermissionLifetimeOption::PermissionLifetimeOption(
     std::u16string label,
     std::optional<base::TimeDelta> lifetime)
-    : label(std::move(label)), lifetime(std::move(lifetime)) {}
+    : label(std::move(label)), lifetime(lifetime) {}
 
 PermissionLifetimeOption::PermissionLifetimeOption(
     const PermissionLifetimeOption&) = default;

--- a/components/request_otr/browser/request_otr_rule.cc
+++ b/components/request_otr/browser/request_otr_rule.cc
@@ -106,7 +106,7 @@ RequestOTRRule::ParseRules(const std::string& contents) {
     }
     for (const URLPattern& pattern : rule->include_pattern_set()) {
       if (!pattern.host().empty()) {
-        const std::string etldp1 =
+        std::string etldp1 =
             RequestOTRRule::GetETLDForRequestOTR(pattern.host());
         if (!etldp1.empty()) {
           hosts.insert(std::move(etldp1));

--- a/components/tor/tor_file_watcher.cc
+++ b/components/tor/tor_file_watcher.cc
@@ -43,7 +43,7 @@ constexpr char kControlAuthCookieName[] = "control_auth_cookie";
 constexpr char kControlPortName[] = "controlport";
 }  // namespace
 
-TorFileWatcher::TorFileWatcher(const base::FilePath& watch_dir_path)
+TorFileWatcher::TorFileWatcher(base::FilePath watch_dir_path)
     : polling_(false),
       repoll_(false),
       watch_dir_path_(std::move(watch_dir_path)),

--- a/components/tor/tor_file_watcher.h
+++ b/components/tor/tor_file_watcher.h
@@ -35,7 +35,7 @@ class TorFileWatcher {
   using WatchCallback = base::OnceCallback<
       void(bool success, std::vector<uint8_t> cookie, int port)>;
 
-  explicit TorFileWatcher(const base::FilePath& watch_dir_path);
+  explicit TorFileWatcher(base::FilePath watch_dir_path);
 
   ~TorFileWatcher();
 


### PR DESCRIPTION
This check has detected a few places where the use of `std::move` has been completely misleading. In one of them we are potentially incurring in a bug, as we are moving a shared callback that is being used in a loop.

https://clang.llvm.org/extra/clang-tidy/checks/performance/move-const-arg.html

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42230

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

