### PR TITLE
Fixes a crash on Quick Search on Android when TemplateUrlService is not loaded yet (uplift to 1.74.x)

### DIFF
--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -173,6 +173,7 @@ import org.chromium.chrome.browser.rate.RateUtils;
 import org.chromium.chrome.browser.rewards.adaptive_captcha.AdaptiveCaptchaHelper;
 import org.chromium.chrome.browser.safe_browsing.SafeBrowsingBridge;
 import org.chromium.chrome.browser.safe_browsing.SafeBrowsingState;
+import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
 import org.chromium.chrome.browser.set_default_browser.BraveSetDefaultBrowserUtils;
 import org.chromium.chrome.browser.set_default_browser.OnBraveSetDefaultBrowserListener;
 import org.chromium.chrome.browser.settings.BraveNewsPreferencesV2;
@@ -2582,6 +2583,17 @@ public abstract class BraveActivity extends ChromeActivity
                     }
                 });
 
+        Runnable onQuickSearchEnginesReady =
+                () -> {
+                    if (isActivityFinishingOrDestroyed()) return;
+
+                    quickSearchEnginesReady(recyclerView, keypadHeight);
+                };
+        TemplateUrlServiceFactory.getForProfile(getCurrentProfile())
+                .runWhenLoaded(onQuickSearchEnginesReady);
+    }
+
+    private void quickSearchEnginesReady(RecyclerView recyclerView, int keypadHeight) {
         List<QuickSearchEnginesModel> searchEngines =
                 QuickSearchEnginesUtil.getQuickSearchEnginesForView(getCurrentProfile());
         QuickSearchEnginesModel leoQuickSearchEnginesModel =

--- a/android/java/org/chromium/chrome/browser/quick_search_engines/settings/QuickSearchEnginesFragment.java
+++ b/android/java/org/chromium/chrome/browser/quick_search_engines/settings/QuickSearchEnginesFragment.java
@@ -28,6 +28,7 @@ import org.chromium.base.supplier.ObservableSupplierImpl;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.quick_search_engines.ItemTouchHelperCallback;
 import org.chromium.chrome.browser.quick_search_engines.utils.QuickSearchEnginesUtil;
+import org.chromium.chrome.browser.search_engines.TemplateUrlServiceFactory;
 import org.chromium.chrome.browser.settings.BravePreferenceFragment;
 import org.chromium.chrome.browser.util.ImageUtils;
 
@@ -137,9 +138,16 @@ public class QuickSearchEnginesFragment extends BravePreferenceFragment
     }
 
     private void refreshData() {
-        List<QuickSearchEnginesModel> quickSearchEngines =
-                QuickSearchEnginesUtil.getQuickSearchEnginesForSettings(getProfile());
-        setRecyclerViewData(quickSearchEngines);
+        Runnable onQuickSearchEnginesReady =
+                () -> {
+                    if (isRemoving() || isDetached()) return;
+
+                    List<QuickSearchEnginesModel> quickSearchEngines =
+                            QuickSearchEnginesUtil.getQuickSearchEnginesForSettings(getProfile());
+                    setRecyclerViewData(quickSearchEngines);
+                };
+        TemplateUrlServiceFactory.getForProfile(getProfile())
+                .runWhenLoaded(onQuickSearchEnginesReady);
     }
 
     private void setRecyclerViewData(List<QuickSearchEnginesModel> searchEngines) {


### PR DESCRIPTION
Uplift of #26940
Resolves https://github.com/brave/brave-browser/issues/42771

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.