### PR TITLE
[CodeHealth] Use `//base` backend for number conversions

### DIFF
--- a/components/brave_wallet/common/string_utils.cc
+++ b/components/brave_wallet/common/string_utils.cc
@@ -10,80 +10,25 @@
 #include <string_view>
 
 #include "base/numerics/safe_math.h"
+#include "base/strings/string_number_conversions_internal.h"
 #include "base/strings/string_util.h"
 
 namespace brave_wallet {
 
-// Determines if the passed in base-10 string is valid
-bool IsValidBase10String(std::string_view input) {
-  if (input.empty()) {
-    return false;
-  }
-  auto check_input =
-      !input.empty() && input.front() == '-' ? input.substr(1) : input;
-  for (const auto& c : check_input) {
-    if (!base::IsAsciiDigit(c)) {
-      return false;
-    }
-  }
-  return true;
-}
-
 std::optional<uint256_t> Base10ValueToUint256(std::string_view input) {
-  if (!IsValidBase10String(input)) {
-    return std::nullopt;
-  }
-
-  base::CheckedNumeric<uint256_t> out = 0;
-  for (char c : input) {
-    out *= 10u;
-    out += static_cast<uint8_t>(base::HexDigitToInt(c));
-  }
-
-  if (!out.IsValid()) {
-    return std::nullopt;
-  }
-  return out.ValueOrDie();
+  uint256_t output;
+  return base::internal::StringToIntImpl(input, output) ? std::optional(output)
+                                                        : std::nullopt;
 }
 
 std::optional<int256_t> Base10ValueToInt256(std::string_view input) {
-  if (!IsValidBase10String(input)) {
-    return std::nullopt;
-  }
-
-  base::CheckedNumeric<int256_t> out = 0;
-  bool negative = (!input.empty() && input.front() == '-');
-  auto check_input = negative ? input.substr(1) : input;
-
-  for (char c : check_input) {
-    out *= 10;
-    if (negative) {
-      out -= base::HexDigitToInt(c);
-    } else {
-      out += base::HexDigitToInt(c);
-    }
-  }
-
-  if (!out.IsValid()) {
-    return std::nullopt;
-  }
-  return out.ValueOrDie();
+  int256_t output;
+  return base::internal::StringToIntImpl(input, output) ? std::optional(output)
+                                                        : std::nullopt;
 }
 
-std::string Uint256ValueToBase10(uint256_t input) {
-  if (input == 0) {
-    return "0";
-  }
-
-  std::string result;
-  result.reserve(78);  // 78 is the max length of a uint256_t in base 10
-
-  while (input > 0) {
-    result += '0' + static_cast<uint8_t>(input % 10);
-    input /= 10;
-  }
-  std::reverse(result.begin(), result.end());
-  return result;
+std::string Uint256ValueToBase10(uint256_t value) {
+  return base::internal::IntToStringT<std::string>(value);
 }
 
 }  // namespace brave_wallet

--- a/components/brave_wallet/common/string_utils.h
+++ b/components/brave_wallet/common/string_utils.h
@@ -15,9 +15,6 @@
 
 namespace brave_wallet {
 
-// Returns true if a string contains only 0-9 digits
-bool IsValidBase10String(std::string_view input);
-
 // Takes a base-10 string as input and converts it to a uint256_t
 std::optional<uint256_t> Base10ValueToUint256(std::string_view input);
 std::optional<int256_t> Base10ValueToInt256(std::string_view input);

--- a/components/brave_wallet/common/string_utils_unittest.cc
+++ b/components/brave_wallet/common/string_utils_unittest.cc
@@ -16,22 +16,6 @@ using ::testing::Optional;
 
 namespace brave_wallet {
 
-TEST(StringUtilsUnitTest, IsValidBase10String) {
-  ASSERT_TRUE(IsValidBase10String("0"));
-  ASSERT_TRUE(IsValidBase10String("1"));
-  ASSERT_TRUE(IsValidBase10String("-1"));
-  ASSERT_TRUE(IsValidBase10String("1234567891011121314"));
-  ASSERT_TRUE(IsValidBase10String("-1234567891011121314"));
-  // Can have 0's before
-  ASSERT_TRUE(IsValidBase10String("0123"));
-  ASSERT_TRUE(IsValidBase10String("-0123"));
-  ASSERT_FALSE(IsValidBase10String("0x0"));
-  ASSERT_FALSE(IsValidBase10String("123A"));
-  ASSERT_FALSE(IsValidBase10String(""));
-  ASSERT_FALSE(IsValidBase10String("hello world"));
-  ASSERT_FALSE(IsValidBase10String("12$$"));
-}
-
 TEST(StringUtilsUnitTest, Base10ValueToUint256) {
   EXPECT_THAT(Base10ValueToUint256("0"), Optional(uint256_t{0u}));
   EXPECT_THAT(Base10ValueToUint256("1"), Optional(uint256_t{1}));


### PR DESCRIPTION
Recently we managed to get a fix upstream to allow safe numerics with `int256_t` and similar types. This was done to correct some undefined behaviour on implemention doing back and forth convertion between 256-bit numbers and string. Nevertheless, as safe numerics can now be used with these large ints, it also allows us to just use the `//base` backend for things like base10 conversions.

This PR removes our own implementations for these conversions, and moves to use the chromium ones.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42300

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

