### PR TITLE
feat(wallet): Add Activity to Portfolio Desktop View

### DIFF
--- a/components/brave_wallet_ui/components/desktop/portfolio_transaction_item/portfolio_transaction_item.style.ts
+++ b/components/brave_wallet_ui/components/desktop/portfolio_transaction_item/portfolio_transaction_item.style.ts
@@ -26,7 +26,6 @@ export const PortfolioTransactionItemWrapper = styled.div<{
   justify-content: space-between;
   flex-direction: row;
   width: 100%;
-  margin-bottom: 16px;
   position: relative;
   transition: background-color 300ms ease-out;
   background-color: ${(p) =>

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -575,7 +575,10 @@ export const Account = () => {
       {selectedTab === AccountPageTabs.AccountTransactionsSub && (
         <>
           {transactionList.length !== 0 ? (
-            <TransactionsWrapper fullWidth={true}>
+            <TransactionsWrapper
+              fullWidth={true}
+              gap='16px'
+            >
               {transactionList.map((transaction) => (
                 <PortfolioTransactionItem
                   key={transaction?.id}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/accounts-and-transctions-list/index.tsx
@@ -422,14 +422,19 @@ export const AccountsAndTransactionsList = ({
           {hash === WalletRoutes.TransactionsHash && (
             <>
               {nonRejectedTransactions.length !== 0 ? (
-                <>
+                <Column
+                  fullWidth={true}
+                  alignItems='flex-start'
+                  justifyContent='flex-start'
+                  gap='16px'
+                >
                   {nonRejectedTransactions.map((transaction) => (
                     <PortfolioTransactionItem
                       key={transaction.id}
                       transaction={transaction}
                     />
                   ))}
-                </>
+                </Column>
               ) : (
                 <Column
                   margin='20px 0px 40px 0px'

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/portfolio-overview.tsx
@@ -63,8 +63,7 @@ import { makePortfolioAssetRoute } from '../../../../utils/routes-utils'
 // Options
 import {
   PortfolioNavOptions,
-  PortfolioPanelNavOptions,
-  PortfolioPanelNavOptionsNoNFTsTab
+  PortfolioNavOptionsNoNFTsTab
 } from '../../../../options/nav-options'
 import {
   AccountsGroupByOption, //
@@ -594,19 +593,15 @@ export const PortfolioOverview = () => {
               />
             </ColumnReveal>
           </BalanceAndLineChartWrapper>
-          <ControlsRow controlsHidden={!isPanel && hidePortfolioNFTsTab}>
-            {!isPanel && hidePortfolioNFTsTab ? null : (
-              <SegmentedControl
-                navOptions={
-                  isPanel && hidePortfolioNFTsTab
-                    ? PortfolioPanelNavOptionsNoNFTsTab
-                    : isPanel
-                    ? PortfolioPanelNavOptions
-                    : PortfolioNavOptions
-                }
-                maxWidth='384px'
-              />
-            )}
+          <ControlsRow>
+            <SegmentedControl
+              navOptions={
+                hidePortfolioNFTsTab
+                  ? PortfolioNavOptionsNoNFTsTab
+                  : PortfolioNavOptions
+              }
+              maxWidth='384px'
+            />
           </ControlsRow>
         </>
       )}
@@ -645,9 +640,9 @@ export const PortfolioOverview = () => {
             fullWidth={true}
             fullHeight={true}
             justifyContent='flex-start'
-            padding='0px 16px'
+            isPanel={isPanel}
           >
-            <TransactionsScreen />
+            <TransactionsScreen isPortfolio={true} />
           </ActivityWrapper>
         </Route>
 

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -170,13 +170,13 @@ export const SelectTimelineWrapper = styled(Row)`
   }
 `
 
-export const ControlsRow = styled(Row)<{ controlsHidden?: boolean }>`
+export const ControlsRow = styled(Row)`
   box-shadow: 0px -1px 1px ${leo.color.elevation.primary};
   border-radius: 16px 16px 0px 0px;
-  padding: ${(p) => (p.controlsHidden ? '12px' : '24px 32px')};
+  padding: 24px 32px;
   background-color: ${leo.color.container.background};
   @media screen and (max-width: ${layoutPanelWidth}px) {
-    padding: ${(p) => (p.controlsHidden ? '8px' : '16px')};
+    padding: 16px;
   }
 `
 
@@ -314,6 +314,13 @@ export const BalanceAndLineChartWrapper = styled(Column)`
   position: relative;
 `
 
-export const ActivityWrapper = styled(Column)`
-  background-color: ${leo.color.container.background};
+export const ActivityWrapper = styled(Column)<{
+  isPanel: boolean
+}>`
+  padding: 0px 32px 32px 32px;
+  background-color: ${(p) =>
+    p.isPanel ? leo.color.container.background : 'transparent'};
+  @media screen and (max-width: ${layoutPanelWidth}px) {
+    padding: 0px 16px 16px 16px;
+  }
 `

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/wallet_settings_menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/wallet_settings_menu.tsx
@@ -219,7 +219,7 @@ export const WalletSettingsMenu = (props: Props) => {
 
       {(walletLocation === WalletRoutes.PortfolioNFTs ||
         walletLocation === WalletRoutes.PortfolioAssets ||
-        (walletLocation === WalletRoutes.PortfolioActivity && isPanel)) && (
+        walletLocation === WalletRoutes.PortfolioActivity) && (
         <>
           <SectionLabel justifyContent='flex-start'>
             {getLocale('braveWalletPortfolioSettings')}

--- a/components/brave_wallet_ui/options/nav-options.ts
+++ b/components/brave_wallet_ui/options/nav-options.ts
@@ -151,15 +151,11 @@ export const PortfolioNavOptions: NavOption[] = [
     name: 'braveWalletTopNavNFTS',
     icon: 'grid04',
     route: WalletRoutes.PortfolioNFTs
-  }
-]
-
-export const PortfolioPanelNavOptions: NavOption[] = [
-  ...PortfolioNavOptions,
+  },
   PortfolioActivityNavOption
 ]
 
-export const PortfolioPanelNavOptionsNoNFTsTab: NavOption[] = [
+export const PortfolioNavOptionsNoNFTsTab: NavOption[] = [
   AssetsNavOption,
   PortfolioActivityNavOption
 ]

--- a/components/brave_wallet_ui/page/screens/transactions/transactions-screen.tsx
+++ b/components/brave_wallet_ui/page/screens/transactions/transactions-screen.tsx
@@ -71,7 +71,13 @@ const txListItemSkeletonProps: LoadingSkeletonStyleProps = {
   enableAnimation: true
 }
 
-export const TransactionsScreen: React.FC = () => {
+interface Props {
+  isPortfolio?: boolean
+}
+
+export const TransactionsScreen = (props: Props) => {
+  const { isPortfolio } = props
+
   // routing
   const history = useHistory()
   const { hash: selectedTransactionIdHash } = useLocation()
@@ -217,7 +223,7 @@ export const TransactionsScreen: React.FC = () => {
   const transactionsView = React.useMemo(() => {
     return (
       <>
-        {isPanel && (
+        {isPortfolio && (
           <Column
             flex={1}
             style={{ minWidth: '100%' }}
@@ -270,6 +276,7 @@ export const TransactionsScreen: React.FC = () => {
                 fullWidth={true}
                 fullHeight={true}
                 justifyContent='flex-start'
+                gap='16px'
               >
                 {filteredTransactions.map((tx) => (
                   <PortfolioTransactionItem
@@ -301,6 +308,7 @@ export const TransactionsScreen: React.FC = () => {
     filteredTransactions,
     isLoadingTxsList,
     isPanel,
+    isPortfolio,
     onClickTransaction,
     searchValue,
     txsForSelectedChain,
@@ -308,7 +316,7 @@ export const TransactionsScreen: React.FC = () => {
   ])
 
   // render
-  if (isPanel) {
+  if (isPortfolio) {
     return (
       <>
         {transactionsView}


### PR DESCRIPTION
## Description 

Adds a `Activity` tab to the Desktop `Portfolio` view.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43024>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open the `Wallet` and navigate to the `Portfolio` tab
2. You should now see an `Activity` tab in the `Segmented Control` nav
3. Click on `Activity`, you should see your transactions

https://github.com/user-attachments/assets/cfa7b12b-e617-4e73-b36a-9c6b5eebe9e5
