### PR TITLE
Fix Leo Yearly Status showing monthly sometimes instead of Yearly unt…

### DIFF
--- a/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
+++ b/ios/brave-ios/Sources/AIChat/AIChatStrings.swift
@@ -537,6 +537,13 @@ extension Strings {
       value: "Premium Subscription",
       comment: "Title showing premium subscription - not determined monthly por yearly"
     )
+    public static let subscriptionNoneTitle = NSLocalizedString(
+      "aichat.subscriptionNoneTitle",
+      tableName: "BraveLeo",
+      bundle: .module,
+      value: "None",
+      comment: "Title showing the user has no subscription."
+    )
     public static let advancedSettingsAutocompleteTitle = NSLocalizedString(
       "aichat.advancedSettingsAutocompleteTitle",
       tableName: "BraveLeo",

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
@@ -129,7 +129,7 @@ public struct AIChatAdvancedSettingsView: View {
     }
 
     // No order found
-    return "None"
+    return Strings.AIChat.subscriptionNoneTitle
   }
 
   private var expirationDateTitle: String {

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
@@ -198,7 +198,7 @@ public struct AIChatAdvancedSettingsView: View {
         if viewModel.canDisplaySubscriptionStatus
           && (model.premiumStatus == .active || model.premiumStatus == .activeDisconnected)
         {
-          if viewModel.isSubscriptionStatusLoading {
+          if viewModel.isSubscriptionStatusLoaded {
             AIChatAdvancedSettingsLabelDetailView(
               title: Strings.AIChat.advancedSettingsSubscriptionStatusTitle,
               detail: subscriptionStatusTitle
@@ -330,9 +330,8 @@ public struct AIChatAdvancedSettingsView: View {
           }
         }
 
-        // Check if there's an AppStore receipt and subscriptions have been loaded
-        if !viewModel.isSubscriptionStatusLoading && viewModel.inAppPurchaseSubscriptionState != nil
-        {
+        // Check if there's an AppStore purchase
+        if viewModel.inAppPurchaseSubscriptionState != nil {
           NavigationLink {
             StoreKitReceiptSimpleView()
           } label: {

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatAdvancedSettingsView.swift
@@ -163,6 +163,10 @@ public struct AIChatAdvancedSettingsView: View {
       return dateFormatter.string(from: date)
     }
 
+    if let expiryDate = viewModel.inAppPurchaseSubscriptionExpiryDate {
+      return dateFormatter.string(from: expiryDate)
+    }
+
     // Display the info from SkusSDK
     if let expiryDate = viewModel.skuOrderExpirationDate {
       return dateFormatter.string(from: expiryDate)

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatSubscriptionDetailModelView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatSubscriptionDetailModelView.swift
@@ -101,13 +101,13 @@ public class AIChatSubscriptionDetailModelView: ObservableObject {
   }
 
   var inAppPurchasedProductType: BraveStoreProduct? {
-    if storeSDK.leoSubscriptionStatus != nil {
-      for product in storeSDK.purchasedProducts.all {
-        if product.id == BraveStoreProduct.leoMonthly.rawValue {
+    if let status = storeSDK.leoSubscriptionStatus {
+      if case .verified(let transaction) = status.transaction {
+        if transaction.productID == BraveStoreProduct.leoMonthly.rawValue {
           return .leoMonthly
         }
 
-        if product.id == BraveStoreProduct.leoYearly.rawValue {
+        if transaction.productID == BraveStoreProduct.leoYearly.rawValue {
           return .leoYearly
         }
       }

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatSubscriptionDetailModelView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatSubscriptionDetailModelView.swift
@@ -121,13 +121,25 @@ public class AIChatSubscriptionDetailModelView: ObservableObject {
   }
 
   var inAppPurchaseSubscriptionPeriod: StoreKit.Product.SubscriptionPeriod? {
-    if storeSDK.leoSubscriptionStatus != nil {
-      if let leoMonthlySubscription = storeSDK.leoMonthlyProduct?.subscription?.subscriptionPeriod {
-        return leoMonthlySubscription
-      }
+    if let status = storeSDK.leoSubscriptionStatus {
+      if case .verified(let transaction) = status.transaction {
+        if transaction.productID == BraveStoreProduct.leoMonthly.rawValue {
+          return storeSDK.leoMonthlyProduct?.subscription?.subscriptionPeriod
+        }
 
-      if let leoYearlySubscription = storeSDK.leoYearlyProduct?.subscription?.subscriptionPeriod {
-        return leoYearlySubscription
+        if transaction.productID == BraveStoreProduct.leoYearly.rawValue {
+          return storeSDK.leoYearlyProduct?.subscription?.subscriptionPeriod
+        }
+      }
+    }
+
+    return nil
+  }
+
+  var inAppPurchaseSubscriptionExpiryDate: Date? {
+    if let status = storeSDK.leoSubscriptionStatus {
+      if case .verified(let transaction) = status.transaction {
+        return transaction.expirationDate
       }
     }
 

--- a/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatSubscriptionDetailModelView.swift
+++ b/ios/brave-ios/Sources/AIChat/Components/Settings/AIChatSubscriptionDetailModelView.swift
@@ -156,7 +156,7 @@ public class AIChatSubscriptionDetailModelView: ObservableObject {
     return false
   }
 
-  var isSubscriptionStatusLoading: Bool {
+  var isSubscriptionStatusLoaded: Bool {
     return storeSDK.leoSubscriptionStatus?.state != nil || credentialSummary != nil
   }
 


### PR DESCRIPTION
## Summary
- Fix Leo Yearly Status showing monthly sometimes instead of Yearly until the screen closes
- Fix Leo Yearly Expiration date showing as Monthly
- Both of the above bugs only happen if you upgrade from Monthly to Yearly. There is a subscription overlap where Apple-Pay waits for monthly to expire first, before actually submitting payment for yearly! So yearly subs CAN show monthly and still be correct. But there was a bug where no matter what it'd show the wrong status or date.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42507

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

