### PR TITLE
fix(privacy): Generic cosmetic filter list rules are not applied on some sites on iOS (uplift to 1.73.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -207,8 +207,11 @@ window.__firefox__.execute(function($) {
    * @returns True or false indicating if anything was extracted
    */
   const extractIDSelectorIfNeeded = (element) => {
-    const id = element.id
+    const id = element.getAttribute('id')
     if (!id) { return false }
+    if (typeof id !== 'string' && !(id instanceof String)) {
+      return false
+    }
     const selector = `#${id}`
     if (!CC.allSelectors.has(selector)) {
       CC.allSelectors.add(selector)


### PR DESCRIPTION
Uplift of #26729
Resolves https://github.com/brave/brave-browser/issues/42471

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.