### PR TITLE
[iOS] Fix crash when invalid URL is checked for Brave Search P3A (uplift to 1.73.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+P3A.swift
@@ -416,7 +416,7 @@ extension BrowserViewController {
   func maybeRecordBraveSearchDailyUsage(url: URL) {
     let braveSearchHost = "search.brave.com"
     let braveSearchPath = "/search"
-    if url.host() != braveSearchHost || url.path() != braveSearchPath {
+    if url.host != braveSearchHost || url.path != braveSearchPath {
       return
     }
     UmaHistogramBoolean("Brave.Search.BraveDaily", true)


### PR DESCRIPTION
Uplift of #26706
Resolves https://github.com/brave/brave-browser/issues/42464

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.