### PR TITLE
bugfix(shields): Fix pulse on some subreddits with Shields and Night Mode enabled on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -1021,18 +1021,23 @@ window.__firefox__.execute(function($) {
     styleElm.setAttribute('type', 'text/css')
     targetElm.appendChild(styleElm)
     CC.cosmeticStyleSheet = styleElm
+    // The previous `nextElementSibling` we moved our stylesheet below
+    var prevNextElementSibling = null;
 
     // Start a timer that moves the stylesheet down
     window.setInterval(() => {
       if (styleElm.nextElementSibling === null || styleElm.parentElement !== targetElm) {
         return
       }
-      // `darkreader` (from our night mode) fights with us to be last element
-      // in `document.body`. Repeatedly moving our stylesheet can cause
-      // unwanted animations to repeat every time we move the stylesheet
-      const nextElementClass = styleElm.getAttribute("class");
-      if (nextElementClass.includes("darkreader")) {
-        return;
+      if (styleElm.nextElementSibling !==  null) {
+        // if we already moved below this element
+        if (prevNextElementSibling === styleElm.nextElementSibling) {
+          // Avoid a loop where we are repeatedly swapping places with another
+          // element. This can happen with `darkreader` (night mode) for
+          // example and cause unwanted animations to repeat.
+          return
+        }
+        prevNextElementSibling = styleElm.nextElementSibling;
       }
       moveStyle()
     }, 1000)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -1027,6 +1027,13 @@ window.__firefox__.execute(function($) {
       if (styleElm.nextElementSibling === null || styleElm.parentElement !== targetElm) {
         return
       }
+      // `darkreader` (from our night mode) fights with us to be last element
+      // in `document.body`. Repeatedly moving our stylesheet can cause
+      // unwanted animations to repeat every time we move the stylesheet
+      const nextElementClass = styleElm.getAttribute("class");
+      if (nextElementClass.includes("darkreader")) {
+        return;
+      }
       moveStyle()
     }, 1000)
   }


### PR DESCRIPTION
- In `SelectorsPollerScript.js`, every 1 second we check if the cosmetic filtering stylesheet is the last element in the `document.body`. If it is not last, we remove the stylesheet and re-append to `document.body` so we are the last element (this is so our stylesheet takes priority over previous `style` elements). However, the DarkReader javascript for Night Mode also does this, which results in a loop of our style element and DarkReader style element competing to be the last element. Every time we move our style element / dark reader moves it's style element, we see the text animate on some old reddit subreddit styles.
  - NOTE: The animation will still occur when the page first loads with Night mode **enabled** & shields **disabled** (seems to be an issue with DarkReader). This PR prevents the animation from occurring repeatedly every 1 second when Night mode and Shields are enabled.
- Store the last element we moved below to avoid repeatedly moving the stylesheet to be last.

Resolves https://github.com/brave/brave-browser/issues/43096

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit `https://old.reddit.com/r/CalgaryFlames`
2. Enable Night Mode & Shields
3. Verify text does not repeatedly animate size / pulse.
    - The pulse happens on initial load, but occurs even with shields disabled (May be subreddit style related).
4. Visit `https://old.reddit.com/r/antivirus/comments/1hshe2l` (or any comments page on r/antivirus)
5. Verify text does not repeatedly animate size / pulse.
    - The pulse happens on initial load, but occurs even with shields disabled (May be subreddit style related).
    

https://github.com/user-attachments/assets/a5a8cebb-0677-411b-b274-dd093d6feab7