### PR TITLE
Fixed empty space is added in guest window's app menu

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -173,6 +173,21 @@ void BraveAppMenuModel::BuildBraveProductsSection() {
 
 #if defined(TOOLKIT_VIEWS)
   if (sidebar::CanUseSidebar(browser())) {
+    auto index = GetNextIndexOfBraveProductsSection();
+    // Remove above separator as sidebar will add its top & bottom
+    // separator.
+    // If |need_separator| is false, there is no item after window section
+    // entry and separator. In this case, need to remove that separator because
+    // we will add different type of separators around sidebar menu entry.
+    if (!need_separator) {
+      RemoveItemAt(index - 1);
+      index--;
+    }
+
+    // Don't need finish this section with more separator as
+    // we'll add another separators around sidebar menu entry below.
+    need_separator = false;
+
     sidebar_show_option_model_ = std::make_unique<ui::ButtonMenuItemModel>(
         IDS_APP_MENU_SIDEBAR_TITLE, this);
 
@@ -182,16 +197,16 @@ void BraveAppMenuModel::BuildBraveProductsSection() {
         IDC_SIDEBAR_SHOW_OPTION_MOUSEOVER, IDS_APP_MENU_SIDEBAR_HOVER);
     sidebar_show_option_model_->AddGroupItemWithStringId(
         IDC_SIDEBAR_SHOW_OPTION_NEVER, IDS_APP_MENU_SIDEBAR_OFF);
-    const auto index = GetNextIndexOfBraveProductsSection();
+
+    // Add additional spacing because LOWER|UPPER separator has more narrow
+    // spacing then normal separator.
+    InsertSeparatorAt(index++, ui::SPACING_SEPARATOR);
+    InsertSeparatorAt(index++, ui::LOWER_SEPARATOR);
     AddButtonItemAt(IDC_SIDEBAR_SHOW_OPTION_MENU,
                     sidebar_show_option_model_.get(),
-                    static_cast<size_t>(index));
-    // Insert separator to the top and bottom
-    InsertSeparatorAt(index, ui::LOWER_SEPARATOR);
-    InsertSeparatorAt(index + 2, ui::UPPER_SEPARATOR);
-
-    // Already added separator.
-    need_separator = false;
+                    static_cast<size_t>(index++));
+    InsertSeparatorAt(index++, ui::UPPER_SEPARATOR);
+    InsertSeparatorAt(index, ui::SPACING_SEPARATOR);
   }
 #endif
   if (need_separator) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/42693

When sidebar menu is handled, it should check previous menu state.
If prev entry is separator, it should be removed before sidebar menu because
sidebar menu will add it's own top & bottom separators.

Guest window app menu before & after

<img width="362" alt="Screenshot 2024-12-05 at 8 50 14 PM" src="https://github.com/user-attachments/assets/3c2a935e-cfb1-411a-b7b3-2d31c3e14ff2">
<img width="359" alt="Screenshot 2024-12-05 at 8 30 50 PM" src="https://github.com/user-attachments/assets/24bac3c5-955e-4805-9861-99dd448d9d87">

Normal window app menu before
<img width="340" alt="Screenshot 2024-12-05 at 8 50 31 PM" src="https://github.com/user-attachments/assets/7d651b8f-22a3-4a4a-8e61-4c9fa14c3a6d">
after
<img width="340" alt="Screenshot 2024-12-05 at 8 30 28 PM" src="https://github.com/user-attachments/assets/6c7cfd68-d2c4-4b5a-962a-362006ace3ac">


Private window app menu before
<img width="340" alt="Screenshot 2024-12-05 at 8 50 43 PM" src="https://github.com/user-attachments/assets/bfe94986-a08c-424a-abeb-a5510b999617">
after
<img width="340" alt="Screenshot 2024-12-05 at 8 31 14 PM" src="https://github.com/user-attachments/assets/d802e05d-7212-4504-bc41-6cd45bbe22c8">

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue