### PR TITLE
Fixed crash when clicking media control toolbar button (uplift to 1.76.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/global_media_controls/media_item_ui_helper.cc
+++ b/chromium_src/chrome/browser/ui/views/global_media_controls/media_item_ui_helper.cc
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/views/global_media_controls/media_item_ui_helper.h"
+
+#include "chrome/browser/media/router/media_router_feature.h"
+
+#define BuildDeviceSelector BuildDeviceSelector_ChromiumImpl
+
+#include "src/chrome/browser/ui/views/global_media_controls/media_item_ui_helper.cc"
+
+#undef BuildDeviceSelector
+
+// TODO(simonhong): Delete this when upstream fixes
+// https://issues.chromium.org/u/3/issues/393606982.
+std::unique_ptr<global_media_controls::MediaItemUIDeviceSelector>
+BuildDeviceSelector(
+    const std::string& id,
+    base::WeakPtr<media_message_center::MediaNotificationItem> item,
+    global_media_controls::mojom::DeviceService* device_service,
+    MediaItemUIDeviceSelectorDelegate* selector_delegate,
+    Profile* profile,
+    global_media_controls::GlobalMediaControlsEntryPoint entry_point,
+    bool show_devices,
+    std::optional<media_message_center::MediaColorTheme> media_color_theme) {
+  if (!media_router::MediaRouterEnabled(profile)) {
+    return nullptr;
+  }
+
+  return BuildDeviceSelector_ChromiumImpl(
+      id, item, device_service, selector_delegate, profile, entry_point,
+      show_devices, media_color_theme);
+}


### PR DESCRIPTION
Uplift of #27451
fix https://github.com/brave/brave-browser/issues/43650

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.