### PR TITLE
[VerticalTab] Move the new tab button to appear immediately after the last tab

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -211,14 +211,15 @@ END_METADATA
 class VerticalTabNewTabButton : public BraveNewTabButton {
   METADATA_HEADER(VerticalTabNewTabButton, BraveNewTabButton)
  public:
-  static constexpr int kHeight = 50;
-
   VerticalTabNewTabButton(TabStrip* tab_strip,
                           PressedCallback callback,
                           const std::u16string& shortcut_text,
                           VerticalTabStripRegionView* region_view)
       : BraveNewTabButton(tab_strip, std::move(callback)),
         region_view_(region_view) {
+    // Turn off inkdrop to have same bg color with tab's.
+    views::InkDrop::Get(this)->SetMode(views::InkDropHost::InkDropMode::OFF);
+
     // We're going to use flex layout for children of this class. Other children
     // from base classes should be handled out of flex layout.
     for (views::View* child : children()) {
@@ -227,13 +228,16 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
 
     SetNotifyEnterExitOnChild(true);
 
+    // In figma, all interior margin uses 10 but left one is
+    // adjusted to align with tab's icon position.
+    // TODO(simonhong): Use 10 for left margin and adjust
+    // tab's layout together.
     SetLayoutManager(std::make_unique<views::FlexLayout>())
         ->SetOrientation(views::LayoutOrientation::kHorizontal)
-        .SetCrossAxisAlignment(views::LayoutAlignment::kStretch);
+        .SetCrossAxisAlignment(views::LayoutAlignment::kStretch)
+        .SetInteriorMargin(gfx::Insets::TLBR(10, 8, 10, 10));
 
     plus_icon_ = AddChildView(std::make_unique<views::ImageView>());
-    plus_icon_->SetPreferredSize(
-        gfx::Size(tabs::kVerticalTabMinWidth, kHeight));
     plus_icon_->SetHorizontalAlignment(views::ImageView::Alignment::kCenter);
     plus_icon_->SetVerticalAlignment(views::ImageView::Alignment::kCenter);
     plus_icon_->SetImage(ui::ImageModel::FromVectorIcon(
@@ -249,6 +253,9 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
         l10n_util::GetStringUTF16(IDS_ACCNAME_NEWTAB)));
     text_->SetHorizontalAlignment(gfx::HorizontalAlignment::ALIGN_LEFT);
     text_->SetVerticalAlignment(gfx::VerticalAlignment::ALIGN_MIDDLE);
+    constexpr int kGapBetweenIconAndText = 16;
+    text_->SetProperty(views::kMarginsKey,
+                       gfx::Insets::TLBR(0, kGapBetweenIconAndText, 0, 0));
     text_->SetProperty(views::kFlexBehaviorKey,
                        views::FlexSpecification(
                            views::MinimumFlexSizeRule::kPreferredSnapToZero,
@@ -269,8 +276,7 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
     shortcut_text_->SetFontList(shortcut_font.DeriveWithSizeDelta(
         kFontSize - shortcut_font.GetFontSize()));
     shortcut_text_->SetProperty(
-        views::kMarginsKey,
-        gfx::Insets::VH(0, tabs::kMarginForVerticalTabContainers));
+        views::kMarginsKey, gfx::Insets::TLBR(0, kGapBetweenIconAndText, 0, 0));
     shortcut_text_->SetProperty(
         views::kFlexBehaviorKey,
         views::FlexSpecification(
@@ -302,45 +308,20 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
   }
 
   void PaintIcon(gfx::Canvas* canvas) override {
-    // Revert back the offset set by NewTabButton::PaintButtonContents(), which
-    // is the caller of this method.
-    gfx::ScopedCanvas scoped_canvas(canvas);
-    canvas->Translate(-GetContentsBounds().OffsetFromOrigin());
-
     // Bypass '+' painting as we have a |plus_icon_| for that.
-    ImageButton::PaintButtonContents(canvas);
+    return;
   }
 
   gfx::Insets GetInsets() const override {
-    return gfx::Insets(tabs::kMarginForVerticalTabContainers);
+    // This button doesn't need any insets. Invalidate parent's one.
+    return gfx::Insets();
   }
 
   void OnPaintFill(gfx::Canvas* canvas) const override {
-    auto* cp = GetColorProvider();
-    CHECK(cp);
-
-    // Override fill color
-    {
-      gfx::ScopedCanvas scoped_canvas_for_scaling(canvas);
-      canvas->UndoDeviceScaleFactor();
-      cc::PaintFlags flags;
-      flags.setAntiAlias(true);
-      flags.setColor(cp->GetColor(kColorToolbar));
-      canvas->DrawPath(GetBorderPath(gfx::Point(), false), flags);
-    }
-
-    // Draw split line on the top.
-    // Revert back the offset set by NewTabButton::PaintButtonContents(), which
-    // is the caller of this method.
-    gfx::ScopedCanvas scoped_canvas_for_translating(canvas);
-    canvas->Translate(-GetContentsBounds().OffsetFromOrigin());
-
-    gfx::Rect separator_bounds = GetLocalBounds();
-    separator_bounds.set_height(1);
-    cc::PaintFlags flags;
-    flags.setStyle(cc::PaintFlags::kFill_Style);
-    flags.setColor(cp->GetColor(kColorToolbar));
-    canvas->DrawRect(gfx::RectF(separator_bounds), flags);
+    // Invalidate upstream's paint operation.
+    // We fill background whenever state changed to have same bg color with
+    // tab's. See StateChanged().
+    // It's difficult to have same bg color with ink drop.
   }
 
   void OnThemeChanged() override {
@@ -357,22 +338,18 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
         cp->GetColor(kColorBraveVerticalTabNTBShortcutTextColor));
   }
 
-  void Layout(PassKey) override {
-    LayoutSuperclass<BraveNewTabButton>(this);
+  void StateChanged(ButtonState old_state) override {
+    BraveNewTabButton::StateChanged(old_state);
 
-    // FlexLayout could set the ink drop container invisible.
-    if (!ink_drop_container()->GetVisible()) {
-      ink_drop_container()->SetVisible(true);
+    int bg_color_id = kColorToolbar;
+    if (GetState() == views::Button::STATE_PRESSED) {
+      bg_color_id = kColorBraveVerticalTabActiveBackground;
+    } else if (GetState() == views::Button::STATE_HOVERED) {
+      bg_color_id = kColorBraveVerticalTabHoveredBackground;
     }
-  }
 
-  gfx::Size CalculatePreferredSize(
-      const views::SizeBounds& available_size) const override {
-    auto size = BraveNewTabButton::CalculatePreferredSize(available_size);
-    if (tabs::utils::ShouldShowVerticalTabs(tab_strip()->GetBrowser())) {
-      size.set_height(kHeight);
-    }
-    return size;
+    SetBackground(views::CreateThemedRoundedRectBackground(bg_color_id,
+                                                           GetCornerRadius()));
   }
 
  private:
@@ -921,26 +898,30 @@ void VerticalTabStripRegionView::Layout(PassKey) {
 
   // As we have to update ScrollView's viewport size and its contents size,
   // laying out children manually will be more handy.
-
-  // 1. New tab should be fixed at the bottom of container.
   const auto contents_bounds = GetContentsBounds();
-  new_tab_button_->SetSize(
-      {contents_bounds.width(), new_tab_button_->GetPreferredSize().height()});
-  new_tab_button_->SetPosition(
-      {contents_bounds.x(),
-       contents_bounds.bottom() - new_tab_button_->height()});
 
   const gfx::Size header_size{contents_bounds.width(),
                               tabs::kVerticalTabHeight + kHeaderInset * 2};
-  header_view_->SetPosition(contents_bounds.origin());
-  header_view_->SetSize(header_size);
+  header_view_->SetBoundsRect(gfx::Rect(contents_bounds.origin(), header_size));
 
-  contents_view_->SetSize(
-      {contents_bounds.width(), contents_bounds.height() -
-                                    new_tab_button_->height() -
-                                    header_view_->height()});
-  contents_view_->SetPosition({contents_bounds.origin().x(),
-                               header_view_->y() + header_view_->height()});
+  constexpr int kNewTabButtonHeight = tabs::kVerticalTabHeight;
+  const int contents_view_max_height =
+      contents_bounds.height() - kNewTabButtonHeight - header_view_->height();
+  const int contents_view_preferred_height =
+      tab_strip()->GetPreferredSize().height();
+  contents_view_->SetBoundsRect(gfx::Rect(
+      header_view_->bounds().bottom_left(),
+      gfx::Size(
+          contents_bounds.width(),
+          std::min(contents_view_max_height, contents_view_preferred_height))));
+
+  gfx::Rect new_tab_button_bounds(
+      contents_view_->bounds().bottom_left(),
+      gfx::Size(contents_bounds.width(), kNewTabButtonHeight));
+  new_tab_button_bounds.Inset(
+      gfx::Insets::VH(0, tabs::kMarginForVerticalTabContainers));
+  new_tab_button_->SetBoundsRect(new_tab_button_bounds);
+
   UpdateOriginalTabSearchButtonVisibility();
 
   // Put resize area, overlapped with contents.
@@ -1252,8 +1233,10 @@ void VerticalTabStripRegionView::UpdateBorder() {
       (sidebar_on_same_side
            ? 0
            : BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_));
-  gfx::Insets border_insets = (is_on_right) ? gfx::Insets::TLBR(0, inset, 0, 0)
-                                            : gfx::Insets::TLBR(0, 0, 0, inset);
+  gfx::Insets border_insets =
+      (is_on_right)
+          ? gfx::Insets::TLBR(0, inset, tabs::kVerticalTabsSpacing, 0)
+          : gfx::Insets::TLBR(0, 0, tabs::kVerticalTabsSpacing, inset);
 
   if (show_visible_border()) {
     SetBorder(views::CreateSolidSidedBorder(

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -213,7 +213,7 @@ END_METADATA
 class ShortcutBox : public views::View {
   METADATA_HEADER(ShortcutBox, views::View)
  public:
-  ShortcutBox(const std::u16string& shortcut_text) {
+  explicit ShortcutBox(const std::u16string& shortcut_text) {
     constexpr int kChildSpacing = 4;
     SetLayoutManager(std::make_unique<views::BoxLayout>(
         views::BoxLayout::Orientation::kHorizontal, gfx::Insets(),

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -1205,7 +1205,7 @@ TabSearchBubbleHost* VerticalTabStripRegionView::GetTabSearchBubbleHost() {
   return header_view_->tab_search_button()->tab_search_bubble_host();
 }
 
-int VerticalTabStripRegionView::GetTabStripViewportHeight() const {
+int VerticalTabStripRegionView::GetTabStripViewportMaxHeight() const {
   // Don't depend on |contents_view_|'s current height. It could be bigger than
   // the actual viewport height.
   return GetContentsBounds().height() - header_view_->height() -

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -259,14 +259,20 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
     text_->SetProperty(views::kFlexBehaviorKey,
                        views::FlexSpecification(
                            views::MinimumFlexSizeRule::kPreferredSnapToZero,
-                           views::MaximumFlexSizeRule::kUnbounded)
-                           .WithOrder(3)
-                           .WithWeight(0));
+                           views::MaximumFlexSizeRule::kPreferred)
+                           .WithOrder(3));
 
     constexpr int kFontSize = 12;
     const auto text_font = text_->font_list();
     text_->SetFontList(
         text_font.DeriveWithSizeDelta(kFontSize - text_font.GetFontSize()));
+
+    auto* spacer = AddChildView(std::make_unique<views::View>());
+    spacer->SetProperty(
+        views::kFlexBehaviorKey,
+        views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToZero,
+                                 views::MaximumFlexSizeRule::kUnbounded)
+            .WithOrder(4));
 
     shortcut_text_ = AddChildView(std::make_unique<views::Label>());
     shortcut_text_->SetHorizontalAlignment(
@@ -279,9 +285,8 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
         views::kMarginsKey, gfx::Insets::TLBR(0, kGapBetweenIconAndText, 0, 0));
     shortcut_text_->SetProperty(
         views::kFlexBehaviorKey,
-        views::FlexSpecification(
-            views::MinimumFlexSizeRule::kPreferredSnapToZero,
-            views::MaximumFlexSizeRule::kPreferred)
+        views::FlexSpecification(views::MinimumFlexSizeRule::kScaleToZero,
+                                 views::MaximumFlexSizeRule::kPreferred)
             .WithOrder(2));
 
     SetTooltipText(l10n_util::GetStringUTF16(IDS_TOOLTIP_NEW_TAB));

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -230,14 +230,11 @@ class VerticalTabNewTabButton : public BraveNewTabButton {
 
     SetNotifyEnterExitOnChild(true);
 
-    // In figma, all interior margin uses 10 but left one is
-    // adjusted to align with tab's icon position.
-    // TODO(simonhong): Use 10 for left margin and adjust
-    // tab's layout together.
+    constexpr int kNewTabPadding = 8;
     SetLayoutManager(std::make_unique<views::FlexLayout>())
         ->SetOrientation(views::LayoutOrientation::kHorizontal)
         .SetCrossAxisAlignment(views::LayoutAlignment::kStretch)
-        .SetInteriorMargin(gfx::Insets::TLBR(10, 8, 10, 10));
+        .SetInteriorMargin(gfx::Insets(kNewTabPadding));
 
     plus_icon_ = AddChildView(std::make_unique<views::ImageView>());
     plus_icon_->SetHorizontalAlignment(views::ImageView::Alignment::kCenter);

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -23,6 +23,7 @@
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
 #include "brave/components/vector_icons/vector_icons.h"
+#include "brave/ui/color/nala/nala_color_id.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/browser_list.h"
@@ -72,6 +73,7 @@
 namespace {
 
 constexpr int kHeaderInset = tabs::kMarginForVerticalTabContainers;
+constexpr int kSeparatorHeight = 1;
 
 // Use toolbar button's ink drop effect.
 class ToggleButton : public ToolbarButton {
@@ -610,7 +612,9 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
       AddChildView(std::make_unique<VerticalTabStripScrollContentsView>(
           this, original_region_view_->tab_strip_));
   header_view_->toggle_button()->SetHighlighted(state_ == State::kExpanded);
-
+  separator_ = AddChildView(std::make_unique<views::View>());
+  separator_->SetBackground(
+      views::CreateThemedSolidBackground(nala::kColorDividerSubtle));
   new_tab_button_ = AddChildView(std::make_unique<VerticalTabNewTabButton>(
       original_region_view_->tab_strip_,
       base::BindRepeating(&TabStrip::NewTabButtonPressed,
@@ -920,11 +924,16 @@ void VerticalTabStripRegionView::Layout(PassKey) {
           contents_bounds.width(),
           std::min(contents_view_max_height, contents_view_preferred_height))));
 
-  gfx::Rect new_tab_button_bounds(
+  gfx::Rect separator_bounds(
       contents_view_->bounds().bottom_left(),
-      gfx::Size(contents_bounds.width(), kNewTabButtonHeight));
-  new_tab_button_bounds.Inset(
+      gfx::Size(contents_bounds.width(), kSeparatorHeight));
+  separator_bounds.Inset(
       gfx::Insets::VH(0, tabs::kMarginForVerticalTabContainers));
+  separator_->SetBoundsRect(separator_bounds);
+  gfx::Rect new_tab_button_bounds(
+      separator_->bounds().bottom_left(),
+      gfx::Size(separator_bounds.width(), kNewTabButtonHeight));
+  new_tab_button_bounds.Offset(0, tabs::kMarginForVerticalTabContainers);
   new_tab_button_->SetBoundsRect(new_tab_button_bounds);
 
   UpdateOriginalTabSearchButtonVisibility();
@@ -1175,6 +1184,7 @@ void VerticalTabStripRegionView::UpdateNewTabButtonVisibility() {
   auto* original_ntb = original_region_view_->new_tab_button();
   original_ntb->SetVisible(!is_vertical_tabs);
   new_tab_button_->SetVisible(is_vertical_tabs);
+  separator_->SetVisible(is_vertical_tabs);
 }
 
 TabSearchBubbleHost* VerticalTabStripRegionView::GetTabSearchBubbleHost() {
@@ -1185,6 +1195,7 @@ int VerticalTabStripRegionView::GetTabStripViewportHeight() const {
   // Don't depend on |contents_view_|'s current height. It could be bigger than
   // the actual viewport height.
   return GetContentsBounds().height() - header_view_->height() -
+         (separator_->height() + tabs::kMarginForVerticalTabContainers) -
          new_tab_button_->height();
 }
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -196,6 +196,9 @@ class VerticalTabStripRegionView : public views::View,
   raw_ptr<HeaderView> header_view_ = nullptr;
   raw_ptr<views::View> contents_view_ = nullptr;
 
+  // Separator between tabs and new tab button.
+  raw_ptr<views::View> separator_ = nullptr;
+
   // New tab button created for vertical tabs
   raw_ptr<BraveNewTabButton> new_tab_button_ = nullptr;
 

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -85,7 +85,7 @@ class VerticalTabStripRegionView : public views::View,
 
   TabSearchBubbleHost* GetTabSearchBubbleHost();
 
-  int GetTabStripViewportHeight() const;
+  int GetTabStripViewportMaxHeight() const;
 
   void set_layout_dirty(base::PassKey<VerticalTabStripScrollContentsView>) {
     layout_dirty_ = true;

--- a/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
@@ -37,14 +37,16 @@ NSString* keyCombinationForMenuItem(NSMenuItem* item) {
   NSMutableString* string = [NSMutableString string];
   NSUInteger modifiers = item.keyEquivalentModifierMask;
 
+  // Appended "+" after the modifier as key combination
+  // is splited to each part and rendered separately.
   if (modifiers & NSEventModifierFlagCommand)
-    [string appendString:@"\u2318"];
+    [string appendString:@"\u2318+"];
   if (modifiers & NSEventModifierFlagControl)
-    [string appendString:@"\u2303"];
+    [string appendString:@"\u2303+"];
   if (modifiers & NSEventModifierFlagOption)
-    [string appendString:@"\u2325"];
+    [string appendString:@"\u2325+"];
   if (modifiers & NSEventModifierFlagShift)
-    [string appendString:@"\u21E7"];
+    [string appendString:@"\u21E7+"];
 
   [string appendString:[item.keyEquivalent uppercaseString]];
   return string;

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -285,7 +285,7 @@ gfx::Size BraveCompoundTabContainer::CalculatePreferredSize(
     }
 
     preferred_size.set_height(
-        std::min(combined_height, region_view->GetTabStripViewportHeight()));
+        std::min(combined_height, region_view->GetTabStripViewportMaxHeight()));
     break;
   }
 

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -271,7 +271,11 @@ gfx::Size BraveCompoundTabContainer::CalculatePreferredSize(
   auto preferred_size =
       CompoundTabContainer::CalculatePreferredSize(available_size);
 
-  // Check if we can expand height to fill the entire scroll area's viewport.
+  const int combined_height =
+      pinned_tab_container_->GetPreferredSize().height() +
+      unpinned_tab_container_->GetPreferredSize().height();
+
+  // Traverse up the parent hierarchy to find the |VerticalTabStripRegionView|
   for (auto* parent_view = parent(); parent_view;
        parent_view = parent_view->parent()) {
     auto* region_view =
@@ -280,7 +284,8 @@ gfx::Size BraveCompoundTabContainer::CalculatePreferredSize(
       continue;
     }
 
-    preferred_size.set_height(region_view->GetTabStripViewportHeight());
+    preferred_size.set_height(
+        std::min(combined_height, region_view->GetTabStripViewportHeight()));
     break;
   }
 

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -68,7 +68,11 @@ bool BraveTabStrip::IsVerticalTabsFloating() const {
   auto* vertical_region_view =
       browser_view->vertical_tab_strip_widget_delegate_view()
           ->vertical_tab_strip_region_view();
-  DCHECK(vertical_region_view);
+
+  if (!vertical_region_view) {
+    // Could be null while closing a window.
+    return false;
+  }
 
   return vertical_region_view->state() ==
              VerticalTabStripRegionView::State::kFloating ||

--- a/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
@@ -7,14 +7,15 @@
 
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
-#define ConvertPointToTarget(THIS, TARGET_GETTER, POINT)                  \
-  if (views::View* target_v = TARGET_GETTER;                              \
-      tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) &&    \
-      (target_v == tabstrip() || !THIS->Contains(target_v))) {            \
-    ConvertPointToScreen(target_v, POINT);                                \
-    ConvertPointFromScreen(THIS, POINT);                                  \
-  } else {                                                                \
-    ConvertPointToTarget(THIS, target_v, POINT);                          \
+// Workaround for vertical tabs to work with drag&drop of text/links.
+#define ConvertPointToTarget(THIS, TARGET_GETTER, POINT)               \
+  if (views::View* target_v = TARGET_GETTER;                           \
+      tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) && \
+      (target_v == tabstrip() || !THIS->Contains(target_v))) {         \
+    ConvertPointToScreen(THIS, POINT);                                 \
+    ConvertPointFromScreen(target_v, POINT);                           \
+  } else {                                                             \
+    ConvertPointToTarget(THIS, target_v, POINT);                       \
   }
 
 #include "src/chrome/browser/ui/views/frame/browser_root_view.cc"


### PR DESCRIPTION
Move the new tab button to appear immediately after the last tab last tab as per the new design.
And Keep the new tab button fixed at the bottom when tabs overflow.

Also this new tab button position change reveals another bug and
`VerticalTabStripRootViewBrowserTest.DragAfterCurrentTab` caught it.
Converting point from root view to tab strip view was wrong in `chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42533
Resolves https://github.com/brave/brave-browser/issues/43226


# OutCome
<img width="213" alt="Screenshot 2025-01-14 at 2 10 56 PM" src="https://github.com/user-attachments/assets/02fbb2df-c102-4c06-ba4a-649c417ed1bd" />

![image](https://github.com/user-attachments/assets/e4165728-490c-46bc-a61a-36c4afb554e0)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.