### PR TITLE
[iOS] - Fix URL-Bar LTR-RTL Clipping - 1.73.x (#26360)

### DIFF
--- a/ios/BUILD.gn
+++ b/ios/BUILD.gn
@@ -34,6 +34,7 @@ import("//brave/ios/browser/api/query_filter/headers.gni")
 import("//brave/ios/browser/api/session_restore/headers.gni")
 import("//brave/ios/browser/api/skus/headers.gni")
 import("//brave/ios/browser/api/storekit_receipt/headers.gni")
+import("//brave/ios/browser/api/unicode/headers.gni")
 import("//brave/ios/browser/api/url/headers.gni")
 import("//brave/ios/browser/api/url_sanitizer/headers.gni")
 import("//brave/ios/browser/api/web/ui/headers.gni")
@@ -124,6 +125,7 @@ brave_core_public_headers += browser_api_features_public_headers
 brave_core_public_headers += credential_provider_public_headers
 brave_core_public_headers += developer_options_code_public_headers
 brave_core_public_headers += browser_api_storekit_receipt_public_headers
+brave_core_public_headers += browser_api_unicode_public_headers
 
 action("brave_core_umbrella_header") {
   script = "//build/config/ios/generate_umbrella_header.py"

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/History/HistoryView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/History/HistoryView.swift
@@ -44,13 +44,10 @@ struct HistoryItemView: View {
             forDisplayOmitSchemePathAndTrivialSubdomains: url.absoluteString
           )
         )
-        .truncationMode(.tail)
         .font(.footnote)
         .frame(maxWidth: .infinity, alignment: .leading)
         .fixedSize(horizontal: false, vertical: true)
         .foregroundStyle(Color(braveSystemName: .textSecondary))
-        .environment(\.layoutDirection, .leftToRight)
-        .flipsForRightToLeftLayoutDirection(false)
       }
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/PageSecurityView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/PageSecurityView.swift
@@ -4,6 +4,7 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import BraveCore
+import BraveShared
 import BraveUI
 import Foundation
 import Shared
