### PR TITLE
Remove assistant entry of page content refine event when refining is done

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1198,6 +1198,15 @@ void ConversationHandler::OnGetRefinedPageContent(
     std::string page_content,
     bool is_video,
     base::expected<std::string, std::string> refined_page_content) {
+  // Remove tenative assistant entry dedicated for page content event
+  const auto& last_turn = chat_history_.back();
+  if (last_turn->events && !last_turn->events->empty() &&
+      last_turn->events->back()->is_page_content_refine_event()) {
+    chat_history_.pop_back();
+    OnHistoryUpdate();
+  } else {
+    VLOG(1) << "last entry should be page content refine event";
+  }
   std::string page_content_to_use = std::move(page_content);
   if (refined_page_content.has_value()) {
     page_content_to_use = std::move(refined_page_content.value());

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -1500,6 +1500,9 @@ TEST_P(PageContentRefineTest, TextEmbedder) {
     conversation_handler_->PerformAssistantGeneration(
         test_case.prompt, test_case.page_content, false, "");
 
+    testing::Mock::VerifyAndClearExpectations(mock_engine);
+    testing::Mock::VerifyAndClearExpectations(mock_text_embedder);
+
     if (test_case.should_refine_page_content && IsPageContentRefineEnabled()) {
       const auto& conversation_history =
           conversation_handler_->GetConversationHistory();
@@ -1508,6 +1511,15 @@ TEST_P(PageContentRefineTest, TextEmbedder) {
       EXPECT_TRUE(conversation_history.back()
                       ->events->back()
                       ->is_page_content_refine_event());
+
+      conversation_handler_->OnGetRefinedPageContent(
+          test_case.prompt, base::DoNothing(), base::DoNothing(),
+          test_case.page_content, false, base::ok("refined_page_content"));
+      EXPECT_FALSE(
+          base::ranges::any_of(conversation_history, [](const auto& turn) {
+            return !turn->events->empty() &&
+                   turn->events->back()->is_page_content_refine_event();
+          }));
     }
   }
 }

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -20,12 +20,8 @@ bool EngineConsumer::CanPerformCompletionRequest(
     return false;
   }
 
-  // Page refine event is fired between a human message and an assistant
-  // response.
   const auto& last_turn = conversation_history.back();
-  if (last_turn->character_type != mojom::CharacterType::HUMAN &&
-      (!last_turn->events->empty() &&
-       !last_turn->events->back()->is_page_content_refine_event())) {
+  if (last_turn->character_type != mojom::CharacterType::HUMAN) {
     return false;
   }
 

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -88,7 +88,7 @@ class EngineConsumer {
  protected:
   // Check if we should call GenerationCompletedCallback early based on the
   // conversation history. Ex. empty history, or if the last entry is not a
-  // human message except page refine event.
+  // human message.
   bool CanPerformCompletionRequest(
       const ConversationHistory& conversation_history) const;
   uint32_t max_associated_content_length_ = 0;

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
@@ -232,35 +232,6 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
           [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
   run_loop->Run();
   testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
-
-  // Test with page content refine event.
-  {
-    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-        mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-        std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-        std::nullopt, false);
-    entry->events->push_back(
-        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-            mojom::PageContentRefineEvent::New()));
-    history.push_back(std::move(entry));
-  }
-  run_loop = std::make_unique<base::RunLoop>();
-  EXPECT_CALL(*mock_remote_completion_client, QueryPrompt(_, _, _, _))
-      .WillOnce([](const std::string& prompt,
-                   const std::vector<std::string>& stop_words,
-                   EngineConsumer::GenerationCompletedCallback callback,
-                   EngineConsumer::GenerationDataCallback data_callback) {
-        std::move(callback).Run("");
-      });
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", GetHistoryWithModifiedReply(), "Who?", "",
-      base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
-  run_loop->Run();
-  testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
 }
 
 TEST_F(EngineConsumerClaudeUnitTest, GenerateAssistantResponseEarlyReturn) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -365,42 +365,6 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_ModifyReply) {
   testing::Mock::VerifyAndClearExpectations(mock_api_client);
 }
 
-TEST_F(EngineConsumerConversationAPIUnitTest,
-       GenerateEvents_PageContentRefine) {
-  auto* mock_api_client = GetMockConversationAPIClient();
-  base::RunLoop run_loop;
-  EXPECT_CALL(*mock_api_client, PerformRequest(_, _, _, _))
-      .WillOnce([&](const std::vector<ConversationEvent>& conversation,
-                    const std::string& selected_language,
-                    EngineConsumer::GenerationDataCallback data_callback,
-                    EngineConsumer::GenerationCompletedCallback callback) {
-        std::move(callback).Run("");
-      });
-
-  std::vector<mojom::ConversationTurnPtr> history;
-  mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New();
-  turn->character_type = mojom::CharacterType::HUMAN;
-  turn->text = "Which show is this about?";
-  history.push_back(std::move(turn));
-
-  mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-      mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-      mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-      std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-      std::nullopt, false);
-  entry->events->push_back(
-      mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-          mojom::PageContentRefineEvent::New()));
-  history.push_back(std::move(entry));
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", history, "Who?", "", base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
-  run_loop.Run();
-  testing::Mock::VerifyAndClearExpectations(mock_api_client);
-}
-
 TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_EarlyReturn) {
   EngineConsumer::ConversationHistory history;
   auto* mock_api_client = GetMockConversationAPIClient();

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
@@ -237,35 +237,6 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
           [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
   run_loop->Run();
   testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
-
-  // Test with page content refine event.
-  {
-    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-        mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-        std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-        std::nullopt, false);
-    entry->events->push_back(
-        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-            mojom::PageContentRefineEvent::New()));
-    history.push_back(std::move(entry));
-  }
-  run_loop = std::make_unique<base::RunLoop>();
-  EXPECT_CALL(*mock_remote_completion_client, QueryPrompt(_, _, _, _))
-      .WillOnce([](const std::string& prompt,
-                   const std::vector<std::string>& stop_words,
-                   EngineConsumer::GenerationCompletedCallback callback,
-                   EngineConsumer::GenerationDataCallback data_callback) {
-        std::move(callback).Run("");
-      });
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", GetHistoryWithModifiedReply(), "Who?", "",
-      base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
-  run_loop->Run();
-  testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
 }
 
 TEST_F(EngineConsumerLlamaUnitTest, GenerateAssistantResponseEarlyReturn) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
