### PR TITLE
Allow popups from inside brave://getting-started iframe

### DIFF
--- a/browser/resources/brave_education/brave_education_app.html.ts
+++ b/browser/resources/brave_education/brave_education_app.html.ts
@@ -10,6 +10,6 @@ import type {BraveEducationAppElement} from './brave_education_app.js';
 export function getHtml(this: BraveEducationAppElement) {
   return this.url_ ?
       html`<iframe id="content" src="${
-          this.url_}" sandbox="allow-scripts allow-same-origin"></iframe>` :
+          this.url_}" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>` :
       '';
 }

--- a/browser/resources/brave_education/brave_education_app.html.ts
+++ b/browser/resources/brave_education/brave_education_app.html.ts
@@ -10,6 +10,7 @@ import type {BraveEducationAppElement} from './brave_education_app.js';
 export function getHtml(this: BraveEducationAppElement) {
   return this.url_ ?
       html`<iframe id="content" src="${
-          this.url_}" sandbox="allow-scripts allow-same-origin allow-popups"></iframe>` :
+          this.url_}" sandbox="allow-scripts allow-same-origin allow-popups
+          allow-popups-to-escape-sandbox"></iframe>` :
       '';
 }


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/43719

Security review https://github.com/brave/reviews/issues/1858

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [x] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [x] New files have MPL-2.0 license header
- [x] Adequate test coverage exists to prevent regressions
- [x] Major classes, functions and non-trivial code blocks are well-commented
- [x] Changes in component dependencies are properly reflected in `gn`
- [x] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [x] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Launch Brave
2. Visit brave://getting-started
3. Scroll down to very bottom and click button `Learn more`
4. Link should open in a new tab
5. Go back to brave://getting-started
6. Scroll down (mid-way) to `See a better web` button and click it
7. Link should open in a new tab