@@ -63,9 +64,12 @@ struct PageSecurityView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 0) {
       VStack(alignment: .leading, spacing: 16) {
-        Text(displayURL)
+        URLElidedText(text: displayURL)
           .font(.headline)
           .foregroundStyle(Color(braveSystemName: .textPrimary))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .fixedSize(horizontal: false, vertical: true)
+
         HStack(alignment: .firstTextBaseline) {
           warningIcon
           VStack(alignment: .leading, spacing: 4) {

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -136,6 +136,55 @@ extension URL {
 
     return URL(string: "\(baseURL)?\(InternalURL.Param.url.rawValue)=\(encodedURL)")
   }
+
+  /// Determines the predominant directionality of the URL's text as defined:
+  /// - Left-To-Right - if a string has a strong LTR directionality, it would be laid out LTR.
+  /// - Right-To-Left - if a string has a strong RTL directionality, it would be laid out RTL.
+  /// - Mixed - if a string contains BOTH a strong LTR and RTL directionality
+  /// - Neutral - if a string contains NEITHER a strong LTR or RTL directionality (empty string)
+  /// Therefore, a string is `Uni-directional`, if it is LTR or RTL, but not both.
+  public var isUnidirectional: Bool {
+    // First format the URL which will decode the puny-coding
+    var renderedString = URLFormatter.formatURL(
+      absoluteString,
+      formatTypes: [.omitDefaults, .omitTrivialSubdomains, .omitTrailingSlashOnBareHostname],
+      unescapeOptions: .normal
+    )
+
+    // Strip scheme
+    if let scheme,
+      let range = renderedString.range(
+        of: "^(\(scheme)://|\(scheme):)",
+        options: .regularExpression
+      )
+    {
+      renderedString.replaceSubrange(range, with: "")
+    }
+
+    return renderedString.bidiDirection != .mixed
+  }
+
+  /// Determines whether the URL would typically be rendered Left-To-Right instead of Right-To-Left
+  public var isRenderedLeftToRight: Bool {
+    // First format the URL which will decode the puny-coding
+    var renderedString = URLFormatter.formatURL(
+      absoluteString,
+      formatTypes: [.omitDefaults, .omitTrivialSubdomains, .omitTrailingSlashOnBareHostname],
+      unescapeOptions: .normal
+    )
+
+    // Strip scheme
+    if let scheme,
+      let range = renderedString.range(
+        of: "^(\(scheme)://|\(scheme):)",
+        options: .regularExpression
+      )
+    {
+      renderedString.replaceSubrange(range, with: "")
+    }
+
+    return renderedString.bidiBaseDirection == .leftToRight
+  }
 }
 
 extension InternalURL {

--- a/ios/brave-ios/Sources/BraveShared/URLElidedTextView.swift
+++ b/ios/brave-ios/Sources/BraveShared/URLElidedTextView.swift
@@ -37,5 +37,8 @@ public struct URLElidedText: View {
         attributes: .init([.font: font ?? .body, .paragraphStyle: paragraphStyle])
       )
     )
+    .truncationMode(.tail)
+    .environment(\.layoutDirection, .leftToRight)
+    .flipsForRightToLeftLayoutDirection(false)
   }
 }

--- a/ios/browser/BUILD.gn
+++ b/ios/browser/BUILD.gn
@@ -40,6 +40,7 @@ source_set("browser") {
     "api/session_restore",
     "api/storekit_receipt",
     "api/sync",
+    "api/unicode",
     "api/url",
     "api/version_info",
     "api/web",

--- a/ios/browser/api/unicode/BUILD.gn
+++ b/ios/browser/api/unicode/BUILD.gn
@@ -1,0 +1,16 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("unicode") {
+  sources = [
+    "NSString+Unicode.h",
+    "NSString+Unicode.mm",
+  ]
+  deps = [
+    "//base",
+    "//third_party/icu",
+  ]
+  frameworks = [ "Foundation.framework" ]
+}

--- a/ios/browser/api/unicode/NSString+Unicode.h
+++ b/ios/browser/api/unicode/NSString+Unicode.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_IOS_BROWSER_API_UNICODE_NSSTRING_UNICODE_H_
+#define BRAVE_IOS_BROWSER_API_UNICODE_NSSTRING_UNICODE_H_
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, ICUUBiDiDirection) {
+  ICUUBiDiDirectionLeftToRight,
+  ICUUBiDiDirectionRightToLeft,
+  ICUUBiDiDirectionMixed,
+  ICUUBiDiDirectionNeutral
+};
+
+OBJC_EXPORT
+@interface NSString (Unicode)
+/// Determines the *overall* direction of the text after processing its entire
+/// contents.
+/// - returns: `Left-To-Right`, `Right-To-Left`, `Mixed`
+/// - note: Can never return `Neutral`
+@property(nonatomic, readonly) ICUUBiDiDirection bidiDirection;
+
+/// Determines the *base* directionality of the text,
+/// based only on the *first* strong directional character, or the absence of
+/// one.
+/// - returns: `Left-To-Right`, `Right-To-Left`, `Neutral`
+/// - note: Can never return `Mixed`
+@property(nonatomic, readonly) ICUUBiDiDirection bidiBaseDirection;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif  // BRAVE_IOS_BROWSER_API_UNICODE_NSSTRING_UNICODE_H_

--- a/ios/browser/api/unicode/NSString+Unicode.mm
+++ b/ios/browser/api/unicode/NSString+Unicode.mm
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include <string>
+
+#include "base/strings/sys_string_conversions.h"
+#include "brave/ios/browser/api/unicode/NSString+Unicode.h"
+#include "third_party/icu/source/common/unicode/ubidi.h"
+
+@implementation NSString (Unicode)
+
+- (ICUUBiDiDirection)bidiDirection {
+  auto utf16_string = base::SysNSStringToUTF16(self);
+  if (!utf16_string.empty()) {
+    UBiDi* bidi = ubidi_open();
+    CHECK(bidi);
+
+    UErrorCode status = U_ZERO_ERROR;
+    ubidi_setPara(bidi, &utf16_string[0],
+                  static_cast<std::int32_t>(utf16_string.size()),
+                  UBIDI_DEFAULT_LTR, nullptr, &status);
+    if (U_FAILURE(status)) {
+      ubidi_close(bidi);
+      // Error as this function can never return neutral
+      return ICUUBiDiDirectionLeftToRight;
+    }
+
+    UBiDiDirection direction = ubidi_getDirection(bidi);
+    ubidi_close(bidi);
+    return static_cast<ICUUBiDiDirection>(direction);
+  }
+
+  return ICUUBiDiDirectionLeftToRight;
+}
+
+- (ICUUBiDiDirection)bidiBaseDirection {
+  auto utf16_string = base::SysNSStringToUTF16(self);
+  if (!utf16_string.empty()) {
+    return static_cast<ICUUBiDiDirection>(ubidi_getBaseDirection(
+        &utf16_string[0], static_cast<std::int32_t>(utf16_string.size())));
+  }
+
+  return ICUUBiDiDirectionNeutral;
+}
+
+@end

--- a/ios/browser/api/unicode/headers.gni
+++ b/ios/browser/api/unicode/headers.gni
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+browser_api_unicode_public_headers =
+    [ "//brave/ios/browser/api/unicode/NSString+Unicode.h" ]


### PR DESCRIPTION
- Fix URL-Bar LTR-RTL
- Fix display of URL in the Page Security View
- Use ICU in Chromium, to determine text direction and base direction

<!-- Add brave-browser issue below that this PR will resolve -->
Uplift of https://github.com/brave/brave-core/pull/26360
Resolves https://github.com/brave/brave-browser/issues/42070
Resolves https://github.com/brave/internal/issues/1228

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

