### PR TITLE
[cr133] Remove all `NOTREACHED_IN_MIGRATION` remaining

### DIFF
--- a/brave_domains/service_domains.cc
+++ b/brave_domains/service_domains.cc
@@ -75,8 +75,7 @@ std::string ConvertEnvironmentToString(brave_domains::ServicesEnvironment env) {
     return it->second;
   }
 
-  NOTREACHED_IN_MIGRATION();
-  return kBraveServicesSwitchValueProduction;
+  NOTREACHED();
 }
 #endif
 

--- a/browser/brave_shields/brave_shields_tab_helper.cc
+++ b/browser/brave_shields/brave_shields_tab_helper.cc
@@ -10,6 +10,7 @@
 
 #include "base/metrics/histogram_macros.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/types/cxx23_to_underlying.h"
 #include "brave/browser/brave_shields/brave_shields_web_contents_observer.h"
 #include "brave/components/brave_shields/content/browser/brave_shields_util.h"
 #include "brave/components/brave_shields/core/common/brave_shield_constants.h"
@@ -260,8 +261,8 @@ CookieBlockMode BraveShieldsTabHelper::GetCookieBlockMode() {
     case ControlType::DEFAULT:
       break;
   }
-  NOTREACHED_IN_MIGRATION();
-  return CookieBlockMode::BLOCKED;
+  NOTREACHED() << "Unexpected value for control_type: "
+               << base::to_underlying(control_type);
 }
 
 HttpsUpgradeMode BraveShieldsTabHelper::GetHttpsUpgradeMode() {

--- a/browser/content_settings/brave_content_settings_browsertest.cc
+++ b/browser/content_settings/brave_content_settings_browsertest.cc
@@ -115,8 +115,7 @@ IN_PROC_BROWSER_TEST_F(BraveContentSettingsBrowserTest,
     if (!unchecked_inherit_in_incognito) {
       switch (info->incognito_behavior()) {
         case content_settings::ContentSettingsInfo::INHERIT_IN_INCOGNITO:
-          NOTREACHED_IN_MIGRATION();
-          break;
+          NOTREACHED();
         case content_settings::ContentSettingsInfo::INHERIT_IF_LESS_PERMISSIVE:
           EXPECT_NE(info->GetInitialDefaultSetting(), CONTENT_SETTING_ALLOW)
               << "INHERIT_IF_LESS_PERMISSIVE setting should not default to "

--- a/browser/farbling/brave_navigator_usb_farbling_browsertest.cc
+++ b/browser/farbling/brave_navigator_usb_farbling_browsertest.cc
@@ -80,15 +80,11 @@ class FakeChooserView : public permissions::ChooserController::View {
     delete this;
   }
 
-  void OnOptionAdded(size_t index) override { NOTREACHED_IN_MIGRATION(); }
-  void OnOptionRemoved(size_t index) override { NOTREACHED_IN_MIGRATION(); }
-  void OnOptionUpdated(size_t index) override { NOTREACHED_IN_MIGRATION(); }
-  void OnAdapterEnabledChanged(bool enabled) override {
-    NOTREACHED_IN_MIGRATION();
-  }
-  void OnRefreshStateChanged(bool refreshing) override {
-    NOTREACHED_IN_MIGRATION();
-  }
+  void OnOptionAdded(size_t index) override { NOTREACHED(); }
+  void OnOptionRemoved(size_t index) override { NOTREACHED(); }
+  void OnOptionUpdated(size_t index) override { NOTREACHED(); }
+  void OnAdapterEnabledChanged(bool enabled) override { NOTREACHED(); }
+  void OnRefreshStateChanged(bool refreshing) override { NOTREACHED(); }
 
  private:
   std::unique_ptr<permissions::ChooserController> controller_;

--- a/browser/metrics/metrics_reporting_util.cc
+++ b/browser/metrics/metrics_reporting_util.cc
@@ -7,6 +7,7 @@
 
 #include "base/logging.h"
 #include "base/notreached.h"
+#include "base/types/cxx23_to_underlying.h"
 #include "brave/browser/metrics/brave_metrics_service_accessor.h"
 #include "brave/browser/metrics/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
@@ -17,7 +18,8 @@
 #include "components/version_info/channel.h"
 
 bool GetDefaultPrefValueForMetricsReporting() {
-  switch (chrome::GetChannel()) {
+  auto channel = chrome::GetChannel();
+  switch (channel) {
     case version_info::Channel::STABLE:
       return false;
     case version_info::Channel::BETA:    // fall through
@@ -26,10 +28,9 @@ bool GetDefaultPrefValueForMetricsReporting() {
       return true;
     case version_info::Channel::UNKNOWN:
       return false;
-    default:
-      NOTREACHED_IN_MIGRATION();
-      return false;
   }
+  NOTREACHED() << "Unexpected value for channel: "
+               << base::to_underlying(channel);
 }
 
 bool ShouldShowCrashReportPermissionAskDialog() {

--- a/browser/net/brave_ad_block_tp_network_delegate_helper.cc
+++ b/browser/net/brave_ad_block_tp_network_delegate_helper.cc
@@ -158,12 +158,12 @@ class AdblockCnameResolveHostClient : public network::mojom::ResolveHostClient {
 
   // Should not be called
   void OnTextResults(const std::vector<std::string>& text_results) override {
-    NOTREACHED_IN_MIGRATION();
+    NOTREACHED();
   }
 
   // Should not be called
   void OnHostnameResults(const std::vector<net::HostPortPair>& hosts) override {
-    NOTREACHED_IN_MIGRATION();
+    NOTREACHED();
   }
 };
 

--- a/browser/net/brave_proxying_url_loader_factory.cc
+++ b/browser/net/brave_proxying_url_loader_factory.cc
@@ -467,12 +467,9 @@ void BraveProxyingURLLoaderFactory::InProgressRequest::ContinueToSendHeaders(
     for (auto& set_header : set_headers) {
       std::optional<std::string> header_value =
           request_.headers.GetHeader(set_header);
-      if (header_value) {
-        pending_follow_redirect_params_->modified_headers.SetHeader(
-            set_header, *header_value);
-      } else {
-        NOTREACHED_IN_MIGRATION();
-      }
+      CHECK(header_value);
+      pending_follow_redirect_params_->modified_headers.SetHeader(
+          set_header, *header_value);
     }
 
     if (target_loader_.is_bound()) {

--- a/browser/net/brave_reduce_language_network_delegate_helper.cc
+++ b/browser/net/brave_reduce_language_network_delegate_helper.cc
@@ -132,7 +132,7 @@ int OnBeforeStartTransaction_ReduceLanguageWork(
     default:
       // Other cases are handled within ShouldDoReduceLanguage, so we should
       // never reach here.
-      NOTREACHED_IN_MIGRATION();
+      NOTREACHED();
   }
 
   headers->SetHeader(net::HttpRequestHeaders::kAcceptLanguage,

--- a/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.cc
+++ b/browser/ui/webui/webcompat_reporter/webcompat_reporter_dialog.cc
@@ -75,8 +75,7 @@ WebcompatReporterDialogDelegate::~WebcompatReporterDialogDelegate() = default;
 ui::mojom::ModalType WebcompatReporterDialogDelegate::GetDialogModalType()
     const {
   // Not used, returning dummy value.
-  NOTREACHED_IN_MIGRATION();
-  return ui::mojom::ModalType::kWindow;
+  NOTREACHED();
 }
 
 std::u16string WebcompatReporterDialogDelegate::GetDialogTitle() const {

--- a/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
+++ b/chromium_src/third_party/blink/renderer/core/execution_context/navigator_base.cc
@@ -47,7 +47,7 @@ void ApplyBraveHardwareConcurrencyOverride(blink::ExecutionContext* context,
       break;
     }
     default:
-      NOTREACHED_IN_MIGRATION();
+      NOTREACHED();
   }
   *hardware_concurrency = farbled_value;
 }

--- a/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
+++ b/chromium_src/third_party/blink/renderer/modules/canvas/canvas2d/base_rendering_context_2d.cc
@@ -66,8 +66,7 @@ ImageData* BaseRenderingContext2D::getImageData(
     int sw,
     int sh,
     ExceptionState& exception_state) {
-  NOTREACHED_IN_MIGRATION();
-  return nullptr;
+  NOTREACHED();
 }
 
 ImageData* BaseRenderingContext2D::getImageData(
@@ -77,8 +76,7 @@ ImageData* BaseRenderingContext2D::getImageData(
     int sh,
     ImageDataSettings* image_data_settings,
     ExceptionState& exception_state) {
-  NOTREACHED_IN_MIGRATION();
-  return nullptr;
+  NOTREACHED();
 }
 
 ImageData* BaseRenderingContext2D::getImageDataInternal(
@@ -88,8 +86,7 @@ ImageData* BaseRenderingContext2D::getImageDataInternal(
     int sh,
     ImageDataSettings* image_data_settings,
     ExceptionState& exception_state) {
-  NOTREACHED_IN_MIGRATION();
-  return nullptr;
+  NOTREACHED();
 }
 
 ImageData* BaseRenderingContext2D::getImageDataInternal_Unused(
@@ -99,8 +96,7 @@ ImageData* BaseRenderingContext2D::getImageDataInternal_Unused(
     int sh,
     ImageDataSettings* image_data_settings,
     ExceptionState& exception_state) {
-  NOTREACHED_IN_MIGRATION();
-  return nullptr;
+  NOTREACHED();
 }
 
 ImageData* BaseRenderingContext2D::getImageData(

--- a/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
+++ b/chromium_src/third_party/blink/renderer/modules/plugins/dom_plugin_array.cc
@@ -6,6 +6,7 @@
 #include "third_party/blink/renderer/modules/plugins/dom_plugin_array.h"
 
 #include "base/compiler_specific.h"
+#include "base/types/cxx23_to_underlying.h"
 #include "brave/third_party/blink/renderer/core/farbling/brave_session_cache.h"
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/core/frame/local_frame.h"
@@ -54,11 +55,12 @@ void FarblePlugins(DOMPluginArray* owner,
                    HeapVector<Member<DOMPlugin>>* dom_plugins) {
   // |owner| is guaranteed to be non-null here.
   // |owner->DomWindow()| might be null but function can handle it.
-  switch (brave::GetBraveFarblingLevelFor(
+  auto farbling_level = brave::GetBraveFarblingLevelFor(
       owner->DomWindow(), ContentSettingsType::BRAVE_WEBCOMPAT_PLUGINS,
-      BraveFarblingLevel::OFF)) {
+      BraveFarblingLevel::OFF);
+  switch (farbling_level) {
     case BraveFarblingLevel::OFF: {
-      break;
+      return;
     }
     case BraveFarblingLevel::MAXIMUM: {
       dom_plugins->clear();
@@ -136,11 +138,11 @@ void FarblePlugins(DOMPluginArray* owner,
       dom_plugins->push_back(fake_dom_plugin_2);
       // Shuffle the list of plugins pseudo-randomly, based on the domain key.
       std::shuffle(dom_plugins->begin(), dom_plugins->end(), prng);
-      break;
+      return;
     }
-    default:
-      NOTREACHED_IN_MIGRATION();
   }
+  NOTREACHED() << "Unexpected value for farbling_level: "
+               << base::to_underlying(farbling_level);
 }
 
 }  // namespace brave

--- a/components/assist_ranker/ranker_model_loader_impl_unittest.cc
+++ b/components/assist_ranker/ranker_model_loader_impl_unittest.cc
@@ -135,13 +135,12 @@ void RankerModelLoaderImplTest::InitModel(const GURL& model_url,
 
 RankerModelStatus RankerModelLoaderImplTest::ValidateModel(
     const RankerModel& model) {
-  NOTREACHED_IN_MIGRATION();
-  return RankerModelStatus::OK;
+  NOTREACHED();
 }
 
 void RankerModelLoaderImplTest::OnModelAvailable(
     std::unique_ptr<RankerModel> model) {
-  NOTREACHED_IN_MIGRATION();
+  NOTREACHED();
 }
 
 }  // namespace

--- a/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
+++ b/components/brave_shields/core/browser/ad_block_filters_provider_manager.cc
@@ -70,7 +70,7 @@ void AdBlockFiltersProviderManager::OnChanged(bool is_for_default_engine) {
 void AdBlockFiltersProviderManager::LoadFilterSet(
     base::OnceCallback<
         void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)>) {
-  NOTREACHED_IN_MIGRATION();
+  NOTREACHED();
 }
 
 void AdBlockFiltersProviderManager::LoadFilterSetForEngine(

--- a/components/brave_wallet/common/eth_abi_utils.cc
+++ b/components/brave_wallet/common/eth_abi_utils.cc
@@ -360,11 +360,7 @@ std::optional<std::vector<uint8_t>> ExtractBytesFromTuple(Span data,
 
 std::optional<std::vector<uint8_t>>
 ExtractFixedBytesFromTuple(Span data, size_t fixed_size, size_t tuple_pos) {
-  if (fixed_size == 0 || fixed_size > 32) {
-    NOTREACHED_IN_MIGRATION();
-    return std::nullopt;
-  }
-
+  CHECK(fixed_size > 0 && fixed_size <= 32);
   // Head contains bytes itself.
   auto head = ExtractHeadFromTuple(data, tuple_pos);
   if (!head) {

--- a/components/request_otr/browser/request_otr_blocking_page.cc
+++ b/components/request_otr/browser/request_otr_blocking_page.cc
@@ -66,20 +66,19 @@ void RequestOTRBlockingPage::CommandReceived(const std::string& command) {
     case security_interstitials::CMD_DONT_PROCEED:
       p3a::RecordInterstitialEnd(profile_prefs_, start_time_);
       request_otr_controller->Proceed();
-      break;
+      return;
     case security_interstitials::CMD_PROCEED:
       p3a::RecordInterstitialEnd(profile_prefs_, start_time_);
       request_otr_controller->ProceedOTR();
-      break;
+      return;
     case security_interstitials::CMD_DO_REPORT:
       request_otr_controller->SetDontWarnAgain(true);
-      break;
+      return;
     case security_interstitials::CMD_DONT_REPORT:
       request_otr_controller->SetDontWarnAgain(false);
-      break;
-    default:
-      NOTREACHED_IN_MIGRATION() << "Unsupported command: " << command;
+      return;
   }
+  NOTREACHED() << "Unsupported command: " << command;
 }
 
 void RequestOTRBlockingPage::PopulateInterstitialStrings(

--- a/components/sidebar/browser/sidebar_service.cc
+++ b/components/sidebar/browser/sidebar_service.cc
@@ -68,8 +68,7 @@ SidebarItem::BuiltInItemType GetBuiltInItemTypeForLegacyURL(
     return SidebarItem::BuiltInItemType::kHistory;
   }
 
-  NOTREACHED_IN_MIGRATION() << url;
-  return SidebarItem::BuiltInItemType::kNone;
+  NOTREACHED() << url;
 }
 
 }  // namespace
@@ -665,12 +664,10 @@ SidebarItem SidebarService::GetBuiltInItemForType(
         return SidebarItem();
       }
     }
-    case SidebarItem::BuiltInItemType::kNone: {
-      NOTREACHED_IN_MIGRATION();
+    case SidebarItem::BuiltInItemType::kNone:
       break;
-    }
   }
-  return SidebarItem();
+  NOTREACHED();
 }
 
 void SidebarService::OnPreferenceChanged(const std::string& pref_name) {

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -383,7 +383,7 @@ bool BraveSessionCache::AllowFontFamily(
   }
   switch (farbling_level_) {
     case BraveFarblingLevel::OFF:
-      break;
+      return true;
     case BraveFarblingLevel::BALANCED:
     case BraveFarblingLevel::MAXIMUM: {
       if (AllowFontByFamilyName(family_name,
@@ -397,10 +397,8 @@ bool BraveSessionCache::AllowFontFamily(
         return false;
       }
     }
-    default:
-      NOTREACHED_IN_MIGRATION();
   }
-  return true;
+  NOTREACHED();
 }
 
 FarblingPRNG BraveSessionCache::MakePseudoRandomGenerator(FarbleKey key) {


### PR DESCRIPTION
`NOTREACHED_IN_MIGRATION` has now been deleted from chromium in M133. This was expected, and the existing occurrances have to be migrated to `NOTRECHEAD`. At this point, the only difference between `NOTREACHED`, and `NOTREACHED_IN_MIGRATION`, is that `NOTREACHED` is tagged as no return.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/e238462dc67196d361ee0bbaf1954969619cab27

```
commit e238462dc67196d361ee0bbaf1954969619cab27
Author: Peter Boström <pbos@chromium.org>
Date:   Fri Nov 15 00:46:51 2024 +0000

    Remove NOTREACHED_IN_MIGRATION()

    Bug: 40580068
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42330

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

