### PR TITLE
Revert "Disable CustomBackgroundFileManagerBrowserTest.SaveImageMultipleTimes on Mac" (uplift to 1.74.x)

### DIFF
--- a/browser/ntp_background/custom_background_file_manager_browsertest.cc
+++ b/browser/ntp_background/custom_background_file_manager_browsertest.cc
@@ -15,7 +15,6 @@
 #include "base/threading/thread_restrictions.h"
 #include "brave/browser/ntp_background/constants.h"
 #include "brave/components/constants/brave_paths.h"
-#include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -112,16 +111,8 @@ IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
   EXPECT_TRUE(base::PathExists(test_file()));
 }
 
-#if BUILDFLAG(IS_MAC) && defined(ARCH_CPU_ARM_FAMILY)
-// On Mac ARM CI node, this test is flaky because of timeout.
-// https://github.com/brave/brave-browser/issues/29762
-#define MAYBE_SaveImageMultipleTimes DISABLED_SaveImageMultipleTimes
-#else
-#define MAYBE_SaveImageMultipleTimes SaveImageMultipleTimes
-#endif
-
 IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
-                       MAYBE_SaveImageMultipleTimes) {
+                       SaveImageMultipleTimes) {
   for (int i = 0; i < 3; i++) {
     base::RunLoop run_loop;
     base::FilePath expected_path =


### PR DESCRIPTION
Uplift of #27014

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.