### PR TITLE
[Android] Fixed missing site settings permissions entries on Android (uplift to 1.73.x)

### DIFF
--- a/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BraveSingleWebsiteSettings.java
+++ b/components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/BraveSingleWebsiteSettings.java
@@ -25,6 +25,10 @@ public class BraveSingleWebsiteSettings extends BaseSiteSettingsFragment {
         switch (type) {
             case ContentSettingsType.AUTOPLAY:
                 return "autoplay_permission_list";
+            case ContentSettingsType.BRAVE_GOOGLE_SIGN_IN:
+                return "brave_google_sign_in";
+            case ContentSettingsType.BRAVE_LOCALHOST_ACCESS:
+                return "brave_localhost_access";
             default:
                 return (String)
                         BraveReflectionUtil.invokeMethod(


### PR DESCRIPTION
Uplift of #26581
Resolves https://github.com/brave/brave-browser/issues/42313

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.