### PR TITLE
[BYOM] Uses Nala components when configuring models

### DIFF
--- a/browser/resources/settings/brave_leo_assistant_page/model_config_ui.html
+++ b/browser/resources/settings/brave_leo_assistant_page/model_config_ui.html
@@ -292,13 +292,13 @@
         </template>
         </div>
       </div>
-      <cr-textarea
+      <leo-textarea
         value="[[modelSystemPrompt]]"
         rows="4"
         placeholder="$i18n{braveLeoAssistantModelSystemPromptPlaceholder}"
         on-change="onModelSystemPromptChange_"
         on-input="constructTokenEstimateString_"
-      ></cr-textarea>
+      ></leo-textarea>
     </div>
 
     <div class="actions-container">

--- a/browser/resources/settings/brave_leo_assistant_page/model_config_ui.html
+++ b/browser/resources/settings/brave_leo_assistant_page/model_config_ui.html
@@ -1,10 +1,4 @@
 <style include="cr-shared-style settings-shared iron-flex">
-  cr-input {
-    --cr-input-border-bottom: none;
-    --cr-input-border-radius: var(--leo-radius-m);
-    --cr-input-error-color: var(--leo-color-systemfeedback-error-icon);
-  }
-
   .primary-title {
     font: var(--leo-font-heading-h3);
     color: var(--leo-color-text-primary);
@@ -14,10 +8,6 @@
   .container {
     width: 100%;
     padding: 16px 0;
-  }
-
-  small {
-    color: var(--leo-color-text-secondary);
   }
 
   .input-container {
@@ -65,10 +55,9 @@
   }
   
   .unsafe-endpoint-label {
-    gap: 1em;
     display: flex;
     justify-content: center;
-    color: var(--leo-color-systemfeedback-error-icon);
+    margin-top: var(--leo-spacing-s);
   }
 </style>
 
@@ -124,13 +113,13 @@
           </leo-tooltip>
         </div>
       </div>
-      <cr-input
+      <leo-input
         required
         auto-validate
         type="text"
         value="[[label]]"
         on-change="onModelLabelChange_"
-      ></cr-input>
+      ></leo-input>
     </div>
     <div class="input-container">
       <div class="custom-label">
@@ -155,13 +144,13 @@
           </leo-tooltip>
         </div>
       </div>
-      <cr-input
+      <leo-input
         required
         auto-validate
         type="text"
         value="[[modelRequestName]]"
         on-change="onModelRequestNameChange_"
-      ></cr-input>
+      ></leo-input>
     </div>
     <div class="input-container">
       <div class="custom-label">
@@ -181,27 +170,30 @@
               kind="plain-faint"
               fab
             >
-              <leo-icon class="small" name="info-outline"></leo-icon>
+              <leo-icon name="info-outline"></leo-icon>
             </leo-button>
           </leo-tooltip>
         </div>
       </div>
-      <div class="note">$i18n{braveLeoAssistantProxyNote}</div>
-      <cr-input
+      <leo-input
         id="endpointInput"
         required
         type="url"
         value="[[endpointUrl]]"
         on-change="onModelServerEndpointChange_"
-        invalid="[[isUrlInvalid]]"
-        error-message="[[invalidUrlErrorMessage]]"
-      ></cr-input>
+        show-errors="[[isUrlInvalid]]"
+      >
+        <div slot="errors">[[invalidUrlErrorMessage]]</div>  
+        <div slot="extra" class="inline-note">
+          $i18n{braveLeoAssistantProxyNote}
+        </div>
+      </leo-input>
       <template is="dom-if" if="[[shouldShowUnsafeEndpointLabel]]">
         <div class="unsafe-endpoint-label">
-          <leo-icon name="lock-open"></leo-icon> 
-          <span class="label-text">
+          <leo-label mode="loud" color="red">
+            <leo-icon name="lock-open" slot="icon-before"></leo-icon> 
             $i18n{braveLeoAssistantEndpointPotentiallyUnsafeError}
-          </span>
+          </leo-label>
         </div>
       </template>
     </div>
@@ -222,18 +214,18 @@
               kind="plain-faint"
               fab
             >
-              <cr-icon class="small" icon="info-outline"></cr-icon>
+              <leo-icon name="info-outline"></leo-icon>
             </leo-button>
           </leo-tooltip>
         </div>
       </div>
-      <cr-input
+      <leo-input
         auto-validate
         type="number"
         value="[[contextSize]]"
         placeholder="$i18n{braveLeoAssistantInputDefaultContextSize}"
         on-change="onContextSizeChange_"
-      ></cr-input>
+      ></leo-input>
     </div>
     <div class="input-container">
       <div class="custom-label">
@@ -251,18 +243,18 @@
               kind="plain-faint"
               fab
             >
-              <leo-icon class="small" name="info-outline"></leo-icon>
+              <leo-icon name="info-outline"></leo-icon>
             </leo-button>
           </leo-tooltip>
         </div>
       </div>
-      <cr-input
+      <leo-input
         auto-validate
         type="text"
         value="[[apiKey]]"
         on-change="onModelApiKeyChange_"
       >
-      </cr-input>
+      </leo-input>
     </div>
 
     <div class="input-container">
@@ -281,15 +273,9 @@
               kind="plain-faint"
               fab
             >
-              <cr-icon class="small"  icon="info-outline"></cr-icon>
+              <leo-icon name="info-outline"></leo-icon>
             </leo-button>
           </leo-tooltip>
-          <template
-          is="dom-if"
-          if="[[promptTokensEstimate]]"
-        >
-          <span class="inline-note">[[promptTokensEstimateString]]</span>
-        </template>
         </div>
       </div>
       <leo-textarea
@@ -298,13 +284,16 @@
         placeholder="$i18n{braveLeoAssistantModelSystemPromptPlaceholder}"
         on-change="onModelSystemPromptChange_"
         on-input="constructTokenEstimateString_"
-      ></leo-textarea>
+      >
+        <div slot="extra" class="inline-note">
+          [[promptTokensEstimateString]]
+        </div>
+      </leo-textarea>
     </div>
 
     <div class="actions-container">
       <leo-button
-        disabled="[[!saveEnabled_(label,
-    modelRequestName, endpointUrl)]]"
+        disabled="[[!saveEnabled_(label, modelRequestName, endpointUrl)]]"
         on-click="handleClick_"
       >
         [[buttonLabel_]]

