### PR TITLE
[ads] Fixes double delay for backoff timers (uplift to 1.74.x)

### DIFF
--- a/components/brave_ads/core/internal/common/timer/backoff_timer.cc
+++ b/components/brave_ads/core/internal/common/timer/backoff_timer.cc
@@ -40,7 +40,7 @@ bool BackoffTimer::Stop() {
 
 base::TimeDelta BackoffTimer::CalculateDelay(const base::TimeDelta delay) {
   int64_t delay_in_seconds = delay.InSeconds();
-  delay_in_seconds <<= ++backoff_count_;
+  delay_in_seconds <<= backoff_count_++;
 
   base::TimeDelta backoff_delay = base::Seconds(delay_in_seconds);
   if (backoff_delay > max_backoff_delay_) {


### PR DESCRIPTION
Uplift of #26759
Resolves https://github.com/brave/brave-browser/issues/42537
Uplift of #26868
Resolves https://github.com/brave/brave-browser/issues/42680

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.