### PR TITLE
Fixed crash when clicking media control toolbar button

### DIFF
--- a/chromium_src/chrome/browser/ui/views/global_media_controls/media_item_ui_helper.cc
+++ b/chromium_src/chrome/browser/ui/views/global_media_controls/media_item_ui_helper.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/views/global_media_controls/media_item_ui_helper.h"
+
+#include "chrome/browser/media/router/media_router_feature.h"
+
+#define BuildDeviceSelector BuildDeviceSelector_ChromiumImpl
+
+#include "src/chrome/browser/ui/views/global_media_controls/media_item_ui_helper.cc"
+
+#undef BuildDeviceSelector
+
+// TODO(simonhong): Delete this when upstream fixes
+// https://issues.chromium.org/u/3/issues/393606982.
+std::unique_ptr<global_media_controls::MediaItemUIDeviceSelector>
+BuildDeviceSelector(
+    const std::string& id,
+    base::WeakPtr<media_message_center::MediaNotificationItem> item,
+    global_media_controls::mojom::DeviceService* device_service,
+    MediaItemUIDeviceSelectorDelegate* selector_delegate,
+    Profile* profile,
+    global_media_controls::GlobalMediaControlsEntryPoint entry_point,
+    bool show_devices,
+    std::optional<media_message_center::MediaColorTheme> media_color_theme) {
+  if (!media_router::MediaRouterEnabled(profile)) {
+    return nullptr;
+  }
+
+  return BuildDeviceSelector_ChromiumImpl(
+      id, item, device_service, selector_delegate, profile, entry_point,
+      show_devices, media_color_theme);
+}


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/43650

This is quick fix before upstream fixes https://issues.chromium.org/u/3/issues/393606982.
Delete this changes when proper fix is merged to upstream.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.