--- a/browser/resources/settings/brave_leo_assistant_page/model_config_ui.ts
+++ b/browser/resources/settings/brave_leo_assistant_page/model_config_ui.ts
@@ -165,11 +165,11 @@ export class ModelConfigUI extends ModelConfigUIBase {
   }
 
   onModelLabelChange_(e: any) {
-    this.label = e.target.value
+    this.label = e.value
   }
 
   onModelRequestNameChange_(e: any) {
-    this.modelRequestName = e.target.value
+    this.modelRequestName = e.value
   }
 
   onModelSystemPromptChange_(e: any) {
@@ -177,16 +177,16 @@ export class ModelConfigUI extends ModelConfigUIBase {
   }
 
   onContextSizeChange_(e: any) {
-    this.contextSize = parseInt(e.target.value, 10);
+    this.contextSize = parseInt(e.value, 10);
   }
 
   onModelServerEndpointChange_(e: any) {
-    this.endpointUrl = e.target.value
+    this.endpointUrl = e.value
     this.checkEndpointValidity_()
   }
 
   onModelApiKeyChange_(e: any) {
-    this.apiKey = e.target.value
+    this.apiKey = e.value
   }
 
   constructTokenEstimateString_(e?: any) {

--- a/browser/resources/settings/brave_leo_assistant_page/model_config_ui.ts
+++ b/browser/resources/settings/brave_leo_assistant_page/model_config_ui.ts
@@ -177,7 +177,7 @@ export class ModelConfigUI extends ModelConfigUIBase {
   }
 
   onContextSizeChange_(e: any) {
-    this.contextSize = parseInt(e.value, 10);
+    this.contextSize = e.valueAsNumber
   }
 
   onModelServerEndpointChange_(e: any) {
@@ -190,13 +190,13 @@ export class ModelConfigUI extends ModelConfigUIBase {
   }
 
   constructTokenEstimateString_(e?: any) {
-    let charsLength = 0;
-    let tokensLength = 0;
+    let charsLength = 0
+    let tokensLength = 0
 
     if (e?.value) {
-      charsLength = e.value.length;
+      charsLength = e.value.length
     } else if (this.modelSystemPrompt) {
-      charsLength = this.modelSystemPrompt.length;
+      charsLength = this.modelSystemPrompt.length
     }
 
     tokensLength = charsLength > 0 ? Math.ceil(charsLength/4) : 0;

--- a/browser/resources/settings/brave_leo_assistant_page/model_config_ui.ts
+++ b/browser/resources/settings/brave_leo_assistant_page/model_config_ui.ts
@@ -7,7 +7,6 @@ import 'chrome://resources/cr_elements/cr_button/cr_button.js'
 import 'chrome://resources/cr_elements/icons.html.js'
 
 import { sendWithPromise } from 'chrome://resources/js/cr.js'
-import type { CrInputElement } from 'chrome://resources/cr_elements/cr_input/cr_input.js'
 import { PrefsMixin } from '/shared/settings/prefs/prefs_mixin.js'
 import { I18nMixin } from 'chrome://resources/cr_elements/i18n_mixin.js'
 import { PolymerElement } from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
@@ -174,7 +173,7 @@ export class ModelConfigUI extends ModelConfigUIBase {
   }
 
   onModelSystemPromptChange_(e: any) {
-    this.modelSystemPrompt = e.target.value
+    this.modelSystemPrompt = e.value;
   }
 
   onContextSizeChange_(e: any) {
@@ -190,13 +189,13 @@ export class ModelConfigUI extends ModelConfigUIBase {
     this.apiKey = e.target.value
   }
 
-  constructTokenEstimateString_( e?: any ) {
+  constructTokenEstimateString_(e?: any) {
     let charsLength = 0;
     let tokensLength = 0;
 
-    if ( e?.target?.value ) {
-      charsLength = e.target.value.length;
-    } else if ( this.modelSystemPrompt ) {
+    if (e?.value) {
+      charsLength = e.value.length;
+    } else if (this.modelSystemPrompt) {
       charsLength = this.modelSystemPrompt.length;
     }
 

--- a/ui/webui/resources/leo/web_components.ts
+++ b/ui/webui/resources/leo/web_components.ts
@@ -7,15 +7,15 @@
 // as <leo-{component}></leo-{component}>.
 import '@brave/leo/web-components/alert'
 import '@brave/leo/web-components/button'
-import '@brave/leo/web-components/dropdown'
 import '@brave/leo/web-components/checkbox'
+import '@brave/leo/web-components/dropdown'
 import '@brave/leo/web-components/icon'
 import '@brave/leo/web-components/input'
 import '@brave/leo/web-components/label'
 import '@brave/leo/web-components/progressRing'
+import '@brave/leo/web-components/textarea'
 import '@brave/leo/web-components/toggle'
 import '@brave/leo/web-components/tooltip'
-import '@brave/leo/web-components/alert'
 import { setIconBasePath } from '@brave/leo/web-components/icon'
 import iconsMeta from '@brave/leo/icons/meta'
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42589

Replaces older cr-* components with newer Nala versions.

![image](https://github.com/user-attachments/assets/a5365e19-13a5-436f-89c6-45145777cbce)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Navigate to brave://settings/leo-ai and verify that newer Nala controls are used instead of older cr-* components. See the screenshot at the top of this issue for a side-by-side comparison.