### PR TITLE
DumpWithoutCrashing with additional crash keys for at TabGroupSyncDelegateDesktop::UpdateLocalTabGroup

### DIFF
--- a/chromium_src/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc
+++ b/chromium_src/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/debug/crash_logging.h"
+#include "base/debug/dump_without_crashing.h"
+
+#define BRAVE_UPDATE_LOCAL_TAB_GROUP_REPORT_AND_SUPPRESS_CRASH            \
+  if (i - tab_range.start() > group.saved_tabs().size()) {                \
+    SCOPED_CRASH_KEY_NUMBER("TgsDiag", "i_minus_tab_range_start",         \
+                            static_cast<int>(i - tab_range.start()));     \
+    SCOPED_CRASH_KEY_NUMBER("TgsDiag", "tab_range_length",                \
+                            static_cast<int>(tab_range.length()));        \
+    SCOPED_CRASH_KEY_NUMBER("TgsDiag", "group_saved_tabs_size",           \
+                            static_cast<int>(group.saved_tabs().size())); \
+    base::debug::DumpWithoutCrashing();                                   \
+    /* With the continue below the crash happens anyway later at*/        \
+    /* SavedTabGroupModelListener::ConnectToLocalTabGroup,*/              \
+    /* CHECK_EQ(local_group_size, tab_guid_mapping.size()). At least we*/ \
+    /* will have additional data assigned to crash*/                      \
+    continue;                                                             \
+  }
+
+#include "src/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc"
+
+#undef BRAVE_UPDATE_LOCAL_TAB_GROUP_REPORT_AND_SUPPRESS_CRASH

--- a/patches/chrome-browser-ui-tabs-saved_tab_groups-tab_group_sync_delegate_desktop.cc.patch
+++ b/patches/chrome-browser-ui-tabs-saved_tab_groups-tab_group_sync_delegate_desktop.cc.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc b/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc
+index fa6a22aa9f3a08cbe2766063e820ffdd3a8bcf75..8d6f17baa58fa2e5f585f934c7667e0fc22be439 100644
+--- a/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc
++++ b/chrome/browser/ui/tabs/saved_tab_groups/tab_group_sync_delegate_desktop.cc
+@@ -146,6 +146,7 @@ void TabGroupSyncDelegateDesktop::UpdateLocalTabGroup(
+     for (auto i = tab_range.start(); i < tab_range.end(); ++i) {
+       tabs::TabModel* tab = tab_strip_model->GetTabAtIndex(i);
+       CHECK(tab);
++      BRAVE_UPDATE_LOCAL_TAB_GROUP_REPORT_AND_SUPPRESS_CRASH
+       tab_guid_mapping.emplace(
+           tab, group.saved_tabs()[i - tab_range.start()].saved_tab_guid());
+     }


### PR DESCRIPTION
This PR adds `DumpWithoutCrashing` for the case before the crash described at https://github.com/brave/brave-browser/issues/41601 

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42239

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
N/A
