### PR TITLE
Removed `Use Sync staging server` at `QA preferences`

### DIFF
--- a/android/java/org/chromium/chrome/browser/settings/developer/BraveQAPreferences.java
+++ b/android/java/org/chromium/chrome/browser/settings/developer/BraveQAPreferences.java
@@ -23,8 +23,6 @@ import android.widget.EditText;
 import androidx.preference.Preference;
 import androidx.preference.Preference.OnPreferenceChangeListener;
 
-import org.jni_zero.CalledByNative;
-
 import org.chromium.base.ContextUtils;
 import org.chromium.base.FileUtils;
 import org.chromium.base.Log;
@@ -56,7 +54,6 @@ import java.io.InputStream;
 public class BraveQAPreferences extends BravePreferenceFragment
         implements OnPreferenceChangeListener, BraveRewardsObserver {
     private static final String PREF_USE_REWARDS_STAGING_SERVER = "use_rewards_staging_server";
-    private static final String PREF_USE_SYNC_STAGING_SERVER = "use_sync_staging_server";
     private static final String PREF_QA_MAXIMIZE_INITIAL_ADS_NUMBER =
             "qa_maximize_initial_ads_number";
     private static final String PREF_QA_DEBUG_NTP = "qa_debug_ntp";
@@ -75,7 +72,6 @@ public class BraveQAPreferences extends BravePreferenceFragment
     private ChromeSwitchPreference mLinkSubscriptionOnStaging;
     private ChromeSwitchPreference mBraveDormantFeatureEngagement;
     private ChromeSwitchPreference mIsStagingServer;
-    private ChromeSwitchPreference mIsSyncStagingServer;
     private ChromeSwitchPreference mMaximizeAdsNumber;
     private ChromeSwitchPreference mDebugNTP;
     private ChromeSwitchPreference mVlogRewards;
@@ -118,13 +114,6 @@ public class BraveQAPreferences extends BravePreferenceFragment
         mIsStagingServer.setChecked(
                 UserPrefs.get(ProfileManager.getLastUsedRegularProfile())
                         .getBoolean(BravePref.USE_REWARDS_STAGING_SERVER));
-
-        mIsSyncStagingServer =
-                (ChromeSwitchPreference) findPreference(PREF_USE_SYNC_STAGING_SERVER);
-        if (mIsSyncStagingServer != null) {
-            mIsSyncStagingServer.setOnPreferenceChangeListener(this);
-        }
-        mIsSyncStagingServer.setChecked(isSyncStagingUsed());
 
         mMaximizeAdsNumber =
                 (ChromeSwitchPreference) findPreference(PREF_QA_MAXIMIZE_INITIAL_ADS_NUMBER);
@@ -268,7 +257,6 @@ public class BraveQAPreferences extends BravePreferenceFragment
         } else if (PREF_QA_MAXIMIZE_INITIAL_ADS_NUMBER.equals(preference.getKey())) {
             enableMaximumAdsNumber((boolean) newValue);
         } else if (PREF_QA_DEBUG_NTP.equals(preference.getKey())
-                || PREF_USE_SYNC_STAGING_SERVER.equals(preference.getKey())
                 || PREF_QA_VLOG_REWARDS.equals(preference.getKey())
                 || LinkSubscriptionUtils.PREF_LINK_SUBSCRIPTION_ON_STAGING.equals(
                         preference.getKey())
@@ -302,11 +290,6 @@ public class BraveQAPreferences extends BravePreferenceFragment
     private static String getPreferenceString(String preferenceName) {
         SharedPreferences sharedPreferences = ContextUtils.getAppSharedPreferences();
         return sharedPreferences.getString(preferenceName, "");
-    }
-
-    @CalledByNative
-    public static boolean isSyncStagingUsed() {
-        return getPreferenceValue(PREF_USE_SYNC_STAGING_SERVER);
     }
 
     public static boolean shouldVlogRewards() {

--- a/android/java/res/xml/qa_preferences.xml
+++ b/android/java/res/xml/qa_preferences.xml
@@ -27,12 +27,6 @@
         android:summaryOff="@string/text_off" />
 
     <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
-        android:key="use_sync_staging_server"
-        android:title="Use Sync staging server"
-        android:summaryOn="@string/text_on"
-        android:summaryOff="@string/text_off" />
-
-    <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
         android:key="qa_maximize_initial_ads_number"
         android:title="Maximize initial ads number"
         android:summaryOn="@string/text_on"

--- a/build/android/BUILD.gn
+++ b/build/android/BUILD.gn
@@ -234,7 +234,6 @@ generate_jni("jni_headers") {
     "//brave/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceFactoryAndroid.java",
     "//brave/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java",
     "//brave/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettings.java",
-    "//brave/android/java/org/chromium/chrome/browser/settings/developer/BraveQAPreferences.java",
     "//brave/android/java/org/chromium/chrome/browser/shields/FilterListServiceFactory.java",
     "//brave/android/java/org/chromium/chrome/browser/shields/UrlSanitizerServiceFactory.java",
     "//brave/android/java/org/chromium/chrome/browser/signin/BraveSigninManager.java",

--- a/build/android/config.gni
+++ b/build/android/config.gni
@@ -122,7 +122,6 @@ brave_jni_headers_sources = [
   "//brave/android/java/org/chromium/chrome/browser/playlist/PlaylistServiceFactoryAndroid.java",
   "//brave/android/java/org/chromium/chrome/browser/preferences/BravePrefServiceBridge.java",
   "//brave/android/java/org/chromium/chrome/browser/preferences/website/BraveShieldsContentSettings.java",
-  "//brave/android/java/org/chromium/chrome/browser/settings/developer/BraveQAPreferences.java",
   "//brave/android/java/org/chromium/chrome/browser/shields/FilterListServiceFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/shields/UrlSanitizerServiceFactory.java",
   "//brave/android/java/org/chromium/chrome/browser/signin/BraveSigninManager.java",

--- a/chromium_src/components/sync/service/DEPS
+++ b/chromium_src/components/sync/service/DEPS
@@ -1,5 +1,4 @@
 include_rules = [
   "+brave/components/brave_sync",
   "+brave/components/sync/service",
-  "+brave/build/android/jni_headers/BraveQAPreferences_jni.h",
 ]

--- a/chromium_src/components/sync/service/sync_service_impl.cc
+++ b/chromium_src/components/sync/service/sync_service_impl.cc
@@ -11,11 +11,6 @@
 #include "components/sync/base/command_line_switches.h"
 #include "components/sync/base/sync_util.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "base/android/jni_android.h"
-#include "brave/build/android/jni_headers/BraveQAPreferences_jni.h"
-#endif
-
 namespace syncer {
 
 GURL BraveGetSyncServiceURL(const base::CommandLine& command_line,
@@ -52,16 +47,6 @@ GURL BraveGetSyncServiceURL(const base::CommandLine& command_line,
                      << value;
       }
     }
-  }
-#else
-  const char kBraveSyncServiceStagingURL[] =
-      "https://sync-v2.bravesoftware.com/v2";
-
-  JNIEnv* env = base::android::AttachCurrentThread();
-  bool b_use_staging_sync_server =
-      Java_BraveQAPreferences_isSyncStagingUsed(env);
-  if (b_use_staging_sync_server) {
-    return GURL(kBraveSyncServiceStagingURL);
   }
 #endif
 

--- a/components/sync/service/sources.gni
+++ b/components/sync/service/sources.gni
@@ -20,7 +20,3 @@ brave_components_sync_service_deps = [
   "//brave/components/brave_sync:prefs",
   "//brave/components/constants",
 ]
-
-if (is_android) {
-  brave_components_sync_service_deps += [ "//brave/build/android:jni_headers" ]
-}


### PR DESCRIPTION
This fixes CI build failure appeared at `v1.75.58` and resolves deps violation

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42596

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. ensure build `npm run create_dist -- Release --channel=nightly --target_os=android --target_arch=x64 --target_android_base=mono --target_android_output_format=apk` succeed
2. ensure there is no option Use Sync staging server` at `QA preferences`
3. ensure staging url `https://sync-v2.bravesoftware.com/v2` can be set through `QA preferences`/`command line` and displayed at `brave://sync-internals/`
