### PR TITLE
[ads] Fixes notification ads are disabled after connecting to a custodian (uplift to 1.74.x)

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -515,21 +515,50 @@ void AdsServiceImpl::NotifyAdsServiceInitialized() const {
   }
 }
 
-void AdsServiceImpl::ShutdownClearDataAndMaybeRestart() {
+void AdsServiceImpl::ShutdownAndClearAdsServiceDataAndMaybeRestart() {
   ShutdownAdsService();
 
   VLOG(6) << "Clearing ads data";
 
+  // Clear catalog preferences to ensure the catalog is redownloaded on restart
+  // because the catalog will be remove from `ads_service`/`database.sqlite`,
+  // leaving these preferences orphaned.
+  prefs_->ClearPref(prefs::kCatalogId);
+  prefs_->ClearPref(prefs::kCatalogVersion);
+  prefs_->ClearPref(prefs::kCatalogPing);
+  prefs_->ClearPref(prefs::kCatalogLastUpdated);
+
+  // Clear reaction preferences as the history will be removed from
+  // `ads_service`/`database.sqlite`, leaving these preferences orphaned.
+  prefs_->ClearPref(prefs::kAdReactions);
+  prefs_->ClearPref(prefs::kSegmentReactions);
+  prefs_->ClearPref(prefs::kSaveAds);
+  prefs_->ClearPref(prefs::kMarkedAsInappropriate);
+
+  ClearAdsServiceDataAndMaybeRestart();
+}
+
+void AdsServiceImpl::ShutdownAndClearPrefsAndAdsServiceDataAndMaybeRestart() {
+  ShutdownAdsService();
+
+  VLOG(6) << "Clearing ads data";
+
+  // Clear all ads preferences.
   prefs_->ClearPrefsWithPrefixSilently("brave.brave_ads");
   local_state_->ClearPref(brave_l10n::prefs::kCountryCode);
 
-  file_task_runner_->PostTaskAndReplyWithResult(
-      FROM_HERE, base::BindOnce(&DeletePathOnFileTaskRunner, ads_service_path_),
-      base::BindOnce(&AdsServiceImpl::ShutdownClearDataAndMaybeRestartCallback,
-                     weak_ptr_factory_.GetWeakPtr()));
+  ClearAdsServiceDataAndMaybeRestart();
 }
 
-void AdsServiceImpl::ShutdownClearDataAndMaybeRestartCallback(
+void AdsServiceImpl::ClearAdsServiceDataAndMaybeRestart() {
+  file_task_runner_->PostTaskAndReplyWithResult(
+      FROM_HERE, base::BindOnce(&DeletePathOnFileTaskRunner, ads_service_path_),
+      base::BindOnce(
+          &AdsServiceImpl::ClearAdsServiceDataAndMaybeRestartCallback,
+          weak_ptr_factory_.GetWeakPtr()));
+}
+
+void AdsServiceImpl::ClearAdsServiceDataAndMaybeRestartCallback(
     const bool success) {
   if (!success) {
     VLOG(0) << "Failed to clear ads data";
@@ -1158,7 +1187,7 @@ void AdsServiceImpl::OnNotificationAdClicked(const std::string& placement_id) {
 
 void AdsServiceImpl::ClearData() {
   UMA_HISTOGRAM_BOOLEAN(kClearDataHistogramName, true);
-  ShutdownClearDataAndMaybeRestart();
+  ShutdownAndClearPrefsAndAdsServiceDataAndMaybeRestart();
 }
 
 void AdsServiceImpl::GetDiagnostics(GetDiagnosticsCallback callback) {
@@ -1906,12 +1935,12 @@ void AdsServiceImpl::OnRewardsWalletCreated() {
 void AdsServiceImpl::OnExternalWalletConnected() {
   ShowReminder(mojom::ReminderType::kExternalWalletConnected);
 
-  ShutdownClearDataAndMaybeRestart();
+  ShutdownAndClearAdsServiceDataAndMaybeRestart();
 }
 
 void AdsServiceImpl::OnCompleteReset(const bool success) {
   if (success) {
-    ShutdownClearDataAndMaybeRestart();
+    ShutdownAndClearPrefsAndAdsServiceDataAndMaybeRestart();
   }
 }
 

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -140,8 +140,10 @@ class AdsServiceImpl final : public AdsService,
 
   void NotifyAdsServiceInitialized() const;
 
-  void ShutdownClearDataAndMaybeRestart();
-  void ShutdownClearDataAndMaybeRestartCallback(bool success);
+  void ShutdownAndClearAdsServiceDataAndMaybeRestart();
+  void ShutdownAndClearPrefsAndAdsServiceDataAndMaybeRestart();
+  void ClearAdsServiceDataAndMaybeRestart();
+  void ClearAdsServiceDataAndMaybeRestartCallback(bool success);
 
   void OnExternalWalletConnectedCallback(bool success);
 


### PR DESCRIPTION
Uplift of #26774
Resolves https://github.com/brave/brave-browser/issues/42436
Resolved https://github.com/brave/brave-browser/issues/42534

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.