### PR TITLE
[iOS] - Fix Blob URL Formatting in Editing URL-Bar and Normal URL-Bar states

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Menu.swift
@@ -483,7 +483,7 @@ extension BrowserViewController {
 
         URLElidedText(
           text: URLFormatter.formatURLOrigin(
-            forDisplayOmitSchemePathAndTrivialSubdomains: url.absoluteString
+            forDisplayOmitSchemePathAndTrivialSubdomains: url.strippingBlobURLAuth.absoluteString
           )
         )
         .font(.footnote)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1900,6 +1900,7 @@ public class BrowserViewController: UIViewController {
         if tab === tabManager.selectedTab && !tab.restoring {
           updateUIForReaderHomeStateForTab(tab)
         }
+
         // Catch history pushState navigation, but ONLY for same origin navigation,
         // for reasons above about URL spoofing risk.
         navigateInTab(tab: tab)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/RecentSearchQRCodeScannerController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/RecentSearchQRCodeScannerController.swift
@@ -192,7 +192,7 @@ extension RecentSearchQRCodeScannerController {
     }
 
     private func processScannedText() -> (string: String?, truncationMode: NSLineBreakMode) {
-      if let text = scannedText, let url = URIFixup.getURL(text) {
+      if let text = scannedText, let url = URIFixup.getURL(text)?.strippingBlobURLAuth {
         let scannedText = URLFormatter.formatURL(
           URLOrigin(url: url).url?.absoluteString ?? url.absoluteString,
           formatTypes: [
@@ -201,8 +201,8 @@ extension RecentSearchQRCodeScannerController {
           unescapeOptions: .normal
         )
 
-        let truncationMode: NSLineBreakMode =
-          ["http", "https"].contains(url.scheme ?? "") ? .byTruncatingHead : .byTruncatingTail
+        let isWebPage = url.isWebPage(includeDataURIs: false) || url.scheme == "blob"
+        let truncationMode: NSLineBreakMode = isWebPage ? .byTruncatingHead : .byTruncatingTail
         return (scannedText, truncationMode)
       }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/History/HistoryView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/BottomToolbar/Menu/History/HistoryView.swift
@@ -41,7 +41,7 @@ struct HistoryItemView: View {
 
         URLElidedText(
           text: URLFormatter.formatURLOrigin(
-            forDisplayOmitSchemePathAndTrivialSubdomains: url.absoluteString
+            forDisplayOmitSchemePathAndTrivialSubdomains: url.strippingBlobURLAuth.absoluteString
           )
         )
         .font(.footnote)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/CollapsedURLBarView.swift
@@ -108,8 +108,9 @@ class CollapsedURLBarView: UIView {
           Strings.PageSecurityView.signIntoWebsiteURLBarTitle
         } else if URLOrigin(url: $0).url != nil || URIFixup.getURL($0.absoluteString) != nil {
           URLFormatter.formatURLOrigin(
-            forDisplayOmitSchemePathAndTrivialSubdomains: URLOrigin(url: $0).url?.absoluteString
-              ?? $0.absoluteString
+            forDisplayOmitSchemePathAndTrivialSubdomains: URLOrigin(url: $0.strippingBlobURLAuth)
+              .url?.absoluteString
+              ?? $0.strippingBlobURLAuth.absoluteString
           )
         } else {
           String()

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsPanelView.swift
@@ -39,7 +39,7 @@ struct ShieldsPanelView: View {
     self.viewModel = ShieldsSettingsViewModel(tab: tab, domain: domain)
     self.actionCallback = callback
     self.displayHost =
-      "\u{200E}\(URLFormatter.formatURLOrigin(forDisplayOmitSchemePathAndTrivialSubdomains: url.absoluteString))"
+      "\u{200E}\(URLFormatter.formatURLOrigin(forDisplayOmitSchemePathAndTrivialSubdomains: url.strippingBlobURLAuth.absoluteString))"
   }
 
   private var shieldsEnabledAccessibiltyLabel: String {

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -5,6 +5,7 @@
 // This code is loosely based on https://github.com/Antol/APAutocompleteTextField
 
 import BraveCore
+import BraveShared
 import BraveUI
 import Shared
 import UIKit
@@ -57,8 +58,17 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
   var highlightColor = AutocompleteTextFieldUX.highlightColor
 
   override public var text: String? {
-    didSet {
-      super.text = text
+    get {
+      super.text
+    }
+
+    set(newValue) {
+      if let text = newValue, let url = URL(string: text) {
+        super.text = url.strippingBlobURLAuth.absoluteString
+      } else {
+        super.text = text
+      }
+
       self.textDidChange(self)
     }
   }
@@ -360,7 +370,12 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
   }
 
   func setTextWithoutSearching(_ text: String) {
-    super.text = text
+    if let url = URL(string: text) {
+      super.text = url.strippingBlobURLAuth.absoluteString
+    } else {
+      super.text = text
+    }
+
     hideCursor = autocompleteTextLabel != nil
     removeCompletion()
   }

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -186,6 +186,27 @@ extension URL {
     return renderedString.bidiBaseDirection == .leftToRight
   }
 
+  public var strippingBlobURLAuth: URL {
+    if self.scheme == "blob",
+      var components = URLComponents(url: self, resolvingAgainstBaseURL: true)
+    {
+      components.scheme = nil
+
+      if let newURL = components.url {
+        if var newComponents = URLComponents(url: newURL, resolvingAgainstBaseURL: true) {
+          newComponents.user = nil
+          newComponents.password = nil
+          newComponents.scheme = newURL.scheme
+
+          if let url = newComponents.url, let result = URL(string: "blob:\(url.absoluteString)") {
+            return result
+          }
+        }
+      }
+    }
+    return self
+  }
+
   /// Matches what `window.origin` would return in javascript.
   public var windowOriginURL: URL {
     var components = URLComponents()

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -206,6 +206,47 @@ class URLExtensionTests: XCTestCase {
     XCTAssertNil(ntpTestURL.urlToShred)
     XCTAssertFalse(ntpTestURL.isShredAvailable)
   }
+
+  func testBlobURLAuthStripping() {
+    var url = URL(string: "blob:https://brave.github.io/1945c9fb-9834-479b-bb3a-e67e3a9408cf")!
+    XCTAssertEqual(
+      url.strippingBlobURLAuth.absoluteString,
+      "blob:https://brave.github.io/1945c9fb-9834-479b-bb3a-e67e3a9408cf"
+    )
+
+    url = URL(
+      string:
+        "blob:https://some.malicious.domain.com@brave.github.io/1945c9fb-9834-479b-bb3a-e67e3a9408cf"
+    )!
+    XCTAssertEqual(
+      url.strippingBlobURLAuth.absoluteString,
+      "blob:https://brave.github.io/1945c9fb-9834-479b-bb3a-e67e3a9408cf"
+    )
+
+    url = URL(string: "blob:https://some.malicious.domain.com@brave.github.io/")!
+    XCTAssertEqual(url.strippingBlobURLAuth.absoluteString, "blob:https://brave.github.io/")
+
+    url = URL(string: "blob:https://some.malicious.domain.com@brave.github.io/?hello=world")!
+    XCTAssertEqual(
+      url.strippingBlobURLAuth.absoluteString,
+      "blob:https://brave.github.io/?hello=world"
+    )
+
+    url = URL(string: "blob:https://some.malicious.domain.com@brave.github.io/helloworld")!
+    XCTAssertEqual(
+      url.strippingBlobURLAuth.absoluteString,
+      "blob:https://brave.github.io/helloworld"
+    )
+
+    url = URL(string: "https://some.malicious.domain.com@brave.github.io/")!
+    XCTAssertEqual(
+      url.strippingBlobURLAuth.absoluteString,
+      "https://some.malicious.domain.com@brave.github.io/"
+    )
+
+    url = URL(string: "https://brave.github.io/")!
+    XCTAssertEqual(url.strippingBlobURLAuth.absoluteString, "https://brave.github.io/")
+  }
 }
 
 private class NavigationDelegate: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43654

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit: https://frozzipies.github.io/blobspoof.html
2. URL-Bar should display: `blob:https://frozzipies.github.io/`
3. Tap on the URL-Bar. Should display the same thing.

---

1. Visit: https://syarifmsajjad.github.io/test-spoofing/bs.html
2. URL-Bar should display: `blob:https://syarifmsajjad.github.io/e2937c6b-9707-4f94-9c94-27ac0bc84012` (the UUID can be different).
3. Tap on the URL-Bar. Should display the same thing.