### PR TITLE
[VerticalTab] Move the new tab button to appear immediately after the last tab (uplift to 1.75.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -85,7 +85,7 @@ class VerticalTabStripRegionView : public views::View,
 
   TabSearchBubbleHost* GetTabSearchBubbleHost();
 
-  int GetTabStripViewportHeight() const;
+  int GetTabStripViewportMaxHeight() const;
 
   void set_layout_dirty(base::PassKey<VerticalTabStripScrollContentsView>) {
     layout_dirty_ = true;
@@ -195,6 +195,9 @@ class VerticalTabStripRegionView : public views::View,
 
   raw_ptr<HeaderView> header_view_ = nullptr;
   raw_ptr<views::View> contents_view_ = nullptr;
+
+  // Separator between tabs and new tab button.
+  raw_ptr<views::View> separator_ = nullptr;
 
   // New tab button created for vertical tabs
   raw_ptr<BraveNewTabButton> new_tab_button_ = nullptr;

--- a/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view_mac.mm
@@ -37,14 +37,16 @@ NSString* keyCombinationForMenuItem(NSMenuItem* item) {
   NSMutableString* string = [NSMutableString string];
   NSUInteger modifiers = item.keyEquivalentModifierMask;
 
+  // Appended "+" after the modifier as key combination
+  // is splited to each part and rendered separately.
   if (modifiers & NSEventModifierFlagCommand)
-    [string appendString:@"\u2318"];
+    [string appendString:@"\u2318+"];
   if (modifiers & NSEventModifierFlagControl)
-    [string appendString:@"\u2303"];
+    [string appendString:@"\u2303+"];
   if (modifiers & NSEventModifierFlagOption)
-    [string appendString:@"\u2325"];
+    [string appendString:@"\u2325+"];
   if (modifiers & NSEventModifierFlagShift)
-    [string appendString:@"\u21E7"];
+    [string appendString:@"\u21E7+"];
 
   [string appendString:[item.keyEquivalent uppercaseString]];
   return string;

--- a/browser/ui/views/tabs/brave_compound_tab_container.cc
+++ b/browser/ui/views/tabs/brave_compound_tab_container.cc
@@ -271,7 +271,11 @@ gfx::Size BraveCompoundTabContainer::CalculatePreferredSize(
   auto preferred_size =
       CompoundTabContainer::CalculatePreferredSize(available_size);
 
-  // Check if we can expand height to fill the entire scroll area's viewport.
+  const int combined_height =
+      pinned_tab_container_->GetPreferredSize().height() +
+      unpinned_tab_container_->GetPreferredSize().height();
+
+  // Traverse up the parent hierarchy to find the |VerticalTabStripRegionView|
   for (auto* parent_view = parent(); parent_view;
        parent_view = parent_view->parent()) {
     auto* region_view =
@@ -280,7 +284,8 @@ gfx::Size BraveCompoundTabContainer::CalculatePreferredSize(
       continue;
     }
 
-    preferred_size.set_height(region_view->GetTabStripViewportHeight());
+    preferred_size.set_height(
+        std::min(combined_height, region_view->GetTabStripViewportMaxHeight()));
     break;
   }
 

--- a/browser/ui/views/tabs/brave_compound_tab_container.h
+++ b/browser/ui/views/tabs/brave_compound_tab_container.h
@@ -45,12 +45,14 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
   Tab* AddTab(std::unique_ptr<Tab> tab,
               int model_index,
               TabPinned pinned) override;
+  void MoveTab(int from_model_index, int to_model_index) override;
+  void RemoveTab(int index, bool was_active) override;
+  void SetTabPinned(int model_index, TabPinned pinned) override;
   int GetUnpinnedContainerIdealLeadingX() const override;
   TabContainer* GetTabContainerAt(
       gfx::Point point_in_local_coords) const override;
   gfx::Rect ConvertUnpinnedContainerIdealBoundsToLocal(
       gfx::Rect ideal_bounds) const override;
-  void OnThemeChanged() override;
   void PaintChildren(const views::PaintInfo& info) override;
   void ChildPreferredSizeChanged(views::View* child) override;
   void SetActiveTab(std::optional<size_t> prev_active_index,
@@ -68,6 +70,7 @@ class BraveCompoundTabContainer : public CompoundTabContainer {
 
   bool ShouldShowVerticalTabs() const;
 
+  void UpdatePinnedTabContainerBorder();
   void UpdateUnpinnedContainerSize();
   void ScrollTabToBeVisible(int model_index);
 

--- a/browser/ui/views/tabs/brave_tab.cc
+++ b/browser/ui/views/tabs/brave_tab.cc
@@ -16,31 +16,15 @@
 #include "brave/browser/ui/views/frame/vertical_tab_strip_region_view.h"
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
-#include "brave/browser/ui/views/view_shadow.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/views/tabs/alert_indicator_button.h"
 #include "chrome/browser/ui/views/tabs/tab_close_button.h"
 #include "chrome/browser/ui/views/tabs/tab_slot_controller.h"
-#include "ui/compositor/layer.h"
-#include "ui/compositor/paint_recorder.h"
 #include "ui/gfx/favicon_size.h"
-#include "ui/gfx/skia_paint_util.h"
 #include "ui/views/animation/ink_drop.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/view_class_properties.h"
-
-namespace {
-
-constexpr ViewShadow::ShadowParameters kShadow{
-    .offset_x = 0,
-    .offset_y = 1,
-    .blur_radius = 4,
-    .shadow_color = SkColorSetA(SK_ColorBLACK, 0.07 * 255)};
-
-}  // namespace
-
-BraveTab::BraveTab(TabSlotController* controller) : Tab(controller) {}
 
 BraveTab::~BraveTab() = default;
 
@@ -77,8 +61,6 @@ void BraveTab::ActiveStateChanged() {
   // see comment on UpdateEnabledForMuteToggle();
   // https://github.com/brave/brave-browser/issues/23476/
   alert_indicator_button_->UpdateEnabledForMuteToggle();
-
-  UpdateShadowForActiveTab();
 }
 
 std::optional<SkColor> BraveTab::GetGroupColor() const {
@@ -167,32 +149,6 @@ bool BraveTab::ShouldRenderAsNormalTab() const {
 bool BraveTab::IsAtMinWidthForVerticalTabStrip() const {
   return tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser()) &&
          width() <= tabs::kVerticalTabMinWidth;
-}
-
-void BraveTab::UpdateShadowForActiveTab() {
-  bool can_render_shadows =
-      tabs::features::HorizontalTabsUpdateEnabled() ||
-      tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser());
-
-  if (IsActive() && can_render_shadows) {
-    if (!view_shadow_) {
-      view_shadow_ = std::make_unique<ViewShadow>(
-          this, tabs::GetTabCornerRadius(*this), kShadow);
-      layer()->SetFillsBoundsOpaquely(false);
-    }
-
-    gfx::Insets shadow_insets;
-    if (!tabs::utils::ShouldShowVerticalTabs(controller()->GetBrowser())) {
-      // For horizontal tabs, inset the shadow layer to match the visual rounded
-      // rectangle of the tab, which is inset from the tab view.
-      shadow_insets = gfx::Insets::VH(brave_tabs::kHorizontalTabVerticalSpacing,
-                                      brave_tabs::kHorizontalTabInset);
-    }
-    view_shadow_->SetInsets(shadow_insets);
-  } else if (view_shadow_) {
-    view_shadow_.reset();
-    DestroyLayer();
-  }
 }
 
 void BraveTab::SetData(TabRendererData data) {

--- a/browser/ui/views/tabs/brave_tab.h
+++ b/browser/ui/views/tabs/brave_tab.h
@@ -6,18 +6,15 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_H_
 #define BRAVE_BROWSER_UI_VIEWS_TABS_BRAVE_TAB_H_
 
-#include <memory>
 #include <optional>
 #include <string>
 
 #include "chrome/browser/ui/views/tabs/tab.h"
 #include "ui/gfx/geometry/point.h"
 
-class ViewShadow;
-
 class BraveTab : public Tab {
  public:
-  explicit BraveTab(TabSlotController* controller);
+  using Tab::Tab;
   BraveTab(const BraveTab&) = delete;
   BraveTab& operator=(const BraveTab&) = delete;
   ~BraveTab() override;
@@ -46,10 +43,6 @@ class BraveTab : public Tab {
   friend class BraveTabTest;
 
   bool IsAtMinWidthForVerticalTabStrip() const;
-  void UpdateShadowForActiveTab();
-
-  std::unique_ptr<ui::Layer> shadow_layer_;
-  std::unique_ptr<ViewShadow> view_shadow_;
 
   static constexpr int kExtraLeftPadding = 4;
 };

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -405,10 +405,6 @@ void BraveTabContainer::PaintChildren(const views::PaintInfo& paint_info) {
     if (!ZOrderableTabContainerElement::CanOrderView(child)) {
       continue;
     }
-    if (child->layer()) {
-      continue;
-    }
-
     orderable_children.emplace_back(child);
   }
 

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -68,7 +68,11 @@ bool BraveTabStrip::IsVerticalTabsFloating() const {
   auto* vertical_region_view =
       browser_view->vertical_tab_strip_widget_delegate_view()
           ->vertical_tab_strip_region_view();
-  DCHECK(vertical_region_view);
+
+  if (!vertical_region_view) {
+    // Could be null while closing a window.
+    return false;
+  }
 
   return vertical_region_view->state() ==
              VerticalTabStripRegionView::State::kFloating ||

--- a/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
+++ b/chromium_src/chrome/browser/ui/views/frame/browser_root_view.cc
@@ -7,14 +7,15 @@
 
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 
-#define ConvertPointToTarget(THIS, TARGET_GETTER, POINT)                  \
-  if (views::View* target_v = TARGET_GETTER;                              \
-      tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) &&    \
-      (target_v == tabstrip() || !THIS->Contains(target_v))) {            \
-    ConvertPointToScreen(target_v, POINT);                                \
-    ConvertPointFromScreen(THIS, POINT);                                  \
-  } else {                                                                \
-    ConvertPointToTarget(THIS, target_v, POINT);                          \
+// Workaround for vertical tabs to work with drag&drop of text/links.
+#define ConvertPointToTarget(THIS, TARGET_GETTER, POINT)               \
+  if (views::View* target_v = TARGET_GETTER;                           \
+      tabs::utils::ShouldShowVerticalTabs(browser_view_->browser()) && \
+      (target_v == tabstrip() || !THIS->Contains(target_v))) {         \
+    ConvertPointToScreen(THIS, POINT);                                 \
+    ConvertPointFromScreen(target_v, POINT);                           \
+  } else {                                                             \
+    ConvertPointToTarget(THIS, target_v, POINT);                       \
   }
 
 #include "src/chrome/browser/ui/views/frame/browser_root_view.cc"

--- a/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/tab_strip.cc
@@ -48,16 +48,8 @@
     return tabs::CalculateBoundsForVerticalDraggedViews(views, tab_strip_); \
   }
 
-#define BRAVE_TAB_DRAG_CONTEXT_IMPL_PAINT_CHILDREN                      \
-  for (const ZOrderableTabContainerElement& child : orderable_children) \
-    if (!child.view()->layer()) {                                       \
-      child.view()->Paint(paint_info);                                  \
-    }                                                                   \
-  return;
-
 #include "src/chrome/browser/ui/views/tabs/tab_strip.cc"
 
-#undef BRAVE_TAB_DRAG_CONTEXT_IMPL_PAINT_CHILDREN
 #undef BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_BOUNDS_FOR_DRAGGED_VIEWS
 #undef BRAVE_TAB_DRAG_CONTEXT_IMPL_CALCULATE_INSERTION_INDEX
 #undef TabHoverCardController

--- a/patches/chrome-browser-ui-views-tabs-tab_strip.cc.patch
+++ b/patches/chrome-browser-ui-views-tabs-tab_strip.cc.patch
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/tabs/tab_strip.cc b/chrome/browser/ui/views/tabs/tab_strip.cc
-index f8d62e947251f221388daba8648e0b6e2e21adbe..ec0a2ccad9675817bc3068a186a7daa496fa7be7 100644
+index f8d62e947251f221388daba8648e0b6e2e21adbe..763142c93cfd642aa10d11278d1cf17cad6730b8 100644
 --- a/chrome/browser/ui/views/tabs/tab_strip.cc
 +++ b/chrome/browser/ui/views/tabs/tab_strip.cc
 @@ -546,6 +546,7 @@ class TabStrip::TabDragContextImpl : public TabDragContext,
@@ -10,15 +10,7 @@ index f8d62e947251f221388daba8648e0b6e2e21adbe..ec0a2ccad9675817bc3068a186a7daa4
      CHECK(!views.empty(), base::NotFatalUntil::M128)
          << "The views vector must not be empty.";
  
-@@ -749,6 +750,7 @@ class TabStrip::TabDragContextImpl : public TabDragContext,
-     // index.
-     std::stable_sort(orderable_children.begin(), orderable_children.end());
- 
-+    BRAVE_TAB_DRAG_CONTEXT_IMPL_PAINT_CHILDREN
-     for (const ZOrderableTabContainerElement& child : orderable_children) {
-       child.view()->Paint(paint_info);
-     }
-@@ -842,6 +844,7 @@ class TabStrip::TabDragContextImpl : public TabDragContext,
+@@ -842,6 +843,7 @@ class TabStrip::TabDragContextImpl : public TabDragContext,
          continue;
        }
  


### PR DESCRIPTION
Uplift of #27117 https://github.com/brave/brave-core/pull/27289 https://github.com/brave/brave-core/pull/27284
Resolves https://github.com/brave/brave-browser/issues/42533
Resolves https://github.com/brave/brave-browser/issues/43226
Resolves https://github.com/brave/brave-browser/issues/43374
Resolves https://github.com/brave/brave-browser/issues/43375

NOTE: The main issue for this PR is https://github.com/brave/brave-browser/issues/42533.
The other issues are revealed or regressed issue from this button position change.
So, included all related fixes in this uplift PR.

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.