### PR TITLE
fix(privacy): FrameCheckWrapper.js given incorrect value for url comparison (uplift to 1.75.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/User Scripts/ScriptFactory.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/User Scripts/ScriptFactory.swift
@@ -194,7 +194,7 @@ class ScriptFactory {
       sourceWrapper = sourceWrapper.replacingOccurrences(of: "$<scriplet>", with: source)
       sourceWrapper = sourceWrapper.replacingOccurrences(
         of: "$<required_href>",
-        with: configuration.frameURL.domainURL.absoluteString
+        with: configuration.frameURL.windowOriginURL.absoluteString
       )
       // when `isMainFrame` is true, we still need to inject to all frames to handle `about:blank` first-party frames
       resultingScript = WKUserScript(

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -185,6 +185,15 @@ extension URL {
 
     return renderedString.bidiBaseDirection == .leftToRight
   }
+
+  /// Matches what `window.origin` would return in javascript.
+  public var windowOriginURL: URL {
+    var components = URLComponents()
+    components.scheme = self.scheme
+    components.port = self.port
+    components.host = self.host
+    return components.url ?? self
+  }
 }
 
 extension InternalURL {


### PR DESCRIPTION
Uplift of #27320
Resolves https://github.com/brave/brave-browser/issues/43454

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.