### PR TITLE
feat(wallet): Add Custom Birthday Input to Shield Account

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1636,7 +1636,13 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletPause", IDS_BRAVE_WALLET_PAUSE},
     {"braveWalletSyncCompleteMessage", IDS_BRAVE_WALLET_SYNC_COMPLETE_MESSAGE},
     {"braveWalletSyncStartedMessage", IDS_BRAVE_WALLET_SYNC_STARTED_MESSAGE},
-    {"braveWalletContinueUsingWallet", IDS_BRAVE_WALLET_CONTINUE_USING_WALLET}};
+    {"braveWalletContinueUsingWallet", IDS_BRAVE_WALLET_CONTINUE_USING_WALLET},
+    {"braveWalletShieldedAccountBirthdayBlock",
+     IDS_BRAVE_WALLET_SHIELDED_ACCOUNT_BIRTHDAY_BLOCK},
+    {"braveWalletAccountBirthdayTooLow",
+     IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW},
+    {"braveWalletAccountBirthdayTooHigh",
+     IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH}};
 
 // 0x swap constants
 inline constexpr char kZeroExBaseAPIURL[] = "https://api.0x.wallet.brave.com";

--- a/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
+++ b/components/brave_wallet_ui/common/async/__mocks__/bridge.ts
@@ -1417,6 +1417,20 @@ export class MockedWalletApiProxy {
     }
   }
 
+  zcashWalletService: Partial<
+    InstanceType<typeof BraveWallet.ZCashWalletServiceInterface>
+  > = {
+    getChainTipStatus: async (_accountId) => {
+      return {
+        status: {
+          chainTip: 7687104,
+          latestScannedBlock: 2687104
+        },
+        errorMessage: null
+      }
+    }
+  }
+
   setMockedQuote(newQuote: typeof this.mockZeroExQuote) {
     this.mockZeroExQuote = newQuote
   }

--- a/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
@@ -11,19 +11,25 @@ import { handleEndpointError } from '../../../utils/api-utils'
 import { WalletApiEndpointBuilderParams } from '../api-base.slice'
 import { mapLimit } from 'async'
 
+type MakeAccountShieldedPayloadType = {
+  accountId: BraveWallet.AccountId
+  accountBirthdayBlock: number
+}
+
 export const zcashEndpoints = ({
   query,
   mutation
 }: WalletApiEndpointBuilderParams) => {
   return {
-    makeAccountShielded: mutation<true, BraveWallet.AccountId>({
+    makeAccountShielded: mutation<true, MakeAccountShieldedPayloadType>({
       queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {
+        const { accountId, accountBirthdayBlock } = args
         try {
           const { zcashWalletService } = baseQuery(undefined).data
 
           const { errorMessage } = await zcashWalletService.makeAccountShielded(
-            args,
-            0
+            accountId,
+            accountBirthdayBlock
           )
 
           if (errorMessage) {

--- a/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.style.ts
+++ b/components/brave_wallet_ui/components/desktop/popup-modals/shield_zcash_account/shield_zcash_account.style.ts
@@ -7,7 +7,7 @@ import * as leo from '@brave/leo/tokens/css/variables'
 import Icon from '@brave/leo/react/icon'
 
 // Shared Styled
-import { Column, Row } from '../../../shared/style'
+import { Column, Row, WalletButton } from '../../../shared/style'
 
 export const StyledWrapper = styled(Column)`
   overflow: hidden;
@@ -35,4 +35,33 @@ export const ShieldIcon = styled(Icon).attrs({
 })`
   --leo-icon-size: 24px;
   color: ${leo.color.systemfeedback.successIcon};
+`
+
+export const AdvancedSettingsWrapper = styled(Column)`
+  border-radius: ${leo.radius.m};
+  border: 1px solid ${leo.color.divider.subtle};
+`
+
+export const AdvancedSettingsButton = styled(WalletButton)`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  background: none;
+  padding: 12px 8px;
+  --leo-icon-size: 16px;
+  --leo-icon-color: ${leo.color.icon.default};
+  outline: none;
+  border: none;
+  width: 100%;
+  cursor: pointer;
+`
+
+export const CollapseIcon = styled(Icon)<{
+  isCollapsed: boolean
+}>`
+  --leo-icon-size: 24px;
+  color: ${leo.color.icon.default};
+  transition-duration: 0.3s;
+  transform: ${(p) => (p.isCollapsed ? 'unset' : 'rotate(180deg)')};
 `

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1545,5 +1545,8 @@ provideStrings({
     'Sync complete. You may now close this window.',
   braveWalletSyncStartedMessage:
     'Please don’t close this window until sync finishes.',
-  braveWalletContinueUsingWallet: 'Continue using wallet in a new tab'
+  braveWalletContinueUsingWallet: 'Continue using wallet in a new tab',
+  braveWalletShieldedAccountBirthdayBlock: 'Shielded account birthday block',
+  braveWalletAccountBirthdayToLow: 'Account birthday must be greater than $1',
+  braveWalletAccountBirthdayToHigh: 'Account birthday must be less than $1'
 })

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1172,6 +1172,9 @@
   <message name="IDS_BRAVE_WALLET_SYNC_COMPLETE_MESSAGE" desc="Sync complete message on sync dialog.">Sync complete. You may now close this window.</message>
   <message name="IDS_BRAVE_WALLET_SYNC_STARTED_MESSAGE" desc="Sync started message on sync dialog.">Please don’t close this window until sync finishes.</message>
   <message name="IDS_BRAVE_WALLET_CONTINUE_USING_WALLET" desc="Continue using wallet button label on sync dialog. ">Continue using wallet in a new tab</message>
+  <message name="IDS_BRAVE_WALLET_SHIELDED_ACCOUNT_BIRTHDAY_BLOCK" desc="Shielded account birthday block input label">Shielded account birthday block</message>
+  <message name="IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW" desc="Account birthday to low error">Account birthday must be greater than <ph name="BLOCK_NUMBER">$1<ex>1687104</ex></ph></message>
+  <message name="IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH" desc="Account birthday to high error">Account birthday must be less than <ph name="BLOCK_NUMBER">$1<ex>7687104</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_BUTTON_RETRY" desc="Retry an action">Retry</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_PREVIEW_FAILED" desc="Explaination that simulation of a transaction has failed">Transaction preview failed.</message>
   <message name="IDS_BRAVE_WALLET_ESTIMATED_BALANCE_CHANGE" desc="Grouping header for estimated balance changes">Estimated balance change</message>


### PR DESCRIPTION
## Description 

Adds a custom `Shielded Account Birthday` input to the `Shield Account` modal to allow users to specify a custom block height for their accounts shielded birthday.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43764>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Make sure that `Zcash Shielded Transactions` is enabled
2. Open the `Wallet` and navigate to the `Accounts` tab
3. Click on the `More Menu` for you Zcash Account
4. Click on `Switch to shielded account`
5. There should now be a custom input for `Shielded account birthday block` under the `Advanced settings` section
6. Enter in a custom `Birthday` block and then `Shield` your account
7. Now open the `Account Details`
8. You should see the `Sync Warning`, click on `Sync account`
9. Confirm that the the start block is the same as you entered for your custom `Birthday`.

https://github.com/user-attachments/assets/a34d8bcc-1c18-4ec0-88ea-146b676af0a4
