### PR TITLE
Add 3-second timer for HTTPS upgrades before falling back to HTTP on iOS 

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -954,6 +954,8 @@ extension BrowserViewController: WKNavigationDelegate {
 
     // Reset the stored http request now that load has committed.
     tab.upgradedHTTPSRequest = nil
+    tab.upgradeHTTPSTimeoutTimer?.invalidate()
+    tab.upgradeHTTPSTimeoutTimer = nil
 
     // Set the committed url which will also set tab.url
     tab.committedURL = webView.url
@@ -1863,8 +1865,23 @@ extension BrowserViewController: WKUIDelegate {
           "Upgrading `\(requestURL.absoluteString)` to HTTPS"
         )
         tab.upgradedHTTPSRequest = navigationAction.request
+        tab.upgradeHTTPSTimeoutTimer?.invalidate()
         var request = navigationAction.request
         request.url = upgradedURL
+
+        tab.upgradeHTTPSTimeoutTimer = Timer.scheduledTimer(
+          withTimeInterval: 3.seconds,
+          repeats: false,
+          block: { [weak tab, weak self] timer in
+            guard let self, let tab else { return }
+            if let url = request.url,
+              let request = handleInvalidHTTPSUpgrade(tab: tab, responseURL: url)
+            {
+              tab.webView?.stopLoading()
+              tab.webView?.load(request)
+            }
+          }
+        )
         return request
       }
     }
@@ -1923,6 +1940,8 @@ extension BrowserViewController: WKUIDelegate {
       )
 
       tab.upgradedHTTPSRequest = nil
+      tab.upgradeHTTPSTimeoutTimer?.invalidate()
+      tab.upgradeHTTPSTimeoutTimer = nil
       if let httpsUpgradeService = HttpsUpgradeServiceFactory.get(privateMode: tab.isPrivate),
         let host = originalURL.host
       {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -1113,6 +1113,11 @@ extension BrowserViewController: WKNavigationDelegate {
     }
 
     if error.code == Int(CFNetworkErrors.cfurlErrorCancelled.rawValue) {
+      // load cancelled / user stopped load. Cancel https upgrade fallback timer.
+      tab.upgradedHTTPSRequest = nil
+      tab.upgradeHTTPSTimeoutTimer?.invalidate()
+      tab.upgradeHTTPSTimeoutTimer = nil
+
       if tab === tabManager.selectedTab {
         updateToolbarCurrentURL(tab.url?.displayURL)
         updateWebViewPageZoom(tab: tab)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/HTTPBlockedHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/HTTPBlockedHandler.swift
@@ -40,7 +40,7 @@ public class HTTPBlockedHandler: InternalSchemeResponse {
         of: "%blocked_title%",
         with: String.localizedStringWithFormat(
           Strings.Shields.theConnectionIsNotSecure,
-          "<tt>\(originalURL.domainURL.absoluteDisplayString)</tt>"
+          "<tt>\(originalURL.host ?? originalURL.domainURL.absoluteDisplayString)</tt>"
         )
       )
       .replacingOccurrences(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -328,6 +328,11 @@ class Tab: NSObject {
   /// This allows us to rollback the upgrade when we encounter a 4xx+
   var upgradedHTTPSRequest: URLRequest?
 
+  /// This is a timer that's started on HTTPS upgrade
+  /// If the upgrade hasn't completed within 3s, it is cancelled
+  /// and we fallback to HTTP or cancel the request (strict vs. standard)
+  var upgradeHTTPSTimeoutTimer: Timer?
+
   /// The tabs new tab page controller.
   ///
   /// Should be setup in BVC then assigned here for future use.


### PR DESCRIPTION
- Add 3-second timer to HTTPS upgrades before falling back to the original http request (aligns with Chromium).
- Update HTTP Blocked / strict mode interstitial to display `host` to align with what is added to allowlist when user taps 'Proceed'.
    - This fixes displaying `alwayshttp.com` in interstitial when trying to load `www.alwayshttp.com`

Resolves https://github.com/brave/brave-browser/issues/42684

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. In Settings -> 'Privacy & Security' set 'Upgrade Connections to HTTPS' to `Standard`
2. Visit `alwayshttp.com`
3. Verify `http://www.alwayshttp.com loads after ~6 seconds.
4. In Settings -> 'Privacy & Security' set 'Upgrade Connections to HTTPS' to `Strict`
5. Visit `alwayshttp.com`
6. After ~3 seconds you should see interstitial for `alwayshttp.com`.
7. Tap proceed on interstitial
8. After ~3 seconds you should see interstitial for `www.alwayshttp.com`.
9. Verify `http://www.alwayshttp.com` loads after ~6 seconds