### PR TITLE
fix(privacy): Fix iOS HTTPs upgrade failure

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -1093,17 +1093,6 @@ extension BrowserViewController: WKNavigationDelegate {
   ) {
     guard let tab = tab(for: webView) else { return }
 
-    // Handle invalid upgrade to https
-    if let responseURL = webView.url,
-      let response = handleInvalidHTTPSUpgrade(
-        tab: tab,
-        responseURL: responseURL
-      )
-    {
-      tab.loadRequest(response)
-      return
-    }
-
     // Ignore the "Frame load interrupted" error that is triggered when we cancel a request
     // to open an external application and hand it over to UIApplication.openURL(). The result
     // will be that we switch to the external app, for example the app store, while keeping the
@@ -1130,6 +1119,15 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
+      // Check for invalid upgrade to https
+      if let response = handleInvalidHTTPSUpgrade(
+        tab: tab,
+        responseURL: url
+      ) {
+        tab.loadRequest(response)
+        return
+      }
+
       ErrorPageHelper(certStore: profile.certStore).loadPage(error, forUrl: url, inWebView: webView)
 
       // Submitting same erroneous URL using toolbar will cause progress bar get stuck

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -1120,10 +1120,13 @@ extension BrowserViewController: WKNavigationDelegate {
 
     if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
       // Check for invalid upgrade to https
-      if let response = handleInvalidHTTPSUpgrade(
-        tab: tab,
-        responseURL: url
-      ) {
+      if url.scheme == "https",  // verify failing url was https
+        let response = handleInvalidHTTPSUpgrade(
+          tab: tab,
+          responseURL: url
+        )
+      {
+        // load original or strict mode interstitial
         tab.loadRequest(response)
         return
       }
@@ -1844,6 +1847,15 @@ extension BrowserViewController: WKUIDelegate {
     if shouldUpgradeToHttps(url: requestURL, isPrivate: tab.isPrivate),
       var urlComponents = URLComponents(url: requestURL, resolvingAgainstBaseURL: true)
     {
+      if let existingUpgradeRequestURL = tab.upgradedHTTPSRequest?.url,
+        existingUpgradeRequestURL == requestURL
+      {
+        // if server redirected https -> http, https load never fails.
+        // `webView(_:decidePolicyFor:preferences:)` will be called before
+        // `webView(_:didReceiveServerRedirectForProvisionalNavigation:)`
+        // so we must prevent upgrade loop.
+        return handleInvalidHTTPSUpgrade(tab: tab, responseURL: requestURL)
+      }
       // Attempt to upgrade to HTTPS
       urlComponents.scheme = "https"
       if let upgradedURL = urlComponents.url {
@@ -1889,8 +1901,7 @@ extension BrowserViewController: WKUIDelegate {
   /// or show the interstitial page
   private func handleInvalidHTTPSUpgrade(tab: Tab, responseURL: URL) -> URLRequest? {
     // Handle invalid upgrade to https
-    guard responseURL.scheme == "https",
-      let originalRequest = tab.upgradedHTTPSRequest,
+    guard let originalRequest = tab.upgradedHTTPSRequest,
       let originalURL = originalRequest.url,
       responseURL.baseDomain == originalURL.baseDomain
     else {


### PR DESCRIPTION
- Check against the error's failing url instead of the web view url when determining if an https upgrade failed.

Resolves https://github.com/brave/brave-browser/issues/42542

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. In Settings -> Shields & Privacy, update `Upgrade Connections to HTTPS` to `Standard`
2. Enter `alwayshttp.com` in url bar
3. Verify `http://www.alwayshttp.com` loads (insecure, https update fails)
4. Enter `alwayshttp.com` in url bar
5. Verify `http://alwayshttp.com` loads (insecure, https upgrade fails)
    - Note: takes a bit longer to timeout than `uaf.cafe`
6. Enter `scrisc.com` in url bar
7. Verify `https://scrisc.com/` loads (https upgrade success).
8. In Settings -> Shields & Privacy, update `Upgrade Connections to HTTPS` to `Strict`
9. Enter `alwayshttp.com` in url bar
10. Verify https not supported interstitial is shown. Proceed should add to allow list and load the page.
11. Enter `alwayshttp.com` in url bar
12. Verify https not supported interstitial is shown. Proceed should add to allow list and load the page.
13. Enter `scrisc.com` in url bar
14. Verify `https://scrisc.com/` loads (https upgrade success).