### PR TITLE
Add SERP entry point to Leo metrics

### DIFF
--- a/components/ai_chat/core/browser/ai_chat_metrics.cc
+++ b/components/ai_chat/core/browser/ai_chat_metrics.cc
@@ -53,6 +53,7 @@ constexpr char kContextMenuEntryPointKey[] = "context_menu";
 constexpr char kToolbarButtonEntryPointKey[] = "toolbar_button";
 constexpr char kMenuItemEntryPointKey[] = "menu_item";
 constexpr char kOmniboxCommandEntryPointKey[] = "omnibox_command";
+constexpr char kBraveSearchEntryPointKey[] = "brave_search";
 
 constexpr auto kContextMenuActionKeys =
     base::MakeFixedFlatMap<ContextMenuAction, const char*>(
@@ -72,7 +73,8 @@ constexpr auto kEntryPointKeys =
          {EntryPoint::kContextMenu, kContextMenuEntryPointKey},
          {EntryPoint::kToolbarButton, kToolbarButtonEntryPointKey},
          {EntryPoint::kMenuItem, kMenuItemEntryPointKey},
-         {EntryPoint::kOmniboxCommand, kOmniboxCommandEntryPointKey}});
+         {EntryPoint::kOmniboxCommand, kOmniboxCommandEntryPointKey},
+         {EntryPoint::kBraveSearch, kBraveSearchEntryPointKey}});
 
 #endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
 
@@ -220,7 +222,7 @@ void AIChatMetrics::RecordReset() {
   UMA_HISTOGRAM_EXACT_LINEAR(kEnabledHistogramName,
                              std::numeric_limits<int>::max() - 1, 3);
   UMA_HISTOGRAM_EXACT_LINEAR(kAcquisitionSourceHistogramName,
-                             std::numeric_limits<int>::max() - 1, 6);
+                             std::numeric_limits<int>::max() - 1, 7);
 }
 
 void AIChatMetrics::OnPremiumStatusUpdated(bool is_new_user,

--- a/components/ai_chat/core/browser/ai_chat_metrics.h
+++ b/components/ai_chat/core/browser/ai_chat_metrics.h
@@ -70,7 +70,8 @@ enum class EntryPoint {
   kToolbarButton = 3,
   kMenuItem = 4,
   kOmniboxCommand = 5,
-  kMaxValue = kOmniboxCommand
+  kBraveSearch = 6,
+  kMaxValue = kBraveSearch
 };
 
 enum class ContextMenuAction {

--- a/components/ai_chat/core/browser/ai_chat_metrics_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_metrics_unittest.cc
@@ -346,11 +346,19 @@ TEST_F(AIChatMetricsUnitTest, MostUsedEntryPoint) {
       kMostUsedEntryPointHistogramName,
       static_cast<int>(EntryPoint::kToolbarButton), 1);
 
-  task_environment_.FastForwardBy(base::Days(7));
-  histogram_tester_.ExpectTotalCount(kMostUsedEntryPointHistogramName, 10);
+  for (size_t i = 0; i < 4; i++) {
+    ai_chat_metrics_->HandleOpenViaEntryPoint(EntryPoint::kBraveSearch);
+  }
+
+  histogram_tester_.ExpectBucketCount(
+      kMostUsedEntryPointHistogramName,
+      static_cast<int>(EntryPoint::kBraveSearch), 1);
 
   task_environment_.FastForwardBy(base::Days(7));
-  histogram_tester_.ExpectTotalCount(kMostUsedEntryPointHistogramName, 10);
+  histogram_tester_.ExpectTotalCount(kMostUsedEntryPointHistogramName, 14);
+
+  task_environment_.FastForwardBy(base::Days(7));
+  histogram_tester_.ExpectTotalCount(kMostUsedEntryPointHistogramName, 14);
 }
 
 #endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -426,6 +426,11 @@ void AIChatService::OpenConversationWithStagedEntries(
       associated_content->GetContentId(), associated_content);
   CHECK(conversation);
 
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+  if (ai_chat_metrics_ != nullptr) {
+    ai_chat_metrics_->HandleOpenViaEntryPoint(EntryPoint::kBraveSearch);
+  }
+#endif
   // Open AI Chat and trigger a fetch of staged conversations from Brave Search.
   std::move(open_ai_chat).Run();
   conversation->MaybeFetchOrClearContentStagedConversation();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42289

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Go to search.brave.com with experimental flags enabled.
2. Type a query and click `Answer with AI`
3. Type a follow-up question in search conversation mode UI
4. Once answer is generated, click "Open in Leo" at the upper-right corner.
5. Once Leo is open, ensure that the two metrics show the correct answer in local state.