### PR TITLE
[iOS] Improve CPU usage of new playlist when backgrounded

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -171,7 +171,8 @@ extension MediaContentView {
           }
         }
       }
-      .task(priority: .low) {
+      .task(id: model.isPlayerInForeground, priority: .low) {
+        if !model.isPlayerInForeground { return }
         self.currentTime = model.currentTime
         for await currentTime in model.currentTimeStream {
           self.currentTime = currentTime

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -337,7 +337,7 @@ public final class PlayerModel: ObservableObject {
     return .init { [weak self] continuation in
       guard let self else { return }
       let timeObserver = player.addCancellablePeriodicTimeObserver(
-        forInterval: 100,
+        forInterval: 150,
         queue: .global()
       ) { [weak self] time in
         guard let self,
@@ -368,6 +368,8 @@ public final class PlayerModel: ObservableObject {
       }
     }
   }
+
+  @MainActor @Published public var isPlayerInForeground: Bool = true
 
   // MARK: - Picture in Picture
 
@@ -780,6 +782,9 @@ public final class PlayerModel: ObservableObject {
       queue: .main
     ) { [weak self] _ in
       guard let self else { return }
+      MainActor.assumeIsolated {
+        self.isPlayerInForeground = false
+      }
       if isPictureInPictureActive || !isPlaying {
         return
       }
@@ -793,6 +798,9 @@ public final class PlayerModel: ObservableObject {
       queue: .main
     ) { [weak self] _ in
       guard let self else { return }
+      MainActor.assumeIsolated {
+        self.isPlayerInForeground = true
+      }
       if isPictureInPictureActive || playerLayer.player != nil {
         return
       }

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
@@ -38,12 +38,17 @@ struct PlayerView: View {
     }
   }
 
+  private var isVideoAmbianceBackgroundEnabled: Bool {
+    !isFullScreen && playerModel.isPlayerInForeground
+      && !ProcessInfo.processInfo.isLowPowerModeEnabled
+  }
+
   var body: some View {
     VideoPlayerLayout(aspectRatio: isFullScreen ? nil : 16 / 9) {
       VideoPlayer(playerLayer: playerModel.playerLayer)
     }
     .background {
-      if !isFullScreen {
+      if isVideoAmbianceBackgroundEnabled {
         VideoAmbianceBackground(playerModel: playerModel)
           .transition(.opacity.animation(.snappy))
           .opacity(playerModel.isPlaying ? 1 : 0.5)
@@ -296,7 +301,8 @@ extension PlayerView {
       .buttonStyle(.playbackControl)
       .tint(Color(braveSystemName: .textPrimary))
       .backgroundStyle(Color.white.opacity(0.2))
-      .task(priority: .low) {
+      .task(id: model.isPlayerInForeground, priority: .low) {
+        if !model.isPlayerInForeground { return }
         self.currentTime = model.currentTime
         for await currentTime in model.currentTimeStream {
           self.currentTime = currentTime

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
@@ -120,7 +120,7 @@ struct LeoPlayingSoundView: View {
       .onReceive(
         Timer.publish(every: 0.3, on: .main, in: .default).autoconnect(),
         perform: { _ in
-          if !isAnimating { return }
+          if !isAnimating || UIApplication.shared.applicationState == .background { return }
           randomizeBarHeights()
         }
       )


### PR DESCRIPTION
This change removes the video background ambiance display and cancels ongoing time tracking while the app is backgrounded which helps keep the CPU usage down. This also disables video background ambiance display while on low power mode

Resolves https://github.com/brave/brave-browser/issues/42408

This shifts Playlist from using ~45% CPU even while backgrounded to using ~35% in the foreground and 0-5% in the background

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

