### PR TITLE
Removed unnecessary separator from more tools menu (uplift to 1.74.x)

### DIFF
--- a/browser/ui/toolbar/brave_app_menu_model.cc
+++ b/browser/ui/toolbar/brave_app_menu_model.cc
@@ -375,8 +375,12 @@ void BraveAppMenuModel::RemoveUpstreamMenus() {
   }
 
   // Remove upstream's `Reading Mode` item as we have our own `Speed reader`.
+  // Also remove associated separator.
   if (const auto index = more_tools_model->GetIndexOfCommandId(
           IDC_SHOW_READING_MODE_SIDE_PANEL)) {
+    CHECK_EQ(ui::MenuModel::TYPE_SEPARATOR,
+             more_tools_model->GetTypeAt(*index + 1));
+    more_tools_model->RemoveItemAt(*index + 1);
     more_tools_model->RemoveItemAt(*index);
   }
 


### PR DESCRIPTION
Uplift of #26898
fix https://github.com/brave/brave-browser/issues/42718

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.