### PR TITLE
Fixed crash with unset NetworkTimeHelper::ui_task_runner_ (uplift to 1.76.x)

### DIFF
--- a/browser/brave_browser_process_impl.h
+++ b/browser/brave_browser_process_impl.h
@@ -139,6 +139,7 @@ class BraveBrowserProcessImpl : public BraveBrowserProcess,
  private:
   // BrowserProcessImpl overrides:
   void Init() override;
+  void PreMainMessageLoopRun() override;
 #if !BUILDFLAG(IS_ANDROID)
   void StartTearDown() override;
   void PostDestroyThreads() override;

--- a/chromium_src/chrome/browser/browser_process_impl.h
+++ b/chromium_src/chrome/browser/browser_process_impl.h
@@ -28,6 +28,7 @@
 #include "services/network/public/mojom/network_service.mojom-forward.h"
 
 #define Init virtual Init
+#define PreMainMessageLoopRun virtual PreMainMessageLoopRun
 
 #if !BUILDFLAG(IS_ANDROID)
 #define StartTearDown virtual StartTearDown
@@ -38,6 +39,7 @@
 
 #undef PostDestroyThreads
 #undef StartTearDown
+#undef PreMainMessageLoopRun
 #undef Init
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_BROWSER_PROCESS_IMPL_H_

--- a/components/brave_sync/network_time_helper.cc
+++ b/components/brave_sync/network_time_helper.cc
@@ -31,14 +31,22 @@ void NetworkTimeHelper::SetNetworkTimeTracker(
   ui_task_runner_ = ui_task_runner;
 }
 
+void NetworkTimeHelper::Shutdown() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  network_time_tracker_ = nullptr;
+}
+
 void NetworkTimeHelper::GetNetworkTime(GetNetworkTimeCallback cb) {
   if (!network_time_for_test_.is_null()) {
     std::move(cb).Run(network_time_for_test_);
     return;
   }
+
+  // TODO(alexeybarabash): redo it using mojo interface
+  // https://github.com/brave/brave-browser/issues/43738
   ui_task_runner_->PostTask(
       FROM_HERE, base::BindOnce(&NetworkTimeHelper::GetNetworkTimeOnUIThread,
-                                weak_ptr_factory_.GetWeakPtr(), std::move(cb)));
+                                base::Unretained(this), std::move(cb)));
 }
 
 void NetworkTimeHelper::SetNetworkTimeForTest(const base::Time& time) {

--- a/components/brave_sync/network_time_helper.h
+++ b/components/brave_sync/network_time_helper.h
@@ -39,6 +39,8 @@ class NetworkTimeHelper {
       network_time::NetworkTimeTracker* tracker,
       const scoped_refptr<base::SingleThreadTaskRunner>& ui_task_runner);
 
+  void Shutdown();
+
   void GetNetworkTime(GetNetworkTimeCallback cb);
 
   void SetNetworkTimeForTest(const base::Time& time);
@@ -56,8 +58,6 @@ class NetworkTimeHelper {
   // Not owned
   raw_ptr<network_time::NetworkTimeTracker, DanglingUntriaged>
       network_time_tracker_ = nullptr;
-
-  base::WeakPtrFactory<NetworkTimeHelper> weak_ptr_factory_{this};
 };
 
 }  // namespace brave_sync

--- a/components/sync/service/brave_sync_service_impl_unittest.cc
+++ b/components/sync/service/brave_sync_service_impl_unittest.cc
@@ -125,6 +125,11 @@ class BraveSyncServiceImplTest : public testing::Test {
         base::SingleThreadTaskRunner::GetCurrentDefault());
   }
 
+  void TearDown() override {
+    brave_sync::NetworkTimeHelper::GetInstance()->Shutdown();
+    testing::Test::TearDown();
+  }
+
   void CreateSyncService(
       DataTypeSet registered_types = DataTypeSet({BOOKMARKS})) {
     DataTypeController::TypeVector controllers;


### PR DESCRIPTION
Uplift of #27499
Resolves https://github.com/brave/brave-browser/issues/43727

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.