### PR TITLE
feature(privacy): Add debug view to iOS to display blocked requests per-tab

### DIFF
--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -107,6 +107,11 @@ BASE_FEATURE(kBraveShredCacheData,
 #else
              base::FEATURE_DISABLED_BY_DEFAULT);
 #endif
+// When enabled, will display debug menu for adblock features in the Shields
+// panel.
+BASE_FEATURE(kBraveIOSDebugAdblock,
+             "BraveIOSDebugAdblock",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 // When enabled, show Strict (aggressive) fingerprinting mode in Brave Shields.
 BASE_FEATURE(kBraveShowStrictFingerprintingMode,
              "BraveShowStrictFingerprintingMode",

--- a/components/brave_shields/core/common/features.h
+++ b/components/brave_shields/core/common/features.h
@@ -34,6 +34,7 @@ BASE_DECLARE_FEATURE(kBraveLocalhostAccessPermission);
 BASE_DECLARE_FEATURE(kBraveReduceLanguage);
 BASE_DECLARE_FEATURE(kBraveShredFeature);
 BASE_DECLARE_FEATURE(kBraveShredCacheData);
+BASE_DECLARE_FEATURE(kBraveIOSDebugAdblock);
 BASE_DECLARE_FEATURE(kBraveShowStrictFingerprintingMode);
 BASE_DECLARE_FEATURE(kCosmeticFilteringExtraPerfMetrics);
 BASE_DECLARE_FEATURE(kCosmeticFilteringJsPerformance);

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdblockBlockedRequestsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdblockBlockedRequestsView.swift
@@ -1,0 +1,74 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveShields
+import Strings
+import SwiftUI
+
+struct AdblockBlockedRequestsView: View {
+
+  let url: String
+  @ObservedObject var contentBlockerHelper: ContentBlockerHelper
+
+  @State private var filterText: String = ""
+
+  private var blockedRequests: [BlockedRequestInfo] {
+    let blockedRequests = Array(contentBlockerHelper.blockedRequests)
+    guard !filterText.isEmpty else {
+      return blockedRequests
+    }
+    return blockedRequests.filter {
+      $0.requestURL.absoluteString.localizedCaseInsensitiveContains(filterText)
+        || $0.sourceURL.absoluteString.localizedCaseInsensitiveContains(filterText)
+        || $0.resourceType.rawValue.localizedCaseInsensitiveContains(filterText)
+        || $0.location.display.localizedCaseInsensitiveContains(filterText)
+    }
+  }
+
+  public var body: some View {
+    List {
+      Section(header: Text(url)) {
+        ForEach(blockedRequests) { request in
+          VStack {
+            row(
+              title: String.localizedStringWithFormat("%@:", Strings.Shields.requestURLLabel),
+              detail: request.requestURL.absoluteString
+            )
+            row(
+              title: String.localizedStringWithFormat("%@:", Strings.Shields.sourceURLLabel),
+              detail: request.sourceURL.absoluteString
+            )
+            row(
+              title: String.localizedStringWithFormat("%@:", Strings.Shields.resourceTypeLabel),
+              detail: request.resourceType.rawValue
+            )
+            row(
+              title: String.localizedStringWithFormat("%@:", Strings.Shields.aggressiveLabel),
+              detail: "\(request.isAggressive)"
+            )
+            row(
+              title: String.localizedStringWithFormat("%@:", Strings.Shields.blockedByLabel),
+              detail: request.location.display
+            )
+          }
+        }
+      }
+    }
+    .navigationTitle(Strings.Shields.blockedRequestsTitle)
+    .toolbar(.visible)
+    .searchable(text: $filterText)
+  }
+
+  @ViewBuilder private func row(title: String, detail: String) -> some View {
+    Group {
+      Text(title)
+      Text(detail)
+        .font(.system(.caption, design: .monospaced))
+        .textSelection(.enabled)
+    }
+    .font(.body)
+    .frame(maxWidth: .infinity, alignment: .leading)
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdblockBlockedRequestsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/Features/ShieldsPrivacy/AdblockBlockedRequestsView.swift
@@ -16,7 +16,7 @@ struct AdblockBlockedRequestsView: View {
 
   private var blockedRequests: [BlockedRequestInfo] {
     let blockedRequests = Array(contentBlockerHelper.blockedRequests)
-    guard !filterText.isEmpty else {
+    if filterText.isEmpty {
       return blockedRequests
     }
     return blockedRequests.filter {
@@ -61,7 +61,7 @@ struct AdblockBlockedRequestsView: View {
     .searchable(text: $filterText)
   }
 
-  @ViewBuilder private func row(title: String, detail: String) -> some View {
+  private func row(title: String, detail: String) -> some View {
     Group {
       Text(title)
       Text(detail)

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
@@ -27,7 +27,7 @@ struct ShieldsPanelView: View {
   }
 
   private let url: URL
-  private weak var tab: Tab?
+  private var tab: Tab?
   private let displayHost: String
   @AppStorage("advancedShieldsExpanded") private var advancedShieldsExpanded = false
   @ObservedObject private var viewModel: ShieldsSettingsViewModel

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
@@ -27,6 +27,7 @@ struct ShieldsPanelView: View {
   }
 
   private let url: URL
+  private weak var tab: Tab?
   private let displayHost: String
   @AppStorage("advancedShieldsExpanded") private var advancedShieldsExpanded = false
   @ObservedObject private var viewModel: ShieldsSettingsViewModel
@@ -34,6 +35,7 @@ struct ShieldsPanelView: View {
 
   @MainActor init(url: URL, tab: Tab, domain: Domain, callback: @escaping (Action) -> Void) {
     self.url = url
+    self.tab = tab
     self.viewModel = ShieldsSettingsViewModel(tab: tab, domain: domain)
     self.actionCallback = callback
     self.displayHost =
@@ -242,6 +244,25 @@ struct ShieldsPanelView: View {
         } label: {
           ShieldSettingsNavigationWrapper {
             Text(Strings.Shields.shredSiteData)
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .multilineTextAlignment(.leading)
+          }
+        }
+        .foregroundStyle(Color(.bravePrimary))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 4)
+      }
+    }
+    if FeatureList.kBraveIOSDebugAdblock.enabled, let contentBlocker = tab?.contentBlocker {
+      ShieldSettingRow {
+        NavigationLink {
+          AdblockBlockedRequestsView(
+            url: url.baseDomain ?? url.absoluteDisplayString,
+            contentBlockerHelper: contentBlocker
+          )
+        } label: {
+          ShieldSettingsNavigationWrapper {
+            Text(Strings.Shields.blockedRequestsTitle)
               .frame(maxWidth: .infinity, alignment: .leading)
               .multilineTextAlignment(.leading)
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/ContentBlockerScriptHandler.swift
@@ -136,8 +136,18 @@ extension ContentBlockerHelper: TabContentScript {
           }
 
           // First check to make sure we're not counting the same repetitive requests multiple times
-          guard !self.blockedRequests.contains(requestURL) else { return }
-          self.blockedRequests.insert(requestURL)
+          guard !self.blockedRequests.contains(where: { $0.requestURL == requestURL }) else {
+            return
+          }
+          self.blockedRequests.append(
+            .init(
+              requestURL: requestURL,
+              sourceURL: sourceURL,
+              resourceType: dto.resourceType,
+              isAggressive: domain.globalBlockAdsAndTrackingLevel.isAggressive,
+              location: .contentBlocker
+            )
+          )
 
           // Increase global stats (here due to BlocklistName being in Client and BraveGlobalShieldStats being
           // in BraveShared)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RequestBlockingContentScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RequestBlockingContentScriptHandler.swift
@@ -109,11 +109,21 @@ class RequestBlockingContentScriptHandler: TabContentScript {
           )
         }
 
-        if shouldBlock && !tab.contentBlocker.blockedRequests.contains(requestURL) {
+        if shouldBlock
+          && !tab.contentBlocker.blockedRequests.contains(where: { $0.requestURL == requestURL })
+        {
           BraveGlobalShieldStats.shared.adblock += 1
           let stats = tab.contentBlocker.stats
           tab.contentBlocker.stats = stats.adding(adCount: 1)
-          tab.contentBlocker.blockedRequests.insert(requestURL)
+          tab.contentBlocker.blockedRequests.append(
+            .init(
+              requestURL: requestURL,
+              sourceURL: windowOriginURL,
+              resourceType: dto.data.resourceType,
+              isAggressive: domain.globalBlockAdsAndTrackingLevel.isAggressive,
+              location: .requestBlocking
+            )
+          )
         }
 
         replyHandler(shouldBlock, nil)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
@@ -31,7 +31,7 @@ window.__firefox__.execute(function($) {
 
     sendInfo.push({
       resourceURL: resourceURL.href,
-      sourceURL: document.location.href,
+      sourceURL: $.windowOrigin,
       resourceType: resourceType
     });
 

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -117,7 +117,7 @@ extension Strings.Shields {
 
 extension Strings.Shields {
   public static let blockedRequestsTitle = NSLocalizedString(
-    "blockedRequestsTitle",
+    "shields.blockedRequestsTitle",
     tableName: "BraveShared",
     bundle: .module,
     value: "Blocked Requests",
@@ -125,7 +125,7 @@ extension Strings.Shields {
       "The title displayed in the navigation bar of Blocked Requests view."
   )
   public static let requestURLLabel = NSLocalizedString(
-    "requestURLLabel",
+    "shields.requestURLLabel",
     tableName: "BraveShared",
     bundle: .module,
     value: "Request URL",
@@ -133,7 +133,7 @@ extension Strings.Shields {
       "A label displayed above the request url that was blocked in Blocked Requests view."
   )
   public static let sourceURLLabel = NSLocalizedString(
-    "sourceURLLabel",
+    "shields.sourceURLLabel",
     tableName: "BraveShared",
     bundle: .module,
     value: "Source URL",
@@ -141,7 +141,7 @@ extension Strings.Shields {
       "A label displayed above the source url of a request that was blocked in Blocked Requests view."
   )
   public static let resourceTypeLabel = NSLocalizedString(
-    "resourceTypeLabel",
+    "shields.resourceTypeLabel",
     tableName: "BraveShared",
     bundle: .module,
     value: "Resource Type",
@@ -149,7 +149,7 @@ extension Strings.Shields {
       "A label displayed above the resource type of a request that was blocked in Blocked Requests view."
   )
   public static let aggressiveLabel = NSLocalizedString(
-    "aggressiveLabel",
+    "shields.aggressiveLabel",
     tableName: "BraveShared",
     bundle: .module,
     value: "Aggressive",
@@ -157,7 +157,7 @@ extension Strings.Shields {
       "A label displayed above a value indicating if the site is in aggressive mode in Blocked Requests view."
   )
   public static let blockedByLabel = NSLocalizedString(
-    "blockedByLabel",
+    "shields.blockedByLabel",
     tableName: "BraveShared",
     bundle: .module,
     value: "Blocked By",
@@ -165,7 +165,7 @@ extension Strings.Shields {
       "A label displayed above the location a request was blocked in Blocked Requests view."
   )
   public static let contentBlocker = NSLocalizedString(
-    "contentBlocker",
+    "shields.contentBlocker",
     tableName: "BraveShared",
     bundle: .module,
     value: "Content Blocker",
@@ -173,7 +173,7 @@ extension Strings.Shields {
       "Used to describe when a request was blocked by the Content Blocker in Blocked Requests view."
   )
   public static let requestBlocking = NSLocalizedString(
-    "requestBlocking",
+    "shields.requestBlocking",
     tableName: "BraveShared",
     bundle: .module,
     value: "Request Blocking",

--- a/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
+++ b/ios/brave-ios/Sources/BraveShields/ShieldStrings.swift
@@ -113,6 +113,75 @@ extension Strings.Shields {
   )
 }
 
+// MARK: - Adblock Debugging
+
+extension Strings.Shields {
+  public static let blockedRequestsTitle = NSLocalizedString(
+    "blockedRequestsTitle",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Blocked Requests",
+    comment:
+      "The title displayed in the navigation bar of Blocked Requests view."
+  )
+  public static let requestURLLabel = NSLocalizedString(
+    "requestURLLabel",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Request URL",
+    comment:
+      "A label displayed above the request url that was blocked in Blocked Requests view."
+  )
+  public static let sourceURLLabel = NSLocalizedString(
+    "sourceURLLabel",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Source URL",
+    comment:
+      "A label displayed above the source url of a request that was blocked in Blocked Requests view."
+  )
+  public static let resourceTypeLabel = NSLocalizedString(
+    "resourceTypeLabel",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Resource Type",
+    comment:
+      "A label displayed above the resource type of a request that was blocked in Blocked Requests view."
+  )
+  public static let aggressiveLabel = NSLocalizedString(
+    "aggressiveLabel",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Aggressive",
+    comment:
+      "A label displayed above a value indicating if the site is in aggressive mode in Blocked Requests view."
+  )
+  public static let blockedByLabel = NSLocalizedString(
+    "blockedByLabel",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Blocked By",
+    comment:
+      "A label displayed above the location a request was blocked in Blocked Requests view."
+  )
+  public static let contentBlocker = NSLocalizedString(
+    "contentBlocker",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Content Blocker",
+    comment:
+      "Used to describe when a request was blocked by the Content Blocker in Blocked Requests view."
+  )
+  public static let requestBlocking = NSLocalizedString(
+    "requestBlocking",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Request Blocking",
+    comment:
+      "Used to describe when a request was blocked by our request blocking scripts in Blocked Requests view."
+  )
+}
+
 // MARK: - Anti Ad-Block Warning
 
 extension Strings.Shields {

--- a/ios/browser/api/features/features.h
+++ b/ios/browser/api/features/features.h
@@ -52,6 +52,7 @@ OBJC_EXPORT
 @property(class, nonatomic, readonly) Feature* kBraveSearchDefaultAPIFeature;
 @property(class, nonatomic, readonly) Feature* kBraveShredFeature;
 @property(class, nonatomic, readonly) Feature* kBraveShredCacheData;
+@property(class, nonatomic, readonly) Feature* kBraveIOSDebugAdblock;
 @property(class, nonatomic, readonly)
     Feature* kBraveShowStrictFingerprintingMode;
 @property(class, nonatomic, readonly) Feature* kBraveSync;

--- a/ios/browser/api/features/features.mm
+++ b/ios/browser/api/features/features.mm
@@ -206,6 +206,11 @@
       initWithFeature:&brave_shields::features::kBraveShredCacheData];
 }
 
++ (Feature*)kBraveIOSDebugAdblock {
+  return [[Feature alloc]
+      initWithFeature:&brave_shields::features::kBraveIOSDebugAdblock];
+}
+
 + (Feature*)kBraveShowStrictFingerprintingMode {
   return
       [[Feature alloc] initWithFeature:&brave_shields::features::

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -113,6 +113,13 @@
           flags_ui::kOsIos,                                                    \
           FEATURE_VALUE_TYPE(                                                  \
               security_interstitials::features::kHttpsOnlyMode),               \
+      },                                                                       \
+      {                                                                        \
+          "ios-debug-adblock",                                                 \
+          "Enable Debug Adblock views",                                        \
+          "Enable debug view for adblock features in Shields panel",           \
+          flags_ui::kOsIos,                                                    \
+          FEATURE_VALUE_TYPE(brave_shields::features::kBraveIOSDebugAdblock),  \
       })
 
 #define BRAVE_AI_CHAT_FEATURE_ENTRIES                                      \


### PR DESCRIPTION
- Add a `BraveIOSDebugAdblock` feature flag (default: disabled) that when enabled will display blocked requests for a given tab in it's Shield panel under advanced controls.
    - The flag name is intentionally generic as it will later be used to incorporate more adblock / content filtering debugging tools in the future.
- These requests are already logged to the console (viewable via Safari debugger when connected to macOS), but now will display in-app

Resolves https://github.com/brave/brave-browser/issues/42842

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enter `brave://flags` and enable `#ios-debug-adblock` feature flag
    - If `brave://flags` is not working (see https://github.com/brave/brave-browser/issues/42843), visit Settings -> 'BraveCore Switches' -> 'Enable Features' and add `BraveIOSDebugAdblock`
2. Restart the app for feature flag to take effect
3. Visit any website, tap Shields icon and open advanced controls
4. Tap `Blocked Requests`
5. Verify blocked requests are displayed
6. Pull down to display search bar, verify filtering works (filters by request url, source url, resource type

![Shields Panel (expanded)](https://github.com/user-attachments/assets/76f10674-8bd1-4c14-b604-3c79ee18f38e) | ![Blocked Requests](https://github.com/user-attachments/assets/a15c9824-040f-46bc-b8f0-407514d3bdad) | ![Blocked Requests (filtered)](https://github.com/user-attachments/assets/0dd62b40-e481-43b1-9d6f-dad9f389d112)
--|--|--