### PR TITLE
[ads] Add SmartNTT epoch and numerical condition matcher defaults (uplift to 1.73.x)

### DIFF
--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/condition_matcher_util_unittest.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/condition_matcher_util_unittest.cc
@@ -33,8 +33,7 @@ TEST_F(BraveAdsConditionMatcherUtilTest, MatchEmptyConditions) {
   EXPECT_TRUE(MatchConditions(&pref_provider_, /*condition_matchers=*/{}));
 }
 
-TEST_F(BraveAdsConditionMatcherUtilTest,
-       MatchConditionsIfAllConditionsAreTrue) {
+TEST_F(BraveAdsConditionMatcherUtilTest, MatchMultipleConditions) {
   // Arrange
   const ConditionMatcherMap condition_matchers = {
       {prefs::kSubdivisionTargetingUserSelectedSubdivision, "AUTO"},
@@ -53,6 +52,18 @@ TEST_F(BraveAdsConditionMatcherUtilTest, MatchEpochEqualOperatorCondition) {
 
   // Act & Assert
   EXPECT_TRUE(MatchConditions(&pref_provider_, condition_matchers));
+}
+
+TEST_F(BraveAdsConditionMatcherUtilTest,
+       DoNotMatchEpochEqualOperatorConditionForUnknownPrefPath) {
+  // Arrange
+  const ConditionMatcherMap condition_matchers = {
+      {"unknown_pref_path", "[T=]:7"}};
+
+  AdvanceClockBy(base::Days(7) - base::Milliseconds(1));
+
+  // Act & Assert
+  EXPECT_FALSE(MatchConditions(&pref_provider_, condition_matchers));
 }
 
 TEST_F(BraveAdsConditionMatcherUtilTest,
@@ -75,6 +86,26 @@ TEST_F(BraveAdsConditionMatcherUtilTest, MatchNumericalEqualOperatorCondition) {
 
   // Act & Assert
   EXPECT_TRUE(MatchConditions(&pref_provider_, condition_matchers));
+}
+
+TEST_F(BraveAdsConditionMatcherUtilTest,
+       MatchNumericalhEqualOperatorConditionForUnknownPrefPath) {
+  // Arrange
+  const ConditionMatcherMap condition_matchers = {
+      {"unknown_pref_path", "[R=]:0"}};
+
+  // Act & Assert
+  EXPECT_TRUE(MatchConditions(&pref_provider_, condition_matchers));
+}
+
+TEST_F(BraveAdsConditionMatcherUtilTest,
+       DoNotMatchNumericalhEqualOperatorConditionForUnknownPrefPath) {
+  // Arrange
+  const ConditionMatcherMap condition_matchers = {
+      {"unknown_pref_path", "[R=]:1"}};
+
+  // Act & Assert
+  EXPECT_FALSE(MatchConditions(&pref_provider_, condition_matchers));
 }
 
 TEST_F(BraveAdsConditionMatcherUtilTest,

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/epoch_operator_condition_matcher_util.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/epoch_operator_condition_matcher_util.cc
@@ -26,6 +26,11 @@ constexpr char kLessThanOrEqualOperatorConditionMatcherPrefix[] = "[T≤]:";
 
 }  // namespace
 
+bool IsEpochOperator(std::string_view condition) {
+  return base::MatchPattern(condition,
+                            kEpochOperatorConditionMatcherPrefixPattern);
+}
+
 bool MatchEpochOperator(const std::string_view value,
                         const std::string_view condition) {
   if (!base::MatchPattern(condition,

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/epoch_operator_condition_matcher_util.h
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/epoch_operator_condition_matcher_util.h
@@ -10,6 +10,9 @@
 
 namespace brave_ads {
 
+// Returns true if the condition is an epoch operator.
+bool IsEpochOperator(std::string_view condition);
+
 // Matches a value against a condition using epoch operators. Supports equality,
 // greater than, greater than or equal, less than. and less than or equal
 // operators.

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/epoch_operator_condition_matcher_util_unittest.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/epoch_operator_condition_matcher_util_unittest.cc
@@ -14,6 +14,16 @@ namespace brave_ads {
 
 class BraveAdsEpochOperatorConditionMatcherUtilTest : public test::TestBase {};
 
+TEST_F(BraveAdsEpochOperatorConditionMatcherUtilTest, IsOperator) {
+  // Act & Assert
+  EXPECT_TRUE(IsEpochOperator("[T=]:1"));
+}
+
+TEST_F(BraveAdsEpochOperatorConditionMatcherUtilTest, IsNotOperator) {
+  // Act & Assert
+  EXPECT_FALSE(IsEpochOperator("[R=]:1"));
+}
+
 TEST_F(BraveAdsEpochOperatorConditionMatcherUtilTest, DoNotMatchNonOperator) {
   // Act & Assert
   EXPECT_FALSE(MatchEpochOperator(

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/numerical_operator_condition_matcher_util.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/numerical_operator_condition_matcher_util.cc
@@ -27,6 +27,11 @@ constexpr char kLessThanOrEqualOperatorConditionMatcherPrefix[] = "[R≤]:";
 
 }  // namespace
 
+bool IsNumericalOperator(std::string_view condition) {
+  return base::MatchPattern(condition,
+                            kNumericalOperatorConditionMatcherPrefixPattern);
+}
+
 bool MatchNumericalOperator(const std::string_view value,
                             const std::string_view condition) {
   if (!base::MatchPattern(condition,

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/numerical_operator_condition_matcher_util.h
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/numerical_operator_condition_matcher_util.h
@@ -10,6 +10,9 @@
 
 namespace brave_ads {
 
+// Returns true if the condition is a numerical operator.
+bool IsNumericalOperator(std::string_view condition);
+
 // Matches a value against a condition using numerical operators. Supports
 // equality, greater than, greater than or equal, less than, less than or equal
 // and not equal operators.

--- a/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/numerical_operator_condition_matcher_util_unittest.cc
+++ b/components/brave_ads/core/internal/serving/targeting/condition_matcher/matchers/numerical_operator_condition_matcher_util_unittest.cc
@@ -14,6 +14,16 @@ namespace brave_ads {
 class BraveAdsNumericalOperatorConditionMatcherUtilTest
     : public test::TestBase {};
 
+TEST_F(BraveAdsNumericalOperatorConditionMatcherUtilTest, IsOperator) {
+  // Act & Assert
+  EXPECT_TRUE(IsNumericalOperator("[R=]:1"));
+}
+
+TEST_F(BraveAdsNumericalOperatorConditionMatcherUtilTest, IsNotOperator) {
+  // Act & Assert
+  EXPECT_FALSE(IsNumericalOperator("[T=]:1"));
+}
+
 TEST_F(BraveAdsNumericalOperatorConditionMatcherUtilTest,
        DoNotMatchNonOperator) {
   // Act & Assert


### PR DESCRIPTION
Uplift of #26590
Resolves https://github.com/brave/brave-browser/issues/42321

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.