### PR TITLE
"IPFSEnabled" Group Policy Documentation is No Longer Relevant (uplift to 1.75.x)

### DIFF
--- a/browser/policy/brave_simple_policy_map.h
+++ b/browser/policy/brave_simple_policy_map.h
@@ -9,6 +9,7 @@
 #include "brave/components/ai_chat/core/common/pref_names.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/constants/pref_names.h"
+#include "brave/components/ipfs/buildflags/buildflags.h"
 #include "brave/components/tor/buildflags/buildflags.h"
 #include "build/build_config.h"
 #include "components/policy/core/browser/configuration_policy_handler.h"
@@ -27,6 +28,10 @@
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/components/brave_vpn/common/pref_names.h"
 #endif
+
+#if BUILDFLAG(DEPRECATE_IPFS)
+#include "brave/components/ipfs/ipfs_prefs.h"
+#endif  // BUILDFLAG(DEPRECATE_IPFS)
 
 namespace policy {
 
@@ -54,6 +59,12 @@ inline constexpr PolicyToPreferenceMapEntry kBraveSimplePolicyMap[] = {
 #endif
     {policy::key::kBraveAIChatEnabled, ai_chat::prefs::kEnabledByPolicy,
      base::Value::Type::BOOLEAN},
+
+#if BUILDFLAG(DEPRECATE_IPFS)
+    {policy::key::kIPFSEnabled, ipfs::prefs::kIPFSEnabledByPolicy,
+     base::Value::Type::BOOLEAN},
+#endif  // BUILDFLAG(DEPRECATE_IPFS)
+
 };
 
 }  // namespace policy

--- a/components/ipfs/ipfs_prefs.cc
+++ b/components/ipfs/ipfs_prefs.cc
@@ -36,9 +36,6 @@ inline constexpr char kIPFSInfobarCount[] = "brave.ipfs.infobar_count";
 // The number of storage used by IPFS Node
 inline constexpr char kIpfsStorageMax[] = "brave.ipfs.storage_max";
 
-// Used to enable/disable IPFS via admin policy.
-inline constexpr char kIPFSEnabled[] = "brave.ipfs.enabled";
-
 // Used to determine if local node was ever used.
 inline constexpr char kIPFSLocalNodeUsed[] = "brave.ipfs.local_node_used";
 
@@ -81,7 +78,7 @@ inline constexpr char kIPFSCompanionEnabled[] = "brave.ipfs_companion_enabled";
 namespace ipfs {
 
 void RegisterDeprecatedIpfsPrefs(PrefRegistrySimple* registry) {
-  registry->RegisterBooleanPref(kIPFSEnabled, true);
+  registry->RegisterBooleanPref(prefs::kIPFSEnabledByPolicy, true);
   registry->RegisterIntegerPref(kIPFSResolveMethod, 0);
   registry->RegisterBooleanPref(kIPFSAutoFallbackToGateway, false);
   registry->RegisterBooleanPref(kIPFSAlwaysStartMode, false);
@@ -105,7 +102,7 @@ void RegisterDeprecatedIpfsPrefs(PrefRegistrySimple* registry) {
 }
 
 void ClearDeprecatedIpfsPrefs(PrefService* registry) {
-  registry->ClearPref(kIPFSEnabled);
+  registry->ClearPref(prefs::kIPFSEnabledByPolicy);
   registry->ClearPref(kIPFSResolveMethod);
   registry->ClearPref(kIPFSAutoFallbackToGateway);
   registry->ClearPref(kIPFSAlwaysStartMode);

--- a/components/ipfs/ipfs_prefs.h
+++ b/components/ipfs/ipfs_prefs.h
@@ -11,6 +11,13 @@
 
 namespace ipfs {
 
+namespace prefs {
+
+// Used to enable/disable IPFS via admin policy. Deprecated
+inline constexpr char kIPFSEnabledByPolicy[] = "brave.ipfs.enabled";
+
+}  // namespace prefs
+
 void RegisterDeprecatedIpfsPrefs(PrefRegistrySimple* registry);
 
 void ClearDeprecatedIpfsPrefs(PrefService* profile_prefs);

--- a/components/policy/resources/templates/policy_definitions/BraveSoftware/IPFSEnabled.yaml
+++ b/components/policy/resources/templates/policy_definitions/BraveSoftware/IPFSEnabled.yaml
@@ -1,0 +1,22 @@
+caption: Enable IPFS feature
+default: null
+desc: |-
+  This policy allows an admin to specify whether IPFS feature can be enabled.
+example_value: true
+features:
+  can_be_mandatory: true
+  can_be_recommended: false
+  dynamic_refresh: false
+  per_profile: true
+owners:
+- clifton@brave.com
+- fmarier@brave.com
+- anthony@brave.com
+- vstruts@brave.com
+schema:
+  type: boolean
+supported_on:
+- chrome.*:87-
+deprecated: true
+tags: []
+type: main


### PR DESCRIPTION
Uplift of #27086
Resolves https://github.com/brave/brave-browser/issues/41529

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.