### PR TITLE
fix(iOS): DAUTests.testMondayOfCurrentWeekFormatted() unit test

### DIFF
--- a/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
+++ b/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
@@ -266,9 +266,10 @@ class DAUTests: XCTestCase {
     let yearString = Date().mondayOfCurrentWeekFormatted?.truncate(length: 4, trailing: "")
     let year = Int(yearString!)!
 
-    // There is no easy way to mock a different calendar in unit tests, just checking if
-    // year we get looks 'correct' should be good enough.
-    XCTAssert(year > 2018 && year < 2025)
+    // Verify the year in `mondayOfCurrentWeekFormatted` matches current gregorian calendar year.
+    let gregorianCalendar = Calendar(identifier: .gregorian)
+    let gregorianCalendarYear = gregorianCalendar.dateComponents([.year], from: Date()).year
+    XCTAssertEqual(gregorianCalendarYear, year)
   }
 
   func testNonDefaultWoiExplicitDate() {

--- a/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
+++ b/ios/brave-ios/Tests/GrowthTests/DAUTests.swift
@@ -262,14 +262,14 @@ class DAUTests: XCTestCase {
   }
 
   func testMondayOfCurrentWeekFormatted() {
+    // Jan 6th, 2025
+    let dateForTest = Date(timeIntervalSince1970: 1_736_139_600)
+
     // Making sure gregorian year is showing
     let yearString = Date().mondayOfCurrentWeekFormatted?.truncate(length: 4, trailing: "")
     let year = Int(yearString!)!
 
-    // Verify the year in `mondayOfCurrentWeekFormatted` matches current gregorian calendar year.
-    let gregorianCalendar = Calendar(identifier: .gregorian)
-    let gregorianCalendarYear = gregorianCalendar.dateComponents([.year], from: Date()).year
-    XCTAssertEqual(gregorianCalendarYear, year)
+    XCTAssertEqual(year, 2025)
   }
 
   func testNonDefaultWoiExplicitDate() {


### PR DESCRIPTION
- Update unit test to grab the year directly from gregorian calendar using `DateComponents` so the year shouldn't need updated.

Resolves https://github.com/brave/brave-browser/issues/43117

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Run `DAUTests.testMondayOfCurrentWeekFormatted()`