### PR TITLE
[cr135] Migrate from `GetAccessibleNodeData`

### DIFF
--- a/browser/ui/views/bookmarks/bookmark_bar_instructions_view.cc
+++ b/browser/ui/views/bookmarks/bookmark_bar_instructions_view.cc
@@ -99,11 +99,6 @@ void BookmarkBarInstructionsView::OnThemeChanged() {
   UpdateColors();
 }
 
-void BookmarkBarInstructionsView::GetAccessibleNodeData(
-    ui::AXNodeData* node_data) {
-  instructions_->GetAccessibleNodeData(node_data);
-}
-
 void BookmarkBarInstructionsView::LinkClicked() {
   chrome::ShowImportDialog(browser_);
 }

--- a/browser/ui/views/bookmarks/bookmark_bar_instructions_view.h
+++ b/browser/ui/views/bookmarks/bookmark_bar_instructions_view.h
@@ -39,7 +39,6 @@ class BookmarkBarInstructionsView : public views::View,
       const views::SizeBounds& available_size) const override;
   void Layout(PassKey) override;
   void OnThemeChanged() override;
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
 
   // views::ContextMenuController:
   void ShowContextMenuForViewImpl(

--- a/browser/ui/views/brave_ads/notification_ad_header_view.cc
+++ b/browser/ui/views/brave_ads/notification_ad_header_view.cc
@@ -13,6 +13,7 @@
 #include "ui/gfx/geometry/insets.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/native_theme/native_theme.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/label.h"
 #include "ui/views/layout/flex_layout.h"
@@ -47,6 +48,8 @@ constexpr auto kTitleBorderInsets = gfx::Insets::TLBR(0, 10, 3, 0);
 
 NotificationAdHeaderView::NotificationAdHeaderView() {
   CreateView();
+
+  GetViewAccessibility().SetRole(ax::mojom::Role::kGenericContainer);
 }
 
 NotificationAdHeaderView::~NotificationAdHeaderView() = default;
@@ -56,20 +59,14 @@ void NotificationAdHeaderView::SetTitle(const std::u16string& text) {
   title_label_->SetText(text);
 
   NotifyAccessibilityEvent(ax::mojom::Event::kTextChanged, true);
+
+  UpdateAccessibleName();
 }
 
 void NotificationAdHeaderView::SetTitleElideBehavior(
     gfx::ElideBehavior elide_behavior) {
   CHECK(title_label_);
   title_label_->SetElideBehavior(elide_behavior);
-}
-
-void NotificationAdHeaderView::GetAccessibleNodeData(
-    ui::AXNodeData* node_data) {
-  node_data->role = ax::mojom::Role::kGenericContainer;
-
-  CHECK(title_label_);
-  node_data->SetName(title_label_->GetText());
 }
 
 void NotificationAdHeaderView::UpdateContent() {
@@ -143,6 +140,10 @@ void NotificationAdHeaderView::UpdateTitleLabel() {
   CHECK(title_label_);
   title_label_->SetEnabledColor(should_use_dark_colors ? kDarkModeTitleColor
                                                        : kLightModeTitleColor);
+}
+
+void NotificationAdHeaderView::UpdateAccessibleName() {
+  GetViewAccessibility().SetName(title_label_->GetText());
 }
 
 BEGIN_METADATA(NotificationAdHeaderView)

--- a/browser/ui/views/brave_ads/notification_ad_header_view.h
+++ b/browser/ui/views/brave_ads/notification_ad_header_view.h
@@ -34,7 +34,6 @@ class NotificationAdHeaderView : public views::View {
   void UpdateContent();
 
   // views::View:
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
   void OnThemeChanged() override;
 
  private:
@@ -42,6 +41,7 @@ class NotificationAdHeaderView : public views::View {
 
   std::unique_ptr<views::Label> CreateTitleLabel();
   void UpdateTitleLabel();
+  void UpdateAccessibleName();
 
   raw_ptr<views::Label> title_label_ = nullptr;
 };

--- a/browser/ui/views/brave_ads/notification_ad_popup.cc
+++ b/browser/ui/views/brave_ads/notification_ad_popup.cc
@@ -42,6 +42,7 @@
 #include "ui/gfx/shadow_value.h"
 #include "ui/gfx/skia_paint_util.h"
 #include "ui/native_theme/native_theme.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/widget/widget.h"
 
@@ -101,6 +102,10 @@ NotificationAdPopup::NotificationAdPopup(
     screen_observation_.Observe(screen);
   }
 
+  GetViewAccessibility().SetRole(ax::mojom::Role::kAlertDialog);
+  GetViewAccessibility().SetRoleDescription(
+      l10n_util::GetStringUTF8(IDS_BRAVE_ADS_NOTIFICATION_AD_ACCESSIBLE_NAME));
+
   FadeIn();
 }
 
@@ -139,12 +144,6 @@ void NotificationAdPopup::OnDisplayMetricsChanged(
     uint32_t changed_metrics) {
   // Called when the metrics of a display change
   RecomputeAlignment();
-}
-
-void NotificationAdPopup::GetAccessibleNodeData(ui::AXNodeData* node_data) {
-  node_data->role = ax::mojom::Role::kAlertDialog;
-  node_data->SetName(
-      l10n_util::GetStringUTF8(IDS_BRAVE_ADS_NOTIFICATION_AD_ACCESSIBLE_NAME));
 }
 
 void NotificationAdPopup::OnDisplayChanged() {

--- a/browser/ui/views/brave_ads/notification_ad_popup.h
+++ b/browser/ui/views/brave_ads/notification_ad_popup.h
@@ -76,7 +76,6 @@ class NotificationAdPopup : public views::WidgetDelegateView,
                                uint32_t changed_metrics) override;
 
   // views::WidgetDelegateView:
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
   void OnDisplayChanged() override;
   void OnWorkAreaChanged() override;
   void OnPaintBackground(gfx::Canvas* canvas) override;

--- a/browser/ui/views/brave_ads/notification_ad_view.cc
+++ b/browser/ui/views/brave_ads/notification_ad_view.cc
@@ -11,6 +11,7 @@
 #include "ui/base/l10n/l10n_util.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/compositor/layer.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/view.h"
 #include "ui/views/widget/widget.h"
 
@@ -19,6 +20,10 @@ namespace brave_ads {
 NotificationAdView::NotificationAdView(const NotificationAd& notification_ad)
     : notification_ad_(notification_ad) {
   CreateView();
+
+  GetViewAccessibility().SetRole(ax::mojom::Role::kGenericContainer);
+  GetViewAccessibility().SetRoleDescription(
+      l10n_util::GetStringUTF8(IDS_BRAVE_ADS_NOTIFICATION_AD_ACCESSIBLE_NAME));
 }
 
 NotificationAdView::~NotificationAdView() = default;
@@ -39,19 +44,6 @@ void NotificationAdView::OnCloseButtonPressed() {
   is_closing_ = true;
 
   NotificationAdPopupHandler::Close(notification_ad_.id(), /*by_user*/ true);
-}
-
-void NotificationAdView::GetAccessibleNodeData(ui::AXNodeData* node_data) {
-  node_data->role = ax::mojom::Role::kGenericContainer;
-  node_data->AddStringAttribute(
-      ax::mojom::StringAttribute::kRoleDescription,
-      l10n_util::GetStringUTF8(IDS_BRAVE_ADS_NOTIFICATION_AD_ACCESSIBLE_NAME));
-
-  if (accessible_name_.empty()) {
-    node_data->SetNameFrom(ax::mojom::NameFrom::kAttributeExplicitlyEmpty);
-  }
-
-  node_data->SetName(accessible_name_);
 }
 
 void NotificationAdView::OnDeviceScaleFactorChanged(
@@ -88,6 +80,16 @@ void NotificationAdView::MaybeNotifyAccessibilityEvent() {
   accessible_name_ = accessible_name;
 
   NotifyAccessibilityEvent(ax::mojom::Event::kTextChanged, true);
+  UpdateAccessibleName();
+}
+
+void NotificationAdView::UpdateAccessibleName() {
+  if (accessible_name_.empty()) {
+    GetViewAccessibility().SetName(
+        "", ax::mojom::NameFrom::kAttributeExplicitlyEmpty);
+  } else {
+    GetViewAccessibility().SetName(accessible_name_);
+  }
 }
 
 BEGIN_METADATA(NotificationAdView)

--- a/browser/ui/views/brave_ads/notification_ad_view.h
+++ b/browser/ui/views/brave_ads/notification_ad_view.h
@@ -34,7 +34,6 @@ class NotificationAdView : public views::View {
   void OnCloseButtonPressed();
 
   // views::View:
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
   void OnDeviceScaleFactorChanged(float old_device_scale_factor,
                                   float new_device_scale_factor) override;
   void OnThemeChanged() override;
@@ -48,6 +47,7 @@ class NotificationAdView : public views::View {
 
   std::u16string accessible_name_;
   void MaybeNotifyAccessibilityEvent();
+  void UpdateAccessibleName();
 };
 
 }  // namespace brave_ads

--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -27,6 +27,7 @@
 #include "ui/gfx/geometry/vector2d.h"
 #include "ui/gfx/skia_paint_util.h"
 #include "ui/native_theme/native_theme.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/border.h"
 #include "ui/views/layout/box_layout.h"
 #include "ui/views/widget/widget.h"
@@ -63,6 +64,10 @@ namespace brave_tooltips {
 BraveTooltipPopup::BraveTooltipPopup(std::unique_ptr<BraveTooltip> tooltip)
     : tooltip_(std::move(tooltip)) {
   CreatePopup();
+
+  GetViewAccessibility().SetRole(ax::mojom::Role::kAlertDialog);
+  GetViewAccessibility().SetRoleDescription(l10n_util::GetStringUTF8(
+      IDS_BRAVE_TOOLTIPS_BRAVE_TOOLTIP_ACCESSIBLE_NAME));
 
   NotifyAccessibilityEvent(ax::mojom::Event::kAlert, true);
 
@@ -147,12 +152,6 @@ void BraveTooltipPopup::OnDisplayMetricsChanged(const display::Display& display,
                                                 uint32_t changed_metrics) {
   // Called when the metrics of a display change
   RecomputeAlignment();
-}
-
-void BraveTooltipPopup::GetAccessibleNodeData(ui::AXNodeData* node_data) {
-  node_data->role = ax::mojom::Role::kAlertDialog;
-  node_data->SetName(l10n_util::GetStringUTF8(
-      IDS_BRAVE_TOOLTIPS_BRAVE_TOOLTIP_ACCESSIBLE_NAME));
 }
 
 void BraveTooltipPopup::OnDisplayChanged() {

--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.h
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.h
@@ -98,7 +98,6 @@ class BraveTooltipPopup : public views::WidgetDelegateView,
                                uint32_t changed_metrics) override;
 
   // views::WidgetDelegateView:
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
   void OnDisplayChanged() override;
   void OnWorkAreaChanged() override;
   void OnPaintBackground(gfx::Canvas* canvas) override;

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.cc
@@ -23,6 +23,7 @@
 #include "ui/gfx/geometry/vector2d.h"
 #include "ui/gfx/paint_vector_icon.h"
 #include "ui/native_theme/native_theme.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/background.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/button/button.h"
@@ -91,23 +92,13 @@ BraveTooltipView::BraveTooltipView(
     : tooltip_popup_(tooltip_popup), tooltip_attributes_(tooltip_attributes) {
   SetSize(kTooltipSize);
   CreateView();
+
+  GetViewAccessibility().SetRole(ax::mojom::Role::kGenericContainer);
+  GetViewAccessibility().SetRoleDescription(l10n_util::GetStringUTF8(
+      IDS_BRAVE_TOOLTIPS_BRAVE_TOOLTIP_ACCESSIBLE_NAME));
 }
 
 BraveTooltipView::~BraveTooltipView() = default;
-
-void BraveTooltipView::GetAccessibleNodeData(ui::AXNodeData* node_data) {
-  node_data->role = ax::mojom::Role::kGenericContainer;
-  node_data->AddStringAttribute(
-      ax::mojom::StringAttribute::kRoleDescription,
-      l10n_util::GetStringUTF8(
-          IDS_BRAVE_TOOLTIPS_BRAVE_TOOLTIP_ACCESSIBLE_NAME));
-
-  if (accessible_name_.empty()) {
-    node_data->SetNameFrom(ax::mojom::NameFrom::kAttributeExplicitlyEmpty);
-  }
-
-  node_data->SetName(accessible_name_);
-}
 
 bool BraveTooltipView::OnMousePressed(const ui::MouseEvent& event) {
   initial_mouse_pressed_location_ = event.location();

--- a/browser/ui/views/brave_tooltips/brave_tooltip_view.h
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_view.h
@@ -6,8 +6,6 @@
 #ifndef BRAVE_BROWSER_UI_VIEWS_BRAVE_TOOLTIPS_BRAVE_TOOLTIP_VIEW_H_
 #define BRAVE_BROWSER_UI_VIEWS_BRAVE_TOOLTIPS_BRAVE_TOOLTIP_VIEW_H_
 
-#include <string>
-
 #include "base/memory/raw_ptr.h"
 #include "brave/browser/ui/brave_tooltips/brave_tooltip.h"
 #include "brave/browser/ui/views/brave_tooltips/brave_tooltip_label_button.h"
@@ -45,7 +43,6 @@ class BraveTooltipView : public views::View {
   views::Button* cancel_button_for_testing() const { return cancel_button_; }
 
   // views::InkDropHostView:
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
   bool OnMousePressed(const ui::MouseEvent& event) override;
   bool OnMouseDragged(const ui::MouseEvent& event) override;
   void OnMouseReleased(const ui::MouseEvent& event) override;
@@ -93,8 +90,6 @@ class BraveTooltipView : public views::View {
 
   raw_ptr<views::LabelButton> ok_button_ = nullptr;
   raw_ptr<views::LabelButton> cancel_button_ = nullptr;
-
-  std::u16string accessible_name_;
 };
 
 }  // namespace brave_tooltips

--- a/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
+++ b/browser/ui/views/omnibox/brave_search_conversion_promotion_view.cc
@@ -40,6 +40,7 @@
 #include "ui/gfx/geometry/skia_conversions.h"
 #include "ui/gfx/range/range.h"
 #include "ui/gfx/skia_paint_util.h"
+#include "ui/views/accessibility/view_accessibility.h"
 #include "ui/views/background.h"
 #include "ui/views/cascading_property.h"
 #include "ui/views/controls/button/image_button.h"
@@ -185,17 +186,16 @@ class CloseButton : public views::ImageButton {
   explicit CloseButton(PressedCallback callback = PressedCallback())
       : ImageButton(std::move(callback)) {
     views::ConfigureVectorImageButton(this);
+
+    // Although this appears visually as a button, expose as a list box option
+    // so that it matches the other options within its list box container.
+    GetViewAccessibility().SetRole(ax::mojom::Role::kListBoxOption);
+    GetViewAccessibility().SetRoleDescription(
+        brave_l10n::GetLocalizedResourceUTF16String(
+            IDS_ACC_BRAVE_SEARCH_CONVERSION_DISMISS_BUTTON));
   }
   CloseButton(const CloseButton&) = delete;
   CloseButton& operator=(const CloseButton&) = delete;
-
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override {
-    // Although this appears visually as a button, expose as a list box option
-    // so that it matches the other options within its list box container.
-    node_data->role = ax::mojom::Role::kListBoxOption;
-    node_data->SetName(brave_l10n::GetLocalizedResourceUTF16String(
-        IDS_ACC_BRAVE_SEARCH_CONVERSION_DISMISS_BUTTON));
-  }
 };
 
 BEGIN_METADATA(CloseButton)

--- a/browser/ui/views/rounded_separator.cc
+++ b/browser/ui/views/rounded_separator.cc
@@ -17,9 +17,16 @@
 #include "ui/color/color_provider.h"
 #include "ui/gfx/canvas.h"
 #include "ui/native_theme/native_theme.h"
+#include "ui/views/accessibility/view_accessibility.h"
 
 // static
-RoundedSeparator::RoundedSeparator() = default;
+RoundedSeparator::RoundedSeparator() {
+  // A valid role must be set in the AXNodeData prior to setting the name
+  // via AXNodeData::SetName.
+  GetViewAccessibility().SetRole(ax::mojom::Role::kSplitter);
+  GetViewAccessibility().SetName(
+      l10n_util::GetStringUTF8(IDS_ACCNAME_SEPARATOR));
+}
 
 RoundedSeparator::~RoundedSeparator() = default;
 
@@ -42,13 +49,6 @@ gfx::Size RoundedSeparator::CalculatePreferredSize(
   gfx::Insets insets = GetInsets();
   size.Enlarge(insets.width(), insets.height());
   return size;
-}
-
-void RoundedSeparator::GetAccessibleNodeData(ui::AXNodeData* node_data) {
-  // A valid role must be set in the AXNodeData prior to setting the name
-  // via AXNodeData::SetName.
-  node_data->role = ax::mojom::Role::kSplitter;
-  node_data->SetName(l10n_util::GetStringUTF8(IDS_ACCNAME_SEPARATOR));
 }
 
 void RoundedSeparator::OnPaint(gfx::Canvas* canvas) {

--- a/browser/ui/views/rounded_separator.h
+++ b/browser/ui/views/rounded_separator.h
@@ -33,7 +33,6 @@ class RoundedSeparator : public views::View {
   // Overridden from View:
   gfx::Size CalculatePreferredSize(
       const views::SizeBounds& available_size) const override;
-  void GetAccessibleNodeData(ui::AXNodeData* node_data) override;
   void OnPaint(gfx::Canvas* canvas) override;
 
  private:


### PR DESCRIPTION
This method has been deprecated for a while as part of the larger ViewsAX refactoring taking place in Chromium. This change migrates all the uses of it to make use of the `ViewAccessibility` instance.

Chromium change:
https://chromium.googlesource.com/chromium/src/+/b7347c9b6d4fc58e790cae845be3750662a0ff40

```
commit b7347c9b6d4fc58e790cae845be3750662a0ff40
Author: Ragvesh Sharma <ragsharma@microsoft.com>
Date:   Wed Feb 5 10:24:10 2025 -0800

    [views-ax] Remove `View::GetAccessibleNodeData()` method

    This CL removes the View::GetAccessibleNodeData() method
    as part of the ongoing ViewsAX project.

    This CL is part of the ViewsAX project:
    https://docs.google.com/document/d/1Ku7HOyDsiZem1yaV6ccZ-tz3lO2XR2NEcm8HjR6d-VY/edit#heading=h.ke1u3utej413

    Bug: 325137417
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

