### PR TITLE
[iOS] Ensure new tab page items are sized correctly

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/New Tab Page/NewTabPageViewController.swift
@@ -67,8 +67,11 @@ extension NTPSectionProvider {
       sectionInset = .zero
     }
     return CGSize(
-      width: collectionView.bounds.width - collectionView.safeAreaInsets.left
-        - collectionView.safeAreaInsets.right - sectionInset.left - sectionInset.right,
+      width: max(
+        0,
+        collectionView.bounds.width - collectionView.safeAreaInsets.left
+          - collectionView.safeAreaInsets.right - sectionInset.left - sectionInset.right
+      ),
       height: 1000
     )
   }
@@ -946,7 +949,7 @@ class NewTabPageViewController: UIViewController {
     }
 
     switch (oldValue, newValue) {
-    case (.loading, .loading):
+    case (.initial, .initial), (.loading, .loading):
       // Nothing to do
       break
     case (

--- a/ios/brave-ios/Sources/BraveNews/FeedItemView.swift
+++ b/ios/brave-ios/Sources/BraveNews/FeedItemView.swift
@@ -357,7 +357,7 @@ extension FeedItemView {
           return 36.0
         }
       }
-      return _height(for: .stack(root))
+      return max(0, _height(for: .stack(root)))
     }
 
     /// Defines a feed item layout where the thumbnail resides on top taking up


### PR DESCRIPTION
This is an attempted crash fix for https://github.com/brave/brave-browser/issues/42601 where an exception is being thrown by `-[UICollectionViewFlowLayout _getSizingInfosWithExistingSizingDictionary:]` which typically happens if the size passed into the layout system is negative. This change ensures that the sizes passed into the flow layout are non-negative

Resolves https://github.com/brave/brave-browser/issues/42601

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

