### PR TITLE
[iOS] - Make Playlist WebCompat only apply to Playlist WebViews and not Tabs

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -512,7 +512,6 @@ public class BrowserViewController: UIViewController {
       self.setupAdsNotificationHandler()
       self.recordAdsUsageType()
     }
-    Preferences.Playlist.webMediaSourceCompatibility.observe(from: self)
     Preferences.PrivacyReports.captureShieldsData.observe(from: self)
     Preferences.PrivacyReports.captureVPNAlerts.observe(from: self)
     Preferences.Wallet.defaultEthWallet.observe(from: self)
@@ -3314,11 +3313,9 @@ extension BrowserViewController: PreferencesObserver {
     case Preferences.Rewards.hideRewardsIcon.key,
       Preferences.Rewards.rewardsToggledOnce.key:
       updateRewardsButtonState()
-    case Preferences.Playlist.webMediaSourceCompatibility.key,
-      Preferences.General.mediaAutoBackgrounding.key:
+    case Preferences.General.mediaAutoBackgrounding.key:
       tabManager.selectedTab?.setScripts(scripts: [
-        .playlistMediaSource: Preferences.Playlist.webMediaSourceCompatibility.value,
-        .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value,
+        .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value
       ])
       tabManager.reloadSelectedTab()
     case Preferences.General.youtubeHighQuality.key:

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -37,7 +37,10 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
     type: .private
   ).then {
     $0.createWebview()
-    $0.setScript(script: .playlistMediaSource, enabled: true)
+    $0.setScript(
+      script: .playlistMediaSource,
+      enabled: Preferences.Playlist.webMediaSourceCompatibility.value
+    )
     $0.webView?.scrollView.layer.masksToBounds = true
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -39,7 +39,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
     $0.createWebview()
     $0.setScript(
       script: .playlistMediaSource,
-      enabled: Preferences.Playlist.webMediaSourceCompatibility.value
+      enabled: true
     )
     $0.webView?.scrollView.layer.masksToBounds = true
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -531,7 +531,6 @@ class Tab: NSObject {
         .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
         .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value,
         .nightMode: Preferences.General.nightModeEnabled.value,
-        .playlistMediaSource: Preferences.Playlist.webMediaSourceCompatibility.value,
       ]
 
       userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/PlaylistSettingsViewController.swift
@@ -185,17 +185,6 @@ class PlaylistSettingsViewController: TableViewController {
       Section(
         rows: [
           .boolRow(
-            title: Strings.PlayList.playlistWebCompatibilityTitle,
-            detailText: Strings.PlayList.playlistWebCompatibilityDescription,
-            option: Preferences.Playlist.webMediaSourceCompatibility
-          )
-        ])
-    )
-
-    dataSource.sections.append(
-      Section(
-        rows: [
-          .boolRow(
             title: Strings.PlaylistFolderSharing.sharedFolderSyncAutomaticallyTitle,
             option: Preferences.Playlist.syncSharedFoldersAutomatically
           )

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -5179,24 +5179,6 @@ extension Strings {
         comment: "Error message when saving a playlist item for offline fails"
       )
 
-    public static let playlistWebCompatibilityTitle =
-      NSLocalizedString(
-        "playlist.playlistWebCompatibilityTitle",
-        tableName: "BraveShared",
-        bundle: .module,
-        value: "Web Compatibility",
-        comment: "Title for Playlist setting"
-      )
-
-    public static let playlistWebCompatibilityDescription =
-      NSLocalizedString(
-        "playlist.playlistWebCompatibilityDescription",
-        tableName: "BraveShared",
-        bundle: .module,
-        value: "Disables the WebKit MediaSource API",
-        comment: "Description for Playlist setting"
-      )
-
     public static let playlistLiveMediaStream =
       NSLocalizedString(
         "playlist.playlistLiveMediaStream",

--- a/ios/brave-ios/Sources/Playlist/PlaylistPreferences.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistPreferences.swift
@@ -53,7 +53,7 @@ extension Preferences {
     /// The Option to disable playlist MediaSource web-compatibility
     public static let webMediaSourceCompatibility = Option<Bool>(
       key: "playlist.webMediaSourceCompatibility",
-      default: false
+      default: UIDevice.isIpad
     )
     /// The option to start the playback where user left-off
     public static let playbackLeftOff = Option<Bool>(key: "playlist.playbackLeftOff", default: true)

--- a/ios/brave-ios/Sources/Playlist/PlaylistPreferences.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistPreferences.swift
@@ -50,11 +50,6 @@ extension Preferences {
       key: "playlist.autoDownload",
       default: PlayListDownloadType.on.rawValue
     )
-    /// The Option to disable playlist MediaSource web-compatibility
-    public static let webMediaSourceCompatibility = Option<Bool>(
-      key: "playlist.webMediaSourceCompatibility",
-      default: UIDevice.isIpad
-    )
     /// The option to start the playback where user left-off
     public static let playbackLeftOff = Option<Bool>(key: "playlist.playbackLeftOff", default: true)
     /// The option to disable long-press-to-add-to-playlist gesture.


### PR DESCRIPTION
## Summary
- Only use WebCompat toggle for Playlist Blobs within Playlist but not actual browsing.
- Enable the Playlist WebCompat toggle for iPad (iPad always uses blobs on Youtube), but not for iPhone (iPhone doesn't always need it).

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41555

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Youtube in a Tab shows in 4K:
![image](https://github.com/user-attachments/assets/56f72aaa-4bad-49a1-8a67-8e51b5623730)

That same video (blob) is added to Playlist and working fine:
![image](https://github.com/user-attachments/assets/c3df6612-1e62-42a7-88b6-5317acf931d8)
