### PR TITLE
Moving `document_extractor` root source to fix `gnrt` failures

### DIFF
--- a/components/web_discovery/browser/content_scraper.cc
+++ b/components/web_discovery/browser/content_scraper.cc
@@ -13,7 +13,7 @@
 #include "base/strings/string_split.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
-#include "brave/components/web_discovery/browser/document_extractor/lib.rs.h"
+#include "brave/components/web_discovery/browser/document_extractor/src/lib.rs.h"
 #include "brave/components/web_discovery/browser/patterns.h"
 #include "brave/components/web_discovery/browser/privacy_guard.h"
 #include "brave/components/web_discovery/browser/util.h"

--- a/components/web_discovery/browser/document_extractor/BUILD.gn
+++ b/components/web_discovery/browser/document_extractor/BUILD.gn
@@ -7,15 +7,15 @@ import("//build/rust/rust_static_library.gni")
 
 rust_static_library("document_extractor") {
   crate_name = "document_extractor"
-  crate_root = "lib.rs"
+  crate_root = "src/lib.rs"
   allow_unsafe = true
 
   edition = "2021"
-  sources = [ "lib.rs" ]
+  sources = [ "src/lib.rs" ]
 
   visibility = [ "//brave/components/web_discovery/browser:*" ]
 
-  cxx_bindings = [ "lib.rs" ]
+  cxx_bindings = [ "src/lib.rs" ]
 
   deps = [
     "//brave/third_party/rust/html5ever/v0_25:lib",

--- a/components/web_discovery/browser/document_extractor/src/lib.rs
+++ b/components/web_discovery/browser/document_extractor/src/lib.rs
@@ -16,9 +16,9 @@ use kuchikiki::{
 #[cxx::bridge(namespace = "web_discovery")]
 mod ffi {
     pub struct SelectAttributeRequest {
-        /// An optional selector for an element within the current selected element.
-        /// The attribute will be retrieved from the embedded element.
-        /// If not needed, an empty string should be provided.
+        /// An optional selector for an element within the current selected
+        /// element. The attribute will be retrieved from the embedded
+        /// element. If not needed, an empty string should be provided.
         pub sub_selector: String,
         /// Arbitrary ID used for storing the scraped result.
         pub key: String,

--- a/third_party/rust/anonymous_credentials/v0_1/README.chromium
+++ b/third_party/rust/anonymous_credentials/v0_1/README.chromium
@@ -1,7 +1,7 @@
 Name: anonymous-credentials
 URL: https://crates.io/crates/anonymous-credentials
 Version: 0.1.4
-License: Mozilla Public License 2.0
+License: Mozilla-Public-License-2.0
 License File:
 Shipped: yes
 Security Critical: yes

--- a/third_party/rust/brave_miracl/v0_1/BUILD.gn
+++ b/third_party/rust/brave_miracl/v0_1/BUILD.gn
@@ -63,4 +63,7 @@ cargo_crate("lib") {
   proc_macro_configs -= [ "//build/config/compiler:chromium_code" ]
   proc_macro_configs += [ "//build/config/compiler:no_chromium_code" ]
   features = [ "std" ]
+  rustflags = [
+    "--cap-lints=allow",  # Suppress all warnings in crates.io crates
+  ]
 }

--- a/third_party/rust/brave_miracl/v0_1/README.chromium
+++ b/third_party/rust/brave_miracl/v0_1/README.chromium
@@ -2,7 +2,7 @@ Name: brave-miracl
 URL: https://crates.io/crates/brave-miracl
 Version: 0.1.3
 Revision: fb447a11105dae466ddd7f9eb666a30cbceff539
-License: Apache 2.0
+License: Apache-2.0
 License File: //brave/third_party/rust/chromium_crates_io/vendor/brave-miracl-0.1.3/LICENSE
 Shipped: yes
 Security Critical: yes

--- a/third_party/rust/document_extractor/v0_1/README.chromium
+++ b/third_party/rust/document_extractor/v0_1/README.chromium
@@ -1,8 +1,9 @@
 Name: document-extractor
 URL: https://crates.io/crates/document-extractor
-Description: 
 Version: 0.1.0
-Security Critical: yes
-Shipped: yes
-License: Mozilla Public License 2.0
+License: Mozilla-Public-License-2.0
 License File:
+Shipped: yes
+Security Critical: yes
+
+Description: 


### PR DESCRIPTION
Runs of `gnrt vendor` are failing due to `document_extractor` being considered invalid for some reason, with the suggestion being moving `lib.rs` to `src/lib.rs`. This fix does just that.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

