### PR TITLE
feat(wallet): ZCash Shielded Account Deposit Modal

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1620,7 +1620,9 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION},
     {"braveWalletAccountShieldedDescription",
      IDS_BRAVE_WALLET_ACCOUNT_SHIELDED_DESCRIPTION},
-    {"braveWalletShielded", IDS_BRAVE_WALLET_SHIELDED}};
+    {"braveWalletShielded", IDS_BRAVE_WALLET_SHIELDED},
+    {"braveWalletUnified", IDS_BRAVE_WALLET_UNIFIED},
+    {"braveWalletTransparent", IDS_BRAVE_WALLET_TRANSPARENT}};
 
 // 0x swap constants
 inline constexpr char kZeroExBaseAPIURL[] = "https://api.0x.wallet.brave.com";

--- a/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/account-settings-modal.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/account-settings-modal/account-settings-modal.style.ts
@@ -5,16 +5,25 @@
 
 import styled from 'styled-components'
 import AlertReact from '@brave/leo/react/alert'
+import * as leo from '@brave/leo/tokens/css/variables'
+import LeoSegmentedControl, {
+  SegmentedControlProps
+} from '@brave/leo/react/segmentedControl'
 
+// Assets
 import ClipboardIcon from '../../../../assets/svg-icons/copy-to-clipboard-icon.svg'
-import { WalletButton } from '../../../shared/style'
+
+// Shared Styles
+import { WalletButton, Row } from '../../../shared/style'
+import {
+  layoutPanelWidth //
+} from '../../wallet-page-wrapper/wallet-page-wrapper.style'
 
 export const StyledWrapper = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 250px;
   padding: 20px 0px;
   height: 100%;
   min-height: 200px;
@@ -32,17 +41,16 @@ export const QRCodeWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 210px;
-  height: 210px;
-  border-radius: 8px;
-  border: 2px solid ${(p) => p.theme.color.disabled};
+  width: 185px;
+  height: 185px;
+  border-radius: 16px;
+  border: 2px solid ${leo.color.divider.subtle};
   margin-bottom: 16px;
 `
 
 export const QRCodeImage = styled.img`
-  width: 210px;
-  height: 210px;
-  border-radius: 8px;
+  width: 170px;
+  height: 170px;
 `
 
 export const AddressButton = styled(WalletButton)`
@@ -86,6 +94,7 @@ export const PrivateKeyWrapper = styled.div`
   justify-content: flex-start;
   width: 100%;
   height: 100%;
+  width: 250px;
 `
 
 export const PrivateKeyBubble = styled(WalletButton)`
@@ -138,34 +147,6 @@ export const Line = styled.div`
   background: ${(p) => p.theme.color.divider01};
 `
 
-export const AccountCircle = styled.div<{
-  orb: string
-}>`
-  width: 40px;
-  height: 40px;
-  border-radius: 100%;
-  background-image: url(${(p) => p.orb});
-  background-size: cover;
-  margin-right: 12px;
-`
-
-export const NameAndIcon = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: row;
-  margin-bottom: 20px;
-`
-
-export const AccountName = styled.span`
-  font-family: Poppins;
-  font-size: 13px;
-  line-height: 20px;
-  letter-spacing: 0.01em;
-  font-weight: 600;
-  color: ${(p) => p.theme.color.text01};
-`
-
 export const Alert = styled(AlertReact)`
   margin-bottom: 15px;
 
@@ -173,3 +154,12 @@ export const Alert = styled(AlertReact)`
     margin: 15px 0px;
   }
 `
+
+export const ControlsWrapper = styled(Row)`
+  margin-bottom: 24px;
+  --leo-segmented-control-width: 100%;
+`
+
+export const SegmentedControl = styled(LeoSegmentedControl).attrs({
+  size: window.innerWidth <= layoutPanelWidth ? 'small' : 'default'
+})<SegmentedControlProps>``

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -1104,3 +1104,9 @@ export const StorybookTransactionOptions: StorybookTransactionTypes[] = [
 export type StorybookTransactionArgs = {
   transactionType: StorybookTransactionTypes
 }
+
+export type zcashAddressTypes = 'unified' | 'shielded' | 'transparent'
+export type zcashAddressOptionType = {
+  addressType: zcashAddressTypes
+  label: string
+}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1530,5 +1530,7 @@ provideStrings({
     'Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.',
   braveWalletAccountShieldedDescription:
     'Upgrading to a shielded account means that these transactions hide the sender, receiver and amount details.',
-  braveWalletShielded: 'Shielded'
+  braveWalletShielded: 'Shielded',
+  braveWalletUnified: 'Unified',
+  braveWalletTransparent: 'Transparent'
 })

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1156,6 +1156,8 @@
   <message name="IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION" desc="ZCash account not shielded description.">Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_SHIELDED_DESCRIPTION" desc="ZCash account shielded description">Upgrading to a shielded account means that these transactions hide the sender, receiver and amount details.</message>
   <message name="IDS_BRAVE_WALLET_SHIELDED" desc="Shielded label">Shielded</message>
+  <message name="IDS_BRAVE_WALLET_UNIFIED" desc="Unified label">Unified</message>
+  <message name="IDS_BRAVE_WALLET_TRANSPARENT" desc="Transparent label">Transparent</message>
   <message name="IDS_BRAVE_WALLET_BUTTON_RETRY" desc="Retry an action">Retry</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_PREVIEW_FAILED" desc="Explaination that simulation of a transaction has failed">Transaction preview failed.</message>
   <message name="IDS_BRAVE_WALLET_ESTIMATED_BALANCE_CHANGE" desc="Grouping header for estimated balance changes">Estimated balance change</message>


### PR DESCRIPTION
## Description 

Adds a `Segmented Control` to the `Deposit` modal to allow switching between `Unified`, `Shielded` and `Transparent` addresses for `ZCash Shielded` accounts.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42221>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Make sure that ZCash Shielded Transactions` is enabled
2. Open the `Wallet` and navigate to the `Accounts` tab
3. Make sure one of you `ZCash` accounts is `shielded`
4. Open that `Accounts Details` and then open the `Deposit` modal
5. You should see the option to switch between `Unified`, `Shielded` and `Transparent` addresses.
6. Now test with an account that is not `shielded`, you should not see these additional options.

https://github.com/user-attachments/assets/31746951-c21e-462e-b87a-7018a7134b89
