### PR TITLE
feat(wallet): Prompt Select Account when Sending from Portfolio

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
@@ -7,7 +7,7 @@ import * as React from 'react'
 import { useHistory } from 'react-router'
 
 // Types
-import { BraveWallet, WalletRoutes } from '../../../constants/types'
+import { BraveWallet } from '../../../constants/types'
 
 // Queries
 import {
@@ -106,11 +106,7 @@ export const AssetItemMenu = (props: Props) => {
   }, [foundMeldBuyToken, history, account, foundAndroidBuyToken, asset])
 
   const onClickSend = React.useCallback(() => {
-    if (account) {
-      history.push(makeSendRoute(asset, account))
-    } else {
-      history.push(WalletRoutes.Send)
-    }
+    history.push(makeSendRoute(asset, account))
   }, [account, history, asset])
 
   const onClickSwap = React.useCallback(() => {

--- a/components/brave_wallet_ui/utils/routes-utils.ts
+++ b/components/brave_wallet_ui/utils/routes-utils.ts
@@ -226,22 +226,25 @@ export const makeDepositFundsAccountRoute = (assetId: string) => {
 
 export const makeSendRoute = (
   asset: BraveWallet.BlockchainToken,
-  account: BraveWallet.AccountInfo
+  account?: BraveWallet.AccountInfo
 ) => {
   const isNftTab = asset.isErc721 || asset.isNft
   const baseQueryParams = {
     chainId: asset.chainId,
-    token: asset.contractAddress || asset.symbol.toUpperCase(),
-    account: account.accountId.uniqueKey
+    token: asset.contractAddress || asset.symbol.toUpperCase()
   }
 
-  const tokenIdQueryParams = asset.tokenId
-    ? { ...baseQueryParams, tokenId: asset.tokenId }
+  const accountIdQueryParams = account
+    ? { ...baseQueryParams, account: account.accountId.uniqueKey }
     : baseQueryParams
+
+  const tokenIdQueryParams = asset.tokenId
+    ? { ...accountIdQueryParams, tokenId: asset.tokenId }
+    : accountIdQueryParams
 
   const params = new URLSearchParams(
     asset.isShielded
-      ? {...tokenIdQueryParams, isShielded: 'true'}
+      ? { ...tokenIdQueryParams, isShielded: 'true' }
       : tokenIdQueryParams
   )
 


### PR DESCRIPTION
## Description 

We will now prompt to select an `Account` when a user clicks `Send` for an asset on the `Portfolio` and their portfolio is not grouped by `Accounts`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43131>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the Wallet and navigate to the `Portfolio` screen
2. Group your assets by `None` or `Networks`
3. Click the `More Menu` for an asset and click `Send`
4. It should navigate to the `Send` screen and prompt you to select an `Account` to send from.
5. If you close the `Select Account` modal, params will be cleared and nothing will be selected.
6. If you click `Back` on the `Select Account` modal, params will be cleared and you can make a new selection.
7. If you have your `Portfolio` grouped by `Accounts` and you click send for an asset, the associated account will be automatically selected on the `Send` screen

https://github.com/user-attachments/assets/43ad2b0d-7eab-492a-b4c3-03ef24cdf33c
