### PR TITLE
[ads] Optimize database queries serialization/deserialization overhead

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -45,7 +45,6 @@
 #include "brave/components/brave_ads/core/public/ad_units/notification_ad/notification_ad_value_util.h"
 #include "brave/components/brave_ads/core/public/ads_constants.h"
 #include "brave/components/brave_ads/core/public/ads_feature.h"
-#include "brave/components/brave_ads/core/public/database/database.h"
 #include "brave/components/brave_ads/core/public/flags/flags_util.h"
 #include "brave/components/brave_ads/core/public/history/site_history.h"
 #include "brave/components/brave_ads/core/public/prefs/pref_names.h"

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -349,6 +349,7 @@ void AdsServiceImpl::StartBatAdsService() {
   }
 
   bat_ads_service_remote_->Create(
+      ads_service_path_,
       bat_ads_client_associated_receiver_.BindNewEndpointAndPassRemote(),
       bat_ads_associated_remote_.BindNewEndpointAndPassReceiver(),
       std::move(bat_ads_client_notifier_pending_receiver_),
@@ -408,16 +409,7 @@ void AdsServiceImpl::Initialize(size_t current_start_number) {
     return;
   }
 
-  InitializeDatabase();
-
   InitializeRewardsWallet(current_start_number);
-}
-
-void AdsServiceImpl::InitializeDatabase() {
-  CHECK(!database_);
-
-  database_ = base::SequenceBound<Database>(
-      file_task_runner_, ads_service_path_.AppendASCII(kDatabaseFilename));
 }
 
 void AdsServiceImpl::InitializeRewardsWallet(size_t current_start_number) {
@@ -1096,8 +1088,6 @@ void AdsServiceImpl::ShutdownAdsService() {
 
   CloseAdaptiveCaptcha();
 
-  database_.Reset();
-
   if (is_bat_ads_initialized_) {
     VLOG(2) << "Shutdown Bat Ads Service";
   }
@@ -1731,17 +1721,6 @@ void AdsServiceImpl::ShowScheduledCaptcha(const std::string& payment_id,
       base::BindOnce(&AdsServiceImpl::SnoozeScheduledCaptchaCallback,
                      weak_ptr_factory_.GetWeakPtr()));
 #endif  // !BUILDFLAG(IS_ANDROID)
-}
-
-void AdsServiceImpl::RunDBTransaction(
-    mojom::DBTransactionInfoPtr mojom_db_transaction,
-    RunDBTransactionCallback callback) {
-  CHECK(mojom_db_transaction);
-  CHECK(database_);
-
-  database_.AsyncCall(&Database::RunDBTransaction)
-      .WithArgs(std::move(mojom_db_transaction))
-      .Then(std::move(callback));
 }
 
 void AdsServiceImpl::RecordP2AEvents(const std::vector<std::string>& events) {

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -19,7 +19,6 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/task/cancelable_task_tracker.h"
-#include "base/threading/sequence_bound.h"
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "brave/components/brave_adaptive_captcha/brave_adaptive_captcha_service.h"
@@ -61,7 +60,6 @@ namespace brave_ads {
 class AdsServiceObserver;
 class AdsTooltipsDelegate;
 class BatAdsServiceFactory;
-class Database;
 class DeviceId;
 class ResourceComponent;
 struct NewTabPageAdInfo;
@@ -124,7 +122,6 @@ class AdsServiceImpl final : public AdsService,
   void InitializeBasePathDirectoryCallback(size_t current_start_number,
                                            bool success);
   void Initialize(size_t current_start_number);
-  void InitializeDatabase();
   void InitializeRewardsWallet(size_t current_start_number);
   void InitializeRewardsWalletCallback(
       size_t current_start_number,
@@ -357,9 +354,6 @@ class AdsServiceImpl final : public AdsService,
   void ShowScheduledCaptcha(const std::string& payment_id,
                             const std::string& captcha_id) override;
 
-  void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
-                        RunDBTransactionCallback callback) override;
-
   // TODO(https://github.com/brave/brave-browser/issues/14666) Decouple P2A
   // business logic.
   void RecordP2AEvents(const std::vector<std::string>& events) override;
@@ -426,8 +420,6 @@ class AdsServiceImpl final : public AdsService,
   PrefChangeRegistrar local_state_pref_change_registrar_;
 
   mojom::SysInfo sys_info_;
-
-  base::SequenceBound<Database> database_;
 
   base::RepeatingTimer idle_state_timer_;
   ui::IdleState last_idle_state_ = ui::IdleState::IDLE_STATE_ACTIVE;

--- a/components/brave_ads/core/internal/BUILD.gn
+++ b/components/brave_ads/core/internal/BUILD.gn
@@ -583,6 +583,7 @@ static_library("internal") {
     "creatives/segments_database_util.cc",
     "creatives/segments_database_util.h",
     "database/database.cc",
+    "database/database.h",
     "database/database_maintenance.cc",
     "database/database_maintenance.h",
     "database/database_manager.cc",

--- a/components/brave_ads/core/internal/account/confirmations/confirmations_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/confirmations_unittest.cc
@@ -7,6 +7,8 @@
 
 #include <memory>
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/confirmation_tokens/confirmation_tokens_test_util.h"
@@ -49,9 +51,12 @@ TEST_F(BraveAdsConfirmationsTest, ConfirmForRewardsUser) {
 
   // Assert
   base::MockCallback<database::table::GetConfirmationQueueCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*confirmation_queue_items=*/::testing::SizeIs(1)));
+                            /*confirmation_queue_items=*/::testing::SizeIs(1)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   confirmation_queue_database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationsTest, ConfirmForNonRewardsUser) {
@@ -68,9 +73,12 @@ TEST_F(BraveAdsConfirmationsTest, ConfirmForNonRewardsUser) {
 
   // Assert
   base::MockCallback<database::table::GetConfirmationQueueCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*confirmation_queue_items=*/::testing::SizeIs(1)));
+                            /*confirmation_queue_items=*/::testing::SizeIs(1)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   confirmation_queue_database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.cc
@@ -18,7 +18,6 @@
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_builder_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_util.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/reward/reward_confirmation_util.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/challenge_bypass_ristretto/blinded_token.h"
 #include "brave/components/brave_ads/core/internal/common/challenge_bypass_ristretto/public_key.h"
 #include "brave/components/brave_ads/core/internal/common/challenge_bypass_ristretto/token.h"
@@ -33,7 +32,6 @@
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_type.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 
 namespace brave_ads::database::table {
 
@@ -395,9 +393,8 @@ void ConfirmationQueue::GetAll(GetConfirmationQueueCallback callback) const {
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void ConfirmationQueue::GetNext(GetConfirmationQueueCallback callback) const {
@@ -432,9 +429,8 @@ void ConfirmationQueue::GetNext(GetConfirmationQueueCallback callback) const {
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 std::string ConfirmationQueue::GetTableName() const {

--- a/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/confirmation_queue_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/confirmation_info.h"
 #include "brave/components/brave_ads/core/internal/account/confirmations/queue/queue_item/confirmation_queue_item_builder.h"
@@ -44,9 +46,12 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, SaveEmptyConfirmationQueue) {
 
   // Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*confirmation_queue_items=*/::testing::IsEmpty()));
+                            /*confirmation_queue_items=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, SaveConfirmationQueueItems) {
@@ -67,8 +72,11 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, SaveConfirmationQueueItems) {
 
   // Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -92,9 +100,12 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
   const ConfirmationQueueItemList expected_confirmation_queue_items = {
       confirmation_queue_items.front(), confirmation_queue_items.front()};
   base::MockCallback<GetConfirmationQueueCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, expected_confirmation_queue_items));
+              Run(/*success=*/true, expected_confirmation_queue_items))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -117,8 +128,11 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
 
   // Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -149,9 +163,13 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ConfirmationQueueItemList{
-                                                  confirmation_queue_item_1}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  ConfirmationQueueItemList{confirmation_queue_item_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetNext(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -192,11 +210,15 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ConfirmationQueueItemList{
-                                                  confirmation_queue_item_2,
-                                                  confirmation_queue_item_3,
-                                                  confirmation_queue_item_1}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  ConfirmationQueueItemList{confirmation_queue_item_2,
+                                            confirmation_queue_item_3,
+                                            confirmation_queue_item_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -226,17 +248,24 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
   test::SaveConfirmationQueueItems(confirmation_queue_items);
 
   base::MockCallback<ResultCallback> delete_callback;
-  EXPECT_CALL(delete_callback, Run(/*success=*/true));
+  base::RunLoop run_loop_delete;
+  EXPECT_CALL(delete_callback, Run(/*success=*/true))
+      .WillOnce(base::test::RunOnceClosure(run_loop_delete.QuitClosure()));
 
   // Act
   database_table_.Delete(confirmation_queue_item_1.confirmation.transaction_id,
                          delete_callback.Get());
+  run_loop_delete.Run();
 
   // Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ConfirmationQueueItemList{
-                                                  confirmation_queue_item_2}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  ConfirmationQueueItemList{confirmation_queue_item_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -273,16 +302,22 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
       BuildConfirmationQueueItem(*confirmation_3, /*process_at=*/test::Now());
 
   base::MockCallback<ResultCallback> delete_callback;
-  EXPECT_CALL(delete_callback, Run(/*success=*/true));
+  base::RunLoop run_loop_delete;
+  EXPECT_CALL(delete_callback, Run(/*success=*/true))
+      .WillOnce(base::test::RunOnceClosure(run_loop_delete.QuitClosure()));
 
   // Act
   database_table_.Delete(confirmation_queue_item_3.confirmation.transaction_id,
                          delete_callback.Get());
+  run_loop_delete.Run();
 
   // Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, RetryConfirmationQueueItem) {
@@ -303,7 +338,9 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, RetryConfirmationQueueItem) {
   test::SaveConfirmationQueueItems(confirmation_queue_items);
 
   base::MockCallback<ResultCallback> retry_callback;
-  EXPECT_CALL(retry_callback, Run(/*success=*/true));
+  base::RunLoop run_loop_retry;
+  EXPECT_CALL(retry_callback, Run(/*success=*/true))
+      .WillOnce(base::test::RunOnceClosure(run_loop_retry.QuitClosure()));
 
   const ScopedRandTimeDeltaSetterForTesting scoped_rand_time_delta(
       base::Minutes(7));
@@ -311,14 +348,18 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, RetryConfirmationQueueItem) {
   // Act
   database_table_.Retry(confirmation_queue_item.confirmation.transaction_id,
                         retry_callback.Get());
+  run_loop_retry.Run();
 
   // Assert
   confirmation_queue_item.process_at = test::Now() + base::Minutes(7);
   confirmation_queue_item.retry_count = 1;
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ConfirmationQueueItemList{
-                                                  confirmation_queue_item}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            ConfirmationQueueItemList{confirmation_queue_item}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
@@ -355,16 +396,22 @@ TEST_F(BraveAdsConfirmationQueueDatabaseTableTest,
       BuildConfirmationQueueItem(*confirmation_3, /*process_at=*/test::Now());
 
   base::MockCallback<ResultCallback> retry_callback;
-  EXPECT_CALL(retry_callback, Run(/*success=*/true));
+  base::RunLoop run_loop_retry;
+  EXPECT_CALL(retry_callback, Run(/*success=*/true))
+      .WillOnce(base::test::RunOnceClosure(run_loop_retry.QuitClosure()));
 
   // Act
   database_table_.Retry(confirmation_queue_item_3.confirmation.transaction_id,
                         retry_callback.Get());
+  run_loop_retry.Run();
 
   // Assert
   base::MockCallback<GetConfirmationQueueCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, confirmation_queue_items))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConfirmationQueueDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/account/deposits/cash_deposit_test.cc
+++ b/components/brave_ads/core/internal/account/deposits/cash_deposit_test.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/deposits/cash_deposit.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposit_interface.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
@@ -35,8 +37,11 @@ TEST_F(BraveAdsCashDepositIntegrationTest, GetValue) {
 
   // Act & Assert
   base::MockCallback<GetDepositCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, test::kValue));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, test::kValue))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   deposit.GetValue(test::kCreativeInstanceId, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCashDepositIntegrationTest,
@@ -46,8 +51,11 @@ TEST_F(BraveAdsCashDepositIntegrationTest,
 
   // Act & Assert
   base::MockCallback<GetDepositCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/false, /*value=*/0.0));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/false, /*value=*/0.0))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   deposit.GetValue(test::kMissingCreativeInstanceId, callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/deposits/deposits_database_table.cc
+++ b/components/brave_ads/core/internal/account/deposits/deposits_database_table.cc
@@ -11,7 +11,6 @@
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
@@ -19,7 +18,6 @@
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/common/time/time_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 
 namespace brave_ads::database::table {
 
@@ -188,10 +186,9 @@ void Deposits::GetForCreativeInstanceId(const std::string& creative_instance_id,
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetForCreativeInstanceIdCallback, creative_instance_id,
-                     std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetForCreativeInstanceIdCallback,
+                                  creative_instance_id, std::move(callback)));
 }
 
 void Deposits::PurgeExpired(ResultCallback callback) const {

--- a/components/brave_ads/core/internal/account/statement/statement_unittest.cc
+++ b/components/brave_ads/core/internal/account/statement/statement_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/statement/statement.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/account/statement/statement_feature.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
@@ -55,8 +57,11 @@ TEST_F(BraveAdsStatementTest, GetForTransactionsThisMonth) {
       {mojom::AdType::kNotificationAd, 2}};
 
   base::MockCallback<BuildStatementCallback> callback;
-  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_mojom_statement))));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_mojom_statement))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   BuildStatement(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsStatementTest,
@@ -136,8 +141,11 @@ TEST_F(BraveAdsStatementTest,
       {mojom::AdType::kNotificationAd, 3}};
 
   base::MockCallback<BuildStatementCallback> callback;
-  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   BuildStatement(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsStatementTest, GetForTransactionsSplitOverTwoYears) {
@@ -202,8 +210,11 @@ TEST_F(BraveAdsStatementTest, GetForTransactionsSplitOverTwoYears) {
       {mojom::AdType::kNotificationAd, 3}};
 
   base::MockCallback<BuildStatementCallback> callback;
-  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   BuildStatement(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsStatementTest, GetForNoTransactions) {
@@ -223,8 +234,11 @@ TEST_F(BraveAdsStatementTest, GetForNoTransactions) {
   expected_statement->ads_summary_this_month.clear();
 
   base::MockCallback<BuildStatementCallback> callback;
-  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   BuildStatement(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsStatementTest, GetWithFilteredTransactions) {
@@ -278,8 +292,11 @@ TEST_F(BraveAdsStatementTest, GetWithFilteredTransactions) {
       {mojom::AdType::kNotificationAd, 1}, {mojom::AdType::kNewTabPageAd, 1}};
 
   base::MockCallback<BuildStatementCallback> callback;
-  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(::testing::Eq(std::ref(expected_statement))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   BuildStatement(callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/account/transactions/transactions_database_table.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_database_table.cc
@@ -241,9 +241,8 @@ void Transactions::GetForDateRange(base::Time from_time,
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void Transactions::Reconcile(const PaymentTokenList& payment_tokens,

--- a/components/brave_ads/core/internal/account/transactions/transactions_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/transactions/transactions_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/account/tokens/payment_tokens/payment_token_info.h"
@@ -28,12 +30,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, SaveEmptyTransactions) {
 
   // Assert
   base::MockCallback<GetTransactionsCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*transactions=*/::testing::IsEmpty()));
+                            /*transactions=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const Transactions database_table;
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest, SaveTransactions) {
@@ -60,12 +65,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, SaveTransactions) {
 
   // Assert
   base::MockCallback<GetTransactionsCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, ::testing::ElementsAreArray(transactions)));
+              Run(/*success=*/true, ::testing::ElementsAreArray(transactions)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const Transactions database_table;
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest, DoNotSaveDuplicateTransactions) {
@@ -85,11 +93,14 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, DoNotSaveDuplicateTransactions) {
 
   // Assert
   base::MockCallback<GetTransactionsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, transactions));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, transactions))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const Transactions database_table;
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest, GetTransactionsForDateRange) {
@@ -117,10 +128,13 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, GetTransactionsForDateRange) {
 
   // Act & Assert
   base::MockCallback<GetTransactionsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, TransactionList{transaction_2}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, TransactionList{transaction_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForDateRange(/*from_time=*/test::Now(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest, ReconcileTransactions) {
@@ -159,13 +173,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, ReconcileTransactions) {
 
   // Assert
   base::MockCallback<GetTransactionsCallback> callback;
-  EXPECT_CALL(callback,
-              Run(/*success=*/true,
-                  ::testing::UnorderedElementsAreArray(
-                      TransactionList{transaction_1, transaction_2})));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            ::testing::UnorderedElementsAreArray(
+                                TransactionList{transaction_1, transaction_2})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest, PurgeExpired) {
@@ -206,13 +222,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest, PurgeExpired) {
   database_table.PurgeExpired(purge_expired_callback.Get());
 
   base::MockCallback<GetTransactionsCallback> callback;
-  EXPECT_CALL(callback,
-              Run(/*success=*/true,
-                  ::testing::UnorderedElementsAreArray(
-                      TransactionList{transaction_2, transaction_3})));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            ::testing::UnorderedElementsAreArray(
+                                TransactionList{transaction_2, transaction_3})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest,
@@ -248,13 +266,15 @@ TEST_F(BraveAdsTransactionsDatabaseTableTest,
   database_table.PurgeExpired(purge_expired_callback.Get());
 
   base::MockCallback<GetTransactionsCallback> callback;
-  EXPECT_CALL(callback,
-              Run(/*success=*/true,
-                  ::testing::UnorderedElementsAreArray(
-                      TransactionList{transaction_1, transaction_2})));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            ::testing::UnorderedElementsAreArray(
+                                TransactionList{transaction_1, transaction_2})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/account/transactions/transactions_unittest.cc
+++ b/components/brave_ads/core/internal/account/transactions/transactions_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/account/transactions/transactions.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transaction_info.h"
 #include "brave/components/brave_ads/core/internal/account/transactions/transactions_database_table.h"
@@ -36,11 +38,14 @@ TEST_F(BraveAdsTransactionsTest, Add) {
 
   // Assert
   base::MockCallback<database::table::GetTransactionsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, TransactionList{transaction}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, TransactionList{transaction}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const database::table::Transactions database_table;
   database_table.GetForDateRange(/*from_time=*/test::DistantPast(),
                                  /*to_time=*/test::DistantFuture(),
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsTransactionsTest, GetForDateRange) {
@@ -74,11 +79,14 @@ TEST_F(BraveAdsTransactionsTest, GetForDateRange) {
 
   // Act & Assert
   base::MockCallback<GetTransactionsCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            TransactionList{transaction_2, transaction_3}));
+                            TransactionList{transaction_2, transaction_3}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   GetTransactionsForDateRange(/*from_time=*/test::Now(),
                               /*to_time=*/test::DistantFuture(),
                               callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_test.cc
+++ b/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_test.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
@@ -42,9 +44,12 @@ class BraveAdsPromotedContentAdIntegrationTest : public test::TestBase {
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       bool should_fire_event) {
     base::MockCallback<TriggerAdEventCallback> callback;
-    EXPECT_CALL(callback, Run(/*success=*/should_fire_event));
+    base::RunLoop run_loop;
+    EXPECT_CALL(callback, Run(/*success=*/should_fire_event))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     GetAds().TriggerPromotedContentAdEvent(placement_id, creative_instance_id,
                                            mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 };
 

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_non_rewards_test.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_non_rewards_test.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h"
@@ -39,10 +41,13 @@ class BraveAdsSearchResultAdForNonRewardsIntegrationTest
       mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
       mojom::SearchResultAdEventType mojom_ad_event_type,
       bool should_fire_event) {
+    base::RunLoop run_loop;
     base::MockCallback<TriggerAdEventCallback> callback;
-    EXPECT_CALL(callback, Run(/*success=*/should_fire_event));
+    EXPECT_CALL(callback, Run(/*success=*/should_fire_event))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     GetAds().TriggerSearchResultAdEvent(std::move(mojom_creative_ad),
                                         mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 
   base::test::ScopedFeatureList scoped_feature_list_;

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_rewards_test.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_rewards_test.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h"
@@ -35,10 +37,13 @@ class BraveAdsSearchResultAdForRewardsIntegrationTest : public test::TestBase {
       mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad,
       mojom::SearchResultAdEventType mojom_ad_event_type,
       bool should_fire_event) {
+    base::RunLoop run_loop;
     base::MockCallback<TriggerAdEventCallback> callback;
-    EXPECT_CALL(callback, Run(/*success=*/should_fire_event));
+    EXPECT_CALL(callback, Run(/*success=*/should_fire_event))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     GetAds().TriggerSearchResultAdEvent(std::move(mojom_creative_ad),
                                         mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 
   base::test::ScopedFeatureList scoped_feature_list_;

--- a/components/brave_ads/core/internal/ads.cc
+++ b/components/brave_ads/core/internal/ads.cc
@@ -11,8 +11,9 @@
 namespace brave_ads {
 
 // static
-std::unique_ptr<Ads> Ads::CreateInstance(AdsClient& ads_client) {
-  return std::make_unique<AdsImpl>(ads_client,
+std::unique_ptr<Ads> Ads::CreateInstance(AdsClient& ads_client,
+                                         const base::FilePath& database_path) {
+  return std::make_unique<AdsImpl>(ads_client, database_path,
                                    std::make_unique<TokenGenerator>());
 }
 

--- a/components/brave_ads/core/internal/ads_client/ads_client_mock.h
+++ b/components/brave_ads/core/internal/ads_client/ads_client_mock.h
@@ -68,10 +68,6 @@ class AdsClientMock : public AdsClient {
               ShowScheduledCaptcha,
               (const std::string& payment_id, const std::string& captcha_id));
 
-  MOCK_METHOD(void,
-              RunDBTransaction,
-              (mojom::DBTransactionInfoPtr, RunDBTransactionCallback));
-
   MOCK_METHOD(void, RecordP2AEvents, (const std::vector<std::string>& events));
 
   MOCK_METHOD(bool, FindProfilePref, (const std::string& path), (const));

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.cc
@@ -1,0 +1,36 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.h"
+
+#include <utility>
+
+#include "base/run_loop.h"
+#include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier.h"
+
+namespace brave_ads::test {
+
+AdsClientNotifierWaiter::AdsClientNotifierWaiter(AdsClientNotifier& notifier)
+    : notifier_(notifier) {
+  notifier_->AddObserver(this);
+}
+
+AdsClientNotifierWaiter::~AdsClientNotifierWaiter() {
+  notifier_->RemoveObserver(this);
+}
+
+void AdsClientNotifierWaiter::WaitForAdsInitialization() {
+  base::RunLoop run_loop;
+  did_initialize_ads_closure_ = run_loop.QuitClosure();
+  run_loop.Run();
+}
+
+void AdsClientNotifierWaiter::OnNotifyDidInitializeAds() {
+  if (did_initialize_ads_closure_) {
+    std::move(did_initialize_ads_closure_).Run();
+  }
+}
+
+}  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.h
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ADS_CLIENT_ADS_CLIENT_NOTIFIER_WAITER_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ADS_CLIENT_ADS_CLIENT_NOTIFIER_WAITER_H_
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ref.h"
+#include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h"
+
+namespace brave_ads {
+class AdsClientNotifier;
+}  // namespace brave_ads
+
+namespace brave_ads::test {
+
+class AdsClientNotifierWaiter : public AdsClientNotifierObserver {
+ public:
+  explicit AdsClientNotifierWaiter(AdsClientNotifier& notifier);
+
+  ~AdsClientNotifierWaiter() override;
+
+  // AdsClientNotifierObserver overrides:
+  void OnNotifyDidInitializeAds() override;
+
+  void WaitForAdsInitialization();
+
+ private:
+  const base::raw_ref<AdsClientNotifier> notifier_;
+  base::OnceClosure did_initialize_ads_closure_;
+};
+
+}  // namespace brave_ads::test
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_ADS_CLIENT_ADS_CLIENT_NOTIFIER_WAITER_H_

--- a/components/brave_ads/core/internal/ads_impl.cc
+++ b/components/brave_ads/core/internal/ads_impl.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/ads_impl.h"
 
+#include <memory>
 #include <optional>
 #include <utility>
 
@@ -41,8 +42,9 @@ void FailedToInitialize(InitializeCallback callback) {
 }  // namespace
 
 AdsImpl::AdsImpl(AdsClient& ads_client,
+                 const base::FilePath& database_path,
                  std::unique_ptr<TokenGeneratorInterface> token_generator)
-    : global_state_(ads_client, std::move(token_generator)),
+    : global_state_(ads_client, database_path, std::move(token_generator)),
       database_maintenance_(std::make_unique<database::Maintenance>()) {}
 
 AdsImpl::~AdsImpl() = default;

--- a/components/brave_ads/core/internal/ads_impl.h
+++ b/components/brave_ads/core/internal/ads_impl.h
@@ -32,6 +32,7 @@ class Maintenance;
 class AdsImpl final : public Ads {
  public:
   AdsImpl(AdsClient& ads_client,
+          const base::FilePath& database_path,
           std::unique_ptr<TokenGeneratorInterface> token_generator);
 
   AdsImpl(const AdsImpl&) = delete;

--- a/components/brave_ads/core/internal/common/database/database_transaction_util.cc
+++ b/components/brave_ads/core/internal/common/database/database_transaction_util.cc
@@ -9,9 +9,10 @@
 
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
+#include "brave/components/brave_ads/core/internal/database/database_manager.h"
+#include "brave/components/brave_ads/core/internal/global_state/global_state.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
+#include "brave/components/brave_ads/core/public/ads_client/ads_client_callback.h"
 
 namespace brave_ads::database {
 
@@ -44,8 +45,14 @@ bool IsError(
 }
 
 void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
+                      ::brave_ads::RunDBTransactionCallback callback) {
+  GlobalState::GetInstance()->GetDatabaseManager().RunDBTransaction(
+      std::move(mojom_db_transaction), std::move(callback));
+}
+
+void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
                       ResultCallback callback) {
-  GetAdsClient().RunDBTransaction(
+  GlobalState::GetInstance()->GetDatabaseManager().RunDBTransaction(
       std::move(mojom_db_transaction),
       base::BindOnce(&RunDBTransactionCallback, std::move(callback)));
 }

--- a/components/brave_ads/core/internal/common/database/database_transaction_util.h
+++ b/components/brave_ads/core/internal/common/database/database_transaction_util.h
@@ -22,6 +22,11 @@ bool IsSuccess(
 bool IsError(
     const mojom::DBTransactionResultInfoPtr& mojom_db_transaction_result);
 
+// Run a database transaction. The callback takes one argument -
+// `mojom::DBTransactionResultInfoPtr` containing the info of the transaction.
+void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
+                      RunDBTransactionCallback callback);
+
 // Run a database transaction.
 void RunDBTransaction(mojom::DBTransactionInfoPtr mojom_db_transaction,
                       ResultCallback callback);

--- a/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
@@ -26,7 +26,6 @@
 #include "brave/components/brave_ads/core/internal/global_state/global_state.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/notification_ad/notification_ad_info.h"
-#include "brave/components/brave_ads/core/public/database/database.h"
 #include "brave/components/brave_ads/core/public/flags/flags_util.h"
 
 namespace brave_ads::test {

--- a/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.cc
@@ -140,20 +140,6 @@ void MockLoadDataResource(AdsClientMock& ads_client_mock) {
           }));
 }
 
-void MockRunDBTransaction(AdsClientMock& ads_client_mock, Database& database) {
-  ON_CALL(ads_client_mock, RunDBTransaction)
-      .WillByDefault(::testing::Invoke(
-          [&database](mojom::DBTransactionInfoPtr mojom_db_transaction,
-                      RunDBTransactionCallback callback) {
-            CHECK(mojom_db_transaction);
-
-            mojom::DBTransactionResultInfoPtr mojom_db_transaction_result =
-                database.RunDBTransaction(std::move(mojom_db_transaction));
-
-            std::move(callback).Run(std::move(mojom_db_transaction_result));
-          }));
-}
-
 void MockFindProfilePref(const AdsClientMock& ads_client_mock) {
   ON_CALL(ads_client_mock, FindProfilePref)
       .WillByDefault(::testing::Invoke([](const std::string& path) -> bool {

--- a/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.h
+++ b/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.h
@@ -8,7 +8,6 @@
 
 #include "base/files/file_path.h"
 #include "brave/components/brave_ads/core/internal/ads_client/ads_client_mock.h"
-#include "brave/components/brave_ads/core/public/database/database.h"
 
 namespace brave_ads::test {
 

--- a/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.h
+++ b/components/brave_ads/core/internal/common/test/internal/mock_test_util_internal.h
@@ -33,8 +33,6 @@ void MockLoadResourceComponent(AdsClientMock& ads_client_mock,
 
 void MockLoadDataResource(AdsClientMock& ads_client_mock);
 
-void MockRunDBTransaction(AdsClientMock& ads_client_mock, Database& database);
-
 void MockFindProfilePref(const AdsClientMock& ads_client_mock);
 void MockGetProfilePref(const AdsClientMock& ads_client_mock);
 void MockSetProfilePref(const AdsClientMock& ads_client_mock,

--- a/components/brave_ads/core/internal/common/test/test_base.cc
+++ b/components/brave_ads/core/internal/common/test/test_base.cc
@@ -32,7 +32,6 @@
 #include "brave/components/brave_ads/core/internal/global_state/global_state.h"
 #include "brave/components/brave_ads/core/public/ads.h"
 #include "brave/components/brave_ads/core/public/ads_constants.h"
-#include "brave/components/brave_ads/core/public/database/database.h"
 
 namespace brave_ads::test {
 
@@ -234,10 +233,6 @@ void TestBase::MockAdsClient() {
 
   MockLoadDataResource(ads_client_mock_);
 
-  database_ =
-      std::make_unique<Database>(ProfilePath().AppendASCII(kDatabaseFilename));
-  MockRunDBTransaction(ads_client_mock_, *database_);
-
   MockFindProfilePref(ads_client_mock_);
   MockGetProfilePref(ads_client_mock_);
   MockSetProfilePref(ads_client_mock_, *this);
@@ -298,7 +293,8 @@ void TestBase::SetUpIntegrationTest() {
       << "SetUpIntegrationTest should only be called if SetUp is initialized "
          "for integration testing";
 
-  ads_ = Ads::CreateInstance(ads_client_mock_);
+  ads_ = Ads::CreateInstance(ads_client_mock_,
+                             ProfilePath().AppendASCII(kDatabaseFilename));
   CHECK(ads_) << "Failed to create ads instance";
 
   // Must be called after `Ads` is instantiated but prior to `Initialize`.
@@ -328,7 +324,8 @@ void TestBase::SetUpUnitTest() {
                                   "SetUp is initialized for unit testing";
 
   global_state_ = std::make_unique<GlobalState>(
-      ads_client_mock_, std::make_unique<TokenGeneratorMock>());
+      ads_client_mock_, ProfilePath().AppendASCII(kDatabaseFilename),
+      std::make_unique<TokenGeneratorMock>());
 
   // Must be called after `GlobalState` is instantiated but prior to
   // `MockDefaultAdsServiceState`.

--- a/components/brave_ads/core/internal/common/test/test_base.cc
+++ b/components/brave_ads/core/internal/common/test/test_base.cc
@@ -27,12 +27,12 @@
 #include "brave/components/brave_ads/core/internal/common/test/test_constants.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_types.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
+#include "brave/components/brave_ads/core/internal/database/database.h"
 #include "brave/components/brave_ads/core/internal/database/database_manager.h"
 #include "brave/components/brave_ads/core/internal/deprecated/client/client_state_manager.h"
 #include "brave/components/brave_ads/core/internal/deprecated/confirmations/confirmation_state_manager.h"
 #include "brave/components/brave_ads/core/internal/global_state/global_state.h"
 #include "brave/components/brave_ads/core/public/ads.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client_notifier_observer.h"
 #include "brave/components/brave_ads/core/public/ads_constants.h"
 
 namespace brave_ads::test {

--- a/components/brave_ads/core/internal/common/test/test_base.h
+++ b/components/brave_ads/core/internal/common/test/test_base.h
@@ -10,6 +10,7 @@
 #include <memory>
 #include <string>
 
+#include "base/files/file_path.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/memory/weak_ptr.h"
 #include "base/test/task_environment.h"
@@ -137,6 +138,7 @@ class TestBase : public AdsClientNotifierForTesting, public ::testing::Test {
  private:
   void SimulateProfile();
   const base::FilePath& ProfilePath() const { return profile_dir_.GetPath(); }
+  base::FilePath DatabasePath() const;
 
   void MockAdsClientNotifier();
   void MockAdsClient();

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.cc
@@ -23,7 +23,6 @@
 #include "brave/components/brave_ads/core/internal/common/time/time_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 
 namespace brave_ads::database::table {
 
@@ -219,9 +218,8 @@ void CreativeSetConversions::GetUnexpired(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void CreativeSetConversions::GetActive(
@@ -251,9 +249,8 @@ void CreativeSetConversions::GetActive(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void CreativeSetConversions::PurgeExpired(ResultCallback callback) const {

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_test.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -35,9 +37,12 @@ TEST_F(BraveAdsConversionsDatabaseTableIntegrationTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*creative_set_conversions=*/::testing::SizeIs(2)));
+                            /*creative_set_conversions=*/::testing::SizeIs(2)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -28,9 +30,12 @@ TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest, EmptySave) {
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*creative_set_conversions=*/::testing::IsEmpty()));
+                            /*creative_set_conversions=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
@@ -58,8 +63,11 @@ TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, creative_set_conversions));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, creative_set_conversions))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
@@ -82,8 +90,11 @@ TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, creative_set_conversions));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, creative_set_conversions))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
@@ -115,9 +126,13 @@ TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, CreativeSetConversionList{
-                                                  creative_set_conversion_1}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  CreativeSetConversionList{creative_set_conversion_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
@@ -151,9 +166,13 @@ TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, CreativeSetConversionList{
-                                                  creative_set_conversion_2}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  CreativeSetConversionList{creative_set_conversion_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeSetConversionDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/creatives/creative_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/creative_ads_database_table.cc
@@ -14,13 +14,11 @@
 #include "base/functional/bind.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "url/gurl.h"
 
 namespace brave_ads::database::table {
@@ -216,10 +214,9 @@ void CreativeAds::GetForCreativeInstanceId(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetForCreativeInstanceIdCallback, creative_instance_id,
-                     std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetForCreativeInstanceIdCallback,
+                                  creative_instance_id, std::move(callback)));
 }
 
 std::string CreativeAds::GetTableName() const {

--- a/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table.cc
@@ -15,7 +15,6 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/containers/container_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
@@ -26,7 +25,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/creative_ad_info.h"
 #include "brave/components/brave_ads/core/internal/segments/segment_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "url/gurl.h"
 
 namespace brave_ads::database::table {
@@ -348,10 +346,9 @@ void CreativeInlineContentAds::GetForCreativeInstanceId(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetForCreativeInstanceIdCallback, creative_instance_id,
-                     std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetForCreativeInstanceIdCallback,
+                                  creative_instance_id, std::move(callback)));
 }
 
 void CreativeInlineContentAds::GetForSegmentsAndDimensions(
@@ -420,10 +417,9 @@ void CreativeInlineContentAds::GetForSegmentsAndDimensions(
 
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetForSegmentsAndDimensionsCallback, segments,
-                     std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetForSegmentsAndDimensionsCallback,
+                                  segments, std::move(callback)));
 }
 
 void CreativeInlineContentAds::GetForDimensions(
@@ -481,7 +477,7 @@ void CreativeInlineContentAds::GetForDimensions(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
+  RunDBTransaction(
       std::move(mojom_db_transaction),
       base::BindOnce(&GetForDimensionsCallback, std::move(callback)));
 }
@@ -534,9 +530,8 @@ void CreativeInlineContentAds::GetForActiveCampaigns(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetAllCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetAllCallback, std::move(callback)));
 }
 
 std::string CreativeInlineContentAds::GetTableName() const {

--- a/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table_test.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -34,14 +36,17 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableIntegrationTest,
   const database::table::CreativeInlineContentAds database_table;
 
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
   EXPECT_CALL(callback, Run(/*success=*/true,
                             /*segments=*/SegmentList{"technology & computing"},
-                            /*creative_ads=*/::testing::SizeIs(1)));
+                            /*creative_ads=*/::testing::SizeIs(1)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForSegmentsAndDimensions(
       /*segments=*/{"technology & computing"}, /*dimensions=*/"200x100",
       callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableIntegrationTest,
@@ -50,12 +55,15 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableIntegrationTest,
   const database::table::CreativeInlineContentAds database_table;
 
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<
       database::table::GetCreativeInlineContentAdsForDimensionsCallback>
       callback;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            /*creative_ads=*/::testing::SizeIs(1)));
+                            /*creative_ads=*/::testing::SizeIs(1)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForDimensions("200x100", callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -30,9 +32,12 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, SaveEmpty) {
   // Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, Save) {
@@ -46,11 +51,13 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, Save) {
   // Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true, SegmentList{"architecture", "arts & entertainment"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, SaveInBatches) {
@@ -66,12 +73,14 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, SaveInBatches) {
   // Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true,
-          SegmentList{"architecture", "arts & entertainment", "automotive"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment",
+                                        "automotive"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, DoNotSaveDuplicates) {
@@ -86,9 +95,12 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, DoNotSaveDuplicates) {
   // Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads));
+              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
@@ -119,11 +131,14 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"food & drink"},
-                            CreativeInlineContentAdList{creative_ad_1}));
+                            CreativeInlineContentAdList{creative_ad_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegmentsAndDimensions(SegmentList{"food & drink"},
                                               /*dimensions=*/"200x100",
                                               callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, GetForEmptySegments) {
@@ -135,11 +150,14 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, GetForEmptySegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
                             /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegmentsAndDimensions(
       /*segments=*/{}, /*dimensions=*/"200x100", callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
@@ -152,10 +170,13 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"NON_EXISTENT"},
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegmentsAndDimensions(
       /*segments=*/{"NON_EXISTENT"}, /*dimensions=*/"200x100", callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
@@ -183,14 +204,17 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(
       callback,
       Run(/*success=*/true, SegmentList{"technology & computing", "automotive"},
           ::testing::UnorderedElementsAreArray(
-              CreativeInlineContentAdList{creative_ad_1, creative_ad_3})));
+              CreativeInlineContentAdList{creative_ad_1, creative_ad_3})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegmentsAndDimensions(
       /*segments=*/{"technology & computing", "automotive"},
       /*dimensions=*/"200x100", callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
@@ -211,10 +235,13 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            creative_ad_1.creative_instance_id, creative_ad_1));
+                            creative_ad_1.creative_instance_id, creative_ad_1))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(creative_ad_1.creative_instance_id,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
@@ -231,10 +258,13 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/false, test::kMissingCreativeInstanceId,
-                            CreativeInlineContentAdInfo{}));
+                            CreativeInlineContentAdInfo{}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(test::kMissingCreativeInstanceId,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, GetNonExpired) {
@@ -260,10 +290,13 @@ TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, GetNonExpired) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeInlineContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{creative_ad_2.segment},
-                  CreativeInlineContentAdList{creative_ad_2}));
+                  CreativeInlineContentAdList{creative_ad_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeInlineContentAdsDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.cc
@@ -15,7 +15,6 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_split.h"
 #include "base/time/time.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/containers/container_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
@@ -26,7 +25,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/creative_ad_info.h"
 #include "brave/components/brave_ads/core/internal/segments/segment_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "brave/components/brave_ads/core/public/serving/targeting/condition_matcher/condition_matcher_util.h"
 #include "url/gurl.h"
 
@@ -387,10 +385,9 @@ void CreativeNewTabPageAds::GetForCreativeInstanceId(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetForCreativeInstanceIdCallback, creative_instance_id,
-                     std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetForCreativeInstanceIdCallback,
+                                  creative_instance_id, std::move(callback)));
 }
 
 void CreativeNewTabPageAds::GetForSegments(
@@ -460,7 +457,7 @@ void CreativeNewTabPageAds::GetForSegments(
 
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
+  RunDBTransaction(
       std::move(mojom_db_transaction),
       base::BindOnce(&GetForSegmentsCallback, segments, std::move(callback)));
 }
@@ -516,9 +513,8 @@ void CreativeNewTabPageAds::GetForActiveCampaigns(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetAllCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetAllCallback, std::move(callback)));
 }
 
 std::string CreativeNewTabPageAds::GetTableName() const {

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table_test.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -36,11 +38,14 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableIntegrationTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{"technology & computing"},
-                  ::testing::SizeIs(1)));
+                  ::testing::SizeIs(1)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForSegments(
       /*segments=*/{"technology & computing"}, callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/new_tab_page_ads/creative_new_tab_page_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -29,9 +31,12 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, SaveEmpty) {
   // Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, Save) {
@@ -45,11 +50,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, Save) {
   // Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true, SegmentList{"architecture", "arts & entertainment"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, SaveInBatches) {
@@ -65,12 +72,14 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, SaveInBatches) {
   // Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true,
-          SegmentList{"architecture", "arts & entertainment", "automotive"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment",
+                                        "automotive"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, DoNotSaveDuplicates) {
@@ -85,9 +94,12 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, DoNotSaveDuplicates) {
   // Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads));
+              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetForSegments) {
@@ -109,10 +121,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetForSegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"food & drink"},
-                            CreativeNewTabPageAdList{creative_ad_1}));
+                            CreativeNewTabPageAdList{creative_ad_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"food & drink"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetForEmptySegments) {
@@ -124,10 +139,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetForEmptySegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
                             /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(/*segments=*/{}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest,
@@ -140,10 +158,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"NON_EXISTENT"},
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"NON_EXISTENT"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetForMultipleSegments) {
@@ -170,13 +191,16 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetForMultipleSegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true,
                   SegmentList{"technology & computing", "food & drink"},
                   ::testing::UnorderedElementsAreArray(
-                      CreativeNewTabPageAdList{creative_ad_1, creative_ad_2})));
+                      CreativeNewTabPageAdList{creative_ad_1, creative_ad_2})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"technology & computing", "food & drink"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest,
@@ -196,10 +220,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            creative_ad_1.creative_instance_id, creative_ad_1));
+                            creative_ad_1.creative_instance_id, creative_ad_1))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(creative_ad_1.creative_instance_id,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest,
@@ -211,10 +238,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/false, test::kMissingCreativeInstanceId,
-                            CreativeNewTabPageAdInfo{}));
+                            CreativeNewTabPageAdInfo{}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(test::kMissingCreativeInstanceId,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetNonExpired) {
@@ -240,10 +270,13 @@ TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetNonExpired) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNewTabPageAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{creative_ad_2.segment},
-                  CreativeNewTabPageAdList{creative_ad_2}));
+                  CreativeNewTabPageAdList{creative_ad_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNewTabPageAdsDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.cc
@@ -14,7 +14,6 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/containers/container_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
@@ -25,7 +24,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/creative_ad_info.h"
 #include "brave/components/brave_ads/core/internal/segments/segment_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "url/gurl.h"
 
 namespace brave_ads::database::table {
@@ -308,7 +306,7 @@ void CreativeNotificationAds::GetForSegments(
 
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
+  RunDBTransaction(
       std::move(mojom_db_transaction),
       base::BindOnce(&GetForSegmentsCallback, segments, std::move(callback)));
 }
@@ -358,9 +356,8 @@ void CreativeNotificationAds::GetForActiveCampaigns(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetAllCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetAllCallback, std::move(callback)));
 }
 
 std::string CreativeNotificationAds::GetTableName() const {

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table_test.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -36,11 +38,14 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableIntegrationTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{"technology & computing"},
-                  ::testing::SizeIs(2)));
+                  ::testing::SizeIs(2)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForSegments(
       /*segments=*/{"technology & computing"}, callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/notification_ads/creative_notification_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
@@ -27,9 +29,12 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, SaveEmpty) {
   // Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, Save) {
@@ -43,11 +48,13 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, Save) {
   // Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true, SegmentList{"architecture", "arts & entertainment"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, SaveInBatches) {
@@ -63,12 +70,14 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, SaveInBatches) {
   // Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true,
-          SegmentList{"architecture", "arts & entertainment", "automotive"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment",
+                                        "automotive"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, DoNotSaveDuplicates) {
@@ -83,9 +92,12 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, DoNotSaveDuplicates) {
   // Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads));
+              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetForSegments) {
@@ -107,9 +119,12 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetForSegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"food & drink"},
-                            CreativeNotificationAdList{creative_ad_1}));
+                            CreativeNotificationAdList{creative_ad_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(/*segments=*/{"food & drink"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetForEmptySegments) {
@@ -121,10 +136,13 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetForEmptySegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
                             /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(/*segments=*/{}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest,
@@ -137,10 +155,13 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"NON_EXISTENT"},
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"NON_EXISTENT"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest,
@@ -168,14 +189,17 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(
       callback,
       Run(/*success=*/true,
           SegmentList{"technology & computing", "food & drink"},
           ::testing::UnorderedElementsAreArray(
-              CreativeNotificationAdList{creative_ad_1, creative_ad_2})));
+              CreativeNotificationAdList{creative_ad_1, creative_ad_2})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"technology & computing", "food & drink"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetNonExpired) {
@@ -201,10 +225,13 @@ TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetNonExpired) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativeNotificationAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{creative_ad_2.segment},
-                  CreativeNotificationAdList{creative_ad_2}));
+                  CreativeNotificationAdList{creative_ad_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativeNotificationAdsDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table.cc
+++ b/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table.cc
@@ -14,7 +14,6 @@
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/containers/container_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
@@ -25,7 +24,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/creative_ad_info.h"
 #include "brave/components/brave_ads/core/internal/segments/segment_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "url/gurl.h"
 
 namespace brave_ads::database::table {
@@ -322,10 +320,9 @@ void CreativePromotedContentAds::GetForCreativeInstanceId(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetForCreativeInstanceIdCallback, creative_instance_id,
-                     std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetForCreativeInstanceIdCallback,
+                                  creative_instance_id, std::move(callback)));
 }
 
 void CreativePromotedContentAds::GetForSegments(
@@ -390,7 +387,7 @@ void CreativePromotedContentAds::GetForSegments(
 
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
+  RunDBTransaction(
       std::move(mojom_db_transaction),
       base::BindOnce(&GetForSegmentsCallback, segments, std::move(callback)));
 }
@@ -440,9 +437,8 @@ void CreativePromotedContentAds::GetForActiveCampaigns(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetAllCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetAllCallback, std::move(callback)));
 }
 
 std::string CreativePromotedContentAds::GetTableName() const {

--- a/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table_test.cc
+++ b/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table_test.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/catalog/catalog_url_request_builder_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/mock_test_util.h"
@@ -34,13 +36,16 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableIntegrationTest,
   const database::table::CreativePromotedContentAds database_table;
 
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{"technology & computing"},
-                  ::testing::SizeIs(1)));
+                  ::testing::SizeIs(1)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table.GetForSegments(
       /*segments=*/{"technology & computing"}, callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/creatives/promoted_content_ads/creative_promoted_content_ads_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -29,9 +31,12 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, SaveEmpty) {
   // Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, Save) {
@@ -45,11 +50,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, Save) {
   // Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true, SegmentList{"architecture", "arts & entertainment"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, SaveInBatches) {
@@ -65,12 +72,14 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, SaveInBatches) {
   // Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
-  EXPECT_CALL(
-      callback,
-      Run(/*success=*/true,
-          SegmentList{"architecture", "arts & entertainment", "automotive"},
-          ::testing::UnorderedElementsAreArray(creative_ads)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true,
+                            SegmentList{"architecture", "arts & entertainment",
+                                        "automotive"},
+                            ::testing::UnorderedElementsAreArray(creative_ads)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
@@ -86,9 +95,12 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
   // Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads));
+              Run(/*success=*/true, SegmentList{"architecture"}, creative_ads))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, GetForSegments) {
@@ -112,10 +124,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, GetForSegments) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"food & drink"},
-                            CreativePromotedContentAdList{creative_ad_1}));
+                            CreativePromotedContentAdList{creative_ad_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"food & drink"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
@@ -128,10 +143,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
                             /*segments=*/::testing::IsEmpty(),
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(/*segments=*/{}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
@@ -144,10 +162,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true, SegmentList{"NON_EXISTENT"},
-                            /*creative_ads=*/::testing::IsEmpty()));
+                            /*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"NON_EXISTENT"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
@@ -178,14 +199,17 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(
       callback,
       Run(/*success=*/true,
           SegmentList{"technology & computing", "food & drink"},
           ::testing::UnorderedElementsAreArray(
-              CreativePromotedContentAdList{creative_ad_1, creative_ad_2})));
+              CreativePromotedContentAdList{creative_ad_1, creative_ad_2})))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForSegments(
       /*segments=*/{"technology & computing", "food & drink"}, callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
@@ -208,10 +232,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            creative_ad_1.creative_instance_id, creative_ad_1));
+                            creative_ad_1.creative_instance_id, creative_ad_1))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(creative_ad_1.creative_instance_id,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
@@ -224,10 +251,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest,
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(/*success=*/false, test::kMissingCreativeInstanceId,
-                            CreativePromotedContentAdInfo{}));
+                            CreativePromotedContentAdInfo{}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(test::kMissingCreativeInstanceId,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, GetNonExpired) {
@@ -255,10 +285,13 @@ TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, GetNonExpired) {
   // Act & Assert
   base::MockCallback<database::table::GetCreativePromotedContentAdsCallback>
       callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(/*success=*/true, SegmentList{creative_ad_2.segment},
-                  CreativePromotedContentAdList{creative_ad_2}));
+                  CreativePromotedContentAdList{creative_ad_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForActiveCampaigns(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsCreativePromotedContentAdsDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/database/database.cc
+++ b/components/brave_ads/core/internal/database/database.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "brave/components/brave_ads/core/public/database/database.h"
+#include "brave/components/brave_ads/core/internal/database/database.h"
 
 #include <tuple>
 #include <utility>

--- a/components/brave_ads/core/internal/database/database.h
+++ b/components/brave_ads/core/internal/database/database.h
@@ -3,8 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_PUBLIC_DATABASE_DATABASE_H_
-#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_PUBLIC_DATABASE_DATABASE_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_DATABASE_DATABASE_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_DATABASE_DATABASE_H_
 
 #include <memory>
 
@@ -80,4 +80,4 @@ class ADS_EXPORT Database final {
 
 }  // namespace brave_ads
 
-#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_PUBLIC_DATABASE_DATABASE_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_INTERNAL_DATABASE_DATABASE_H_

--- a/components/brave_ads/core/internal/database/database_manager.cc
+++ b/components/brave_ads/core/internal/database/database_manager.cc
@@ -10,7 +10,8 @@
 #include "base/check_op.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/functional/bind.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
 #include "brave/components/brave_ads/core/internal/global_state/global_state.h"
@@ -19,11 +20,15 @@
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_migration.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_raze.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
+#include "brave/components/brave_ads/core/public/database/database.h"
 
 namespace brave_ads {
 
-DatabaseManager::DatabaseManager() = default;
+DatabaseManager::DatabaseManager(const base::FilePath& path)
+    : database_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
+          {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+           base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
+      database_(base::SequenceBound<Database>(database_task_runner_, path)) {}
 
 DatabaseManager::~DatabaseManager() = default;
 
@@ -53,10 +58,21 @@ void DatabaseManager::CreateOrOpen(ResultCallback callback) {
   mojom_db_action->type = mojom::DBActionInfo::Type::kInitialize;
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
+  RunDBTransaction(
       std::move(mojom_db_transaction),
       base::BindOnce(&DatabaseManager::CreateOrOpenCallback,
                      weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void DatabaseManager::RunDBTransaction(
+    mojom::DBTransactionInfoPtr mojom_db_transaction,
+    RunDBTransactionCallback callback) {
+  CHECK(mojom_db_transaction);
+  CHECK(callback);
+
+  database_.AsyncCall(&Database::RunDBTransaction)
+      .WithArgs(std::move(mojom_db_transaction))
+      .Then(std::move(callback));
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/components/brave_ads/core/internal/database/database_manager.cc
+++ b/components/brave_ads/core/internal/database/database_manager.cc
@@ -14,13 +14,13 @@
 #include "base/task/thread_pool.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_transaction_util.h"
 #include "brave/components/brave_ads/core/internal/common/logging_util.h"
+#include "brave/components/brave_ads/core/internal/database/database.h"
 #include "brave/components/brave_ads/core/internal/global_state/global_state.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_constants.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_creation.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_migration.h"
 #include "brave/components/brave_ads/core/internal/legacy_migration/database/database_raze.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/database/database.h"
 
 namespace brave_ads {
 

--- a/components/brave_ads/core/internal/database/database_manager.h
+++ b/components/brave_ads/core/internal/database/database_manager.h
@@ -76,7 +76,6 @@ class DatabaseManager final {
   void NotifyDatabaseIsReady() const;
 
   const scoped_refptr<base::SequencedTaskRunner> database_task_runner_;
-
   const base::SequenceBound<Database> database_;
 
   base::ObserverList<DatabaseManagerObserver> observers_;

--- a/components/brave_ads/core/internal/global_state/global_state.cc
+++ b/components/brave_ads/core/internal/global_state/global_state.cc
@@ -28,6 +28,7 @@ namespace brave_ads {
 
 GlobalState::GlobalState(
     AdsClient& ads_client,
+    const base::FilePath& database_path,
     std::unique_ptr<TokenGeneratorInterface> token_generator)
     : ads_client_(ads_client),
       global_state_holder_(std::make_unique<GlobalStateHolder>(this)) {
@@ -35,7 +36,7 @@ GlobalState::GlobalState(
   browser_manager_ = std::make_unique<BrowserManager>();
   client_state_manager_ = std::make_unique<ClientStateManager>();
   confirmation_state_manager_ = std::make_unique<ConfirmationStateManager>();
-  database_manager_ = std::make_unique<DatabaseManager>();
+  database_manager_ = std::make_unique<DatabaseManager>(database_path);
   diagnostic_manager_ = std::make_unique<DiagnosticManager>();
   ad_history_manager_ = std::make_unique<AdHistoryManager>();
   notification_ad_manager_ = std::make_unique<NotificationAdManager>();

--- a/components/brave_ads/core/internal/global_state/global_state.h
+++ b/components/brave_ads/core/internal/global_state/global_state.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/files/file_path.h"
 #include "base/memory/raw_ref.h"
 #include "base/memory/weak_ptr.h"
 #include "base/sequence_checker.h"
@@ -35,9 +36,9 @@ class UserActivityManager;
 
 class GlobalState final {
  public:
-  explicit GlobalState(
-      AdsClient& ads_client,
-      std::unique_ptr<TokenGeneratorInterface> token_generator);
+  GlobalState(AdsClient& ads_client,
+              const base::FilePath& database_path,
+              std::unique_ptr<TokenGeneratorInterface> token_generator);
 
   GlobalState(const GlobalState& other) = delete;
   GlobalState& operator=(const GlobalState& other) = delete;

--- a/components/brave_ads/core/internal/history/ad_history_database_table.cc
+++ b/components/brave_ads/core/internal/history/ad_history_database_table.cc
@@ -12,7 +12,6 @@
 #include "base/debug/dump_without_crashing.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/containers/container_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
@@ -23,7 +22,6 @@
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_type.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "brave/components/brave_ads/core/public/history/ad_history_feature.h"
 
 namespace brave_ads::database::table {
@@ -264,9 +262,8 @@ void AdHistory::GetForDateRange(base::Time from_time,
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdHistory::GetHighestRankedPlacementsForDateRange(
@@ -368,9 +365,8 @@ void AdHistory::GetHighestRankedPlacementsForDateRange(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdHistory::GetForCreativeInstanceId(
@@ -403,9 +399,8 @@ void AdHistory::GetForCreativeInstanceId(
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdHistory::PurgeExpired(ResultCallback callback) const {

--- a/components/brave_ads/core/internal/history/ad_history_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/history/ad_history_database_table_unittest.cc
@@ -7,6 +7,8 @@
 
 #include <vector>
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
@@ -59,11 +61,14 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, Save) {
 
   // Assert
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(::testing::Optional(
-                            ::testing::UnorderedElementsAreArray(ad_history))));
+                            ::testing::UnorderedElementsAreArray(ad_history))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForDateRange(/*from_time=*/test::DistantPast(),
                                   /*to_time=*/test::DistantFuture(),
                                   callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, SaveEmpty) {
@@ -72,11 +77,14 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, SaveEmpty) {
 
   // Assert
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*ad_history=*/::testing::Optional(::testing::IsEmpty())));
+              Run(/*ad_history=*/::testing::Optional(::testing::IsEmpty())))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForDateRange(/*from_time=*/test::DistantPast(),
                                   /*to_time=*/test::DistantFuture(),
                                   callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, SaveInBatches) {
@@ -95,11 +103,14 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, SaveInBatches) {
 
   // Assert
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(::testing::Optional(
-                            ::testing::UnorderedElementsAreArray(ad_history))));
+                            ::testing::UnorderedElementsAreArray(ad_history))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForDateRange(/*from_time=*/test::DistantPast(),
                                   /*to_time=*/test::DistantFuture(),
                                   callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, GetForDateRange) {
@@ -124,11 +135,14 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, GetForDateRange) {
 
   // Act & Assert
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(::testing::Optional(
-                  ::testing::UnorderedElementsAreArray(ad_history_2))));
+                  ::testing::UnorderedElementsAreArray(ad_history_2))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForDateRange(from_time, /*to_time=*/test::DistantFuture(),
                                   callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest,
@@ -171,11 +185,14 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest,
   ASSERT_THAT(expected_ad_history, ::testing::SizeIs(3));
 
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
               Run(::testing::Optional(
-                  ::testing::UnorderedElementsAreArray(expected_ad_history))));
+                  ::testing::UnorderedElementsAreArray(expected_ad_history))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetHighestRankedPlacementsForDateRange(
       from_time, /*to_time=*/test::DistantFuture(), callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, GetForCreativeInstanceId) {
@@ -189,10 +206,13 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, GetForCreativeInstanceId) {
 
   // Act & Assert
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback, Run(::testing::Optional(
-                            ::testing::UnorderedElementsAreArray(ad_history))));
+                            ::testing::UnorderedElementsAreArray(ad_history))))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(test::kCreativeInstanceId,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest,
@@ -207,10 +227,13 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*ad_history=*/::testing::Optional(::testing::IsEmpty())));
+              Run(/*ad_history=*/::testing::Optional(::testing::IsEmpty())))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetForCreativeInstanceId(test::kCreativeInstanceId,
                                            callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, PurgeExpired) {
@@ -233,16 +256,22 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, PurgeExpired) {
 
   // Act & Assert
   base::MockCallback<ResultCallback> purge_expired_callback;
-  EXPECT_CALL(purge_expired_callback, Run(/*success=*/true));
+  base::RunLoop run_loop;
+  EXPECT_CALL(purge_expired_callback, Run(/*success=*/true))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.PurgeExpired(purge_expired_callback.Get());
+  run_loop.Run();
 
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop2;
   EXPECT_CALL(callback,
               Run(::testing::Optional(
-                  ::testing::UnorderedElementsAreArray(ad_history_2))));
+                  ::testing::UnorderedElementsAreArray(ad_history_2))))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetForDateRange(/*from_time=*/test::DistantPast(),
                                   /*to_time=*/test::DistantFuture(),
                                   callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, DoNotPurgeOnTheCuspOfExpiration) {
@@ -258,15 +287,21 @@ TEST_F(BraveAdsAdHistoryDatabaseTableTest, DoNotPurgeOnTheCuspOfExpiration) {
 
   // Act & Assert
   base::MockCallback<ResultCallback> purge_expired_callback;
-  EXPECT_CALL(purge_expired_callback, Run(/*success=*/true));
+  base::RunLoop run_loop;
+  EXPECT_CALL(purge_expired_callback, Run(/*success=*/true))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.PurgeExpired(purge_expired_callback.Get());
+  run_loop.Run();
 
   base::MockCallback<GetAdHistoryCallback> callback;
+  base::RunLoop run_loop2;
   EXPECT_CALL(callback, Run(::testing::Optional(
-                            ::testing::UnorderedElementsAreArray(ad_history))));
+                            ::testing::UnorderedElementsAreArray(ad_history))))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetForDateRange(/*from_time=*/test::DistantPast(),
                                   /*to_time=*/test::DistantFuture(),
                                   callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdHistoryDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/serving/eligible_ads/pipelines/inline_content_ads/eligible_inline_content_ads_v2_unittest.cc
+++ b/components/brave_ads/core/internal/serving/eligible_ads/pipelines/inline_content_ads/eligible_inline_content_ads_v2_unittest.cc
@@ -7,6 +7,8 @@
 
 #include <memory>
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/inline_content_ads/creative_inline_content_ad_info.h"
@@ -58,8 +60,10 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAds) {
   database::SaveCreativeInlineContentAds(creative_ads);
 
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
-  EXPECT_CALL(callback, Run(CreativeInlineContentAdList{creative_ad_1}));
+  EXPECT_CALL(callback, Run(CreativeInlineContentAdList{creative_ad_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   eligible_ads_->GetForUserModel(
       UserModelInfo{
           IntentUserModelInfo{},
@@ -67,6 +71,7 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAds) {
           InterestUserModelInfo{SegmentList{"untargeted"}},
       },
       /*dimensions=*/"200x100", callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAdsForNoMatchingSegments) {
@@ -86,10 +91,13 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test, GetAdsForNoMatchingSegments) {
   database::SaveCreativeInlineContentAds(creative_ads);
 
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
-  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
+  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   eligible_ads_->GetForUserModel(/*user_model=*/{}, /*dimensions=*/"200x100",
                                  callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsEligibleInlineContentAdsV2Test,
@@ -104,22 +112,28 @@ TEST_F(BraveAdsEligibleInlineContentAdsV2Test,
   database::SaveCreativeInlineContentAds(creative_ads);
 
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
-  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
+  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   eligible_ads_->GetForUserModel(UserModelInfo{},
                                  /*dimensions=*/"?x?", callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsEligibleInlineContentAdsV2Test, DoNotGetAdsIfNoEligibleAds) {
   // Act & Assert
+  base::RunLoop run_loop;
   base::MockCallback<EligibleAdsCallback<CreativeInlineContentAdList>> callback;
-  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()));
+  EXPECT_CALL(callback, Run(/*creative_ads=*/::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   eligible_ads_->GetForUserModel(
       UserModelInfo{
           IntentUserModelInfo{SegmentList{"parent-child", "parent"}},
           LatentInterestUserModelInfo{},
           InterestUserModelInfo{SegmentList{"parent-child", "parent"}}},
       /*dimensions=*/"200x100", callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/serving/new_tab_page_ad_serving_unittest.cc
+++ b/components/brave_ads/core/internal/serving/new_tab_page_ad_serving_unittest.cc
@@ -7,6 +7,8 @@
 
 #include <utility>
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -31,14 +33,15 @@ class BraveAdsNewTabPageAdServingTest : public test::TestBase {
   void MaybeServeAd(MaybeServeNewTabPageAdCallback callback) {
     SubdivisionTargeting subdivision_targeting;
     AntiTargetingResource anti_targeting_resource;
-    NewTabPageAdServing ad_serving(subdivision_targeting,
-                                   anti_targeting_resource);
-    ad_serving.SetDelegate(&delegate_mock_);
+    ad_serving_ = std::make_unique<NewTabPageAdServing>(
+        subdivision_targeting, anti_targeting_resource);
+    ad_serving_->SetDelegate(&delegate_mock_);
 
-    ad_serving.MaybeServeAd(std::move(callback));
+    ad_serving_->MaybeServeAd(std::move(callback));
   }
 
   ::testing::StrictMock<NewTabPageAdServingDelegateMock> delegate_mock_;
+  std::unique_ptr<NewTabPageAdServing> ad_serving_;
 };
 
 TEST_F(BraveAdsNewTabPageAdServingTest, DoNotServeAdForUnsupportedVersion) {
@@ -57,8 +60,11 @@ TEST_F(BraveAdsNewTabPageAdServingTest, DoNotServeAdForUnsupportedVersion) {
   EXPECT_CALL(delegate_mock_, OnFailedToServeNewTabPageAd);
 
   base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
-  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   MaybeServeAd(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdServingTest, ServeAd) {
@@ -76,8 +82,11 @@ TEST_F(BraveAdsNewTabPageAdServingTest, ServeAd) {
   EXPECT_CALL(delegate_mock_, OnDidServeNewTabPageAd);
 
   base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
-  EXPECT_CALL(callback, Run(/*ad=*/::testing::Ne(std::nullopt)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*ad=*/::testing::Ne(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   MaybeServeAd(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdServingTest, DoNotServeAdIfMissingWallpapers) {
@@ -95,8 +104,11 @@ TEST_F(BraveAdsNewTabPageAdServingTest, DoNotServeAdIfMissingWallpapers) {
   EXPECT_CALL(delegate_mock_, OnFailedToServeNewTabPageAd);
 
   base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
-  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   MaybeServeAd(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdServingTest, DoNotServeAdIfNoEligibleAdsFound) {
@@ -109,8 +121,11 @@ TEST_F(BraveAdsNewTabPageAdServingTest, DoNotServeAdIfNoEligibleAdsFound) {
   EXPECT_CALL(delegate_mock_, OnFailedToServeNewTabPageAd);
 
   base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
-  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   MaybeServeAd(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdServingTest,
@@ -124,8 +139,11 @@ TEST_F(BraveAdsNewTabPageAdServingTest,
   EXPECT_CALL(delegate_mock_, OnFailedToServeNewTabPageAd);
 
   base::MockCallback<MaybeServeNewTabPageAdCallback> callback;
-  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*ad=*/::testing::Eq(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   MaybeServeAd(callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.cc
@@ -12,7 +12,6 @@
 #include "base/functional/bind.h"
 #include "base/strings/string_util.h"
 #include "base/time/time.h"
-#include "brave/components/brave_ads/core/internal/ads_client/ads_client_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_column_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_statement_util.h"
 #include "brave/components/brave_ads/core/internal/common/database/database_table_util.h"
@@ -23,7 +22,6 @@
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/account/confirmations/confirmation_type.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_type.h"
-#include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 
 namespace brave_ads::database::table {
 
@@ -205,9 +203,8 @@ void AdEvents::GetAll(GetAdEventsCallback callback) const {
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdEvents::Get(mojom::AdType mojom_ad_type,
@@ -245,9 +242,8 @@ void AdEvents::Get(mojom::AdType mojom_ad_type,
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdEvents::GetUnexpired(GetAdEventsCallback callback) const {
@@ -285,9 +281,8 @@ void AdEvents::GetUnexpired(GetAdEventsCallback callback) const {
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdEvents::GetUnexpired(mojom::AdType mojom_ad_type,
@@ -329,9 +324,8 @@ void AdEvents::GetUnexpired(mojom::AdType mojom_ad_type,
   BindColumnTypes(mojom_db_action);
   mojom_db_transaction->actions.push_back(std::move(mojom_db_action));
 
-  GetAdsClient().RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(&GetCallback, std::move(callback)));
+  RunDBTransaction(std::move(mojom_db_transaction),
+                   base::BindOnce(&GetCallback, std::move(callback)));
 }
 
 void AdEvents::PurgeExpired(ResultCallback callback) const {

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_database_table.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test_util.h"
@@ -45,8 +47,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, RecordEvent) {
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, Get) {
@@ -106,11 +111,14 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, Get) {
 
   // Act & Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
+  base::RunLoop run_loop;
   EXPECT_CALL(callback,
-              Run(/*success=*/true, AdEventList{ad_event_2, ad_event_5}));
+              Run(/*success=*/true, AdEventList{ad_event_2, ad_event_5}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.Get(mojom::AdType::kNotificationAd,
                       mojom::ConfirmationType::kServedImpression,
                       /*time_window=*/base::Days(1), callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, GetUnexpired) {
@@ -143,8 +151,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, GetUnexpired) {
 
   // Act & Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_2}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest,
@@ -178,8 +189,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, GetUnexpiredOnTheCuspOfExpiry) {
@@ -203,8 +217,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, GetUnexpiredOnTheCuspOfExpiry) {
 
   // Act & Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetUnexpired(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, GetUnexpiredForAdType) {
@@ -246,8 +263,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, GetUnexpiredForAdType) {
 
   // Act & Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_3}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_3}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetUnexpired(mojom::AdType::kNewTabPageAd, callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest,
@@ -291,8 +311,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest,
 
   // Act & Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_1}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_1}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetUnexpired(mojom::AdType::kNotificationAd, callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeExpired) {
@@ -328,8 +351,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeExpired) {
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_2}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeExpiredForNonRewardsUser) {
@@ -367,8 +393,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeExpiredForNonRewardsUser) {
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_2}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event_2}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest,
@@ -406,8 +435,11 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest,
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}));
+  base::RunLoop run_loop2;
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeOrphanedForType) {
@@ -459,12 +491,15 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeOrphanedForType) {
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
+  base::RunLoop run_loop2;
   EXPECT_CALL(
       callback,
       Run(/*success=*/true,
           ::testing::UnorderedElementsAreArray(AdEventList{
-              ad_event_1_served, ad_event_1_viewed, ad_event_2_served})));
+              ad_event_1_served, ad_event_1_viewed, ad_event_2_served})))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeOrphaned) {
@@ -514,12 +549,15 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeOrphaned) {
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
+  base::RunLoop run_loop2;
   EXPECT_CALL(
       callback,
       Run(/*success=*/true,
           ::testing::UnorderedElementsAreArray(AdEventList{
-              ad_event_1_served, ad_event_1_viewed, ad_event_3_served})));
+              ad_event_1_served, ad_event_1_viewed, ad_event_3_served})))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeAllOrphaned) {
@@ -567,10 +605,13 @@ TEST_F(BraveAdsAdEventsDatabaseTableTest, PurgeAllOrphaned) {
 
   // Assert
   base::MockCallback<database::table::GetAdEventsCallback> callback;
+  base::RunLoop run_loop2;
   EXPECT_CALL(callback, Run(/*success=*/true,
                             ::testing::UnorderedElementsAreArray(AdEventList{
-                                ad_event_1_served, ad_event_1_viewed})));
+                                ad_event_1_served, ad_event_1_viewed})))
+      .WillOnce(base::test::RunOnceClosure(run_loop2.QuitClosure()));
   database_table_.GetAll(callback.Get());
+  run_loop2.Run();
 }
 
 TEST_F(BraveAdsAdEventsDatabaseTableTest, GetTableName) {

--- a/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/ad_events_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_events.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -37,10 +39,13 @@ TEST_F(BraveAdsAdEventsTest, RecordAdEvent) {
                 record_ad_event_callback.Get());
 
   // Assert
+  base::RunLoop run_loop;
   base::MockCallback<database::table::GetAdEventsCallback> callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}));
+  EXPECT_CALL(callback, Run(/*success=*/true, AdEventList{ad_event}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const database::table::AdEvents database_table;
   database_table.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsAdEventsTest, PurgeOrphanedAdEvents) {
@@ -90,11 +95,14 @@ TEST_F(BraveAdsAdEventsTest, PurgeOrphanedAdEvents) {
                         purge_orphaned_ad_events_callback.Get());
 
   // Assert
+  base::RunLoop run_loop;
   base::MockCallback<database::table::GetAdEventsCallback> callback;
   EXPECT_CALL(callback, Run(/*success=*/true,
-                            AdEventList{ad_event_2a, ad_event_2b, ad_event_3}));
+                            AdEventList{ad_event_2a, ad_event_2b, ad_event_3}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const database::table::AdEvents database_table;
   database_table.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/inline_content_ads/inline_content_ad_event_handler_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/inline_content_ads/inline_content_ad_event_handler_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/inline_content_ads/inline_content_ad_event_handler.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/ad_units/inline_content_ad/inline_content_ad_test_util.h"
@@ -32,10 +34,13 @@ class BraveAdsInlineContentAdEventHandlerTest : public test::TestBase {
       mojom::InlineContentAdEventType mojom_ad_event_type,
       bool should_fire_event) {
     base::MockCallback<FireInlineContentAdEventHandlerCallback> callback;
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     EXPECT_CALL(callback, Run(/*success=*/should_fire_event, placement_id,
-                              mojom_ad_event_type));
+                              mojom_ad_event_type))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     event_handler_.FireEvent(placement_id, creative_instance_id,
                              mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 
   InlineContentAdEventHandler event_handler_;
@@ -48,11 +53,14 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest, FireServedEvent) {
       test::BuildAndSaveInlineContentAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireInlineContentAdServedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireInlineContentAdServedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::InlineContentAdEventType::kServedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest, FireViewedEvent) {
@@ -62,11 +70,14 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest, FireViewedEvent) {
   test::RecordAdEvent(ad, mojom::ConfirmationType::kServedImpression);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireInlineContentAdViewedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireInlineContentAdViewedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::InlineContentAdEventType::kViewedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
@@ -78,14 +89,17 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireInlineContentAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::InlineContentAdEventType::kViewedImpression));
+                  mojom::InlineContentAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::InlineContentAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
@@ -95,14 +109,17 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest,
       test::BuildAndSaveInlineContentAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireInlineContentAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::InlineContentAdEventType::kViewedImpression));
+                  mojom::InlineContentAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::InlineContentAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest, FireClickedEvent) {
@@ -113,10 +130,13 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest, FireClickedEvent) {
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireInlineContentAdClickedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireInlineContentAdClickedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::InlineContentAdEventType::kClicked,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
@@ -129,12 +149,15 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_, OnFailedToFireInlineContentAdEvent(
                                   ad.placement_id, ad.creative_instance_id,
-                                  mojom::InlineContentAdEventType::kClicked));
+                                  mojom::InlineContentAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::InlineContentAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
@@ -144,38 +167,47 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest,
       test::BuildAndSaveInlineContentAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_, OnFailedToFireInlineContentAdEvent(
                                   ad.placement_id, ad.creative_instance_id,
-                                  mojom::InlineContentAdEventType::kClicked));
+                                  mojom::InlineContentAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::InlineContentAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
        DoNotFireEventWithInvalidPlacementId) {
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireInlineContentAdEvent(
                   test::kInvalidPlacementId, test::kCreativeInstanceId,
-                  mojom::InlineContentAdEventType::kServedImpression));
+                  mojom::InlineContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kInvalidPlacementId, test::kCreativeInstanceId,
       mojom::InlineContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
        DoNotFireEventWithInvalidCreativeInstanceId) {
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireInlineContentAdEvent(
                   test::kPlacementId, test::kInvalidCreativeInstanceId,
-                  mojom::InlineContentAdEventType::kServedImpression));
+                  mojom::InlineContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kPlacementId, test::kInvalidCreativeInstanceId,
       mojom::InlineContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsInlineContentAdEventHandlerTest,
@@ -185,14 +217,17 @@ TEST_F(BraveAdsInlineContentAdEventHandlerTest,
       test::BuildAndSaveInlineContentAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireInlineContentAdEvent(
                   ad.placement_id, test::kMissingCreativeInstanceId,
-                  mojom::InlineContentAdEventType::kServedImpression));
+                  mojom::InlineContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, test::kMissingCreativeInstanceId,
       mojom::InlineContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_for_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/new_tab_page_ads/new_tab_page_ad_event_handler_for_rewards_unittest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/ad_units/new_tab_page_ad/new_tab_page_ad_test_util.h"
@@ -32,10 +34,13 @@ class BraveAdsNewTabPageAdEventHandlerForRewardsTest : public test::TestBase {
       mojom::NewTabPageAdEventType mojom_ad_event_type,
       bool should_fire_event) {
     base::MockCallback<FireNewTabPageAdEventHandlerCallback> callback;
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     EXPECT_CALL(callback, Run(/*success=*/should_fire_event, placement_id,
-                              mojom_ad_event_type));
+                              mojom_ad_event_type))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     event_handler_.FireEvent(placement_id, creative_instance_id,
                              mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 
   NewTabPageAdEventHandler event_handler_;
@@ -48,11 +53,14 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest, FireServedEvent) {
       test::BuildAndSaveNewTabPageAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdServedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdServedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::NewTabPageAdEventType::kServedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest, FireViewedEvent) {
@@ -62,11 +70,14 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest, FireViewedEvent) {
   test::RecordAdEvent(ad, mojom::ConfirmationType::kServedImpression);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdViewedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdViewedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::NewTabPageAdEventType::kViewedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
@@ -78,14 +89,17 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireNewTabPageAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::NewTabPageAdEventType::kViewedImpression));
+                  mojom::NewTabPageAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::NewTabPageAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
@@ -95,14 +109,17 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
       test::BuildAndSaveNewTabPageAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireNewTabPageAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::NewTabPageAdEventType::kViewedImpression));
+                  mojom::NewTabPageAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::NewTabPageAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest, FireClickedEvent) {
@@ -113,10 +130,13 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest, FireClickedEvent) {
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdClickedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNewTabPageAdClickedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::NewTabPageAdEventType::kClicked,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
@@ -129,12 +149,15 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_, OnFailedToFireNewTabPageAdEvent(
                                   ad.placement_id, ad.creative_instance_id,
-                                  mojom::NewTabPageAdEventType::kClicked));
+                                  mojom::NewTabPageAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::NewTabPageAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
@@ -144,38 +167,47 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
       test::BuildAndSaveNewTabPageAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_, OnFailedToFireNewTabPageAdEvent(
                                   ad.placement_id, ad.creative_instance_id,
-                                  mojom::NewTabPageAdEventType::kClicked));
+                                  mojom::NewTabPageAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::NewTabPageAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
        DoNotFireEventWithInvalidPlacementId) {
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireNewTabPageAdEvent(
                   test::kInvalidPlacementId, test::kCreativeInstanceId,
-                  mojom::NewTabPageAdEventType::kServedImpression));
+                  mojom::NewTabPageAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kInvalidPlacementId, test::kCreativeInstanceId,
       mojom::NewTabPageAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
        DoNotFireEventWithInvalidCreativeInstanceId) {
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireNewTabPageAdEvent(
                   test::kPlacementId, test::kInvalidCreativeInstanceId,
-                  mojom::NewTabPageAdEventType::kServedImpression));
+                  mojom::NewTabPageAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kPlacementId, test::kInvalidCreativeInstanceId,
       mojom::NewTabPageAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
@@ -185,14 +217,17 @@ TEST_F(BraveAdsNewTabPageAdEventHandlerForRewardsTest,
       test::BuildAndSaveNewTabPageAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireNewTabPageAdEvent(
                   ad.placement_id, test::kMissingCreativeInstanceId,
-                  mojom::NewTabPageAdEventType::kServedImpression));
+                  mojom::NewTabPageAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, test::kMissingCreativeInstanceId,
       mojom::NewTabPageAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/notification_ads/notification_ad_event_handler_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/notification_ads/notification_ad_event_handler_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/notification_ads/notification_ad_event_handler.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/ad_units/notification_ad/notification_ad_test_util.h"
@@ -32,9 +34,12 @@ class BraveAdsNotificationAdEventHandlerTest : public test::TestBase {
       mojom::NotificationAdEventType mojom_ad_event_type,
       bool should_fire_event) {
     base::MockCallback<FireNotificationAdEventHandlerCallback> callback;
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     EXPECT_CALL(callback, Run(/*success=*/should_fire_event, placement_id,
-                              mojom_ad_event_type));
+                              mojom_ad_event_type))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     event_handler_.FireEvent(placement_id, mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 
   NotificationAdEventHandler event_handler_;
@@ -47,10 +52,13 @@ TEST_F(BraveAdsNotificationAdEventHandlerTest, FireServedEvent) {
       test::BuildAndSaveNotificationAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdServedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdServedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, mojom::NotificationAdEventType::kServedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNotificationAdEventHandlerTest, FireViewedEvent) {
@@ -59,10 +67,13 @@ TEST_F(BraveAdsNotificationAdEventHandlerTest, FireViewedEvent) {
       test::BuildAndSaveNotificationAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdViewedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdViewedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, mojom::NotificationAdEventType::kViewedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNotificationAdEventHandlerTest, FireClickedEvent) {
@@ -71,10 +82,13 @@ TEST_F(BraveAdsNotificationAdEventHandlerTest, FireClickedEvent) {
       test::BuildAndSaveNotificationAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdClickedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdClickedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id,
                                  mojom::NotificationAdEventType::kClicked,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNotificationAdEventHandlerTest, FireDismissedEvent) {
@@ -83,10 +97,13 @@ TEST_F(BraveAdsNotificationAdEventHandlerTest, FireDismissedEvent) {
       test::BuildAndSaveNotificationAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdDismissedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdDismissedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id,
                                  mojom::NotificationAdEventType::kDismissed,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNotificationAdEventHandlerTest, FireTimedOutEvent) {
@@ -95,10 +112,13 @@ TEST_F(BraveAdsNotificationAdEventHandlerTest, FireTimedOutEvent) {
       test::BuildAndSaveNotificationAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdTimedOutEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireNotificationAdTimedOutEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id,
                                  mojom::NotificationAdEventType::kTimedOut,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsNotificationAdEventHandlerTest,
@@ -108,14 +128,17 @@ TEST_F(BraveAdsNotificationAdEventHandlerTest,
       test::BuildAndSaveNotificationAd(/*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireNotificationAdEvent(
                   test::kMissingPlacementId,
-                  mojom::NotificationAdEventType::kViewedImpression));
+                  mojom::NotificationAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kMissingPlacementId,
       mojom::NotificationAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/promoted_content_ads/promoted_content_ad_event_handler_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/promoted_content_ads/promoted_content_ad_event_handler_unittest.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/promoted_content_ads/promoted_content_ad_event_handler.h"
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/ad_units/promoted_content_ad/promoted_content_ad_feature.h"
@@ -37,10 +39,13 @@ class BraveAdsPromotedContentAdEventHandlerTest : public test::TestBase {
       mojom::PromotedContentAdEventType mojom_ad_event_type,
       bool should_fire_event) {
     base::MockCallback<FirePromotedContentAdEventHandlerCallback> callback;
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     EXPECT_CALL(callback, Run(/*success=*/should_fire_event, placement_id,
-                              mojom_ad_event_type));
+                              mojom_ad_event_type))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     event_handler_.FireEvent(placement_id, creative_instance_id,
                              mojom_ad_event_type, callback.Get());
+    run_loop.Run();
   }
 
   PromotedContentAdEventHandler event_handler_;
@@ -55,11 +60,14 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest, FireViewedEvent) {
   test::RecordAdEvent(ad, mojom::ConfirmationType::kServedImpression);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdViewedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdViewedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kViewedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -71,14 +79,17 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::PromotedContentAdEventType::kViewedImpression));
+                  mojom::PromotedContentAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -88,14 +99,17 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
       /*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::PromotedContentAdEventType::kViewedImpression));
+                  mojom::PromotedContentAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest, FireClickedEvent) {
@@ -106,10 +120,13 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest, FireClickedEvent) {
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdClickedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdClickedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::PromotedContentAdEventType::kClicked,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -122,12 +139,15 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_, OnFailedToFirePromotedContentAdEvent(
                                   ad.placement_id, ad.creative_instance_id,
-                                  mojom::PromotedContentAdEventType::kClicked));
+                                  mojom::PromotedContentAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::PromotedContentAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -137,38 +157,47 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
       /*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_, OnFailedToFirePromotedContentAdEvent(
                                   ad.placement_id, ad.creative_instance_id,
-                                  mojom::PromotedContentAdEventType::kClicked));
+                                  mojom::PromotedContentAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(ad.placement_id, ad.creative_instance_id,
                                  mojom::PromotedContentAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
        DoNotFireEventWithInvalidPlacementId) {
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   test::kInvalidPlacementId, test::kCreativeInstanceId,
-                  mojom::PromotedContentAdEventType::kServedImpression));
+                  mojom::PromotedContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kInvalidPlacementId, test::kCreativeInstanceId,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
        DoNotFireEventWithInvalidCreativeInstanceId) {
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   test::kPlacementId, test::kInvalidCreativeInstanceId,
-                  mojom::PromotedContentAdEventType::kServedImpression));
+                  mojom::PromotedContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       test::kPlacementId, test::kInvalidCreativeInstanceId,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -178,14 +207,17 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
       /*should_generate_random_uuids=*/false);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   ad.placement_id, test::kMissingCreativeInstanceId,
-                  mojom::PromotedContentAdEventType::kServedImpression));
+                  mojom::PromotedContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, test::kMissingCreativeInstanceId,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -199,11 +231,14 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
   AdvanceClockBy(base::Hours(1) - base::Milliseconds(1));
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdServedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdServedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -217,14 +252,17 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
   AdvanceClockBy(base::Hours(1) - base::Milliseconds(1));
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::PromotedContentAdEventType::kServedImpression));
+                  mojom::PromotedContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -238,11 +276,14 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
   AdvanceClockBy(base::Days(1) - base::Milliseconds(1));
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdServedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFirePromotedContentAdServedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
@@ -256,14 +297,17 @@ TEST_F(BraveAdsPromotedContentAdEventHandlerTest,
   AdvanceClockBy(base::Days(1) - base::Milliseconds(1));
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFirePromotedContentAdEvent(
                   ad.placement_id, ad.creative_instance_id,
-                  mojom::PromotedContentAdEventType::kServedImpression));
+                  mojom::PromotedContentAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       ad.placement_id, ad.creative_instance_id,
       mojom::PromotedContentAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_for_non_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_for_non_rewards_unittest.cc
