### PR TITLE
[iOS] Remove video ambiance decoration in new Playlist UI

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
@@ -38,22 +38,9 @@ struct PlayerView: View {
     }
   }
 
-  private var isVideoAmbianceBackgroundEnabled: Bool {
-    !isFullScreen && playerModel.isPlayerInForeground
-      && !ProcessInfo.processInfo.isLowPowerModeEnabled
-  }
-
   var body: some View {
     VideoPlayerLayout(aspectRatio: isFullScreen ? nil : 16 / 9) {
       VideoPlayer(playerLayer: playerModel.playerLayer)
-    }
-    .background {
-      if isVideoAmbianceBackgroundEnabled {
-        VideoAmbianceBackground(playerModel: playerModel)
-          .transition(.opacity.animation(.snappy))
-          .opacity(playerModel.isPlaying ? 1 : 0.5)
-          .animation(.default, value: playerModel.isPlaying)
-      }
     }
     .allowsHitTesting(false)
     // For some reason this is required or the status bar breaks when touching anything on the
@@ -306,31 +293,6 @@ extension PlayerView {
         self.currentTime = model.currentTime
         for await currentTime in model.currentTimeStream {
           self.currentTime = currentTime
-        }
-      }
-    }
-  }
-}
-
-struct VideoAmbianceBackground: View {
-  var playerModel: PlayerModel
-
-  @State private var videoAmbianceDecorationImage: UIImage?
-
-  var body: some View {
-    VStack {
-      if let videoAmbianceDecorationImage {
-        Image(uiImage: videoAmbianceDecorationImage)
-          .resizable()
-          .blur(radius: 30)
-          .id(videoAmbianceDecorationImage)
-          .transition(.opacity)
-      }
-    }
-    .task(priority: .medium) {
-      for await image in playerModel.videoAmbianceImageStream {
-        withAnimation {
-          videoAmbianceDecorationImage = image.size == .zero ? nil : image
         }
       }
     }


### PR DESCRIPTION
This feature was unfortunately causing multiple issues:

- The very act of adding a new `AVPlayerItemVideoOutput` to `AVPlayerItem` caused audio-stutters when disconnecting the player layer from the player for background audio
- It caused the `AVPlayerLayer` to break upon being restored back to the `AVPlayer` until paused + played
- It caused high CPU usage which likely contributed to user reports of their phones getting hot while using the new playlist.

For now this will be removed until we can find an alternative solution

Resolves https://github.com/brave/brave-browser/issues/42468

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

