### PR TITLE
[iOS] - Inject VPN subscription info on script message

### DIFF
--- a/ios/brave-ios/Sources/Brave/BraveSkus/BraveSkusAccountLink.swift
+++ b/ios/brave-ios/Sources/Brave/BraveSkus/BraveSkusAccountLink.swift
@@ -12,7 +12,7 @@ import os.log
 
 extension BraveStoreProduct {
   /// The key to use when storing the receipt in WebKit's LocalStorage
-  fileprivate var localStorageKey: String {
+  var localStorageKey: String {
     switch self {
     case .vpnMonthly, .vpnYearly: return "braveVpn.receipt"
     case .leoMonthly, .leoYearly: return "braveLeo.receipt"

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
@@ -38,8 +38,7 @@ class BraveSkusScriptHandler: TabContentScript {
 
     return WKUserScript(
       source: secureScript(
-        handlerNamesMap: ["$<message_handler>": messageHandlerName]
-          .merging(Method.map, uniquingKeysWith: { $1 }),
+        handlerNamesMap: ["$<message_handler>": messageHandlerName],
         securityToken: scriptId,
         script: script
       ),

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/BraveSkusScriptHandler.swift
@@ -6,8 +6,10 @@
 import AIChat
 import BraveCore
 import BraveShared
+import BraveStore
 import BraveVPN
 import Foundation
+import Preferences
 import Shared
 import WebKit
 import os.log
@@ -109,6 +111,30 @@ class BraveSkusScriptHandler: TabContentScript {
     case .credentialsSummary:
       let summary = try CredentialSummaryMessage.from(message: message)
       return await skusManager.credentialSummary(for: summary.domain)
+
+    case .setLocalStorageReceipt:
+      let storeMessage = try StoreReceiptMessage.from(message: message)
+      if storeMessage.message == "vpn" {
+        if let vpnSubscriptionProductId = Preferences.VPN.subscriptionProductId.value,
+          let product = BraveStoreProduct(rawValue: vpnSubscriptionProductId)
+        {
+          let storageKey = product.localStorageKey
+          let receipt = try BraveSkusSDK.receipt(for: product)
+          return ["key": storageKey, "data": receipt]
+        }
+      }
+
+      if storeMessage.message == "leo" {
+        if let aiChatSubscriptionProductId = Preferences.AIChat.subscriptionProductId.value,
+          let orderId = Preferences.AIChat.subscriptionOrderId.value,
+          let product = BraveStoreProduct(rawValue: aiChatSubscriptionProductId)
+        {
+          let storageKey = product.localStorageKey
+          let receipt = try BraveSkusSDK.receipt(for: product)
+          return ["key": storageKey, "data": receipt, "braveLeo.orderId": orderId]
+        }
+      }
+      throw SkusWebMessageError.invalidFormat
     }
   }
 }
@@ -119,6 +145,7 @@ extension BraveSkusScriptHandler {
     case fetchOrderCredentials = 2
     case prepareCredentialsPresentation = 3
     case credentialsSummary = 4
+    case setLocalStorageReceipt = 5
 
     static var map: [String: String] {
       var jsDict = [String: String]()
@@ -140,6 +167,10 @@ extension BraveSkusScriptHandler {
 
   private struct CredentialSummaryMessage: SkusWebMessage {
     let domain: String
+  }
+
+  private struct StoreReceiptMessage: SkusWebMessage {
+    let message: String
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSkusScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/BraveSkusScript.js
@@ -17,6 +17,31 @@ window.__firefox__.includeOnce("BraveSkusScript", function($) {
   if (!window.chrome) {
     window.chrome = {};
   }
+  
+  // Request VPN Receipt
+  sendMessage($<setLocalStorageReceipt>, { "message": "vpn" })
+  .then(function(jsonData) {
+    if (jsonData) {
+      window.localStorage.setItem(jsonData["key"], jsonData["data"]);
+    } else {
+      console.error("No VPN Subscription Data");
+    }
+  }).catch(function(err) {
+    console.error(`An error occurred setting the local storage receipt: ${err}`);
+  });
+  
+  // Request Leo Receipt
+  sendMessage($<setLocalStorageReceipt>, { "message": "leo" })
+  .then(function(jsonData) {
+    if (jsonData) {
+      window.localStorage.setItem("braveLeo.orderId", jsonData["braveLeo.orderId"])
+      window.localStorage.setItem(jsonData["key"], jsonData["data"]);
+    } else {
+      console.error("No Leo Subscription Data");
+    }
+  }).catch(function(err) {
+    console.error(`An error occurred setting the local storage receipt: ${err}`);
+  });
 
   Object.defineProperty(window.chrome, 'braveSkus', {
     enumerable: false,

--- a/ios/brave-ios/Sources/BraveVPN/Components/BuyVPN/Paywall/BraveVPNPaywallView.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/BuyVPN/Paywall/BraveVPNPaywallView.swift
@@ -202,9 +202,9 @@ public struct BraveVPNPaywallView: View {
             .font(.body.weight(.semibold))
             .foregroundColor(Color(.white))
             .padding()
-            .frame(maxWidth: .infinity)
           }
         }
+        .frame(maxWidth: .infinity)
         .background(
           LinearGradient(
             gradient:


### PR DESCRIPTION
## Summary
- Similar to Brave-Translate, inject code on the fly at request. The receipt is injected into the page in `didFinish`, but sometimes it seems to NOT work :S
- This PR injects subscriptions info on message `.atDocumentStart` before the page is loaded.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42801

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

