### PR TITLE
Refresh receipt for VPN + Public Receipt Viewer

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -601,6 +601,13 @@ extension Strings {
       value: "Subscription",
       comment: "The title for the header for subscription details"
     )
+    public static let advancedSettingsViewReceiptTitle = NSLocalizedString(
+      "aichat.advancedSettingsViewReceiptTitle",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "View AppStore Receipt",
+      comment: "The title for the button that allows the user to view the AppStore Receipt"
+    )
     public static let appStoreErrorTitle = NSLocalizedString(
       "aichat.appStoreErrorTitle",
       tableName: "BraveLeo",

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveStore
 import BraveUI
 import DesignSystem
 import Preferences
@@ -327,6 +328,16 @@ public struct AIChatAdvancedSettingsView: View {
               dismissButton: .default(Text(Strings.OKString))
             )
           }
+        }
+
+        // Check if there's an AppStore receipt and subscriptions have been loaded
+        if !viewModel.isSubscriptionStatusLoading && viewModel.inAppPurchaseSubscriptionState != nil
+        {
+          NavigationLink {
+            StoreKitReceiptSimpleView()
+          } label: {
+            LabelView(title: Strings.AIChat.advancedSettingsViewReceiptTitle)
+          }.listRowBackground(Color(.secondaryBraveGroupedBackground))
         }
       } header: {
         Text(Strings.AIChat.advancedSettingsSubscriptionHeaderTitle.uppercased())

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
@@ -94,7 +94,6 @@ class BraveSkusScriptHandler: TabContentScript {
     switch method {
     case .refreshOrder:
       let order = try OrderMessage.from(message: message)
-      // Serialize to jsonObject???
       return await skusManager.refreshOrder(for: order.orderId, domain: skusDomain)
 
     case .fetchOrderCredentials:

--- a/ios/brave-ios/Sources/BraveStore/Debug/StoreKitReceiptView.swift
+++ b/ios/brave-ios/Sources/BraveStore/Debug/StoreKitReceiptView.swift
@@ -63,7 +63,16 @@ public struct StoreKitReceiptView: View {
 
         NavigationLink(
           destination: {
-            groupedProductsView(for: receipt.inAppPurchaseReceipts)
+            let purchaseDate = Date.now
+            let expirationDate = Date.distantFuture
+
+            groupedProductsView(
+              for: receipt.inAppPurchaseReceipts.sorted(by: {
+                $0.purchaseDate ?? purchaseDate > $1.purchaseDate ?? purchaseDate
+                  || $0.subscriptionExpirationDate ?? expirationDate > $1.subscriptionExpirationDate
+                    ?? expirationDate
+              })
+            )
           },
           label: {
             Text("In-App Purchases")

--- a/ios/brave-ios/Sources/BraveStore/Views/StoreKitReceiptSimpleView.swift
+++ b/ios/brave-ios/Sources/BraveStore/Views/StoreKitReceiptSimpleView.swift
@@ -44,76 +44,58 @@ public struct StoreKitReceiptSimpleView: View {
   }
 
   public var body: some View {
-    if let receipt = receipt {
-      List {
-        StoreKitReceiptSimpleLineView(
-          title: Strings.ReceiptViewer.applicationVersionTitle,
-          value: receipt.appVersion
-        )
+    VStack {
+      if let receipt = receipt {
+        List {
+          StoreKitReceiptSimpleLineView(
+            title: Strings.ReceiptViewer.applicationVersionTitle,
+            value: receipt.appVersion
+          )
 
-        StoreKitReceiptSimpleLineView(
-          title: Strings.ReceiptViewer.receiptDateTitle,
-          value: formatDate(receipt.receiptCreationDate)
-        )
+          StoreKitReceiptSimpleLineView(
+            title: Strings.ReceiptViewer.receiptDateTitle,
+            value: formatDate(receipt.receiptCreationDate)
+          )
 
-        productsView(for: groupProducts(receipt: receipt))
-      }
-      .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
-      .navigationViewStyle(.stack)
-      .introspectNavigationController { controller in
-        controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
-      }
-      .toolbar {
-        if let base64EncodedReceipt {
-          ToolbarItem(placement: .navigationBarTrailing) {
-            ShareLink(item: base64EncodedReceipt) {
-              Label(Strings.ReceiptViewer.shareReceiptTitle, systemImage: "square.and.arrow.up")
-            }
-            .padding()
-          }
+          productsView(for: groupProducts(receipt: receipt))
         }
-      }
-    } else if loading {
-      ProgressView(Strings.ReceiptViewer.receiptViewerLoadingTitle)
-        .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
-        .navigationViewStyle(.stack)
-        .introspectNavigationController { controller in
-          controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
-        }
-        .task {
-          if let receipt = try? AppStoreReceipt.receipt {
-            self.base64EncodedReceipt = receipt
+      } else if loading {
+        ProgressView(Strings.ReceiptViewer.receiptViewerLoadingTitle)
+          .task {
+            if let receipt = try? AppStoreReceipt.receipt {
+              self.base64EncodedReceipt = receipt
 
-            if let data = Data(base64Encoded: receipt) {
-              self.receipt = BraveStoreKitReceipt(data: data)
-              loading = false
-            }
-          }
-        }
-    } else {
-      VStack {
-        Text(
-          base64EncodedReceipt == nil
-            ? Strings.ReceiptViewer.noReceiptFoundTitle
-            : Strings.ReceiptViewer.receiptLoadingErrorTitle
-        )
-        .fixedSize(horizontal: false, vertical: true)
-        .frame(maxWidth: .infinity)
-        .padding(30.0)
-        .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
-        .navigationViewStyle(.stack)
-        .introspectNavigationController { controller in
-          controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
-        }
-        .toolbar {
-          if let base64EncodedReceipt {
-            ToolbarItem(placement: .navigationBarTrailing) {
-              ShareLink(item: base64EncodedReceipt) {
-                Label(Strings.ReceiptViewer.shareReceiptTitle, systemImage: "square.and.arrow.up")
+              if let data = Data(base64Encoded: receipt) {
+                self.receipt = BraveStoreKitReceipt(data: data)
+                loading = false
               }
-              .padding()
             }
           }
+      } else {
+        VStack {
+          Text(
+            base64EncodedReceipt == nil
+              ? Strings.ReceiptViewer.noReceiptFoundTitle
+              : Strings.ReceiptViewer.receiptLoadingErrorTitle
+          )
+          .fixedSize(horizontal: false, vertical: true)
+          .frame(maxWidth: .infinity)
+          .padding(30.0)
+        }
+      }
+    }
+    .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
+    .navigationViewStyle(.stack)
+    .introspectNavigationController { controller in
+      controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
+    }
+    .toolbar {
+      if let base64EncodedReceipt {
+        ToolbarItem(placement: .navigationBarTrailing) {
+          ShareLink(item: base64EncodedReceipt) {
+            Label(Strings.ReceiptViewer.shareReceiptTitle, systemImage: "square.and.arrow.up")
+          }
+          .padding()
         }
       }
     }

--- a/ios/brave-ios/Sources/BraveStore/Views/StoreKitReceiptSimpleView.swift
+++ b/ios/brave-ios/Sources/BraveStore/Views/StoreKitReceiptSimpleView.swift
@@ -1,0 +1,237 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveStrings
+import Introspect
+import SwiftUI
+
+private struct StoreKitReceiptSimpleLineView: View {
+  var title: String
+  var value: String
+
+  var body: some View {
+    HStack {
+      Text("\(title):")
+        .font(.headline)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(alignment: .leading)
+        .padding(.trailing, 16.0)
+
+      Text(value)
+        .font(.callout)
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity, alignment: .trailing)
+    }
+    .padding()
+  }
+}
+
+public struct StoreKitReceiptSimpleView: View {
+  @State
+  private var loading: Bool = true
+
+  @State
+  private var base64EncodedReceipt: String?
+
+  @State
+  private var receipt: BraveStoreKitReceipt?
+
+  public init() {
+
+  }
+
+  public var body: some View {
+    if let receipt = receipt {
+      List {
+        StoreKitReceiptSimpleLineView(
+          title: Strings.ReceiptViewer.applicationVersionTitle,
+          value: receipt.appVersion
+        )
+
+        StoreKitReceiptSimpleLineView(
+          title: Strings.ReceiptViewer.receiptDateTitle,
+          value: formatDate(receipt.receiptCreationDate)
+        )
+
+        productsView(for: groupProducts(receipt: receipt))
+      }
+      .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
+      .navigationViewStyle(.stack)
+      .introspectNavigationController { controller in
+        controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
+      }
+      .toolbar {
+        if let base64EncodedReceipt {
+          ToolbarItem(placement: .navigationBarTrailing) {
+            ShareLink(item: base64EncodedReceipt) {
+              Label(Strings.ReceiptViewer.shareReceiptTitle, systemImage: "square.and.arrow.up")
+            }
+            .padding()
+          }
+        }
+      }
+    } else if loading {
+      ProgressView(Strings.ReceiptViewer.receiptViewerLoadingTitle)
+        .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
+        .navigationViewStyle(.stack)
+        .introspectNavigationController { controller in
+          controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
+        }
+        .task {
+          if let receipt = try? AppStoreReceipt.receipt {
+            self.base64EncodedReceipt = receipt
+
+            if let data = Data(base64Encoded: receipt) {
+              self.receipt = BraveStoreKitReceipt(data: data)
+              loading = false
+            }
+          }
+        }
+    } else {
+      VStack {
+        Text(
+          base64EncodedReceipt == nil
+            ? Strings.ReceiptViewer.noReceiptFoundTitle
+            : Strings.ReceiptViewer.receiptLoadingErrorTitle
+        )
+        .fixedSize(horizontal: false, vertical: true)
+        .frame(maxWidth: .infinity)
+        .padding(30.0)
+        .navigationTitle(Strings.ReceiptViewer.receiptViewerTitle)
+        .navigationViewStyle(.stack)
+        .introspectNavigationController { controller in
+          controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
+        }
+        .toolbar {
+          if let base64EncodedReceipt {
+            ToolbarItem(placement: .navigationBarTrailing) {
+              ShareLink(item: base64EncodedReceipt) {
+                Label(Strings.ReceiptViewer.shareReceiptTitle, systemImage: "square.and.arrow.up")
+              }
+              .padding()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private func groupProducts(receipt: BraveStoreKitReceipt) -> [Purchase] {
+    let purchaseDate = Date.now
+    let expirationDate = Date.distantFuture
+    let purchases = receipt.inAppPurchaseReceipts.sorted(by: {
+      $0.purchaseDate ?? purchaseDate > $1.purchaseDate ?? purchaseDate
+        || $0.subscriptionExpirationDate ?? expirationDate > $1.subscriptionExpirationDate
+          ?? expirationDate
+    })
+
+    return Dictionary(grouping: purchases, by: { $0.productId }).compactMap {
+      (key, purchases) -> Purchase? in
+      guard let latestPurchase = purchases.first else {
+        return nil
+      }
+      return Purchase(productId: key, purchase: latestPurchase)
+    }
+    .sorted(by: { $0.productId < $1.productId })
+  }
+
+  @ViewBuilder
+  private func productsView(for products: [Purchase]) -> some View {
+    ForEach(products) { product in
+      NavigationLink(
+        destination: {
+          List {
+            purchaseView(for: product.purchase)
+          }
+          .navigationTitle(productName(from: product.productId))
+          .introspectNavigationController { controller in
+            controller.navigationBar.topItem?.backButtonDisplayMode = .minimal
+          }
+        },
+        label: {
+          Text(productName(from: product.productId))
+            .font(.headline)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      )
+      .navigationBarTitleDisplayMode(.inline)
+      .buttonStyle(PlainButtonStyle())
+      .padding()
+    }
+  }
+
+  @ViewBuilder
+  private func purchaseView(for purchase: BraveStoreKitPurchase) -> some View {
+    VStack {
+      StoreKitReceiptSimpleLineView(
+        title: Strings.ReceiptViewer.receiptOrderIDTitle,
+        value: "\(purchase.webOrderLineItemId)"
+      )
+
+      StoreKitReceiptSimpleLineView(
+        title: Strings.ReceiptViewer.receiptTransactionIDTitle,
+        value: purchase.transactionId
+      )
+
+      StoreKitReceiptSimpleLineView(
+        title: Strings.ReceiptViewer.receiptOriginalPurchaseDateTitle,
+        value: formatDate(purchase.originalPurchaseDate)
+      )
+
+      StoreKitReceiptSimpleLineView(
+        title: Strings.ReceiptViewer.receiptPurchaseDate,
+        value: formatDate(purchase.purchaseDate)
+      )
+
+      StoreKitReceiptSimpleLineView(
+        title: Strings.ReceiptViewer.receiptExpirationDate,
+        value: formatDate(purchase.subscriptionExpirationDate)
+      )
+
+      if let cancellationDate = purchase.cancellationDate {
+        StoreKitReceiptSimpleLineView(
+          title: Strings.ReceiptViewer.receiptCancellationDate,
+          value: formatDate(cancellationDate)
+        )
+      }
+    }
+  }
+
+  private func productName(from bundleId: String) -> String {
+    switch bundleId {
+    case BraveStoreProduct.vpnMonthly.rawValue:
+      return Strings.ReceiptViewer.vpnMonthlySubscriptionName
+    case BraveStoreProduct.vpnYearly.rawValue:
+      return Strings.ReceiptViewer.vpnYearlySubscriptionName
+    case BraveStoreProduct.leoMonthly.rawValue:
+      return Strings.ReceiptViewer.leoMonthlySubscriptionName
+    case BraveStoreProduct.leoYearly.rawValue:
+      return Strings.ReceiptViewer.leoYearlySubscriptionName
+    default: return bundleId
+    }
+  }
+
+  private func formatDate(_ date: Date?) -> String {
+    guard let date = date else {
+      return Strings.ReceiptViewer.receiptInvalidDate
+    }
+
+    let formatter = DateFormatter()
+    formatter.dateStyle = .long
+    formatter.timeStyle = .long
+    return formatter.string(from: date)
+  }
+
+  private struct Purchase: Identifiable {
+    let productId: String
+    let purchase: BraveStoreKitPurchase
+
+    var id: String {
+      productId
+    }
+  }
+}

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -6132,6 +6132,156 @@ extension Strings {
   }
 }
 
+// MARK: - StoreKit Receipt Viewer
+
+extension Strings {
+  public struct ReceiptViewer {
+    public static let vpnMonthlySubscriptionName =
+      NSLocalizedString(
+        "storekitReceiptViewer.vpnMonthlySubscriptionName",
+        bundle: .module,
+        value: "Brave VPN Monthly",
+        comment: "The title of the product subscription the user purchased (Monthly subscription)"
+      )
+
+    public static let vpnYearlySubscriptionName =
+      NSLocalizedString(
+        "storekitReceiptViewer.vpnYearlySubscriptionName",
+        bundle: .module,
+        value: "Brave VPN Yearly",
+        comment: "The title of the product subscription the user purchased (Yearly subscription)"
+      )
+
+    public static let leoMonthlySubscriptionName =
+      NSLocalizedString(
+        "storekitReceiptViewer.leoMonthlySubscriptionName",
+        bundle: .module,
+        value: "Brave Leo Monthly",
+        comment: "The title of the product subscription the user purchased (Monthly subscription)"
+      )
+
+    public static let leoYearlySubscriptionName =
+      NSLocalizedString(
+        "storekitReceiptViewer.leoYearlySubscriptionName",
+        bundle: .module,
+        value: "Brave Leo Yearly",
+        comment: "The title of the product subscription the user purchased (Yearly subscription)"
+      )
+
+    public static let receiptViewerTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptViewerTitle",
+        bundle: .module,
+        value: "App Store Receipt",
+        comment: "The title of the screen that shows the App Store Receipt"
+      )
+
+    public static let noReceiptFoundTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.noReceiptFoundTitle",
+        bundle: .module,
+        value: "Sorry, no App Store receipts were found",
+        comment: "The error message when the App Store Receipt was not found in the Application Bundle"
+      )
+
+    public static let receiptLoadingErrorTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptLoadingErrorTitle",
+        bundle: .module,
+        value: "Sorry, the App Store receipt could not be loaded",
+        comment: "The error message when the App Store Receipt was found in the Application Bundle, but could not be loaded"
+      )
+
+    public static let applicationVersionTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.applicationVersionTitle",
+        bundle: .module,
+        value: "Application Version",
+        comment: "The title of the label that shows the Application Version"
+      )
+
+    public static let receiptDateTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptDateTitle",
+        bundle: .module,
+        value: "Receipt Date",
+        comment: "The title of the label that shows the date the receipt was created"
+      )
+
+    public static let receiptOrderIDTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptOrderIDTitle",
+        bundle: .module,
+        value: "Order ID",
+        comment: "The title of the label that shows the Order ID of the user's purchase"
+      )
+
+    public static let receiptTransactionIDTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptTransactionIDTitle",
+        bundle: .module,
+        value: "Transaction ID",
+        comment: "The title of the label that shows the Transaction ID of the user's purchase"
+      )
+
+    public static let receiptOriginalPurchaseDateTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptOriginalPurchaseDateTitle",
+        bundle: .module,
+        value: "Original Purchase Date",
+        comment: "The title of the label that shows the date when the product subscription was first purchased"
+      )
+
+    public static let receiptPurchaseDate =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptPurchaseDate",
+        bundle: .module,
+        value: "Purchase Date",
+        comment: "The title of the label that shows the date when the product subscription was recently purchased or renewed"
+      )
+
+    public static let receiptExpirationDate =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptExpirationDate",
+        bundle: .module,
+        value: "Expiration Date",
+        comment: "The title of the label that shows the date when the product subscription expired"
+      )
+
+    public static let receiptCancellationDate =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptCancellationDate",
+        bundle: .module,
+        value: "Cancellation Date",
+        comment: "The title of the label that shows the date when the product subscription was cancelled"
+      )
+
+    public static let receiptInvalidDate =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptInvalidDate",
+        bundle: .module,
+        value: "N/A",
+        comment: "The title of the label that shows any invalid date - Not Available or N/A for short is displayed"
+      )
+
+    public static let receiptViewerLoadingTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.receiptViewerLoadingTitle",
+        bundle: .module,
+        value: "Loading Please Wait...",
+        comment: "The title of the label that shows when the Receipt Viewer is still loading resources and subscription information"
+      )
+
+    public static let shareReceiptTitle =
+      NSLocalizedString(
+        "storekitReceiptViewer.shareReceiptTitle",
+        bundle: .module,
+        value: "Share Receipt",
+        comment: "The title of the button that shows a system action sheet, to share the receipt"
+      )
+  }
+}
+
 // MARK: - Shortcuts
 
 extension Strings {

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveShared
+import BraveStore
 import BraveUI
 import GuardianConnect
 import Preferences
@@ -113,6 +114,17 @@ public class BraveVPNSettingsViewController: TableViewController {
         ),
       ]
     }
+
+    rows.append(
+      Row(
+        text: Strings.VPN.settingsViewReceipt,
+        selection: { [unowned self] in
+          let controller = UIHostingController(rootView: StoreKitReceiptSimpleView())
+          self.navigationController?.pushViewController(controller, animated: true)
+        },
+        cellClass: ButtonCell.self
+      )
+    )
 
     return rows
   }

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -80,6 +80,9 @@ public class BraveVPNSettingsViewController: TableViewController {
       Row(
         text: Strings.VPN.settingsLinkReceipt,
         selection: { [unowned self] in
+          Task {
+            try await BraveVPNInAppPurchaseObserver.refreshReceipt()
+          }
           openURL?(.brave.braveVPNLinkReceiptProd)
         },
         cellClass: ButtonCell.self
@@ -91,6 +94,9 @@ public class BraveVPNSettingsViewController: TableViewController {
         Row(
           text: "[Staging] Link Receipt",
           selection: { [unowned self] in
+            Task {
+              try await BraveVPNInAppPurchaseObserver.refreshReceipt()
+            }
             openURL?(.brave.braveVPNLinkReceiptStaging)
           },
           cellClass: ButtonCell.self
@@ -98,6 +104,9 @@ public class BraveVPNSettingsViewController: TableViewController {
         Row(
           text: "[Dev] Link Receipt",
           selection: { [unowned self] in
+            Task {
+              try await BraveVPNInAppPurchaseObserver.refreshReceipt()
+            }
             openURL?(.brave.braveVPNLinkReceiptDev)
           },
           cellClass: ButtonCell.self

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -240,6 +240,14 @@ extension Strings {
         comment: "Footer text to link your VPN receipt to other devices."
       )
 
+    public static let settingsViewReceipt =
+      NSLocalizedString(
+        "vpn.settingsViewReceipt",
+        bundle: .module,
+        value: "View AppStore Receipt",
+        comment: "Button to allow the user to view the app-store receipt."
+      )
+
     public static let settingsServerHost =
       NSLocalizedString(
         "vpn.settingsServerHost",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42302

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

![IMG_9086](https://github.com/user-attachments/assets/11d91da3-1d18-47e4-a71d-25bd9954d3e8)
![IMG_9087](https://github.com/user-attachments/assets/70e2bdd6-0afa-4059-bf60-ecfd141d365d)
![IMG_9088](https://github.com/user-attachments/assets/af392a40-cd30-4739-94a5-3c41581504f2)
