### PR TITLE
Exposes `GetPasswordStrength()` via the PWM.

### DIFF
--- a/chromium_src/components/component_updater/component_installer.cc
+++ b/chromium_src/components/component_updater/component_installer.cc
@@ -40,7 +40,6 @@ void ComponentInstaller::Register(
     "gcmjkmgdlgnkkcocmoeiminaijmmjnii",  // Subresource Filter Rules
     "imefjhfbkmcmebodilednhmaccmincoa",  // Client Side Phishing Detection
     "llkgjffcdpffmhiakmfcdcblohccpfmo",  // Origin Trials
-    "ojhpjlocmbogdgmfpkhlaaeamibhnphh",  // Zxcvbn Data Dictionaries
     "gonpemdgkjcecdgbnaabipppbmgfggbe",  // First Party Sets
     "dhlpobdgcjafebgbbhjdnapejmpkgiie",  // Desktop Sharing Hub
 #if BUILDFLAG(IS_ANDROID)

--- a/chromium_src/components/password_manager/core/browser/ui/weak_check_utility.cc
+++ b/chromium_src/components/password_manager/core/browser/ui/weak_check_utility.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/password_manager/core/browser/ui/weak_check_utility.cc"
+
+#include "base/strings/utf_string_conversions.h"
+
+namespace password_manager {
+
+int GetPasswordStrength(const std::string& password) {
+  if (password.empty()) {
+    return 0;
+  }
+
+  // The score returned by PasswordWeakCheck() is an integer between 0 and 4
+  // (https://github.com/dropbox/zxcvbn). 0 is weakest.
+  return (PasswordWeakCheck(base::UTF8ToUTF16(password)) + 1) / 5.0 * 100;
+}
+
+}  // namespace password_manager

--- a/chromium_src/components/password_manager/core/browser/ui/weak_check_utility.h
+++ b/chromium_src/components/password_manager/core/browser/ui/weak_check_utility.h
@@ -1,0 +1,20 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_PASSWORD_MANAGER_CORE_BROWSER_UI_WEAK_CHECK_UTILITY_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_PASSWORD_MANAGER_CORE_BROWSER_UI_WEAK_CHECK_UTILITY_H_
+
+#include <string>
+
+#define BulkWeakCheck(...)    \
+  BulkWeakCheck(__VA_ARGS__); \
+  int GetPasswordStrength(const std::string& password)
+// Returns strength for `password` on a scale from 0 to 100.
+
+#include "src/components/password_manager/core/browser/ui/weak_check_utility.h"  // IWYU pragma: export
+
+#undef BulkWeakCheck
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_PASSWORD_MANAGER_CORE_BROWSER_UI_WEAK_CHECK_UTILITY_H_

--- a/chromium_src/components/password_manager/core/browser/ui/weak_check_utility_unittest.cc
+++ b/chromium_src/components/password_manager/core/browser/ui/weak_check_utility_unittest.cc
@@ -1,0 +1,33 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/components/password_manager/core/browser/ui/weak_check_utility_unittest.cc"
+
+#include <string>
+#include <utility>
+
+namespace password_manager {
+
+using ParamType = std::pair<std::string,  // password
+                            int           // expected strength
+                            >;
+
+class WeakCheckUtilityTest : public testing::TestWithParam<ParamType> {};
+
+TEST_P(WeakCheckUtilityTest, GetPasswordStrength) {
+  EXPECT_EQ(GetPasswordStrength(std::get<0>(GetParam())),
+            std::get<1>(GetParam()));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    WeakCheckUtilityTest,
+    WeakCheckUtilityTest,
+    testing::Values(ParamType{"", 0},
+                    ParamType{base::UTF16ToUTF8(kWeakShortPassword), 20},
+                    ParamType{base::UTF16ToUTF8(kWeakLongPassword), 20},
+                    ParamType{base::UTF16ToUTF8(kStrongShortPassword), 100},
+                    ParamType{base::UTF16ToUTF8(kStrongLongPassword), 100}));
+
+}  // namespace password_manager

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -416,6 +416,7 @@ test("brave_unit_tests") {
       "//components/gcm_driver/gcm_delayed_task_controller_unittest.cc",
       "//components/gcm_driver/gcm_driver_desktop_unittest.cc",
       "//components/gcm_driver/gcm_driver_unittest.cc",
+      "//components/password_manager/core/browser/ui/weak_check_utility_unittest.cc",
 
       # TODO(samartnik): this should work on Android, we will review it once unit tests are set up on CI
       "//brave/browser/ui/brave_shields_data_controller_unittest.cc",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42407.
Security review: https://github.com/brave/reviews/issues/1800

This PR removes `Zxcvbn Data Dictionaries` (`ojhpjlocmbogdgmfpkhlaaeamibhnphh`) from the list of disallowed components, and exposes the password strength logic used by Chromium's `Password Manager` in [weak_check_utility.cc](https://source.chromium.org/chromium/chromium/src/+/00227da17e5d8292c21626f5af1a4d36648373d8:components/password_manager/core/browser/ui/weak_check_utility.cc;l=50-54). 

Known issues that need a fix in upstream code:
- `//third_party/zxcvbn-cpp` assumes that by the time it uses the dictionary files from `Zxcvbn Data Dictionaries` (`ojhpjlocmbogdgmfpkhlaaeamibhnphh`) via a call to `zxcvbn::omnimatch()` (ex. triggered by `weak_check_utility.cc` [here](https://source.chromium.org/chromium/chromium/src/+/00227da17e5d8292c21626f5af1a4d36648373d8:components/password_manager/core/browser/ui/weak_check_utility.cc;l=50)), they have already been populated by `ZxcvbnDataComponentInstallerPolicy` (via `zxcvbn::SetRankedDicts()` [here](https://source.chromium.org/chromium/chromium/src/+/423f1b3dfa07fada7c86300bf71b7cda42fdf1aa:chrome/browser/component_updater/zxcvbn_data_component_installer.cc;l=161)). However, this isn't necessarily the case — as a result, the library might calculate incorrect scores for passwords, e.g. without the dictionary files in `Zxcvbn Data Dictionaries` (`ojhpjlocmbogdgmfpkhlaaeamibhnphh`), `//third_party/zxcvbn-cpp` calculates a score of `4`/`4` for the password `neverforget`, whereas it's a `1`/`4` with the dictionaries in place. Suggested queuing up requests in `//third_party/zxcvbn-cpp` via a `base::OneShotEvent` in Chromium Slack.
- `weak_check_utility.cc` assumes that `password16` is a UTF-16 string, but at the same time it calls `std::basic_string<>::substr()` on it [here](https://source.chromium.org/chromium/chromium/src/+/00227da17e5d8292c21626f5af1a4d36648373d8:components/password_manager/core/browser/ui/weak_check_utility.cc;l=49), which might or might not work, depending on whether `password16` contains Unicode code points outside the **Basic Multilingual Plane** (e.g. emojis, which are in the **Supplementary Multilingual Plane** — and are encoded using 32 bits). Technically, the code assumes that `password16` is UCS-2, but UCS-2 `!=` UTF-16. Suggested in Chromium Slack to use `base::UTF16ToUTF8()` + `base::TruncateUTF8ToByteSize()` instead, or, alternatively use the tools in `//third_party/icu` to introduce a proper substring mechanism for UTF-16 strings.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
—
