### PR TITLE
Remove assistant entry of page content refine event when refining is done (uplift to 1.74.x)

### DIFF
--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1141,6 +1141,15 @@ void ConversationHandler::OnGetRefinedPageContent(
     std::string page_content,
     bool is_video,
     base::expected<std::string, std::string> refined_page_content) {
+  // Remove tenative assistant entry dedicated for page content event
+  const auto& last_turn = chat_history_.back();
+  if (last_turn->events && !last_turn->events->empty() &&
+      last_turn->events->back()->is_page_content_refine_event()) {
+    chat_history_.pop_back();
+    OnHistoryUpdate();
+  } else {
+    VLOG(1) << "last entry should be page content refine event";
+  }
   std::string page_content_to_use = std::move(page_content);
   if (refined_page_content.has_value()) {
     page_content_to_use = std::move(refined_page_content.value());

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -1475,6 +1475,9 @@ TEST_P(PageContentRefineTest, TextEmbedder) {
     conversation_handler_->PerformAssistantGeneration(
         test_case.prompt, test_case.page_content, false, "");
 
+    testing::Mock::VerifyAndClearExpectations(mock_engine);
+    testing::Mock::VerifyAndClearExpectations(mock_text_embedder);
+
     if (test_case.should_refine_page_content && IsPageContentRefineEnabled()) {
       const auto& conversation_history =
           conversation_handler_->GetConversationHistory();
@@ -1483,6 +1486,15 @@ TEST_P(PageContentRefineTest, TextEmbedder) {
       EXPECT_TRUE(conversation_history.back()
                       ->events->back()
                       ->is_page_content_refine_event());
+
+      conversation_handler_->OnGetRefinedPageContent(
+          test_case.prompt, base::DoNothing(), base::DoNothing(),
+          test_case.page_content, false, base::ok("refined_page_content"));
+      EXPECT_FALSE(
+          base::ranges::any_of(conversation_history, [](const auto& turn) {
+            return !turn->events->empty() &&
+                   turn->events->back()->is_page_content_refine_event();
+          }));
     }
   }
 }

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -20,12 +20,8 @@ bool EngineConsumer::CanPerformCompletionRequest(
     return false;
   }
 
-  // Page refine event is fired between a human message and an assistant
-  // response.
   const auto& last_turn = conversation_history.back();
-  if (last_turn->character_type != mojom::CharacterType::HUMAN &&
-      (!last_turn->events->empty() &&
-       !last_turn->events->back()->is_page_content_refine_event())) {
+  if (last_turn->character_type != mojom::CharacterType::HUMAN) {
     return false;
   }
 

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -88,7 +88,7 @@ class EngineConsumer {
  protected:
   // Check if we should call GenerationCompletedCallback early based on the
   // conversation history. Ex. empty history, or if the last entry is not a
-  // human message except page refine event.
+  // human message.
   bool CanPerformCompletionRequest(
       const ConversationHistory& conversation_history) const;
   uint32_t max_associated_content_length_ = 0;

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude_unittest.cc
@@ -232,35 +232,6 @@ TEST_F(EngineConsumerClaudeUnitTest, TestGenerateAssistantResponse) {
           [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
   run_loop->Run();
   testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
-
-  // Test with page content refine event.
-  {
-    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-        mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-        std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-        std::nullopt, false);
-    entry->events->push_back(
-        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-            mojom::PageContentRefineEvent::New()));
-    history.push_back(std::move(entry));
-  }
-  run_loop = std::make_unique<base::RunLoop>();
-  EXPECT_CALL(*mock_remote_completion_client, QueryPrompt(_, _, _, _))
-      .WillOnce([](const std::string& prompt,
-                   const std::vector<std::string>& stop_words,
-                   EngineConsumer::GenerationCompletedCallback callback,
-                   EngineConsumer::GenerationDataCallback data_callback) {
-        std::move(callback).Run("");
-      });
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", GetHistoryWithModifiedReply(), "Who?", "",
-      base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
-  run_loop->Run();
-  testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
 }
 
 TEST_F(EngineConsumerClaudeUnitTest, GenerateAssistantResponseEarlyReturn) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -365,42 +365,6 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_ModifyReply) {
   testing::Mock::VerifyAndClearExpectations(mock_api_client);
 }
 
-TEST_F(EngineConsumerConversationAPIUnitTest,
-       GenerateEvents_PageContentRefine) {
-  auto* mock_api_client = GetMockConversationAPIClient();
-  base::RunLoop run_loop;
-  EXPECT_CALL(*mock_api_client, PerformRequest(_, _, _, _))
-      .WillOnce([&](const std::vector<ConversationEvent>& conversation,
-                    const std::string& selected_language,
-                    EngineConsumer::GenerationDataCallback data_callback,
-                    EngineConsumer::GenerationCompletedCallback callback) {
-        std::move(callback).Run("");
-      });
-
-  std::vector<mojom::ConversationTurnPtr> history;
-  mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New();
-  turn->character_type = mojom::CharacterType::HUMAN;
-  turn->text = "Which show is this about?";
-  history.push_back(std::move(turn));
-
-  mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-      mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-      mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-      std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-      std::nullopt, false);
-  entry->events->push_back(
-      mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-          mojom::PageContentRefineEvent::New()));
-  history.push_back(std::move(entry));
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", history, "Who?", "", base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop.Quit(); }));
-  run_loop.Run();
-  testing::Mock::VerifyAndClearExpectations(mock_api_client);
-}
-
 TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_EarlyReturn) {
   EngineConsumer::ConversationHistory history;
   auto* mock_api_client = GetMockConversationAPIClient();

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama_unittest.cc
@@ -237,35 +237,6 @@ TEST_F(EngineConsumerLlamaUnitTest, TestGenerateAssistantResponse) {
           [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
   run_loop->Run();
   testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
-
-  // Test with page content refine event.
-  {
-    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-        mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-        std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-        std::nullopt, false);
-    entry->events->push_back(
-        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-            mojom::PageContentRefineEvent::New()));
-    history.push_back(std::move(entry));
-  }
-  run_loop = std::make_unique<base::RunLoop>();
-  EXPECT_CALL(*mock_remote_completion_client, QueryPrompt(_, _, _, _))
-      .WillOnce([](const std::string& prompt,
-                   const std::vector<std::string>& stop_words,
-                   EngineConsumer::GenerationCompletedCallback callback,
-                   EngineConsumer::GenerationDataCallback data_callback) {
-        std::move(callback).Run("");
-      });
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", GetHistoryWithModifiedReply(), "Who?", "",
-      base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
-  run_loop->Run();
-  testing::Mock::VerifyAndClearExpectations(mock_remote_completion_client);
 }
 
 TEST_F(EngineConsumerLlamaUnitTest, GenerateAssistantResponseEarlyReturn) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai_unittest.cc
