### PR TITLE
[Android] Fix warning from pack symbols of android_clang_* dir

### DIFF
--- a/app/android/BUILD.gn
+++ b/app/android/BUILD.gn
@@ -46,7 +46,10 @@ action("create_symbol_archive") {
   shell_script = "//brave/build/android/pack_symbols.sh"
 
   deps = [ "//brave/build/android:brave" ]
-  archive_name = "$root_out_dir/dist/Default$target_cpu$target_android_base.tar"
+
+  archive_dir_path = "$root_out_dir/dist"
+  archive_file_name = "Default$target_cpu$target_android_base.tar"
+  archive_file_path = "$archive_dir_path/$archive_file_name"
 
   inputs = [
     script,
@@ -54,10 +57,10 @@ action("create_symbol_archive") {
     brave_android_output,
   ]
 
-  outputs = [ archive_name ]
-
+  outputs = [ archive_file_path ]
   args = [
     rebase_path(shell_script, root_build_dir),
-    rebase_path(archive_name, root_out_dir),
+    rebase_path(archive_dir_path, root_out_dir),
+    rebase_path(archive_file_path, root_out_dir),
   ]
 }

--- a/build/android/pack_symbols.sh
+++ b/build/android/pack_symbols.sh
@@ -12,5 +12,3 @@ mkdir -p "$1"
 shopt -s nullglob
 
 tar -czvf "$2" ./*.so apks android_clang_*/*.so android_clang_*/lib.unstripped lib.unstripped android_chrome_versions.txt
-
-shopt -u nullglob

--- a/build/android/pack_symbols.sh
+++ b/build/android/pack_symbols.sh
@@ -7,8 +7,8 @@
 
 set -euo pipefail
 
-mkdir -p "$1"
+mkdir -p "${1:?}"
 
 shopt -s nullglob
 
-tar -czvf "$2" ./*.so apks android_clang_*/*.so android_clang_*/lib.unstripped lib.unstripped android_chrome_versions.txt
+tar -czvf "${2:?}" ./*.so apks android_clang_*/*.so android_clang_*/lib.unstripped lib.unstripped android_chrome_versions.txt

--- a/build/android/pack_symbols.sh
+++ b/build/android/pack_symbols.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
 set -euo pipefail
 
 mkdir -p dist
-tar -czvf $1 --ignore-failed-read *.so apks android_clang_*/*.so android_clang_*/lib.unstripped lib.unstripped android_chrome_versions.txt
+
+objects_to_compress="*.so apks lib.unstripped android_chrome_versions.txt"
+
+if ls android_clang_*/*.so 1> /dev/null 2>&1; then
+    objects_to_compress="${objects_to_compress} android_clang_*/*.so"
+fi
+
+if ls android_clang_*/lib.unstripped 1> /dev/null 2>&1; then
+    objects_to_compress="${objects_to_compress} android_clang_*/lib.unstripped"
+fi
+
+tar -czvf $1 --ignore-failed-read ${objects_to_compress}

--- a/build/android/pack_symbols.sh
+++ b/build/android/pack_symbols.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-mkdir -p dist
+mkdir -p $1
 
 objects_to_compress="*.so apks lib.unstripped android_chrome_versions.txt"
 
@@ -19,4 +19,4 @@ if ls android_clang_*/lib.unstripped 1> /dev/null 2>&1; then
     objects_to_compress="${objects_to_compress} android_clang_*/lib.unstripped"
 fi
 
-tar -czvf $1 --ignore-failed-read ${objects_to_compress}
+tar -czvf $2 --ignore-failed-read ${objects_to_compress}

--- a/build/android/pack_symbols.sh
+++ b/build/android/pack_symbols.sh
@@ -9,14 +9,8 @@ set -euo pipefail
 
 mkdir -p "$1"
 
-objects_to_compress="*.so apks lib.unstripped android_chrome_versions.txt"
+shopt -s nullglob
 
-if ls android_clang_*/*.so 1> /dev/null 2>&1; then
-    objects_to_compress="${objects_to_compress} android_clang_*/*.so"
-fi
+tar -czvf "$2" ./*.so apks android_clang_*/*.so android_clang_*/lib.unstripped lib.unstripped android_chrome_versions.txt
 
-if ls android_clang_*/lib.unstripped 1> /dev/null 2>&1; then
-    objects_to_compress="${objects_to_compress} android_clang_*/lib.unstripped"
-fi
-
-tar -czvf "$2" --ignore-failed-read "${objects_to_compress}"
+shopt -u nullglob

--- a/build/android/pack_symbols.sh
+++ b/build/android/pack_symbols.sh
@@ -7,7 +7,7 @@
 
 set -euo pipefail
 
-mkdir -p $1
+mkdir -p "$1"
 
 objects_to_compress="*.so apks lib.unstripped android_chrome_versions.txt"
 
@@ -19,4 +19,4 @@ if ls android_clang_*/lib.unstripped 1> /dev/null 2>&1; then
     objects_to_compress="${objects_to_compress} android_clang_*/lib.unstripped"
 fi
 
-tar -czvf $2 --ignore-failed-read ${objects_to_compress}
+tar -czvf "$2" --ignore-failed-read "${objects_to_compress}"


### PR DESCRIPTION
This PR suppresses the warning from pack symbols script.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42317

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. run `npm run create_dist -- Release  --target_os=android --target_arch=arm --target_android_base=mono  --target_android_output_format=aab`
2. ensure there are no warnings like
```
tar: android_clang_*/*.so: Warning: Cannot stat: No such file or directory
tar: android_clang_*/lib.unstripped: Warning: Cannot stat: No such file or directory
```


