### PR TITLE
Adds a feature controlling Chromium's user education service.

### DIFF
--- a/browser/sources.gni
+++ b/browser/sources.gni
@@ -290,6 +290,7 @@ if (!is_android) {
   brave_chrome_browser_deps += [
     "//brave/browser/ui/ai_chat",
     "//brave/browser/ui/webui/brave_news_internals",
+    "//brave/browser/user_education:features",
     "//components/feed:feature_list",
     "//components/feed/core/v2:feed_core_v2",
     "//components/feed/mojom:mojo_bindings",

--- a/browser/user_education/BUILD.gn
+++ b/browser/user_education/BUILD.gn
@@ -3,6 +3,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+source_set("features") {
+  sources = [
+    "features.cc",
+    "features.h",
+  ]
+
+  deps = [ "//base" ]
+}
+
 source_set("unit_tests") {
   testonly = true
 
@@ -11,6 +20,7 @@ source_set("unit_tests") {
 
     deps = [
       "//base",
+      "//brave/browser/user_education:features",
       "//chrome/browser",
       "//chrome/test:test_support",
       "//content/test:test_support",

--- a/browser/user_education/features.cc
+++ b/browser/user_education/features.cc
@@ -1,0 +1,14 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/user_education/features.h"
+
+namespace features {
+
+BASE_FEATURE(kChromiumUserEducation,
+             "ChromiumUserEducation",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+}  // namespace features

--- a/browser/user_education/features.h
+++ b/browser/user_education/features.h
@@ -1,0 +1,17 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_USER_EDUCATION_FEATURES_H_
+#define BRAVE_BROWSER_USER_EDUCATION_FEATURES_H_
+
+#include "base/feature_list.h"
+
+namespace features {
+
+BASE_DECLARE_FEATURE(kChromiumUserEducation);
+
+}  // namespace features
+
+#endif  // BRAVE_BROWSER_USER_EDUCATION_FEATURES_H_

--- a/browser/user_education/user_education_service_unittest.cc
+++ b/browser/user_education/user_education_service_unittest.cc
@@ -6,23 +6,31 @@
 #include "chrome/browser/user_education/user_education_service.h"
 
 #include "base/files/scoped_temp_dir.h"
+#include "base/test/scoped_feature_list.h"
+#include "brave/browser/user_education/features.h"
 #include "chrome/browser/user_education/user_education_service_factory.h"
 #include "chrome/test/base/testing_profile.h"
 #include "content/public/test/browser_task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-class UserEducationServiceTest : public testing::Test {
+class UserEducationServiceTest : public testing::Test,
+                                 public ::testing::WithParamInterface<bool> {
  public:
   UserEducationServiceTest() = default;
   UserEducationServiceTest(const UserEducationServiceTest&) = delete;
   UserEducationServiceTest& operator=(const UserEducationServiceTest&) = delete;
 
   void SetUp() override {
+    if (!IsChromiumUserEductionEnabled()) {
+      features_.InitWithFeatures({}, {features::kChromiumUserEducation});
+    }
     ASSERT_TRUE(profile_dir_.CreateUniqueTempDir());
     TestingProfile::Builder profile_builder;
     profile_builder.SetPath(profile_dir_.GetPath());
     profile_ = profile_builder.Build();
   }
+
+  bool IsChromiumUserEductionEnabled() { return GetParam(); }
 
   Profile* profile() { return profile_.get(); }
 
@@ -30,9 +38,16 @@ class UserEducationServiceTest : public testing::Test {
   base::ScopedTempDir profile_dir_;
   content::BrowserTaskEnvironment task_environment_;
   std::unique_ptr<TestingProfile> profile_;
+  base::test::ScopedFeatureList features_;
 };
 
-TEST_F(UserEducationServiceTest, NoUserEducationService) {
+TEST_P(UserEducationServiceTest, UserEducationServiceFeature) {
   auto* service = UserEducationServiceFactory::GetForBrowserContext(profile());
-  EXPECT_EQ(nullptr, service);
+  if (IsChromiumUserEductionEnabled()) {
+    EXPECT_NE(nullptr, service);
+  } else {
+    EXPECT_EQ(nullptr, service);
+  }
 }
+
+INSTANTIATE_TEST_SUITE_P(, UserEducationServiceTest, ::testing::Bool());

--- a/chromium_src/chrome/browser/user_education/user_education_service_factory.cc
+++ b/chromium_src/chrome/browser/user_education/user_education_service_factory.cc
@@ -5,11 +5,20 @@
 
 #include "chrome/browser/user_education/user_education_service_factory.h"
 
+#include "brave/browser/user_education/features.h"
 #include "chrome/browser/profiles/profile_selections.h"
 
-// Do not create education service for regular and guest profiles.
-#define WithRegular(SELECTION) WithRegular(ProfileSelection::kNone)
-#define WithGuest(SELECTION) WithGuest(ProfileSelection::kNone)
+// Do not create education service for regular and guest profiles if disabled
+// by feature.
+#define WithRegular(SELECTION)                                               \
+  WithRegular(base::FeatureList::IsEnabled(features::kChromiumUserEducation) \
+                  ? SELECTION                                                \
+                  : ProfileSelection::kNone)
+
+#define WithGuest(SELECTION)                                               \
+  WithGuest(base::FeatureList::IsEnabled(features::kChromiumUserEducation) \
+                ? SELECTION                                                \
+                : ProfileSelection::kNone)
 
 #include "src/chrome/browser/user_education/user_education_service_factory.cc"
 #undef WithGuest

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1981,23 +1981,10 @@
 -LiveCaptionAutomaticLanguageDownloadTest.*
 -LiveCaptionControllerTest.*
 
-# These tests are disabled because we disable creation of UserEducationService
-# for regular and guest profiles.
--All/MLPromotionInstallDialogBrowserTest.*
 -All/ProfileMenuViewExtensionsIphDismissTest.CloseIPH/_ProfileSwitch
 -All/ProfileMenuViewExtensionsIphDismissTest.CloseIPH/_SupervisedUser
--BatterySaverHelpPromoTest.*
--BrowserUserEducationService*
--FirstRunIntroPixelTest.InvokeUi_default/*
--HelpBubbleFactoryViewsBrowsertest.*
--LowUsageHelpControllerBrowsertest.NoPromoOnFreshProfile
--MLPromotionBrowserTest*
 -PrivacySandboxQueueTestNotice.*
 -PrivacySandboxQueueTestNoticeWithSearchEngine.*
--SavedTabGroupV2Promo/SavedTabGroupV2PromoTest.*
--ShowPromoInPageBrowserTest.*
--StartTutorialInPageBrowserTest.*
-
 # This test fails because we stub out NetworkService::UpdateKeysPinList
 -PKIMetadataComponentInstallerTest.InstallComponentUpdatesPinningConfig
 

--- a/test/filters/unit_tests.filter
+++ b/test/filters/unit_tests.filter
@@ -718,11 +718,6 @@
 -RecentTabsSubMenuModelTest.OtherDevices
 -RecentTabsSubMenuModelTest.OtherDevicesDynamicUpdate
 
-# These tests are disabled because we disable creation of UserEducationService
-# for regular and guest profiles.
--BrowserFeaturePromoController*
--NewTabPageFeaturePromoHelperTest.*
-
 # zoom_level.display_name is "(Brave error pages)"
 -SiteSettingsHandlerTest.ZoomLevels
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43481

This partially reverts https://github.com/brave/brave-core/pull/26447 by adding a feature that would allow disabling Chromium's education service (to still satisfy https://github.com/brave/brave-browser/issues/41133 in not showing any help bubbles) instead of having it always disabled.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

