### PR TITLE
[iOS] Use original initial profile name for main profile creation

### DIFF
--- a/ios/app/brave_core_main.mm
+++ b/ios/app/brave_core_main.mm
@@ -99,12 +99,12 @@ ProfileIOS* CreateMainProfileIOS() {
   // Initialize and set the main browser state.
   auto* localState = GetApplicationContext()->GetLocalState();
   auto* profileManager = GetApplicationContext()->GetProfileManager();
-  std::string profileName = localState->GetString(prefs::kLastUsedProfile);
-  if (profileName.empty()) {
-    profileName = profileManager->ReserveNewProfileName();
-    localState->SetString(prefs::kLastUsedProfile, profileName);
-  }
-  DCHECK(!profileName.empty());
+  std::string profileName =
+      "Default";  // kIOSChromeInitialProfile which is now removed
+  // Set this as the last used profile always so that its saved for the future
+  // where we may have multiple profile support and need to read it from local
+  // state before creating the profile
+  localState->SetString(prefs::kLastUsedProfile, profileName);
   ScopedAllowBlockingForProfile allow_blocking;
   return profileManager->CreateProfile(profileName);
 }


### PR DESCRIPTION
This changes the reliance on the pref which was never set in the past (`prefs::kLastUsedProfile`) and uses the original "Default" profile name used in CR132 and below.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43541

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

