### PR TITLE
Improve contrast on active tab for dark mode

### DIFF
--- a/ui/color/brave_sys_color_mixer.cc
+++ b/ui/color/brave_sys_color_mixer.cc
@@ -26,7 +26,7 @@ void AddBraveSysColorMixer(ColorProvider* provider,
   mixer[kColorSysHeader] = {kColorRefNeutral5};
   mixer[kColorSysHeaderInactive] = {kColorRefNeutral5};
 
-  mixer[kColorSysBase] = {kColorRefNeutral15};
+  mixer[kColorSysBase] = {kColorRefNeutral20};
   mixer[kColorSysOmniboxContainer] = {kColorRefNeutral5};
   mixer[kColorSysTonalOutline] = {kColorSysPrimary};
 }

--- a/ui/color/brave_sys_color_mixer_unittest.cc
+++ b/ui/color/brave_sys_color_mixer_unittest.cc
@@ -26,7 +26,7 @@ TEST(BraveSysColorMixer, DarkModeGrayscaleOverridesAreApplied) {
   // Sanity check these two colors are overriden.
   EXPECT_EQ(provider.GetColor(kColorRefNeutral5),
             provider.GetColor(kColorSysHeader));
-  EXPECT_EQ(provider.GetColor(kColorRefNeutral15),
+  EXPECT_EQ(provider.GetColor(kColorRefNeutral20),
             provider.GetColor(kColorSysBase));
 }
 
@@ -43,7 +43,7 @@ TEST(BraveSysColorMixer, LightModeGrayscaleOverridesAreNotApplied) {
   // theme.
   EXPECT_NE(provider.GetColor(kColorRefNeutral5),
             provider.GetColor(kColorSysHeader));
-  EXPECT_NE(provider.GetColor(kColorRefNeutral15),
+  EXPECT_NE(provider.GetColor(kColorRefNeutral20),
             provider.GetColor(kColorSysBase));
 }
 
@@ -60,7 +60,7 @@ TEST(BraveSysColorMixer, OverridesAreNotAppliedInNonGrayscale) {
   // theme.
   EXPECT_NE(provider_dark.GetColor(kColorRefNeutral5),
             provider_dark.GetColor(kColorSysHeader));
-  EXPECT_NE(provider_dark.GetColor(kColorRefNeutral15),
+  EXPECT_NE(provider_dark.GetColor(kColorRefNeutral20),
             provider_dark.GetColor(kColorSysBase));
 
   key.color_mode = ColorProviderKey::ColorMode::kLight;
@@ -72,7 +72,7 @@ TEST(BraveSysColorMixer, OverridesAreNotAppliedInNonGrayscale) {
   // theme.
   EXPECT_NE(provider_light.GetColor(kColorRefNeutral5),
             provider_light.GetColor(kColorSysHeader));
-  EXPECT_NE(provider_light.GetColor(kColorRefNeutral15),
+  EXPECT_NE(provider_light.GetColor(kColorRefNeutral20),
             provider_light.GetColor(kColorSysBase));
 }
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42751

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
- Active tabs in dark mode should have more contrast and be more obvious.


Before update:
<img width="1554" alt="image" src="https://github.com/user-attachments/assets/c60247f3-72cb-4208-aa17-c83d1a362cef">


After update:
<img width="1622" alt="image" src="https://github.com/user-attachments/assets/89b47888-f9dc-4a1c-837e-c3f85c6e21d7">


