### PR TITLE
Add dumps to debug empty shields settings in v8 workers. (uplift to 1.73.x)

### DIFF
--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -8,6 +8,8 @@
 #include <string_view>
 
 #include "base/command_line.h"
+#include "base/debug/alias.h"
+#include "base/debug/dump_without_crashing.h"
 #include "base/feature_list.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/string_number_conversions.h"
@@ -219,6 +221,12 @@ BraveSessionCache::BraveSessionCache(ExecutionContext& context)
   if (auto* settings_client = GetContentSettingsClientFor(&context, true)) {
     auto shields_settings = settings_client->GetBraveShieldsSettings(
         ContentSettingsType::BRAVE_WEBCOMPAT_NONE);
+    // https://github.com/brave/brave-browser/issues/41724 debug.
+    if (!shields_settings) {
+      base::debug::Alias(settings_client);
+      base::debug::DumpWithoutCrashing();
+      return;
+    }
     farbling_level_ =
         base::FeatureList::IsEnabled(
             brave_shields::features::kBraveShowStrictFingerprintingMode)
@@ -413,6 +421,12 @@ BraveFarblingLevel BraveSessionCache::GetBraveFarblingLevel(
             GetContentSettingsClientFor(GetSupplementable(), true)) {
       auto shields_settings =
           settings_client->GetBraveShieldsSettings(webcompat_content_settings);
+      // https://github.com/brave/brave-browser/issues/41724 debug.
+      if (!shields_settings) {
+        base::debug::Alias(settings_client);
+        base::debug::DumpWithoutCrashing();
+        return farbling_level_;
+      }
       farbling_levels_.insert(webcompat_content_settings,
                               shields_settings->farbling_level);
       return shields_settings->farbling_level;


### PR DESCRIPTION
Uplift of #26115
Resolves https://github.com/brave/brave-browser/issues/41724

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.