@@ -7,6 +7,8 @@
 #include <string>
 
 #include "base/check.h"
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/account/deposits/deposits_database_table.h"
@@ -33,21 +35,27 @@ namespace {
 void VerifyDepositForCreativeInstanceIdExpectation(
     const std::string& creative_instance_id) {
   base::MockCallback<database::table::GetDepositsCallback> callback;
+  base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   EXPECT_CALL(callback, Run(/*success=*/::testing::_,
-                            /*deposit=*/::testing::Eq(std::nullopt)));
+                            /*deposit=*/::testing::Eq(std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const database::table::Deposits database_table;
   database_table.GetForCreativeInstanceId(creative_instance_id, callback.Get());
+  run_loop.Run();
 }
 
 void VerifyCreativeSetConversionExpectation(size_t expected_count) {
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
+  base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
   EXPECT_CALL(
       callback,
       Run(/*success=*/::testing::_,
-          /*creative_set_conversions=*/::testing::SizeIs(expected_count)));
+          /*creative_set_conversions=*/::testing::SizeIs(expected_count)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   const database::table::CreativeSetConversions database_table;
   database_table.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 }  // namespace
@@ -73,11 +81,14 @@ class BraveAdsSearchResultAdEventHandlerForNonRewardsTest
     CHECK(mojom_creative_ad);
 
     base::MockCallback<FireSearchResultAdEventHandlerCallback> callback;
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
     EXPECT_CALL(callback,
                 Run(/*success=*/should_fire_event,
-                    mojom_creative_ad->placement_id, mojom_ad_event_type));
+                    mojom_creative_ad->placement_id, mojom_ad_event_type))
+        .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
     event_handler_.FireEvent(mojom_creative_ad.Clone(), mojom_ad_event_type,
                              callback.Get());
