### PR TITLE
feat(wallet): Cancel & Speed Up Tx in Tx Status Screen

### DIFF
--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -440,7 +440,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
           let originalTxGasFee = BDouble(parsedTx.gasFee?.fee ?? "0"),
           activeTxGasFee > originalTxGasFee
         {
-          return .cancel(toCancelParsedTx: parsedTx)
+          return .cancel(originalParsedTx: parsedTx)
         }
       }
     } else if activeTransaction.coin == .eth {
@@ -461,7 +461,7 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
           let originalTxGasFee = BDouble(parsedTx.gasFee?.fee ?? "0"),
           activeTxGasFee > originalTxGasFee
         {
-          return .speedUp
+          return .speedUp(originalParsedTx: parsedTx)
         }
       }
     }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionConfirmationStore.swift
@@ -375,7 +375,8 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     else { return nil }
 
     let allTokens =
-    await blockchainRegistry.allTokens(chainId: network.chainId, coin: txInfo.coin) + tokenInfoCache
+      await blockchainRegistry.allTokens(chainId: network.chainId, coin: txInfo.coin)
+      + tokenInfoCache
     let userAssets = await assetManager.getAllUserAssetsInNetworkAssets(
       networks: [network],
       includingUserDeleted: true
@@ -396,16 +397,15 @@ public class TransactionConfirmationStore: ObservableObject, WalletObserverStore
     var followUpAction = TransactionStatusStore.FollowUpAction.none
     if case .ethSend(let detail) = activeParsedTransaction.details,
       let fromValue = BDouble(detail.fromAmount),
-       fromValue == 0, activeTransaction.ethTxData.isEmpty
+      fromValue == 0, activeTransaction.ethTxData.isEmpty
     {
       // loop through allTx to find if there is a tx that has the same chain id, coin type, nonce and from address
       // maxFeePerGas/gasPrice is smaller than this active tx
       if let txInfo = allTxs.first(where: {
-        $0.id != activeTransaction.id &&
-        $0.coin == activeTransaction.coin &&
-        $0.chainId == activeTransaction.chainId &&
-        $0.ethTxNonce == activeTransaction.ethTxNonce &&
-        $0.fromAddress == activeTransaction.fromAddress
+        $0.id != activeTransaction.id && $0.coin == activeTransaction.coin
+          && $0.chainId == activeTransaction.chainId
+          && $0.ethTxNonce == activeTransaction.ethTxNonce
+          && $0.fromAddress == activeTransaction.fromAddress
       }), let parsedTx = await parseTransaction(txInfo) {
         followUpAction = .cancel(toCancelParsedTx: parsedTx)
       }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionStatusStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionStatusStore.swift
@@ -82,7 +82,7 @@ public class TransactionStatusStore: ObservableObject, WalletObserverStore {
     self.txServiceObserver = TxServiceObserver(
       txService: txService,
       _onNewUnapprovedTx: { _ in
-       // tx speed up and cancellation will be handled inside `TxConfirmationStore`
+        // tx speed up and cancellation will be handled inside `TxConfirmationStore`
       },
       _onUnapprovedTxUpdated: { _ in
         // should only handle tx speed up and tx cancellation

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionStatusStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionStatusStore.swift
@@ -13,7 +13,6 @@ import Strings
 public class TransactionStatusStore: ObservableObject, WalletObserverStore {
   @Published var activeTxStatus: BraveWallet.TransactionStatus {
     didSet {
-      print("Debug - tx status changed to \(activeTxStatus)")
       originalTxStatus = activeTxStatus
     }
   }
@@ -50,6 +49,10 @@ public class TransactionStatusStore: ObservableObject, WalletObserverStore {
     } else {
       return true
     }
+  }
+
+  var isSpeedUpAvailable: Bool {
+    return activeParsedTx.transaction.coin == .eth
   }
 
   init(

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionStatusStore.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Stores/TransactionStatusStore.swift
@@ -20,7 +20,7 @@ public class TransactionStatusStore: ObservableObject, WalletObserverStore {
 
   enum FollowUpAction: Equatable {
     case cancel(toCancelParsedTx: ParsedTransaction)
-    case speedup
+    case speedUp
     case none
   }
 

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -153,7 +153,7 @@ struct TransactionConfirmationView: View {
                 onDismiss()
                 onViewInActivity()
               },
-              onCancelCreated: { txId in
+              onFollowUpTxCreated: { txId in
                 Task { @MainActor in
                   // fetch and update `confirmationStore.unapprovedTxs` with this new tx with `txId`
                   if await confirmationStore.updateAllTx(with: txId) == false {

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionConfirmationView.swift
@@ -152,6 +152,20 @@ struct TransactionConfirmationView: View {
               onViewInActivity: {
                 onDismiss()
                 onViewInActivity()
+              },
+              onCancelCreated: { txId in
+                Task { @MainActor in
+                  // fetch and update `confirmationStore.unapprovedTxs` with this new tx with `txId`
+                  if await confirmationStore.updateAllTx(with: txId) == false {
+                    if confirmationStore.unapprovedTxs.count == 0 {
+                      onDismiss()
+                    }
+                  }
+                  // update activeTransactionId
+                  confirmationStore.updateActiveTxIdAfterSignedClosed()
+                  // close tx status store
+                  confirmationStore.closeTxStatusStore()
+                }
               }
             )
           }

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
@@ -603,18 +603,52 @@ struct TransactionStatusView: View {
       GeometryReader { geometry in
         ScrollView(.vertical) {
           VStack {
-            speedUpView
-              .hidden(isHidden: !isShowingSpeedUpBanner)
-            Spacer()
-            txStatusIconView
+            if txStatusStore.isOriginalTxConfirmed {
+              Spacer()
+              ZStack {
+                Circle()
+                  .fill(Color(braveSystemName: .systemfeedbackErrorBackground))
+                  .frame(width: 100, height: 100)
+                Image(braveSystemName: "leo.close")
+                  .font(.title.weight(.semibold))
+                  .foregroundColor(Color(braveSystemName: .systemfeedbackErrorIcon))
+              }
               .padding(.bottom, 30)
-            txStatusTextView
+              VStack {
+                Group {
+                  switch txStatusStore.followUpAction {
+                  case .cancel(_):
+                    Text(Strings.Wallet.unableToCancel)
+                  case .speedUp:
+                    Text(Strings.Wallet.unableToSpeedUp)
+                  case .none:
+                    EmptyView()
+                  }
+                }
+                .font(.title2.weight(.semibold))
+                .foregroundColor(Color(braveSystemName: .textPrimary))
+                .padding(.bottom, 8)
+                Text(Strings.Wallet.originalTransactionIsConfirmed)
+                  .font(.subheadline)
+                  .foregroundColor(Color(braveSystemName: .textSecondary))
+              }
+              .multilineTextAlignment(.center)
               .padding(.top, 10)
-            Spacer()
-            disclosureView
-              .padding(.bottom, 8)
-              .hidden(isHidden: hideDisclosureView)
-            buttonContainerView
+              Spacer()
+            } else {
+              speedUpView
+                .hidden(isHidden: !isShowingSpeedUpBanner)
+              Spacer()
+              txStatusIconView
+                .padding(.bottom, 30)
+              txStatusTextView
+                .padding(.top, 10)
+              Spacer()
+              disclosureView
+                .padding(.bottom, 8)
+                .hidden(isHidden: hideDisclosureView)
+              buttonContainerView
+            }
           }
           .frame(maxWidth: .infinity, minHeight: geometry.size.height)
           .padding(.horizontal, 24)

--- a/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Crypto/Transaction Confirmations/TransactionStatusView.swift
@@ -15,14 +15,15 @@ struct TransactionStatusView: View {
 
   let onDismiss: () -> Void
   var onViewInActivity: () -> Void
+  var onCancelCreated: (_ txId: String) -> Void
 
   @Environment(\.openURL) private var openWalletURL
-  @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
 
   @State private var isSpinning: Bool = false
   @State private var isConfirmSpinning: Bool = false
   @State private var isConfirmSpinningFinished: Bool = false
   @State private var scrollViewContentSize: CGSize = .zero
+  @State private var isShowingTxCancellationConfirmation: Bool = false
 
   @ViewBuilder private var statusIcon: some View {
     switch txStatusStore.activeTxStatus {
@@ -218,82 +219,124 @@ struct TransactionStatusView: View {
     })
   }
 
+  private func revertFromValue(parsedTx: ParsedTransaction) -> String {
+    switch parsedTx.details {
+    case .erc20Transfer(let detail):
+      return "\(detail.fromAmount) \(detail.fromToken?.symbol ?? "")"
+    case .erc721Transfer(let detail):
+      return "\(detail.fromAmount) \(detail.fromToken?.symbol ?? "")"
+    case .ethSend(let detail):
+      return "\(detail.fromAmount) \(detail.fromToken?.symbol ?? "ETH")"
+    case .ethErc20Approve(let detail):
+      return "\(detail.approvalAmount) \(detail.token?.symbol ?? "")"
+    case .ethSwap(let detail):
+      return "\(detail.fromAmount) \(detail.fromToken?.symbol ?? "")"
+    default:
+      return ""
+    }
+  }
+
+  private func txCancelledMsg(parsedTx: ParsedTransaction) -> String {
+    if case .ethErc20Approve(_) = parsedTx.details {
+      return Strings.Wallet.cancelERC20ApprovalTxRevertMsg
+    } else {
+      return Strings.Wallet.cancelTxRevertMsg
+    }
+  }
+
   @ViewBuilder private var txStatusTextView: some View {
     switch txStatusStore.activeTxStatus {
     case .submitted:
-      // Sending
-      //
-      // Transaction Submitted
-      // Sending 0.1 ETH to Oxabcd
-      //
-      // Approving ERC20
-      //
-      // Transaction Submitted
-      // Approving 1 DAI on Account 1
-      //
-      // Swapping on Eth
-      //
-      // Transaction Submitted
-      // Swapping 0.1 ETH to 2.3 USDC
-      // on Ethereum mainnet
-      //
-      // Swapping on Sol
-      //
-      // Transaction Submitted
-      // Solana Swap
-      // on Solana Mainnet
-      VStack {
-        Text(Strings.Wallet.submittedTransactionTitle)
-          .font(.title2.weight(.semibold))
-          .padding(.bottom, 8)
-        Group {
-          if isTxSolSwap {
-            HStack {
-              Text(Strings.Wallet.transactionSummarySolanaSwap)
-                .fontWeight(.semibold)
-              explorerButton
-            }
-            Text("\(Strings.Wallet.txStatusOn) \(activeTxNetwork?.chainName ?? "")")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-          } else if isTxERC20Approve {
-            Text("\(Strings.Wallet.txStatusApproving) ")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-              + Text(txFromValue)
-              .fontWeight(.semibold)
-              + Text(" \(Strings.Wallet.txStatusOn) ")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-            HStack {
-              Text(txToValue)
-                .fontWeight(.semibold)
-              explorerButton
-            }
-          } else if isTxEthSwap {
-            Text("\(Strings.Wallet.txStatusSwapping) ")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-              + Text(txFromValue)
-              .fontWeight(.semibold)
-              + Text(" \(Strings.Wallet.txStatusTo) ")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-              + Text(txToValue)
-              .fontWeight(.semibold)
-          } else {
-            Text("\(Strings.Wallet.txStatusSending) ")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-              + Text(txFromValue)
-              .fontWeight(.semibold)
-              + Text(" \(Strings.Wallet.txStatusTo) ")
-              .foregroundColor(Color(braveSystemName: .textSecondary))
-            HStack {
-              Text(txToValue)
-                .fontWeight(.semibold)
-              explorerButton
-            }
+      if case .cancel(_) = txStatusStore.followUpAction {
+        // Cancelling transaction
+        // Cancellation request submitted
+        VStack {
+          Text(Strings.Wallet.cancellingTransactionTitle)
+            .font(.title2.weight(.semibold))
+            .padding(.bottom, 8)
+          HStack {
+            Text(Strings.Wallet.cancellingTransactionDescription)
+              .font(.subheadline)
+            explorerButton
           }
         }
-        .font(.subheadline)
+        .foregroundColor(Color(braveSystemName: .textPrimary))
+        .multilineTextAlignment(.center)
+      } else {
+        // Sending (not cancelling)
+        //
+        // Transaction Submitted
+        // Sending 0.1 ETH to Oxabcd
+        //
+        // Approving ERC20
+        //
+        // Transaction Submitted
+        // Approving 1 DAI on Account 1
+        //
+        // Swapping on Eth
+        //
+        // Transaction Submitted
+        // Swapping 0.1 ETH to 2.3 USDC
+        // on Ethereum mainnet
+        //
+        // Swapping on Sol
+        //
+        // Transaction Submitted
+        // Solana Swap
+        // on Solana Mainnet
+        VStack {
+          Text(Strings.Wallet.submittedTransactionTitle)
+            .font(.title2.weight(.semibold))
+            .padding(.bottom, 8)
+          Group {
+            if isTxSolSwap {
+              HStack {
+                Text(Strings.Wallet.transactionSummarySolanaSwap)
+                  .fontWeight(.semibold)
+                explorerButton
+              }
+              Text("\(Strings.Wallet.txStatusOn) \(activeTxNetwork?.chainName ?? "")")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+            } else if isTxERC20Approve {
+              Text("\(Strings.Wallet.txStatusApproving) ")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+                + Text(txFromValue)
+                .fontWeight(.semibold)
+                + Text(" \(Strings.Wallet.txStatusOn) ")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+              HStack {
+                Text(txToValue)
+                  .fontWeight(.semibold)
+                explorerButton
+              }
+            } else if isTxEthSwap {
+              Text("\(Strings.Wallet.txStatusSwapping) ")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+                + Text(txFromValue)
+                .fontWeight(.semibold)
+                + Text(" \(Strings.Wallet.txStatusTo) ")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+                + Text(txToValue)
+                .fontWeight(.semibold)
+            } else {
+              Text("\(Strings.Wallet.txStatusSending) ")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+                + Text(txFromValue)
+                .fontWeight(.semibold)
+                + Text(" \(Strings.Wallet.txStatusTo) ")
+                .foregroundColor(Color(braveSystemName: .textSecondary))
+              HStack {
+                Text(txToValue)
+                  .fontWeight(.semibold)
+                explorerButton
+              }
+            }
+          }
+          .font(.subheadline)
+        }
+        .foregroundColor(Color(braveSystemName: .textPrimary))
+        .multilineTextAlignment(.center)
       }
-      .foregroundColor(Color(braveSystemName: .textPrimary))
-      .multilineTextAlignment(.center)
     case .signed:
       // Signed send tx
       //
@@ -317,82 +360,108 @@ struct TransactionStatusView: View {
       .foregroundColor(Color(braveSystemName: .textPrimary))
       .multilineTextAlignment(.center)
     case .confirmed:
-      // Sending
-      //
-      // Sent!
-      // 0.1 ETH has been sent to account Oxabcd
-      //
-      // Approving ERC20
-      //
-      // Approved!
-      // 1 DAI has been approved on your Account 1
-      //
-      // Swapping on Eth
-      //
-      // Completed!
-      // 2.3 USDC has been added to your Account 1
-      // on Ethereum Mainnet
-      //
-      // Swapping on Sol
-      //
-      // Completed!
-      // Solana Swap
-      // on Solana Mainnet
-      VStack {
-        if isTxSolSwap {
-          Text("\(Strings.Wallet.txStatusCompleted)!")
+      if case .cancel(let parsedTx) = txStatusStore.followUpAction {
+        // Transaction cancellation
+        //
+        // Transaction cancelled!
+        // 0.1 ETH has been reverted to account 0xf333...095F
+        //
+        VStack {
+          Text(Strings.Wallet.confirmedTransactionCancellationTitle)
             .font(.title2.weight(.semibold))
             .padding(.bottom, 8)
-          HStack {
-            Text(Strings.Wallet.transactionSummarySolanaSwap)
-              .fontWeight(.semibold)
-            explorerButton
-          }
-          Text("\(Strings.Wallet.txStatusOn) \(activeTxNetwork?.chainName ?? "")")
-            .foregroundColor(Color(braveSystemName: .textSecondary))
-        } else if isTxEthSwap {
-          Text("\(Strings.Wallet.txStatusCompleted)!")
-            .font(.title2.weight(.semibold))
-            .padding(.bottom, 8)
-          Text(txToValue)
+          Text(revertFromValue(parsedTx: parsedTx))
             .fontWeight(.semibold)
-            + Text(" \(Strings.Wallet.txStatusSwappedMsg)")
+            + Text(" \(txCancelledMsg(parsedTx: parsedTx)) ")
             .foregroundColor(Color(braveSystemName: .textSecondary))
           HStack {
-            Text(txStatusStore.activeParsedTx.fromAccountInfo.name)
-              .fontWeight(.semibold)
-            explorerButton
-          }
-        } else if isTxERC20Approve {
-          Text("\(Strings.Wallet.txStatusCompleted)!")
-            .font(.title2.weight(.semibold))
-            .padding(.bottom, 8)
-          Text(txFromValue)
-            .fontWeight(.semibold)
-            + Text(" \(Strings.Wallet.txStatusERC20ApprovalMsg)")
-            .foregroundColor(Color(braveSystemName: .textSecondary))
-          HStack {
-            Text(txToValue)
-              .fontWeight(.semibold)
-            explorerButton
-          }
-        } else {
-          Text("\(Strings.Wallet.sent)!")
-            .font(.title2.weight(.semibold))
-            .padding(.bottom, 8)
-          Text(txFromValue)
-            .fontWeight(.semibold)
-            + Text(" \(Strings.Wallet.txStatusSentMsg)")
-            .foregroundColor(Color(braveSystemName: .textSecondary))
-          HStack {
-            Text(txToValue)
+            Text("\(Strings.Wallet.confirmedTransactionCancellationAccount) ")
+              .foregroundColor(Color(braveSystemName: .textSecondary))
+              + Text(parsedTx.fromAccountInfo.address.truncatedAddress)
               .fontWeight(.semibold)
             explorerButton
           }
         }
+        .foregroundColor(Color(braveSystemName: .textPrimary))
+        .multilineTextAlignment(.center)
+      } else {
+        // Sending (not cancelling)
+        //
+        // Sent!
+        // 0.1 ETH has been sent to account Oxabcd
+        //
+        // Approving ERC20
+        //
+        // Approved!
+        // 1 DAI has been approved on your Account 1
+        //
+        // Swapping on Eth
+        //
+        // Completed!
+        // 2.3 USDC has been added to your Account 1
+        // on Ethereum Mainnet
+        //
+        // Swapping on Sol
+        //
+        // Completed!
+        // Solana Swap
+        // on Solana Mainnet
+        VStack {
+          if isTxSolSwap {
+            Text("\(Strings.Wallet.txStatusCompleted)!")
+              .font(.title2.weight(.semibold))
+              .padding(.bottom, 8)
+            HStack {
+              Text(Strings.Wallet.transactionSummarySolanaSwap)
+                .fontWeight(.semibold)
+              explorerButton
+            }
+            Text("\(Strings.Wallet.txStatusOn) \(activeTxNetwork?.chainName ?? "")")
+              .foregroundColor(Color(braveSystemName: .textSecondary))
+          } else if isTxEthSwap {
+            Text("\(Strings.Wallet.txStatusCompleted)!")
+              .font(.title2.weight(.semibold))
+              .padding(.bottom, 8)
+            Text(txToValue)
+              .fontWeight(.semibold)
+              + Text(" \(Strings.Wallet.txStatusSwappedMsg)")
+              .foregroundColor(Color(braveSystemName: .textSecondary))
+            HStack {
+              Text(txStatusStore.activeParsedTx.fromAccountInfo.name)
+                .fontWeight(.semibold)
+              explorerButton
+            }
+          } else if isTxERC20Approve {
+            Text("\(Strings.Wallet.txStatusCompleted)!")
+              .font(.title2.weight(.semibold))
+              .padding(.bottom, 8)
+            Text(txFromValue)
+              .fontWeight(.semibold)
+              + Text(" \(Strings.Wallet.txStatusERC20ApprovalMsg)")
+              .foregroundColor(Color(braveSystemName: .textSecondary))
+            HStack {
+              Text(txToValue)
+                .fontWeight(.semibold)
+              explorerButton
+            }
+          } else {
+            Text("\(Strings.Wallet.sent)!")
+              .font(.title2.weight(.semibold))
+              .padding(.bottom, 8)
+            Text(txFromValue)
+              .fontWeight(.semibold)
+              + Text(" \(Strings.Wallet.txStatusSentMsg)")
+              .foregroundColor(Color(braveSystemName: .textSecondary))
+            HStack {
+              Text(txToValue)
+                .fontWeight(.semibold)
+              explorerButton
+            }
+          }
+        }
+        .foregroundColor(Color(braveSystemName: .textPrimary))
+        .multilineTextAlignment(.center)
       }
-      .foregroundColor(Color(braveSystemName: .textPrimary))
-      .multilineTextAlignment(.center)
     case .error:
       VStack {
         Group {
@@ -435,7 +504,28 @@ struct TransactionStatusView: View {
 
   @ViewBuilder private var buttonContainerView: some View {
     switch txStatusStore.activeTxStatus {
-    case .submitted, .confirmed:
+    case .submitted:
+      HStack {
+        if txStatusStore.isCancelAvailable {
+          Button {
+            isShowingTxCancellationConfirmation = true
+          } label: {
+            Text(Strings.Wallet.cancelTransactionStatusButtonTitle)
+              .font(.footnote.weight(.semibold))
+              .frame(maxWidth: .infinity)
+          }
+          .buttonStyle(BraveOutlineButtonStyle(size: .large))
+        }
+        Button {
+          onViewInActivity()
+        } label: {
+          Text(Strings.Wallet.txStatusViewInActivity)
+            .font(.footnote.weight(.semibold))
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(BraveFilledButtonStyle(size: .large))
+      }
+    case .confirmed:
       Button {
         onViewInActivity()
       } label: {
@@ -492,7 +582,7 @@ struct TransactionStatusView: View {
       }
       .interactiveDismissDisabled()
       .background(Color(braveSystemName: .containerBackground).ignoresSafeArea())
-      .transparentNavigationBar()
+      .transparentNavigationBar(backButtonDisplayMode: .minimal)
       .toolbar {
         ToolbarItemGroup(placement: .destructiveAction) {
           Button {
@@ -504,6 +594,75 @@ struct TransactionStatusView: View {
         }
       }
       .navigationBarTitleDisplayMode(.inline)
+      .navigationDestination(
+        isPresented: $isShowingTxCancellationConfirmation,
+        destination: {
+          TxCancellationConfirmationView(
+            txStatusStore: txStatusStore,
+            onCancelCreationSucceeded: {
+              isShowingTxCancellationConfirmation = false
+              onCancelCreated($0)
+            },
+            onCancelCreationFailed: {
+              isShowingTxCancellationConfirmation = false
+            }
+          )
+          .padding(16)
+        }
+      )
+    }
+  }
+}
+
+struct TxCancellationConfirmationView: View {
+  var txStatusStore: TransactionStatusStore
+  var onCancelCreationSucceeded: (_ txId: String) -> Void
+  var onCancelCreationFailed: () -> Void
+
+  @State private var cancelError: String?
+
+  var body: some View {
+    VStack {
+      Spacer()
+      Text(Strings.Wallet.cancelTransactionStatusButtonTitle)
+        .foregroundColor(Color(braveSystemName: .textPrimary))
+        .font(.title2.weight(.semibold))
+        .padding(.bottom, 8)
+      Text(Strings.Wallet.cancelTransactionStatusConfirmationDescription)
+        .foregroundColor(Color(braveSystemName: .textTertiary))
+      Spacer()
+      Button {
+        Task { @MainActor in
+          let (txId, error) = await txStatusStore.handleTransactionFollowUpAction(.cancel)
+          if let error {
+            cancelError = error
+          } else if let txId {
+            onCancelCreationSucceeded(txId)
+          }
+        }
+      } label: {
+        Text(Strings.Wallet.cancelTransactionStatusButtonTitle)
+          .frame(maxWidth: .infinity)
+      }
+      .buttonStyle(BraveFilledButtonStyle(size: .large))
+    }
+    .multilineTextAlignment(.center)
+    .alert(
+      isPresented: Binding(
+        get: { cancelError != nil },
+        set: {
+          if !$0 {
+            cancelError = nil
+            onCancelCreationFailed()
+          }
+        }
+      )
+    ) {
+      Alert(
+        title: Text(Strings.genericErrorTitle),
+        message: Text(cancelError ?? ""),
+        dismissButton: .default(Text(Strings.OKString))
+      )
     }
   }
 }
@@ -515,7 +674,8 @@ struct TransactionStatusView_Previews: PreviewProvider {
       txStatusStore: .previewStore,
       networkStore: .previewStore,
       onDismiss: {},
-      onViewInActivity: {}
+      onViewInActivity: {},
+      onCancelCreated: { _ in }
     )
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/Preview Content/MockStores.swift
+++ b/ios/brave-ios/Sources/BraveWallet/Preview Content/MockStores.swift
@@ -242,7 +242,8 @@ extension TransactionStatusStore {
       txProviderError: nil,
       keyringService: MockKeyringService(),
       rpcService: MockJsonRpcService(),
-      txService: MockTxService()
+      txService: MockTxService(),
+      followUpAction: .none
     )
   }
 }

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -4505,6 +4505,62 @@ extension Strings {
       value: "Please save the error message for future reference.",
       comment: "A description of the view that will display the error message."
     )
+    public static let cancelERC20ApprovalTxRevertMsg = NSLocalizedString(
+      "wallet.cancelERC20ApprovalTxRevertMsg",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "allowance has not been approved under",
+      comment: "A part of the message in a transaction status screen. It will follow the amount of tokens that users were attempt to approve but cancelled after. For exapmple: 10 ETH allowance has not been approve under account 0x345...436"
+    )
+    public static let cancelTxRevertMsg = NSLocalizedString(
+      "wallet.cancelTxRevertMsg",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "has been reverted to",
+      comment: "A part of the message in a transaction status screen. It will follow the amount of tokens that users were attempt to send but cancelled after. For exapmple: 10 ETH has been reverted to account 0x345...436"
+    )
+    public static let cancellingTransactionTitle = NSLocalizedString(
+      "wallet.cancellingTransactionTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Cancelling transaction",
+      comment: "A title of transaction status view indicating this transaction is submitted to chain which is cancelling another transaction."
+    )
+    public static let cancellingTransactionDescription = NSLocalizedString(
+      "wallet.cancellingTransactionDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Cancellation request submitted",
+      comment: "A description of transaction status view indicating this transaction is submitted to chain which is cancelling another transaction."
+    )
+    public static let confirmedTransactionCancellationTitle = NSLocalizedString(
+      "wallet.confirmedTransactionCancellationTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Transaction cancelled!",
+      comment: "A title of transaction status view indicating this transaction is confirmed on the chain which has cancelled another transaction."
+    )
+    public static let confirmedTransactionCancellationAccount = NSLocalizedString(
+      "wallet.confirmedTransactionCancellationAccount",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "account",
+      comment: "When a cancellation transaction has been confirmed, we will display which account the amount of value has been reverted to. For example: 10 ETH has been reverted to account 0x123...456"
+    )
+    public static let cancelTransactionStatusButtonTitle = NSLocalizedString(
+      "wallet.cancelTransactionStatusButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Cancel transaction",
+      comment: "The button title that for user to cancel a submitted transaction inside transaction status view."
+    )
+    public static let cancelTransactionStatusConfirmationDescription = NSLocalizedString(
+      "wallet.cancelTransactionStatusConfirmationDescription",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "A new transaction will be created to cancel your existing transaction",
+      comment: "The description inside the view when asking user to confirm they want to cancel a transaction."
+    )
     public static let ensOffchainGatewayTitle = NSLocalizedString(
       "wallet.ensOffchainGatewayTitle",
       tableName: "BraveWallet",

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -4551,7 +4551,7 @@ extension Strings {
       "wallet.cancelTransactionStatusButtonTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Cancel transaction",
+      value: "Cancel Transaction",
       comment: "The button title that for user to cancel a submitted transaction inside transaction status view."
     )
     public static let cancelTransactionStatusConfirmationDescription = NSLocalizedString(
@@ -4572,8 +4572,29 @@ extension Strings {
       "wallet.speedUpButtonTitle",
       tableName: "BraveWallet",
       bundle: .module,
-      value: "Speed up",
+      value: "Speed Up",
       comment: "The button title for the button inside speed up banner."
+    )
+    public static let unableToCancel = NSLocalizedString(
+      "wallet.unableToCancel",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Unable to cancel",
+      comment: "The title will be displayed when a cancel tx has been dropped or replaced on chain."
+    )
+    public static let unableToSpeedUp = NSLocalizedString(
+      "wallet.unableToSpeedUp",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Unable to speed up",
+      comment: "The title will be displayed when a speed-up tx has been dropped or replaced on chain."
+    )
+    public static let originalTransactionIsConfirmed = NSLocalizedString(
+      "wallet.originalTransactionIsConfirmed",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "The original transaction has been confirmed.",
+      comment: "The message will be displayed when a cancel/speed-up tx has been dropped or replaced on chain."
     )
     public static let ensOffchainGatewayTitle = NSLocalizedString(
       "wallet.ensOffchainGatewayTitle",

--- a/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
+++ b/ios/brave-ios/Sources/BraveWallet/WalletStrings.swift
@@ -4561,6 +4561,20 @@ extension Strings {
       value: "A new transaction will be created to cancel your existing transaction",
       comment: "The description inside the view when asking user to confirm they want to cancel a transaction."
     )
+    public static let speedUpBannerTitle = NSLocalizedString(
+      "wallet.speedUpBannerTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Take longer than expected?",
+      comment: "The title of the banner which will be displayed at the top of the transaction status screen when transaction is in submitted status and user wants to speed it up."
+    )
+    public static let speedUpButtonTitle = NSLocalizedString(
+      "wallet.speedUpButtonTitle",
+      tableName: "BraveWallet",
+      bundle: .module,
+      value: "Speed up",
+      comment: "The button title for the button inside speed up banner."
+    )
     public static let ensOffchainGatewayTitle = NSLocalizedString(
       "wallet.ensOffchainGatewayTitle",
       tableName: "BraveWallet",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41799
Resolves https://github.com/brave/brave-browser/issues/41800

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create either a `.ethSend`, `.erc20Approval`, `.erc20Transfer`, `.eth721Transfer` or `.ethSwap`
2. Once the tx is submitted to the chain, you are in the flow of displaying the current tx's status
3. You will see `Cancel transaction` button enabled once the tx has been submitted 
4. Quickly click this button you will see a confirmation screen shows up 
5. Click the back button the cancel 
6. You might need to repeat step 1 to 4 if your transaction gets confirmed 
7. Click `Cancel transaction` in the confirmation 
8. The status screen will be dismissed and a new pending transaction created 
9. Click confirm
10. Now you are entering again the tx status flow but for this new transaction 
11. Notice there is no `Cancel transaction` button anymore 
12. Let it gets confirmed 
13. You will see the confirmed status will display correct message.
14. Go back to `Activity` tab 
15. You will see a transaction that sent 0 ETH is successfully confirmed on chain
16. Create other transaction that is not Eth coin type
17. You will not see the `Cancel transaction` button in the tx status flow

Cancel button | Confirmation | Activity
--- | --- | ---
![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-06 at 14 35 08](https://github.com/user-attachments/assets/1352220a-dba0-451d-b8de-31c24eacf292) | ![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-09 at 17 52 37](https://github.com/user-attachments/assets/c31f0554-2070-40e0-a837-95eab991b395) | ![Simulator Screenshot - iPhone 16 Pro - 2024-12-04 at 14 03 30](https://github.com/user-attachments/assets/79c88e92-6131-4a57-94c6-0ac104bf17bb)
Cancellation Tx | Send Tx Cancelled | ERC20Approval Cancelled
![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-06 at 14 35 08](https://github.com/user-attachments/assets/6b358182-3e93-4365-8aea-2cf7041eb2e8) | ![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-06 at 14 35 22](https://github.com/user-attachments/assets/ed3297a6-857d-47e2-83f7-11263e80deb3) | ![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-06 at 15 06 19](https://github.com/user-attachments/assets/3dc011ab-17b6-4c1a-85a1-d700e95df658)
ERC20 Tx Cancelled | |
![Simulator Screenshot - iPhone 16 Pro Max - 2024-12-06 at 15 43 31](https://github.com/user-attachments/assets/16655c14-8a8d-41b1-9a16-e9faa359ee56) | |

Speed up a eth tx
For demo purpose the banner will be displayed 1 second after tx status screen is visible. But the actual timer is 5 seconds. If you tx is confirmed or errored out before 5 seconds you won't see the speed up banner
https://github.com/user-attachments/assets/fd653976-db8b-4771-b55b-5291ad710fcd
1. create a ETH tx and confirm it. Please take a glance of the gas fee.
2. once the tx status shows up, wait for the speed up banner to be shown 
3. click the speed up button
4. you will see the tx status screen will be dismissed and a new pending tx will be shown and notice that this pending tx's gas fee should be greater than the gas fee in step 1
5. confirm this pending tx
6. tx should get confirmed shortly. 



