### PR TITLE
Do not require screenlock on ChromeOS for passwords sync

### DIFF
--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -25,6 +25,7 @@ import org.chromium.chrome.browser.password_manager.settings.ReauthenticationMan
 import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
 import org.chromium.ui.widget.Toast;
 
+import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 
@@ -50,6 +51,7 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
 
     public static final String ARC_FEATURE = "org.chromium.arc";
     public static final String ARC_DEVICE_MANAGEMENT_FEATURE = "org.chromium.arc.device_management";
+    private static Optional<Boolean> sIsChromeOSForTesting = Optional.empty();
 
     private void verboseIfEnabled(String message) {
         if (!mVerboseSyncPasswordsPref) {
@@ -116,7 +118,15 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
         }
     }
 
-    private static boolean isRunningOnChromeOS() {
+    @VisibleForTesting
+    public static void setIsRunningOnChromeOSForTesting(Boolean isRunningOnChromeOS) {
+        sIsChromeOSForTesting = Optional.of(isRunningOnChromeOS);
+    }
+
+    private static Boolean isRunningOnChromeOS() {
+        if (sIsChromeOSForTesting.isPresent()) {
+            return sIsChromeOSForTesting.get();
+        }
         PackageManager pm = ContextUtils.getApplicationContext().getPackageManager();
         return pm.hasSystemFeature(ARC_FEATURE)
                 || pm.hasSystemFeature(ARC_DEVICE_MANAGEMENT_FEATURE);

--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -6,6 +6,7 @@
 package org.chromium.chrome.browser.sync.settings;
 
 import android.app.Activity;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -27,9 +28,7 @@ import org.chromium.ui.widget.Toast;
 import java.util.Timer;
 import java.util.TimerTask;
 
-/**
- * See org.brave.bytecode.BraveManageSyncSettingsClassAdapter
- */
+/** See org.brave.bytecode.BraveManageSyncSettingsClassAdapter */
 public class BraveManageSyncSettings extends ManageSyncSettings {
     private static final String TAG = "BMSS";
 
@@ -48,6 +47,9 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
     private Boolean mVerboseSyncPasswordsPref = false;
     private static final String VERBOSE_SYNC_PASSWORDS_PREF_COMMAND_LINE_KEY =
             "verbose_sync_passwords_pref";
+
+    public static final String ARC_FEATURE = "org.chromium.arc";
+    public static final String ARC_DEVICE_MANAGEMENT_FEATURE = "org.chromium.arc.device_management";
 
     private void verboseIfEnabled(String message) {
         if (!mVerboseSyncPasswordsPref) {
@@ -105,8 +107,19 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
         mPrefSyncPasswords = findPreference(PREF_SYNC_PASSWORDS);
         assert mPrefSyncPasswords != null : "Something has changed in the upstream!";
 
-        overrideWithAuthConfirmationSyncPasswords();
-        overrideWithAuthConfirmationSyncEverything();
+        // We cannot require Android screenlock if browser runs at ChromeOS
+        // Google App Runtime emulator, because it is managed by ChromeOS and
+        // not by the Android subsystem
+        if (!isRunningOnChromeOS()) {
+            overrideWithAuthConfirmationSyncPasswords();
+            overrideWithAuthConfirmationSyncEverything();
+        }
+    }
+
+    private static boolean isRunningOnChromeOS() {
+        PackageManager pm = ContextUtils.getApplicationContext().getPackageManager();
+        return pm.hasSystemFeature(ARC_FEATURE)
+                || pm.hasSystemFeature(ARC_DEVICE_MANAGEMENT_FEATURE);
     }
 
     private void showScreenLockToast() {

--- a/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
+++ b/android/java/org/chromium/chrome/browser/sync/settings/BraveManageSyncSettings.java
@@ -49,6 +49,7 @@ public class BraveManageSyncSettings extends ManageSyncSettings {
     private static final String VERBOSE_SYNC_PASSWORDS_PREF_COMMAND_LINE_KEY =
             "verbose_sync_passwords_pref";
 
+    // Android Runtime for Chrome
     public static final String ARC_FEATURE = "org.chromium.arc";
     public static final String ARC_DEVICE_MANAGEMENT_FEATURE = "org.chromium.arc.device_management";
     private static Optional<Boolean> sIsChromeOSForTesting = Optional.empty();

--- a/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java
@@ -1,0 +1,85 @@
+/* Copyright (c) 2024 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+package org.chromium.chrome.browser.sync;
+
+import androidx.preference.Preference;
+import androidx.test.filters.SmallTest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.chromium.base.test.util.CommandLineFlags;
+import org.chromium.base.test.util.DoNotBatch;
+import org.chromium.base.test.util.Feature;
+import org.chromium.base.test.util.Features.DisableFeatures;
+import org.chromium.chrome.browser.flags.ChromeFeatureList;
+import org.chromium.chrome.browser.flags.ChromeSwitches;
+import org.chromium.chrome.browser.settings.SettingsActivity;
+import org.chromium.chrome.browser.settings.SettingsActivityTestRule;
+import org.chromium.chrome.browser.sync.settings.BraveManageSyncSettings;
+import org.chromium.chrome.browser.sync.settings.ManageSyncSettings;
+import org.chromium.chrome.test.ChromeJUnit4ClassRunner;
+import org.chromium.components.browser_ui.settings.ChromeSwitchPreference;
+
+/** Tests for BraveManageSyncSettings. */
+@RunWith(ChromeJUnit4ClassRunner.class)
+@CommandLineFlags.Add({ChromeSwitches.DISABLE_FIRST_RUN_EXPERIENCE})
+@DoNotBatch(reason = "TODO(crbug.com/40743432): SyncTestRule doesn't support batching.")
+public class BraveManageSyncSettingsTest {
+    private SettingsActivity mSettingsActivity;
+
+    private final SettingsActivityTestRule<BraveManageSyncSettings> mSettingsActivityTestRule =
+            new SettingsActivityTestRule<>(BraveManageSyncSettings.class);
+
+    @Before
+    public void setUp() {}
+
+    @Test
+    @SmallTest
+    @Feature({"Sync"})
+    @DisableFeatures({ChromeFeatureList.REPLACE_SYNC_PROMOS_WITH_SIGN_IN_PROMOS})
+    public void syncEverythingOrPasswordsHandlerIsOriginalOnChromeOS() {
+        syncEverythingOrPasswordsOverridden(true, false);
+    }
+
+    @Test
+    @SmallTest
+    @Feature({"Sync"})
+    @DisableFeatures({ChromeFeatureList.REPLACE_SYNC_PROMOS_WITH_SIGN_IN_PROMOS})
+    public void syncEverythingOrPasswordsHandlerOverriddenOnNonChromeOS() {
+        syncEverythingOrPasswordsOverridden(false, true);
+    }
+
+    void syncEverythingOrPasswordsOverridden(
+            Boolean isChromeOS, Boolean handlerShouldBeOverridden) {
+        BraveManageSyncSettings.setIsRunningOnChromeOSForTesting(isChromeOS);
+        BraveManageSyncSettings fragment = startManageSyncPreferences();
+
+        ChromeSwitchPreference prefSyncPasswords =
+                fragment.findPreference(ManageSyncSettings.PREF_SYNC_PASSWORDS);
+        ChromeSwitchPreference syncEverything =
+                fragment.findPreference(ManageSyncSettings.PREF_SYNC_EVERYTHING);
+
+        Preference.OnPreferenceChangeListener origSyncPasswordsListner =
+                prefSyncPasswords.getOnPreferenceChangeListener();
+        Preference.OnPreferenceChangeListener origSyncEverythingListner =
+                syncEverything.getOnPreferenceChangeListener();
+
+        Assert.assertEquals(
+                handlerShouldBeOverridden,
+                origSyncPasswordsListner != (Preference.OnPreferenceChangeListener) fragment);
+        Assert.assertEquals(
+                handlerShouldBeOverridden,
+                origSyncEverythingListner != (Preference.OnPreferenceChangeListener) fragment);
+    }
+
+    private BraveManageSyncSettings startManageSyncPreferences() {
+        mSettingsActivity = mSettingsActivityTestRule.startSettingsActivity();
+        return mSettingsActivityTestRule.getFragment();
+    }
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1249,6 +1249,7 @@ if (is_android) {
       "//brave/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/safe_browsing/settings/BraveSafeBrowsingSettingsFragmentTest.java",
       "//brave/android/javatests/org/chromium/chrome/browser/safety_check/BraveSafetyCheckSettingsFragmentTest.java",
+      "//brave/android/javatests/org/chromium/chrome/browser/sync/BraveManageSyncSettingsTest.java",
     ]
 
     deps = [
@@ -1266,6 +1267,7 @@ if (is_android) {
       "//chrome/browser/contextmenu:java",
       "//chrome/browser/data_sharing:tab_group_ui_java",
       "//chrome/browser/feed/android:java",
+      "//chrome/browser/flags:java",
       "//chrome/browser/fullscreen/android:java",
       "//chrome/browser/hub:java",
       "//chrome/browser/password_manager/android:java",
@@ -1288,6 +1290,7 @@ if (is_android) {
       "//chrome/browser/ui/android/toolbar:java",
       "//chrome/browser/ui/messages/android:java",
       "//chrome/browser/user_education:java",
+      "//chrome/test:test_support_java",
       "//chrome/test/android:chrome_java_integration_test_support",
       "//chrome/test/android:chrome_java_test_support_common",
       "//components/browser_ui/bottomsheet/android:java",
@@ -1315,6 +1318,7 @@ if (is_android) {
       "//components/sync/android:sync_java",
       "//components/variations/android:variations_java",
       "//content/public/android:content_full_java",
+      "//third_party/androidx:androidx_annotation_annotation_java",
       "//third_party/androidx:androidx_appcompat_appcompat_java",
       "//third_party/androidx:androidx_fragment_fragment_java",
       "//third_party/androidx:androidx_preference_preference_java",


### PR DESCRIPTION
Fixes brave/brave-browser#42816

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42816

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them. Requested https://github.com/brave/reviews/issues/1826
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

The one at issue https://github.com/brave/brave-browser/issues/42816 is great.
