### PR TITLE
[iOS] Remake the playlist queue after updating a playlist folder (move/delete/re-order) (uplift to 1.74.x)

### DIFF
--- a/ios/brave-ios/Sources/Data/models/PlaylistItem.swift
+++ b/ios/brave-ios/Sources/Data/models/PlaylistItem.swift
@@ -213,7 +213,8 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
   public static func reorderItems(
     in folder: PlaylistFolder,
     fromOffsets indexSet: IndexSet,
-    toOffset offset: Int
+    toOffset offset: Int,
+    completion: (() -> Void)? = nil
   ) {
     let frc = PlaylistItem.frc(parentFolder: folder)
     try? frc.performFetch()
@@ -231,6 +232,10 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
         try frc.managedObjectContext.save()
       } catch {
         Logger.module.error("\(error.localizedDescription)")
+      }
+
+      DispatchQueue.main.async {
+        completion?()
       }
     }
   }
@@ -540,7 +545,11 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
     }
   }
 
-  public static func moveItems(items: [NSManagedObjectID], to folderUUID: String?) {
+  public static func moveItems(
+    items: [NSManagedObjectID],
+    to folderUUID: String?,
+    completion: (() -> Void)? = nil
+  ) {
     DataController.perform { context in
       var folder: PlaylistFolder?
       if let folderUUID = folderUUID {
@@ -553,6 +562,10 @@ final public class PlaylistItem: NSManagedObject, CRUD, Identifiable {
       playlistItems.forEach {
         $0.playlistFolder = folder
         folder?.playlistItems?.insert($0)
+      }
+
+      DispatchQueue.main.async {
+        completion?()
       }
     }
   }

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -421,13 +421,21 @@ public class PlaylistManager: NSObject {
       // Do NOT delete the item if we can't delete it's local cache.
       // That will cause zombie items.
       if await deleteCache(item: item) {
-        PlaylistItem.removeItems([item])
+        await withCheckedContinuation { continuation in
+          PlaylistItem.removeItems([item]) {
+            continuation.resume()
+          }
+        }
         onDownloadStateChanged(id: item.tagId, state: .invalid, displayName: nil, error: nil)
         return true
       }
       return false
     } else {
-      PlaylistItem.removeItems([item])
+      await withCheckedContinuation { continuation in
+        PlaylistItem.removeItems([item]) {
+          continuation.resume()
+        }
+      }
       onDownloadStateChanged(id: item.tagId, state: .invalid, displayName: nil, error: nil)
       return true
     }

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistContentView.swift
@@ -79,7 +79,11 @@ struct PlaylistContentView: View {
             }
           }
         ),
-        isPlaying: playerModel.isPlaying
+        isPlaying: playerModel.isPlaying,
+        onPlaylistUpdated: {
+          // Update the queue to reflect updated playlist
+          playerModel.makeItemQueue(selectedItemID: selectedItemID)
+        }
       )
     } sidebarHeader: {
       if let selectedFolder = selectedFolder {
@@ -165,7 +169,9 @@ struct PlaylistContentView: View {
     }
     .sheet(isPresented: $isEditModePresented) {
       if let selectedFolder {
-        EditFolderView(folder: selectedFolder, folders: Array(folders))
+        EditFolderView(folder: selectedFolder, folders: Array(folders)) {
+          playerModel.makeItemQueue(selectedItemID: playerModel.selectedItemID)
+        }
       }
     }
     .alert(Strings.Playlist.newPlaylistButtonTitle, isPresented: $isNewPlaylistAlertPresented) {

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistSidebarList.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistSidebarList.swift
@@ -15,6 +15,7 @@ struct PlaylistSidebarList: View {
   var selectedFolderID: PlaylistFolder.ID
   @Binding var selectedItemID: PlaylistItem.ID?
   var isPlaying: Bool
+  var onPlaylistUpdated: () -> Void
 
   @Environment(\.openTabURL) private var openTabURL
   @FetchRequest private var items: FetchedResults<PlaylistItem>
@@ -26,7 +27,8 @@ struct PlaylistSidebarList: View {
     folders: [PlaylistFolder],
     folderID: PlaylistFolder.ID,
     selectedItemID: Binding<PlaylistItem.ID?>,
-    isPlaying: Bool
+    isPlaying: Bool,
+    onPlaylistUpdated: @escaping () -> Void
   ) {
     self.folders = folders
     self.selectedFolderID = folderID
@@ -39,6 +41,7 @@ struct PlaylistSidebarList: View {
     )
     self._selectedItemID = selectedItemID
     self.isPlaying = isPlaying
+    self.onPlaylistUpdated = onPlaylistUpdated
   }
 
   var body: some View {
@@ -127,7 +130,9 @@ struct PlaylistSidebarList: View {
                 selection: Binding(
                   get: { selectedFolderID },
                   set: {
-                    PlaylistItem.moveItems(items: [item.objectID], to: $0)
+                    PlaylistItem.moveItems(items: [item.objectID], to: $0) {
+                      onPlaylistUpdated()
+                    }
                   }
                 )
               ) {
@@ -146,6 +151,7 @@ struct PlaylistSidebarList: View {
                 if selectedItemID == item.id {
                   selectedItemID = nil
                 }
+                onPlaylistUpdated()
               }
             } label: {
               Label(Strings.Playlist.deleteItem, braveSystemImage: "leo.trash")
@@ -370,6 +376,12 @@ struct PlaylistSidebarContentUnavailableView: View {
 
 #if DEBUG
 #Preview {
-  PlaylistSidebarList(folders: [], folderID: "", selectedItemID: .constant(nil), isPlaying: false)
+  PlaylistSidebarList(
+    folders: [],
+    folderID: "",
+    selectedItemID: .constant(nil),
+    isPlaying: false,
+    onPlaylistUpdated: {}
+  )
 }
 #endif


### PR DESCRIPTION
Uplift of #26740
Resolves https://github.com/brave/brave-browser/issues/42355

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.