### PR TITLE
[iOS] Improve new playlist UI responsiveness

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistLegacyCarplayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistLegacyCarplayController.swift
@@ -825,7 +825,7 @@ extension PlaylistLegacyCarplayController {
     let cacheState = PlaylistManager.shared.state(for: item.tagId)
     if cacheState != .invalid {
       if let index = PlaylistManager.shared.index(of: item.tagId),
-        let asset = PlaylistManager.shared.assetAtIndex(index)
+        let asset = PlaylistManager.shared.assetAtIndexSynchronous(index)
       {
 
         do {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Controllers/PlaylistViewController.swift
@@ -1064,7 +1064,7 @@ extension PlaylistViewController: VideoViewDelegate {
     let cacheState = PlaylistManager.shared.state(for: item.tagId)
     if cacheState != .invalid {
       if let index = PlaylistManager.shared.index(of: item.tagId),
-        let asset = PlaylistManager.shared.assetAtIndex(index)
+        let asset = PlaylistManager.shared.assetAtIndexSynchronous(index)
       {
 
         do {

--- a/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistMediaStreamer.swift
@@ -38,7 +38,7 @@ public class PlaylistMediaStreamer {
     // We need to check if the item is cached locally.
     // If the item is cached (downloaded)
     // then we can play it directly without having to stream it.
-    let cacheState = PlaylistManager.shared.state(for: item.tagId)
+    let cacheState = await PlaylistManager.shared.downloadState(for: item.tagId)
     if cacheState != .invalid {
       return item
     }

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistSidebarList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistSidebarList.swift
@@ -155,10 +155,10 @@ struct PlaylistSidebarList: View {
       }
     }
     .frame(maxWidth: .infinity, alignment: .leading)
-    .onAppear {
+    .task {
       for item in items {
         guard let uuid = item.uuid else { continue }
-        downloadStates[uuid] = PlaylistManager.shared.state(for: uuid)
+        downloadStates[uuid] = await PlaylistManager.shared.downloadState(for: uuid)
       }
     }
     .onReceive(PlaylistManager.shared.downloadStateChanged) { output in


### PR DESCRIPTION
This change adds async versions to many synchronous AVKit operations that were being called in Playlist such as loading the duration of the video, fetching the download state, and setting the duration in PlayerModel once per load rather than have it computed.

Resolves https://github.com/brave/brave-browser/issues/42501

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

In addition to STR in the issue, also test these things on both old and new playlist:
- Downloading a video for offline correctly fetches the duration and displays it correctly in the list