+    run_loop.Run();
 
     size_t expected_count = 0;
 
@@ -112,12 +123,14 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_,
-              OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kClicked));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnFailedToFireSearchResultAdEvent(
+                                  ad, mojom::SearchResultAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(mojom_creative_ad,
                                  mojom::SearchResultAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -129,12 +142,15 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kServedImpression));
+                  ad, mojom::SearchResultAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       mojom_creative_ad, mojom::SearchResultAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -146,12 +162,15 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kServedImpression));
+                  ad, mojom::SearchResultAdEventType::kServedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       mojom_creative_ad, mojom::SearchResultAdEventType::kServedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -163,12 +182,15 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kViewedImpression));
+                  ad, mojom::SearchResultAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       mojom_creative_ad, mojom::SearchResultAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -180,12 +202,15 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(delegate_mock_,
               OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kViewedImpression));
+                  ad, mojom::SearchResultAdEventType::kViewedImpression))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(
       mojom_creative_ad, mojom::SearchResultAdEventType::kViewedImpression,
       /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -196,12 +221,14 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_,
-              OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kClicked));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnFailedToFireSearchResultAdEvent(
+                                  ad, mojom::SearchResultAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(mojom_creative_ad,
                                  mojom::SearchResultAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -213,10 +240,13 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_, OnDidFireSearchResultAdClickedEvent(ad));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnDidFireSearchResultAdClickedEvent(ad))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(mojom_creative_ad,
                                  mojom::SearchResultAdEventType::kClicked,
                                  /*should_fire_event=*/true);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -229,12 +259,14 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   test::RecordAdEvent(ad, mojom::ConfirmationType::kClicked);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_,
