### PR TITLE
Add more brave.adblock traces

### DIFF
--- a/components/brave_component_updater/browser/dat_file_util.cc
+++ b/components/brave_component_updater/browser/dat_file_util.cc
@@ -35,21 +35,24 @@ void GetDATFileData(const base::FilePath& file_path,
 namespace brave_component_updater {
 
 DATFileDataBuffer ReadDATFileData(const base::FilePath& dat_file_path) {
-  TRACE_EVENT_BEGIN1("brave.adblock", "ReadDATFileData", "path",
-                     dat_file_path.MaybeAsASCII());
+  TRACE_EVENT_BEGIN("brave.adblock", "ReadDATFileData", "path",
+                    dat_file_path.MaybeAsASCII());
   DATFileDataBuffer buffer;
   GetDATFileData(dat_file_path, &buffer);
-  TRACE_EVENT_END1("brave.adblock", "ReadDATFileData", "size", buffer.size());
+  TRACE_EVENT_END("brave.adblock", "size", buffer.size());
   return buffer;
 }
 
 std::string GetDATFileAsString(const base::FilePath& file_path) {
+  TRACE_EVENT_BEGIN("brave.adblock", "GetDATFileAsString", "path",
+                    file_path.MaybeAsASCII());
   std::string contents;
   bool success = base::ReadFileToString(file_path, &contents);
   if (!success || contents.empty()) {
     LOG(ERROR) << "GetDATFileAsString: cannot "
                << "read dat file " << file_path;
   }
+  TRACE_EVENT_END("brave.adblock", "size", contents.size());
   return contents;
 }
 

--- a/components/brave_shields/content/browser/ad_block_custom_filters_provider.cc
+++ b/components/brave_shields/content/browser/ad_block_custom_filters_provider.cc
@@ -10,8 +10,10 @@
 #include <utility>
 #include <vector>
 
+#include "base/rand_util.h"
 #include "base/strings/string_tokenizer.h"
 #include "base/task/single_thread_task_runner.h"
+#include "base/trace_event/trace_event.h"
 #include "brave/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
@@ -23,7 +25,10 @@ namespace {
 
 void AddDATBufferToFilterSet(uint8_t permission_mask,
                              DATFileDataBuffer buffer,
+                             uint64_t flow_id,
                              rust::Box<adblock::FilterSet>* filter_set) {
+  TRACE_EVENT("brave.adblock", "AddDATBufferToFilterSet_CustomFiltersProvider",
+              perfetto::TerminatingFlow::ProcessScoped(flow_id));
   (*filter_set)->add_filter_list_with_permissions(buffer, permission_mask);
 }
 
@@ -113,6 +118,9 @@ bool AdBlockCustomFiltersProvider::UpdateCustomFiltersFromSettings(
 void AdBlockCustomFiltersProvider::LoadFilterSet(
     base::OnceCallback<
         void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb) {
+  const uint64_t flow_id = base::RandUint64();
+  TRACE_EVENT("brave.adblock", "AdBlockCustomFiltersProvider::LoadFilterSet",
+              perfetto::TerminatingFlow::ProcessScoped(flow_id));
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   auto custom_filters = GetCustomFilters();
 
@@ -121,10 +129,10 @@ void AdBlockCustomFiltersProvider::LoadFilterSet(
 
   // PostTask so this has an async return to match other loaders
   base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
-      FROM_HERE,
-      base::BindOnce(std::move(cb),
-                     base::BindOnce(&AddDATBufferToFilterSet,
-                                    kCustomFiltersPermissionLevel, buffer)));
+      FROM_HERE, base::BindOnce(std::move(cb),
+                                base::BindOnce(&AddDATBufferToFilterSet,
+                                               kCustomFiltersPermissionLevel,
+                                               buffer, flow_id)));
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/content/browser/ad_block_engine.cc
+++ b/components/brave_shields/content/browser/ad_block_engine.cc
@@ -265,6 +265,8 @@ void AdBlockEngine::UpdateAdBlockClient(
     rust::Box<adblock::Engine> ad_block_client,
     const std::string& resources_json) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  TRACE_EVENT("brave.adblock", "UpdateAdBlockClient");
   ad_block_client_ = std::move(ad_block_client);
   if (regex_discard_policy_) {
     ad_block_client_->set_regex_discard_policy(*regex_discard_policy_);
@@ -289,12 +291,12 @@ void AdBlockEngine::OnFilterSetLoaded(rust::Box<adblock::FilterSet> filter_set,
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   base::ElapsedTimer timer;
-  TRACE_EVENT_BEGIN1("brave.adblock", "MakeEngineWithRules",
-                     "is_default_engine", is_default_engine_);
+  TRACE_EVENT_BEGIN("brave.adblock", "MakeEngineWithRules", "is_default_engine",
+                    is_default_engine_);
 
   auto result = adblock::engine_from_filter_set(std::move(filter_set));
 
-  TRACE_EVENT_END0("brave.adblock", "MakeEngineWithRules");
+  TRACE_EVENT_END("brave.adblock");
   if (is_default_engine_) {
     base::UmaHistogramTimes("Brave.Adblock.MakeEngineWithRules.Default",
                             timer.Elapsed());
@@ -316,12 +318,12 @@ void AdBlockEngine::OnListSourceLoaded(const DATFileDataBuffer& filters,
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   base::ElapsedTimer timer;
-  TRACE_EVENT_BEGIN2("brave.adblock", "MakeEngineWithRules", "size",
-                     filters.size(), "is_default_engine", is_default_engine_);
+  TRACE_EVENT_BEGIN("brave.adblock", "MakeEngineWithRules", "size",
+                    filters.size(), "is_default_engine", is_default_engine_);
 
   auto result = adblock::engine_with_rules(filters);
 
-  TRACE_EVENT_END0("brave.adblock", "MakeEngineWithRules");
+  TRACE_EVENT_END("brave.adblock");
   if (is_default_engine_) {
     base::UmaHistogramTimes("Brave.Adblock.MakeEngineWithRules.Default",
                             timer.Elapsed());
@@ -348,13 +350,13 @@ void AdBlockEngine::OnDATLoaded(const DATFileDataBuffer& dat_buf,
   }
 
   base::ElapsedTimer timer;
-  TRACE_EVENT_BEGIN2("brave.adblock", "EngineDeserialize", "size",
-                     dat_buf.size(), "is_default_engine", is_default_engine_);
+  TRACE_EVENT_BEGIN("brave.adblock", "EngineDeserialize", "size",
+                    dat_buf.size(), "is_default_engine", is_default_engine_);
 
   auto client = adblock::new_engine();
   const auto result = client->deserialize(dat_buf);
 
-  TRACE_EVENT_END0("brave.adblock", "EngineDeserialize");
+  TRACE_EVENT_END("brave.adblock");
   if (is_default_engine_) {
     base::UmaHistogramTimes("Brave.Adblock.EngineDeserialize.Default",
                             timer.Elapsed());

--- a/components/brave_shields/content/browser/ad_block_subscription_filters_provider.h
+++ b/components/brave_shields/content/browser/ad_block_subscription_filters_provider.h
@@ -10,6 +10,7 @@
 
 #include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
+#include "base/trace_event/trace_event.h"
 #include "brave/components/brave_component_updater/browser/dat_file_util.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider.h"
 
@@ -46,6 +47,7 @@ class AdBlockSubscriptionFiltersProvider : public AdBlockFiltersProvider {
   void OnDATFileDataReady(
       base::OnceCallback<
           void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb,
+      const perfetto::Flow& flow,
       const DATFileDataBuffer& dat_buf);
 
   std::string GetNameForDebugging() override;

--- a/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_component_filters_provider.cc
@@ -11,7 +11,9 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/rand_util.h"
 #include "base/task/thread_pool.h"
+#include "base/trace_event/trace_event.h"
 #include "brave/components/brave_shields/core/browser/ad_block_component_installer.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
@@ -29,7 +31,10 @@ void AddNothingToFilterSet(rust::Box<adblock::FilterSet>*) {}
 // static
 void AddDATBufferToFilterSet(uint8_t permission_mask,
                              DATFileDataBuffer buffer,
+                             const perfetto::Flow& flow,
                              rust::Box<adblock::FilterSet>* filter_set) {
+  TRACE_EVENT("brave.adblock",
+              "AddDATBufferToFilterSet_AdBlockComponentFiltersProvider", flow);
   (*filter_set)->add_filter_list_with_permissions(buffer, permission_mask);
 }
 
@@ -38,9 +43,12 @@ void OnReadDATFileData(
     base::OnceCallback<
         void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb,
     uint8_t permission_mask,
+    const perfetto::Flow& flow,
     DATFileDataBuffer buffer) {
+  TRACE_EVENT("brave.adblock",
+              "OnReadDATFileData_AdBlockComponentFiltersProvider", flow);
   std::move(cb).Run(
-      base::BindOnce(&AddDATBufferToFilterSet, permission_mask, buffer));
+      base::BindOnce(&AddDATBufferToFilterSet, permission_mask, buffer, flow));
 }
 
 }  // namespace
@@ -58,6 +66,9 @@ AdBlockComponentFiltersProvider::AdBlockComponentFiltersProvider(
       component_updater_service_(cus) {
   // Can be nullptr in unit tests
   if (cus) {
+    TRACE_EVENT("brave.adblock", "AdBlockComponentFiltersProvider::Register",
+                perfetto::Flow::FromPointer(this), "component_id",
+                component_id_);
     RegisterAdBlockFiltersComponent(
         cus, base64_public_key, component_id_, title,
         base::BindRepeating(&AdBlockComponentFiltersProvider::OnComponentReady,
@@ -91,6 +102,9 @@ void AdBlockComponentFiltersProvider::UnregisterComponent() {
 
 void AdBlockComponentFiltersProvider::OnComponentReady(
     const base::FilePath& path) {
+  TRACE_EVENT(
+      "brave.adblock", "AdBlockComponentFiltersProvider::OnComponentReady",
+      perfetto::TerminatingFlow::FromPointer(this), "path", path.value());
   base::FilePath old_path = component_path_;
   component_path_ = path;
 
@@ -121,6 +135,10 @@ void AdBlockComponentFiltersProvider::LoadFilterSet(
         void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb) {
   base::FilePath list_file_path = GetFilterSetPath();
 
+  const auto flow = perfetto::Flow::ProcessScoped(base::RandUint64());
+  TRACE_EVENT("brave.adblock", "AdBlockComponentFiltersProvider::LoadFilterSet",
+              flow);
+
   if (list_file_path.empty()) {
     // If the path is not ready yet, provide a no-op callback immediately. An
     // update will be pushed later to notify about the newly available list.
@@ -131,7 +149,8 @@ void AdBlockComponentFiltersProvider::LoadFilterSet(
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock()},
       base::BindOnce(&brave_component_updater::ReadDATFileData, list_file_path),
-      base::BindOnce(&OnReadDATFileData, std::move(cb), permission_mask_));
+      base::BindOnce(&OnReadDATFileData, std::move(cb), permission_mask_,
+                     flow));
 }
 
 }  // namespace brave_shields

--- a/components/brave_shields/core/browser/ad_block_filter_list_catalog_provider.cc
+++ b/components/brave_shields/core/browser/ad_block_filter_list_catalog_provider.cc
@@ -10,6 +10,7 @@
 
 #include "base/files/file_path.h"
 #include "base/task/thread_pool.h"
+#include "base/trace_event/trace_event.h"
 #include "brave/components/brave_shields/core/browser/ad_block_component_installer.h"
 
 constexpr char kListCatalogFile[] = "list_catalog.json";
@@ -18,6 +19,8 @@ namespace brave_shields {
 
 AdBlockFilterListCatalogProvider::AdBlockFilterListCatalogProvider(
     component_updater::ComponentUpdateService* cus) {
+  TRACE_EVENT("brave.adblock", "RegisterAdBlockFilterListCatalogComponent",
+              perfetto::Flow::FromPointer(this));
   // Can be nullptr in unit tests
   if (cus) {
     RegisterAdBlockFilterListCatalogComponent(
@@ -41,6 +44,10 @@ void AdBlockFilterListCatalogProvider::RemoveObserver(
 
 void AdBlockFilterListCatalogProvider::OnFilterListCatalogLoaded(
     const std::string& catalog_json) {
+  TRACE_EVENT("brave.adblock",
+              "AdBlockFilterListCatalogProvider::OnFilterListCatalogLoaded",
+              perfetto::TerminatingFlow::FromPointer(this), "catalog_json_size",
+              catalog_json.size());
   for (auto& observer : observers_) {
     observer.OnFilterListCatalogLoaded(catalog_json);
   }
@@ -48,6 +55,9 @@ void AdBlockFilterListCatalogProvider::OnFilterListCatalogLoaded(
 
 void AdBlockFilterListCatalogProvider::OnComponentReady(
     const base::FilePath& path) {
+  TRACE_EVENT("brave.adblock",
+              "AdBlockFilterListCatalogProvider::OnComponentReady",
+              perfetto::Flow::FromPointer(this), "path", path.value());
   component_path_ = path;
 
   // Load the filter list catalog (as a string)

--- a/components/brave_shields/core/browser/ad_block_filters_provider_manager.h
+++ b/components/brave_shields/core/browser/ad_block_filters_provider_manager.h
@@ -67,6 +67,7 @@ class AdBlockFiltersProviderManager : public AdBlockFiltersProvider,
   void FinishCombinating(
       base::OnceCallback<
           void(base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>)> cb,
+      uint64_t flow_id,
       std::vector<base::OnceCallback<void(rust::Box<adblock::FilterSet>*)>>
           results);
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
For https://github.com/brave/brave-browser/issues/43858

The PR adds extra traces to adblock code to highlight startup delays.
An example how it looks like:

![image](https://github.com/user-attachments/assets/9b7d811e-6010-433c-9d35-b188091f4cc8)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

