### PR TITLE
[iOS] - Fix authentication popup showing the realm

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
@@ -91,11 +91,7 @@ class Authenticator {
         }
       }
 
-      origin += protectionSpace.host
-
-      if protectionSpace.port != 80 && protectionSpace.port != 443 {
-        origin += ":\(protectionSpace.port)"
-      }
+      origin += "\(protectionSpace.host):\(protectionSpace.port)"
 
       let formatted = String(format: Strings.authPromptAlertMessageText, origin)
       let alert = AlertController(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Authenticator.swift
@@ -82,28 +82,27 @@ class Authenticator {
     }
 
     return try await withCheckedThrowingContinuation { continuation in
-      let alert: AlertController
-
-      if !(protectionSpace.realm?.isEmpty ?? true) {
-        let formatted = String(
-          format: Strings.authPromptAlertFormatRealmMessageText,
-          protectionSpace.host,
-          protectionSpace.realm ?? ""
-        )
-        alert = AlertController(
-          title: Strings.authPromptAlertTitle,
-          message: formatted,
-          preferredStyle: .alert
-        )
-      } else {
-
-        let formatted = String(format: Strings.authPromptAlertMessageText, protectionSpace.host)
-        alert = AlertController(
-          title: Strings.authPromptAlertTitle,
-          message: formatted,
-          preferredStyle: .alert
-        )
+      var origin = ""
+      if let scheme = protectionSpace.protocol {
+        if scheme == "http" || scheme == "https" {
+          origin += "\(scheme)://"
+        } else {
+          origin += "\(scheme):"
+        }
       }
+
+      origin += protectionSpace.host
+
+      if protectionSpace.port != 80 && protectionSpace.port != 443 {
+        origin += ":\(protectionSpace.port)"
+      }
+
+      let formatted = String(format: Strings.authPromptAlertMessageText, origin)
+      let alert = AlertController(
+        title: Strings.authPromptAlertTitle,
+        message: formatted,
+        preferredStyle: .alert
+      )
 
       // Add a button to log in.
       let action = UIAlertAction(title: Strings.authPromptAlertLogInButtonTitle, style: .default) {

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -425,14 +425,6 @@ extension Strings {
     value: "Authentication required",
     comment: "Authentication prompt title"
   )
-  public static let authPromptAlertFormatRealmMessageText = NSLocalizedString(
-    "AuthPromptAlertFormatRealmMessageText",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "A username and password are being requested by %@. The site says: %@",
-    comment:
-      "Authentication prompt message with a realm. First parameter is the hostname. Second is the realm string"
-  )
   public static let authPromptAlertMessageText = NSLocalizedString(
     "AuthPromptAlertMessageText",
     tableName: "BraveShared",


### PR DESCRIPTION
## Summary
- Remove realm from auth popup
- Show full origin in the auth popup.
- Port is always shown.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43072

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

