### PR TITLE
[iOS] Validate playlist sleep timer when displaying countdown (uplift to 1.75.x)

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaContentView.swift
@@ -305,8 +305,11 @@ extension MediaContentView {
                 // FIXME: iOS 16 - Menu doesn't apply button styles
                 Label(Strings.Playlist.sleepTimer, braveSystemImage: "leo.sleep.timer")
                   .labelStyle(.iconOnly)
-                if case .date(let sleepTimerFireDate) = model.sleepTimerCondition {
-                  Text(timerInterval: .now...sleepTimerFireDate, countsDown: true)
+                let now = Date.now
+                if case .date(let sleepTimerFireDate) = model.sleepTimerCondition,
+                  sleepTimerFireDate >= now
+                {
+                  Text(timerInterval: now...sleepTimerFireDate, countsDown: true)
                     .font(.callout.weight(.semibold))
                     .transition(.opacity)
                 }


### PR DESCRIPTION
Uplift of #27312
Resolves https://github.com/brave/brave-browser/issues/43425

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.