### PR TITLE
feat(ai chat): Delete Conversation Confirmation Dialog

### DIFF
--- a/components/ai_chat/core/browser/constants.cc
+++ b/components/ai_chat/core/browser/constants.cc
@@ -100,6 +100,8 @@ base::span<const webui::LocalizedString> GetLocalizedStrings() {
        {"feedbackPremiumNote", IDS_CHAT_UI_FEEDBACK_PREMIUM_NOTE},
        {"submitButtonLabel", IDS_CHAT_UI_SUBMIT_BUTTON_LABEL},
        {"cancelButtonLabel", IDS_CHAT_UI_CANCEL_BUTTON_LABEL},
+       {"deleteButtonLabel", IDS_CHAT_UI_DELETE_BUTTON_LABEL},
+       {"deleteConversationWarning", IDS_CHAT_UI_DELETE_CONVERSATION_WARNING},
        {"saveButtonLabel", IDS_CHAT_UI_SAVE_BUTTON_LABEL},
        {"editedLabel", IDS_CHAT_UI_EDITED_LABEL},
        {"editButtonLabel", IDS_CHAT_UI_EDIT_BUTTON_LABEL},

--- a/components/ai_chat/resources/page/components/conversations_list/index.tsx
+++ b/components/ai_chat/resources/page/components/conversations_list/index.tsx
@@ -79,7 +79,7 @@ function ConversationItem(props: ConversationItemProps) {
 
   const handleDelete: EventListener = (e) => {
     e.preventDefault()
-    aiChatContext.service?.deleteConversation(uuid)
+    aiChatContext.setDeletingConversationId(uuid)
   }
 
   const isEditing = aiChatContext.editingConversationId === uuid

--- a/components/ai_chat/resources/page/components/delete_conversation_modal/index.tsx
+++ b/components/ai_chat/resources/page/components/delete_conversation_modal/index.tsx
@@ -1,0 +1,70 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as React from 'react'
+import Button from '@brave/leo/react/button'
+import Dialog from '@brave/leo/react/dialog'
+import { getLocale } from '$web-common/locale'
+import { useAIChat } from '../../state/ai_chat_context'
+import styles from './style.module.scss'
+
+export default function DeleteConversationModal() {
+  // Context
+  const aiChatContext = useAIChat()
+
+  // Computed
+  const title = aiChatContext.visibleConversations.find(
+        (conversation) =>
+          conversation.uuid === aiChatContext.deletingConversationId
+      )?.title || getLocale('conversationListUntitled')
+
+  return (
+    <Dialog
+      isOpen={!!aiChatContext.deletingConversationId}
+      showClose
+      onClose={() => aiChatContext.setDeletingConversationId(null)}
+      className={styles.deleteConversationDialog}
+    >
+      <div
+        slot='title'
+        className={styles.deleteConversationDialogTitle}
+      >
+        {getLocale('menuDeleteConversation')}
+      </div>
+      <div className={styles.deleteConversationBody}>
+        <div className={styles.conversationNameWrapper}>{title}</div>
+        {getLocale('deleteConversationWarning')}
+      </div>
+      <div
+        slot='actions'
+        className={styles.deleteConversationActionsRow}
+      >
+        <div className={styles.buttonsWrapper}>
+          <Button
+            kind='plain-faint'
+            size='medium'
+            onClick={() => aiChatContext.setDeletingConversationId(null)}
+          >
+            {getLocale('cancelButtonLabel')}
+          </Button>
+          <Button
+            kind='filled'
+            size='medium'
+            onClick={() => {
+              if (aiChatContext.deletingConversationId) {
+                aiChatContext.service?.deleteConversation(
+                  aiChatContext.deletingConversationId
+                )
+                aiChatContext.setDeletingConversationId(null)
+              }
+            }}
+          >
+            {getLocale('deleteButtonLabel')}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  )
+}

--- a/components/ai_chat/resources/page/components/delete_conversation_modal/style.module.scss
+++ b/components/ai_chat/resources/page/components/delete_conversation_modal/style.module.scss
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// you can obtain one at https://mozilla.org/MPL/2.0/.
+
+.conversationNameWrapper {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  padding: var(--leo-spacing-l);
+  border-radius: var(--leo-radius-m);
+  border: 1px solid var(--leo-color-divider-subtle);
+  font: var(--leo-font-heading-h4);
+  color: var(--leo-color-text-secondary);
+}
+
+.deleteConversationDialogTitle {
+  font: var(--leo-font-heading-h3);
+}
+
+.deleteConversationDialog {
+  --leo-dialog-padding: 24px;
+}
+
+.deleteConversationBody {
+  display: flex;
+  flex-direction: column;
+  gap: var(--leo-spacing-xl);
+}
+
+.deleteConversationActionsRow {
+  justify-content: flex-end;
+}
+
+.buttonsWrapper {
+  display: flex;
+  gap: var(--leo-spacing-m);
+}

--- a/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/feature_button_menu/index.tsx
@@ -124,7 +124,7 @@ export default function FeatureMenu(props: Props) {
             </div>
           </div>
         </leo-menu-item>
-        <leo-menu-item onClick={() => aiChatContext.service?.deleteConversation(conversationContext.conversationUuid!)}>
+        <leo-menu-item onClick={() => aiChatContext.setDeletingConversationId(conversationContext.conversationUuid!)}>
           <div className={classnames(
             styles.menuItemWithIcon,
             styles.menuItemMainItem

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -23,6 +23,7 @@ import LongConversationInfo from '../alerts/long_conversation_info'
 import NoticeConversationStorage from '../notices/notice_conversation_storage'
 import WarningPremiumDisconnected from '../alerts/warning_premium_disconnected'
 import ConversationsList from '../conversations_list'
+import DeleteConversationModal from '../delete_conversation_modal'
 import FeedbackForm from '../feedback_form'
 import { ConversationHeader } from '../header'
 import InputBox from '../input_box'
@@ -353,6 +354,7 @@ function Main() {
           />
         </ToolsButtonMenu>
       </div>
+      <DeleteConversationModal />
     </main>
   )
 }

--- a/components/ai_chat/resources/page/state/ai_chat_context.tsx
+++ b/components/ai_chat/resources/page/state/ai_chat_context.tsx
@@ -32,6 +32,8 @@ type AIChatContextInternal = AIChatContextProps & {
 
   editingConversationId: string | null
   setEditingConversationId: (uuid: string | null) => void,
+  deletingConversationId: string | null
+  setDeletingConversationId: (uuid: string | null) => void
 
   showSidebar: boolean,
   toggleSidebar: () => void
@@ -52,6 +54,8 @@ const defaultContext: AIChatContext = {
 
   editingConversationId: null,
   setEditingConversationId: () => { },
+  deletingConversationId: null,
+  setDeletingConversationId: () => { },
 
   showSidebar: false,
   toggleSidebar: () => { },
@@ -71,6 +75,8 @@ export function AIChatContextProvider(props: React.PropsWithChildren<AIChatConte
   const context = useAPIState(api, defaultContext)
   const [editingConversationId, setEditingConversationId] =
     React.useState<string | null>(null)
+  const [deletingConversationId, setDeletingConversationId] =
+    React.useState<string | null>(null)
   const isSmall = useIsSmall()
   const [showSidebar, setShowSidebar] = React.useState(isSmall)
 
@@ -87,6 +93,8 @@ export function AIChatContextProvider(props: React.PropsWithChildren<AIChatConte
     service: api.service,
     editingConversationId,
     setEditingConversationId,
+    deletingConversationId,
+    setDeletingConversationId,
     showSidebar,
     toggleSidebar: () => setShowSidebar(s => !s),
     conversationEntriesComponent: props.conversationEntriesComponent

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -406,6 +406,7 @@ type CustomArgs = {
   inputText: string
   hasConversation: boolean
   editingConversationId: string | null
+  deletingConversationId: string | null
   visibleConversationListCount: number
   hasSuggestedQuestions: boolean
   hasSiteInfo: boolean
@@ -436,6 +437,7 @@ const args: CustomArgs = {
   hasSuggestedQuestions: true,
   hasSiteInfo: true,
   editingConversationId: null,
+  deletingConversationId: null,
   isFeedbackFormVisible: false,
   isStorageNoticeDismissed: false,
   canShowPremiumPrompt: false,
@@ -478,6 +480,10 @@ const meta: Meta<CustomArgs> = {
     },
     visibleConversationListCount: {
       control: { type: 'number' }
+    },
+    deletingConversationId: {
+      options: CONVERSATIONS.map(conversation => conversation.uuid),
+      control: { type: 'select' }
     }
   },
   args,
@@ -532,6 +538,7 @@ function StoryContext(props: React.PropsWithChildren<{args: CustomArgs, setArgs:
     conversationEntriesComponent: StorybookConversationEntries,
     initialized: options.args.initialized,
     editingConversationId: options.args.editingConversationId,
+    deletingConversationId: options.args.deletingConversationId,
     visibleConversations,
     isStoragePrefEnabled: options.args.isStoragePrefEnabled,
     hasAcceptedAgreement: options.args.hasAcceptedAgreement,
@@ -552,6 +559,7 @@ function StoryContext(props: React.PropsWithChildren<{args: CustomArgs, setArgs:
     dismissPremiumPrompt: () => {},
     userRefreshPremiumSession: () => {},
     setEditingConversationId: (id: string | null) => setArgs({ editingConversationId: id }),
+    setDeletingConversationId: (id: string | null) => setArgs({ deletingConversationId: id }),
     showSidebar: showSidebar,
     toggleSidebar: () => setShowSidebar(s => !s)
   }

--- a/components/ai_chat/resources/page/stories/story_utils/locale.ts
+++ b/components/ai_chat/resources/page/stories/story_utils/locale.ts
@@ -120,4 +120,7 @@ provideStrings({
   goBackToActiveConversationButton: 'Go back to the active conversation',
   conversationListUntitled: 'New conversation',
   stopGenerationButtonLabel: 'Stop answering',
+  deleteButtonLabel: 'Delete',
+  deleteConversationWarning: 'Are you sure you want to delete this conversation? This action cannot be undone.',
+  menuDeleteConversation: 'Delete conversation'
 })

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -213,6 +213,12 @@
   <message name="IDS_CHAT_UI_CANCEL_BUTTON_LABEL" desc="Button label to cancel action">
     Cancel
   </message>
+  <message name="IDS_CHAT_UI_DELETE_BUTTON_LABEL" desc="Button label to delete conversation">
+    Delete
+  </message>
+  <message name="IDS_CHAT_UI_DELETE_CONVERSATION_WARNING" desc="A warning issued when the user is trying to delete a conversation">
+    Are you sure you want to delete this conversation? This action cannot be undone.
+  </message>
   <message name="IDS_CHAT_UI_SAVE_BUTTON_LABEL" desc="Button label to save data/form">
     Save
   </message>


### PR DESCRIPTION
## Description 

Will now prompt the user with a `Confirmation` dialog when attempting to delete a conversation.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/42969>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Start multiple conversations with `Leo`
2. Click the `More Menu` for a chat and then click `Delete conversation`
3. You should be prompted with a `Confirmation Dialog` to either `Cancel` or `Delete` the conversation.

https://github.com/user-attachments/assets/128204d5-ea70-477d-8698-152e50959852
