### PR TITLE
[1.74 uplift] Fix crash in AI Chat when conversation is unassociated from page content (#26495)

### DIFF
--- a/components/ai_chat/core/browser/associated_content_driver.cc
+++ b/components/ai_chat/core/browser/associated_content_driver.cc
@@ -74,7 +74,7 @@ void AssociatedContentDriver::AddRelatedConversation(
   associated_conversations_.insert(conversation);
 }
 
-void AssociatedContentDriver::OnRelatedConversationDestroyed(
+void AssociatedContentDriver::OnRelatedConversationDisassociated(
     ConversationHandler* conversation) {
   associated_conversations_.erase(conversation);
 }

--- a/components/ai_chat/core/browser/associated_content_driver.h
+++ b/components/ai_chat/core/browser/associated_content_driver.h
@@ -10,6 +10,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <vector>
 
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
@@ -48,7 +49,7 @@ class AssociatedContentDriver
 
   // ConversationHandler::AssociatedContentDelegate
   void AddRelatedConversation(ConversationHandler* conversation) override;
-  void OnRelatedConversationDestroyed(
+  void OnRelatedConversationDisassociated(
       ConversationHandler* conversation) override;
   int GetContentId() const override;
   GURL GetURL() const override;

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -67,7 +67,7 @@ class ConversationHandler : public mojom::ConversationHandler,
     AssociatedContentDelegate();
     virtual ~AssociatedContentDelegate();
     virtual void AddRelatedConversation(ConversationHandler* conversation) {}
-    virtual void OnRelatedConversationDestroyed(
+    virtual void OnRelatedConversationDisassociated(
         ConversationHandler* conversation) {}
     // Unique ID for the content. For browser Tab content, this should be
     // a navigation ID that's re-used during back navigations.
@@ -299,6 +299,12 @@ class ConversationHandler : public mojom::ConversationHandler,
   void PerformQuestionGeneration(std::string page_content,
                                  bool is_video,
                                  std::string invalidation_token);
+
+  // Disassociate with the current associated content. Use this instead of
+  // settings associated_content_delegegate_ to nullptr to ensure that we
+  // inform the delegate, otherwise when this class instance is destroyed,
+  // the delegate will not be informed.
+  void DisassociateContentDelegate();
 
   void OnGetStagedEntriesFromContent(
       const std::optional<std::vector<SearchQuerySummary>>& entries);


### PR DESCRIPTION
* AIChat ConversationHandler remove NOTREACHED_IN_MIGRATION
* ConversationHandler notifies AssociatedContentDelegate when conversation is not associated

Uplift of https://github.com/brave/brave-core/pull/26495
Resolves https://github.com/brave/brave-browser/issues/42091
Resolves https://github.com/brave/brave-browser/issues/42092
Resolves https://github.com/brave/brave-browser/issues/42089