### PR TITLE
Allow deep linking to default search engine dialogs

### DIFF
--- a/browser/resources/settings/brave_overrides/config.ts
+++ b/browser/resources/settings/brave_overrides/config.ts
@@ -10,11 +10,12 @@ import {RegisterPolymerComponentToIgnore} from 'chrome://resources/brave/polymer
 // 1. Make sure we ignore the chromium components when they are defined
 // 2. Override the chromium components with a subclass and define the
 //    components with their original chromium name.
-// (This is because the chomium components define themselves via customElements.define
-// in their module, so we want to register to ignore the component before the module
-// is imported).
+// (This is because the chomium components define themselves via
+// customElements.define in their module, so we want to register to ignore the
+// component before the module is imported).
 
 RegisterPolymerComponentToIgnore('add-site-dialog')
-RegisterPolymerComponentToIgnore('settings-site-settings-page')
-RegisterPolymerComponentToIgnore('settings-clear-browsing-data-dialog')
 RegisterPolymerComponentToIgnore('settings-autofill-page')
+RegisterPolymerComponentToIgnore('settings-clear-browsing-data-dialog')
+RegisterPolymerComponentToIgnore('settings-search-page')
+RegisterPolymerComponentToIgnore('settings-site-settings-page')

--- a/browser/resources/settings/brave_overrides/search_page.ts
+++ b/browser/resources/settings/brave_overrides/search_page.ts
@@ -5,15 +5,23 @@
 
 import '../brave_search_engines_page/brave_search_engines_page.js'
 
-import '../brave_search_engines_page/private_search_engine_list_dialog.js';
+import '../brave_search_engines_page/private_search_engine_list_dialog.js'
 
