### PR TITLE
Enable the Element Picker feature by default for Android (uplift to 1.75.x)

### DIFF
--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -136,11 +136,7 @@ BASE_FEATURE(kBlockAllCookiesToggle,
 // when enabled, allow to select and block HTML elements
 BASE_FEATURE(kBraveShieldsElementPicker,
              "BraveShieldsElementPicker",
-#if BUILDFLAG(IS_ANDROID)
-             base::FEATURE_DISABLED_BY_DEFAULT);
-#else
              base::FEATURE_ENABLED_BY_DEFAULT);
-#endif
 
 // Enables extra TRACE_EVENTs in content filter js. The feature is
 // primary designed for local debugging.


### PR DESCRIPTION
Uplift of #27144
Resolves https://github.com/brave/brave-browser/issues/43144

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.