### PR TITLE
[iOS] Fallback Menu Playlist controls to Buttons on iOS 16

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/PlaybackControlButtonStyle.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaybackControlButtonStyle.swift
@@ -83,7 +83,15 @@ struct PlaybackControlButtonStyle: ButtonStyle {
       .background {
         if isPressed {
           RoundedRectangle(cornerRadius: 8, style: .continuous)
-            .foregroundStyle(.background)
+            .osAvailabilityModifiers { content in
+              if #available(iOS 17.0, *) {
+                content
+                  .foregroundStyle(.background)
+              } else {
+                content
+                  .foregroundStyle(Color(braveSystemName: .containerHighlight))
+              }
+            }
             // May want to reconsider this later and just add 8pt padding to button itself
             .padding(-8)
             .transition(

--- a/ios/brave-ios/Sources/PlaylistUI/PlaybackControls.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaybackControls.swift
@@ -12,22 +12,34 @@ import SwiftUI
 struct PlaybackSpeedPicker: View {
   @Binding var playbackSpeed: PlayerModel.PlaybackSpeed
 
+  private var label: some View {
+    Label(
+      Strings.Playlist.accessibilityPlaybackSpeed,
+      braveSystemImage: playbackSpeed.braveSystemName
+    )
+    .transition(.opacity.animation(.linear(duration: 0.1)))
+  }
+
   var body: some View {
-    Menu {
-      Picker("", selection: $playbackSpeed) {
-        ForEach(PlayerModel.PlaybackSpeed.supportedSpeeds) { speed in
-          Text(verbatim: "\(speed.rate.formatted())×")
-            .tag(speed)
+    if #available(iOS 17.0, *) {
+      Menu {
+        Picker("", selection: $playbackSpeed) {
+          ForEach(PlayerModel.PlaybackSpeed.supportedSpeeds) { speed in
+            Text(verbatim: "\(speed.rate.formatted())×")
+              .tag(speed)
+          }
         }
+      } label: {
+        label
+      } primaryAction: {
+        playbackSpeed.cycle()
       }
-    } label: {
-      Label(
-        Strings.Playlist.accessibilityPlaybackSpeed,
-        braveSystemImage: playbackSpeed.braveSystemName
-      )
-      .transition(.opacity.animation(.linear(duration: 0.1)))
-    } primaryAction: {
-      playbackSpeed.cycle()
+    } else {
+      Button {
+        playbackSpeed.cycle()
+      } label: {
+        label
+      }
     }
   }
 }
@@ -37,30 +49,42 @@ struct PlaybackSpeedPicker: View {
 struct RepeatModePicker: View {
   @Binding var repeatMode: PlayerModel.RepeatMode
 
+  private var label: some View {
+    Group {
+      switch repeatMode {
+      case .none:
+        Label(Strings.Playlist.accessibilityRepeatModeOff, braveSystemImage: "leo.loop.off")
+      case .one:
+        Label(Strings.Playlist.accessibilityRepeatModeOne, braveSystemImage: "leo.loop.1")
+      case .all:
+        Label(Strings.Playlist.accessibilityRepeatModeAll, braveSystemImage: "leo.loop.all")
+      }
+    }
+    .transition(.opacity.animation(.linear(duration: 0.1)))
+  }
+
   var body: some View {
-    Menu {
-      Picker("", selection: $repeatMode) {
-        Label(Strings.Playlist.repeatModeOptionNone, braveSystemImage: "leo.loop.off")
-          .tag(PlayerModel.RepeatMode.none)
-        Label(Strings.Playlist.repeatModeOptionOne, braveSystemImage: "leo.loop.1")
-          .tag(PlayerModel.RepeatMode.one)
-        Label(Strings.Playlist.repeatModeOptionAll, braveSystemImage: "leo.loop.all")
-          .tag(PlayerModel.RepeatMode.all)
-      }
-    } label: {
-      Group {
-        switch repeatMode {
-        case .none:
-          Label(Strings.Playlist.accessibilityRepeatModeOff, braveSystemImage: "leo.loop.off")
-        case .one:
-          Label(Strings.Playlist.accessibilityRepeatModeOne, braveSystemImage: "leo.loop.1")
-        case .all:
-          Label(Strings.Playlist.accessibilityRepeatModeAll, braveSystemImage: "leo.loop.all")
+    if #available(iOS 17.0, *) {
+      Menu {
+        Picker("", selection: $repeatMode) {
+          Label(Strings.Playlist.repeatModeOptionNone, braveSystemImage: "leo.loop.off")
+            .tag(PlayerModel.RepeatMode.none)
+          Label(Strings.Playlist.repeatModeOptionOne, braveSystemImage: "leo.loop.1")
+            .tag(PlayerModel.RepeatMode.one)
+          Label(Strings.Playlist.repeatModeOptionAll, braveSystemImage: "leo.loop.all")
+            .tag(PlayerModel.RepeatMode.all)
         }
+      } label: {
+        label
+      } primaryAction: {
+        repeatMode.cycle()
       }
-      .transition(.opacity.animation(.linear(duration: 0.1)))
-    } primaryAction: {
-      repeatMode.cycle()
+    } else {
+      Button {
+        repeatMode.cycle()
+      } label: {
+        label
+      }
     }
   }
 }


### PR DESCRIPTION
There's a SwiftUI bug that doesn't properly apply `ButtonStyle`'s to `Menu` controls, so this change only uses a Button on iOS 16 to cycle playback speed & repeat mode rather than allow long-pressing to select a specific option

Resolves https://github.com/brave/brave-browser/issues/42509

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

