### PR TITLE
chore(wallet): Remove Activity Tab from Side Nav

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/crypto/index.tsx
@@ -63,7 +63,6 @@ import {
   RemoveAccountModal //
 } from '../../popup-modals/confirm-password-modal/remove-account-modal'
 import { AccountSettingsModal } from '../../popup-modals/account-settings-modal/account-settings-modal'
-import TransactionsScreen from '../../../../page/screens/transactions/transactions-screen'
 import {
   WalletPageWrapper //
 } from '../../wallet-page-wrapper/wallet-page-wrapper'
@@ -370,14 +369,6 @@ export const CryptoView = ({ sessionRoute }: Props) => {
           exact={true}
         >
           <Redirect to={WalletRoutes.Market} />
-        </Route>
-
-        {/* Transactions */}
-        <Route
-          path={WalletRoutes.Activity}
-          exact={true}
-        >
-          <TransactionsScreen />
         </Route>
 
         <Redirect to={sessionRoute || WalletRoutes.PortfolioAssets} />

--- a/components/brave_wallet_ui/constants/types.ts
+++ b/components/brave_wallet_ui/constants/types.ts
@@ -556,9 +556,6 @@ export enum WalletRoutes {
   Restore = '/crypto/restore-wallet',
   Unlock = '/crypto/unlock',
 
-  // Activity (Transactions)
-  Activity = '/crypto/activity',
-
   // portfolio
   Portfolio = '/crypto/portfolio',
   PortfolioAssets = '/crypto/portfolio/assets',

--- a/components/brave_wallet_ui/options/nav-options.ts
+++ b/components/brave_wallet_ui/options/nav-options.ts
@@ -77,13 +77,6 @@ export const BuySendSwapDepositOptions: NavOption[] = [
   }
 ]
 
-const ActivityNavOption: NavOption = {
-  id: 'activity',
-  name: 'braveWalletActivity',
-  icon: 'activity',
-  route: WalletRoutes.Activity
-}
-
 const PortfolioActivityNavOption: NavOption = {
   id: 'activity',
   name: 'braveWalletActivity',
@@ -128,7 +121,6 @@ export const NavOptions: NavOption[] = [
     icon: 'coins',
     route: WalletRoutes.Portfolio
   },
-  ActivityNavOption,
   {
     id: 'accounts',
     name: 'braveWalletTopNavAccounts',
@@ -140,8 +132,7 @@ export const NavOptions: NavOption[] = [
 
 export const AllNavOptions: NavOption[] = [
   ...NavOptions,
-  ...BuySendSwapDepositOptions,
-  ActivityNavOption
+  ...BuySendSwapDepositOptions
 ]
 
 export const PortfolioNavOptions: NavOption[] = [


### PR DESCRIPTION
## Description 

Removes the `Activity` tab from the Wallet `Side Navigation`. Users are now able to view there activity from the `Portfolio`, `Asset Details` and `Account Details` screens

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43500>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet`
2. You should no longer see `Activity` in the `Side Navigation`
3. User will be able to access their activity from the `Portfolio`, `Asset Details` or `Account Details` screens.

Before:

![Screenshot 10](https://github.com/user-attachments/assets/ec603afc-0a43-483e-9cfc-cbe876b913b3)

After:

![Screenshot 9](https://github.com/user-attachments/assets/b16c95c5-9d5f-415a-bb81-58457785afcf)
