### PR TITLE
Fixed blank tab is shown after attaching split view

### DIFF
--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -856,14 +856,12 @@ void BraveBrowserView::OnTileTabs(const TabTile& tile) {
   UpdateContentsWebViewVisual();
 }
 
-void BraveBrowserView::OnWillBreakTile(const TabTile& tile) {
+void BraveBrowserView::OnDidBreakTile(const TabTile& tile) {
   if (!IsActiveWebContentsTiled(tile)) {
     return;
   }
 
-  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE, base::BindOnce(&BraveBrowserView::UpdateContentsWebViewVisual,
-                                weak_ptr_.GetWeakPtr()));
+  UpdateContentsWebViewVisual();
 }
 
 void BraveBrowserView::OnSwapTabsInTile(const TabTile& tile) {

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -131,7 +131,7 @@ class BraveBrowserView : public BrowserView,
 
   // SplitViewBrowserDataObserver:
   void OnTileTabs(const TabTile& tile) override;
-  void OnWillBreakTile(const TabTile& tile) override;
+  void OnDidBreakTile(const TabTile& tile) override;
   void OnSwapTabsInTile(const TabTile& tile) override;
 
   views::WebView* secondary_contents_web_view() {

--- a/browser/ui/views/frame/split_view_browsertest.cc
+++ b/browser/ui/views/frame/split_view_browsertest.cc
@@ -82,7 +82,6 @@ IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest,
       split_view_data->IsTabTiled(tab_strip_model().GetTabHandleAt(0)));
 
   // Then, the secondary web view should become hidden
-  base::RunLoop().RunUntilIdle();
   EXPECT_FALSE(secondary_contents_view().GetVisible());
 }
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/41852

When split view transfers to another browser,
its web contents should be cleared before attached to target browser.
It's done by SplitView::UpdateContentsWebViewVisual().

So far, we posted it to next turn when we break tile.
If we break a tile by unsplit, it doesn't cause any issue because
any other secondary web view doesn't host that secondary web contents.

However, if it's attached to another browser window, it's another story.
When we detach a split view from browser A and attach to browser B,
browser A breaks a tile after detached.
And then, they are attached to browser B and we make them as a split view.
If we don't clear secondary web contents after break the tile synchronously,
browser A and browser B's secondary web view has same web contents till posted `UpdateContentsWebViewVisual()` executed.
This could cause unexpected behavior like above issue.
So, secondary web view should be cleared synchronously after breaking a tile.


https://github.com/user-attachments/assets/0a7c2099-fe48-4643-a686-ea7f10bdaa46



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

SplitViewBrowserTest.BreakingTileMakesSecondaryWebViewHidden

See the linked issue for manul test