### PR TITLE
Fixes a crash when SafeBrowsing API returns an error in certain cases (uplift to 1.76.x)

### DIFF
--- a/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingApiHandler.java
+++ b/components/safe_browsing/android/java/src/org/chromium/components/safe_browsing/BraveSafeBrowsingApiHandler.java
@@ -162,15 +162,17 @@ public class BraveSafeBrowsingApiHandler implements SafeBrowsingApiHandler {
                                 if (isDebuggable()) {
                                     Log.d(TAG, error);
                                 }
-                                mBraveSafeBrowsingApiHandlerDelegate.maybeShowSafeBrowsingError(
-                                        error);
-                                if (apiException.getStatusCode()
-                                        == CommonStatusCodes.API_NOT_CONNECTED) {
-                                    // That means that device doesn't have Google Play Services API.
-                                    // Delegate is used to turn off safe browsing option as every
-                                    // request is
-                                    // delayed when it's turned on and not working
-                                    mBraveSafeBrowsingApiHandlerDelegate.turnSafeBrowsingOff();
+                                if (mBraveSafeBrowsingApiHandlerDelegate != null) {
+                                    mBraveSafeBrowsingApiHandlerDelegate.maybeShowSafeBrowsingError(
+                                            error);
+                                    if (apiException.getStatusCode()
+                                            == CommonStatusCodes.API_NOT_CONNECTED) {
+                                        // That means that device doesn't have Google Play Services
+                                        // API. Delegate is used to turn off safe browsing option as
+                                        // every request is delayed when it's turned on and not
+                                        // working
+                                        mBraveSafeBrowsingApiHandlerDelegate.turnSafeBrowsingOff();
+                                    }
                                 }
 
                                 // Note: If the status code, apiException.getStatusCode(),
@@ -199,8 +201,10 @@ public class BraveSafeBrowsingApiHandler implements SafeBrowsingApiHandler {
                                 if (isDebuggable()) {
                                     Log.d(TAG, error);
                                 }
-                                mBraveSafeBrowsingApiHandlerDelegate.maybeShowSafeBrowsingError(
-                                        error);
+                                if (mBraveSafeBrowsingApiHandlerDelegate != null) {
+                                    mBraveSafeBrowsingApiHandlerDelegate.maybeShowSafeBrowsingError(
+                                            error);
+                                }
                                 mObserver.onUrlCheckDone(
                                         callbackId,
                                         LookupResult.FAILURE_API_CALL_TIMEOUT,


### PR DESCRIPTION
Uplift of #27472
Resolves https://github.com/brave/brave-browser/issues/43702

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.