### PR TITLE
[iOS] - Fix race condition for private browsing only mode

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -598,16 +598,18 @@ extension SceneDelegate {
         Logger.module.info("[SCENE] - SESSION RESTORED")
       } else {
         // Try to restore active window
-        windowId = restoreOrCreateWindow().windowId
-        isPrivate = false
-        privateBrowsingManager.isPrivateBrowsing = false
+        let windowInfo = restoreOrCreateWindow()
+        windowId = windowInfo.windowId
+        isPrivate = windowInfo.isPrivate
+        privateBrowsingManager.isPrivateBrowsing = windowInfo.isPrivate
         urlToOpen = nil
       }
     } else {
       // iPhones don't care about user-activity or session info since it will always have one window anyway
-      windowId = restoreOrCreateWindow().windowId
-      isPrivate = false
-      privateBrowsingManager.isPrivateBrowsing = false
+      let windowInfo = restoreOrCreateWindow()
+      windowId = windowInfo.windowId
+      isPrivate = windowInfo.isPrivate
+      privateBrowsingManager.isPrivateBrowsing = windowInfo.isPrivate
       urlToOpen = nil
     }
 
@@ -682,16 +684,18 @@ extension SceneDelegate {
         // iPhones should not create new windows
         if let activeWindow = activeWindow {
           // If there's no active window, fall through and create one
-          return (activeWindow.windowId, false, nil)
+          let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+          return (activeWindow.windowId, isPrivate, nil)
         }
       }
 
       // An existing window is already active on screen
       // So create a new window
       let windowId = UUID()
-      SessionWindow.createWindow(isPrivate: false, isSelected: true, uuid: windowId)
+      let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+      SessionWindow.createWindow(isPrivate: isPrivate, isSelected: true, uuid: windowId)
       Logger.module.info("[SCENE] - CREATED NEW WINDOW")
-      return (windowId, false, nil)
+      return (windowId, isPrivate, nil)
     }
 
     // Restore the active window if possible
@@ -704,9 +708,10 @@ extension SceneDelegate {
     }
 
     // Create a new session window if it does not already exist
-    SessionWindow.createWindow(isPrivate: false, isSelected: true, uuid: windowId)
+    let isPrivate = Preferences.Privacy.privateBrowsingOnly.value
+    SessionWindow.createWindow(isPrivate: isPrivate, isSelected: true, uuid: windowId)
     Logger.module.info("[SCENE] - RESTORING ACTIVE WINDOW OR CREATING A NEW WINDOW")
-    return (windowId, false, nil)
+    return (windowId, isPrivate, nil)
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix a race condition where opening URLs when Brave is NOT in the background, opens with `isPrivate: false` and does not consider PBO.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42717

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Make Brave your default browser
2. Enable Private Browsing Only mode
3. Open Google Maps
4. Find a restaurant or park with a website
5. Tap on it
6. Tap on "Website" button
7. Brave opens
8. URL should be opened in PBO.