### PR TITLE
Fixes NTP Sponsored Images are not updated in 15 minutes interval

### DIFF
--- a/components/ntp_background_images/browser/BUILD.gn
+++ b/components/ntp_background_images/browser/BUILD.gn
@@ -15,6 +15,8 @@ static_library("browser") {
     "ntp_background_images_data.h",
     "ntp_background_images_service.cc",
     "ntp_background_images_service.h",
+    "ntp_background_images_update_util.cc",
+    "ntp_background_images_update_util.h",
     "ntp_p3a_helper.h",
     "ntp_p3a_util.cc",
     "ntp_p3a_util.h",

--- a/components/ntp_background_images/browser/features.h
+++ b/components/ntp_background_images/browser/features.h
@@ -34,6 +34,11 @@ inline constexpr base::FeatureParam<int> kCountToBrandedWallpaper{
 inline constexpr base::FeatureParam<base::TimeDelta> kResetCounterAfter{
     &kBraveNTPBrandedWallpaper, "reset_counter_after", base::Days(1)};
 
+inline constexpr base::FeatureParam<base::TimeDelta>
+    kSponsoredImagesUpdateCheckAfter{&kBraveNTPBrandedWallpaper,
+                                     "sponsored_images_update_check_after",
+                                     base::Minutes(15)};
+
 }  // namespace features
 }  // namespace ntp_background_images
 

--- a/components/ntp_background_images/browser/ntp_background_images_component_installer.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_component_installer.cc
@@ -13,6 +13,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
+#include "brave/components/ntp_background_images/browser/ntp_background_images_update_util.h"
 #include "brave/components/ntp_background_images/browser/sponsored_images_component_data.h"
 #include "components/component_updater/component_installer.h"
 #include "components/component_updater/component_updater_service.h"
@@ -148,8 +149,16 @@ bool NTPBackgroundImagesComponentInstallerPolicy::IsBraveComponent() const {
   return true;
 }
 
-void OnRegistered(const std::string& component_id) {
+void RegisterNTPBackgroundImagesComponentCallback(
+    const std::string& component_id) {
   BraveOnDemandUpdater::GetInstance()->EnsureInstalled(component_id);
+}
+
+void RegisterNTPSponsoredImagesComponentCallback(
+    const std::string& component_id) {
+  // Unlike other components that are only installed during registration,
+  // we always update the sponsored images component upon registration.
+  CheckAndUpdateSponsoredImagesComponent(component_id);
 }
 
 }  // namespace
@@ -165,7 +174,9 @@ void RegisterNTPBackgroundImagesComponent(
       std::make_unique<NTPBackgroundImagesComponentInstallerPolicy>(
           kNTPBIComponentPublicKey, kNTPBIComponentID, "NTP Background Images",
           callback));
-  installer->Register(cus, base::BindOnce(&OnRegistered, kNTPBIComponentID));
+  installer->Register(
+      cus, base::BindOnce(&RegisterNTPBackgroundImagesComponentCallback,
+                          kNTPBIComponentID));
 }
 
 void RegisterNTPSponsoredImagesComponent(
@@ -184,8 +195,9 @@ void RegisterNTPSponsoredImagesComponent(
           component_id,
           component_name,
           callback));
-  installer->Register(cus,
-                      base::BindOnce(&OnRegistered, component_id));
+  installer->Register(
+      cus, base::BindOnce(&RegisterNTPSponsoredImagesComponentCallback,
+                          component_id));
 }
 
 }  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/ntp_background_images_service.h
