### PR TITLE
fix(privacy): FrameCheckWrapper.js given incorrect value for url comparison

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/User Scripts/ScriptFactory.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/User Scripts/ScriptFactory.swift
@@ -194,7 +194,7 @@ class ScriptFactory {
       sourceWrapper = sourceWrapper.replacingOccurrences(of: "$<scriplet>", with: source)
       sourceWrapper = sourceWrapper.replacingOccurrences(
         of: "$<required_href>",
-        with: configuration.frameURL.domainURL.absoluteString
+        with: configuration.frameURL.windowOriginURL.absoluteString
       )
       // when `isMainFrame` is true, we still need to inject to all frames to handle `about:blank` first-party frames
       resultingScript = WKUserScript(

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -185,6 +185,15 @@ extension URL {
 
     return renderedString.bidiBaseDirection == .leftToRight
   }
+
+  /// Matches what `window.origin` would return in javascript.
+  public var windowOriginURL: URL {
+    var components = URLComponents()
+    components.scheme = self.scheme
+    components.port = self.port
+    components.host = self.host
+    return components.url ?? self
+  }
 }
 
 extension InternalURL {

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -148,6 +148,10 @@ class URLExtensionTests: XCTestCase {
       (URL(string: "https://www.example.com/?v=1234567")!, "https://www.example.com"),
       // match
       (URL(string: "https://www.example.com")!, "https://www.example.com"),
+      // punycode
+      (URL(string: "http://Дом.ru/")!, "http://xn--d1aqf.ru"),
+      // punycode
+      (URL(string: "http://Дoм.ru/")!, "http://xn--o-gtbz.ru"),
     ]
 
     let webView = WKWebView()
@@ -161,7 +165,7 @@ class URLExtensionTests: XCTestCase {
         webView.loadHTMLString("", baseURL: value)
 
         // await load of html
-        await fulfillment(of: [expectation], timeout: 1)
+        await fulfillment(of: [expectation], timeout: 2)
 
         guard let result = try await webView.evaluateJavaScript("window.origin") as? String else {
           XCTFail("Expected a String result")

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -176,7 +176,7 @@ class URLExtensionTests: XCTestCase {
   }
 }
 
-class NavigationDelegate: NSObject, WKNavigationDelegate {
+private class NavigationDelegate: NSObject, WKNavigationDelegate {
   private var didFinish: () -> Void
 
   init(didFinish: @escaping () -> Void) {


### PR DESCRIPTION
- Some scriptlets are failing to execute due to the comparison in [`FrameCheckWrapper.js`](https://github.com/brave/brave-core/blob/58fb0f04c59a55fa402ef190a47567d6ecb8367c/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/DomainSpecific/Paged/FrameCheckWrapper.js#L12) failing due to the `requiredHref` being stripped of `m`, `mobile`, and `www` subdomains.

Resolves https://github.com/brave/brave-browser/issues/43454

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Play some videos Shields up on YouTube
2. Verify no ads are displayed or metadata shown (`0:00/0:06` / `0:00:0:15` timestamps shown before video plays)