### PR TITLE
fix(vpn): Fix server region changed popup blocks the whole browser. 

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -53,7 +53,7 @@ extension BrowserViewController {
         settingTitleEnabled: false,
         regionSelectAction: { [unowned menuController] in
           let vpnRegionListView = BraveVPNRegionListView(
-            onServerRegionSet: { region in
+            onServerRegionSet: { _ in
               let controller = PopupViewController(
                 rootView: BraveVPNRegionConfirmationView(
                   country: BraveVPN.serverLocationDetailed.country,
@@ -118,9 +118,9 @@ extension BrowserViewController {
 
       // Region Button is populated including the details for privacy feature menu
       RegionMenuButton(
-        regionSelectAction: {
+        regionSelectAction: { [unowned menuController] in
           let vpnRegionListView = BraveVPNRegionListView(
-            onServerRegionSet: { region in
+            onServerRegionSet: { _ in
               let controller = PopupViewController(
                 rootView: BraveVPNRegionConfirmationView(
                   country: BraveVPN.serverLocationDetailed.country,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -51,10 +51,24 @@ extension BrowserViewController {
       // Region Button is populated without current selected detail title for features menu
       RegionMenuButton(
         settingTitleEnabled: false,
-        regionSelectAction: {
-          let vc = UIHostingController(
-            rootView: BraveVPNRegionListView()
+        regionSelectAction: { [unowned menuController] in
+          let vpnRegionListView = BraveVPNRegionListView(
+            onServerRegionSet: { region in
+              let controller = PopupViewController(
+                rootView: BraveVPNRegionConfirmationView(
+                  country: BraveVPN.serverLocationDetailed.country,
+                  city: BraveVPN.serverLocationDetailed.city,
+                  countryISOCode: BraveVPN.serverLocation.isoCode
+                ),
+                isDismissable: true
+              )
+              menuController.present(controller, animated: true)
+              Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
+                controller.dismiss(animated: true)
+              }
+            }
           )
+          let vc = UIHostingController(rootView: vpnRegionListView)
           vc.title = Strings.VPN.vpnRegionListServerScreenTitle
 
           (self.presentedViewController as? MenuViewController)?
@@ -105,9 +119,23 @@ extension BrowserViewController {
       // Region Button is populated including the details for privacy feature menu
       RegionMenuButton(
         regionSelectAction: {
-          let vc = UIHostingController(
-            rootView: BraveVPNRegionListView()
+          let vpnRegionListView = BraveVPNRegionListView(
+            onServerRegionSet: { region in
+              let controller = PopupViewController(
+                rootView: BraveVPNRegionConfirmationView(
+                  country: BraveVPN.serverLocationDetailed.country,
+                  city: BraveVPN.serverLocationDetailed.city,
+                  countryISOCode: BraveVPN.serverLocation.isoCode
+                ),
+                isDismissable: true
+              )
+              menuController.present(controller, animated: true)
+              Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
+                controller.dismiss(animated: true)
+              }
+            }
           )
+          let vc = UIHostingController(rootView: vpnRegionListView)
           vc.title = Strings.VPN.vpnRegionListServerScreenTitle
 
           (self.presentedViewController as? MenuViewController)?

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -51,21 +51,10 @@ extension BrowserViewController {
       // Region Button is populated without current selected detail title for features menu
       RegionMenuButton(
         settingTitleEnabled: false,
-        regionSelectAction: { [unowned menuController] in
+        regionSelectAction: { [unowned self] in
           let vpnRegionListView = BraveVPNRegionListView(
             onServerRegionSet: { _ in
-              let controller = PopupViewController(
-                rootView: BraveVPNRegionConfirmationView(
-                  country: BraveVPN.serverLocationDetailed.country,
-                  city: BraveVPN.serverLocationDetailed.city,
-                  countryISOCode: BraveVPN.serverLocation.isoCode
-                ),
-                isDismissable: true
-              )
-              menuController.present(controller, animated: true)
-              Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
-                controller.dismiss(animated: true)
-              }
+              self.presentVPNServerRegionPopup()
             }
           )
           let vc = UIHostingController(rootView: vpnRegionListView)
@@ -118,21 +107,10 @@ extension BrowserViewController {
 
       // Region Button is populated including the details for privacy feature menu
       RegionMenuButton(
-        regionSelectAction: { [unowned menuController] in
+        regionSelectAction: { [unowned self] in
           let vpnRegionListView = BraveVPNRegionListView(
             onServerRegionSet: { _ in
-              let controller = PopupViewController(
-                rootView: BraveVPNRegionConfirmationView(
-                  country: BraveVPN.serverLocationDetailed.country,
-                  city: BraveVPN.serverLocationDetailed.city,
-                  countryISOCode: BraveVPN.serverLocation.isoCode
-                ),
-                isDismissable: true
-              )
-              menuController.present(controller, animated: true)
-              Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
-                controller.dismiss(animated: true)
-              }
+              self.presentVPNServerRegionPopup()
             }
           )
           let vc = UIHostingController(rootView: vpnRegionListView)
@@ -339,6 +317,26 @@ extension BrowserViewController {
           self.present(playlistController, animated: true)
         }
       }
+    }
+  }
+
+  // Present a popup when VPN server region has been changed
+  private func presentVPNServerRegionPopup() {
+    let controller = PopupViewController(
+      rootView: BraveVPNRegionConfirmationView(
+        country: BraveVPN.serverLocationDetailed.country,
+        city: BraveVPN.serverLocationDetailed.city,
+        countryISOCode: BraveVPN.serverLocation.isoCode
+      ),
+      isDismissable: true
+    )
+    if let presentedViewController {
+      presentedViewController.present(controller, animated: true)
+    } else {
+      present(controller, animated: true)
+    }
+    Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { [weak controller] _ in
+      controller?.dismiss(animated: true)
     }
   }
 

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -416,8 +416,8 @@ public class BraveVPNSettingsViewController: TableViewController {
         isDismissable: true
       )
       self?.present(controller, animated: true)
-      Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
-        controller.dismiss(animated: true)
+      Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { [weak controller] _ in
+        controller?.dismiss(animated: true)
       }
     }
     let vc = UIHostingController(rootView: vpnRegionListView)

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -406,7 +406,7 @@ public class BraveVPNSettingsViewController: TableViewController {
       return
     }
 
-    let vpnRegionListView = BraveVPNRegionListView { [weak self] region in
+    let vpnRegionListView = BraveVPNRegionListView { [weak self] _ in
       let controller = PopupViewController(
         rootView: BraveVPNRegionConfirmationView(
           country: BraveVPN.serverLocationDetailed.country,

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -406,7 +406,21 @@ public class BraveVPNSettingsViewController: TableViewController {
       return
     }
 
-    let vc = UIHostingController(rootView: BraveVPNRegionListView())
+    let vpnRegionListView = BraveVPNRegionListView { [weak self] region in
+      let controller = PopupViewController(
+        rootView: BraveVPNRegionConfirmationView(
+          country: BraveVPN.serverLocationDetailed.country,
+          city: BraveVPN.serverLocationDetailed.city,
+          countryISOCode: BraveVPN.serverLocation.isoCode
+        ),
+        isDismissable: true
+      )
+      self?.present(controller, animated: true)
+      Timer.scheduledTimer(withTimeInterval: 2, repeats: false) { _ in
+        controller.dismiss(animated: true)
+      }
+    }
+    let vc = UIHostingController(rootView: vpnRegionListView)
     vc.title = Strings.VPN.vpnRegionListServerScreenTitle
     navigationController?.pushViewController(vc, animated: true)
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41831

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues/41831) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Enable VPN (when previously set to NOT automatic server)
2. Switch to Automatic server
3. Quickly tap back before connection established
4. Region change modal appears
5. Observe the modal will get dismissed after couple seconds and not blocking the whole browser 
6. Repeat step 1 to 4
7. Tapping anywhere on the popup
8. Observe the popup will dismiss