@@ -393,36 +393,6 @@ TEST_F(EngineConsumerOAIUnitTest,
           }));
   run_loop->Run();
   testing::Mock::VerifyAndClearExpectations(client);
-
-  // Test with page content refine event.
-  {
-    mojom::ConversationTurnPtr entry = mojom::ConversationTurn::New(
-        mojom::CharacterType::ASSISTANT, mojom::ActionType::RESPONSE,
-        mojom::ConversationTurnVisibility::VISIBLE, "", std::nullopt,
-        std::vector<mojom::ConversationEntryEventPtr>{}, base::Time::Now(),
-        std::nullopt, false);
-    entry->events->push_back(
-        mojom::ConversationEntryEvent::NewPageContentRefineEvent(
-            mojom::PageContentRefineEvent::New()));
-    history.push_back(std::move(entry));
-  }
-  run_loop = std::make_unique<base::RunLoop>();
-  EXPECT_CALL(*client, PerformRequest(_, _, _, _))
-      .WillOnce(
-          [](const mojom::CustomModelOptions, base::Value::List messages,
-             EngineConsumer::GenerationDataCallback,
-             EngineConsumer::GenerationCompletedCallback completed_callback) {
-            std::move(completed_callback)
-                .Run(EngineConsumer::GenerationResult(""));
-          });
-
-  engine_->GenerateAssistantResponse(
-      false, "This is my page.", GetHistoryWithModifiedReply(), "Who?", "",
-      base::DoNothing(),
-      base::BindLambdaForTesting(
-          [&run_loop](EngineConsumer::GenerationResult) { run_loop->Quit(); }));
-  run_loop->Run();
-  testing::Mock::VerifyAndClearExpectations(client);
 }
 
 TEST_F(EngineConsumerOAIUnitTest, GenerateAssistantResponseEarlyReturn) {


### PR DESCRIPTION
Uplift of #26521
Resolves https://github.com/brave/brave-browser/issues/42251

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.