### PR TITLE
Add minimal presubmit patch check

### DIFF
--- a/PRESUBMIT.py
+++ b/PRESUBMIT.py
@@ -13,7 +13,6 @@ import brave_node
 import chromium_presubmit_overrides
 import override_utils
 
-USE_PYTHON3 = True
 PRESUBMIT_VERSION = '2.0.0'
 
 

--- a/chromium_presubmit_config.json5
+++ b/chromium_presubmit_config.json5
@@ -30,6 +30,8 @@
       "CheckTreeIsOpen",
       // We run our own format check.
       "CheckPatchFormatted",
+      // We don't use Chromium LSC process for Brave repository.
+      "CheckLargeScaleChange",
     ],
   },
 

--- a/chromium_src/PRESUBMIT.py
+++ b/chromium_src/PRESUBMIT.py
@@ -6,7 +6,6 @@
 import brave_chromium_utils
 import chromium_presubmit_overrides
 
-USE_PYTHON3 = True
 PRESUBMIT_VERSION = '2.0.0'
 
 

--- a/patches/PRESUBMIT.py
+++ b/patches/PRESUBMIT.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import chromium_presubmit_overrides
+
+PRESUBMIT_VERSION = '2.0.0'
+
+
+# Adds support for chromium_presubmit_config.json5 and some helpers.
+def CheckToModifyInputApi(input_api, _output_api):
+    chromium_presubmit_overrides.modify_input_api(input_api)
+    return []
+
+
+def CheckPatchFile(input_api, output_api):
+    files_to_check = (r'.+\.patch$', )
+    files_to_skip = ()
+
+    file_filter = lambda f: input_api.FilterSourceFile(
+        f, files_to_check=files_to_check, files_to_skip=files_to_skip)
+
+    items = []
+    for f in input_api.AffectedSourceFiles(file_filter):
+        contents = list(f.NewContents())
+        for lineno, line in enumerate(contents, 1):
+            # Prevent removing empty lines, it's a guaranteed git conflict.
+            if line == '-':
+                items.append(f'{f.LocalPath()}:{lineno} (removed empty line)')
+                continue
+
+            # Prevent adding empty lines at diff block boundaries. This doesn't
+            # affect git conflict resolution, but adds unnecessary noise. It's
+            # okay to have empty lines in the middle of a diff block.
+            if line != '+':
+                continue
+
+            # Look at previous and next lines to determine if this empty line is
+            # at diff block boundary.
+            prev_line = contents[lineno - 2] if lineno > 1 else ''
+            next_line = contents[lineno] if lineno < len(contents) else ''
+
+            # Empty line at block boundary or single-line block.
+            if not (prev_line.startswith('+') and next_line.startswith('+')):
+                items.append(f'{f.LocalPath()}:{lineno} (added empty line)')
+
+    if not items:
+        return []
+
+    return [
+        output_api.PresubmitError(
+            'Patch file should not add or remove empty lines', items)
+    ]

--- a/patches/PRESUBMIT_test.py
+++ b/patches/PRESUBMIT_test.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2024 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+import brave_chromium_utils
+
+# pylint: disable=import-error,no-member
+import PRESUBMIT
+
+with brave_chromium_utils.sys_path("//"):
+    from PRESUBMIT_test_mocks import MockFile, MockAffectedFile
+    from PRESUBMIT_test_mocks import MockInputApi, MockOutputApi
+
+
+class PatchFileTest(unittest.TestCase):
+
+    def testEmptyLinesInPatch(self):
+        cases = [
+            {
+                'name': 'valid patch without empty lines',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '+void func() {',
+                    '+  DoSomething();',
+                    '+}',
+                ],
+                'expected_errors': 0
+            },
+            {
+                'name': 'added single empty line',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '+',
+                ],
+                'expected_errors': 1
+            },
+            {
+                'name': 'added multiple empty lines',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '+',
+                    '+',
+                ],
+                'expected_errors': 1
+            },
+            {
+                'name': 'removed empty line',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '-',
+                ],
+                'expected_errors': 1
+            },
+            {
+                'name': 'empty line at start of block',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '+',
+                    '+void func() {',
+                    '+  DoSomething();',
+                    '+}',
+                ],
+                'expected_errors': 1
+            },
+            {
+                'name': 'empty line at end of block',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '+void func() {',
+                    '+  DoSomething();',
+                    '+}',
+                    '+',
+                ],
+                'expected_errors': 1
+            },
+            {
+                'name': 'empty line in middle is ok',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    '+void func() {',
+                    '+',
+                    '+  DoSomething();',
+                    '+}',
+                ],
+                'expected_errors': 0
+            },
+            {
+                'name': 'removed empty line',
+                'contents': [
+                    'diff --git a/file.cc b/file.cc',
+                    ' void func() {',
+                    '-',
+                    '   DoSomething();',
+                    ' }',
+                ],
+                'expected_errors': 1
+            },
+        ]
+
+        for case in cases:
+            with self.subTest(name=case['name']):
+                affected_file = MockAffectedFile('test.patch',
+                                                 case['contents'])
+                input_api = MockInputApi()
+                input_api.files = [affected_file]
+
+                results = PRESUBMIT.CheckPatchFile(input_api, MockOutputApi())
+
+                actual_errors = len(results)
+                self.assertEqual(
+                    case['expected_errors'], actual_errors,
+                    f"Expected {case['expected_errors']} errors, got {actual_errors}"
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/perf/PRESUBMIT.py
+++ b/tools/perf/PRESUBMIT.py
@@ -7,7 +7,6 @@ import pathlib
 import platform
 import os
 
-USE_PYTHON3 = True
 PRESUBMIT_VERSION = '2.0.0'
 
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Move some PR-review chores to presubmit.

Resolves https://github.com/brave/brave-browser/issues/42611

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

