### PR TITLE
[iOS] Improve display of item duration shown in the drawer/sidebar

### DIFF
--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -764,6 +764,11 @@ extension PlaylistManager {
       return
     }
 
+    if let url = URL(string: item.src), url.scheme == "blob" {
+      completion(nil)
+      return
+    }
+
     fetchAssetDuration(item: item) { [weak self] duration in
       guard let self = self else {
         completion(nil)

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerModel.swift
@@ -651,6 +651,11 @@ public final class PlayerModel: ObservableObject {
     if let playerItem = playerItemToReplace {
       if let (_, _, duration) = try? await playerItem.asset.load(.isPlayable, .tracks, .duration) {
         self.duration = itemDurationForAssetDuration(duration)
+        // Update the PlaylistItem's duration if its missing
+        if item.duration.isZero, case .seconds(let timeInterval) = self.duration, timeInterval > 0 {
+          item.duration = timeInterval
+          PlaylistItem.updateItem(.init(item: item))
+        }
       }
       if playImmediately {
         pause()

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
@@ -56,7 +56,11 @@ struct PlaylistItemView: View {
         HStack(alignment: .firstTextBaseline) {
           switch duration {
           case .seconds(let duration):
-            Text(.seconds(duration), format: .time(pattern: .minuteSecond))
+            if duration > 0 {
+              Text(.seconds(duration), format: .time(pattern: .minuteSecond))
+            } else {
+              EmptyView()
+            }
           case .indefinite:
             Text(Strings.Playlist.liveIndicator)
           case .unknown:


### PR DESCRIPTION
This changes the fetch flow a bit to:
1. Update the selected playlist item's duration based on the loaded assets duration when its empty
2. Hides the duration when its not available yet
3. Doesn't bother attempting to fetch the duration of a remote blob source

Resolves https://github.com/brave/brave-browser/issues/42569


## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

