### PR TITLE
[Android][Sync] Sync passwords from Android to Desktop

### DIFF
--- a/browser/password_manager/android/brave_password_manager_android_util_unittest.cc
+++ b/browser/password_manager/android/brave_password_manager_android_util_unittest.cc
@@ -7,6 +7,7 @@
 #include "base/files/file_util.h"
 #include "base/test/scoped_feature_list.h"
 #include "base/test/test_file_util.h"
+#include "base/types/cxx23_to_underlying.h"
 #include "chrome/browser/password_manager/android/password_manager_android_util.h"
 #include "components/password_manager/core/browser/features/password_features.h"
 #include "components/password_manager/core/browser/password_manager_constants.h"
@@ -37,7 +38,7 @@ class BravePasswordManagerAndroidUtilTest : public testing::Test {
         0);
     pref_service_.registry()->RegisterIntegerPref(
         password_manager::prefs::kPasswordsUseUPMLocalAndSeparateStores,
-        static_cast<int>(kOff));
+        base::to_underlying(kOff));
     pref_service_.registry()->RegisterBooleanPref(
         password_manager::prefs::kCredentialsEnableService, false);
     pref_service_.registry()->RegisterBooleanPref(
@@ -90,7 +91,7 @@ TEST_F(BravePasswordManagerAndroidUtilTest,
 
   // This is a state of a local user that has just been migrated.
   pref_service()->SetInteger(kPasswordsUseUPMLocalAndSeparateStores,
-                             static_cast<int>(kOn));
+                             base::to_underlying(kOn));
   pref_service()->SetBoolean(
       password_manager::prefs::kUserAcknowledgedLocalPasswordsMigrationWarning,
       true);
@@ -122,7 +123,7 @@ TEST_F(BravePasswordManagerAndroidUtilTest,
   // Pref should be kOff, as we want keep using profile store instead of the
   // account store, so the paswords will be synced from Android to Desktop
   EXPECT_EQ(pref_service()->GetInteger(kPasswordsUseUPMLocalAndSeparateStores),
-            static_cast<int>(kOff));
+            base::to_underlying(kOff));
 
   // SetUsesSplitStoresAndUPMForLocal must not delete DB on Brave
   EXPECT_TRUE(PathExists(profile_db_path));

--- a/browser/password_manager/android/brave_password_manager_android_util_unittest.cc
+++ b/browser/password_manager/android/brave_password_manager_android_util_unittest.cc
@@ -119,9 +119,12 @@ TEST_F(BravePasswordManagerAndroidUtilTest,
 
   SetUsesSplitStoresAndUPMForLocal(pref_service(), login_db_directory());
 
-  // SetUsesSplitStoresAndUPMForLocal must not delete DB on Brave
+  // Pref should be kOff, as we want keep using profile store instead of the
+  // account store, so the paswords will be synced from Android to Desktop
   EXPECT_EQ(pref_service()->GetInteger(kPasswordsUseUPMLocalAndSeparateStores),
-            static_cast<int>(kOn));
+            static_cast<int>(kOff));
+
+  // SetUsesSplitStoresAndUPMForLocal must not delete DB on Brave
   EXPECT_TRUE(PathExists(profile_db_path));
   EXPECT_TRUE(PathExists(account_db_path));
   EXPECT_TRUE(PathExists(profile_db_journal_path));

--- a/chromium_src/chrome/browser/password_manager/android/password_manager_android_util.cc
+++ b/chromium_src/chrome/browser/password_manager/android/password_manager_android_util.cc
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+#include "components/password_manager/core/common/password_manager_pref_names.h"
+#include "components/prefs/pref_service.h"
+
 #define SetUsesSplitStoresAndUPMForLocal \
   SetUsesSplitStoresAndUPMForLocal_ChromiumImpl
 
@@ -12,11 +15,42 @@
 
 namespace password_manager_android_util {
 
+namespace {
+
+// On Android passwords can be saved into two stores: kAccountStore and
+// kProfileStore. Account store is not synced through Chromium sync and supposed
+// to store passwords at Google Account. Profile store is the store which saves
+// passwords at profile and passwords are synced as before. Decision which store
+// to use is made at PasswordSaveManagerImpl::GetPasswordStoreForSavingImpl.
+// Finally, `kPasswordsUseUPMLocalAndSeparateStores` pref is checked.
+// The stack:
+//        features_util::CanCreateAccountStore
+//        features_util::internal::CanAccountStorageBeEnabled
+//        features_util::internal::IsUserEligibleForAccountStorage
+//        features_util::GetDefaultPasswordStore
+//        PasswordFeatureManagerImpl::GetDefaultPasswordStore
+//        PasswordSaveManagerImpl::AccountStoreIsDefault
+//        PasswordSaveManagerImpl::GetPasswordStoreForSavingImpl
+// There are two ways to make passwords be saved at the profile store and be
+// synced:
+//   1) override PasswordSaveManagerImpl::AccountStoreIsDefault
+//   2) set `kPasswordsUseUPMLocalAndSeparateStores` pref to `kOff`
+// Choosing option 2.
+void ForcePasswordsProfileStore(PrefService* pref_service) {
+  pref_service->SetInteger(
+      password_manager::prefs::kPasswordsUseUPMLocalAndSeparateStores,
+      static_cast<int>(UseUpmLocalAndSeparateStoresState::kOff));
+}
+
+}  // namespace
+
 // Prevent deleting passwords local DB during migration.
 // Happens at SetUsesSplitStoresAndUPMForLocal =>
 //      MaybeDeactivateSplitStoresAndLocalUpm =>
 //      MaybeDeleteLoginDataFiles
 void SetUsesSplitStoresAndUPMForLocal(
     PrefService* pref_service,
-    const base::FilePath& login_db_directory) {}
+    const base::FilePath& login_db_directory) {
+  ForcePasswordsProfileStore(pref_service);
+}
 }  // namespace password_manager_android_util


### PR DESCRIPTION
This PR forces passwords on Android to be saved into `Profile Store` instead of `Account Store`, this allows passwords to be synced.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43303

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create sync chain with Android and Desktop, enable passwords syncing
2. Login to some site on Desktop, save password
3. Ensure the password is synced to Android
4. Login to some other site on Android, save password
5. Expected the password from Android is synced to Desktop

