### PR TITLE
[AI Chat]: Provide hint for selecting omnibox result

### DIFF
--- a/browser/ui/views/omnibox/brave_omnibox_result_view.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.cc
@@ -15,6 +15,7 @@
 #include "brave/components/omnibox/browser/promotion_utils.h"
 #include "brave/grit/brave_theme_resources.h"
 #include "chrome/browser/browser_process.h"
+#include "chrome/browser/ui/views/omnibox/omnibox_match_cell_view.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_popup_view_views.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_suggestion_button_row_view.h"
 #include "components/grit/brave_components_strings.h"
@@ -35,6 +36,7 @@
 #include "ui/views/controls/label.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"
+#include "ui/views/layout/flex_layout_types.h"
 #include "ui/views/view_class_properties.h"
 
 BraveOmniboxResultView::~BraveOmniboxResultView() = default;
@@ -46,7 +48,8 @@ void BraveOmniboxResultView::ResetChildren() {
   }
 
   if (leo_match_label_) {
-    RemoveChildViewT(leo_match_label_.ExtractAsDangling());
+    leo_match_label_->parent()->RemoveChildViewT(
+        leo_match_label_.ExtractAsDangling());
   }
 
   // Reset children visibility. Their visibility could be configured later
@@ -152,11 +155,20 @@ void BraveOmniboxResultView::UpdateForLeoMatch() {
           gfx::Insets().set_top(kLeoMatchPadding)));
 
       if (!leo_match_label_) {
-        leo_match_label_ = AddChildView(std::make_unique<views::Label>(
-            l10n_util::GetStringUTF16(IDS_OMNIBOX_SELECT_ASK_LEO_HINT)));
+        // Note: The |suggestion_view_| is a child of suggestion_and_button_row
+        // which has a FlexLayout but is not stored in a field, so we have to
+        // go via |suggestion_view_->parent()| to add |leo_match_label_|.
+        leo_match_label_ = suggestion_view_->parent()->AddChildView(
+            std::make_unique<views::Label>(
+                l10n_util::GetStringUTF16(IDS_OMNIBOX_SELECT_ASK_LEO_HINT)));
         leo_match_label_->SetHorizontalAlignment(gfx::ALIGN_RIGHT);
         leo_match_label_->SetBorder(
-            views::CreateEmptyBorder(gfx::Insets().set_right(32)));
+            views::CreateEmptyBorder(gfx::Insets().set_left_right(24, 24)));
+        leo_match_label_->SetProperty(
+            views::kFlexBehaviorKey,
+            views::FlexSpecification(views::LayoutOrientation::kHorizontal,
+                                     views::MinimumFlexSizeRule::kPreferred,
+                                     views::MaximumFlexSizeRule::kUnbounded));
       }
 
       // The "Press ↑ to highlight" label should only be visible when pressing

--- a/browser/ui/views/omnibox/brave_omnibox_result_view.cc
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.cc
@@ -17,6 +17,7 @@
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_popup_view_views.h"
 #include "chrome/browser/ui/views/omnibox/omnibox_suggestion_button_row_view.h"
+#include "components/grit/brave_components_strings.h"
 #include "components/omnibox/browser/autocomplete_controller.h"
 #include "components/omnibox/browser/autocomplete_match.h"
 #include "components/omnibox/browser/autocomplete_provider_client.h"
@@ -24,12 +25,14 @@
 #include "components/omnibox/browser/omnibox_controller.h"
 #include "components/omnibox/browser/omnibox_edit_model.h"
 #include "components/omnibox/browser/omnibox_popup_selection.h"
+#include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/base/window_open_disposition.h"
 #include "ui/gfx/canvas.h"
 #include "ui/gfx/scoped_canvas.h"
 #include "ui/views/controls/button/image_button.h"
+#include "ui/views/controls/label.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/layout/flex_layout.h"
 #include "ui/views/view_class_properties.h"
@@ -40,6 +43,10 @@ void BraveOmniboxResultView::ResetChildren() {
   if (brave_search_promotion_view_) {
     RemoveChildViewT(brave_search_promotion_view_);
     brave_search_promotion_view_ = nullptr;
+  }
+
+  if (leo_match_label_) {
+    RemoveChildViewT(leo_match_label_.ExtractAsDangling());
   }
 
   // Reset children visibility. Their visibility could be configured later
@@ -143,6 +150,19 @@ void BraveOmniboxResultView::UpdateForLeoMatch() {
               gfx::Insets().set_top(1),
               cp->GetColor(kColorBraveOmniboxResultViewSeparator)),
           gfx::Insets().set_top(kLeoMatchPadding)));
+
+      if (!leo_match_label_) {
+        leo_match_label_ = AddChildView(std::make_unique<views::Label>(
+            l10n_util::GetStringUTF16(IDS_OMNIBOX_SELECT_ASK_LEO_HINT)));
+        leo_match_label_->SetHorizontalAlignment(gfx::ALIGN_RIGHT);
+        leo_match_label_->SetBorder(
+            views::CreateEmptyBorder(gfx::Insets().set_right(32)));
+      }
+
+      // The "Press ↑ to highlight" label should only be visible when pressing
+      // up will actually highlight it.
+      leo_match_label_->SetVisible(popup_view_->GetSelection().line == 0 &&
+                                   !GetMatchSelected());
     }
   } else {
     ClearProperty(views::kMarginsKey);

--- a/browser/ui/views/omnibox/brave_omnibox_result_view.h
+++ b/browser/ui/views/omnibox/brave_omnibox_result_view.h
@@ -13,6 +13,10 @@
 class BraveSearchConversionPromotionView;
 class BraveOmniboxPopupViewViews;
 
+namespace views {
+class Label;
+}
+
 // This will render brave specific matches such as the braver search conversion
 // promotion.
 class BraveOmniboxResultView : public OmniboxResultView {
@@ -43,6 +47,8 @@ class BraveOmniboxResultView : public OmniboxResultView {
   // Brave search conversion promotion
   raw_ptr<BraveSearchConversionPromotionView> brave_search_promotion_view_ =
       nullptr;
+
+  raw_ptr<views::Label> leo_match_label_ = nullptr;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_OMNIBOX_BRAVE_OMNIBOX_RESULT_VIEW_H_

--- a/components/resources/omnibox_strings.grdp
+++ b/components/resources/omnibox_strings.grdp
@@ -14,4 +14,7 @@
   <message name="IDS_OMNIBOX_ASK_LEO_DESCRIPTION" desc="The label in the omnibox explaning that the match item will open Leo">
     Ask Leo
   </message>
+  <message name="IDS_OMNIBOX_SELECT_ASK_LEO_HINT" desc="The hint displayed in the omnibox for selecting the Ask Leo match">
+    Press ↑ to highlight
+  </message>
 </grit-part>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43775

[Screencast From 2025-02-07 10-35-14.webm](https://github.com/user-attachments/assets/4f13c983-33a6-4adb-bf19-f7724f8c8432)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enter a query that shows the `Ask Leo` result in the Omnibox
2. It should have a `Press ↑ to highlight` message
3. The message should not show up if pressing up will not highlight the `Ask Leo` query
4. The message should not show up when the `Ask Leo` query is selected

**Note:** Does not apply to mouse selection, only keyboard 