### PR TITLE
Fixed issue of unable to switch on the passwords sync on Android (uplift to 1.73.x)

### DIFF
--- a/chromium_src/components/sync/service/sync_prefs.cc
+++ b/chromium_src/components/sync/service/sync_prefs.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/sync/service/sync_prefs.h"
+
+#define SetPasswordSyncAllowed SetPasswordSyncAllowed_ChromiumImpl
+
+#include "src/components/sync/service/sync_prefs.cc"
+
+#undef SetPasswordSyncAllowed
+
+namespace syncer {
+
+void SyncPrefs::SetPasswordSyncAllowed(bool allowed) {}
+
+}  // namespace syncer

--- a/chromium_src/components/sync/service/sync_prefs.h
+++ b/chromium_src/components/sync/service/sync_prefs.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_PREFS_H_
+#define BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_PREFS_H_
+
+void SetPasswordSyncAllowed(bool allowed);
+
+#define SetPasswordSyncAllowed                       \
+  SetPasswordSyncAllowed_ChromiumImpl(bool allowed); \
+  void SetPasswordSyncAllowed
+
+#include "src/components/sync/service/sync_prefs.h"  // IWYU pragma: export
+
+#undef SetPasswordSyncAllowed
+
+#endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_SYNC_SERVICE_SYNC_PREFS_H_

--- a/components/brave_sync/BUILD.gn
+++ b/components/brave_sync/BUILD.gn
@@ -157,5 +157,6 @@ source_set("unit_tests") {
     "//components/os_crypt/sync:test_support",
     "//components/prefs:test_support",
     "//components/sync/base",
+    "//components/sync/service",
   ]
 }


### PR DESCRIPTION
Uplift of #26876
Resolves https://github.com/brave/brave-browser/issues/36190

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.