### PR TITLE
(Wallet) Fix Dapps dialog not dismissed when creating a new tab

### DIFF
--- a/android/brave_java_resources.gni
+++ b/android/brave_java_resources.gni
@@ -382,6 +382,7 @@ brave_java_resources = [
   "java/res/drawable/crypto_wallet_hollow_button.xml",
   "java/res/drawable/crypto_wallet_onboarding_blue_button.xml",
   "java/res/drawable/custodian_text_background.xml",
+  "java/res/drawable/dapps_permission_dialog_background.xml",
   "java/res/drawable/default_dot.xml",
   "java/res/drawable/default_indicator.xml",
   "java/res/drawable/ellipse_217.xml",

--- a/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
+++ b/android/java/org/chromium/chrome/browser/crypto_wallet/permission/BraveDappPermissionPromptDialog.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.ViewParent;
+import android.view.Window;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -60,6 +61,7 @@ public class BraveDappPermissionPromptDialog
     private final ModalDialogManager mModalDialogManager;
     private final int mCoinType;
     private final Context mContext;
+    private final Window mWindow;
     private long mNativeDialogController;
     private PropertyModel mPropertyModel;
     private String mFavIconURL;
@@ -85,13 +87,13 @@ public class BraveDappPermissionPromptDialog
 
     public BraveDappPermissionPromptDialog(
             long nativeDialogController,
-            WindowAndroid windowAndroid,
+            @NonNull WindowAndroid windowAndroid,
             String favIconURL,
             @CoinType.EnumType int coinType) {
         mNativeDialogController = nativeDialogController;
         mFavIconURL = favIconURL;
         mContext = windowAndroid.getActivity().get();
-
+        mWindow = windowAndroid.getWindow();
         mModalDialogManager = windowAndroid.getModalDialogManager();
         mCoinType = coinType;
         mMojoServicesClosed = false;
@@ -113,7 +115,7 @@ public class BraveDappPermissionPromptDialog
     void show() {
         View customView =
                 LayoutInflaterUtils.inflate(
-                        mContext, R.layout.brave_permission_prompt_dialog, null);
+                        mWindow, R.layout.brave_permission_prompt_dialog, null, false);
 
         mFavIconImage = customView.findViewById(R.id.favicon);
         mCvFavContainer = customView.findViewById(R.id.permission_prompt_fav_container);
@@ -142,7 +144,7 @@ public class BraveDappPermissionPromptDialog
                                         R.string.permissions_connect_brave_wallet_back_button_text))
                         .with(ModalDialogProperties.FILTER_TOUCH_FOR_SECURITY, true)
                         .build();
-        mModalDialogManager.showDialog(mPropertyModel, ModalDialogType.APP);
+        mModalDialogManager.showDialog(mPropertyModel, ModalDialogType.TAB);
         initKeyringService();
         try {
             BraveActivity activity = BraveActivity.getBraveActivity();
@@ -160,7 +162,7 @@ public class BraveDappPermissionPromptDialog
                 mPermissionDialogPositiveButton.setEnabled(false);
             }
         } catch (BraveActivity.BraveActivityNotFoundException e) {
-            Log.e(TAG, "show " + e);
+            Log.e(TAG, "show", e);
         }
         initAccounts();
     }
@@ -172,7 +174,7 @@ public class BraveDappPermissionPromptDialog
 
     @NonNull
     private ViewGroup getPermissionModalViewContainer(@NonNull View customView) {
-        ViewParent viewParent = customView.getParent();
+        ViewParent viewParent = (ViewParent) customView;
         while (viewParent.getParent() != null) {
             viewParent = viewParent.getParent();
             if (viewParent instanceof ModalDialogView) {

--- a/android/java/res/drawable/dapps_permission_dialog_background.xml
+++ b/android/java/res/drawable/dapps_permission_dialog_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/brave_wallet_dn_panel_bg" />
+    <corners
+        android:topLeftRadius="24dp"
+        android:topRightRadius="24dp"
+        />
+</shape>

--- a/android/java/res/layout/brave_permission_prompt_dialog.xml
+++ b/android/java/res/layout/brave_permission_prompt_dialog.xml
@@ -8,7 +8,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     style="@style/AlertDialogContent"
-    android:background="@color/brave_wallet_dn_panel_bg"
+    android:background="@drawable/dapps_permission_dialog_background"
     android:gravity="start">
 
     <TextView


### PR DESCRIPTION
## Resolves https://github.com/brave/brave-browser/issues/43167

Fixes an issue where Dapps dialog was not properly dismissed when creating a new tap from homescreen shortcut.

### Demo


https://github.com/user-attachments/assets/0ec7495a-3c15-4a3c-b2c4-b34ed260c2f7



<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Visit https://kjozwiak.github.io/crash.html
- Unlock Brave Wallet if requested
- Observe the Dapp connection dialog shows up
- Background the app
- Long press on icon and select New Tab
- Observe the Dapp connection dialog not showing up