### PR TITLE
fix(privacy): Improve cosmetic filtering performance on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -481,6 +481,8 @@ extension BrowserViewController: TopToolbarDelegate {
       browser.tabManager.allTabs.forEach {
         if $0.url?.baseDomain == currentDomain {
           $0.reload()
+          // Domain specific shield setting changed, reset selectors cache.
+          $0.contentBlocker.resetSelectorsCache()
         }
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -404,6 +404,23 @@ public class BrowserViewController: UIViewController {
       // Accessing `STWebpageController` on Vision OS results in a crash
       screenTimeViewController = STWebpageController()
     }
+
+    braveCore.adblockService.registerFilterListChanges { [weak self] _ in
+      // Filter lists updated, reset selectors cache(s).
+      self?.tabManager.allTabs.forEach {
+        $0.contentBlocker.resetSelectorsCache()
+      }
+    }
+
+    FilterListStorage.shared.$filterLists
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] _ in
+        // Filter lists selections changed, reset selectors cache(s).
+        self?.tabManager.allTabs.forEach {
+          $0.contentBlocker.resetSelectorsCache()
+        }
+      }
+      .store(in: &cancellables)
   }
 
   deinit {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3256,6 +3256,10 @@ extension BrowserViewController: PreferencesObserver {
     case ShieldPreferences.blockAdsAndTrackingLevelRaw.key:
       tabManager.reloadSelectedTab()
       recordGlobalAdBlockShieldsP3A()
+      // Global shield setting changed, reset selectors cache.
+      tabManager.allTabs.forEach({
+        $0.contentBlocker.resetSelectorsCache()
+      })
     case Preferences.Shields.fingerprintingProtection.key:
       tabManager.reloadSelectedTab()
       recordGlobalFingerprintingShieldsP3A()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1540,10 +1540,6 @@ extension TabManager: WKNavigationDelegate {
   func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
     if let tab = self[webView] {
       tab.contentBlocker.clearPageStats()
-      // if url eTLD+1 has changed, reset selectors cache.
-      if webView.url?.baseDomain != tab.url?.baseDomain {
-        tab.contentBlocker.resetSelectorsCache()
-      }
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabManager.swift
@@ -1540,6 +1540,10 @@ extension TabManager: WKNavigationDelegate {
   func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
     if let tab = self[webView] {
       tab.contentBlocker.clearPageStats()
+      // if url eTLD+1 has changed, reset selectors cache.
+      if webView.url?.baseDomain != tab.url?.baseDomain {
+        tab.contentBlocker.resetSelectorsCache()
+      }
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -88,8 +88,13 @@ class CosmeticFiltersScriptHandler: TabContentScript {
         }
 
         // cache blocked selectors
-        tab.contentBlocker.hiddenStandardSelectors.formUnion(standardSelectors)
-        tab.contentBlocker.hiddenAggressiveSelectors.formUnion(aggressiveSelectors)
+        if let url = tab.url {
+          tab.contentBlocker.cacheSelectors(
+            for: url,
+            standardSelectors: standardSelectors,
+            aggressiveSelectors: aggressiveSelectors
+          )
+        }
 
         replyHandler(
           [

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -87,6 +87,10 @@ class CosmeticFiltersScriptHandler: TabContentScript {
           }
         }
 
+        // cache blocked selectors
+        tab.contentBlocker.hiddenStandardSelectors.formUnion(standardSelectors)
+        tab.contentBlocker.hiddenAggressiveSelectors.formUnion(aggressiveSelectors)
+
         replyHandler(
           [
             "aggressiveSelectors": Array(aggressiveSelectors),

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -78,7 +78,9 @@ class SiteStateListenerScriptHandler: TabContentScript {
           )
           let setup = try self.makeSetup(
             from: models,
-            isAggressive: domain.globalBlockAdsAndTrackingLevel.isAggressive
+            isAggressive: domain.globalBlockAdsAndTrackingLevel.isAggressive,
+            cachedStandardSelectors: tab.contentBlocker.hiddenStandardSelectors,
+            cachedAggressiveSelectors: tab.contentBlocker.hiddenAggressiveSelectors
           )
 
           // Join the procedural actions
@@ -108,10 +110,12 @@ class SiteStateListenerScriptHandler: TabContentScript {
 
   @MainActor private func makeSetup(
     from modelTuples: [AdBlockGroupsManager.CosmeticFilterModelTuple],
-    isAggressive: Bool
+    isAggressive: Bool,
+    cachedStandardSelectors: Set<String>,
+    cachedAggressiveSelectors: Set<String>
   ) throws -> UserScriptType.SelectorsPollerSetup {
-    var standardSelectors: Set<String> = []
-    var aggressiveSelectors: Set<String> = []
+    var standardSelectors = cachedStandardSelectors
+    var aggressiveSelectors = cachedAggressiveSelectors
 
     for modelTuple in modelTuples {
       if modelTuple.isAlwaysAggressive {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -76,11 +76,20 @@ class SiteStateListenerScriptHandler: TabContentScript {
             forFrameURL: frameURL,
             domain: domain
           )
+
+          var cachedStandardSelectors: Set<String> = .init()
+          var cachedAggressiveSelectors: Set<String> = .init()
+          if let url = tab.url,
+            let (standard, aggressive) = tab.contentBlocker.cachedSelectors(for: url)
+          {
+            cachedStandardSelectors = standard
+            cachedAggressiveSelectors = aggressive
+          }
           let setup = try self.makeSetup(
             from: models,
             isAggressive: domain.globalBlockAdsAndTrackingLevel.isAggressive,
-            cachedStandardSelectors: tab.contentBlocker.hiddenStandardSelectors,
-            cachedAggressiveSelectors: tab.contentBlocker.hiddenAggressiveSelectors
+            cachedStandardSelectors: cachedStandardSelectors,
+            cachedAggressiveSelectors: cachedAggressiveSelectors
           )
 
           // Join the procedural actions

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -46,6 +46,21 @@ window.__firefox__.execute(function($) {
     })
   })
 
+  /**
+   Throttles the given function by the given delay
+   */
+  const throttle = $((func, delay) => {
+    let timerId = null;
+    return (...args) => {
+      if (timerId === null) {
+        func(...args);
+        timerId = setTimeout(() => {
+          timerId = null;
+        }, delay);
+      }
+    };
+  })
+
   // Start looking for things to unhide before at most this long after
   // the backend script is up and connected (eg backgroundReady = true),
   // or sooner if the thread is idle.
@@ -1047,6 +1062,7 @@ window.__firefox__.execute(function($) {
    * Rewrite the stylesheet body with the hidden rules and style rules
    */
   const setRulesOnStylesheet = () => {
+    console.log('LOG: setRulesOnStylesheet()');
     const hideRules = Array.from(CC.hiddenSelectors).map(selector => {
       return selector + '{display:none !important;}'
     })
@@ -1073,17 +1089,7 @@ window.__firefox__.execute(function($) {
    * This is an optimaization so we don't constantly re-apply rules
    * for each small change that may happen simultaneously.
    */
-  const setRulesOnStylesheetThrottled = () => {
-    if (setRulesTimerId) {
-      // Each time this is called cancell the timer and allow a new one to start
-      window.clearTimeout(setRulesTimerId)
-    }
-
-    setRulesTimerId = window.setTimeout(() => {
-      setRulesOnStylesheet()
-      delete setRulesTimerId
-    }, 200)
-  }
+  const setRulesOnStylesheetThrottled = throttle(setRulesOnStylesheet, 200);
 
   /**
    * Start polling the page for content and start the queue pump (if needed)

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/SelectorsPollerScript.js
@@ -1062,7 +1062,6 @@ window.__firefox__.execute(function($) {
    * Rewrite the stylesheet body with the hidden rules and style rules
    */
   const setRulesOnStylesheet = () => {
-    console.log('LOG: setRulesOnStylesheet()');
     const hideRules = Array.from(CC.hiddenSelectors).map(selector => {
       return selector + '{display:none !important;}'
     })

--- a/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -82,6 +82,8 @@ class ContentBlockerHelper: ObservableObject {
 
   var statsDidChange: ((TPPageStats) -> Void)?
   @Published var blockedRequests: OrderedSet<BlockedRequestInfo> = []
+  var hiddenStandardSelectors: Set<String> = []
+  var hiddenAggressiveSelectors: Set<String> = []
 
   init(tab: Tab) {
     self.tab = tab
@@ -113,5 +115,10 @@ class ContentBlockerHelper: ObservableObject {
     ]
 
     ContentBlockerManager.log.debug("Set rule lists:\n\(parts.joined(separator: "\n"))")
+  }
+
+  func resetSelectorsCache() {
+    hiddenStandardSelectors.removeAll()
+    hiddenAggressiveSelectors.removeAll()
   }
 }

--- a/ios/brave-ios/Sources/Brave/WebFilters/FilterListStorage.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/FilterListStorage.swift
@@ -346,16 +346,6 @@ extension AdblockService {
     }
   }
 
-  @MainActor fileprivate func filterListChangesStream() -> AsyncStream<
-    GroupedAdBlockEngine.EngineType
-  > {
-    return AsyncStream { continuation in
-      registerFilterListChanges({ isDefaultFilterList in
-        continuation.yield(isDefaultFilterList ? .standard : .aggressive)
-      })
-    }
-  }
-
   /// Get a list of files for the given engine type if the path exists
   @MainActor func fileInfos(
     for engineType: GroupedAdBlockEngine.EngineType

--- a/ios/browser/api/brave_shields/adblock_service.mm
+++ b/ios/browser/api/brave_shields/adblock_service.mm
@@ -100,7 +100,8 @@ void AdBlockResourceObserver::OnResourcesLoaded(
       _serviceManager;
   std::unique_ptr<brave_shields::AdBlockDefaultResourceProvider>
       _resourceProvider;
-  std::unique_ptr<brave_shields::AdBlockServiceObserver> _serviceObserver;
+  std::vector<std::unique_ptr<brave_shields::AdBlockServiceObserver>>
+      _serviceObservers;
   std::unique_ptr<brave_shields::AdBlockCatalogObserver> _catalogObserver;
   std::unique_ptr<brave_shields::AdBlockResourceObserver> _resourceObserver;
 }
@@ -132,10 +133,12 @@ void AdBlockResourceObserver::OnResourcesLoaded(
 }
 
 - (void)registerFilterListChanges:(void (^)(bool isDefaultEngine))callback {
-  _serviceObserver = std::make_unique<brave_shields::AdBlockServiceObserver>(
-      base::BindRepeating(callback));
+  auto _serviceObserver =
+      std::make_unique<brave_shields::AdBlockServiceObserver>(
+          base::BindRepeating(callback));
   brave_shields::AdBlockFiltersProviderManager::GetInstance()->AddObserver(
       _serviceObserver.get());
+  _serviceObservers.push_back(std::move(_serviceObserver));
 }
 
 - (void)registerCatalogChanges:(void (^)())callback {


### PR DESCRIPTION
- Update `setRulesOnStylesheetThrottled` to throttle instead of debounce. 
    - Currently we wait for a page to not have any mutations for 200ms before we update the stylesheet. This can result in us knowing about selectors to hide but not hiding them until a page has stopped mutating. By throttling instead, we update the stylesheet at most every 200ms.
- Cache previously hidden selectors for per eTLD+1 on the tab. 
    - When we first inject `SelectorsPollerScript.js` we provide the page with a initial list of selectors to hide, then we send the remaining selectors on the page to `CosmeticFiltersScriptHandler` to check against `AdblockEngine`. The `AdblockEngine` tells us which selectors to hide, and we send these back to the page to be hidden.
    - By caching these selectors (in memory only, cached per-tab), we can then inject them with the initial when we first inject `SelectorsPollerScript.js` so we don't have to wait for the round trip from our javascript -> ScriptHandler -> AdblockEngine -> our javascript. This cache is reset when:
        - Tab is closed / browser restart.
        - Filter lists are updated.
        - Global shields level (standard/aggressive) is changed.
        - Domain specific shields level is changed.

Resolves https://github.com/brave/brave-browser/issues/42530

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

