### PR TITLE
Fixed wrong gap between tab and toolbar

### DIFF
--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -133,6 +133,13 @@ SkPath BraveVerticalTabStyle::GetPath(
         gfx::InsetsF::VH(brave_tabs::kHorizontalTabVerticalSpacing * scale,
                          brave_tabs::kHorizontalTabInset * scale));
 
+    // |aligned_bounds| is tab's bounds(). So, it includes insets also.
+    // Shrink height more if it's overlapped.
+    if (path_type != TabStyle::PathType::kHitTest) {
+      aligned_bounds.Inset(gfx::InsetsF::TLBR(
+          0, 0, GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP) * scale, 0));
+    }
+
     // For hit testing, expand the rectangle so that the visual margins around
     // tabs can be used to select the tab. This will ensure that there is no
     // "dead space" between tabs, or between the tab shape and the tab hover
@@ -250,7 +257,15 @@ gfx::Insets BraveVerticalTabStyle::GetContentsInsets() const {
   }
 
   // Ignore any stroke widths when determining the horizontal contents insets.
-  return tab_style()->GetContentsInsets();
+  // To make contents vertically align evenly regardless of overlap in non
+  // vertical tab, use it as bottom inset in a tab as it's hidden by
+  // overlapping.
+  const int bottom_inset = ShouldShowVerticalTabs()
+                               ? 0
+                               : GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP);
+
+  return tab_style()->GetContentsInsets() +
+         gfx::Insets::TLBR(0, 0, bottom_inset, 0);
 }
 
 TabStyle::SeparatorBounds BraveVerticalTabStyle::GetSeparatorBounds(

--- a/browser/ui/views/tabs/brave_tab_unittest.cc
+++ b/browser/ui/views/tabs/brave_tab_unittest.cc
@@ -4,11 +4,17 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 #include "brave/browser/ui/views/tabs/brave_tab.h"
+
+#include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/views/tabs/fake_tab_slot_controller.h"
+#include "chrome/browser/ui/views/tabs/tab_style_views.h"
 #include "chrome/test/views/chrome_views_test_base.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkPath.h"
+#include "third_party/skia/include/core/SkRegion.h"
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/rect.h"
+#include "ui/gfx/geometry/skia_conversions.h"
 #include "ui/views/test/views_test_utils.h"
 
 class BraveTabTest : public ChromeViewsTestBase {
@@ -38,4 +44,41 @@ TEST_F(BraveTabTest, ExtraPaddingLayoutTest) {
   LayoutAndCheckBorder(&tab, {0, 0, 100, 50});
   LayoutAndCheckBorder(&tab, {0, 0, 150, 50});
   LayoutAndCheckBorder(&tab, {0, 0, 30, 50});
+}
+
+// Check tab's region inside of vertical padding.
+TEST_F(BraveTabTest, TabHeightTest) {
+  FakeTabSlotController tab_slot_controller;
+  BraveTab tab(&tab_slot_controller);
+  tab.SetBoundsRect({0, 0, 100, GetLayoutConstant(TAB_STRIP_HEIGHT)});
+  EXPECT_EQ(tab.GetLocalBounds().height() -
+                GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP),
+            tab.GetContentsBounds().height());
+
+  SkPath mask = tab.tab_style_views()->GetPath(TabStyle::PathType::kFill,
+                                               /* scale */ 1.0,
+                                               /* force_active */ false,
+                                               TabStyle::RenderUnits::kDips);
+  SkRegion clip_region;
+  clip_region.setRect({0, 0, tab.width(), tab.height()});
+  SkRegion mask_region;
+  ASSERT_TRUE(mask_region.setPath(mask, clip_region));
+
+  // Check outside of tab region.
+  gfx::Rect rect(50, 0, 1, 1);
+  EXPECT_FALSE(mask_region.intersects(RectToSkIRect(rect)));
+  rect.set_y(GetLayoutConstant(TAB_STRIP_PADDING) - 1);
+  EXPECT_FALSE(mask_region.intersects(RectToSkIRect(rect)));
+
+  // Check inside of tab region.
+  rect.set_y(GetLayoutConstant(TAB_STRIP_PADDING));
+  EXPECT_TRUE(mask_region.intersects(RectToSkIRect(rect)));
+  rect.set_y(GetLayoutConstant(TAB_STRIP_PADDING) +
+             GetLayoutConstant(TAB_HEIGHT) - 1);
+  EXPECT_TRUE(mask_region.intersects(RectToSkIRect(rect)));
+
+  // Check outside of tab region.
+  rect.set_y(GetLayoutConstant(TAB_STRIP_PADDING) +
+             GetLayoutConstant(TAB_HEIGHT));
+  EXPECT_FALSE(mask_region.intersects(RectToSkIRect(rect)));
 }


### PR DESCRIPTION
It should be 4px when horizontal kBraveHorizontalTabsUpdate feature is enabled.
Also tab's contents should be vertically centered.

`TABSTRIP_TOOLBAR_OVERLAP` is set by https://github.com/brave/brave-core/pull/25537 to make non empty contents area and this change made bottom gap 3px.

fix https://github.com/brave/brave-browser/issues/42930

Horizontal mode:
![Screenshot 2024-12-17 150747](https://github.com/user-attachments/assets/eabaf28a-db13-4820-9108-657fbd8eb181)
![Screenshot 2024-12-17 150805](https://github.com/user-attachments/assets/d2b31ffd-090c-4fd6-9356-42adb669b09a)
![Screenshot 2024-12-17 150814](https://github.com/user-attachments/assets/692500ba-871e-4290-8ce6-50bb3f2361cf)
![Screenshot 2024-12-17 150844](https://github.com/user-attachments/assets/bc7e0adc-add2-4077-8eac-32a643eb9b23)

Horizontal compact mode:
![Screenshot 2024-12-17 154342](https://github.com/user-attachments/assets/e3b4617d-d44d-4909-9f5d-7f689b526d33)
![Screenshot 2024-12-17 154801](https://github.com/user-attachments/assets/80a04e9a-e277-466b-b8d3-bf886103bd8f)
![Screenshot 2024-12-17 154810](https://github.com/user-attachments/assets/c8b15eed-105b-4c6a-a3eb-50626591b369)
![Screenshot 2024-12-17 154815](https://github.com/user-attachments/assets/9a208719-435b-416f-a82d-573272c28724)


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`BraveTabTest.TabHeightTest`