### PR TITLE
fix(wallet): Speedup Transaction

### DIFF
--- a/components/brave_wallet_ui/components/extension/post-confirmation/common/speed_up_alert.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/common/speed_up_alert.tsx
@@ -4,28 +4,56 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 import * as React from 'react'
 import Button from '@brave/leo/react/button'
+import { useDispatch } from 'react-redux'
+
+// Actions
+import * as WalletPanelActions from '../../../../panel/actions/wallet_panel_actions'
 
 // Utils
 import { getLocale } from '$web-common/locale'
+import { getCoinFromTxDataUnion } from '../../../../utils/network-utils'
+
+// Types
+import { SerializableTransactionInfo } from '../../../../constants/types'
+
+// Hooks
+import {
+  useSpeedupTransactionMutation //
+} from '../../../../common/slices/api.slice'
 
 // Styled Components
 import { Alert } from './common.style'
 
 interface Props {
-  onSpeedUp?: () => void
+  transaction: SerializableTransactionInfo
 }
 
 export const SpeedUpAlert = (props: Props) => {
-  const { onSpeedUp } = props
+  const { transaction } = props
+
+  // Computed
+  const txCoinType = getCoinFromTxDataUnion(transaction.txDataUnion)
+
+  // Hooks
+  const [speedupTx] = useSpeedupTransactionMutation()
+  const dispatch = useDispatch()
+
+  // Methods
+  const onClickSpeedUpTransaction = () => {
+    speedupTx({
+      coinType: txCoinType,
+      chainId: transaction.chainId,
+      transactionId: transaction.id
+    })
+    dispatch(WalletPanelActions.setSelectedTransactionId(undefined))
+  }
 
   return (
-    <Alert
-      type='info'
-    >
+    <Alert type='info'>
       {getLocale('braveWalletTransactionTakingLongTime')}
       <div slot='content-after'>
         <Button
-          onClick={onSpeedUp}
+          onClick={onClickSpeedUpTransaction}
           kind='outline'
           size='tiny'
         >

--- a/components/brave_wallet_ui/components/extension/post-confirmation/submitted_or_signed/submitted_or_signed.tsx
+++ b/components/brave_wallet_ui/components/extension/post-confirmation/submitted_or_signed/submitted_or_signed.tsx
@@ -94,7 +94,7 @@ export const TransactionSubmittedOrSigned = (props: Props) => {
           padding='0px 24px'
         >
           {txCoinType === BraveWallet.CoinType.ETH && showSpeedUpAlert ? (
-            <SpeedUpAlert />
+            <SpeedUpAlert transaction={transaction} />
           ) : (
             <VerticalSpace space='114px' />
           )}


### PR DESCRIPTION
## Description 

Fixes a bug where the `Speedup` transaction button was not initiating a new transaction.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42799>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create and submit an `EVM` transaction
2. Wait for the `Speedup` transaction alert to show up
3. Click `Speedup` transaction
4. It should initiate a `Speedup` transaction for you


Before:

https://github.com/user-attachments/assets/fcd7b840-0694-4a88-a01b-f45923984f04

After:

https://github.com/user-attachments/assets/ab03376d-e409-481d-a591-8cbeb875564f