-              OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kClicked));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnFailedToFireSearchResultAdEvent(
+                                  ad, mojom::SearchResultAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(mojom_creative_ad,
                                  mojom::SearchResultAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -247,12 +279,14 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_,
-              OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kClicked));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnFailedToFireSearchResultAdEvent(
+                                  ad, mojom::SearchResultAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(mojom_creative_ad,
                                  mojom::SearchResultAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
@@ -265,12 +299,14 @@ TEST_F(BraveAdsSearchResultAdEventHandlerForNonRewardsTest,
   const SearchResultAdInfo ad = FromMojomBuildSearchResultAd(mojom_creative_ad);
 
   // Act & Assert
-  EXPECT_CALL(delegate_mock_,
-              OnFailedToFireSearchResultAdEvent(
-                  ad, mojom::SearchResultAdEventType::kClicked));
+  base::RunLoop run_loop;
+  EXPECT_CALL(delegate_mock_, OnFailedToFireSearchResultAdEvent(
+                                  ad, mojom::SearchResultAdEventType::kClicked))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   FireEventAndVerifyExpectations(mojom_creative_ad,
                                  mojom::SearchResultAdEventType::kClicked,
                                  /*should_fire_event=*/false);
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_non_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_non_rewards_unittest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_builder.h"
@@ -58,9 +60,13 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
 
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, CreativeSetConversionList{
-                                                  *creative_set_conversion}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  CreativeSetConversionList{*creative_set_conversion}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   creative_set_conversions_database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
@@ -84,8 +90,11 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   creative_set_conversions_database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
@@ -101,8 +110,11 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   creative_set_conversions_database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_rewards_unittest.cc
@@ -3,6 +3,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_builder.h"
@@ -56,9 +58,13 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForRewardsTest,
 
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, CreativeSetConversionList{
-                                                  *creative_set_conversion}));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback,
+              Run(/*success=*/true,
+                  CreativeSetConversionList{*creative_set_conversion}))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   creative_set_conversions_database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForRewardsTest,
@@ -83,8 +89,11 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForRewardsTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   creative_set_conversions_database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForRewardsTest,
@@ -100,8 +109,11 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForRewardsTest,
   // Assert
   base::MockCallback<database::table::GetCreativeSetConversionsCallback>
       callback;
