### PR TITLE
Disable CSSRelativeColorLateResolveAlways (uplift to 1.74.x)

### DIFF
--- a/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
+++ b/patches/third_party-blink-renderer-platform-runtime_enabled_features.json5.patch
@@ -2,6 +2,15 @@ diff --git a/third_party/blink/renderer/platform/runtime_enabled_features.json5 
 index db7c64eebdf34913139d556429f2717d08f39a56..dd1624786018139b6dca63279f5803a34b972f82 100644
 --- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
 +++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
+@@ -1193,7 +1193,7 @@
+     {
+       // crbug.com/359616070
+       name: "CSSRelativeColorLateResolveAlways",
+-      status: "stable",
++      status: "experimental",
+     },
+     {
+       // crbug.com/365818844
 @@ -1965,6 +1965,7 @@
        // In-development features for the File System Access API.
        name: "FileSystemAccessAPIExperimental",


### PR DESCRIPTION
Uplift of #27338
Resolves https://github.com/brave/brave-browser/issues/43479

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.