### PR TITLE
[iOS] Only set web view background color when night mode is enabled

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BraveWebView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BraveWebView.swift
@@ -5,6 +5,7 @@
 import BraveShared
 import DesignSystem
 import Foundation
+import Preferences
 import Shared
 import UserAgent
 import WebKit
@@ -44,11 +45,23 @@ class BraveWebView: WKWebView {
       isInspectable = true
     }
 
-    backgroundColor = UIColor(braveSystemName: .containerBackground)
-    scrollView.backgroundColor = UIColor(braveSystemName: .containerBackground)
-    // WKWebView flashes white screen on load regardless of background colour assignments without
-    // setting `isOpaque` to false
-    isOpaque = false
+    updateBackgroundColor()
+    Preferences.General.nightModeEnabled.observe(from: self)
+  }
+
+  private func updateBackgroundColor() {
+    if Preferences.General.nightModeEnabled.value {
+      let color = UIColor(braveSystemName: .containerBackground)
+      backgroundColor = color
+      scrollView.backgroundColor = color
+      // WKWebView flashes white screen on load regardless of background colour assignments without
+      // setting `isOpaque` to false
+      isOpaque = false
+    } else {
+      backgroundColor = nil
+      scrollView.backgroundColor = nil
+      isOpaque = true
+    }
   }
 
   static func removeNonPersistentStore() {
@@ -63,6 +76,12 @@ class BraveWebView: WKWebView {
   override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
     lastHitPoint = point
     return super.hitTest(point, with: event)
+  }
+}
+
+extension BraveWebView: PreferencesObserver {
+  func preferencesDidChange(for key: String) {
+    updateBackgroundColor()
   }
 }
 


### PR DESCRIPTION
This fixes webcompat issues where the website's stylesheet will set the background to transparent making the assumption that the background will always be white

Resolves https://github.com/brave/brave-browser/issues/43214

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- With light mode and dark mode visit the site in the issue and verify text is readable
- With the site still loaded toggle night mode on and off and verify text is readable in each state
- With night mode enabled verify a new tab loading the site doesnt flash white and the text is still readable