### PR TITLE
Brave crashed when clicked on settings icon in the sidebar in the guest window (uplift to 1.76.x)

### DIFF
--- a/browser/ui/webui/settings/default_brave_shields_handler.cc
+++ b/browser/ui/webui/settings/default_brave_shields_handler.cc
@@ -366,6 +366,7 @@ void DefaultBraveShieldsHandler::GetContactInfo(const base::Value::List& args) {
     params_dict.Set("contactInfo", "");
     params_dict.Set("contactInfoSaveFlag", false);
     ResolveJavascriptCallback(args[0].Clone(), std::move(params_dict));
+    return;
   }
 
   webcompat_reporter_service->GetContactInfo(


### PR DESCRIPTION
Uplift of #27410
Resolves https://github.com/brave/brave-browser/issues/43554

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.