### PR TITLE
[iOS] Fallback to default value correctly for optional preferences (uplift to 1.73.x)

### DIFF
--- a/ios/brave-ios/Sources/Preferences/Preferences.swift
+++ b/ios/brave-ios/Sources/Preferences/Preferences.swift
@@ -131,7 +131,7 @@ extension Preferences.Option where ValueType: ExpressibleByNilLiteral {
     defaultValue: ValueType,
     container: UserDefaults
   ) where V: UserDefaultsEncodable, ValueType == V? {
-    let initialValue = (container.value(forKey: key) as? ValueType) ?? defaultValue
+    let initialValue = (container.value(forKey: key) as? V) ?? defaultValue
     self.init(
       key: key,
       initialValue: initialValue,


### PR DESCRIPTION
Uplift of #26610
Resolves https://github.com/brave/brave-browser/issues/42320

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.