### PR TITLE
feat(wallet): Buy Send Swap Bridge Deposit Asset Detail Buttons

### DIFF
--- a/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_asset_action_button/portfolio_asset_action_button.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/components/portfolio_asset_action_button/portfolio_asset_action_button.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Icon from '@brave/leo/react/icon'
+import Button from '@brave/leo/react/button'
+
+// Styled Components
+import { Column, Text } from '../../../../../shared/style'
+
+interface Props {
+  text: string
+  icon: string
+  onClick: () => void
+}
+
+export const PortfolioAssetActionButton = (props: Props) => {
+  const { text, icon, onClick } = props
+
+  return (
+    <Column gap='4px'>
+      <Button
+        fab={true}
+        onClick={onClick}
+      >
+        <Icon name={icon} />
+      </Button>
+      <Text
+        textSize='12px'
+        isBold={true}
+        textColor='primary'
+      >
+        {text}
+      </Text>
+    </Column>
+  )
+}

--- a/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
+++ b/components/brave_wallet_ui/components/desktop/views/portfolio/style.ts
@@ -79,7 +79,7 @@ export const ButtonRow = styled.div<{
   margin: ${(p) => (p.noMargin ? '0px' : '20px 0px')};
   padding: 0px
     ${(p) => (p.horizontalPadding !== undefined ? p.horizontalPadding : 0)}px;
-  gap: 10px;
+  gap: 12px;
 `
 
 export const BalanceRow = styled.div<{ gap?: string }>`

--- a/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
+++ b/components/brave_wallet_ui/components/desktop/wallet-menus/asset-item-menu.tsx
@@ -31,7 +31,10 @@ import {
   makeSendRoute,
   makeSwapOrBridgeRoute
 } from '../../../utils/routes-utils'
-import { getAssetIdKey } from '../../../utils/asset-utils'
+import {
+  getAssetIdKey,
+  getDoesCoinSupportSwapOrBridge
+} from '../../../utils/asset-utils'
 
 // Components
 import {
@@ -45,10 +48,6 @@ import {
   PopupButtonText,
   ButtonIcon
 } from './wellet-menus.style'
-
-const coinSupportsSwapOrBridge = (coin: BraveWallet.CoinType) => {
-  return [BraveWallet.CoinType.ETH, BraveWallet.CoinType.SOL].includes(coin)
-}
 
 interface Props {
   asset: BraveWallet.BlockchainToken
@@ -86,7 +85,7 @@ export const AssetItemMenu = (props: Props) => {
     return new Amount(assetBalance).isZero()
   }, [assetBalance])
 
-  const isSwapOrBridgeSupported = coinSupportsSwapOrBridge(asset.coin)
+  const isSwapOrBridgeSupported = getDoesCoinSupportSwapOrBridge(asset.coin)
 
   const isSellSupported = React.useMemo(() => {
     return account !== undefined && checkIsAssetSellSupported(asset)

--- a/components/brave_wallet_ui/utils/asset-utils.ts
+++ b/components/brave_wallet_ui/utils/asset-utils.ts
@@ -569,3 +569,7 @@ export function getCoinTypeName(coin: BraveWallet.CoinType) {
   }
   return ''
 }
+
+export const getDoesCoinSupportSwapOrBridge = (coin: BraveWallet.CoinType) => {
+  return [BraveWallet.CoinType.ETH, BraveWallet.CoinType.SOL].includes(coin)
+}


### PR DESCRIPTION
## Description 

Will now always display the `Buy, Send, Swap, Bridge, Deposit` buttons on the `Asset Details` screen if supported for that asset.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43198>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open the `Wallet` and navigate to the `Portfolio` screen
2. Click on an asset to view it's details
3. You should see the `Buy, Send, Swap, Bridge, Deposit` buttons.
4. Some buttons may not be available if that asset does not support the action.

![Screenshot 40](https://github.com/user-attachments/assets/8efc1ea8-4582-4fc2-9361-0255365d88dc)