@@ -393,36 +393,6 @@ TEST_F(EngineConsumerOAIUnitTest,
           }));
   run_loop->Run();
   testing::Mock::VerifyAndClearExpectations(client);
-
-  // Test with page content refine event.
-  {
-    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-        mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-        std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-        std::nullopt, false);
-    entry->events->push_back(
-        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-            mojom::PageContentRefineEvent::New()));
-    history.push_back(std::move(entry));
-  }
-  run_loop = std::make_unique<base::RunLoop>();
-  EXPECT_CALL(*client, PerformRequest(_, _, _, _))
-      .WillOnce(
-          [](const mojom::CustomModelOptions, base::Value::List messages,
-             EngineConsumer::GenerationDataCallback,
-             EngineConsumer::GenerationCompletedCallback completed_callback) {
-            std::move(completed_callback)
-                .Run(EngineConsumer::GenerationResult(""));
-          });
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", GetHistoryWithModifiedReply(), "Who?", "",
-      base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
-  run_loop->Run();
-  testing::Mock::VerifyAndClearExpectations(client);
 }
 
 TEST_F(EngineConsumerOAIUnitTest, GenerateAssistantResponseEarlyReturn) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42251

The page content refine event is only used to display indicator while refining is in progress, it should not be sent to server because it doesn't expect last turn message to be assistant message.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
STR in the issue and also check we can still see indicator.
