### PR TITLE
[cr133 follow up] Fixes partial disabing of kPrivateStateTokens. (uplift to 1.76.x)

### DIFF
--- a/renderer/brave_content_renderer_client.cc
+++ b/renderer/brave_content_renderer_client.cc
@@ -118,6 +118,8 @@ void BraveContentRendererClient::
         "FileSystemAccessAPIExperimental", false);
   }
   blink::WebRuntimeFeatures::EnableFeatureFromString("FledgeMultiBid", false);
+  blink::WebRuntimeFeatures::EnableFeatureFromString("PrivateStateTokens",
+                                                     false);
 
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_LINUX)
   if (base::FeatureList::IsEnabled(

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -532,10 +532,12 @@
 -ZoomControllerForPrerenderingTest.*
 
 # These tests fail because we intentionally disable trust tokens via
-# network::features::kPrivateStateTokens
+# disabling PrivateStateTokens runtime feature in blink and disabling the
+# installation of Trust Tokens component.
 -All/BrowsingDataModelBrowserTest.FederatedIdentityHandledCorrectly/*
 -All/BrowsingDataModelBrowserTest.TrustTokenIssuance/*
 -BrowsingDataModelBrowserTest.TrustTokenIssuance
+-TrustTokenUseCountersBrowsertest.*
 
 # These tests fail because we disable Browsing Topics (and Trust Tokens, and
 # Fledge, and Interest Groups, etc.)


### PR DESCRIPTION
Uplift of #27425
Resolves https://github.com/brave/brave-browser/issues/43624

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.