+++ b/components/ntp_background_images/browser/ntp_background_images_service.h
@@ -140,7 +140,8 @@ class NTPBackgroundImagesService {
   bool IsValidSuperReferralComponentInfo(
       const base::Value::Dict& component_info) const;
 
-  void CheckImagesComponentUpdate(const std::string& component_id);
+  void ScheduleNextSponsoredImagesComponentUpdate();
+  void CheckSponsoredImagesComponentUpdate(const std::string& component_id);
 
   // virtual for test.
   virtual void CheckSuperReferralComponent();

--- a/components/ntp_background_images/browser/ntp_background_images_update_util.cc
+++ b/components/ntp_background_images/browser/ntp_background_images_update_util.cc
@@ -1,0 +1,85 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/ntp_background_images/browser/ntp_background_images_update_util.h"
+
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/types/cxx23_to_underlying.h"
+#include "brave/components/brave_component_updater/browser/brave_on_demand_updater.h"
+#include "components/component_updater/component_updater_service.h"
+
+namespace ntp_background_images {
+
+namespace {
+
+void CheckAndUpdateSponsoredImagesComponentCallback(
+    const std::string& component_id,
+    const update_client::Error error) {
+  switch (error) {
+    case update_client::Error::NONE: {
+      VLOG(6)
+          << "Checked for updates to NTP Sponsored Images component with ID "
+          << component_id;
+      break;
+    }
+    case update_client::Error::UPDATE_IN_PROGRESS: {
+      VLOG(6) << "NTP Sponsored Images component update in progress";
+      break;
+    }
+    case update_client::Error::UPDATE_CANCELED: {
+      VLOG(6) << "NTP Sponsored Images component update canceled";
+      break;
+    }
+    case update_client::Error::RETRY_LATER: {
+      VLOG(6) << "NTP Sponsored Images component update failed, retry later";
+      break;
+    }
+    case update_client::Error::SERVICE_ERROR: {
+      VLOG(6) << "NTP Sponsored Images component update failed due to service "
+                 "error";
+      break;
+    }
+    case update_client::Error::UPDATE_CHECK_ERROR: {
+      VLOG(6) << "NTP Sponsored Images component update failed due to update "
+                 "check error";
+      break;
+    }
+    case update_client::Error::CRX_NOT_FOUND: {
+      VLOG(6) << "NTP Sponsored Images component update failed due to CRX not "
+                 "found";
+      break;
+    }
+    case update_client::Error::INVALID_ARGUMENT: {
+      VLOG(6) << "NTP Sponsored Images component update failed due to invalid "
+                 "argument";
+      break;
+    }
+    case update_client::Error::BAD_CRX_DATA_CALLBACK: {
+      VLOG(6) << "NTP Sponsored Images component update failed due to bad CRX "
+                 "data callback";
+      break;
+    }
+    case update_client::Error::MAX_VALUE: {
+      VLOG(6) << "NTP Sponsored Images component update failed due to unknown "
+                 "error";
+      break;
+    }
+  }
+}
+
+}  // namespace
+
+void CheckAndUpdateSponsoredImagesComponent(const std::string& component_id) {
+  VLOG(6) << "Checking for updates to NTP Sponsored Images component with ID "
+          << component_id;
+
+  brave_component_updater::BraveOnDemandUpdater::GetInstance()->OnDemandUpdate(
+      component_id, component_updater::OnDemandUpdater::Priority::FOREGROUND,
+      base::BindOnce(&CheckAndUpdateSponsoredImagesComponentCallback,
+                     component_id));
+}
+
+}  // namespace ntp_background_images

--- a/components/ntp_background_images/browser/ntp_background_images_update_util.h
+++ b/components/ntp_background_images/browser/ntp_background_images_update_util.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_BACKGROUND_IMAGES_UPDATE_UTIL_H_
+#define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_BACKGROUND_IMAGES_UPDATE_UTIL_H_
+
+#include <string>
+
+namespace ntp_background_images {
+
+void CheckAndUpdateSponsoredImagesComponent(const std::string& component_id);
+
+}  // namespace ntp_background_images
+
+#endif  // BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_BACKGROUND_IMAGES_UPDATE_UTIL_H_


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42531

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Test Case 1: Verify Ads Component Update During Normal Operation

Steps to Reproduce:

- Start the browser.
- Keep the system active and running for 30 minutes.
- Monitor the ads component update logs.

Expected Result: Ads component checks for updates at 15-minute intervals (at least two updates in 30 minutes).

--

Test Case 2: Verify Timer Resumes After Short Downtime

Steps to Reproduce:

- Start the browser.
- Allow the system to run for 10 minutes.
- Suspend the system for 30 minutes.
- Resume the system.
- Monitor the ads component update logs.

Expected Result: Ads component checks for updates after 5 minutes.

--

Test Case 3: Verify Timer Triggers Ads Component Update After Extended Downtime

Steps to Reproduce:

- Start the browser.
- Allow the system to run for 5 minutes.
- Suspend the system for 5 hours.
- Resume the system.
- Monitor the ads component update logs.

Expected Result: Ads component checks for updates after 10 minutes.

--

Test Case 4: Verify Ads Component Update Timer Behavior with Restart

Steps to Reproduce:

- Start the browser.
- Monitor the ads component update logs.

Expected Result: An ads component checks for updates after 1 minute.