### PR TITLE
feat(wallet): Zcash Sync Warning in Accounts List

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
@@ -12,6 +12,7 @@ import { layoutPanelWidth } from '../wallet-page-wrapper/wallet-page-wrapper.sty
 
 export const StyledWrapper = styled.div<{
   isRewardsAccount: boolean
+  isOutOfSync: boolean
 }>`
   cursor: ${(p) => (p.isRewardsAccount ? 'default' : 'pointer')};
   display: flex;
@@ -21,6 +22,8 @@ export const StyledWrapper = styled.div<{
   width: 100%;
   padding-right: 14px;
   border-bottom: 1px solid ${leo.color.divider.subtle};
+  background-color: ${(p) =>
+    p.isOutOfSync ? leo.color.yellow[5] : 'transparent'};
   transition: background-color 300ms ease-out;
   &:first-child {
     border-radius: ${leo.radius.l} ${leo.radius.l} 0px 0px;
@@ -135,4 +138,11 @@ export const AccountNameWrapper = styled(Row)`
     flex-direction: column;
     align-items: flex-start;
   }
+`
+
+export const WarningIcon = styled(Icon).attrs({
+  name: 'warning-triangle-filled'
+})`
+  --leo-icon-size: 20px;
+  color: ${leo.color.systemfeedback.warningIcon};
 `


### PR DESCRIPTION
## Description 

Will now display an `Out of sync` warning label on the `Account List` item when a shielded `Zcash` account is out of sync.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/43893>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a brand new `Profile` and `Wallet` account and then create a `Zcash` account
2. Shield that account with a `birthday` value of `10000` or less then the current block height. You can find the current block height on https://blockexplorer.one/zcash/mainnet
3. You should see the `Out of sync` warning on the `Accounts List` item
4. Open the `Account Details` and sync the account.
5. After it has complete syncing, go back to the `Accounts` tab
6. There should no longer be an `Out of sync` warning.

![Screenshot 41](https://github.com/user-attachments/assets/61eac9b8-7626-4a9a-8b92-b76a41c6dcea)

https://github.com/user-attachments/assets/973de940-31c4-4470-94ab-bfa66eeaeba4
