### PR TITLE
[Android] Prevent wiping passwords on cr132

### DIFF
--- a/browser/password_manager/android/BUILD.gn
+++ b/browser/password_manager/android/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "brave_password_manager_android_util_unittest.cc" ]
+
+  deps = [
+    "//base/test:test_support",
+    "//chrome/browser/password_manager/android:utils",
+    "//components/password_manager/core/browser",
+    "//components/password_manager/core/browser/features:password_features",
+    "//components/prefs:test_support",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/browser/password_manager/android/brave_password_manager_android_util_unittest.cc
+++ b/browser/password_manager/android/brave_password_manager_android_util_unittest.cc
@@ -1,0 +1,132 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "base/android/build_info.h"
+#include "base/files/file_util.h"
+#include "base/test/scoped_feature_list.h"
+#include "base/test/test_file_util.h"
+#include "chrome/browser/password_manager/android/password_manager_android_util.h"
+#include "components/password_manager/core/browser/features/password_features.h"
+#include "components/password_manager/core/browser/password_manager_constants.h"
+#include "components/password_manager/core/browser/split_stores_and_local_upm.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/sync/base/data_type.h"
+#include "components/sync/base/pref_names.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+using password_manager::GetLocalUpmMinGmsVersion;
+using password_manager::prefs::kPasswordsUseUPMLocalAndSeparateStores;
+using password_manager::prefs::UseUpmLocalAndSeparateStoresState;
+using password_manager::prefs::UseUpmLocalAndSeparateStoresState::kOff;
+using password_manager::prefs::UseUpmLocalAndSeparateStoresState::kOn;
+
+namespace password_manager_android_util {
+namespace {
+
+class BravePasswordManagerAndroidUtilTest : public testing::Test {
+ public:
+  BravePasswordManagerAndroidUtilTest() {
+    pref_service_.registry()->RegisterBooleanPref(
+        password_manager::prefs::kUnenrolledFromGoogleMobileServicesDueToErrors,
+        false);
+    pref_service_.registry()->RegisterIntegerPref(
+        password_manager::prefs::kCurrentMigrationVersionToGoogleMobileServices,
+        0);
+    pref_service_.registry()->RegisterIntegerPref(
+        password_manager::prefs::kPasswordsUseUPMLocalAndSeparateStores,
+        static_cast<int>(kOff));
+    pref_service_.registry()->RegisterBooleanPref(
+        password_manager::prefs::kCredentialsEnableService, false);
+    pref_service_.registry()->RegisterBooleanPref(
+        password_manager::prefs::kCredentialsEnableAutosignin, false);
+    pref_service_.registry()->RegisterBooleanPref(
+        password_manager::prefs::kEmptyProfileStoreLoginDatabase, false);
+    pref_service_.registry()->RegisterBooleanPref(
+        syncer::prefs::internal::kSyncInitialSyncFeatureSetupComplete, false);
+    pref_service_.registry()->RegisterBooleanPref(
+        syncer::prefs::internal::kSyncKeepEverythingSynced, false);
+    pref_service_.registry()->RegisterBooleanPref(
+        base::StrCat(
+            {syncer::prefs::internal::
+                 kSyncDataTypeStatusForSyncToSigninMigrationPrefix,
+             ".", syncer::DataTypeToStableLowerCaseString(syncer::PASSWORDS)}),
+        false);
+    pref_service_.registry()->RegisterBooleanPref(
+        password_manager::prefs::
+            kUserAcknowledgedLocalPasswordsMigrationWarning,
+        false);
+    pref_service_.registry()->RegisterBooleanPref(
+        password_manager::prefs::kSettingsMigratedToUPMLocal, false);
+
+    base::WriteFile(login_db_directory_.Append(
+                        password_manager::kLoginDataForProfileFileName),
+                    "");
+
+    // Most tests check the modern GmsCore case.
+    base::android::BuildInfo::GetInstance()->set_gms_version_code_for_test(
+        base::NumberToString(GetLocalUpmMinGmsVersion()));
+  }
+
+  TestingPrefServiceSimple* pref_service() { return &pref_service_; }
+
+  const base::FilePath& login_db_directory() { return login_db_directory_; }
+
+ private:
+  TestingPrefServiceSimple pref_service_;
+  const base::FilePath login_db_directory_ =
+      base::CreateUniqueTempDirectoryScopedToTest();
+};
+
+// Based on Chromium's PasswordManagerAndroidUtilTest.
+// SetUsesSplitStoresAndUPMForLocal_DeletesLoginDataFilesForMigratedUsers.
+// We don't migrate and don't delete passwords DB.
+TEST_F(BravePasswordManagerAndroidUtilTest,
+       SetUsesSplitStoresAndUPMForLocal_DeletesLoginDataFilesForMigratedUsers) {
+  base::test::ScopedFeatureList feature_list(
+      password_manager::features::kClearLoginDatabaseForAllMigratedUPMUsers);
+
+  // This is a state of a local user that has just been migrated.
+  pref_service()->SetInteger(kPasswordsUseUPMLocalAndSeparateStores,
+                             static_cast<int>(kOn));
+  pref_service()->SetBoolean(
+      password_manager::prefs::kUserAcknowledgedLocalPasswordsMigrationWarning,
+      true);
+  pref_service()->SetBoolean(
+      password_manager::prefs::kEmptyProfileStoreLoginDatabase, false);
+
+  // Creating the login data files for testing.
+  base::FilePath profile_db_path = login_db_directory().Append(
+      password_manager::kLoginDataForProfileFileName);
+  base::FilePath account_db_path = login_db_directory().Append(
+      password_manager::kLoginDataForAccountFileName);
+  base::FilePath profile_db_journal_path = login_db_directory().Append(
+      password_manager::kLoginDataJournalForProfileFileName);
+  base::FilePath account_db_journal_path = login_db_directory().Append(
+      password_manager::kLoginDataJournalForAccountFileName);
+
+  base::WriteFile(profile_db_path, "Test content");
+  base::WriteFile(account_db_path, "Test content");
+  base::WriteFile(profile_db_journal_path, "Test content");
+  base::WriteFile(account_db_journal_path, "Test content");
+
+  EXPECT_TRUE(PathExists(profile_db_path));
+  EXPECT_TRUE(PathExists(account_db_path));
+  EXPECT_TRUE(PathExists(profile_db_journal_path));
+  EXPECT_TRUE(PathExists(account_db_journal_path));
+
+  SetUsesSplitStoresAndUPMForLocal(pref_service(), login_db_directory());
+
+  // SetUsesSplitStoresAndUPMForLocal must not delete DB on Brave
+  EXPECT_EQ(pref_service()->GetInteger(kPasswordsUseUPMLocalAndSeparateStores),
+            static_cast<int>(kOn));
+  EXPECT_TRUE(PathExists(profile_db_path));
+  EXPECT_TRUE(PathExists(account_db_path));
+  EXPECT_TRUE(PathExists(profile_db_journal_path));
+  EXPECT_TRUE(PathExists(account_db_journal_path));
+}
+
+}  // namespace
+}  // namespace password_manager_android_util

--- a/chromium_src/chrome/browser/password_manager/android/password_manager_android_util.cc
+++ b/chromium_src/chrome/browser/password_manager/android/password_manager_android_util.cc
@@ -1,0 +1,22 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#define SetUsesSplitStoresAndUPMForLocal \
+  SetUsesSplitStoresAndUPMForLocal_ChromiumImpl
+
+#include "src/chrome/browser/password_manager/android/password_manager_android_util.cc"
+
+#undef SetUsesSplitStoresAndUPMForLocal
+
+namespace password_manager_android_util {
+
+// Prevent deleting passwords local DB during migration.
+// Happens at SetUsesSplitStoresAndUPMForLocal =>
+//      MaybeDeactivateSplitStoresAndLocalUpm =>
+//      MaybeDeleteLoginDataFiles
+void SetUsesSplitStoresAndUPMForLocal(
+    PrefService* pref_service,
+    const base::FilePath& login_db_directory) {}
+}  // namespace password_manager_android_util

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -493,6 +493,7 @@ test("brave_unit_tests") {
   if (is_android) {
     deps += [
       "//brave:brave_pak_assets",
+      "//brave/browser/password_manager/android:unit_tests",
       "//brave/components/brave_mobile_subscription/renderer/android:unit_tests",
       "//chrome/android:chrome_apk_paks",
       "//chrome/test/android:chrome_java_test_support_common",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43171

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

### I. Passwords are not saved on Android if the Sync is not turned on.

1. Take fresh install of the version containing fix 
2. Ensure the sync is turned off
3. Login to some site, save the password when will be prompted
4. Go to Settings => Brave Password Manager, ensure the password is there
5. Restart browser
6. Go again to Settings => Brave Password Manager
7. Expected:  the saved password should persist

### II. Existing passwords are wiped on Android if the Sync is not turned on when upgrading from cr131 to cr132.

1. Take fresh install of the version based on `cr131`, `v1.75.66`
2. Ensure the sync is turned off
3. Login to some site, save the password when will be prompted
4. Go to Settings => Brave Password Manager, ensure the password is there
5. Update browser to the version of `cr132` which contains the fix
6. Launch browser
7. Go again to Settings => Brave Password Manager
8. Expected - the saved password should persist


