### PR TITLE
(Wallet) Fix Wallet restore action when triggered from unlock screen

### DIFF
--- a/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletOnboardingPagerAdapter.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/adapters/WalletOnboardingPagerAdapter.java
@@ -125,7 +125,7 @@ public class WalletOnboardingPagerAdapter extends FragmentStateAdapter {
             }
             case PASSWORD_CREATION -> {
                 final boolean isOnboarding = true;
-
+                final boolean overridePreviousWallet = false;
                 if (position == 0) {
                     return new OnboardingInitWalletFragment(
                             mRestartSetupAction, mRestartRestoreAction);
@@ -138,7 +138,7 @@ public class WalletOnboardingPagerAdapter extends FragmentStateAdapter {
                 } else if (position == 4) {
                     return new OnboardingFingerprintUnlockFragment();
                 } else if (position == 5) {
-                    return new OnboardingCreatingWalletFragment();
+                    return OnboardingCreatingWalletFragment.newInstance(overridePreviousWallet);
                 } else if (position == 6) {
                     return OnboardingRecoveryPhraseFragment.newInstance(isOnboarding);
                 } else if (position == 7) {
@@ -158,6 +158,7 @@ public class WalletOnboardingPagerAdapter extends FragmentStateAdapter {
                 }
             }
             case ONBOARDING_RESTORE -> {
+                final boolean overridePreviousWallet = false;
                 if (position == 0) {
                     return new OnboardingInitWalletFragment(
                             mRestartSetupAction, mRestartRestoreAction);
@@ -172,7 +173,7 @@ public class WalletOnboardingPagerAdapter extends FragmentStateAdapter {
                 } else if (position == 5) {
                     return new OnboardingFingerprintUnlockFragment();
                 } else if (position == 6) {
-                    return new OnboardingCreatingWalletFragment();
+                    return OnboardingCreatingWalletFragment.newInstance(overridePreviousWallet);
                 } else if (position == 7) {
                     return new OnboardingConfirmationFragment();
                 } else {
@@ -187,17 +188,20 @@ public class WalletOnboardingPagerAdapter extends FragmentStateAdapter {
                 return new UnlockWalletFragment();
             }
             case RESTORE -> {
+                final boolean overridePreviousWallet = true;
                 if (position == 0) {
                     return new UnlockWalletFragment();
                 } else if (position == 1) {
                     return OnboardingRestoreWalletFragment.newInstance();
                 } else if (position == 2) {
-                    return new OnboardingSecurePasswordFragment();
+                    return OnboardingNetworkSelectionFragment.newInstance();
                 } else if (position == 3) {
-                    return new OnboardingFingerprintUnlockFragment();
+                    return new OnboardingSecurePasswordFragment();
                 } else if (position == 4) {
-                    return new OnboardingCreatingWalletFragment();
+                    return new OnboardingFingerprintUnlockFragment();
                 } else if (position == 5) {
+                    return OnboardingCreatingWalletFragment.newInstance(overridePreviousWallet);
+                } else if (position == 6) {
                     return new OnboardingConfirmationFragment();
                 } else {
                     throw new IllegalStateException(
@@ -241,7 +245,7 @@ public class WalletOnboardingPagerAdapter extends FragmentStateAdapter {
         } else if (mWalletAction == WalletAction.UNLOCK) {
             return 1;
         } else if (mWalletAction == WalletAction.RESTORE) {
-            return 6;
+            return 7;
         } else if (mWalletAction == WalletAction.BACKUP) {
             return 5;
         }

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/UnlockWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/UnlockWalletFragment.java
@@ -118,6 +118,7 @@ public class UnlockWalletFragment extends BaseWalletNextPageFragment
 
         mUnlockWalletRestoreButton.setOnClickListener(
                 v -> {
+                    mUnlockWalletRestoreButton.setEnabled(false);
                     onNextPage.gotoRestorePage(false);
                     mUnlockWalletPassword.setText(null);
                 });
@@ -143,6 +144,7 @@ public class UnlockWalletFragment extends BaseWalletNextPageFragment
     @Override
     public void onResume() {
         super.onResume();
+        mUnlockWalletRestoreButton.setEnabled(true);
         if (mOnNextPage != null) {
             mOnNextPage.showCloseButton(false);
             mOnNextPage.showBackButton(false);

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingCreatingWalletFragment.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/fragments/onboarding/OnboardingCreatingWalletFragment.java
@@ -31,8 +31,27 @@ import java.util.Set;
 public class OnboardingCreatingWalletFragment extends BaseOnboardingWalletFragment {
 
     private static final int NEXT_PAGE_DELAY_MS = 700;
+    private static final String OVERRIDE_PREVIOUS_WALLET_ARG = "overridePreviousWallet";
 
     private boolean mAddTransitionDelay = true;
+    private boolean mOverridePreviousWallet;
+
+    @NonNull
+    public static OnboardingCreatingWalletFragment newInstance(
+            final boolean overridePreviousWallet) {
+        OnboardingCreatingWalletFragment fragment = new OnboardingCreatingWalletFragment();
+        Bundle args = new Bundle();
+        args.putBoolean(OVERRIDE_PREVIOUS_WALLET_ARG, overridePreviousWallet);
+        fragment.setArguments(args);
+        return fragment;
+    }
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        mOverridePreviousWallet =
+                requireArguments().getBoolean(OVERRIDE_PREVIOUS_WALLET_ARG, false);
+    }
 
     @Override
     public View onCreateView(
@@ -55,10 +74,12 @@ public class OnboardingCreatingWalletFragment extends BaseOnboardingWalletFragme
 
         KeyringModel keyringModel = getKeyringModel();
         if (keyringModel != null) {
-            // Check if a wallet is already present and skip if that's the case.
+            // Check if a wallet is already present and skip only
+            // when not restoring a wallet over an existing one from
+            // unlock screen button.
             keyringModel.isWalletCreated(
                     isCreated -> {
-                        if (isCreated) {
+                        if (isCreated && !mOverridePreviousWallet) {
                             goToNextPage();
                             return;
                         }


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/42497

Fixes an issue affecting Brave Wallet restoration when called from Restore button in the unlock screen.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Lock the Wallet
- Navigate to unlock screen and tap on Restore button
- Follow all the steps to restore a pre-existing Wallet
- Observe the Wallet is restored correctly
