### PR TITLE
bugfix(shields): Remove Image.prototype.src getter/setter readonly protections on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
@@ -166,11 +166,11 @@ window.__firefox__.execute(function($) {
     delete Image.prototype.src;
 
     Object.defineProperty(Image.prototype, "src", {
-      get: $(function() {
+      get: function() {
         return originalImageSrc.get.call(this);
-      }),
+      },
 
-      set: $(function(value) {
+      set: function(value) {
         // Only attach the `error` event listener once for this
         // Image instance.
         if (!this[localErrorHandlerProp]) {
@@ -184,7 +184,7 @@ window.__firefox__.execute(function($) {
         }
 
         originalImageSrc.set.call(this, value);
-      }),
+      },
       enumerable: true,
       configurable: true
     });


### PR DESCRIPTION
- The `$()` wrapper on our `Image.prototype.src` getter/setter in `TrackingProtectionStats.js` is causing an error that results in a blank screen on `dillards.com` and some other sites: ```[Error] TypeError: Attempted to assign to readonly property.```
- `TrackingProtectionStats.js` is used for us to determine the number of ads/trackers blocked on a page. The potential consequence of removing this protection is the site could manipulate our `Image.prototype.src` override and we may not know if an image was blocked to count in our tracking stats, **however the image would still be blocked** (it just won't be included in our "Ads and other creepy things blocked" stats / count). This count is considered an estimate; it's better we don't have webcompat issues than a perfectly correct stats count.

- This same error is also observed on `petsafe.com`, however there is another issue on that site causing a white screen that is not fixed by this PR. 
    - Slimlist is blocking `typekit.net` css which the page requires to load: ```[Error] Error: Loading CSS chunk 1869 failed.```
    - To verify this, you must comment out / disable [the content blocker](https://github.com/brave/brave-core/blob/886363cccfee3d0d19418354fe0894e2fa676a57/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift#L91-L115) then visit petsafe.com. 
    - `petsafe.com` will only display with content blocker (or slimlist disabled) AND this PR's fix to remove `$()` wrapper on `Image.prototype.src`.

Resolves https://github.com/brave/brave-browser/issues/43286

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit https://www.dillards.com/ with Shields up
2. Verify webpage is displayed correctly