### PR TITLE
Fixed new tab is not shown when it's first tab

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -440,7 +440,6 @@ class VerticalTabStripScrollContentsView : public views::View {
     // Prevent reentrance caused by container_->Layout()
     base::AutoReset<bool> in_preferred_size_change(&in_preferred_size_changed_,
                                                    true);
-    container_->set_layout_dirty({});
     container_->DeprecatedLayoutImmediately();
   }
 
@@ -917,13 +916,6 @@ gfx::Size VerticalTabStripRegionView::GetMinimumSize() const {
 }
 
 void VerticalTabStripRegionView::Layout(PassKey) {
-  if (!layout_dirty_ && last_size_ == size()) {
-    return;
-  }
-
-  layout_dirty_ = false;
-  last_size_ = size();
-
   // As we have to update ScrollView's viewport size and its contents size,
   // laying out children manually will be more handy.
   const auto contents_bounds = GetContentsBounds();
@@ -987,7 +979,6 @@ void VerticalTabStripRegionView::OnBrowserPanelsMoved() {
 }
 
 void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
-  layout_dirty_ = true;
   if (tabs::utils::ShouldShowVerticalTabs(browser_) && !in_destruction) {
     if (!Contains(original_region_view_)) {
       original_parent_of_region_view_ = original_region_view_->parent();
@@ -1134,11 +1125,6 @@ void VerticalTabStripRegionView::OnBoundsChanged(
             BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_));
   }
 #endif
-}
-
-void VerticalTabStripRegionView::PreferredSizeChanged() {
-  layout_dirty_ = true;
-  views::View::PreferredSizeChanged();
 }
 
 void VerticalTabStripRegionView::AddedToWidget() {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -133,6 +133,8 @@ class VerticalTabStripRegionView : public views::View,
                            OriginalTabSearchButton);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedState);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedWidth);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
+                           LayoutAfterFirstTabCreation);
 
   FullscreenController* GetFullscreenController() const;
   bool IsTabFullscreen() const;

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -87,10 +87,6 @@ class VerticalTabStripRegionView : public views::View,
 
   int GetTabStripViewportMaxHeight() const;
 
-  void set_layout_dirty(base::PassKey<VerticalTabStripScrollContentsView>) {
-    layout_dirty_ = true;
-  }
-
   void ResetExpandedWidth();
   bool IsMenuShowing() const;
 
@@ -103,7 +99,6 @@ class VerticalTabStripRegionView : public views::View,
   void OnMouseExited(const ui::MouseEvent& event) override;
   void OnMouseEntered(const ui::MouseEvent& event) override;
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
-  void PreferredSizeChanged() override;
   void AddedToWidget() override;
 
   // views::ResizeAreaDelegate
@@ -223,9 +218,6 @@ class VerticalTabStripRegionView : public views::View,
   base::OneShotTimer mouse_enter_timer_;
 
   bool mouse_events_for_test_ = false;
-
-  bool layout_dirty_ = false;
-  gfx::Size last_size_;
 
   gfx::SlideAnimation width_animation_{this};
 


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/43656

So far, we only do re-layout vertical tab strip when it gets child's preferred size changed noti.
However, upstream doesn't give it for first tab. See TabContainerImpl::AddTab() for more detail.
We optimized like that to avoid redundant re-layout but we need to relayout whenever child view's layout is invalidated. That constraints was added to fix https://github.com/brave/brave-browser/issues/28967
but confirmed that it doesn't happen anymore w/o this constraints.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`VerticalTabStripBrowserTest.LayoutAfterFirstTabCreation`
See the linked issue for manual test.