### PR TITLE
fix(iOS): Brave Search as DSE for private mode in all regions (new user/install only)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
@@ -125,7 +125,7 @@ public class SearchEngines {
   func setInitialDefaultEngine(_ engine: String) {
     // update engine
     DefaultEngineType.standard.option.value = engine
-    // set Brave Search as the DSE for private node
+    // set Brave Search as the DSE for private mode
     DefaultEngineType.privateMode.option.value =
       InitialSearchEngines.SearchEngineID.braveSearch.rawValue
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
@@ -111,9 +111,11 @@ public class SearchEngines {
       return defaultEngine
     }
 
-    let defaultEngineName = initialSearchEngines.defaultSearchEngine.rawValue
+    let defaultEngineName = engineType.option.value ?? ""
 
-    let defaultEngine = orderedEngines.first(where: { $0.engineID == defaultEngineName })
+    let defaultEngine = orderedEngines.first(where: {
+      $0.engineID?.caseInsensitiveCompare(defaultEngineName) == .orderedSame
+    })
     return defaultEngine ?? orderedEngines.first
   }
 
@@ -123,7 +125,9 @@ public class SearchEngines {
   func setInitialDefaultEngine(_ engine: String) {
     // update engine
     DefaultEngineType.standard.option.value = engine
-    DefaultEngineType.privateMode.option.value = engine
+    // set Brave Search as the DSE for private node
+    DefaultEngineType.privateMode.option.value =
+      InitialSearchEngines.SearchEngineID.braveSearch.rawValue
 
     let priorityEngine = initialSearchEngines.priorityEngine?.rawValue
     let defEngine = defaultEngine(forType: .standard)


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves
https://github.com/brave/brave-browser/issues/43697

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. fresh install the app
2. open a private tab and search something from the omnibox 
3. observe the search is performed with Brave Search as the search engine
4. Go to settings/search engines
5. observe Brave Search is displayed for private tab
6. repeat step 1 to 5 with a different region set in OS settings

1. install an older version of Brave
2. go to settings/search engines/private gab
3. change DSE for private tab to some engine that is not Brave Search
4. download a nightly build with this PR changes 
5. open a private tab and search something from the omnibox 
6. observe the search is performed with the search engine that is set in step 3
4. Go to settings/search engines
7. observe correct search engine name is displayed for private tab
