### PR TITLE
[Rewards 3.0] Fix custodial-related strings

### DIFF
--- a/browser/ui/webui/brave_rewards/rewards_page_data_source.cc
+++ b/browser/ui/webui/brave_rewards/rewards_page_data_source.cc
@@ -233,7 +233,6 @@ static constexpr webui::LocalizedString kStrings[] = {
     {"onboardingTitle", IDS_REWARDS_ONBOARDING_TITLE},
     {"payoutAccountBalanceLabel", IDS_REWARDS_PAYOUT_ACCOUNT_BALANCE_LABEL},
     {"payoutAccountConnectedLabel", IDS_REWARDS_PAYOUT_ACCOUNT_CONNECTED_LABEL},
-    {"payoutAccountDetailsTitle", IDS_REWARDS_PAYOUT_ACCOUNT_DETAILS_TITLE},
     {"payoutAccountLabel", IDS_REWARDS_PAYOUT_ACCOUNT_LABEL},
     {"payoutAccountLink", IDS_REWARDS_PAYOUT_ACCOUNT_LINK},
     {"payoutAccountLoggedOutTitle",

--- a/components/brave_rewards/resources/rewards_page/components/home/payout_account_card.tsx
+++ b/components/brave_rewards/resources/rewards_page/components/home/payout_account_card.tsx
@@ -138,11 +138,7 @@ export function PayoutAccountCard() {
           <div className='provider'>
             <WalletProviderIcon provider={externalWallet.provider} />
             <span className='provider-name'>
-              {
-                formatMessage(getString('payoutAccountDetailsTitle'), [
-                  providerName
-                ])
-              }
+              {providerName}
             </span>
             <Label color='green'>
               <Icon name='check-circle-outline' slot='icon-before' />

--- a/components/brave_rewards/resources/rewards_page/lib/locale_strings.ts
+++ b/components/brave_rewards/resources/rewards_page/lib/locale_strings.ts
@@ -161,7 +161,6 @@ export type StringKey =
   'onboardingTitle' |
   'payoutAccountBalanceLabel' |
   'payoutAccountConnectedLabel' |
-  'payoutAccountDetailsTitle' |
   'payoutAccountLabel' |
   'payoutAccountLink' |
   'payoutAccountLoggedOutTitle' |

--- a/components/brave_rewards/resources/rewards_page/stories/storybook_strings.ts
+++ b/components/brave_rewards/resources/rewards_page/stories/storybook_strings.ts
@@ -159,7 +159,6 @@ export const localeStrings: { [K in StringKey]: string }  = {
   onboardingTitle: 'Turn on Brave Rewards',
   payoutAccountBalanceLabel: 'Your balance',
   payoutAccountConnectedLabel: 'Connected',
-  payoutAccountDetailsTitle: '$1 wallet',
   payoutAccountLabel: 'Payout account',
   payoutAccountLink: 'Go to my account',
   payoutAccountLoggedOutTitle: 'Logged Out',

--- a/components/resources/rewards_strings.grdp
+++ b/components/resources/rewards_strings.grdp
@@ -627,7 +627,7 @@
     It's possible your profile was flagged in error, and no immediate action is required on your part. The flag on your profile may be removed in the future.
   </message>
   <message name="IDS_REWARDS_AUTHORIZE_FLAGGED_WALLET_TEXT_4" desc="">
-    <ph name="BEGIN_LINK">$2</ph>Learn more about Brave's process for flagging Rewards profiles.<ph name="END_LINK">$3</ph>
+    Learn more about Brave's process for flagging Rewards profiles.
   </message>
   <message name="IDS_REWARDS_AUTHORIZE_FLAGGED_WALLET_TITLE" desc="">
     Brave Rewards profile is flagged
@@ -793,9 +793,6 @@
   </message>
   <message name="IDS_REWARDS_PAYOUT_ACCOUNT_CONNECTED_LABEL" desc="">
     Connected
-  </message>
-  <message name="IDS_REWARDS_PAYOUT_ACCOUNT_DETAILS_TITLE" desc="">
-    <ph name="PROVIDER">$1</ph> wallet
   </message>
   <message name="IDS_REWARDS_PAYOUT_ACCOUNT_LABEL" desc="">
     Payout account


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43714
Resolves https://github.com/brave/brave-browser/issues/43698

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

