### PR TITLE
bugfix(shields): Remove Image.prototype.src getter/setter readonly protections on iOS (uplift to 1.75.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Paged/TrackingProtectionStats.js
@@ -166,11 +166,11 @@ window.__firefox__.execute(function($) {
     delete Image.prototype.src;
 
     Object.defineProperty(Image.prototype, "src", {
-      get: $(function() {
+      get: function() {
         return originalImageSrc.get.call(this);
-      }),
+      },
 
-      set: $(function(value) {
+      set: function(value) {
         // Only attach the `error` event listener once for this
         // Image instance.
         if (!this[localErrorHandlerProp]) {
@@ -184,7 +184,7 @@ window.__firefox__.execute(function($) {
         }
 
         originalImageSrc.set.call(this, value);
-      }),
+      },
       enumerable: true,
       configurable: true
     });


### PR DESCRIPTION
Uplift of #27234
Resolves https://github.com/brave/brave-browser/issues/43286

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.