### PR TITLE
Fix broken tab group menu options

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -353,6 +353,12 @@ void BraveAppMenuModel::RemoveUpstreamMenus() {
     RemoveItemAt(*index);
   }
 
+  // Remove upstream's "Tab groups" menu item, as this functionality is already
+  // available in multiple other places
+  if (const auto index = GetIndexOfCommandId(IDC_SAVED_TAB_GROUPS_MENU)) {
+    RemoveItemAt(*index);
+  }
+
   // Remove upstream's dev tools menu and associated separator.
   // It'll be changed its position in more tools.
   if (const auto index = more_tools_model->GetIndexOfCommandId(IDC_DEV_TOOLS)) {

--- a/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
+++ b/browser/ui/toolbar/brave_app_menu_model_browsertest.cc
@@ -192,6 +192,7 @@ IN_PROC_BROWSER_TEST_F(BraveAppMenuModelBrowserTest, MenuOrderTest) {
 
   std::vector<int> commands_disabled_for_normal_profile = {
       IDC_NEW_TOR_CONNECTION_FOR_SITE,
+      IDC_SAVED_TAB_GROUPS_MENU,
   };
   CheckCommandsAreInOrderInMenuModel(browser(),
                                      commands_in_order_for_normal_profile);

--- a/browser/ui/views/toolbar/brave_app_menu.cc
+++ b/browser/ui/views/toolbar/brave_app_menu.cc
@@ -48,12 +48,25 @@ using views::MenuItemView;
 
 namespace {
 
+constexpr int kBookmarksCommandIdOffset =
+    AppMenuModel::kMinBookmarksCommandId - IDC_FIRST_UNBOUNDED_MENU;
+constexpr int kTabGroupsCommandIdOffset =
+    AppMenuModel::kMinTabGroupsCommandId - IDC_FIRST_UNBOUNDED_MENU;
+
 // Copied from app_menu.cc to dump w/o crashing
 bool IsBookmarkCommand(int command_id) {
   return command_id >= IDC_FIRST_UNBOUNDED_MENU &&
          ((command_id - IDC_FIRST_UNBOUNDED_MENU) %
               AppMenuModel::kNumUnboundedMenuTypes ==
-          0);
+          kBookmarksCommandIdOffset);
+}
+
+// Copied from app_menu.cc to dump w/o crashing
+bool IsTabGroupsCommand(int command_id) {
+  return command_id >= IDC_FIRST_UNBOUNDED_MENU &&
+         ((command_id - IDC_FIRST_UNBOUNDED_MENU) %
+              AppMenuModel::kNumUnboundedMenuTypes ==
+          kTabGroupsCommandIdOffset);
 }
 
 // A button that resides inside menu item.
@@ -192,10 +205,11 @@ void BraveAppMenu::ExecuteCommand(int command_id, int mouse_event_flags) {
   // Suspect that the entry is null but can't imagine which command causes it.
   // See
   // https://github.com/brave/brave-browser/issues/37862#issuecomment-2078553575
-  if (!IsBookmarkCommand(command_id) && command_id != IDC_EDIT_MENU &&
+  if (!IsBookmarkCommand(command_id) && !IsTabGroupsCommand(command_id) &&
+      command_id != IDC_CREATE_NEW_TAB_GROUP && command_id != IDC_EDIT_MENU &&
       command_id != IDC_ZOOM_MENU &&
       command_id_to_entry_.find(command_id) == command_id_to_entry_.end()) {
-    LOG(ERROR) << __func__ << " entry should be exsit for " << command_id;
+    LOG(ERROR) << __func__ << " entry should exist for " << command_id;
     SCOPED_CRASH_KEY_NUMBER("BraveAppMenu", "command_id", command_id);
     base::debug::DumpWithoutCrashing();
     return;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42663
Resolves https://github.com/brave/brave-browser/issues/42664
Resolves https://github.com/brave/brave-browser/issues/42665
Resolves https://github.com/brave/brave-browser/issues/42666
Resolves https://github.com/brave/brave-browser/issues/42667
Resolves https://github.com/brave/brave-browser/issues/42668

@simonhong Made a quick fix to get this working post-cr132, but it seems like maybe we should fix/address this in a better way in the future. It will be brittle as new exceptions are added upstream (that's what happened here).

@simonhong One more quick note! After I fixed the underlying issue with the tab group menus, @rebron mentioned that we want to hide that entire top-level menu anyway. So this PR contains two commits: one that fixes the underlying issue with that menu and one that hides the menu. Hope that makes sense.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Verify that "Tab groups" menu item no longer appears in Hamburger menu
