### PR TITLE
Fixed new tab is not shown when it's first tab (uplift to 1.76.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -440,7 +440,6 @@ class VerticalTabStripScrollContentsView : public views::View {
     // Prevent reentrance caused by container_->Layout()
     base::AutoReset<bool> in_preferred_size_change(&in_preferred_size_changed_,
                                                    true);
-    container_->set_layout_dirty({});
     container_->DeprecatedLayoutImmediately();
   }
 
@@ -917,13 +916,6 @@ gfx::Size VerticalTabStripRegionView::GetMinimumSize() const {
 }
 
 void VerticalTabStripRegionView::Layout(PassKey) {
-  if (!layout_dirty_ && last_size_ == size()) {
-    return;
-  }
-
-  layout_dirty_ = false;
-  last_size_ = size();
-
   // As we have to update ScrollView's viewport size and its contents size,
   // laying out children manually will be more handy.
   const auto contents_bounds = GetContentsBounds();
@@ -987,7 +979,6 @@ void VerticalTabStripRegionView::OnBrowserPanelsMoved() {
 }
 
 void VerticalTabStripRegionView::UpdateLayout(bool in_destruction) {
-  layout_dirty_ = true;
   if (tabs::utils::ShouldShowVerticalTabs(browser_) && !in_destruction) {
     if (!Contains(original_region_view_)) {
       original_parent_of_region_view_ = original_region_view_->parent();
@@ -1134,11 +1125,6 @@ void VerticalTabStripRegionView::OnBoundsChanged(
             BraveContentsViewUtil::GetRoundedCornersWebViewMargin(browser_));
   }
 #endif
-}
-
-void VerticalTabStripRegionView::PreferredSizeChanged() {
-  layout_dirty_ = true;
-  views::View::PreferredSizeChanged();
 }
 
 void VerticalTabStripRegionView::AddedToWidget() {

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -87,10 +87,6 @@ class VerticalTabStripRegionView : public views::View,
 
   int GetTabStripViewportMaxHeight() const;
 
-  void set_layout_dirty(base::PassKey<VerticalTabStripScrollContentsView>) {
-    layout_dirty_ = true;
-  }
-
   void ResetExpandedWidth();
   bool IsMenuShowing() const;
 
@@ -103,7 +99,6 @@ class VerticalTabStripRegionView : public views::View,
   void OnMouseExited(const ui::MouseEvent& event) override;
   void OnMouseEntered(const ui::MouseEvent& event) override;
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
-  void PreferredSizeChanged() override;
   void AddedToWidget() override;
 
   // views::ResizeAreaDelegate
@@ -138,6 +133,8 @@ class VerticalTabStripRegionView : public views::View,
                            OriginalTabSearchButton);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedState);
   FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest, ExpandedWidth);
+  FRIEND_TEST_ALL_PREFIXES(VerticalTabStripBrowserTest,
+                           LayoutAfterFirstTabCreation);
 
   FullscreenController* GetFullscreenController() const;
   bool IsTabFullscreen() const;
@@ -223,9 +220,6 @@ class VerticalTabStripRegionView : public views::View,
   base::OneShotTimer mouse_enter_timer_;
 
   bool mouse_events_for_test_ = false;
-
-  bool layout_dirty_ = false;
-  gfx::Size last_size_;
 
   gfx::SlideAnimation width_animation_{this};
 

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -14,8 +14,10 @@
 #include "brave/browser/ui/views/frame/vertical_tab_strip_widget_delegate_view.h"
 #include "brave/browser/ui/views/tabs/brave_browser_tab_strip_controller.h"
 #include "brave/browser/ui/views/tabs/brave_compound_tab_container.h"
+#include "brave/browser/ui/views/tabs/brave_new_tab_button.h"
 #include "brave/browser/ui/views/tabs/brave_tab_context_menu_contents.h"
 #include "brave/browser/ui/views/tabs/brave_tab_strip.h"
+#include "brave/browser/ui/views/tabs/brave_tab_strip_layout_helper.h"
 #include "brave/browser/ui/views/tabs/switches.h"
 #include "brave/browser/ui/views/tabs/vertical_tab_utils.h"
 #include "brave/components/constants/pref_names.h"
@@ -501,6 +503,44 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, LayoutSanity) {
     EXPECT_TRUE(GetBoundsInScreen(region_view, region_view->GetLocalBounds())
                     .Contains(GetBoundsInScreen(tab, tab->GetLocalBounds())));
   }
+}
+
+IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
+                       LayoutAfterFirstTabCreation) {
+  ToggleVerticalTabStrip();
+
+  auto* widget_delegate_view =
+      browser_view()->vertical_tab_strip_widget_delegate_view();
+  ASSERT_TRUE(widget_delegate_view);
+
+  auto* region_view = widget_delegate_view->vertical_tab_strip_region_view();
+  ASSERT_TRUE(region_view);
+  ASSERT_EQ(VerticalTabStripRegionView::State::kExpanded, region_view->state());
+
+  auto* model = browser()->tab_strip_model();
+  model->SetTabPinned(0, true);
+  ASSERT_EQ(1, model->count());
+
+  browser_view()->tabstrip()->StopAnimating(/* layout= */ true);
+
+  int contents_view_height = region_view->contents_view_->height();
+  AppendTab(browser());
+  browser_view()->tabstrip()->StopAnimating(/* layout= */ true);
+
+  // When first tab is added, height should have tab's height plush top & bottom
+  // margin.
+  contents_view_height +=
+      (tabs::kVerticalTabHeight + tabs::kMarginForVerticalTabContainers * 2);
+  EXPECT_EQ(region_view->contents_view_->height(), contents_view_height);
+
+  AppendTab(browser());
+  browser_view()->tabstrip()->StopAnimating(/* layout= */ true);
+
+  // When second tab is added, height should be increased with tab height plus
+  // tab spacing.
+  contents_view_height +=
+      (tabs::kVerticalTabHeight + tabs::kVerticalTabsSpacing);
+  EXPECT_EQ(region_view->contents_view_->height(), contents_view_height);
 }
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ScrollBarVisibility) {


### PR DESCRIPTION
Uplift of #27477
Resolves https://github.com/brave/brave-browser/issues/43656
Resolves https://github.com/brave/brave-browser/issues/43688
Resolves https://github.com/brave/brave-browser/issues/43700 (possibly fixed/addressed)

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.