### PR TITLE
fix(wallet): Transactions Partner Modal Bugs

### DIFF
--- a/components/brave_wallet_ui/components/desktop/popup-modals/partners_consent_modal/partners_consent_modal.stories.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/partners_consent_modal/partners_consent_modal.stories.tsx
@@ -20,7 +20,6 @@ export const _PartnersConsentModal = () => {
         isOpen={isOpen}
         onClose={() => setIsOpen(false)}
         onContinue={() => setIsOpen(false)}
-        onCancel={() => setIsOpen(false)}
       />
     </WalletPageStory>
   )

--- a/components/brave_wallet_ui/components/desktop/popup-modals/partners_consent_modal/partners_consent_modal.tsx
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/partners_consent_modal/partners_consent_modal.tsx
@@ -32,13 +32,12 @@ interface PartnerConsentModalProps {
   isOpen: boolean
   onClose: () => void
   onContinue: () => void
-  onCancel: () => void
 }
 
 export function PartnersConsentModal(
   props: Readonly<PartnerConsentModalProps>
 ) {
-  const { isOpen, onCancel, onClose, onContinue } = props
+  const { isOpen, onClose, onContinue } = props
 
   // state
   const [termsAccepted, setTermsAccepted] = React.useState(false)
@@ -98,7 +97,7 @@ export function PartnersConsentModal(
       >
         <Button
           kind='outline'
-          onClick={onCancel}
+          onClick={onClose}
         >
           {getLocale('braveWalletButtonCancel')}
         </Button>

--- a/components/brave_wallet_ui/page/router/unlocked_wallet_routes.tsx
+++ b/components/brave_wallet_ui/page/router/unlocked_wallet_routes.tsx
@@ -4,19 +4,10 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import * as React from 'react'
-import { Prompt, Route, Switch, useHistory } from 'react-router'
-import { Location } from 'history'
+import { Route, Switch } from 'react-router'
 
 // Utils
 import { loadTimeData } from '../../../common/loadTimeData'
-
-// Hooks
-import { useLocalStorage } from '../../common/hooks/use_local_storage'
-
-// Constants
-import {
-  LOCAL_STORAGE_KEYS //
-} from '../../common/constants/local-storage-keys'
 
 // Types
 import { WalletRoutes } from '../../constants/types'
@@ -37,9 +28,6 @@ import { SimplePageWrapper } from '../screens/page-screen.styles'
 import {
   OnboardingSuccess //
 } from '../screens/onboarding/onboarding_success/onboarding_success'
-import {
-  PartnersConsentModal //
-} from '../../components/desktop/popup-modals/partners_consent_modal/partners_consent_modal'
 
 export const UnlockedWalletRoutes = ({
   sessionRoute
@@ -49,60 +37,9 @@ export const UnlockedWalletRoutes = ({
   // Computed
   const isAndroid = loadTimeData.getBoolean('isAndroid') || false
 
-  // State
-  const [isModalOpen, setModalOpen] = React.useState(false)
-  const [nextLocation, setNextLocation] = React.useState<Location | null>(null)
-  const [shouldBlock, setShouldBlock] = React.useState(!isAndroid)
-
-  // Hooks
-  const history = useHistory()
-  const [acceptedTerms, setAcceptedTerms] = useLocalStorage(
-    LOCAL_STORAGE_KEYS.HAS_ACCEPTED_PARTNER_TERMS,
-    false
-  )
-
-  // Methods
-  const handleAccept = () => {
-    setAcceptedTerms(true)
-    setModalOpen(false)
-    setShouldBlock(false)
-    if (nextLocation) {
-      history.block(() => {})
-      history.push(nextLocation.pathname)
-    }
-  }
-
-  const handleDecline = () => {
-    setModalOpen(false)
-    setNextLocation(null)
-  }
-
-  const handleBlockedNavigation = (location: Location) => {
-    if (
-      !isAndroid &&
-      !acceptedTerms &&
-      location.pathname.startsWith(WalletRoutes.FundWalletPageStart)
-    ) {
-      setModalOpen(true)
-      setNextLocation(location)
-      return false
-    }
-    return true
-  }
-
   // render
   return (
     <>
-      <Prompt
-        when={shouldBlock}
-        message={(location) => handleBlockedNavigation(location)}
-      />
-      <PartnersConsentModal
-        isOpen={isModalOpen}
-        onClose={() => {}}
-        onCancel={handleDecline}
-        onContinue={handleAccept}
-      />
       <Switch>
         <Route
           path={WalletRoutes.OnboardingComplete}


### PR DESCRIPTION
## Description 

- Fixes a bug where the `Transactions Partner` consent modal would keep popping up when navigating to other tabs.
- Fixes a bug where the `Transactions Partner` consent modal would not pop up when navigating from `Swap, Send, Bridge or Deposit`
- Fixes a bug where the `Transactions Partner` consent modal would not pop up if you manually navigated to brave://wallet/crypto/fund-wallet

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42984>
Resolves <https://github.com/brave/brave-browser/issues/42785>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### Test Modal Keeps Appearing Bug

1. Create a band new Wallet.
2. Navigate to the `Buy` screen, once the `Transactions Partner` consent modal pops up click the `x` button to close.
3. Now navigate to any other tab for example `Activity`.
4. The modal should not reappear unless you navigate back to the `Buy` tab.

Before:

https://github.com/user-attachments/assets/a39fd0a7-4822-49a2-80d8-6159d5e0f111

After:

https://github.com/user-attachments/assets/117d19ee-8b90-4353-b66b-46b985d5642e

### Test Modal Not Appearing when Manually navigating Bug

1. Create a band new Wallet.
2. Manually enter brave://wallet/crypto/fund-wallet in the address bar.
3. The `Transactions Partner` consent modal should appear.

Before:

https://github.com/user-attachments/assets/bd05bc59-dcbf-4024-9df4-2651a6576d82

After:

https://github.com/user-attachments/assets/fd3512cb-df86-4e6d-b4d1-fca5a0be836e

### Test Modal Not Appearing when navigating from Send/Swap/Bridge/Deposit Bug

1. Create a band new Wallet.
2. Navigate to `Send, Swap, Bridge or Deposit`.
3. Now navigate to the `Buy` tab.
4. The `Transactions Partner` consent modal should appear.

Before:

https://github.com/user-attachments/assets/2de282da-3707-4691-b877-e04ea7c87ac3

After:

https://github.com/user-attachments/assets/e4efac62-288a-4f3e-835b-c459d1102b3e
