### PR TITLE
fix(wallet): Backup Wallet Progress Indicator

### DIFF
--- a/components/brave_wallet_ui/page/screens/backup-wallet/verify-recovery-phrase/components/verification_progress.tsx
+++ b/components/brave_wallet_ui/page/screens/backup-wallet/verify-recovery-phrase/components/verification_progress.tsx
@@ -20,7 +20,7 @@ export const VerificationProgress = ({ steps, currentStep }: Props) => {
         <Rectangle
           key={index}
           isActive={currentStep >= index}
-          width={index === 0 ? '20px' : '16px'}
+          width={index === currentStep ? '24px' : '12px'}
         />
       ))}
     </Wrapper>


### PR DESCRIPTION
## Description 

Fixes the Backup Wallet `Progress Step` indicator `size` and `current` step.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42790>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a new `Wallet` and then click the `Backup Now` button
2. Once you copy your seed phrase and get to the input verification, you should see the 3 `Indicator Steps` at the top right.
3. The `Current` step should be `24px` wide and all others `12px` wide
4. The `Current` and `Completed` steps should be `filled` and the others should not.

Before:

![image](https://github.com/user-attachments/assets/f3a149b0-cc9d-46e6-b01b-eed190b2f946) | ![image](https://github.com/user-attachments/assets/90c9087c-e478-47c3-870f-b255c95f92d7) | ![image](https://github.com/user-attachments/assets/f43757c3-4d8d-4925-ad49-d8c6114e66c2)
--|--|--

After:


![image](https://github.com/user-attachments/assets/6da9308b-8457-4a17-9da9-fbd61e1375a0) | ![image](https://github.com/user-attachments/assets/ea8f21ff-6224-49a1-b478-509c4d21b731) | ![image](https://github.com/user-attachments/assets/66dfcbec-4994-4853-b3a9-75bcce7e0aa2)
--|--|--
