### PR TITLE
Revert "Disable SaveImageMultipleTimes browser test on x64"

### DIFF
--- a/browser/ntp_background/custom_background_file_manager_browsertest.cc
+++ b/browser/ntp_background/custom_background_file_manager_browsertest.cc
@@ -15,7 +15,6 @@
 #include "base/threading/thread_restrictions.h"
 #include "brave/browser/ntp_background/constants.h"
 #include "brave/components/constants/brave_paths.h"
-#include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/test/base/in_process_browser_test.h"
@@ -112,16 +111,8 @@ IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
   EXPECT_TRUE(base::PathExists(test_file()));
 }
 
-// On Mac x64 CI node we presume this test crashes the whole suite.
-// https://github.com/brave/brave-browser/issues/38988
-#if BUILDFLAG(IS_MAC) && defined(ARCH_CPU_ARM_FAMILY)
-#define MAYBE_SaveImageMultipleTimes SaveImageMultipleTimes
-#else
-#define MAYBE_SaveImageMultipleTimes DISABLED_SaveImageMultipleTimes
-#endif
-
 IN_PROC_BROWSER_TEST_F(CustomBackgroundFileManagerBrowserTest,
-                       MAYBE_SaveImageMultipleTimes) {
+                       SaveImageMultipleTimes) {
   for (int i = 0; i < 3; i++) {
     base::RunLoop run_loop;
     base::FilePath expected_path =


### PR DESCRIPTION
Reverts brave/brave-core#27103

Related https://github.com/brave/brave-browser/issues/38988