### PR TITLE
Alias settings_client internals to see it in a memory dump.

### DIFF
--- a/chromium_src/base/debug/alias.h
+++ b/chromium_src/base/debug/alias.h
@@ -1,0 +1,63 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_BASE_DEBUG_ALIAS_H_
+#define BRAVE_CHROMIUM_SRC_BASE_DEBUG_ALIAS_H_
+
+#include "base/containers/span.h"
+#include "base/memory/raw_ptr_exclusion.h"
+#include "base/memory/stack_allocated.h"
+#include "base/ranges/algorithm.h"
+
+#include "src/base/debug/alias.h"  // IWYU pragma: export
+
+namespace base::debug {
+
+// StackObjectCopy creates a byte-for-byte copy of an object on the stack,
+// allowing the object to be inspected in crash dumps even if the original
+// object is optimized away by the compiler or is stored in protected memory.
+// The copy maintains proper alignment and can be viewed as the original type in
+// a debugger.
+template <typename T>
+class StackObjectCopy {
+  STACK_ALLOCATED();
+
+ public:
+  explicit StackObjectCopy(const T* original) {
+    if (original) {
+      // SAFETY: `original` is a valid pointer to a T object, and `kSize` is the
+      // size of T.
+      auto original_object_memory = UNSAFE_BUFFERS(
+          base::make_span(reinterpret_cast<const uint8_t*>(original), kSize));
+      base::span(buffer_).copy_from(std::move(original_object_memory));
+    } else {
+      base::ranges::fill(buffer_, 0);
+    }
+  }
+
+  StackObjectCopy(const StackObjectCopy&) = delete;
+  StackObjectCopy& operator=(const StackObjectCopy&) = delete;
+
+ private:
+  constexpr static size_t kSize = sizeof(T);
+
+  alignas(T) uint8_t buffer_[kSize];
+  RAW_PTR_EXCLUSION const T* const typed_view_ =
+      reinterpret_cast<const T*>(buffer_);
+};
+
+}  // namespace base::debug
+
+// DEBUG_ALIAS_FOR_OBJECT creates a stack copy of an object and ensures it
+// remains in memory for crash dumps. This is useful when you need to ensure an
+// object's state is captured in crash reports, especially when the object might
+// otherwise be optimized away or is not directly accessible.
+//
+// Usage: DEBUG_ALIAS_FOR_OBJECT(alias_name, pointer_to_object);
+#define DEBUG_ALIAS_FOR_OBJECT(var_name, object)         \
+  const ::base::debug::StackObjectCopy var_name(object); \
+  ::base::debug::Alias(&var_name)
+
+#endif  // BRAVE_CHROMIUM_SRC_BASE_DEBUG_ALIAS_H_

--- a/chromium_src/check_chromium_src_config.json5
+++ b/chromium_src/check_chromium_src_config.json5
@@ -50,6 +50,9 @@
     // These symbols found in associated paths will be ignored.
     // Please, keep paths and symbols in alphabetical order.
     "symbol_excludes": {
+        "base/debug/alias.h": [
+            "DEBUG_ALIAS_FOR_OBJECT",
+        ],
         "base/trace_event/builtin_categories.h": [
             "BRAVE_INTERNAL_TRACE_LIST_BUILTIN_CATEGORIES",
         ],

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -144,7 +144,7 @@ blink::WebContentSettingsClient* GetContentSettingsClientFor(
     return worker_or_worklet->ContentSettingsClient();
   }
 
-  base::debug::Alias(context);
+  DEBUG_ALIAS_FOR_OBJECT(context_alias, context);
   NOTREACHED() << "Unhandled ExecutionContext type";
 }
 

--- a/third_party/blink/renderer/core/farbling/brave_session_cache.cc
+++ b/third_party/blink/renderer/core/farbling/brave_session_cache.cc
@@ -446,9 +446,9 @@ BraveFarblingLevel BraveSessionCache::GetBraveFarblingLevel(
             GetContentSettingsClientFor(GetSupplementable())) {
       auto shields_settings =
           settings_client->GetBraveShieldsSettings(webcompat_content_settings);
-      // https://github.com/brave/brave-browser/issues/41724 debug.
+      // https://github.com/brave/brave-browser/issues/41889 debug.
       if (!shields_settings) {
-        base::debug::Alias(settings_client);
+        DEBUG_ALIAS_FOR_OBJECT(settings_client_alias, settings_client);
         base::debug::DumpWithoutCrashing();
         return default_shields_settings_->farbling_level;
       }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Look into the client to see what the actual type was when we got the list. I have a slight suspicion that we get the non-overridden version of `WorkerContentSettingsClient`, because any other code path should return a non-empty `ShieldsSettingsPtr` object.

Related https://github.com/brave/brave-browser/issues/41889

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

