### PR TITLE
Enable password sync by default (for new users)

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -21,6 +21,7 @@
 #include "brave/components/brave_rewards/core/buildflags/buildflags.h"
 #include "brave/components/brave_rewards/core/features.h"
 #include "brave/components/brave_shields/core/common/features.h"
+#include "brave/components/brave_sync/features.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/brave_wallet/common/buildflags.h"
 #include "brave/components/brave_wallet/common/features.h"
@@ -1142,6 +1143,14 @@ constexpr flags_ui::FeatureEntry::Choice kVerticalTabCollapseDelayChoices[] = {
           kOsAll,                                                              \
           ORIGIN_LIST_VALUE_TYPE(syncer::kSyncServiceURL, ""),                 \
           kBraveSyncImplLink,                                                  \
+      },                                                                       \
+      {                                                                        \
+          "brave-sync-default-passwords",                                      \
+          "Enable password syncing by default",                                \
+          "Turn on password syncing when Sync is enabled.",                    \
+          kOsAll,                                                              \
+          FEATURE_VALUE_TYPE(                                                  \
+              brave_sync::features::kBraveSyncDefaultPasswords),               \
       })                                                                       \
   BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \
   BRAVE_NEWS_FEATURE_ENTRIES                                                   \

--- a/components/brave_sync/features.cc
+++ b/components/brave_sync/features.cc
@@ -10,5 +10,8 @@
 namespace brave_sync::features {
 
 BASE_FEATURE(kBraveSync, "BraveSync", base::FEATURE_ENABLED_BY_DEFAULT);
+BASE_FEATURE(kBraveSyncDefaultPasswords,
+             "BraveSyncDefaultPasswords",
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 }  // namespace brave_sync::features

--- a/components/brave_sync/features.h
+++ b/components/brave_sync/features.h
@@ -12,6 +12,7 @@ namespace brave_sync {
 namespace features {
 
 BASE_DECLARE_FEATURE(kBraveSync);
+BASE_DECLARE_FEATURE(kBraveSyncDefaultPasswords);
 
 }  // namespace features
 }  // namespace brave_sync

--- a/components/sync/service/BUILD.gn
+++ b/components/sync/service/BUILD.gn
@@ -19,6 +19,7 @@ source_set("unit_tests") {
   deps = [
     "//base/test:test_support",
     "//brave/components/brave_sync:crypto",
+    "//brave/components/brave_sync:features",
     "//brave/components/brave_sync:network_time_helper",
     "//brave/components/brave_sync:p3a",
     "//brave/components/brave_sync:prefs",

--- a/components/sync/service/brave_sync_service_impl.cc
+++ b/components/sync/service/brave_sync_service_impl.cc
@@ -16,6 +16,7 @@
 #include "base/strings/string_util.h"
 #include "brave/components/brave_sync/brave_sync_p3a.h"
 #include "brave/components/brave_sync/crypto/crypto.h"
+#include "brave/components/brave_sync/features.h"
 #include "brave/components/sync/service/brave_sync_auth_manager.h"
 #include "brave/components/sync/service/sync_service_impl_delegate.h"
 #include "build/build_config.h"
@@ -44,7 +45,6 @@ BraveSyncServiceImpl::BraveSyncServiceImpl(
       brave_sync::Prefs::GetSeedPath(),
       base::BindRepeating(&BraveSyncServiceImpl::OnBraveSyncPrefsChanged,
                           base::Unretained(this)));
-
   bool failed_to_decrypt = false;
   GetBraveSyncAuthManager()->DeriveSigningKeys(
       brave_sync_prefs_.GetSeed(&failed_to_decrypt));
@@ -167,7 +167,7 @@ void BraveSyncServiceImpl::OnBraveSyncPrefsChanged(const std::string& path) {
 
     if (!seed.empty()) {
       GetBraveSyncAuthManager()->DeriveSigningKeys(seed);
-      // Default enabled types: Bookmarks
+      // Default enabled types: Bookmarks, Passwords
 
       // Related Chromium change: 33441a0f3f9a591693157f2fd16852ce072e6f9d
       // We need to acquire setup handle before change selected types.
@@ -177,6 +177,10 @@ void BraveSyncServiceImpl::OnBraveSyncPrefsChanged(const std::string& path) {
 
       syncer::UserSelectableTypeSet selected_types;
       selected_types.Put(UserSelectableType::kBookmarks);
+      if (base::FeatureList::IsEnabled(
+              brave_sync::features::kBraveSyncDefaultPasswords)) {
+        selected_types.Put(UserSelectableType::kPasswords);
+      }
       GetUserSettings()->SetSelectedTypes(false, selected_types);
 
       brave_sync_prefs_.ClearLeaveChainDetails();

--- a/components/sync/service/sources.gni
+++ b/components/sync/service/sources.gni
@@ -15,6 +15,7 @@ brave_components_sync_driver_sources = [
 brave_components_sync_driver_deps = [
   "//brave/components/brave_sync",
   "//brave/components/brave_sync:crypto",
+  "//brave/components/brave_sync:features",
   "//brave/components/brave_sync:network_time_helper",
   "//brave/components/brave_sync:prefs",
   "//brave/components/constants",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/48915. 

Add `UserSelectableType::kPasswords` to list of default enabled Sync types. Also gate this behavior behind a default-enabled flag, in case we need to roll this back. 

See the issue for more details.
