### PR TITLE
[iOS] Only set web view background color when night mode is enabled (uplift to 1.75.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BraveWebView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BraveWebView.swift
@@ -5,6 +5,7 @@
 import BraveShared
 import DesignSystem
 import Foundation
+import Preferences
 import Shared
 import UserAgent
 import WebKit
@@ -44,11 +45,23 @@ class BraveWebView: WKWebView {
       isInspectable = true
     }
 
-    backgroundColor = UIColor(braveSystemName: .containerBackground)
-    scrollView.backgroundColor = UIColor(braveSystemName: .containerBackground)
-    // WKWebView flashes white screen on load regardless of background colour assignments without
-    // setting `isOpaque` to false
-    isOpaque = false
+    updateBackgroundColor()
+    Preferences.General.nightModeEnabled.observe(from: self)
+  }
+
+  private func updateBackgroundColor() {
+    if Preferences.General.nightModeEnabled.value {
+      let color = UIColor(braveSystemName: .containerBackground)
+      backgroundColor = color
+      scrollView.backgroundColor = color
+      // WKWebView flashes white screen on load regardless of background colour assignments without
+      // setting `isOpaque` to false
+      isOpaque = false
+    } else {
+      backgroundColor = nil
+      scrollView.backgroundColor = nil
+      isOpaque = true
+    }
   }
 
   static func removeNonPersistentStore() {
@@ -63,6 +76,12 @@ class BraveWebView: WKWebView {
   override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
     lastHitPoint = point
     return super.hitTest(point, with: event)
+  }
+}
+
+extension BraveWebView: PreferencesObserver {
+  func preferencesDidChange(for key: String) {
+    updateBackgroundColor()
   }
 }
 


### PR DESCRIPTION
Uplift of #27203
Resolves https://github.com/brave/brave-browser/issues/43214

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.