### PR TITLE
Test split view bg color in custom theme from web store

### DIFF
--- a/browser/ui/color/brave_color_id.h
+++ b/browser/ui/color/brave_color_id.h
@@ -112,6 +112,7 @@
 #define BRAVE_VERTICAL_TAB_COLOR_IDS                        \
     E_CPONLY(kColorBraveVerticalTabSeparator)               \
     E_CPONLY(kColorBraveVerticalTabActiveBackground)        \
+    E_CPONLY(kColorBraveVerticalTabHoveredBackground)       \
     E_CPONLY(kColorBraveVerticalTabInactiveBackground)      \
     E_CPONLY(kColorBraveVerticalTabNTBIconColor)            \
     E_CPONLY(kColorBraveVerticalTabNTBTextColor)            \

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -22,7 +22,9 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
   auto& mixer = provider->AddMixer();
 
   mixer[kColorBraveVerticalTabActiveBackground] = {
-      kColorTabBackgroundInactiveFrameActive};
+      nala::kColorDesktopbrowserTabbarActiveTabVertical};
+  mixer[kColorBraveVerticalTabHoveredBackground] = {
+      nala::kColorDesktopbrowserTabbarHoverTabVertical};
   mixer[kColorBraveVerticalTabInactiveBackground] = {kColorToolbar};
   mixer[kColorBraveVerticalTabSeparator] = {kColorToolbarContentAreaSeparator};
   mixer[kColorBraveVerticalTabNTBIconColor] = {
@@ -61,13 +63,17 @@ void AddBraveTabPrivateThemeColorMixer(ui::ColorProvider* provider,
                                        const ui::ColorProviderKey& key) {
   auto& mixer = provider->AddMixer();
   mixer[kColorBraveVerticalTabActiveBackground] = {
-      mixer.GetResultColor(kColorTabBackgroundActiveFrameActive)};
+      nala::kColorPrimitivePrivateWindow30};
   mixer[kColorBraveVerticalTabInactiveBackground] = {
       mixer.GetResultColor(kColorToolbar)};
+  mixer[kColorBraveVerticalTabHoveredBackground] = {
+      ui::AlphaBlend(kColorBraveVerticalTabActiveBackground,
+                     kColorBraveVerticalTabInactiveBackground,
+                     /* 40% opacity */ 0.4 * SK_AlphaOPAQUE)};
   mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
       nala::kColorPrimitivePrivateWindow10};
   mixer[kColorBraveSplitViewTileBackgroundVertical] = {
-      kColorBraveSplitViewTileBackgroundHorizontal};
+      nala::kColorPrimitivePrivateWindow5};
   mixer[kColorBraveSplitViewTileDivider] = {
       nala::kColorPrimitivePrivateWindow20};
 }
@@ -76,13 +82,17 @@ void AddBraveTabTorThemeColorMixer(ui::ColorProvider* provider,
                                    const ui::ColorProviderKey& key) {
   auto& mixer = provider->AddMixer();
   mixer[kColorBraveVerticalTabActiveBackground] = {
-      mixer.GetResultColor(kColorTabBackgroundActiveFrameActive)};
+      nala::kColorPrimitiveTorWindow30};
   mixer[kColorBraveVerticalTabInactiveBackground] = {
       mixer.GetResultColor(kColorToolbar)};
+  mixer[kColorBraveVerticalTabHoveredBackground] = {
+      ui::AlphaBlend(kColorBraveVerticalTabActiveBackground,
+                     kColorBraveVerticalTabInactiveBackground,
+                     /* 40% opacity */ 0.4 * SK_AlphaOPAQUE)};
   mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
       nala::kColorPrimitiveTorWindow10};
   mixer[kColorBraveSplitViewTileBackgroundVertical] = {
-      kColorBraveSplitViewTileBackgroundHorizontal};
+      nala::kColorPrimitiveTorWindow5};
   mixer[kColorBraveSplitViewTileDivider] = {nala::kColorPrimitiveTorWindow20};
 }
 

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -8,18 +8,52 @@
 #include "base/containers/fixed_flat_map.h"
 #include "brave/browser/ui/color/brave_color_id.h"
 #include "brave/ui/color/nala/nala_color_id.h"
+#include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "ui/color/color_mixer.h"
 #include "ui/color/color_provider.h"
 #include "ui/color/color_provider_key.h"
 #include "ui/color/color_recipe.h"
 #include "ui/color/color_transform.h"