-  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()));
+  base::RunLoop run_loop;
+  EXPECT_CALL(callback, Run(/*success=*/true, ::testing::IsEmpty()))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   creative_set_conversions_database_table_.GetUnexpired(callback.Get());
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForRewardsTest,

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_inline_content_ad_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_inline_content_ad_unittest.cc
@@ -3,6 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "base/run_loop.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_test_util.h"
@@ -35,9 +36,12 @@ TEST_F(BraveAdsConversionsInlineContentAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsInlineContentAdTest,
@@ -73,9 +77,12 @@ TEST_F(BraveAdsConversionsInlineContentAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsInlineContentAdTest,
@@ -91,9 +98,12 @@ TEST_F(BraveAdsConversionsInlineContentAdTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsInlineContentAdTest,
@@ -131,9 +141,12 @@ TEST_F(BraveAdsConversionsInlineContentAdTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_new_tab_page_ad_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_new_tab_page_ad_unittest.cc
@@ -35,9 +35,12 @@ TEST_F(BraveAdsConversionsNewTabPageAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsNewTabPageAdTest,
@@ -92,9 +95,12 @@ TEST_F(BraveAdsConversionsNewTabPageAdTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsNewTabPageAdTest,

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_notification_ad_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_notification_ad_unittest.cc
@@ -35,9 +35,12 @@ TEST_F(BraveAdsConversionsNotificationAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsNotificationAdTest,
@@ -92,9 +95,12 @@ TEST_F(BraveAdsConversionsNotificationAdTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsNotificationAdTest,

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_promoted_content_ad_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_promoted_content_ad_unittest.cc
@@ -37,9 +37,12 @@ TEST_F(BraveAdsConversionsPromotedContentAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsPromotedContentAdTest,
@@ -75,9 +78,12 @@ TEST_F(BraveAdsConversionsPromotedContentAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsPromotedContentAdTest,
@@ -93,9 +99,12 @@ TEST_F(BraveAdsConversionsPromotedContentAdTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsPromotedContentAdTest,
@@ -138,9 +147,12 @@ TEST_F(BraveAdsConversionsPromotedContentAdTest,
                       /*verifiable_conversion=*/std::nullopt);
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_search_result_ad_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_search_result_ad_unittest.cc
@@ -37,9 +37,12 @@ TEST_F(BraveAdsConversionsSearchResultAdTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsSearchResultAdTest,
@@ -74,9 +77,12 @@ TEST_F(BraveAdsConversionsSearchResultAdTest,
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsSearchResultAdTest,
@@ -141,9 +147,12 @@ TEST_F(
   test::RecordAdEvent(ad, mojom::ConfirmationType::kClicked);
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_test_base.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_test_base.cc
@@ -5,6 +5,9 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions_test_base.h"
 
+#include <utility>
+
+#include "base/test/gmock_callback_support.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_test_util.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversion/conversion_info.h"  // IWYU pragma: keep
@@ -33,12 +36,14 @@ void BraveAdsConversionsTestBase::TearDown() {
 
 void BraveAdsConversionsTestBase::VerifyOnDidConvertAdExpectation(
     const AdInfo& ad,
-    ConversionActionType action_type) {
+    ConversionActionType action_type,
+    base::OnceClosure did_convert_ad_closure) {
   EXPECT_CALL(conversions_observer_mock_,
               OnDidConvertAd(/*conversion=*/::testing::FieldsAre(
                   ad.type, ad.creative_instance_id, ad.creative_set_id,
                   ad.campaign_id, ad.advertiser_id, ad.segment, action_type,
-                  /*verifiable*/ std::nullopt)));
+                  /*verifiable*/ std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(std::move(did_convert_ad_closure)));
 }
 
 void BraveAdsConversionsTestBase::VerifyOnDidNotConvertAdExpectation() {
@@ -48,12 +53,14 @@ void BraveAdsConversionsTestBase::VerifyOnDidNotConvertAdExpectation() {
 void BraveAdsConversionsTestBase::VerifyOnDidConvertVerifiableAdExpectation(
     const AdInfo& ad,
     ConversionActionType action_type,
-    const VerifiableConversionInfo& verifiable_conversion) {
+    const VerifiableConversionInfo& verifiable_conversion,
+    base::OnceClosure did_convert_ad_closure) {
   EXPECT_CALL(
       conversions_observer_mock_,
       OnDidConvertAd(/*conversion=*/::testing::FieldsAre(
           ad.type, ad.creative_instance_id, ad.creative_set_id, ad.campaign_id,
-          ad.advertiser_id, ad.segment, action_type, verifiable_conversion)));
+          ad.advertiser_id, ad.segment, action_type, verifiable_conversion)))
+      .WillOnce(base::test::RunOnceClosure(std::move(did_convert_ad_closure)));
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_test_base.h
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_test_base.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/functional/callback.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/actions/conversion_action_types.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions_observer_mock.h"
@@ -35,15 +36,18 @@ class BraveAdsConversionsTestBase : public TestBase {
   void TearDown() override;
 
  protected:
-  void VerifyOnDidConvertAdExpectation(const AdInfo& ad,
-                                       ConversionActionType action_type);
+  void VerifyOnDidConvertAdExpectation(
+      const AdInfo& ad,
+      ConversionActionType action_type,
+      base::OnceClosure did_convert_ad_closure);
 
   void VerifyOnDidNotConvertAdExpectation();
 
   void VerifyOnDidConvertVerifiableAdExpectation(
       const AdInfo& ad,
       ConversionActionType action_type,
-      const VerifiableConversionInfo& verifiable_conversion);
+      const VerifiableConversionInfo& verifiable_conversion,
+      base::OnceClosure did_convert_ad_closure);
 
   std::unique_ptr<Conversions> conversions_;
 

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_unittest.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions.h"
 
+#include "base/run_loop.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
@@ -54,10 +55,16 @@ TEST_F(BraveAdsConversionsTest,
                               mojom::ConfirmationType::kClicked});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad_1, ConversionActionType::kViewThrough);
-  VerifyOnDidConvertAdExpectation(ad_2, ConversionActionType::kClickThrough);
+  base::RunLoop view_through_run_loop;
+  VerifyOnDidConvertAdExpectation(ad_1, ConversionActionType::kViewThrough,
+                                  view_through_run_loop.QuitClosure());
+  base::RunLoop click_through_run_loop;
+  VerifyOnDidConvertAdExpectation(ad_2, ConversionActionType::kClickThrough,
+                                  click_through_run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  view_through_run_loop.Run();
+  click_through_run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, DoNotCapConversionsWithinTheSameCreativeSet) {
@@ -74,14 +81,20 @@ TEST_F(BraveAdsConversionsTest, DoNotCapConversionsWithinTheSameCreativeSet) {
   test::RecordAdEvents(ad, {mojom::ConfirmationType::kServedImpression,
                             mojom::ConfirmationType::kViewedImpression});
 
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop view_through_run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  view_through_run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  view_through_run_loop.Run();
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop click_through_run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  click_through_run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  click_through_run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, CapConversionsWithinTheSameCreativeSet) {
@@ -98,13 +111,19 @@ TEST_F(BraveAdsConversionsTest, CapConversionsWithinTheSameCreativeSet) {
   test::RecordAdEvents(ad, {mojom::ConfirmationType::kServedImpression,
                             mojom::ConfirmationType::kViewedImpression});
 
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop view_through_run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  view_through_run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  view_through_run_loop.Run();
 
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop click_through_run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  click_through_run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  click_through_run_loop.Run();
 
   // Act & Assert
   VerifyOnDidNotConvertAdExpectation();
@@ -124,9 +143,12 @@ TEST_F(BraveAdsConversionsTest, ConvertViewedAdAfterTheSameAdWasDismissed) {
                             mojom::ConfirmationType::kDismissed});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, DoNotConvertNonViewedOrClickedAds) {
@@ -196,9 +218,12 @@ TEST_F(BraveAdsConversionsTest,
                               mojom::ConfirmationType::kViewedImpression,
                               mojom::ConfirmationType::kDismissed});
 
-  VerifyOnDidConvertAdExpectation(ad_1, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad_1, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 
   AdInfo ad_2 = ad_1;
   ad_2.creative_instance_id = test::kAnotherCreativeInstanceId;
@@ -242,9 +267,12 @@ TEST_F(BraveAdsConversionsTest,
   AdvanceClockBy(base::Days(3) - base::Milliseconds(1));
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest,
@@ -281,9 +309,12 @@ TEST_F(BraveAdsConversionsTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildVerifiableConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(
@@ -303,9 +334,12 @@ TEST_F(
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest,
@@ -324,9 +358,12 @@ TEST_F(BraveAdsConversionsTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(
       /*redirect_chain=*/{GURL("https://foo.com/bar?qux=quux")}, /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, ConvertAdIfVerifiableUrlConversionIdExists) {
@@ -344,13 +381,15 @@ TEST_F(BraveAdsConversionsTest, ConvertAdIfVerifiableUrlConversionIdExists) {
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
+  base::RunLoop run_loop;
   VerifyOnDidConvertVerifiableAdExpectation(
       ad, ConversionActionType::kViewThrough,
       VerifiableConversionInfo{
-          /*id=*/"xyzzy",
-          test::kVerifiableConversionAdvertiserPublicKeyBase64});
+          /*id=*/"xyzzy", test::kVerifiableConversionAdvertiserPublicKeyBase64},
+      run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildVerifiableConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest,
@@ -369,9 +408,12 @@ TEST_F(BraveAdsConversionsTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, ConvertAdIfVerifiableHtmlConversionIdExists) {
@@ -389,14 +431,16 @@ TEST_F(BraveAdsConversionsTest, ConvertAdIfVerifiableHtmlConversionIdExists) {
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
+  base::RunLoop run_loop;
   VerifyOnDidConvertVerifiableAdExpectation(
       ad, ConversionActionType::kViewThrough,
       VerifiableConversionInfo{
-          /*id=*/"waldo",
-          test::kVerifiableConversionAdvertiserPublicKeyBase64});
+          /*id=*/"waldo", test::kVerifiableConversionAdvertiserPublicKeyBase64},
+      run_loop.QuitClosure());
   conversions_->MaybeConvert(
       test::BuildDefaultConversionRedirectChain(),
       /*html=*/R"(<html><div id="xyzzy-id">waldo</div></html>)");
+  run_loop.Run();
 }
 
 TEST_F(
@@ -416,9 +460,12 @@ TEST_F(
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kViewThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(
       /*redirect_chain=*/{GURL("https://qux.com/quux/corge")}, /*html=*/"");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest,
@@ -437,13 +484,16 @@ TEST_F(BraveAdsConversionsTest,
                             mojom::ConfirmationType::kViewedImpression});
 
   // Act & Assert
+  base::RunLoop run_loop;
   VerifyOnDidConvertVerifiableAdExpectation(
       ad, ConversionActionType::kViewThrough,
       VerifiableConversionInfo{
-          /*id=*/"fred", test::kVerifiableConversionAdvertiserPublicKeyBase64});
+          /*id=*/"fred", test::kVerifiableConversionAdvertiserPublicKeyBase64},
+      run_loop.QuitClosure());
   conversions_->MaybeConvert(
       /*redirect_chain=*/{GURL("https://qux.com/quux/corge")},
       /*html=*/R"(<html><meta name="ad-conversion-id" content="fred"></html>)");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, VerifiableConversion) {
@@ -462,13 +512,16 @@ TEST_F(BraveAdsConversionsTest, VerifiableConversion) {
                             mojom::ConfirmationType::kClicked});
 
   // Act & Assert
+  base::RunLoop run_loop;
   VerifyOnDidConvertVerifiableAdExpectation(
       ad, ConversionActionType::kClickThrough,
       VerifiableConversionInfo{
-          /*id=*/"fred", test::kVerifiableConversionAdvertiserPublicKeyBase64});
+          /*id=*/"fred", test::kVerifiableConversionAdvertiserPublicKeyBase64},
+      run_loop.QuitClosure());
   conversions_->MaybeConvert(
       test::BuildDefaultConversionRedirectChain(),
       /*html=*/R"(<html><meta name="ad-conversion-id" content="fred"></html>)");
+  run_loop.Run();
 }
 
 TEST_F(BraveAdsConversionsTest, FallbackToDefaultConversionForNonRewardsUser) {
@@ -492,10 +545,13 @@ TEST_F(BraveAdsConversionsTest, FallbackToDefaultConversionForNonRewardsUser) {
   test::RecordAdEvent(ad, mojom::ConfirmationType::kClicked);
 
   // Act & Assert
-  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough);
+  base::RunLoop run_loop;
+  VerifyOnDidConvertAdExpectation(ad, ConversionActionType::kClickThrough,
+                                  run_loop.QuitClosure());
   conversions_->MaybeConvert(
       test::BuildDefaultConversionRedirectChain(),
       /*html=*/R"(<html><meta name="ad-conversion-id" content="fred"></html>)");
+  run_loop.Run();
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/reactions/reactions_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/reactions/reactions_unittest.cc
@@ -8,6 +8,8 @@
 #include <optional>
 #include <utility>
 
+#include "base/run_loop.h"
+#include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/components/brave_ads/core/internal/account/account.h"
 #include "brave/components/brave_ads/core/internal/account/account_observer_mock.h"
@@ -49,18 +51,21 @@ TEST_F(BraveAdsReactionsTest, ToggleLikeAd) {
       test::BuildReaction(mojom::AdType::kNotificationAd);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(
       account_observer_mock_,
       OnDidProcessDeposit(/*transaction=*/::testing::FieldsAre(
           /*id*/ ::testing::_, /*created_at*/ test::Now(),
           test::kCreativeInstanceId, test::kSegment, /*value*/ 0.0,
           mojom::AdType::kNotificationAd, mojom::ConfirmationType::kLikedAd,
-          /*reconciled_at*/ std::nullopt)));
+          /*reconciled_at*/ std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   EXPECT_CALL(account_observer_mock_, OnFailedToProcessDeposit).Times(0);
 
   base::MockCallback<ToggleReactionCallback> callback;
   EXPECT_CALL(callback, Run(/*success=*/true));
   GetReactions().ToggleLikeAd(std::move(mojom_reaction), callback.Get());
+  run_loop.Run();
   EXPECT_EQ(mojom::ReactionType::kLiked,
             GetReactions().AdReactionTypeForId(test::kAdvertiserId));
 }
@@ -73,18 +78,21 @@ TEST_F(BraveAdsReactionsTest, ToggleDislikeAd) {
       test::BuildReaction(mojom::AdType::kNotificationAd);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(
       account_observer_mock_,
       OnDidProcessDeposit(/*transaction=*/::testing::FieldsAre(
           /*id*/ ::testing::_, /*created_at*/ test::Now(),
           test::kCreativeInstanceId, test::kSegment, /*value*/ 0.0,
           mojom::AdType::kNotificationAd, mojom::ConfirmationType::kDislikedAd,
-          /*reconciled_at*/ std::nullopt)));
+          /*reconciled_at*/ std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   EXPECT_CALL(account_observer_mock_, OnFailedToProcessDeposit).Times(0);
 
   base::MockCallback<ToggleReactionCallback> callback;
   EXPECT_CALL(callback, Run(/*success=*/true));
   GetReactions().ToggleDislikeAd(std::move(mojom_reaction), callback.Get());
+  run_loop.Run();
   EXPECT_EQ(mojom::ReactionType::kDisliked,
             GetReactions().AdReactionTypeForId(test::kAdvertiserId));
 }
@@ -232,18 +240,21 @@ TEST_F(BraveAdsReactionsTest, ToggleSaveAd) {
       test::BuildReaction(mojom::AdType::kNotificationAd);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(
       account_observer_mock_,
       OnDidProcessDeposit(/*transaction=*/::testing::FieldsAre(
           /*id*/ ::testing::_, /*created_at*/ test::Now(),
           test::kCreativeInstanceId, test::kSegment, /*value*/ 0.0,
           mojom::AdType::kNotificationAd, mojom::ConfirmationType::kSavedAd,
-          /*reconciled_at*/ std::nullopt)));
+          /*reconciled_at*/ std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   EXPECT_CALL(account_observer_mock_, OnFailedToProcessDeposit).Times(0);
 
   base::MockCallback<ToggleReactionCallback> callback;
   EXPECT_CALL(callback, Run(/*success=*/true));
   GetReactions().ToggleSaveAd(std::move(mojom_reaction), callback.Get());
+  run_loop.Run();
   EXPECT_TRUE(GetReactions().IsAdSaved(test::kCreativeInstanceId));
 }
 
@@ -260,19 +271,22 @@ TEST_F(BraveAdsReactionsTest, ToggleMarkAdAsInappropriate) {
       test::BuildReaction(mojom::AdType::kNotificationAd);
 
   // Act & Assert
+  base::RunLoop run_loop;
   EXPECT_CALL(account_observer_mock_,
               OnDidProcessDeposit(/*transaction=*/::testing::FieldsAre(
                   /*id*/ ::testing::_, /*created_at*/ test::Now(),
                   test::kCreativeInstanceId, test::kSegment, /*value*/ 0.0,
                   mojom::AdType::kNotificationAd,
                   mojom::ConfirmationType::kMarkAdAsInappropriate,
-                  /*reconciled_at*/ std::nullopt)));
+                  /*reconciled_at*/ std::nullopt)))
+      .WillOnce(base::test::RunOnceClosure(run_loop.QuitClosure()));
   EXPECT_CALL(account_observer_mock_, OnFailedToProcessDeposit).Times(0);
 
   base::MockCallback<ToggleReactionCallback> callback;
   EXPECT_CALL(callback, Run(/*success=*/true));
   GetReactions().ToggleMarkAdAsInappropriate(std::move(mojom_reaction),
                                              callback.Get());
+  run_loop.Run();
   EXPECT_TRUE(GetReactions().IsAdMarkedAsInappropriate(test::kCreativeSetId));
 }
 

--- a/components/brave_ads/core/public/BUILD.gn
+++ b/components/brave_ads/core/public/BUILD.gn
@@ -31,7 +31,6 @@ source_set("headers") {
     "ads_feature.h",
     "ads_observer_interface.h",
     "ads_util.h",
-    "database/database.h",
     "export.h",
     "flags/flags_util.h",
     "history/ad_history_feature.h",
@@ -53,7 +52,6 @@ source_set("headers") {
 
   deps = [
     "//base",
-    "//sql",
     "//url",
   ]
 

--- a/components/brave_ads/core/public/ads.h
+++ b/components/brave_ads/core/public/ads.h
@@ -33,7 +33,9 @@ class ADS_EXPORT Ads {
 
   virtual ~Ads() = default;
 
-  static std::unique_ptr<Ads> CreateInstance(AdsClient& ads_client);
+  static std::unique_ptr<Ads> CreateInstance(
+      AdsClient& ads_client,
+      const base::FilePath& database_path);
 
   virtual void AddObserver(
       std::unique_ptr<AdsObserverInterface> ads_observer) = 0;

--- a/components/brave_ads/core/public/ads_client/ads_client.h
+++ b/components/brave_ads/core/public/ads_client/ads_client.h
@@ -97,12 +97,6 @@ class ADS_EXPORT AdsClient {
   virtual void ShowScheduledCaptcha(const std::string& payment_id,
                                     const std::string& captcha_id) = 0;
 
-  // Run a database transaction. The callback takes one argument -
-  // `mojom::DBTransactionResultInfoPtr` containing the info of the transaction.
-  virtual void RunDBTransaction(
-      mojom::DBTransactionInfoPtr mojom_db_transaction,
-      RunDBTransactionCallback callback) = 0;
-
   // Record P2A (Private Advertising Analytics) `events`.
   virtual void RecordP2AEvents(const std::vector<std::string>& events) = 0;
 

--- a/components/brave_ads/core/test/BUILD.gn
+++ b/components/brave_ads/core/test/BUILD.gn
@@ -196,6 +196,8 @@ source_set("brave_ads_unit_tests") {
     "//brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_observer_mock.cc",
     "//brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_observer_mock.h",
     "//brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_unittest.cc",
+    "//brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.cc",
+    "//brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_waiter.h",
     "//brave/components/brave_ads/core/internal/ads_feature_unittest.cc",
     "//brave/components/brave_ads/core/internal/ads_observer_mock.cc",
     "//brave/components/brave_ads/core/internal/ads_observer_mock.h",

--- a/components/services/bat_ads/bat_ads_client_mojo_bridge.cc
+++ b/components/services/bat_ads/bat_ads_client_mojo_bridge.cc
@@ -210,18 +210,6 @@ std::string BatAdsClientMojoBridge::LoadDataResource(const std::string& name) {
   return value;
 }
 
-void BatAdsClientMojoBridge::RunDBTransaction(
-    brave_ads::mojom::DBTransactionInfoPtr mojom_db_transaction,
-    brave_ads::RunDBTransactionCallback callback) {
-  if (!bat_ads_client_associated_remote_.is_bound()) {
-    std::move(callback).Run(brave_ads::mojom::DBTransactionResultInfoPtr());
-    return;
-  }
-
-  bat_ads_client_associated_remote_->RunDBTransaction(
-      std::move(mojom_db_transaction), std::move(callback));
-}
-
 void BatAdsClientMojoBridge::ShowScheduledCaptcha(
     const std::string& payment_id,
     const std::string& captcha_id) {

--- a/components/services/bat_ads/bat_ads_client_mojo_bridge.h
+++ b/components/services/bat_ads/bat_ads_client_mojo_bridge.h
@@ -79,10 +79,6 @@ class BatAdsClientMojoBridge : public brave_ads::AdsClient {
   void ShowScheduledCaptcha(const std::string& payment_id,
                             const std::string& captcha_id) override;
 
-  void RunDBTransaction(
-      brave_ads::mojom::DBTransactionInfoPtr mojom_db_transaction,
-      brave_ads::RunDBTransactionCallback callback) override;
-
   void RecordP2AEvents(const std::vector<std::string>& events) override;
 
   bool FindProfilePref(const std::string& path) const override;

--- a/components/services/bat_ads/bat_ads_impl.h
+++ b/components/services/bat_ads/bat_ads_impl.h
@@ -25,7 +25,8 @@ class BatAdsClientMojoBridge;
 
 class BatAdsImpl : public mojom::BatAds {
  public:
-  BatAdsImpl(mojo::PendingAssociatedRemote<mojom::BatAdsClient>
+  BatAdsImpl(const base::FilePath& service_path,
+             mojo::PendingAssociatedRemote<mojom::BatAdsClient>
                  bat_ads_client_pending_associated_remote,
              mojo::PendingReceiver<mojom::BatAdsClientNotifier>
                  bat_ads_client_notifier_pending_receiver);

--- a/components/services/bat_ads/bat_ads_service_impl.cc
+++ b/components/services/bat_ads/bat_ads_service_impl.cc
@@ -8,6 +8,7 @@
 #include <memory>
 #include <utility>
 
+#include "base/files/file_path.h"
 #include "brave/components/services/bat_ads/bat_ads_impl.h"
 #include "brave/components/services/bat_ads/public/interfaces/bat_ads.mojom.h"
 #include "mojo/public/cpp/bindings/sync_call_restrictions.h"
@@ -33,6 +34,7 @@ BatAdsServiceImpl::BatAdsServiceImpl(mojo::PendingReceiver<mojom::BatAdsService>
 BatAdsServiceImpl::~BatAdsServiceImpl() = default;
 
 void BatAdsServiceImpl::Create(
+    const base::FilePath& service_path,
     mojo::PendingAssociatedRemote<mojom::BatAdsClient>
         bat_ads_client_pending_associated_remote,
     mojo::PendingAssociatedReceiver<mojom::BatAds>
@@ -44,7 +46,7 @@ void BatAdsServiceImpl::Create(
 
   bat_ads_associated_receivers_.Add(
       std::make_unique<BatAdsImpl>(
-          std::move(bat_ads_client_pending_associated_remote),
+          service_path, std::move(bat_ads_client_pending_associated_remote),
           std::move(bat_ads_client_notifier_pending_receiver)),
       std::move(bat_ads_pending_associated_receiver));
 

--- a/components/services/bat_ads/bat_ads_service_impl.h
+++ b/components/services/bat_ads/bat_ads_service_impl.h
@@ -35,7 +35,8 @@ class BatAdsServiceImpl : public mojom::BatAdsService {
   ~BatAdsServiceImpl() override;
 
   // BatAdsService:
-  void Create(mojo::PendingAssociatedRemote<mojom::BatAdsClient>
+  void Create(const base::FilePath& service_path,
+              mojo::PendingAssociatedRemote<mojom::BatAdsClient>
                   bat_ads_client_pending_associated_remote,
               mojo::PendingAssociatedReceiver<mojom::BatAds>
                   bat_ads_pending_associated_receiver,

--- a/components/services/bat_ads/public/interfaces/bat_ads.mojom
+++ b/components/services/bat_ads/public/interfaces/bat_ads.mojom
@@ -7,12 +7,14 @@ module bat_ads.mojom;
 import "brave/components/brave_ads/core/mojom/brave_ads.mojom";
 import "mojo/public/mojom/base/big_string.mojom";
 import "mojo/public/mojom/base/file.mojom";
+import "mojo/public/mojom/base/file_path.mojom";
 import "mojo/public/mojom/base/time.mojom";
 import "mojo/public/mojom/base/values.mojom";
 import "url/mojom/url.mojom";
 
 interface BatAdsService {
-  Create(pending_associated_remote<BatAdsClient>
+  Create(mojo_base.mojom.FilePath service_path,
+         pending_associated_remote<BatAdsClient>
              bat_ads_client_pending_associated_remote,
          pending_associated_receiver<BatAds>
              bat_ads_pending_associated_receiver,
@@ -99,9 +101,6 @@ interface BatAdsClient {
   LoadDataResource(string name) => (mojo_base.mojom.BigString value);
 
   ShowScheduledCaptcha(string payment_id, string captcha_id);
-
-  RunDBTransaction(brave_ads.mojom.DBTransactionInfo mojom_db_transaction) =>
-      (brave_ads.mojom.DBTransactionResultInfo mojom_db_transaction_result);
 
   RecordP2AEvents(array<string> events);
 

--- a/ios/browser/api/ads/ads_client_bridge.h
+++ b/ios/browser/api/ads/ads_client_bridge.h
@@ -49,9 +49,6 @@
 - (void)closeNotificationAd:(const std::string&)placement_id;
 - (void)UrlRequest:(brave_ads::mojom::UrlRequestInfoPtr)url_request
           callback:(brave_ads::UrlRequestCallback)callback;
-- (void)runDBTransaction:
-            (brave_ads::mojom::DBTransactionInfoPtr)mojom_db_transaction
-                callback:(brave_ads::RunDBTransactionCallback)callback;
 - (void)setProfilePref:(const std::string&)path value:(base::Value)value;
 - (bool)findProfilePref:(const std::string&)path;
 - (std::optional<base::Value>)getProfilePref:(const std::string&)path;

--- a/ios/browser/api/ads/ads_client_ios.h
+++ b/ios/browser/api/ads/ads_client_ios.h
@@ -54,9 +54,6 @@ class AdsClientIOS : public brave_ads::AdsClient {
            int line,
            int verbose_level,
            const std::string& message) override;
-  void RunDBTransaction(
-      brave_ads::mojom::DBTransactionInfoPtr mojom_db_transaction,
-      brave_ads::RunDBTransactionCallback callback) override;
   void SetProfilePref(const std::string& path, base::Value value) override;
   bool FindProfilePref(const std::string& path) const override;
   std::optional<base::Value> GetProfilePref(const std::string& path) override;

--- a/ios/browser/api/ads/ads_client_ios.mm
+++ b/ios/browser/api/ads/ads_client_ios.mm
@@ -113,13 +113,6 @@ void AdsClientIOS::Log(const char* file,
   [bridge_ log:file line:line verboseLevel:verbose_level message:message];
 }
 
-void AdsClientIOS::RunDBTransaction(
-    brave_ads::mojom::DBTransactionInfoPtr mojom_db_transaction,
-    brave_ads::RunDBTransactionCallback callback) {
-  [bridge_ runDBTransaction:std::move(mojom_db_transaction)
-                   callback:std::move(callback)];
-}
-
 void AdsClientIOS::SetProfilePref(const std::string& path, base::Value value) {
   [bridge_ setProfilePref:path value:std::move(value)];
 }

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -1370,25 +1370,6 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
                               captchaId:base::SysUTF8ToNSString(captcha_id)];
 }
 
-- (void)runDBTransaction:
-            (brave_ads::mojom::DBTransactionInfoPtr)mojom_db_transaction
-                callback:(brave_ads::RunDBTransactionCallback)completion {
-  if (![self isServiceRunning]) {
-    return std::move(completion)
-        .Run(brave_ads::mojom::DBTransactionResultInfo::New());
-  }
-
-  adsService->RunDBTransaction(
-      std::move(mojom_db_transaction),
-      base::BindOnce(
-          ^(brave_ads::RunDBTransactionCallback callback,
-            brave_ads::mojom::DBTransactionResultInfoPtr
-                mojom_db_transaction_result) {
-            std::move(callback).Run(std::move(mojom_db_transaction_result));
-          },
-          std::move(completion)));
-}
-
 - (void)recordP2AEvents:(const std::vector<std::string>&)events {
   // TODO(https://github.com/brave/brave-browser/issues/33786): Unify Brave Ads
   // P3A analytics.

--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -11,7 +11,6 @@
 #include <vector>
 
 #include "base/memory/weak_ptr.h"
-#include "base/threading/sequence_bound.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom-forward.h"
 #include "brave/components/brave_ads/core/public/ads_callback.h"
@@ -28,7 +27,6 @@ namespace brave_ads {
 
 class Ads;
 class AdsClient;
-class Database;
 
 class AdsServiceImplIOS : public AdsService {
  public:
@@ -163,7 +161,6 @@ class AdsServiceImplIOS : public AdsService {
 
   void InitializeAds(InitializeCallback callback);
   void InitializeAdsCallback(InitializeCallback callback, bool success);
-  void InitializeDatabase();
 
   void ShutdownAdsCallback(ShutdownCallback callback, bool success);
 
@@ -172,15 +169,13 @@ class AdsServiceImplIOS : public AdsService {
 
   const raw_ptr<PrefService> prefs_ = nullptr;  // Not owned.
 
-  const scoped_refptr<base::SequencedTaskRunner> database_queue_;
+  const scoped_refptr<base::SequencedTaskRunner> file_task_runner_;
 
   base::FilePath storage_path_;
   std::unique_ptr<AdsClient> ads_client_;
   mojom::SysInfoPtr mojom_sys_info_;
   mojom::BuildChannelInfoPtr mojom_build_channel_;
   mojom::WalletInfoPtr mojom_wallet_;
-
-  base::SequenceBound<Database> database_;
 
   std::unique_ptr<Ads> ads_;
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42598
Resolves https://github.com/brave/brave-browser/issues/41632

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Make sure that Brave Ads core functionality works as expected:
- Join Brave Rewards
- Make sure that search Ads, NTT, Brave News, Notification ads can be served, viewed and clicked
- Make sure that served, viewed and clicked confirmations are sent to the server
