### PR TITLE
Cleanup forgetful browsing storage only if a profile window appeared.

### DIFF
--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.cc
@@ -311,12 +311,13 @@ content::EvalJsResult EphemeralStorageBrowserTest::GetCookiesInFrame(
   return content::EvalJs(host, "document.cookie");
 }
 
-size_t EphemeralStorageBrowserTest::WaitForCleanupAfterKeepAlive(Browser* b) {
-  if (!b) {
-    b = browser();
+size_t EphemeralStorageBrowserTest::WaitForCleanupAfterKeepAlive(
+    Profile* profile) {
+  if (!profile) {
+    profile = browser()->profile();
   }
   const size_t fired_cnt = EphemeralStorageServiceFactory::GetInstance()
-                               ->GetForContext(b->profile())
+                               ->GetForContext(profile)
                                ->FireCleanupTimersForTesting();
 
   // NetworkService closes existing connections when a data removal action
@@ -324,8 +325,7 @@ size_t EphemeralStorageBrowserTest::WaitForCleanupAfterKeepAlive(Browser* b) {
   // failures when the timing is "just right". Do a no-op removal here to make
   // sure the queued Ephemeral Storage cleanup was complete.
   BrowsingDataRemoverObserver data_remover_observer;
-  content::BrowsingDataRemover* remover =
-      b->profile()->GetBrowsingDataRemover();
+  content::BrowsingDataRemover* remover = profile->GetBrowsingDataRemover();
   remover->AddObserver(&data_remover_observer);
   remover->RemoveAndReply(base::Time(), base::Time::Max(), 0, 0,
                           &data_remover_observer);

--- a/browser/ephemeral_storage/ephemeral_storage_browsertest.h
+++ b/browser/ephemeral_storage/ephemeral_storage_browsertest.h
@@ -88,7 +88,7 @@ class EphemeralStorageBrowserTest : public InProcessBrowserTest {
                                                StorageType storage_type);
   void SetCookieInFrame(content::RenderFrameHost* host, std::string cookie);
   content::EvalJsResult GetCookiesInFrame(content::RenderFrameHost* host);
-  size_t WaitForCleanupAfterKeepAlive(Browser* browser = nullptr);
+  size_t WaitForCleanupAfterKeepAlive(Profile* profile = nullptr);
   void ExpectValuesFromFramesAreEmpty(const base::Location& location,
                                       const ValuesFromFrames& values);
   void ExpectValuesFromFrameAreEmpty(const base::Location& location,

--- a/components/ephemeral_storage/ephemeral_storage_service.cc
+++ b/components/ephemeral_storage/ephemeral_storage_service.cc
@@ -56,7 +56,10 @@ EphemeralStorageService::EphemeralStorageService(
   if (base::FeatureList::IsEnabled(
           net::features::kBraveForgetFirstPartyStorage) &&
       !context_->IsOffTheRecord()) {
-    ScheduleFirstPartyStorageAreasCleanupOnStartup();
+    delegate_->RegisterFirstWindowOpenedCallback(
+        base::BindOnce(&EphemeralStorageService::
+                           ScheduleFirstPartyStorageAreasCleanupOnStartup,
+                       weak_ptr_factory_.GetWeakPtr()));
   }
 }
 

--- a/components/ephemeral_storage/ephemeral_storage_service_delegate.h
+++ b/components/ephemeral_storage/ephemeral_storage_service_delegate.h
@@ -7,10 +7,9 @@
 #define BRAVE_COMPONENTS_EPHEMERAL_STORAGE_EPHEMERAL_STORAGE_SERVICE_DELEGATE_H_
 
 #include <string>
-#include <utility>
 
+#include "base/functional/callback.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_types.h"
-#include "url/origin.h"
 
 namespace ephemeral_storage {
 
@@ -20,10 +19,13 @@ class EphemeralStorageServiceDelegate {
   virtual ~EphemeralStorageServiceDelegate() = default;
 
   // Cleanups ephemeral storages (local storage, cookies).
-  virtual void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) {}
+  virtual void CleanupTLDEphemeralArea(const TLDEphemeralAreaKey& key) = 0;
   // Cleanups non-ephemeral first party storage areas (cache, dom storage).
   virtual void CleanupFirstPartyStorageArea(
-      const std::string& registerable_domain) {}
+      const std::string& registerable_domain) = 0;
+  // Registers a callback to be called when the first window is opened.
+  virtual void RegisterFirstWindowOpenedCallback(
+      base::OnceClosure callback) = 0;
 };
 
 }  // namespace ephemeral_storage


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Prevent forgetful browsing storage cleanup if only incognito window was created (ex. browser was launched in incognito from scratch).

Based on work from @Ilie-Lesan https://github.com/brave/brave-core/pull/27111, but uses a more reliable approach of scheduling the cleanup only after a profile-bound window appeared.

Resolves https://github.com/brave/brave-browser/issues/39107

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

