### PR TITLE
[iOS] Fix using embedded DarkReader for night mode

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -406,7 +406,7 @@ class Tab: NSObject {
     didSet {
       var isNightModeEnabled = false
 
-      if let fetchedTabURL = fetchedURL, !fetchedTabURL.isNightModeBlockedURL, nightMode {
+      if let fetchedTabURL = fetchedURL, nightMode {
         isNightModeEnabled = true
       }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/DarkReaderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/DarkReaderScriptHandler.swift
@@ -56,6 +56,13 @@ public class DarkReaderScriptHandler: TabContentScript {
 
   /// Enables DarkReader
   static func enable(for webView: WKWebView) {
+    // This is needed to ensure that CORS fetches work correctly, otherwise you get this error:
+    // "Embedded Dark Reader cannot access a cross-origin resource"
+    webView.evaluateSafeJavaScript(
+      functionName: "DarkReader.setFetchMethod(window.fetch)",
+      contentWorld: Self.scriptSandbox,
+      asFunction: false
+    )
     webView.evaluateSafeJavaScript(
       functionName: "DarkReader.enable",
       args: configuration.isEmpty ? [] : [configuration],
@@ -75,6 +82,13 @@ public class DarkReaderScriptHandler: TabContentScript {
   /// - Parameter enabled - If true, automatically listens for system's dark-mode vs. light-mode. If false, disables listening.
   static func auto(enabled: Bool = true, for webView: WKWebView) {
     if enabled {
+      // This is needed to ensure that CORS fetches work correctly, otherwise you get this error:
+      // "Embedded Dark Reader cannot access a cross-origin resource"
+      webView.evaluateSafeJavaScript(
+        functionName: "DarkReader.setFetchMethod(window.fetch)",
+        contentWorld: Self.scriptSandbox,
+        asFunction: false
+      )
       webView.evaluateSafeJavaScript(
         functionName: "DarkReader.auto",
         args: configuration.isEmpty ? [] : [configuration],
@@ -93,7 +107,7 @@ public class DarkReaderScriptHandler: TabContentScript {
     Preferences.General.nightModeEnabled.value = enabled
 
     for tab in tabManager.allTabs {
-      if let fetchedTabURL = tab.fetchedURL, !fetchedTabURL.isNightModeBlockedURL {
+      if let fetchedTabURL = tab.fetchedURL {
         tab.nightMode = enabled
       }
     }

--- a/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/Shared/Extensions/URLExtensions.swift
@@ -297,39 +297,6 @@ extension URL {
 // Helpers to deal with ErrorPage URLs
 
 extension URL {
-
-  // Check if the website is a night mode blocked site
-  public var isNightModeBlockedURL: Bool {
-    guard let host = self.normalizedHostAndPath else {
-      return false
-    }
-
-    /// Site domains that should not inject night mode
-    let majorsiteList = [
-      "twitter", "youtube", "twitch",
-      "soundcloud", "github", "netflix",
-      "imdb", "mail.proton", "amazon",
-      "x",
-    ]
-
-    let searchSiteList = [
-      "search.brave", "google", "qwant",
-      "startpage", "duckduckgo", "presearch",
-    ]
-
-    let devSiteList = ["macrumors", "9to5mac", "developer.apple"]
-
-    let casualSiteList = [
-      "wowhead", "xbox", "thegamer",
-      "cineplex", "starwars",
-    ]
-
-    let darkModeEnabledSiteList =
-      majorsiteList + searchSiteList + devSiteList + casualSiteList
-
-    return darkModeEnabledSiteList.contains(where: host.contains)
-  }
-
   // Check if the website is search engine
   public var isSearchEngineURL: Bool {
     guard let host = self.normalizedHostAndPath else {


### PR DESCRIPTION
This change fixes night mode by using the `DarkReader.setFetchMethod` to ensure CORS requests load correctly. It also removes the list of legacy night mode blocked urls as it's no longer needed anyways and was causing a bug that any URL with a `x` in the host or path would be run dark mode on it.

Resolves https://github.com/brave/brave-browser/issues/41888

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

