### PR TITLE
[Rewards 3.0] Fix "$1" in logged out message (uplift to 1.75.x)

### DIFF
--- a/components/brave_rewards/resources/rewards_page/components/contribute/payment_form.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/contribute/payment_form.tsx
@@ -165,7 +165,13 @@ export function PaymentForm(props: Props) {
                 ])
               }
             </h4>
-            <p>{getString('contributeLoggedOutText')}</p>
+            <p>
+              {
+                formatMessage(getString('contributeLoggedOutText'), [
+                  providerName
+                ])
+              }
+            </p>
             {web3URL && <p>{getString('contributeLoggedOutWeb3Text')}</p>}
           </div>
         </div>


### PR DESCRIPTION
Uplift of #27448
Resolves https://github.com/brave/brave-browser/issues/43665

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.