### PR TITLE
[iOS] Don't read pasteboard for text when evaluating search suggestions

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -221,11 +221,14 @@ extension BrowserViewController: TopToolbarDelegate {
     } else {
       showSearchController()
 
+      let locationLastReplacement = topToolbar.locationLastReplacement
+      let isPasting = topToolbar.isPastingInURLBar
       Task {
         await searchController?.setSearchQuery(
           query: text,
           showSearchSuggestions: URLBarHelper.shared.shouldShowSearchSuggestions(
-            using: topToolbar.locationLastReplacement
+            using: locationLastReplacement,
+            isPasting: isPasting
           )
         )
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -119,6 +119,10 @@ class TopToolbarView: UIView, ToolbarProtocol {
     locationTextField?.lastReplacement ?? ""
   }
 
+  var isPastingInURLBar: Bool {
+    locationTextField?.isPasting == true
+  }
+
   // MARK: Views
 
   private var locationTextField: AutocompleteTextField?

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -92,6 +92,7 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
             self,
             didEnterText: self.text?.preferredSearchSuggestionText ?? ""
           )
+          self.isPasting = false
         }
       }
     )
@@ -215,6 +216,13 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
     autocompleteTextLabel?.removeFromSuperview()
     autocompleteTextLabel = nil
     return hasActiveCompletion
+  }
+
+  private(set) var isPasting: Bool = false
+
+  public override func paste(_ sender: Any?) {
+    isPasting = true
+    super.paste(sender)
   }
 
   // `shouldChangeCharactersInRange` is called before the text changes, and textDidChange is called after.

--- a/ios/brave-ios/Sources/Brave/Helpers/URLBarHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Helpers/URLBarHelper.swift
@@ -10,27 +10,11 @@ class URLBarHelper {
 
   static let shared = URLBarHelper()
 
-  func shouldShowSearchSuggestions(using lastReplacement: String) async -> Bool {
-    // Check if last entry to url textfield needs to be checked as suspicious.
-    // The reason of checking count is bigger than 1 is the single character
-    // entries will always be safe and only way to achieve multi character entry is
-    // using paste board.
-    // This check also allow us to handle paste permission case
-    guard lastReplacement.count > 1 else {
-      return true
-    }
-
-    // Check if paste board has any text to guarantee the case
-    guard UIPasteboard.general.hasStrings || UIPasteboard.general.hasURLs else {
-      return true
-    }
-
-    // Perform check on pasted text
-    if let pasteboardContents = UIPasteboard.general.string {
-      let isSuspicious = await isSuspiciousQuery(pasteboardContents)
+  func shouldShowSearchSuggestions(using lastReplacement: String, isPasting: Bool) async -> Bool {
+    if isPasting {
+      let isSuspicious = await isSuspiciousQuery(lastReplacement)
       return !isSuspicious
     }
-
     return true
   }
 


### PR DESCRIPTION
This change alters how we determine if some text was inserted by pasting contents from the pasteboard for users using keyboards that assemble words/characters using multiple key inputs.

Resolves https://github.com/brave/brave-browser/issues/42526

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

