### PR TITLE
fix(wallet): Only Show Loading State for Selected Buy Provider

### DIFF
--- a/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/fund_wallet_v2.tsx
@@ -102,7 +102,7 @@ export const FundWalletScreen = ({ isAndroid }: Props) => {
     selectedPaymentMethod,
     onSelectPaymentMethod,
     onSelectCountry,
-    isCreatingWidget,
+    isCreatingWidgetFor,
     onBuy,
     searchTerm,
     onSearch,
@@ -336,7 +336,9 @@ export const FundWalletScreen = ({ isAndroid }: Props) => {
                               filteredQuotes.length > 1 && index === 0
                             }
                             isOpenOverride={index === 0}
-                            isCreatingWidget={isCreatingWidget}
+                            isCreatingWidget={
+                              isCreatingWidgetFor === quote.serviceProvider
+                            }
                             onBuy={onBuy}
                             selectedAsset={selectedAsset}
                           />

--- a/components/brave_wallet_ui/page/screens/fund-wallet/hooks/useBuy.ts
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/hooks/useBuy.ts
@@ -132,7 +132,9 @@ export const useBuy = () => {
   const [selectedCountryCode, setSelectedCountryCode] = useState<string>('US')
   const [selectedPaymentMethod, setSelectedPaymentMethod] =
     useState<MeldPaymentMethod>(DEFAULT_PAYMENT_METHOD)
-  const [isCreatingWidget, setIsCreatingWidget] = useState(false)
+  const [isCreatingWidgetFor, setIsCreatingWidgetFor] = useState<
+    string | undefined
+  >(undefined)
   const [searchTerm, setSearchTerm] = useState<string>('')
 
   // Mutations
@@ -436,12 +438,12 @@ export const useBuy = () => {
       }
 
       try {
-        setIsCreatingWidget(true)
+        setIsCreatingWidgetFor(quote.serviceProvider)
         const { widget } = await createMeldBuyWidget({
           sessionData,
           customerData
         }).unwrap()
-        setIsCreatingWidget(false)
+        setIsCreatingWidgetFor(undefined)
 
         if (widget) {
           const { widgetUrl } = widget
@@ -449,7 +451,7 @@ export const useBuy = () => {
         }
       } catch (error) {
         console.error('createMeldBuyWidget failed', error)
-        setIsCreatingWidget(false)
+        setIsCreatingWidgetFor(undefined)
       }
     },
     [
@@ -520,7 +522,7 @@ export const useBuy = () => {
     onSelectCountry,
     onSelectPaymentMethod,
     onBuy,
-    isCreatingWidget,
+    isCreatingWidgetFor,
     searchTerm,
     onSearch: setSearchTerm,
     cryptoEstimate,


### PR DESCRIPTION
## Description 

Fixes a bug where `Loading` state was being shared between all `Buy` providers.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42079>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Buy` screen
2. Wait for `Quotes` to be generated for `ETH`
3. Expand multiple `Providers` and then click `Buy` for one of them
4. Only the `Provider` that you clicked `Buy` for should show a loading state in the button.

Before:

https://github.com/user-attachments/assets/5c0b63dd-480f-45fb-ba12-c93b214cfbfa

After:

https://github.com/user-attachments/assets/ba0870c1-8410-4643-854e-375ec2d4b1d7
