### PR TITLE
Don't run Sparkle and Omaha 4 concurrently

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -91,7 +91,7 @@ hooks = [
     'pattern': '.',
     'condition': 'checkout_mac',
     'action': ['vpython3', 'build/download_dep.py',
-               'omaha4/BraveUpdater-131.1.75.54.zip',
+               'omaha4/BraveUpdater-132.1.75.66.zip',
                '//build/mac_files/omaha4'],
   },
   {

--- a/DEPS
+++ b/DEPS
@@ -91,7 +91,7 @@ hooks = [
     'pattern': '.',
     'condition': 'checkout_mac',
     'action': ['vpython3', 'build/download_dep.py',
-               'omaha4/BraveUpdater-128.1.70.58.zip',
+               'omaha4/BraveUpdater-131.1.75.54.zip',
                '//build/mac_files/omaha4'],
   },
   {

--- a/chromium_src/chrome/updater/mac/setup/mac_setup.mm
+++ b/chromium_src/chrome/updater/mac/setup/mac_setup.mm
@@ -16,5 +16,5 @@
 #define GetWakeTaskPlistPath(scope) \
   std::nullopt;                     \
   return true;
-#include "src/chrome/updater/mac/setup/setup.mm"
+#include "src/chrome/updater/mac/setup/mac_setup.mm"
 #undef GetWakeTaskPlistPath

--- a/chromium_src/chrome/updater/mac/setup/setup.mm
+++ b/chromium_src/chrome/updater/mac/setup/setup.mm
@@ -5,10 +5,14 @@
 
 #include "chrome/updater/util/mac_util.h"
 
-// We must prevent Omaha 4 from running at the same time as Sparkle. We can
-// control this in the browser, where we invoke either Omaha 4 or Sparkle. But
-// we have no control over when Omaha 4's background updates run. We therefore
-// disable them by not registering the wake job:
+// We are in the process of migrating from Sparkle to Omaha 4. The two operate
+// differently: Sparkle checks for updates in the browser, while Omaha 4
+// registers a wake job that runs periodically in the background, also when the
+// browser isn't running. We must prevent Omaha 4 and Sparkle from running at
+// the same time. We do this by not registering Omaha 4's wake job, and instead
+// invoking its on-demand API from inside the browser instead of Sparkle. Once
+// the migration to Sparkle is complete, we will re-enable the wake job by
+// releasing a new version of Omaha 4 itself.
 #define GetWakeTaskPlistPath(scope) \
   std::nullopt;                     \
   return true;

--- a/chromium_src/chrome/updater/mac/setup/setup.mm
+++ b/chromium_src/chrome/updater/mac/setup/setup.mm
@@ -1,0 +1,16 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/updater/util/mac_util.h"
+
+// We must prevent Omaha 4 from running at the same time as Sparkle. We can
+// control this in the browser, where we invoke either Omaha 4 or Sparkle. But
+// we have no control over when Omaha 4's background updates run. We therefore
+// disable them by not registering the wake job:
+#define GetWakeTaskPlistPath(scope) \
+  std::nullopt;                     \
+  return true;
+#include "src/chrome/updater/mac/setup/setup.mm"
+#undef GetWakeTaskPlistPath

--- a/chromium_src/chrome/updater/test/integration_tests_mac.mm
+++ b/chromium_src/chrome/updater/test/integration_tests_mac.mm
@@ -11,8 +11,8 @@
 
 #include <optional>
 
-#include "base/files/file_path.h"
 #include "base/auto_reset.h"
+#include "base/files/file_path.h"
 #include "chrome/updater/updater_scope.h"
 #include "chrome/updater/util/mac_util.h"
 

--- a/chromium_src/chrome/updater/test/integration_tests_mac.mm
+++ b/chromium_src/chrome/updater/test/integration_tests_mac.mm
@@ -1,0 +1,59 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+// We disable Omaha 4's background task to prevent it from running at the same
+// time as Sparkle. This breaks upstream's integration tests. The code in this
+// file fixes them and tests our desired behavior.
+
+#include "chrome/updater/test/integration_tests_mac.h"
+
+#include <optional>
+
+#include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/functional/callback_helpers.h"
+#include "chrome/updater/updater_scope.h"
+#include "chrome/updater/util/mac_util.h"
+
+namespace {
+
+thread_local bool g_in_expect_installed = false;
+
+}  // namespace
+
+namespace updater {
+
+std::optional<base::FilePath> GetWakeTaskPlistPath_BraveImpl(
+    UpdaterScope scope) {
+  if (g_in_expect_installed) {
+    // Pretend that the wake job is registered by returning an existing path:
+    return base::FilePath("/");
+  }
+  return GetWakeTaskPlistPath(scope);
+}
+
+}  // namespace updater
+
+#define GetWakeTaskPlistPath GetWakeTaskPlistPath_BraveImpl
+#define ExpectInstalled ExpectInstalled_ChromiumImpl
+#include "src/chrome/updater/test/integration_tests_mac.mm"
+#undef GetWakeTaskPlistPath
+#undef ExpectInstalled
+
+namespace updater::test {
+
+void ExpectInstalled(UpdaterScope scope) {
+  // Test for our desired behavior. We don't want the wake job to be registered:
+  EXPECT_FALSE(base::PathExists(*GetWakeTaskPlistPath(scope)));
+
+  // Call the original implementation in such a way that it believes the wake
+  // job is registered:
+  g_in_expect_installed = true;
+  base::ScopedClosureRunner cleanup(
+      base::BindOnce([]() { g_in_expect_installed = false; }));
+  ExpectInstalled_ChromiumImpl(scope);
+}
+
+}  // namespace updater::test

--- a/chromium_src/chrome/updater/test/integration_tests_mac.mm
+++ b/chromium_src/chrome/updater/test/integration_tests_mac.mm
@@ -12,8 +12,7 @@
 #include <optional>
 
 #include "base/files/file_path.h"
-#include "base/functional/callback.h"
-#include "base/functional/callback_helpers.h"
+#include "base/auto_reset.h"
 #include "chrome/updater/updater_scope.h"
 #include "chrome/updater/util/mac_util.h"
 
@@ -50,9 +49,7 @@ void ExpectInstalled(UpdaterScope scope) {
 
   // Call the original implementation in such a way that it believes the wake
   // job is registered:
-  g_in_expect_installed = true;
-  base::ScopedClosureRunner cleanup(
-      base::BindOnce([]() { g_in_expect_installed = false; }));
+  base::AutoReset<bool> auto_reset(&g_in_expect_installed, true);
   ExpectInstalled_ChromiumImpl(scope);
 }
 

--- a/chromium_src/chrome/updater/util/mac_util.mm
+++ b/chromium_src/chrome/updater/util/mac_util.mm
@@ -1,0 +1,26 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#import "chrome/updater/util/mac_util.h"
+
+#include "chrome/updater/updater_scope.h"
+
+#define RemoveWakeJobFromLaunchd RemoveWakeJobFromLaunchd_Unused
+#include "src/chrome/updater/util/mac_util.mm"
+#undef RemoveWakeJobFromLaunchd
+
+namespace updater {
+
+bool RemoveWakeJobFromLaunchd(UpdaterScope scope) {
+  // We must prevent Omaha 4 from running at the same time as Sparkle. We can
+  // control this in the browser, where we invoke either Omaha 4 or Sparkle. But
+  // we have no control over when Omaha 4's background task runs. We therefore
+  // disable it by not registering the wake job. This would make the original
+  // implementation of this function fail. Return true to pretend that the job
+  // (which was never registered in the first place) was successfully removed:
+  return true;
+}
+
+}  // namespace updater


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/42365.

This PR disables Omaha 4's background updates, which also disables updates of O4 itself. After merging this PR, we need to have a follow-up task that brings this functionality back (via on-demand updates).

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

All tests only need to be performed on macOS.

The user-visible change of this PR is that the notification _Background Items Added_ should no longer appear when Brave checks for updates with Omaha 4:

![image](https://github.com/user-attachments/assets/3e996820-b2e8-47ee-997b-62b50e891473)

For system-wide installations:

1. Install Brave Nightly from the PKG. This installs Brave system-wide, in that the installation directory is owned by user `root`, and not by your own user.
2. Launch Brave from the command line, as follows: `/Applications/Brave\ Browser\ Nightly.app/Contents/MacOS/Brave\ Browser\ Nightly --enable-features=BraveUseOmaha4Alpha`
3. There should be a banner at the top saying "Brave may not be able to keep itself updated". Click the "Set up automatic updates" button inside it.
4. Enter your admin password when prompted.
5. Go to (or reload) `brave://settings/help`. It should say that no update is available.
6. In the above steps, you should NOT see the _Background Items Added_ notification.
7. Make sure that the file `/Library/LaunchDaemons/com.brave.Updater.wake.system.plist` does NOT exist.
8. Close Brave.
9. Run the following command in a terminal: `sudo nano "/Library/Application Support/BraveSoftware/BraveUpdater/prefs.json"` (it is intentional that there is no `~`).
10. Enter your password when prompted.
11. Use the arrow keys to locate the entry `"com.brave.browser.nightly":{...}`. Add the following inside the curly braces: "cohort":"testers". Be sure to add a comma after this, unless it is the last entry before the closing curly brace. For example: `"com.brave.browser.nightly":{"cohort":"testers","ap_key":...}`.
12. Press Ctrl+O to save the file.
13. Confirm the suggested file path with Enter.
14. Press Ctrl+X to exit.
15. Launch Brave again with `BraveUseOmaha4Alpha`.
16. Go to `brave://settings/help`.
17. An update should now be applied. When it is done, do _not_ click the Relaunch button. Instead close Brave manually and relaunch with `BraveUseOmaha4Alpha`.
18. Brave should now be at a very high version.

For per-user installations:

1. Install Brave Nightly from the DMG.
2. Launch Brave from the command line, as follows: `/Applications/Brave\ Browser\ Nightly.app/Contents/MacOS/Brave\ Browser\ Nightly --enable-features=BraveUseOmaha4Alpha`
3. Go to (or reload) `brave://settings/help`. It should say that no update is available.
4. In the above steps, you should NOT see the _Background Items Added_ notification.
5. Close Brave.
6. Run the following command in a terminal: `nano ~/Library/Application\ Support/BraveSoftware/BraveUpdater/prefs.json`
7. Use the arrow keys to locate the entry `"com.brave.browser.nightly":{...}`. Add the following inside the curly braces: "cohort":"testers". Be sure to add a comma after this, unless it is the last entry before the closing curly brace. For example: `"com.brave.browser.nightly":{"cohort":"testers","ap_key":...}`.
8. Press Ctrl+O to save the file.
9. Confirm the suggested file path with Enter.
10. Press Ctrl+X to exit.
11. Launch Brave again with `BraveUseOmaha4Alpha`.
12. Go to `brave://settings/help`.
13. An update should now be applied. When it is done, do _not_ click the Relaunch button. Instead close Brave manually and relaunch with `BraveUseOmaha4Alpha`.
14. Brave should now be at a very high version.
15. Make sure that the file `~/Library/LaunchAgents/com.brave.Updater.wake.plist` does not exist.