### PR TITLE
Fixed issue of unable to switch on the passwords sync on Android

### DIFF
--- a/chromium_src/components/sync/service/sync_prefs.cc
+++ b/chromium_src/components/sync/service/sync_prefs.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/sync/service/sync_prefs.h"
+
+#define SetPasswordSyncAllowed SetPasswordSyncAllowed_ChromiumImpl
+
+#include "src/components/sync/service/sync_prefs.cc"
+
+#undef SetPasswordSyncAllowed
+
+namespace syncer {
+
+void SyncPrefs::SetPasswordSyncAllowed(bool allowed) {}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/service/sync_prefs.h
+++ b/chromium_src/components/sync/service/sync_prefs.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_PREFS_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_PREFS_H_
+
+void SetPasswordSyncAllowed(bool allowed);
+
+#define SetPasswordSyncAllowed                       \
+  SetPasswordSyncAllowed_ChromiumImpl(bool allowed); \
+  void SetPasswordSyncAllowed
+
+#include "src/components/sync/service/sync_prefs.h"  // IWYU pragma: export
+
+#undef SetPasswordSyncAllowed
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_PREFS_H_

--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -157,5 +157,6 @@ source_set("unit_tests") {
     "//components/os_crypt/sync:test_support",
     "//components/prefs:test_support",
     "//components/sync/base",
+    "//components/sync/service",
   ]
 }


### PR DESCRIPTION
At this PR overridden  SyncPrefs::SetPasswordSyncAllowed to keep `password_sync_allowed_ always` true; this fixed issue of unable to switch on the passwords sync on Android.

For the migration of passwords into Google Account upstream disables syncing of passwords. This is managed by 
`kPasswordsUseUPMLocalAndSeparateStores` pref [with values](https://source.chromium.org/chromium/chromium/src/+/main:components/password_manager/core/common/password_manager_pref_names.h;l=155-160;drc=5103ac6102b144aff2bb3b45fe525521ecf3320d?q=UseUpmLocalAndSeparateStoresState&ss=chromium%2Fchromium%2Fsrc)
```
enum class UseUpmLocalAndSeparateStoresState {
  kOff = 0,
  kOffAndMigrationPending = 1,
  kOn = 2,
  kMaxValue = kOn
};
```


During the start of the sync service `kPasswordsUseUPMLocalAndSeparateStores` is checked  at 
[ChromeSyncClient::IsPasswordSyncAllowed()](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/sync/chrome_sync_client.cc;l=160;drc=5103ac6102b144aff2bb3b45fe525521ecf3320d?q=ChromeSyncClient::IsPasswordSyncAllowed()&ss=chromium%2Fchromium%2Fsrc)
If the value is `kOffAndMigrationPending` then password sync is not allowed.

At Android UI after switching passwords sync on the refresh happens and `SyncPrefs::GetSelectedTypesForSyncingUser` is invoked, which excludes passwords from the selected types [link](https://source.chromium.org/chromium/chromium/src/+/main:components/sync/service/sync_prefs.cc;l=349-351;drc=5103ac6102b144aff2bb3b45fe525521ecf3320d?q=SyncPrefs::GetSelectedTypesForSyncingUser&ss=chromium%2Fchromium%2Fsrc)
```
  if (!password_sync_allowed_) {
    selected_types.Remove(UserSelectableType::kPasswords);
  }
```
and the switch control was turned back into off state.


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/36190

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
#### I. Test plan on Release channel

1. Install https://github.com/brave/brave-browser/releases/tag/v1.65.133, `Release v1.65.133 (Chromium 124.0.6367.208)`, `Bravearm64Universal.apk`
2. Save any password (I logged in into GMail), ensure it presents at Brave Password Manager
3. Enable Sync, switch Sync Passwords on
4. Update to the latest version through Google Play, I received 1.73.91
5. Go to Settings => Sync => Data types 
6. Try to switch passwords on - actual - cannot switch passwords on 
7. Install on a top a version with a fix - enable passwords should work

#### II. Test plan on Release channel

1. Install https://github.com/brave/brave-browser/releases/tag/v1.67.52, `Nightly v1.67.52 (Chromium 124.0.6367.91)`, `Bravearm64Universal.apk`
2. Save any password (I logged in into GMail), ensure it presents at Brave Password Manager
3. Enable Sync, switch Sync Passwords on
4. Update to the latest version through Google Play, I received 1.73.91
5. Go to Settings => Sync => Data types 
6. Try to switch passwords on - actual - cannot switch passwords on 
7. Install on a top a version with a fix - enable passwords should work
