### PR TITLE
feat(wallet): Prompt Select Account for Swap or Bridge from Portfolio

### DIFF
--- a/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
@@ -46,7 +46,7 @@ import {
   ButtonIcon
 } from './wellet-menus.style'
 
-const coinSupportsSwap = (coin: BraveWallet.CoinType) => {
+const coinSupportsSwapOrBridge = (coin: BraveWallet.CoinType) => {
   return [BraveWallet.CoinType.ETH, BraveWallet.CoinType.SOL].includes(coin)
 }
 
@@ -86,7 +86,7 @@ export const AssetItemMenu = (props: Props) => {
     return new Amount(assetBalance).isZero()
   }, [assetBalance])
 
-  const isSwapSupported = coinSupportsSwap(asset.coin) && account !== undefined
+  const isSwapOrBridgeSupported = coinSupportsSwapOrBridge(asset.coin)
 
   const isSellSupported = React.useMemo(() => {
     return account !== undefined && checkIsAssetSellSupported(asset)
@@ -103,17 +103,18 @@ export const AssetItemMenu = (props: Props) => {
     history.push(makeSendRoute(asset, account))
   }, [account, history, asset])
 
-  const onClickSwap = React.useCallback(() => {
-    if (account) {
+  const onClickSwapOrBridge = React.useCallback(
+    (routeType: 'swap' | 'bridge') => {
       history.push(
         makeSwapOrBridgeRoute({
           fromToken: asset,
           fromAccount: account,
-          routeType: 'swap'
+          routeType
         })
       )
-    }
-  }, [account, history, asset])
+    },
+    [account, history, asset]
+  )
 
   const onClickDeposit = React.useCallback(() => {
     history.push(makeDepositFundsRoute(getAssetIdKey(asset)))
@@ -151,11 +152,17 @@ export const AssetItemMenu = (props: Props) => {
           <PopupButtonText>{getLocale('braveWalletSend')}</PopupButtonText>
         </PopupButton>
       )}
-      {isSwapSupported && !isAssetsBalanceZero && (
-        <PopupButton onClick={onClickSwap}>
-          <ButtonIcon name='currency-exchange' />
-          <PopupButtonText>{getLocale('braveWalletSwap')}</PopupButtonText>
-        </PopupButton>
+      {isSwapOrBridgeSupported && (
+        <>
+          <PopupButton onClick={() => onClickSwapOrBridge('swap')}>
+            <ButtonIcon name='currency-exchange' />
+            <PopupButtonText>{getLocale('braveWalletSwap')}</PopupButtonText>
+          </PopupButton>
+          <PopupButton onClick={() => onClickSwapOrBridge('bridge')}>
+            <ButtonIcon name='web3-bridge' />
+            <PopupButtonText>{getLocale('braveWalletBridge')}</PopupButtonText>
+          </PopupButton>
+        </>
       )}
       <PopupButton onClick={onClickDeposit}>
         <ButtonIcon name='money-bag-coins' />

--- a/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
+++ b/components/brave_wallet_ui/page/screens/composer_ui/select_token_modal/select_token_modal.tsx
@@ -632,23 +632,33 @@ export const SelectTokenModal = React.forwardRef<HTMLDivElement, Props>(
       [accounts, checkIsAccountOptionDisabled]
     )
 
+    const clearParams = React.useCallback(() => {
+      history.replace(
+        modalType === 'send'
+          ? WalletRoutes.Send
+          : modalType === 'bridge'
+          ? WalletRoutes.Bridge
+          : WalletRoutes.Swap
+      )
+    }, [modalType, history])
+
     const handleOnClose = React.useCallback(() => {
       // Ensure we clear route params if an account is not selected
       // to prevent a broken state.
-      if (needsAccount && modalType === 'send') {
-        history.replace(WalletRoutes.Send)
+      if (needsAccount) {
+        clearParams()
       }
       onClose()
-    }, [modalType, needsAccount, history, onClose])
+    }, [clearParams, needsAccount, onClose])
 
     const handleOnBack = React.useCallback(() => {
       // Clears route params if an account is not selected
       // and user clicks back.
-      if (needsAccount && modalType === 'send') {
-        history.replace(WalletRoutes.Send)
+      if (needsAccount) {
+        clearParams()
       }
       setPendingSelectedAssetState(undefined)
-    }, [modalType, needsAccount, history])
+    }, [clearParams, needsAccount])
 
     // Computed & Memos
     const emptyTokensList =

--- a/components/brave_wallet_ui/page/screens/swap/swap.tsx
+++ b/components/brave_wallet_ui/page/screens/swap/swap.tsx
@@ -90,7 +90,8 @@ export const Swap = () => {
     timeUntilNextQuote,
     selectedProvider,
     availableProvidersForSwap,
-    isSubmittingSwap
+    isSubmittingSwap,
+    needsAccountSelected
   } = swap
 
   // State
@@ -272,6 +273,7 @@ export const Swap = () => {
           }
           modalType={isBridge ? 'bridge' : 'swap'}
           selectedSendOption='#token'
+          needsAccount={needsAccountSelected}
         />
       )}
       {showPrivacyModal && (


### PR DESCRIPTION
## Description 

We will now prompt to select an `Account` when a user clicks `Swap` or `Bridge` for an asset on the `Portfolio` and their portfolio is not grouped by `Accounts`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43441>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the Wallet and navigate to the `Portfolio` screen
2. Group your assets by `None` or `Networks`
3. Click the `More Menu` for an asset and click `Swap` or `Bridge`
4. It should navigate to the `Swap` or `Bridge` screen and prompt you to select an `Account` to `Swap` or `Bridge` from.
5. If you close the `Select Account` modal, params will be cleared and nothing will be selected.
6. If you click `Back` on the `Select Account` modal, params will be cleared and you can make a new selection.
7. If you have your `Portfolio` grouped by `Accounts` and you click `Swap` or `Bridge` for an asset, the associated account will be automatically selected on the `Swap` or `Bridge` screen.

https://github.com/user-attachments/assets/fcea91a6-71a9-4c84-af6e-6637259982e2
