### PR TITLE
Don't show toast notifications when copying links or images (uplift to 1.74.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/toasts/toast_controller.cc
+++ b/chromium_src/chrome/browser/ui/toasts/toast_controller.cc
@@ -1,0 +1,18 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/toasts/toast_controller.h"
+
+#define MaybeShowToast MaybeShowToast_ChromiumImpl
+#include "src/chrome/browser/ui/toasts/toast_controller.cc"
+#undef MaybeShowToast
+
+bool ToastController::MaybeShowToast(ToastParams params) {
+  if (params.toast_id == ToastId::kLinkCopied ||
+      params.toast_id == ToastId::kImageCopied) {
+    return false;
+  }
+  return MaybeShowToast_ChromiumImpl(std::move(params));
+}

--- a/chromium_src/chrome/browser/ui/toasts/toast_controller.h
+++ b/chromium_src/chrome/browser/ui/toasts/toast_controller.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_TOASTS_TOAST_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_TOASTS_TOAST_CONTROLLER_H_
+
+#define MaybeShowToast                             \
+  MaybeShowToast_ChromiumImpl(ToastParams params); \
+  bool MaybeShowToast
+
+#include "src/chrome/browser/ui/toasts/toast_controller.h"  // IWYU pragma: export
+
+#undef MaybeShowToast
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_TOASTS_TOAST_CONTROLLER_H_

--- a/chromium_src/chrome/browser/ui/toasts/toast_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toasts/toast_controller_unittest.cc
@@ -1,0 +1,43 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/toasts/api/toast_id.h"
+
+// All of the upstream unit tests use kLinkCopied or kImageCopied when creating
+// test toasts, but those are the two notifications we want to hide so redefine
+// their identifiers here so we can continue to run the upstream tests.
+#define kLinkCopied kLinkToHighlightCopied
+#define kImageCopied kAddedToReadingList
+#include "src/chrome/browser/ui/toasts/toast_controller_unittest.cc"
+#undef kImageCopied
+#undef kLinkCopied
+
+TEST_F(ToastControllerUnitTest, NeverShowToastForLinkCopied) {
+  ToastRegistry* const registry = toast_registry();
+  registry->RegisterToast(
+      ToastId::kLinkCopied,
+      ToastSpecification::Builder(vector_icons::kEmailIcon, 0).Build());
+
+  auto controller = std::make_unique<TestToastController>(registry);
+
+  EXPECT_FALSE(controller->IsShowingToast());
+  EXPECT_TRUE(controller->CanShowToast(ToastId::kLinkCopied));
+  EXPECT_FALSE(controller->MaybeShowToast(ToastParams(ToastId::kLinkCopied)));
+  EXPECT_FALSE(controller->IsShowingToast());
+}
+
+TEST_F(ToastControllerUnitTest, NeverShowToastForImageCopied) {
+  ToastRegistry* const registry = toast_registry();
+  registry->RegisterToast(
+      ToastId::kImageCopied,
+      ToastSpecification::Builder(vector_icons::kEmailIcon, 0).Build());
+
+  auto controller = std::make_unique<TestToastController>(registry);
+
+  EXPECT_FALSE(controller->IsShowingToast());
+  EXPECT_TRUE(controller->CanShowToast(ToastId::kImageCopied));
+  EXPECT_FALSE(controller->MaybeShowToast(ToastParams(ToastId::kImageCopied)));
+  EXPECT_FALSE(controller->IsShowingToast());
+}

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1939,6 +1939,11 @@
 -ComponentManagerUpdateCheckBrowserTest.RegisterAndUnregisterTranslateKitLanguagePackComponent
 -ComponentManagerUpdateCheckBrowserTest.RegisterTranslateKitComponent
 
+# We disable the ImageCopied/LinkCopied toast notifications
+-All/ContextMenuBrowserTest.ShowsToastOnImageCopied/*
+-All/ContextMenuBrowserTest.ShowsToastOnLinkCopied/*
+-BrowserCommandsTest.CopyingUrlOpensToast
+
 # Tests below this point have not been diagnosed or had issues created yet.
 -_/WebrtcLoggingPrivateApiStartEventLoggingTestFeatureAndPolicyEnabled.*
 -AccessCodeCastHandlerBrowserTest.*


### PR DESCRIPTION
Uplift of #26970
Resolves https://github.com/brave/brave-browser/issues/42782

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.