### PR TITLE
[iOS] Fix new menu item reordering

### DIFF
--- a/ios/brave-ios/Sources/BrowserMenu/BrowserMenuModel.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/BrowserMenuModel.swift
@@ -101,8 +101,26 @@ import SwiftUI
     reloadActions()
   }
 
+  /// Moves a visible action found at a given index to a given offset based on the way that
+  /// SwiftUI supplies source indexes + destination offsets.
+  ///
+  /// The destination offset not an index and instead a distance from the startIndex where an item
+  /// will be placed, which means the final offset is actually the endIndex (array count/"past the
+  /// end" index)
+  func moveVisibleActions(fromOffsets source: IndexSet, toOffset destination: Int) {
+    // For now we're just going to support moving a single item and drop any extras
+    guard let index = source.first, let action = visibleActions[safe: index] else { return }
+    reorderVisibleAction(
+      action,
+      to: destination >= visibleActions.endIndex ? visibleActions.endIndex - 1 : destination
+    )
+  }
+
+  /// Moves a visible action to a valid index
   func reorderVisibleAction(_ action: Action, to index: Int) {
-    if visibleActions.isEmpty || !visibleActions.contains(where: { action.id == $0.id }) {
+    if visibleActions.isEmpty || !visibleActions.contains(where: { action.id == $0.id })
+      || index >= visibleActions.endIndex
+    {
       return
     }
     var newRank: Double = 0

--- a/ios/brave-ios/Sources/BrowserMenu/CustomizeMenuView.swift
+++ b/ios/brave-ios/Sources/BrowserMenu/CustomizeMenuView.swift
@@ -38,19 +38,8 @@ struct CustomizeMenuView: View {
               }
             }
           }
-          .onMove { indexSet, offset in
-            guard let index = indexSet.first, let action = model.visibleActions[safe: index] else {
-              return
-            }
-            // SwiftUI's move offset logic is a bit strange where the destination can be the
-            // count instead of the final valid index, so its safer to use SwiftUI's Collection
-            // API to handle it then get the valid destination index of that mutated array.
-            var ids = model.visibleActions.map(\.id)
-            ids.move(fromOffsets: indexSet, toOffset: offset)
-            guard let destination = ids.firstIndex(of: action.id) else {
-              return
-            }
-            model.reorderVisibleAction(action, to: destination)
+          .onMove { source, destination in
+            model.moveVisibleActions(fromOffsets: source, toOffset: destination)
           }
           .listRowBackground(Color(.secondaryBraveGroupedBackground))
         } header: {


### PR DESCRIPTION
This introduces a similar `move(fromOffsets:toOffset:)` method to `BrowserMenuModel` that will be used when re-ordering visible items from SwiftUI hierarchies.

Resolves https://github.com/brave/brave-browser/issues/42937

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Enable new menu UI via feature flag confirm item reordering works in the following scenarios:

- First item to middle
- First item to last
- Middle to middle
- Middle to first
- Middle to last
- Last to first
- Last to middle
