### PR TITLE
Remove lion animation onboarding

### DIFF
--- a/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
+++ b/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
@@ -9,10 +9,8 @@ package org.chromium.chrome.browser.firstrun;
 
 import static org.chromium.ui.base.ViewUtils.dpToPx;
 
-import android.Manifest;
 import android.animation.LayoutTransition;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.RemoteException;
@@ -35,7 +33,6 @@ import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResp
 import com.android.installreferrer.api.InstallReferrerStateListener;
 import com.android.installreferrer.api.ReferrerDetails;
 
-import org.chromium.base.BraveFeatureList;
 import org.chromium.base.BravePreferenceKeys;
 import org.chromium.base.Log;
 import org.chromium.base.ThreadUtils;
@@ -43,7 +40,6 @@ import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveLocalState;
 import org.chromium.chrome.browser.back_press.SecondaryActivityBackPressUma.SecondaryActivity;
 import org.chromium.chrome.browser.customtabs.CustomTabActivity;
-import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.metrics.ChangeMetricsReportingStateCalledFrom;
 import org.chromium.chrome.browser.metrics.UmaSessionStats;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
@@ -232,11 +228,7 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
     }
 
     private boolean shouldForceDefaultBrowserPrompt() {
-        return isNewOnboardingEnabled() && !isDefaultBrowser();
-    }
-
-    private boolean isNewOnboardingEnabled() {
-        return ChromeFeatureList.isEnabled(BraveFeatureList.BRAVE_NEW_ANDROID_ONBOARDING);
+        return !isDefaultBrowser();
     }
 
     private void setDefaultBrowserAndProceedToNextStep() {
@@ -251,8 +243,12 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
         return BraveSetDefaultBrowserUtils.isBraveSetAsDefaultBrowser(this);
     }
 
-    ActivityResultLauncher<String> mRequestPermissionLauncher = registerForActivityResult(
-            new ActivityResultContracts.RequestPermission(), isGranted -> { nextOnboardingStep(); });
+    ActivityResultLauncher<String> mRequestPermissionLauncher =
+            registerForActivityResult(
+                    new ActivityResultContracts.RequestPermission(),
+                    isGranted -> {
+                        nextOnboardingStep();
+                    });
 
     private void nextOnboardingStep() {
         if (isActivityFinishingOrDestroyed()) return;
@@ -261,8 +257,7 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
         if (mCurrentStep == 0) {
             showIntroPage();
         } else if (mCurrentStep == 1) {
-            if (!isNewOnboardingEnabled()
-                    || !BraveSetDefaultBrowserUtils.supportsDefaultRoleManager()) {
+            if (!BraveSetDefaultBrowserUtils.supportsDefaultRoleManager()) {
                 showBrowserSelectionPage();
             } else if (!isDefaultBrowser()) {
                 setDefaultBrowserAndProceedToNextStep();
@@ -318,11 +313,7 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
                         },
                         200);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !isNewOnboardingEnabled()) {
-            mRequestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
-        } else {
-            nextOnboardingStep();
-        }
+        nextOnboardingStep();
     }
 
     private void showBrowserSelectionPage() {

--- a/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
+++ b/android/java/org/chromium/chrome/browser/firstrun/WelcomeOnboardingActivity.java
@@ -251,12 +251,8 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
         return BraveSetDefaultBrowserUtils.isBraveSetAsDefaultBrowser(this);
     }
 
-    private void startTimer(int delayMillis) {
-        new Handler().postDelayed(this::nextOnboardingStep, delayMillis);
-    }
-
     ActivityResultLauncher<String> mRequestPermissionLauncher = registerForActivityResult(
-            new ActivityResultContracts.RequestPermission(), isGranted -> { startTimer(3000); });
+            new ActivityResultContracts.RequestPermission(), isGranted -> { nextOnboardingStep(); });
 
     private void nextOnboardingStep() {
         if (isActivityFinishingOrDestroyed()) return;
@@ -325,7 +321,7 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !isNewOnboardingEnabled()) {
             mRequestPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS);
         } else {
-            startTimer(3000);
+            nextOnboardingStep();
         }
     }
 
@@ -525,7 +521,7 @@ public class WelcomeOnboardingActivity extends FirstRunActivityBase {
 
     private void finishNativeInitializationPostWork() {
         assert mInitializeViewsDone;
-        startTimer(1000);
+        nextOnboardingStep();
     }
 
     @Override

--- a/android/java/res/layout/activity_welcome_onboarding.xml
+++ b/android/java/res/layout/activity_welcome_onboarding.xml
@@ -67,17 +67,6 @@
             android:layout_height="wrap_content"
             android:gravity="center"
             android:orientation="vertical">
-    
-            <TextView
-                android:id="@+id/tv_welcome"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:gravity="center"
-                android:textSize="24sp"
-                android:alpha="0"
-                android:visibility="gone"
-                android:textColor="@color/onboarding_welcome_text_color"
-                android:text="@string/welcome_to_brave"/>
 
             <LinearLayout
                 android:id="@+id/layout_card"
@@ -182,6 +171,7 @@
                 android:adjustViewBounds="true"
                 android:layout_gravity="center_horizontal"
                 android:contentDescription="@null"
+                android:visibility="gone"
                 android:src="@drawable/ic_brave_onboarding"/>
 
         </LinearLayout>

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -881,9 +881,6 @@ This file contains all "about" strings.  It is set to NOT be translated, in tran
       </message>
 
       <!-- Onboarding strings -->
-      <message name="IDS_WELCOME_TO_BRAVE" desc="Text for welcome onboarding">
-        Welcome to Brave
-      </message>
       <message name="IDS_PRIVACY_ONBOARDING" desc="Text for privacy onboarding">
         Privacy. Made simple.
       </message>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43116
Resolves https://github.com/brave/brave-browser/issues/43290

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Recording for < android 10 devices
https://github.com/user-attachments/assets/d33fa716-1c97-4241-a8a6-9441a81c1d25

2. Recording for > android 9 devices
https://github.com/user-attachments/assets/fe69e799-6ae7-4fa7-9e78-7302b887f498

