### PR TITLE
Remove toast notification for adding article to reading list (uplift to 1.74.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/toasts/toast_controller.cc
+++ b/chromium_src/chrome/browser/ui/toasts/toast_controller.cc
@@ -11,7 +11,8 @@
 
 bool ToastController::MaybeShowToast(ToastParams params) {
   if (params.toast_id == ToastId::kLinkCopied ||
-      params.toast_id == ToastId::kImageCopied) {
+      params.toast_id == ToastId::kImageCopied ||
+      params.toast_id == ToastId::kAddedToReadingList) {
     return false;
   }
   return MaybeShowToast_ChromiumImpl(std::move(params));

--- a/chromium_src/chrome/browser/ui/toasts/toast_controller_unittest.cc
+++ b/chromium_src/chrome/browser/ui/toasts/toast_controller_unittest.cc
@@ -9,7 +9,7 @@
 // test toasts, but those are the two notifications we want to hide so redefine
 // their identifiers here so we can continue to run the upstream tests.
 #define kLinkCopied kLinkToHighlightCopied
-#define kImageCopied kAddedToReadingList
+#define kImageCopied kClearBrowsingData
 #include "src/chrome/browser/ui/toasts/toast_controller_unittest.cc"
 #undef kImageCopied
 #undef kLinkCopied
@@ -39,5 +39,20 @@ TEST_F(ToastControllerUnitTest, NeverShowToastForImageCopied) {
   EXPECT_FALSE(controller->IsShowingToast());
   EXPECT_TRUE(controller->CanShowToast(ToastId::kImageCopied));
   EXPECT_FALSE(controller->MaybeShowToast(ToastParams(ToastId::kImageCopied)));
+  EXPECT_FALSE(controller->IsShowingToast());
+}
+
+TEST_F(ToastControllerUnitTest, NeverShowToastForAddedToReadingList) {
+  ToastRegistry* const registry = toast_registry();
+  registry->RegisterToast(
+      ToastId::kAddedToReadingList,
+      ToastSpecification::Builder(vector_icons::kEmailIcon, 0).Build());
+
+  auto controller = std::make_unique<TestToastController>(registry);
+
+  EXPECT_FALSE(controller->IsShowingToast());
+  EXPECT_TRUE(controller->CanShowToast(ToastId::kAddedToReadingList));
+  EXPECT_FALSE(
+      controller->MaybeShowToast(ToastParams(ToastId::kAddedToReadingList)));
   EXPECT_FALSE(controller->IsShowingToast());
 }

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1939,9 +1939,10 @@
 -ComponentManagerUpdateCheckBrowserTest.RegisterAndUnregisterTranslateKitLanguagePackComponent
 -ComponentManagerUpdateCheckBrowserTest.RegisterTranslateKitComponent
 
-# We disable the ImageCopied/LinkCopied toast notifications
+# We disable the AddToReadingList/ImageCopied/LinkCopied toast notifications
 -All/ContextMenuBrowserTest.ShowsToastOnImageCopied/*
 -All/ContextMenuBrowserTest.ShowsToastOnLinkCopied/*
+-BrowserCommandsTest.AddingToReadingListOpensToast
 -BrowserCommandsTest.CopyingUrlOpensToast
 
 # Tests below this point have not been diagnosed or had issues created yet.


### PR DESCRIPTION
Uplift of #26998
Resolves https://github.com/brave/brave-browser/issues/42857

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.