### PR TITLE
Workaround for crbug.com/378381144

### DIFF
--- a/build/commands/lib/buildChromiumRelease.js
+++ b/build/commands/lib/buildChromiumRelease.js
@@ -98,7 +98,6 @@ function getChromiumGnArgs() {
     target_cpu: targetArch,
     target_os: targetOs,
     is_official_build: true,
-    enable_keystone_registration_framework: false,
     ffmpeg_branding: 'Chrome',
     enable_widevine: true,
     ignore_missing_widevine_signing_cert: true,

--- a/build/commands/lib/buildChromiumRelease.js
+++ b/build/commands/lib/buildChromiumRelease.js
@@ -154,6 +154,12 @@ function buildChromiumRelease(buildOptions = {}) {
     chromiumConfig.extraHooks()
   }
 
+  // A workaround for
+  // https://chromium-review.googlesource.com/c/chromium/src/+/6013664
+  const v8CompileFix = '1e3bed631cff17487775e33626121bfd5f0e664e'
+  util.runGit(config.srcDir, ['fetch', 'origin', v8CompileFix])
+  util.runGit(config.srcDir, ['cherry-pick', 'FETCH_HEAD'])
+
   util.runGnGen(config.outputDir, getChromiumGnArgs())
 
   Log.progressScope(`remove recursive symlinks`, () => {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42719

Also removes outdated `enable_keystone_registration_framework`:
```
[2024-12-06T08:11:14.732Z] WARNING at //out/android_Release_arm64_chromium/args_generated.gni:7:40: Build argument has no effect.
[2024-12-06T08:11:14.732Z] enable_keystone_registration_framework=false
[2024-12-06T08:11:14.732Z]                                        ^----
[2024-12-06T08:11:14.733Z] The variable "enable_keystone_registration_framework" was set as a build argument
[2024-12-06T08:11:14.733Z] but never appeared in a declare_args() block in any buildfile.
```

A test build (GREEN): https://ci.brave.com/job/brave-chromium-build-android/408/

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

