### PR TITLE
Adjusted location bar right edge padding

### DIFF
--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -80,6 +80,7 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
       return 16;
     case LOCATION_BAR_ELEMENT_PADDING:
     case LOCATION_BAR_PAGE_INFO_ICON_VERTICAL_PADDING:
+    case LOCATION_BAR_TRAILING_DECORATION_EDGE_PADDING:
       return 2;
     default:
       break;

--- a/browser/ui/brave_layout_constants_unittest.cc
+++ b/browser/ui/brave_layout_constants_unittest.cc
@@ -15,4 +15,6 @@ TEST(BraveLayoutConstantsTest, BraveValueTest) {
   EXPECT_EQ(gfx::Insets(5), GetLayoutInsets(TOOLBAR_BUTTON));
   EXPECT_EQ(28, GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT));
   EXPECT_EQ(4, GetLayoutConstant(LOCATION_BAR_CHILD_CORNER_RADIUS));
+  EXPECT_EQ(GetLayoutConstant(LOCATION_BAR_ELEMENT_PADDING),
+            GetLayoutConstant(LOCATION_BAR_TRAILING_DECORATION_EDGE_PADDING));
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/39976

Right edge should has same padding value with left edge.
LOCATION_BAR_ELEMENT_PADDING is used for left edge.
Use same value for LOCATION_BAR_TRAILING_DECORATION_EDGE_PADDING.

Before
<img width="272" alt="image" src="https://github.com/user-attachments/assets/e6c05345-d793-4911-875f-08d2cea67d88">

After
<img width="640" alt="Screenshot 2024-12-06 at 11 19 28 PM" src="https://github.com/user-attachments/assets/7a6b644c-addc-4d69-a2e2-3a70e6654064">
<img width="623" alt="Screenshot 2024-12-06 at 11 20 04 PM" src="https://github.com/user-attachments/assets/c46b45df-404d-4846-bcb9-185edcdcc89c">


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Check right edge of omnibox