### PR TITLE
fix(wallet): Only Show Speed Up Alert for ETH CoinType (uplift to 1.73.x)

### DIFF
--- a/components/brave_wallet_ui/components/extension/post-confirmation/submitted_or_signed/submitted_or_signed.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/submitted_or_signed/submitted_or_signed.tsx
@@ -13,6 +13,9 @@ import {
 
 // Utils
 import { getLocale } from '$web-common/locale'
+import {
+  getCoinFromTxDataUnion //
+} from '../../../../utils/network-utils'
 
 // Components
 import {
@@ -52,6 +55,7 @@ export const TransactionSubmittedOrSigned = (props: Props) => {
   const isSwap = isSwapTransaction(transaction)
   const isERC20Approval =
     transaction.txType === BraveWallet.TransactionType.ERC20Approve
+  const txCoinType = getCoinFromTxDataUnion(transaction.txDataUnion)
 
   // Memos
   const statusIconName = React.useMemo(() => {
@@ -89,7 +93,7 @@ export const TransactionSubmittedOrSigned = (props: Props) => {
           fullWidth={true}
           padding='0px 24px'
         >
-          {showSpeedUpAlert ? (
+          {txCoinType === BraveWallet.CoinType.ETH && showSpeedUpAlert ? (
             <SpeedUpAlert />
           ) : (
             <VerticalSpace space='114px' />


### PR DESCRIPTION
Uplift of #26646
Resolves https://github.com/brave/brave-browser/issues/42379

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.