### PR TITLE
[AI Chat]: Cleanup SiteInfo - now the presence/absence of the struct indicates whether content association is possible

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -385,10 +385,9 @@ void AIChatUIPageHandler::BindParentUIFrameFromChildFrame(
 
 void AIChatUIPageHandler::GetFaviconImageDataForAssociatedContent(
     GetFaviconImageDataCallback callback,
-    mojom::SiteInfoPtr content_info,
+    mojom::AssociatedContentPtr content_info,
     bool should_send_page_contents) {
-  if (!content_info->is_content_association_possible ||
-      !content_info->url.has_value() || !content_info->url->is_valid()) {
+  if (!content_info || !content_info->url.is_valid()) {
     std::move(callback).Run(std::nullopt);
     return;
   }
@@ -409,7 +408,7 @@ void AIChatUIPageHandler::GetFaviconImageDataForAssociatedContent(
       };
 
   favicon_service_->GetRawFaviconForPageURL(
-      content_info->url.value(), icon_types, kDesiredFaviconSizePixels, true,
+      content_info->url, icon_types, kDesiredFaviconSizePixels, true,
       base::BindOnce(on_favicon_available, std::move(callback)),
       &favicon_task_tracker_);
 }

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -93,7 +93,7 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
 
   void GetFaviconImageDataForAssociatedContent(
       GetFaviconImageDataCallback callback,
-      mojom::SiteInfoPtr content_info,
+      mojom::AssociatedContentPtr content_info,
       bool should_send_page_contents);
 
   raw_ptr<AIChatTabHelper> active_chat_tab_helper_ = nullptr;

--- a/components/ai_chat/core/browser/ai_chat_database.cc
+++ b/components/ai_chat/core/browser/ai_chat_database.cc
@@ -1033,7 +1033,8 @@ bool AIChatDatabase::DeleteAssociatedWebContent(
   // Set any associated content url, title and content to NULL where
   // conversation had any entry between begin_time and end_time.
   static constexpr char kQuery[] =
-      "DELETE FROM associated_content"
+      "UPDATE associated_content"
+      " SET url=NULL, title=NULL, last_contents=NULL"
       " WHERE conversation_uuid IN ("
       "  SELECT conversation_uuid"
       "  FROM conversation_entry"

--- a/components/ai_chat/core/browser/ai_chat_database.h
+++ b/components/ai_chat/core/browser/ai_chat_database.h
@@ -50,9 +50,10 @@ class AIChatDatabase {
                        mojom::ConversationTurnPtr first_entry);
 
   // Update any properties of associated content metadata or full-text content
-  bool AddOrUpdateAssociatedContent(std::string_view conversation_uuid,
-                                    mojom::SiteInfoPtr associated_content,
-                                    std::optional<std::string> content);
+  bool AddOrUpdateAssociatedContent(
+      std::string_view conversation_uuid,
+      mojom::AssociatedContentPtr associated_content,
+      std::optional<std::string> content);
 
   // Adds a new conversation entry to the conversation with the provided UUID
   bool AddConversationEntry(

--- a/components/ai_chat/core/browser/ai_chat_database_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_database_unittest.cc
@@ -523,7 +523,8 @@ TEST_P(AIChatDatabaseTest, DeleteAssociatedWebContent) {
   conversations = db_->GetAllConversations();
   EXPECT_EQ(conversations.size(), 2u);
   ExpectConversationEquals(FROM_HERE, conversations[0], metadata_first);
-  metadata_second->associated_content = nullptr;
+  metadata_second->associated_content->url = GURL();
+  metadata_second->associated_content->title = "";
   ExpectConversationEquals(FROM_HERE, conversations[1], metadata_second);
 
   archive_result = db_->GetConversationData("second");

--- a/components/ai_chat/core/browser/ai_chat_database_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_database_unittest.cc
@@ -126,15 +126,12 @@ TEST_P(AIChatDatabaseTest, AddAndGetConversationAndEntries) {
     // recent entry.
     const GURL page_url = GURL("https://example.com/page");
     const std::string expected_contents = "Page contents";
-    mojom::SiteInfoPtr associated_content =
+    mojom::AssociatedContentPtr associated_content =
         has_content
-            ? mojom::SiteInfo::New(
+            ? mojom::AssociatedContent::New(
                   content_uuid, mojom::ContentType::PageContent, "page title",
                   page_url.host(), 1, page_url, 62, true, true)
-            : mojom::SiteInfo::New(
-                  std::nullopt, mojom::ContentType::PageContent, std::nullopt,
-                  std::nullopt, mojom::kContentIdNone, std::nullopt, 0, false,
-                  false);
+            : nullptr;
     const mojom::ConversationPtr metadata =
         mojom::Conversation::New(uuid, "title", now - base::Hours(2), true,
                                  std::nullopt, std::move(associated_content));
@@ -264,9 +261,7 @@ TEST_P(AIChatDatabaseTest, WebSourcesEvent) {
   const GURL page_url = GURL("https://example.com/page");
   mojom::ConversationPtr metadata = mojom::Conversation::New(
       uuid, "title", base::Time::Now() - base::Hours(2), true, std::nullopt,
-      mojom::SiteInfo::New(std::nullopt, mojom::ContentType::PageContent,
-                           std::nullopt, std::nullopt, mojom::kContentIdNone,
-                           std::nullopt, 0, false, false));
+      nullptr);
 
   // Test 2 entries to verify they are recorded against different entries
   auto history = CreateSampleChatHistory(2u);
@@ -311,9 +306,7 @@ TEST_P(AIChatDatabaseTest, WebSourcesEvent_Invalid) {
   const GURL page_url = GURL("https://example.com/page");
   mojom::ConversationPtr metadata = mojom::Conversation::New(
       uuid, "title", base::Time::Now() - base::Hours(2), true, std::nullopt,
-      mojom::SiteInfo::New(std::nullopt, mojom::ContentType::PageContent,
-                           std::nullopt, std::nullopt, mojom::kContentIdNone,
-                           std::nullopt, 0, false, false));
+      nullptr);
 
   // Test 2 entries to verify they are recorded against different entries. Make
   // some entries invalid to verify they are not persisted.
@@ -373,9 +366,7 @@ TEST_P(AIChatDatabaseTest, UpdateConversationTitle) {
     const std::string updated_title = "updated title";
     mojom::ConversationPtr metadata = mojom::Conversation::New(
         uuid, initial_title, base::Time::Now(), true, std::nullopt,
-        mojom::SiteInfo::New(std::nullopt, mojom::ContentType::PageContent,
-                             std::nullopt, std::nullopt, mojom::kContentIdNone,
-                             std::nullopt, 0, false, false));
+        nullptr);
 
     // Persist the first entry (and get the response ready)
     const auto history = CreateSampleChatHistory(1u);
@@ -405,9 +396,9 @@ TEST_P(AIChatDatabaseTest, AddOrUpdateAssociatedContent) {
   const GURL page_url = GURL("https://example.com/page");
   mojom::ConversationPtr metadata = mojom::Conversation::New(
       uuid, "title", base::Time::Now() - base::Hours(2), true, std::nullopt,
-      mojom::SiteInfo::New(content_uuid, mojom::ContentType::PageContent,
-                           "page title", page_url.host(), 1, page_url, 62, true,
-                           true));
+      mojom::AssociatedContent::New(content_uuid,
+                                    mojom::ContentType::PageContent,
+                                    "page title", 1, page_url, 62, true));
 
   auto history = CreateSampleChatHistory(1u);
 
@@ -436,7 +427,7 @@ TEST_P(AIChatDatabaseTest, AddOrUpdateAssociatedContent) {
   result = db_->GetConversationData(uuid);
   EXPECT_EQ(result->associated_content.size(), 1u);
   EXPECT_EQ(result->associated_content[0]->content_uuid,
-            metadata->associated_content->uuid.value());
+            metadata->associated_content->uuid);
   EXPECT_EQ(result->associated_content[0]->content, expected_contents);
   conversations = db_->GetAllConversations();
   EXPECT_EQ(conversations.size(), 1u);
@@ -448,9 +439,7 @@ TEST_P(AIChatDatabaseTest, DeleteAllData) {
   const GURL page_url = GURL("https://example.com/page");
   mojom::ConversationPtr metadata = mojom::Conversation::New(
       uuid, "title", base::Time::Now() - base::Hours(2), true, std::nullopt,
-      mojom::SiteInfo::New(std::nullopt, mojom::ContentType::PageContent,
-                           std::nullopt, std::nullopt, mojom::kContentIdNone,
-                           std::nullopt, 0, false, false));
+      nullptr);
 
   auto history = CreateSampleChatHistory(1u);
 
@@ -487,14 +476,14 @@ TEST_P(AIChatDatabaseTest, DeleteAssociatedWebContent) {
   // are persisted.
   mojom::ConversationPtr metadata_first = mojom::Conversation::New(
       "first", "title", base::Time::Now() - base::Hours(2), true, std::nullopt,
-      mojom::SiteInfo::New("first-content", mojom::ContentType::PageContent,
-                           "page title", page_url.host(), 1, page_url, 62, true,
-                           true));
+      mojom::AssociatedContent::New("first-content",
+                                    mojom::ContentType::PageContent,
+                                    "page title", 1, page_url, 62, true));
   mojom::ConversationPtr metadata_second = mojom::Conversation::New(
       "second", "title", base::Time::Now() - base::Hours(1), true, "model-2",
-      mojom::SiteInfo::New("second-content", mojom::ContentType::PageContent,
-                           "page title", page_url.host(), 2, page_url, 62, true,
-                           true));
+      mojom::AssociatedContent::New("second-content",
+                                    mojom::ContentType::PageContent,
+                                    "page title", 2, page_url, 62, true));
 
   auto history_first = CreateSampleChatHistory(1u, -2);
   auto history_second = CreateSampleChatHistory(1u, -1);
@@ -534,8 +523,7 @@ TEST_P(AIChatDatabaseTest, DeleteAssociatedWebContent) {
   conversations = db_->GetAllConversations();
   EXPECT_EQ(conversations.size(), 2u);
   ExpectConversationEquals(FROM_HERE, conversations[0], metadata_first);
-  metadata_second->associated_content->url = std::nullopt;
-  metadata_second->associated_content->title = std::nullopt;
+  metadata_second->associated_content = nullptr;
   ExpectConversationEquals(FROM_HERE, conversations[1], metadata_second);
 
   archive_result = db_->GetConversationData("second");
@@ -647,12 +635,9 @@ TEST_P(AIChatDatabaseMigrationTest, MigrationToVCurrent) {
     // ConversationEntry table changed, check it persists correctly
     auto now = base::Time::Now();
     const std::string uuid = "migrationtest";
-    mojom::SiteInfoPtr associated_content = mojom::SiteInfo::New(
-        std::nullopt, mojom::ContentType::PageContent, std::nullopt,
-        std::nullopt, mojom::kContentIdNone, std::nullopt, 0, false, false);
     const mojom::ConversationPtr metadata =
         mojom::Conversation::New(uuid, "title", now - base::Hours(2), true,
-                                 std::nullopt, std::move(associated_content));
+                                 std::nullopt, nullptr);
 
     // Persist the first entry (and get the response ready)
     auto history = CreateSampleChatHistory(1u);

--- a/components/ai_chat/core/browser/ai_chat_database_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_database_unittest.cc
@@ -127,11 +127,10 @@ TEST_P(AIChatDatabaseTest, AddAndGetConversationAndEntries) {
     const GURL page_url = GURL("https://example.com/page");
     const std::string expected_contents = "Page contents";
     mojom::AssociatedContentPtr associated_content =
-        has_content
-            ? mojom::AssociatedContent::New(
-                  content_uuid, mojom::ContentType::PageContent, "page title",
-                  page_url.host(), 1, page_url, 62, true, true)
-            : nullptr;
+        has_content ? mojom::AssociatedContent::New(
+                          content_uuid, mojom::ContentType::PageContent,
+                          "page title", 1, page_url, 62, true)
+                    : nullptr;
     const mojom::ConversationPtr metadata =
         mojom::Conversation::New(uuid, "title", now - base::Hours(2), true,
                                  std::nullopt, std::move(associated_content));
@@ -365,8 +364,7 @@ TEST_P(AIChatDatabaseTest, UpdateConversationTitle) {
         base::StrCat({"for_conversation_title_", initial_title});
     const std::string updated_title = "updated title";
     mojom::ConversationPtr metadata = mojom::Conversation::New(
-        uuid, initial_title, base::Time::Now(), true, std::nullopt,
-        nullptr);
+        uuid, initial_title, base::Time::Now(), true, std::nullopt, nullptr);
 
     // Persist the first entry (and get the response ready)
     const auto history = CreateSampleChatHistory(1u);
@@ -636,9 +634,8 @@ TEST_P(AIChatDatabaseMigrationTest, MigrationToVCurrent) {
     // ConversationEntry table changed, check it persists correctly
     auto now = base::Time::Now();
     const std::string uuid = "migrationtest";
-    const mojom::ConversationPtr metadata =
-        mojom::Conversation::New(uuid, "title", now - base::Hours(2), true,
-                                 std::nullopt, nullptr);
+    const mojom::ConversationPtr metadata = mojom::Conversation::New(
+        uuid, "title", now - base::Hours(2), true, std::nullopt, nullptr);
 
     // Persist the first entry (and get the response ready)
     auto history = CreateSampleChatHistory(1u);

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -159,11 +159,7 @@ ConversationHandler* AIChatService::CreateConversation() {
   // Create the conversation metadata
   {
     mojom::ConversationPtr conversation = mojom::Conversation::New(
-        conversation_uuid, "", base::Time::Now(), false, std::nullopt,
-        mojom::SiteInfo::New(base::Uuid::GenerateRandomV4().AsLowercaseString(),
-                             mojom::ContentType::PageContent, std::nullopt,
-                             std::nullopt, mojom::kContentIdNone, std::nullopt,
-                             0, false, false));
+        conversation_uuid, "", base::Time::Now(), false, std::nullopt, nullptr);
     conversations_.insert_or_assign(conversation_uuid, std::move(conversation));
   }
   mojom::Conversation* conversation =
@@ -749,7 +745,7 @@ void AIChatService::HandleFirstEntry(
   DVLOG(1) << __func__ << " Conversation " << conversation->uuid
            << " being persisted for first time.";
   CHECK(entry->uuid.has_value());
-  CHECK(conversation->associated_content->uuid.has_value());
+
   // We can persist the conversation metadata for the first time as well as the
   // entry.
   if (ai_chat_db_) {
@@ -785,7 +781,7 @@ void AIChatService::HandleNewEntry(
                   conversation->model_key, std::nullopt);
 
     if (associated_content_value.has_value() &&
-        conversation->associated_content->is_content_association_possible) {
+        conversation->associated_content) {
       ai_chat_db_
           .AsyncCall(
               base::IgnoreResult(&AIChatDatabase::AddOrUpdateAssociatedContent))

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1683,7 +1683,6 @@ void ConversationHandler::BuildAssociatedContentInfo() {
     // Note: We don't create a new AssociatedContent object here unless one
     // doesn't exist. If we generate one with a new UUID the deserializer
     // breaks.
-    // TODO: Confirm with @petemill if I should try and fix this.
     if (!metadata_->associated_content) {
       metadata_->associated_content = mojom::AssociatedContent::New();
       metadata_->associated_content->uuid =

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -297,7 +297,8 @@ void ConversationHandler::OnConversationMetadataUpdated() {
           metadata_->associated_content->content_type ==
               mojom::ContentType::VideoTranscript);
     } else {
-      archive_content_->SetMetadata(GURL(), u"", false);
+      archive_content_ = nullptr;
+      associated_content_delegate_ = nullptr;
     }
   }
 
@@ -1686,8 +1687,6 @@ void ConversationHandler::UpdateAssociatedContentInfo() {
       metadata_->associated_content = mojom::AssociatedContent::New();
       metadata_->associated_content->uuid =
           base::Uuid::GenerateRandomV4().AsLowercaseString();
-      LOG(ERROR) << "Created new AssociatedContent "
-                 << metadata_->associated_content->uuid;
     }
     metadata_->associated_content->title =
         base::UTF16ToUTF8(associated_content_delegate_->GetTitle());

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -297,7 +297,6 @@ void ConversationHandler::OnConversationMetadataUpdated() {
           metadata_->associated_content->content_type ==
               mojom::ContentType::VideoTranscript);
     } else {
-      // TODO: Confirm with @petemill if this is the correct behavior
       archive_content_->SetMetadata(GURL(), u"", false);
     }
   }
@@ -514,7 +513,7 @@ void ConversationHandler::GetState(GetStateCallback callback) {
                  [](auto& model) { return model.Clone(); });
   auto model_key = GetCurrentModel().key;
 
-  BuildAssociatedContentInfo();
+  UpdateAssociatedContentInfo();
 
   std::vector<std::string> suggestions;
   std::ranges::transform(suggestions_, std::back_inserter(suggestions),
@@ -972,7 +971,7 @@ void ConversationHandler::DisassociateContentDelegate() {
 
 void ConversationHandler::GetAssociatedContentInfo(
     GetAssociatedContentInfoCallback callback) {
-  BuildAssociatedContentInfo();
+  UpdateAssociatedContentInfo();
   std::move(callback).Run(metadata_->associated_content
                               ? metadata_->associated_content->Clone()
                               : nullptr,
@@ -1677,7 +1676,7 @@ bool ConversationHandler::IsContentAssociationPossible() {
   return (associated_content_delegate_ != nullptr);
 }
 
-void ConversationHandler::BuildAssociatedContentInfo() {
+void ConversationHandler::UpdateAssociatedContentInfo() {
   // Only modify associated content metadata here
   if (associated_content_delegate_) {
     // Note: We don't create a new AssociatedContent object here unless one
@@ -1729,7 +1728,7 @@ ConversationHandler::GetStateForConversationEntries() {
 }
 
 void ConversationHandler::OnAssociatedContentInfoChanged() {
-  BuildAssociatedContentInfo();
+  UpdateAssociatedContentInfo();
   for (auto& client : conversation_ui_handlers_) {
     client->OnAssociatedContentInfoChanged(
         metadata_->associated_content ? metadata_->associated_content->Clone()

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -366,7 +366,7 @@ class ConversationHandler : public mojom::ConversationHandler,
   };
 
   void InitEngine();
-  void BuildAssociatedContentInfo();
+  void UpdateAssociatedContentInfo();
   mojom::ConversationEntriesStatePtr GetStateForConversationEntries();
   bool IsContentAssociationPossible();
   int GetContentUsedPercentage();

--- a/components/ai_chat/core/browser/test_utils.cc
+++ b/components/ai_chat/core/browser/test_utils.cc
@@ -77,8 +77,8 @@ void ExpectConversationEquals(base::Location location,
 }
 
 void ExpectAssociatedContentEquals(base::Location location,
-                                   const mojom::SiteInfoPtr& a,
-                                   const mojom::SiteInfoPtr& b) {
+                                   const mojom::AssociatedContentPtr& a,
+                                   const mojom::AssociatedContentPtr& b) {
   SCOPED_TRACE(testing::Message() << location.ToString());
   if (!a || !b) {
     EXPECT_EQ(a, b);  // Both should be null or neither
@@ -90,8 +90,6 @@ void ExpectAssociatedContentEquals(base::Location location,
   EXPECT_EQ(a->content_type, b->content_type);
   EXPECT_EQ(a->content_used_percentage, b->content_used_percentage);
   EXPECT_EQ(a->is_content_refined, b->is_content_refined);
-  EXPECT_EQ(a->is_content_association_possible,
-            b->is_content_association_possible);
 }
 
 void ExpectConversationHistoryEquals(

--- a/components/ai_chat/core/browser/test_utils.h
+++ b/components/ai_chat/core/browser/test_utils.h
@@ -19,8 +19,8 @@ void ExpectConversationEquals(base::Location location,
                               const mojom::ConversationPtr& b);
 
 void ExpectAssociatedContentEquals(base::Location location,
-                                   const mojom::SiteInfoPtr& a,
-                                   const mojom::SiteInfoPtr& b);
+                                   const mojom::AssociatedContentPtr& a,
+                                   const mojom::AssociatedContentPtr& b);
 
 void ExpectConversationEntryEquals(base::Location location,
                                    const mojom::ConversationTurnPtr& a,

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -478,10 +478,6 @@ interface ConversationHandler {
   // the assistant.
   SubmitSuggestion(string suggestion);
 
-  // Submit one of the generated suggested questions for response from
-  // the assistant.
-  SubmitSuggestion(string suggestion);
-
   // Get associated page information. If there is none then |associated_content|
   // will be |null|. If the reason for that is it's still being fetched, then
   // |is_fetching| will be |true|.

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -75,35 +75,24 @@ enum ContentType {
   VideoTranscript,
 };
 
-// A piece of content associated with a conversation.
-// TODO(petemill): Rename to AssociatedContent and have hostname/url/title be
-// part of a detail property (which would have different structure possibilities
-// depending on content type.
-struct SiteInfo {
-  string? uuid;
-  ContentType content_type;
-  // Web page specific fields, if available and allowed
-  string? title;
-  string? hostname;
+// Represents the content that is associated with a conversation.
+struct AssociatedContent {
+  string uuid;
 
-  // Note: iOS doesn't support optional int32s in mojom, so we use
-  // |kContentIdNone| to indicate that the content id is not set.
+  ContentType content_type;
+  string title;
+
   // This is the ID of the content currently loaded in the tab.
   int32 content_id;
 
-  url.mojom.Url? url;
+  url.mojom.Url url;
 
   // Percentage of the content that has been utilized by remote LLM (0-100)
   int32 content_used_percentage;
+
   // Indicates content has been refined through extracting most relevant parts
   // from long page content
   bool is_content_refined;
-
-  // Indicates if the URL scheme is of a type that allows for
-  // content association.
-  // TODO(petemill): SiteInfo should just not exist if content-associated is
-  // not possible.
-  bool is_content_association_possible;
 };
 
 struct Conversation {
@@ -117,7 +106,7 @@ struct Conversation {
   // Model key, if different than default
   string? model_key;
 
-  SiteInfo associated_content;
+  AssociatedContent? associated_content;
 };
 
 struct ContentArchive {
@@ -435,7 +424,7 @@ struct ConversationState {
   string current_model_key;
   array<string> suggested_questions;
   SuggestionGenerationStatus suggestion_status;
-  SiteInfo associated_content_info;
+  AssociatedContent? associated_content;
   bool should_send_content;
   APIError error;
   // TODO(petemill): include conversation history, once
@@ -489,11 +478,15 @@ interface ConversationHandler {
   // the assistant.
   SubmitSuggestion(string suggestion);
 
-  // Get associated page information. If there is none then |site_info| will be
-  // |null|. If the reason for that is it's still being fetched, then
+  // Submit one of the generated suggested questions for response from
+  // the assistant.
+  SubmitSuggestion(string suggestion);
+
+  // Get associated page information. If there is none then |associated_content|
+  // will be |null|. If the reason for that is it's still being fetched, then
   // |is_fetching| will be |true|.
   GetAssociatedContentInfo() => (
-      SiteInfo associated_content_info, bool should_send_content);
+      AssociatedContent? associated_content, bool should_send_content);
 
   SetShouldSendPageContents(bool should_send);
 
@@ -559,10 +552,10 @@ interface ConversationUI {
   // Browser window.
   OnSuggestedQuestionsChanged(
       array<string> questions, SuggestionGenerationStatus status);
-  // Associated page information has changed. If there is none then |site_info|
+  // Associated page information has changed. If there is none then |associated_content|
   // will be |null|. If the reason for that is it's still being fetched, then
   // |is_fetching| will be |true|.
-  OnAssociatedContentInfoChanged(SiteInfo info, bool should_send_page_contents);
+  OnAssociatedContentInfoChanged(AssociatedContent? associated_content, bool should_send_page_contents);
   OnFaviconImageDataChanged();
   OnConversationDeleted();
 };

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -479,8 +479,7 @@ interface ConversationHandler {
   SubmitSuggestion(string suggestion);
 
   // Get associated page information. If there is none then |associated_content|
-  // will be |null|. If the reason for that is it's still being fetched, then
-  // |is_fetching| will be |true|.
+  // will be |null|.
   GetAssociatedContentInfo() => (
       AssociatedContent? associated_content, bool should_send_content);
 
@@ -549,8 +548,7 @@ interface ConversationUI {
   OnSuggestedQuestionsChanged(
       array<string> questions, SuggestionGenerationStatus status);
   // Associated page information has changed. If there is none then |associated_content|
-  // will be |null|. If the reason for that is it's still being fetched, then
-  // |is_fetching| will be |true|.
+  // will be |null|.
   OnAssociatedContentInfoChanged(AssociatedContent? associated_content, bool should_send_page_contents);
   OnFaviconImageDataChanged();
   OnConversationDeleted();

--- a/components/ai_chat/resources/page/components/feedback_form/index.tsx
+++ b/components/ai_chat/resources/page/components/feedback_form/index.tsx
@@ -84,13 +84,13 @@ function FeedbackForm() {
             />
           </label>
         </fieldset>
-        {conversationContext.associatedContentInfo?.hostname && (
+        {conversationContext.associatedContentInfo && (
           <fieldset>
             <Checkbox checked={shouldSendUrl} onChange={handleCheckboxChange}>
               <label>{
                 formatMessage(getLocale('sendSiteHostnameLabel'), {
                   placeholders: {
-                    $1: conversationContext.associatedContentInfo.hostname
+                    $1: new URL(conversationContext.associatedContentInfo.url.url).hostname
                   }
                 })
               }</label>

--- a/components/ai_chat/resources/page/components/feedback_form/index.tsx
+++ b/components/ai_chat/resources/page/components/feedback_form/index.tsx
@@ -20,6 +20,14 @@ const CATEGORY_OPTIONS = new Map([
   ['other', getLocale('optionOther')]
 ])
 
+const getHostName = (url: string) => {
+  try {
+    return new URL(url).hostname
+  } catch (e) {
+    return ''
+  }
+}
+
 function FeedbackForm() {
   const ref = React.useRef<HTMLDivElement>(null)
   const [category, setCategory] = React.useState('')
@@ -90,7 +98,7 @@ function FeedbackForm() {
               <label>{
                 formatMessage(getLocale('sendSiteHostnameLabel'), {
                   placeholders: {
-                    $1: new URL(conversationContext.associatedContentInfo.url.url).hostname
+                    $1: getHostName(conversationContext.associatedContentInfo.url.url)
                   }
                 })
               }</label>

--- a/components/ai_chat/resources/page/components/main/index.tsx
+++ b/components/ai_chat/resources/page/components/main/index.tsx
@@ -74,7 +74,7 @@ function Main() {
     !conversationContext.apiHasError && // Don't show premium prompt and errors (rate limit error has its own premium prompt suggestion)
     !shouldShowStorageNotice && // Don't show premium prompt and storage notice
     aiChatContext.canShowPremiumPrompt &&
-    conversationContext.associatedContentInfo === null && // SiteInfo request has finished and this is a standalone conversation
+    conversationContext.associatedContentInfo === null && // AssociatedContent request has finished and this is a standalone conversation
     !aiChatContext.isPremiumUser
 
 
@@ -84,7 +84,7 @@ function Main() {
   const showContextToggle =
     (conversationContext.conversationHistory.length === 0 ||
       isLastTurnBraveSearchSERPSummary) &&
-    conversationContext.associatedContentInfo?.isContentAssociationPossible
+    !!conversationContext.associatedContentInfo
 
   const showAttachments = useSupportsAttachments()
     && conversationContext.showAttachments
@@ -228,7 +228,7 @@ function Main() {
               <>
                 <ModelIntro />
 
-                {conversationContext.associatedContentInfo?.isContentAssociationPossible && conversationContext.shouldSendPageContents && (
+                {conversationContext.associatedContentInfo && conversationContext.shouldSendPageContents && (
                   <div className={styles.siteTitleContainer}>
                     <SiteTitle size='default' />
                   </div>

--- a/components/ai_chat/resources/page/components/welcome_guide/index.tsx
+++ b/components/ai_chat/resources/page/components/welcome_guide/index.tsx
@@ -26,7 +26,7 @@ function WelcomeGuide() {
         <h4 className={styles.cardTitle}>
           {getLocale('welcomeGuideSiteHelpCardTitle')}
         </h4>
-        {conversationContext.associatedContentInfo?.isContentAssociationPossible &&
+        {conversationContext.associatedContentInfo &&
         conversationContext.shouldSendPageContents ? (
           <>
             <p>{getLocale('welcomeGuideSiteHelpCardDescWithAction')}</p>

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -26,7 +26,7 @@ export type ConversationContext = SendFeedbackState & CharCountContext & {
   historyInitialized: boolean
   conversationUuid?: string
   conversationHistory: Mojom.ConversationTurn[]
-  associatedContentInfo?: Mojom.SiteInfo
+  associatedContentInfo?: Mojom.AssociatedContent
   allModels: Mojom.Model[]
   currentModel?: Mojom.Model
   suggestedQuestions: string[]
@@ -221,7 +221,7 @@ export function ConversationContextProvider(props: React.PropsWithChildren) {
         currentModelKey,
         suggestedQuestions,
         suggestionStatus,
-        associatedContentInfo,
+        associatedContent,
         shouldSendContent,
         error
       } } = await conversationHandler.getState()
@@ -231,7 +231,7 @@ export function ConversationContextProvider(props: React.PropsWithChildren) {
         ...getModelContext(currentModelKey, models),
         suggestedQuestions,
         suggestionStatus,
-        associatedContentInfo,
+        associatedContentInfo: associatedContent,
         shouldSendPageContents: shouldSendContent,
         currentError: error
       })
@@ -280,7 +280,7 @@ export function ConversationContextProvider(props: React.PropsWithChildren) {
 
     id = callbackRouter.onAssociatedContentInfoChanged.addListener(
       (
-        associatedContentInfo: Mojom.SiteInfo,
+        associatedContentInfo: Mojom.AssociatedContent,
         shouldSendPageContents: boolean
       ) => {
         setPartialContext({

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -77,25 +77,13 @@ function getPageContentRefineEvent(): Mojom.ConversationEntryEvent {
   }
 }
 
-const associatedContentNone: Mojom.SiteInfo =  {
-  uuid: undefined,
-  contentType: Mojom.ContentType.PageContent,
-  isContentAssociationPossible: false,
-  contentUsedPercentage: 0,
-  isContentRefined: false,
-  title: undefined,
-  hostname: undefined,
-  url: undefined,
-  contentId: -1,
-}
-
 const CONVERSATIONS: Mojom.Conversation[] = [
   {
     title: 'Star Trek Poem',
     uuid: '1',
     hasContent: true,
     updatedTime: { internalValue: BigInt('13278618001000000') },
-    associatedContent: associatedContentNone,
+    associatedContent: undefined,
     modelKey: undefined,
   },
   {
@@ -103,7 +91,7 @@ const CONVERSATIONS: Mojom.Conversation[] = [
     uuid: '2',
     hasContent: true,
     updatedTime: { internalValue: BigInt('13278618001000001') },
-    associatedContent: associatedContentNone,
+    associatedContent: undefined,
     modelKey: undefined,
   },
   {
@@ -111,7 +99,7 @@ const CONVERSATIONS: Mojom.Conversation[] = [
     uuid: '3',
     hasContent: true,
     updatedTime: { internalValue: BigInt('13278618001000002') },
-    associatedContent: associatedContentNone,
+    associatedContent: undefined,
     modelKey: undefined,
   }
 ]
@@ -399,16 +387,14 @@ const SAMPLE_QUESTIONS = [
   'Why did google executives disregard this character in the company?'
 ]
 
-const SITE_INFO: Mojom.SiteInfo = {
-  uuid: undefined,
+const ASSOCIATED_CONTENT: Mojom.AssociatedContent = {
+  uuid: 'uuid',
   contentType: Mojom.ContentType.PageContent,
   title: 'Tiny Tweaks to Neurons Can Rewire Animal Motion',
   contentUsedPercentage: 40,
-  isContentAssociationPossible: true,
-  hostname: 'www.example.com',
   url: { url: 'https://www.example.com/a' },
   isContentRefined: false,
-  contentId: -1,
+  contentId: 1,
 }
 
 type CustomArgs = {
@@ -421,7 +407,7 @@ type CustomArgs = {
   deletingConversationId: string | null
   visibleConversationListCount: number
   hasSuggestedQuestions: boolean
-  hasSiteInfo: boolean
+  hasAssociatedContent: boolean
   isFeedbackFormVisible: boolean
   isStorageNoticeDismissed: boolean
   canShowPremiumPrompt: boolean
@@ -447,7 +433,7 @@ const args: CustomArgs = {
   hasConversation: true,
   visibleConversationListCount: CONVERSATIONS.length,
   hasSuggestedQuestions: true,
-  hasSiteInfo: true,
+  hasAssociatedContent: true,
   editingConversationId: null,
   deletingConversationId: null,
   isFeedbackFormVisible: false,
@@ -517,10 +503,10 @@ function StoryContext(props: React.PropsWithChildren<{ args: CustomArgs, setArgs
   const options = { args: props.args }
   const { setArgs } = props
 
-  const siteInfo = options.args.hasSiteInfo ? SITE_INFO : new Mojom.SiteInfo()
+  const associatedContent = options.args.hasAssociatedContent ? ASSOCIATED_CONTENT : new Mojom.AssociatedContent()
   const suggestedQuestions = options.args.hasSuggestedQuestions
     ? SAMPLE_QUESTIONS
-    : siteInfo
+    : associatedContent
       ? [SAMPLE_QUESTIONS[0]]
       : []
 
@@ -592,7 +578,7 @@ function StoryContext(props: React.PropsWithChildren<{ args: CustomArgs, setArgs
     historyInitialized: true,
     conversationUuid: CONVERSATIONS[1].uuid,
     conversationHistory: options.args.hasConversation ? HISTORY : [],
-    associatedContentInfo: siteInfo,
+    associatedContentInfo: associatedContent,
     allModels: MODELS,
     currentModel,
     suggestedQuestions,
@@ -604,7 +590,7 @@ function StoryContext(props: React.PropsWithChildren<{ args: CustomArgs, setArgs
     shouldDisableUserInput: false,
     shouldShowLongPageWarning: options.args.shouldShowLongPageWarning,
     shouldShowLongConversationInfo: options.args.shouldShowLongConversationInfo,
-    shouldSendPageContents: siteInfo?.isContentAssociationPossible,
+    shouldSendPageContents: !!associatedContent,
     inputText,
     actionList: ACTIONS_LIST,
     selectedActionType: undefined,

--- a/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
+++ b/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
@@ -27,7 +27,7 @@ public class AIChatViewModel: NSObject, ObservableObject {
   private let braveTalkScript: AIChatBraveTalkJavascript?
   var querySubmited: String?
 
-  @Published var siteInfo: AiChat.SiteInfo?
+  @Published var siteInfo: AiChat.AssociatedContent?
   @Published var _shouldSendPageContents: Bool = true
   @Published var _canShowPremiumPrompt: Bool = false
   @Published var premiumStatus: AiChat.PremiumStatus = .inactive
@@ -324,7 +324,7 @@ extension AIChatViewModel: AIChatDelegate {
   }
 
   public func onPageHasContent(
-    _ siteInfo: AiChat.SiteInfo,
+    _ siteInfo: AiChat.AssociatedContent,
     shouldSendContent shouldSendPageContents: Bool
   ) {
     self.siteInfo = siteInfo

--- a/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
+++ b/ios/brave-ios/Sources/AIChat/ModelView/AIChatViewModel.swift
@@ -194,7 +194,7 @@ public class AIChatViewModel: NSObject, ObservableObject {
     self.requestInProgress = state.isRequestInProgress
     self.suggestedQuestions = state.suggestedQuestions
     self.suggestionsStatus = state.suggestionStatus
-    self.siteInfo = state.associatedContentInfo
+    self.siteInfo = state.associatedContent
     self._shouldSendPageContents = state.shouldSendContent
     self.apiError = state.error
     self.models = state.allModels

--- a/ios/browser/api/ai_chat/ai_chat_delegate.h
+++ b/ios/browser/api/ai_chat/ai_chat_delegate.h
@@ -26,7 +26,7 @@ OBJC_EXPORT
              modelList:(NSArray<AiChatModel*>*)modelList;
 - (void)onSuggestedQuestionsChanged:(NSArray<NSString*>*)questions
                              status:(AiChatSuggestionGenerationStatus)status;
-- (void)onPageHasContent:(AiChatSiteInfo*)siteInfo
+- (void)onPageHasContent:(AiChatAssociatedContent*)siteInfo
        shouldSendContent:(bool)shouldSendContent;
 - (void)onServiceStateChanged:(AiChatServiceState*)state;
 @end

--- a/ios/browser/api/ai_chat/conversation_client.h
+++ b/ios/browser/api/ai_chat/conversation_client.h
@@ -43,8 +43,9 @@ class ConversationClient : public mojom::ConversationUI,
   void OnSuggestedQuestionsChanged(
       const std::vector<std::string>& questions,
       mojom::SuggestionGenerationStatus status) override;
-  void OnAssociatedContentInfoChanged(const mojom::SiteInfoPtr site_info,
-                                      bool should_send_content) override;
+  void OnAssociatedContentInfoChanged(
+      const mojom::AssociatedContentPtr site_info,
+      bool should_send_content) override;
   void OnFaviconImageDataChanged() override;
   void OnConversationDeleted() override;
 

--- a/ios/browser/api/ai_chat/conversation_client.mm
+++ b/ios/browser/api/ai_chat/conversation_client.mm
@@ -71,8 +71,8 @@ void ConversationClient::OnSuggestedQuestionsChanged(
 void ConversationClient::OnAssociatedContentInfoChanged(
     const mojom::AssociatedContentPtr site_info,
     bool should_send_content) {
-  [bridge_ onPageHasContent:[[AiChatSiteInfo alloc]
-                                initWithSiteInfoPtr:site_info->Clone()]
+  [bridge_ onPageHasContent:[[AiChatAssociatedContent alloc]
+                                initWithAssociatedContentPtr:site_info->Clone()]
           shouldSendContent:should_send_content];
 }
 

--- a/ios/browser/api/ai_chat/conversation_client.mm
+++ b/ios/browser/api/ai_chat/conversation_client.mm
@@ -69,7 +69,7 @@ void ConversationClient::OnSuggestedQuestionsChanged(
 }
 
 void ConversationClient::OnAssociatedContentInfoChanged(
-    const mojom::SiteInfoPtr site_info,
+    const mojom::AssociatedContentPtr site_info,
     bool should_send_content) {
   [bridge_ onPageHasContent:[[AiChatSiteInfo alloc]
                                 initWithSiteInfoPtr:site_info->Clone()]


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43293

The changes are mostly to `ai_chat.mojom` - everything else is just adapting to the new shape of the API

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

N/A - no user facing changes