### PR TITLE
[ads] Disable NotificationAdPopupBrowserTest (uplift to 1.73.x)

### DIFF
--- a/browser/ui/views/brave_ads/notification_ad_popup_browsertest.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup_browsertest.cc
@@ -59,7 +59,8 @@ class NotificationAdPopupBrowserTest
   base::test::ScopedFeatureList scoped_feature_list_;
 };
 
-IN_PROC_BROWSER_TEST_P(NotificationAdPopupBrowserTest, CheckThemeChanged) {
+IN_PROC_BROWSER_TEST_P(NotificationAdPopupBrowserTest,
+                       DISABLED_CheckThemeChanged) {
   // Check appearance in light theme.
   dark_mode::SetBraveDarkModeType(
       dark_mode::BraveDarkModeType::BRAVE_DARK_MODE_TYPE_LIGHT);


### PR DESCRIPTION
Uplift of #26960
Resolves https://github.com/brave/brave-browser/issues/42797

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.