### PR TITLE
Don't need to have rounded contents margin in tab-fullscreen (uplift to 1.74.x)

### DIFF
--- a/browser/ui/views/frame/brave_browser_view_layout.cc
+++ b/browser/ui/views/frame/brave_browser_view_layout.cc
@@ -266,6 +266,13 @@ void BraveBrowserViewLayout::UpdateContentsContainerInsets(
   // Control contents's margin with sidebar & vertical tab state.
   gfx::Insets contents_margins = GetContentsMargins();
 
+  // Don't need to have additional contents margin for rounded corners
+  // in tab-initiated fullscreen. Web contents occupies whole screen.
+  if (IsFullscreenForTab()) {
+    contents_container_bounds.Inset(contents_margins);
+    return;
+  }
+
   // In rounded corners mode, we need to include a little margin so we have
   // somewhere to draw the shadow.
   int contents_margin_for_rounded_corners =


### PR DESCRIPTION
Uplift of #27150
fix https://github.com/brave/brave-browser/issues/43136

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.