### PR TITLE
[iOS] Fix request desktop site action in new menu UI

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -145,9 +145,15 @@ extension BrowserViewController {
       }
 
       // Request Desktop Site Activity
+      let isDesktopSite = tab?.isDesktopSite ?? false
+      var requestDesktopSite = BasicMenuActivity.ActivityType.requestDesktopSite
+      if isDesktopSite {
+        requestDesktopSite.title = Strings.appMenuViewMobileSiteTitleString
+        requestDesktopSite.braveSystemImage = "leo.smartphone"
+      }
       activities.append(
         BasicMenuActivity(
-          activityType: tab?.isDesktopSite == true ? .requestMobileSite : .requestDesktopSite,
+          activityType: requestDesktopSite,
           callback: {
             tab?.switchUserAgent()
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -961,6 +961,7 @@ extension BrowserViewController: ToolbarDelegate {
       presentBrowserMenu(
         from: tabToolbar.menuButton,
         activities: activities,
+        tab: tabManager.selectedTab,
         pageURL: selectedTabURL,
         webView: tabManager.selectedTab?.webView
       )

--- a/ios/brave-ios/Sources/Brave/Frontend/Share/ShareExtensionHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Share/ShareExtensionHelper.swift
@@ -94,13 +94,8 @@ extension BasicMenuActivity.ActivityType {
     title: Strings.addToFavorites,
     braveSystemImage: "leo.widget.generic"
   )
-  static let requestMobileSite: Self = .init(
-    id: "RequestMobileSite",
-    title: Strings.appMenuViewMobileSiteTitleString,
-    braveSystemImage: "leo.smartphone"
-  )
   static let requestDesktopSite: Self = .init(
-    id: "RequestDesktopSite",
+    id: "ToggleUserAgent",
     title: Strings.appMenuViewDesktopSiteTitleString,
     braveSystemImage: "leo.monitor"
   )

--- a/ios/brave-ios/Sources/BrowserMenu/BrowserMenu.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/BrowserMenu.swift
@@ -132,10 +132,8 @@ public struct BrowserMenu: View {
             }
           }
           .modifier(MenuRowButtonStyleModifier())
-          .background(
-            Color(braveSystemName: .iosBrowserContainerHighlightIos),
-            in: .rect(cornerRadius: 14, style: .continuous)
-          )
+          .background(Color(braveSystemName: .iosBrowserContainerHighlightIos))
+          .clipShape(.rect(cornerRadius: 14, style: .continuous))
           .transition(.blurReplace())
         }
         Button {
@@ -144,10 +142,8 @@ public struct BrowserMenu: View {
           Label(Strings.BrowserMenu.allSettingsButtonTitle, braveSystemImage: "leo.settings")
         }
         .modifier(MenuRowButtonStyleModifier())
-        .background(
-          Color(braveSystemName: .iosBrowserContainerHighlightIos),
-          in: .rect(cornerRadius: 14, style: .continuous)
-        )
+        .background(Color(braveSystemName: .iosBrowserContainerHighlightIos))
+        .clipShape(.rect(cornerRadius: 14, style: .continuous))
       }
       .padding()
     }


### PR DESCRIPTION
This change merges the UIActivity version of "Request Desktop Site"/"Request Mobile Site" to a single identifier that matches the new menu UI's action identifier and then correctly sets it up in the new menu.

We specifically set it up as such because the new menu has to treat "Request Desktop Site" & "Request Mobile Site" as a single item since its user customizable

Resolves https://github.com/brave/brave-browser/issues/42875


## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Test that request desktop/mobile site works correctly on the old/current menu UI
- Test that request desktop/mobile site works correctly on the new menu UI (using feature flag to show)