### PR TITLE
[CodeHealth] Migrate constants to use `string_view`

### DIFF
--- a/chromium_src/net/base/lookup_string_in_fixed_set.cc
+++ b/chromium_src/net/base/lookup_string_in_fixed_set.cc
@@ -32,23 +32,21 @@ int LookupSuffixInReversedSet(base::span<const uint8_t> graph,
   // omnibox, it will be parsed as OmniboxInputType::URL input type instead of
   // OmniboxInputType::UNKNOWN, The first entry in the autocomplete list will be
   // URL instead of search.
-  for (auto* unstoppable_domain : decentralized_dns::kUnstoppableDomains) {
-    if (host.ends_with(unstoppable_domain)) {
-      *suffix_length = strlen(unstoppable_domain) - 1;
-      return kDafsaFound;
-    }
+  if (auto domain = decentralized_dns::GetUnstoppableDomainSuffix(host)) {
+    *suffix_length = domain->size() - 1;
+    return kDafsaFound;
   }
   if (host.ends_with(decentralized_dns::kEthDomain)) {
-    *suffix_length = strlen(decentralized_dns::kEthDomain) - 1;
+    *suffix_length = decentralized_dns::kEthDomain.size() - 1;
     return kDafsaFound;
   }
   if (host.ends_with(decentralized_dns::kSolDomain)) {
-    *suffix_length = strlen(decentralized_dns::kSolDomain) - 1;
+    *suffix_length = decentralized_dns::kSolDomain.size() - 1;
     return kDafsaFound;
   }
 
   if (include_private && host.ends_with(decentralized_dns::kDNSForEthDomain)) {
-    *suffix_length = strlen(decentralized_dns::kDNSForEthDomain) - 1;
+    *suffix_length = decentralized_dns::kDNSForEthDomain.size() - 1;
     return kDafsaFound;
   }
 

--- a/components/decentralized_dns/content/decentralized_dns_opt_in_page.cc
+++ b/components/decentralized_dns/content/decentralized_dns_opt_in_page.cc
@@ -79,15 +79,6 @@ void DecentralizedDnsOptInPage::PopulateInterstitialStrings(
   const std::u16string sol_domain = base::ASCIIToUTF16(std::string(kSolDomain));
   const std::u16string eth_domain = base::ASCIIToUTF16(std::string(kEthDomain));
 
-  std::u16string unstoppable_domains;
-  for (auto* const domain : kUnstoppableDomains) {
-    unstoppable_domains =
-        base::StrCat({unstoppable_domains, base::ASCIIToUTF16(domain), u", "});
-  }
-  if (!unstoppable_domains.empty()) {
-    unstoppable_domains.resize(unstoppable_domains.size() - 2);
-  }
-
   if (IsUnstoppableDomainsTLD(request_url_.host_piece())) {
     load_time_data.Set("tabTitle", brave_l10n::GetLocalizedResourceUTF16String(
                                        IDS_UNSTOPPABLE_DOMAINS_OPT_IN_TITLE));
@@ -99,7 +90,7 @@ void DecentralizedDnsOptInPage::PopulateInterstitialStrings(
         base::ReplaceStringPlaceholders(
             brave_l10n::GetLocalizedResourceUTF16String(
                 IDS_UNSTOPPABLE_DOMAINS_AND_ENS_OPT_IN_PRIMARY_PARAGRAPH),
-            {infura, unstoppable_domains,
+            {infura, base::ASCIIToUTF16(GetUnstoppableDomainSuffixFullList()),
              brave_l10n::GetLocalizedResourceUTF16String(
                  IDS_UNSTOPPABLE_DOMAINS_OPT_IN_TITLE),
              infura_tou, infura_privacy_policy},

--- a/components/decentralized_dns/core/utils.cc
+++ b/components/decentralized_dns/core/utils.cc
@@ -55,12 +55,7 @@ void MigrateObsoleteLocalStatePrefs(PrefService* local_state) {
 }
 
 bool IsUnstoppableDomainsTLD(std::string_view host) {
-  for (auto* domain : kUnstoppableDomains) {
-    if (host.ends_with(domain)) {
-      return true;
-    }
-  }
-  return false;
+  return GetUnstoppableDomainSuffix(host).has_value();
 }
 
 void SetUnstoppableDomainsResolveMethod(PrefService* local_state,

--- a/components/p3a/histograms_braveizer.cc
+++ b/components/p3a/histograms_braveizer.cc
@@ -5,6 +5,9 @@
 
 #include "brave/components/p3a/histograms_braveizer.h"
 
+#include <array>
+#include <string>
+
 #include "base/functional/bind.h"
 #include "base/memory/ref_counted.h"
 #include "base/metrics/histogram_macros.h"
@@ -17,13 +20,13 @@ namespace {
 
 // Please keep this list sorted and synced with |DoHistogramBravezation|.
 // clang-format off
-constexpr const char* kBravezationHistograms[] = {
+constexpr auto kBravezationHistograms = std::to_array<std::string_view>({
     "DefaultBrowser.State",
     "Extensions.LoadExtension",
     "Tabs.TabCount",
     "Tabs.TabCountPerLoad",
     "Tabs.WindowCount",
-};
+});
 // clang-format on
 
 }  // namespace
@@ -40,11 +43,11 @@ HistogramsBraveizer::HistogramsBraveizer() = default;
 HistogramsBraveizer::~HistogramsBraveizer() = default;
 
 void HistogramsBraveizer::InitCallbacks() {
-  for (const char* histogram_name : kBravezationHistograms) {
+  for (std::string_view histogram_name : kBravezationHistograms) {
     histogram_sample_callbacks_.push_back(
         std::make_unique<
             base::StatisticsRecorder::ScopedHistogramSampleObserver>(
-            histogram_name,
+            std::string(histogram_name),
             base::BindRepeating(&HistogramsBraveizer::DoHistogramBravetization,
                                 this)));
   }

--- a/net/BUILD.gn
+++ b/net/BUILD.gn
@@ -8,6 +8,7 @@ source_set("unit_tests") {
   testonly = true
   sources = [
     "base/brave_host_port_pair_unittest.cc",
+    "decentralized_dns/constants_unittest.cc",
     "http/partitioned_host_state_map_unittest.cc",
     "http/transport_security_state_unittest.cc",
   ]

--- a/net/decentralized_dns/constants.cc
+++ b/net/decentralized_dns/constants.cc
@@ -1,0 +1,96 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/net/decentralized_dns/constants.h"
+
+#include "base/containers/fixed_flat_set.h"
+#include "base/ranges/algorithm.h"
+#include "base/strings/string_util.h"
+
+namespace decentralized_dns {
+
+namespace {
+
+// A struct to be used to guide the lookup of domain suffixes in the fixed flat
+// set below. Lookups using this wrapper will match based on the suffix after
+// the last '.' in the domain. Lookups for suffix can be done like:
+//
+// kUnstoppableDomains.contains(DomainSuffixLookup("https://foo.crypto"))
+//
+struct DomainSuffixLookup {
+  constexpr explicit DomainSuffixLookup(std::string_view domain)
+      : domain(ExtractSuffix(domain)) {}
+
+  // Used to initialise the view from the last '.' in the domain, if any exist.
+  // Otherwise, passes the whole string for comparison.
+  static std::string_view ExtractSuffix(std::string_view domain) {
+    size_t pos = domain.find_last_of('.');
+    return pos != std::string_view::npos ? domain.substr(pos) : domain;
+  }
+
+  std::string_view domain;
+};
+
+// A custom comparator with strict weak ordering, to allow the lookup of a
+// domain with `DomainSuffixLookup`.
+struct SuffixComparator {
+  using is_transparent = void;
+
+  constexpr bool operator()(const std::string_view& lhs,
+                            const std::string_view& rhs) const {
+    return lhs < rhs;
+  }
+
+  constexpr bool operator()(const std::string_view& lhs,
+                            DomainSuffixLookup rhs) const {
+    return (*this)(lhs, rhs.domain);
+  }
+
+  constexpr bool operator()(DomainSuffixLookup lhs,
+                            const std::string_view& rhs) const {
+    return (*this)(lhs.domain, rhs);
+  }
+};
+
+inline constexpr auto kUnstoppableDomains =
+    base::MakeFixedFlatSet<std::string_view>(
+        {".crypto",     ".x",          ".nft",     ".dao",         ".wallet",
+         ".blockchain", ".bitcoin",    ".zil",     ".altimist",    ".anime",
+         ".klever",     ".manga",      ".polygon", ".unstoppable", ".pudgy",
+         ".tball",      ".stepn",      ".secret",  ".raiin",       ".pog",
+         ".clay",       ".metropolis", ".witg",    ".ubu",         ".kryptic",
+         ".farms",      ".dfz",        ".kresus",  ".binanceus",   ".austin",
+         ".bitget",     ".wrkx"},
+        SuffixComparator());
+
+// Ensure all domain suffixes start with `.`
+constexpr bool CheckAllDomainSuffixesStartWithDot() {
+  for (const auto& domain : kUnstoppableDomains) {
+    if (domain[0] != '.' && base::ranges::count(domain, '.') == 1) {
+      return false;
+    }
+  }
+  return true;
+}
+static_assert(CheckAllDomainSuffixesStartWithDot(),
+              "kUnstoppableDomains must start with a '.', and only one "
+              "occurence of the '.'");
+
+}  // namespace
+
+std::optional<std::string_view> GetUnstoppableDomainSuffix(
+    std::string_view host) {
+  auto domain = kUnstoppableDomains.find(DomainSuffixLookup(host));
+  if (domain == kUnstoppableDomains.end()) {
+    return std::nullopt;
+  }
+  return *domain;
+}
+
+std::string GetUnstoppableDomainSuffixFullList() {
+  return base::JoinString(kUnstoppableDomains, ", ");
+}
+
+}  // namespace decentralized_dns

--- a/net/decentralized_dns/constants.h
+++ b/net/decentralized_dns/constants.h
@@ -6,21 +6,25 @@
 #ifndef BRAVE_NET_DECENTRALIZED_DNS_CONSTANTS_H_
 #define BRAVE_NET_DECENTRALIZED_DNS_CONSTANTS_H_
 
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "net/base/net_export.h"
+
 namespace decentralized_dns {
 
-inline constexpr const char* kUnstoppableDomains[] = {
-    ".crypto",     ".x",          ".nft",     ".dao",         ".wallet",
-    ".blockchain", ".bitcoin",    ".zil",     ".altimist",    ".anime",
-    ".klever",     ".manga",      ".polygon", ".unstoppable", ".pudgy",
-    ".tball",      ".stepn",      ".secret",  ".raiin",       ".pog",
-    ".clay",       ".metropolis", ".witg",    ".ubu",         ".kryptic",
-    ".farms",      ".dfz",        ".kresus",  ".binanceus",   ".austin",
-    ".bitget",     ".wrkx"};
+inline constexpr std::string_view kEthDomain = ".eth";
+inline constexpr std::string_view kDNSForEthDomain = ".eth.link";
+inline constexpr std::string_view kSolDomain = ".sol";
 
-inline constexpr char kEthDomain[] = ".eth";
-inline constexpr char kDNSForEthDomain[] = ".eth.link";
+// Checks if a given host ends with the suffix of an unstoppable domain, e.g.
+// foo.crypto. Returns a reference to the domain entry.
+NET_EXPORT std::optional<std::string_view> GetUnstoppableDomainSuffix(
+    std::string_view host);
 
-inline constexpr char kSolDomain[] = ".sol";
+// Returns a full list of unstoppable domain suffixes separated by commas.
+NET_EXPORT std::string GetUnstoppableDomainSuffixFullList();
 
 }  // namespace decentralized_dns
 

--- a/net/decentralized_dns/constants_unittest.cc
+++ b/net/decentralized_dns/constants_unittest.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/net/decentralized_dns/constants.h"
+
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using testing::Optional;
+
+namespace decentralized_dns {
+
+TEST(DecentralisedDnsConstantsTest, UnstoppableDomainsSuffixLookup) {
+  EXPECT_THAT(GetUnstoppableDomainSuffix("https://foo.crypto"),
+              Optional(std::string_view(".crypto")));
+  EXPECT_THAT(GetUnstoppableDomainSuffix("https://foo.bar.crypto"),
+              Optional(std::string_view(".crypto")));
+  EXPECT_FALSE(
+      GetUnstoppableDomainSuffix("https://foo.bar.crypto.unknown").has_value());
+  EXPECT_THAT(GetUnstoppableDomainSuffix("https://foo.unstoppable"),
+              Optional(std::string_view(".unstoppable")));
+  EXPECT_FALSE(GetUnstoppableDomainSuffix("https://unstoppable").has_value());
+}
+
+}  // namespace decentralized_dns

--- a/net/sources.gni
+++ b/net/sources.gni
@@ -4,6 +4,7 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 brave_net_sources = [
+  "//brave/net/decentralized_dns/constants.cc",
   "//brave/net/decentralized_dns/constants.h",
   "//brave/net/http/partitioned_host_state_map.cc",
   "//brave/net/http/partitioned_host_state_map.h",


### PR DESCRIPTION
This PR changes a few places where we used to have we had something like:

```cxx
constexpr const char* kConstant[] = ...
```

These arrays array are not as safe as proper containers. There's also the challange that the strings referred by these arrays cannot have their sizes encoded on the type, so there's a certain reliance on `strlen` to determine the size.

This change converts on of these arrays to `std::array`. The other array was converted to a `constexpr` flat set, as that is what this array was being used for. This flat set requires a custom comparator though, as the search of the elements as matching against `end_with`. With this change, the lookup will be a bit less wasteful.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42484

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

