### PR TITLE
fix(wallet): Prevent Double Account Creation on Buy Screen

### DIFF
--- a/components/brave_wallet_ui/page/screens/fund-wallet/components/create_account/create_account.tsx
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/components/create_account/create_account.tsx
@@ -47,7 +47,10 @@ import { Column, Row, Text } from '../../../../../components/shared/style'
 interface Props extends DialogProps {
   isOpen: boolean
   token?: MeldCryptoCurrency
-  onSelectToken: (asset: MeldCryptoCurrency) => void
+  onSelectToken: (
+    asset: MeldCryptoCurrency,
+    account?: BraveWallet.AccountInfo
+  ) => void
   onClose: () => void
 }
 
@@ -92,7 +95,7 @@ export const CreateAccount = (props: Props) => {
       }).unwrap()
 
       if (account) {
-        onSelectToken(token)
+        onSelectToken(token, account)
       }
     } catch (error) {
       console.log(error)

--- a/components/brave_wallet_ui/page/screens/fund-wallet/hooks/useBuy.ts
+++ b/components/brave_wallet_ui/page/screens/fund-wallet/hooks/useBuy.ts
@@ -395,10 +395,12 @@ export const useBuy = () => {
   )
 
   const onSelectToken = useCallback(
-    async (asset: MeldCryptoCurrency) => {
+    async (asset: MeldCryptoCurrency, account?: BraveWallet.AccountInfo) => {
       const incomingAssetsCoinType = getMeldTokensCoinType(asset)
       const accountToUse =
-        selectedAccount.accountId.coin !== incomingAssetsCoinType
+        account !== undefined
+          ? account
+          : selectedAccount.accountId.coin !== incomingAssetsCoinType
           ? getFirstAccountByCoinType(incomingAssetsCoinType, accounts)
           : selectedAccount
       if (!accountToUse) {


### PR DESCRIPTION
## Description 

Fixes a bug where `2` ZCash accounts were being created when prompt to create an account on the `Buy` screen.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42788>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a brand new `Wallet`
2. Navigate to the `Buy` screen
3. Select `ZCash` as the asset to buy
4. When prompt to create an account, click `Create Account`
5. It should only create `1` ZCash account

https://github.com/user-attachments/assets/142748f3-5220-421c-94e4-9a425c4b9225