-import {RegisterPolymerTemplateModifications} from 'chrome://resources/brave/polymer_overriding.js'
+import {
+  RegisterPolymerComponentReplacement,
+  RegisterPolymerTemplateModifications
+} from 'chrome://resources/brave/polymer_overriding.js'
+
+import {SettingsSearchPageElement} from '../search_page/search_page.js'
+import {routes} from '../route.js'
+import {type Route, RouteObserverMixin, Router} from '../router.js'
 import {getTrustedHTML} from 'chrome://resources/js/static_types.js'
 import {loadTimeData} from '../i18n_setup.js'
 
 RegisterPolymerTemplateModifications({
   'settings-search-page': (templateContent) => {
-    const enginesSubpageTrigger = templateContent.getElementById('enginesSubpageTrigger')
+    const enginesSubpageTrigger =
+      templateContent.getElementById('enginesSubpageTrigger')
     if (!enginesSubpageTrigger) {
       console.error(`[Settings] Couldn't find enginesSubpageTrigger`)
     } else {
@@ -34,3 +42,34 @@ RegisterPolymerTemplateModifications({
     }
   }
 })
+
+// Subclass and replace the settings-search-page to make the default search
+// dialog navigable via deep linking
+RegisterPolymerComponentReplacement(
+  'settings-search-page',
+  class BraveSettingsSearchPageElement
+  extends RouteObserverMixin(SettingsSearchPageElement) {
+    override ready() {
+      super.ready()
+
+      // onOpenDialogButtonClick_ is private in the superclass, so we have to
+      // replace it to change its functionality
+      const anyThis = this as any
+      anyThis.onOpenDialogButtonClick_ = () => {
+        Router.getInstance().navigateTo(routes.DEFAULT_SEARCH)
+      }
+
+      // onSearcgEngineListDialogClose_ is private in the superclass, so we have
+      // to replace it to change its functionality
+      anyThis.onSearchEngineListDialogClose_ = () => {
+        Router.getInstance().navigateTo(routes.SEARCH)
+      }
+    }
+
+    override currentRouteChanged() {
+      const anyThis = this as any
+      anyThis.showSearchEngineListDialog_ =
+        Router.getInstance().getCurrentRoute() === routes.DEFAULT_SEARCH
+    }
+  }
+)

--- a/browser/resources/settings/brave_routes.ts
+++ b/browser/resources/settings/brave_routes.ts
@@ -59,7 +59,13 @@ export default function addBraveRoutes(r: Partial<SettingsRoutes>) {
     if (r.FONTS) {
         delete r.FONTS
     }
-    r.FONTS = r.BRAVE_CONTENT.createChild('/fonts');
+    r.FONTS = r.BRAVE_CONTENT.createChild('/fonts')
+  }
+  if (r.SEARCH) {
+    r.DEFAULT_SEARCH = r.SEARCH.createChild('defaultSearch')
+    r.DEFAULT_SEARCH.isNavigableDialog = true
+    r.PRIVATE_SEARCH = r.SEARCH.createChild('privateSearch')
+    r.PRIVATE_SEARCH.isNavigableDialog = true
   }
   if (r.SITE_SETTINGS) {
     r.SITE_SETTINGS_AUTOPLAY = r.SITE_SETTINGS.createChild('autoplay')

--- a/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
+++ b/browser/resources/settings/brave_search_engines_page/brave_search_engines_page.ts
@@ -9,13 +9,16 @@ import '../settings_vars.css.js'
 import {PolymerElement} from 'chrome://resources/polymer/v3_0/polymer/polymer_bundled.min.js'
 import {WebUiListenerMixin} from 'chrome://resources/cr_elements/web_ui_listener_mixin.js'
 import {I18nMixin} from 'chrome://resources/cr_elements/i18n_mixin.js'
+import {RouteObserverMixin, Router} from '../router.js'
+import {routes} from '../route.js'
 import {loadTimeData} from '../i18n_setup.js'
 import {BraveSearchEnginesPageBrowserProxyImpl} from './brave_search_engines_page_browser_proxy.js'
 import {getTemplate} from './brave_search_engines_page.html.js'
 import type {CrToastElement} from 'chrome://resources/cr_elements/cr_toast/cr_toast.js'
 import type {SearchEngine} from '../search_engines_page/search_engines_browser_proxy.js'
 
-const BraveSearchEnginesPageBase = WebUiListenerMixin(I18nMixin(PolymerElement))
+const BraveSearchEnginesPageBase =
+  WebUiListenerMixin(I18nMixin(RouteObserverMixin(PolymerElement)))
 
 class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
   static get is() {
@@ -68,12 +71,17 @@ class BraveSearchEnginesPage extends BraveSearchEnginesPageBase {
       'private-search-engines-changed', updatePrivateSearchEngines)
   }
 
+  override currentRouteChanged() {
+    this.showPrivateSearchEngineListDialog_ =
+      Router.getInstance().getCurrentRoute() === routes.PRIVATE_SEARCH
+  }
+
   private onOpenPrivateDialogButtonClick_() {
-    this.showPrivateSearchEngineListDialog_ = true
+    Router.getInstance().navigateTo(routes.PRIVATE_SEARCH)
   }
 
   private onPrivateSearchEngineListDialogClose_() {
-    this.showPrivateSearchEngineListDialog_ = false
+    Router.getInstance().navigateTo(routes.SEARCH)
   }
 
   private onPrivateSearchEngineChangedInDialog_(e: CustomEvent) {

--- a/patches/chrome-browser-resources-settings-router.ts.patch
+++ b/patches/chrome-browser-resources-settings-router.ts.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/resources/settings/router.ts b/chrome/browser/resources/settings/router.ts
-index afe6eb3c611c80833e7ceaa32368a45cf8f2dcad..f714d77dd58abb5aafa3495c7e48ff9f71431a98 100644
+index afe6eb3c611c80833e7ceaa32368a45cf8f2dcad..7cdd33a762c5be031e45e2d97bbdd867663cb293 100644
 --- a/chrome/browser/resources/settings/router.ts
 +++ b/chrome/browser/resources/settings/router.ts
 @@ -121,6 +121,7 @@ export interface SettingsRoutes {
    IMPORT_DATA: Route;
    SIGN_OUT: Route;
    // </if>
-+  GET_STARTED: Route; SHIELDS: Route; SOCIAL_BLOCKING: Route; EXTENSIONS: Route; EXTENSIONS_V2: Route; BRAVE_SYNC: Route; BRAVE_SYNC_SETUP: Route; BRAVE_WALLET: Route; BRAVE_WEB3: Route; BRAVE_NEW_TAB: Route; THEMES: Route; SITE_SETTINGS_AUTOPLAY: Route; SITE_SETTINGS_GOOGLE_SIGN_IN: Route; SITE_SETTINGS_LOCALHOST_ACCESS: Route; SITE_SETTINGS_BRAVE_OPEN_AI_CHAT: Route; SITE_SETTINGS_ETHEREUM: Route; SITE_SETTINGS_SOLANA: Route; SITE_SETTINGS_SHIELDS_STATUS: Route; SHIELDS_ADBLOCK: Route; SHORTCUTS: Route; BRAVE_WALLET_NETWORKS: Route; BRAVE_LEO_ASSISTANT: Route; BRAVE_CONTENT: Route;
++  GET_STARTED: Route; SHIELDS: Route; SOCIAL_BLOCKING: Route; EXTENSIONS: Route; EXTENSIONS_V2: Route; BRAVE_SYNC: Route; BRAVE_SYNC_SETUP: Route; BRAVE_WALLET: Route; BRAVE_WEB3: Route; BRAVE_NEW_TAB: Route; THEMES: Route; SITE_SETTINGS_AUTOPLAY: Route; SITE_SETTINGS_GOOGLE_SIGN_IN: Route; SITE_SETTINGS_LOCALHOST_ACCESS: Route; SITE_SETTINGS_BRAVE_OPEN_AI_CHAT: Route; SITE_SETTINGS_ETHEREUM: Route; SITE_SETTINGS_SOLANA: Route; SITE_SETTINGS_SHIELDS_STATUS: Route; SHIELDS_ADBLOCK: Route; SHORTCUTS: Route; BRAVE_WALLET_NETWORKS: Route; BRAVE_LEO_ASSISTANT: Route; BRAVE_CONTENT: Route; DEFAULT_SEARCH: Route; PRIVATE_SEARCH: Route;
  }
  
  /** Class for navigable routes. */


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/42999

Makes the dialogs to set the regular default search engine and the default search engine for private windows navigable via deep linking. The link for setting the regular default search engine is brave://settings/search/defaultSearch and the link for setting the default search engine for private windows is brave://settings/search/privateSearch.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Clean profile
- Visit brave://settings/search/defaultSearch
- Ensure that default search dialog appears and works correctly
- Ensure that URL bar shows brave://settings/search/defaultSearch
- Ensure that accepting the new default search engine works
- After accepting (or cancelling the dialog) the browser should automatically navigate to brave://settings/search
- Test that the new default search engine works
- Perform all of the same testing for the private search (brave://settings/search/privateSearch)