### PR TITLE
[Rewards 3.0] Clear unsupported Rewards notifications on page load (uplift to 1.75.x)

### DIFF
--- a/browser/ui/webui/brave_rewards/rewards_page_handler.cc
+++ b/browser/ui/webui/brave_rewards/rewards_page_handler.cc
@@ -581,26 +581,21 @@ void RewardsPageHandler::GetRewardsNotifications(
   }
   std::vector<mojom::RewardsNotificationPtr> notifications;
   for (auto [_, value] : notification_service->GetAllNotifications()) {
-    std::optional<mojom::RewardsNotificationType> type;
+    auto type = mojom::RewardsNotificationType::kGeneral;
     switch (value.type_) {
       case RewardsNotificationService::REWARDS_NOTIFICATION_TIPS_PROCESSED:
         type = mojom::RewardsNotificationType::kTipsProcessed;
         break;
-      case RewardsNotificationService::REWARDS_NOTIFICATION_GENERAL:
-        type = mojom::RewardsNotificationType::kGeneral;
-        break;
       default:
         break;
     }
-    if (type) {
-      auto notification = mojom::RewardsNotification::New();
-      notification->id = value.id_;
-      notification->type = type.value();
-      notification->timestamp =
-          base::Time::FromSecondsSinceUnixEpoch(value.timestamp_);
-      notification->args = /* copy */ value.args_;
-      notifications.push_back(std::move(notification));
-    }
+    auto notification = mojom::RewardsNotification::New();
+    notification->id = value.id_;
+    notification->type = type;
+    notification->timestamp =
+        base::Time::FromSecondsSinceUnixEpoch(value.timestamp_);
+    notification->args = /* copy */ value.args_;
+    notifications.push_back(std::move(notification));
   }
   std::move(callback).Run(std::move(notifications));
 }


### PR DESCRIPTION
Uplift of #27331
Resolves https://github.com/brave/brave-browser/issues/43450

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.