+#include "ui/gfx/color_utils.h"
 
 namespace tabs {
+
+SkColor IsToolbarColorDark(const ui::ColorProviderKey& key,
+                           const ui::ColorMixer& mixer) {
+  CHECK(key.custom_theme);
+  auto toolbar_color = mixer.GetResultColor(kColorToolbar);
+  SkColor custom_toolbar_color;
+  if (key.custom_theme->GetColor(ThemeProperties::COLOR_TOOLBAR,
+                                 &custom_toolbar_color)) {
+    toolbar_color = custom_toolbar_color;
+  }
+
+  return color_utils::IsDark(toolbar_color);
+}
 
 void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
                                 const ui::ColorProviderKey& key) {
   auto& mixer = provider->AddMixer();
+
+  if (key.custom_theme) {
+    const bool is_toolbar_dark = IsToolbarColorDark(key, mixer);
+    mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
+        is_toolbar_dark ? nala::kColorPrimitiveNeutral10
+                        : nala::kColorPrimitiveNeutral80};
+    mixer[kColorBraveSplitViewTileBackgroundVertical] = {
+        kColorBraveSplitViewTileBackgroundHorizontal};
+    mixer[kColorBraveSplitViewTileDivider] = {
+        is_toolbar_dark ? nala::kColorPrimitiveNeutral20
+                        : nala::kColorPrimitiveNeutral90};
+  } else {
+    mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
+        nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal};
+    mixer[kColorBraveSplitViewTileBackgroundVertical] = {
+        nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical};
+    mixer[kColorBraveSplitViewTileDivider] = {
+        nala::kColorDesktopbrowserTabbarSplitViewDivider};
+  }
 
   mixer[kColorBraveVerticalTabActiveBackground] = {
       nala::kColorDesktopbrowserTabbarActiveTabVertical};
@@ -34,12 +68,6 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorBraveVerticalTabNTBShortcutTextColor] = {
       kColorTabForegroundActiveFrameActive};
 
-  mixer[kColorBraveSplitViewTileBackgroundHorizontal] = {
-      nala::kColorDesktopbrowserTabbarSplitViewBackgroundHorizontal};
-  mixer[kColorBraveSplitViewTileBackgroundVertical] = {
-      nala::kColorDesktopbrowserTabbarSplitViewBackgroundVertical};
-  mixer[kColorBraveSplitViewTileDivider] = {
-      nala::kColorDesktopbrowserTabbarSplitViewDivider};
   mixer[kColorBraveSplitViewMenuItemIcon] = {nala::kColorIconDefault};
   mixer[kColorBraveSplitViewUrl] = {nala::kColorTextTertiary};
   mixer[kColorBraveSplitViewMenuButtonBorder] = {nala::kColorDividerSubtle};

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -366,9 +366,8 @@ void BraveTabContainer::PaintBoundingBoxForTile(gfx::Canvas& canvas,
     separator_top.Offset(0, gap);
     auto separator_bottom = separator_top;
     separator_bottom.Offset(0, kSplitViewSeparatorHeight);
-    canvas.DrawLine(
-        separator_top, separator_bottom,
-        cp->GetColor(nala::kColorDesktopbrowserTabbarSplitViewDivider));
+    canvas.DrawLine(separator_top, separator_bottom,
+                    cp->GetColor(kColorBraveSplitViewTileDivider));
   }
 }
 

--- a/browser/ui/views/tabs/brave_tab_style_views.inc.cc
+++ b/browser/ui/views/tabs/brave_tab_style_views.inc.cc
@@ -445,11 +445,11 @@ SkColor BraveVerticalTabStyle::GetTargetTabBackgroundColor(
   }
 
   if (tab()->IsActive()) {
-    return cp->GetColor(nala::kColorDesktopbrowserTabbarActiveTabVertical);
+    return cp->GetColor(kColorBraveVerticalTabActiveBackground);
   }
 
   if (hovered) {
-    return cp->GetColor(nala::kColorDesktopbrowserTabbarHoverTabVertical);
+    return cp->GetColor(kColorBraveVerticalTabHoveredBackground);
   }
 
   if (selection_state == TabStyle::TabSelectionState::kSelected) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/43052

<img width="847" alt="Screenshot 2025-01-06 at 3 31 52 PM" src="https://github.com/user-attachments/assets/45b1c69e-47f8-41bd-bf5c-cec7066d5579" />
<img width="1040" alt="Screenshot 2025-01-06 at 3 33 45 PM" src="https://github.com/user-attachments/assets/6b39a0e4-394e-4735-8208-1df426312e49" />
<img width="936" alt="Screenshot 2025-01-06 at 3 33 53 PM" src="https://github.com/user-attachments/assets/906f0e30-107a-4808-ad10-fb1476c40d26" />
<img width="900" alt="Screenshot 2025-01-06 at 3 35 24 PM" src="https://github.com/user-attachments/assets/ec71c9ca-2649-41e2-afd0-2def197d3138" />
<img width="783" alt="Screenshot 2025-01-06 at 3 37 07 PM" src="https://github.com/user-attachments/assets/f1cecb4d-9598-4e2e-b9ff-8b6dd9c2d9c2" />


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

