### PR TITLE
fix(privacy): Hide/disable Shred for internal urls

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -649,9 +649,10 @@ extension BrowserViewController {
         return .updateAction(actionCopy)
       },
     ]
-    if BraveCore.FeatureList.kBraveShredFeature.enabled, let tabURL = tabManager.selectedTab?.url {
+    if BraveCore.FeatureList.kBraveShredFeature.enabled {
+      let isShredAvailable = tabManager.selectedTab?.url?.isShredAvailable ?? false
       actions.append(
-        .init(id: .shredData, attributes: tabURL.isShredAvailable ? [] : [.disabled]) {
+        .init(id: .shredData, attributes: isShredAvailable ? [] : [.disabled]) {
           @MainActor [unowned self] _ in
           self.dismiss(animated: true) {
             guard let tab = self.tabManager.selectedTab, let url = tab.url else { return }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -470,7 +470,10 @@ extension BrowserViewController: TabManagerDelegate {
 
     var closeAllTabMenuChildren: [UIAction] = []
 
-    if FeatureList.kBraveShredFeature.enabled {
+    if FeatureList.kBraveShredFeature.enabled,
+      let url = tabManager.selectedTab?.url,
+      url.isShredAvailable
+    {
       let shredDataAction = UIAction(
         title: Strings.Shields.shredSiteData,
         image: UIImage(braveSystemNamed: "leo.shred.data"),

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -919,6 +919,8 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func presentMenu(from tabToolbar: ToolbarProtocol) {
+    /// The selected tab's url, or the extracted url from
+    /// error page or reader mode page
     let selectedTabURL: URL? = {
       guard let url = tabManager.selectedTab?.url else { return nil }
 
@@ -933,6 +935,8 @@ extension BrowserViewController: TopToolbarDelegate {
       }
       return url
     }()
+    /// The selected tab's url
+    let selectedTabOriginalURL = tabManager.selectedTab?.url
 
     displayPageZoom(visible: false)
 
@@ -974,11 +978,12 @@ extension BrowserViewController: TopToolbarDelegate {
           }
           Divider()
           destinationMenuSection(menuController, isShownOnWebPage: isShownOnWebPage)
-          if let tabURL = selectedTabURL {
+          if let tabURL = selectedTabURL, let originalTabURL = selectedTabOriginalURL {
             Divider()
             PageActionsMenuSection(
               browserViewController: self,
               tabURL: tabURL,
+              originalTabURL: originalTabURL,
               activities: activities
             )
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -1017,6 +1017,10 @@ extension TabTrayController: TabManagerDelegate {
     if tabManager.tabsForCurrentMode.count < 1 {
       dismiss(animated: true)
     }
+
+    if BraveCore.FeatureList.kBraveShredFeature.enabled {
+      shredButton.isHidden = tabManager.selectedTab?.url?.isShredAvailable == false
+    }
   }
 
   func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tabs/TabTray/TabTrayController.swift
@@ -425,7 +425,10 @@ class TabTrayController: AuthenticationController {
 
     containerView.addSubview(contentStackView)
 
-    if FeatureList.kBraveShredFeature.enabled {
+    if FeatureList.kBraveShredFeature.enabled,
+      let url = tabManager.selectedTab?.url,
+      url.isShredAvailable
+    {
       tabTypeSelectorContainerView.addSubview(shredButton)
 
       shredButton.snp.makeConstraints {

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -194,6 +194,11 @@ extension URL {
     components.host = self.host
     return components.url ?? self
   }
+
+  /// Returns true if we should show Shred option for the given URL.
+  public var isShredAvailable: Bool {
+    InternalURL(self) == nil
+  }
 }
 
 extension InternalURL {

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -197,7 +197,20 @@ extension URL {
 
   /// Returns true if we should show Shred option for the given URL.
   public var isShredAvailable: Bool {
-    InternalURL(self) == nil
+    urlToShred != nil
+  }
+
+  /// The URL to shred. Extracts reader mode url if it's a reader
+  /// mode internal url.
+  public var urlToShred: URL? {
+    if let internalURL = InternalURL(self) {
+      if internalURL.isReaderModePage {
+        return internalURL.extractedUrlParam
+      }
+      // only allow reader mode InternalURL to be shred
+      return nil
+    }
+    return self
   }
 }
 

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -178,6 +178,34 @@ class URLExtensionTests: XCTestCase {
       }
     }
   }
+
+  func testURLToShred() {
+    let testURL = URL(string: "https://brave.com")!
+
+    // Verify regular url
+    XCTAssertEqual(testURL, testURL.urlToShred)
+    XCTAssertTrue(testURL.isShredAvailable)
+
+    // Verify original url returned for reader mode
+    let readerModeTestURL = testURL.encodeEmbeddedInternalURL(for: .readermode, headers: [:])!
+    XCTAssertNotEqual(readerModeTestURL, testURL)
+    XCTAssertEqual(readerModeTestURL.urlToShred, testURL)
+    XCTAssertTrue(readerModeTestURL.isShredAvailable)
+
+    // Verify nil for other `InternalURL`s
+    let errorPageTestURL = testURL.encodeEmbeddedInternalURL(for: .errorpage)!
+    XCTAssertNil(errorPageTestURL.urlToShred)
+    XCTAssertFalse(errorPageTestURL.isShredAvailable)
+
+    let blockedTestURL = testURL.encodeEmbeddedInternalURL(for: .blocked)!
+    XCTAssertNil(blockedTestURL.urlToShred)
+    XCTAssertFalse(blockedTestURL.isShredAvailable)
+
+    // Verify nil for new tab page
+    let ntpTestURL = URL(string: "\(InternalURL.baseUrl)/about/home#panel=0")!
+    XCTAssertNil(ntpTestURL.urlToShred)
+    XCTAssertFalse(ntpTestURL.isShredAvailable)
+  }
 }
 
 private class NavigationDelegate: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
- Hide or disable Shred button for internal urls (New Tab Page, error page, interstitials).
- Fix Shred when viewing reader mode.
- Hide shred buttons in menu & new menu when feature flag is disabled.

Resolves https://github.com/brave/brave-browser/issues/43577
Resolves https://github.com/brave/brave-browser/issues/43663

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open New Tab Page or any other internal page (ex. error page, HTTP strict mode interstitial, etc.)
2. Tap & hold on tab tray button.
3. Verify Shred not shown in contextual menu.
4. Tap `...` to open browser menu.
5. Verify Shred not shown / disabled:
    - If new browser menu is enabled (`#brave-use-modern-browser-menu`), Shred will be in disabled state.
    - If new browser menu is disabled, Shred will not be shown.
6. Tap tab tray button.
7. Verify Shred button is not visible.

Regression test: 
1. Open a any real web page
2. Verify Shred visible and enabled in tab tray contextual menu, browser menu / `...` menu, tab tray grid. 

Reader Mode test:
1. Open 2 tabs of any site that supports reader mode. Ex. Wikipedia
2. Turn on reader mode for one of the 2 tabs
3. Check Settings -> Privacy & Security -> Manage Website Data
4. Confirm items are listed for site from step 1
5. Return to the reader mode tab.
6. Tap & hold on the tab tray icon and tap `Shred Site Data`
7. Verify both tabs are closed (reader mode and regular), verify data is Shred from Settings -> Privacy & Security -> Manage Website Data

![Tab Tray Contextual Menu](https://github.com/user-attachments/assets/91c4d3dd-97ca-4ba3-93eb-d387de6ac0c1) | ![Modern Browser Menu](https://github.com/user-attachments/assets/1343e6f7-fd99-4609-bfa1-d5ec774e2de0) | ![Existing Browser Menu](https://github.com/user-attachments/assets/387b6d91-606e-4b32-b376-a471f3697243) | ![Tab Tray](https://github.com/user-attachments/assets/f4ead999-ad1a-4872-bdcc-40cbc64a8f49)
--|--|--|--
![Tab Tray Contextual Menu - error page](https://github.com/user-attachments/assets/59ff6280-1298-4f28-b579-c7d20fd55413) | ![Modern Browser Menu - error page](https://github.com/user-attachments/assets/0bf00dfa-543c-4538-a826-cb560221081d) | ![Existing Browser Menu - error page](https://github.com/user-attachments/assets/7849a84c-6fb4-467d-9e46-781eb2fec273) | ![Tab Tray - error page](https://github.com/user-attachments/assets/9943b66f-7d5d-430d-9751-d411d620a956)

