### PR TITLE
feat(wallet): Always Display Buy Send Swap Deposit in Portfolio

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.style.ts
@@ -6,15 +6,7 @@
 import styled from 'styled-components'
 import * as leo from '@brave/leo/tokens/css/variables'
 import Icon from '@brave/leo/react/icon'
-import { WalletButton, Column, Row } from '../../../../../shared/style'
-import { layoutSmallWidth } from '../../../../wallet-page-wrapper/wallet-page-wrapper.style'
-
-export const ButtonsRow = styled(Row)`
-  display: none;
-  @media screen and (max-width: ${layoutSmallWidth}px) {
-    display: flex;
-  }
-`
+import { WalletButton, Column } from '../../../../../shared/style'
 
 export const ButtonWrapper = styled(Column)`
   margin-right: 28px;

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/buy-send-swap-deposit-nav/buy-send-swap-deposit-nav.tsx
@@ -33,9 +33,9 @@ import {
   ButtonIcon,
   ButtonText,
   ButtonWrapper,
-  ButtonsRow,
   MoreMenuWrapper
 } from './buy-send-swap-deposit-nav.style'
+import { Row } from '../../../../../shared/style'
 
 export const BuySendSwapDepositNav = () => {
   // Routing
@@ -59,7 +59,7 @@ export const BuySendSwapDepositNav = () => {
   )
 
   return (
-    <ButtonsRow width='unset'>
+    <Row width='unset'>
       {BuySendSwapDepositOptions.slice(0, 3).map((option) => (
         <ButtonWrapper key={option.id}>
           <Button onClick={() => onClick(option)}>
@@ -75,7 +75,7 @@ export const BuySendSwapDepositNav = () => {
         <ButtonText>{getLocale('braveWalletButtonMore')}</ButtonText>
         {showMoreMenu && <PortfolioAccountMenu onClick={onClick} />}
       </MoreMenuWrapper>
-    </ButtonsRow>
+    </Row>
   )
 }
 

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -196,8 +196,10 @@ export const BalanceAndButtonsWrapper = styled(Column)`
 
 export const BalanceAndChangeWrapper = styled(Column)`
   position: relative;
+  margin-bottom: 24px;
   @media screen and (max-width: ${layoutSmallWidth}px) {
     align-items: flex-start;
+    margin-bottom: 0px;
   }
   @media screen and (max-width: ${layoutPanelWidth}px) {
     flex-direction: column;


### PR DESCRIPTION
## Description 

Will now always the display the `Buy, Send, Swap, Deposit, Bridge` buttons on the `Portfolio` view.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43073>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Portfolio` view
2. You should see the `Buy, Send, Swap, Deposit, Bridge` buttons

![image](https://github.com/user-attachments/assets/ff9a8ed1-b7a8-46c2-9ff0-23387287b546) | ![image](https://github.com/user-attachments/assets/86c5ea34-7c4b-4a6c-add8-4d739f684ba2)
--|--

