### PR TITLE
[Draft] Move NotificationHelperImpl from UI thread

### DIFF
--- a/browser/brave_ads/ads_service_delegate.cc
+++ b/browser/brave_ads/ads_service_delegate.cc
@@ -194,22 +194,27 @@ void AdsServiceDelegate::InitNotificationHelper() {
   NotificationHelper::GetInstance()->InitForProfile(&*profile_);
 }
 
-bool AdsServiceDelegate::
-    CanShowSystemNotificationsWhileBrowserIsBackgrounded() {
-  return NotificationHelper::GetInstance()
-      ->CanShowSystemNotificationsWhileBrowserIsBackgrounded();
+void AdsServiceDelegate::CanShowSystemNotificationsWhileBrowserIsBackgrounded(
+    base::OnceCallback<void(bool)> callback) {
+  NotificationHelper::GetInstance()
+      ->CanShowSystemNotificationsWhileBrowserIsBackgrounded(
+          std::move(callback));
 }
 
 bool AdsServiceDelegate::DoesSupportSystemNotifications() {
   return NotificationHelper::GetInstance()->DoesSupportSystemNotifications();
 }
 
-bool AdsServiceDelegate::CanShowNotifications() {
-  return NotificationHelper::GetInstance()->CanShowNotifications();
+void AdsServiceDelegate::CanShowNotifications(
+    base::OnceCallback<void(bool)> callback) {
+  NotificationHelper::GetInstance()->CanShowNotifications(
+      std::move(callback));
 }
 
-bool AdsServiceDelegate::ShowOnboardingNotification() {
-  return NotificationHelper::GetInstance()->ShowOnboardingNotification();
+void AdsServiceDelegate::ShowOnboardingNotification(
+    base::OnceCallback<void(bool)> callback) {
+  NotificationHelper::GetInstance()->ShowOnboardingNotification(
+      std::move(callback));
 }
 
 void AdsServiceDelegate::ShowScheduledCaptcha(const std::string& payment_id,

--- a/browser/brave_ads/ads_service_delegate.h
+++ b/browser/brave_ads/ads_service_delegate.h
@@ -50,10 +50,12 @@ class AdsServiceDelegate : public AdsService::Delegate {
 
   // AdsService::Delegate implementation
   void InitNotificationHelper() override;
-  bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() override;
+  void CanShowSystemNotificationsWhileBrowserIsBackgrounded(
+      base::OnceCallback<void(bool)> callback) override;
   bool DoesSupportSystemNotifications() override;
-  bool CanShowNotifications() override;
-  bool ShowOnboardingNotification() override;
+  void CanShowNotifications(base::OnceCallback<void(bool)> callback) override;
+  void ShowOnboardingNotification(
+      base::OnceCallback<void(bool)> callback) override;
   void ShowScheduledCaptcha(const std::string& payment_id,
                             const std::string& captcha_id) override;
   void ClearScheduledCaptcha() override;

--- a/browser/brave_ads/application_state/notification_helper/notification_helper.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper.h
@@ -8,7 +8,9 @@
 
 #include <memory>
 
+#include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
+#include "base/threading/sequence_bound.h"
 
 class Profile;
 
@@ -30,10 +32,11 @@ class NotificationHelper final {
 
   void InitForProfile(Profile* profile);
 
-  bool CanShowNotifications();
-  bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() const;
+  void CanShowNotifications(base::OnceCallback<void(bool)> callback) const;
+  void CanShowSystemNotificationsWhileBrowserIsBackgrounded(
+      base::OnceCallback<void(bool)> callback) const;
 
-  bool ShowOnboardingNotification();
+  void ShowOnboardingNotification(base::OnceCallback<void(bool)> callback);
 
   bool DoesSupportSystemNotifications() const;
 
@@ -48,7 +51,7 @@ class NotificationHelper final {
 
   bool does_support_system_notifications_ = true;
 
-  std::unique_ptr<NotificationHelperImpl> impl_;
+  base::SequenceBound<std::unique_ptr<NotificationHelperImpl>> impl_;
 
   base::WeakPtrFactory<NotificationHelper> weak_factory_{this};
 };

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -1554,8 +1554,8 @@ void AdsServiceImpl::CanShowNotificationAds(
 
 void AdsServiceImpl::CanShowNotificationAdsWhileBrowserIsBackgrounded(
     CanShowNotificationAdsWhileBrowserIsBackgroundedCallback callback) {
-  std::move(callback).Run(
-      delegate_->CanShowSystemNotificationsWhileBrowserIsBackgrounded());
+  delegate_->CanShowSystemNotificationsWhileBrowserIsBackgrounded(
+      std::move(callback));
 }
 
 void AdsServiceImpl::ShowNotificationAd(base::Value::Dict dict) {

--- a/components/brave_ads/core/browser/service/ads_service.h
+++ b/components/brave_ads/core/browser/service/ads_service.h
@@ -34,10 +34,13 @@ class AdsService : public KeyedService {
     virtual ~Delegate() = default;
 
     virtual void InitNotificationHelper() = 0;
-    virtual bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() = 0;
+    virtual void CanShowSystemNotificationsWhileBrowserIsBackgrounded(
+        base::OnceCallback<void(bool)> callback) = 0;
     virtual bool DoesSupportSystemNotifications() = 0;
-    virtual bool CanShowNotifications() = 0;
-    virtual bool ShowOnboardingNotification() = 0;
+    virtual void CanShowNotifications(
+        base::OnceCallback<void(bool)> callback) = 0;
+    virtual void ShowOnboardingNotification(
+        base::OnceCallback<void(bool)> callback) = 0;
     virtual void ShowScheduledCaptcha(const std::string& payment_id,
                                       const std::string& captcha_id) = 0;
     virtual void ClearScheduledCaptcha() = 0;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
For https://github.com/brave/brave-browser/issues/43712
The draft moves NotificationHelperImpl from UI thread to the thread pool to avoid UI hangs using base::SequenceBound.

The work to be done:
1. Adopt AdsServiceImpl to the changes (from sync to async calls)
2. Check all the platforms, including Android.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

