### PR TITLE
UI: Update toolbar button and icon sizes for quality

### DIFF
--- a/browser/ui/brave_layout_constants.cc
+++ b/browser/ui/brave_layout_constants.cc
@@ -20,9 +20,9 @@ std::optional<gfx::Insets> GetBraveLayoutInsets(LayoutInset inset) {
     case LOCATION_BAR_PAGE_ACTION_ICON_PADDING:
       return gfx::Insets::VH(4, 4);
     case TOOLBAR_BUTTON:
-      // Use 5 inset - (TOOLBAR_BUTTON_HEIGHT(28) - icon size(18)) / 2
+      // Use 4 inset - (TOOLBAR_BUTTON_HEIGHT(28) - icon size(20)) / 2
       // icon size - ToolbarButton::kDefaultIconSize
-      return gfx::Insets(touch_ui ? 12 : 5);
+      return gfx::Insets(touch_ui ? 12 : 4);
     case TOOLBAR_INTERIOR_MARGIN:
       return touch_ui ? gfx::Insets() : gfx::Insets::VH(4, 8);
     default:
@@ -66,6 +66,7 @@ std::optional<int> GetBraveLayoutConstant(LayoutConstant constant) {
       return 16;
     }
     case TOOLBAR_BUTTON_HEIGHT: {
+      // See also SidebarButtonView::kSidebarButtonSize
       return touch ? 48 : 28;
     }
     case TOOLBAR_CORNER_RADIUS: {

--- a/browser/ui/brave_layout_constants_unittest.cc
+++ b/browser/ui/brave_layout_constants_unittest.cc
@@ -12,7 +12,7 @@ TEST(BraveLayoutConstantsTest, BraveValueTest) {
   ui::MockTouchUiController controller;
   EXPECT_FALSE(controller.touch_ui());
 
-  EXPECT_EQ(gfx::Insets(5), GetLayoutInsets(TOOLBAR_BUTTON));
+  EXPECT_EQ(gfx::Insets(4), GetLayoutInsets(TOOLBAR_BUTTON));
   EXPECT_EQ(28, GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT));
   EXPECT_EQ(4, GetLayoutConstant(LOCATION_BAR_CHILD_CORNER_RADIUS));
   EXPECT_EQ(GetLayoutConstant(LOCATION_BAR_ELEMENT_PADDING),

--- a/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
+++ b/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
@@ -77,9 +77,9 @@ BraveAvatarToolbarButton::BraveAvatarToolbarButton(BrowserView* browser_view)
   // However, avatar button's icon image size is 16.
   // So, set delta insets to make its height to 28.
 #if BUILDFLAG(IS_LINUX)
-  // On linux, only add horizontal delta as its size is 26x28.
+  // Linux requires only 1px vertical padding and 2px horizontal padding.
   // TODO(simonhong): check why it's different from other platforms.
-  SetLayoutInsetDelta(gfx::Insets::VH(0, 4));
+  SetLayoutInsetDelta(gfx::Insets::VH(1, 2));
 #else
   SetLayoutInsetDelta(gfx::Insets(2));
 #endif

--- a/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
+++ b/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
@@ -79,7 +79,7 @@ BraveAvatarToolbarButton::BraveAvatarToolbarButton(BrowserView* browser_view)
 #if BUILDFLAG(IS_LINUX)
   // On linux, only add horizontal delta as its size is 26x28.
   // TODO(simonhong): check why it's different from other platforms.
-  SetLayoutInsetDelta(gfx::Insets::VH(0, 2));
+  SetLayoutInsetDelta(gfx::Insets::VH(0, 4));
 #else
   SetLayoutInsetDelta(gfx::Insets(2));
 #endif

--- a/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
+++ b/browser/ui/views/profiles/brave_avatar_toolbar_button.cc
@@ -73,15 +73,15 @@ class BraveAvatarButtonHighlightPathGenerator
 BraveAvatarToolbarButton::BraveAvatarToolbarButton(BrowserView* browser_view)
     : AvatarToolbarButton(browser_view) {
   // Our toolbar button height is 28.
-  // Icon image size 18 + vertical insets 10(5x2).
+  // Icon image size 20 + vertical insets 8(4x2).
   // However, avatar button's icon image size is 16.
   // So, set delta insets to make its height to 28.
 #if BUILDFLAG(IS_LINUX)
   // On linux, only add horizontal delta as its size is 26x28.
   // TODO(simonhong): check why it's different from other platforms.
-  SetLayoutInsetDelta(gfx::Insets::VH(0, 1));
+  SetLayoutInsetDelta(gfx::Insets::VH(0, 2));
 #else
-  SetLayoutInsetDelta(gfx::Insets(1));
+  SetLayoutInsetDelta(gfx::Insets(2));
 #endif
 }
 

--- a/browser/ui/views/sidebar/sidebar_button_view.h
+++ b/browser/ui/views/sidebar/sidebar_button_view.h
@@ -13,10 +13,14 @@
 class SidebarButtonView : public views::ImageButton {
   METADATA_HEADER(SidebarButtonView, views::ImageButton)
  public:
-  static constexpr int kSidebarButtonSize = 32;
-  static constexpr int kDefaultIconSize = 18;
-  static constexpr int kExternalIconSize = 16;
-  static constexpr int kMargin = 4;
+  // Value ought to follow TOOLBAR_BUTTON_HEIGHT in brave_layout_constants.cc
+  static constexpr int kSidebarButtonSize = 28;
+  // Value ought to follow kDefaultIconSize in toolbar_button.h
+  static constexpr int kDefaultIconSize = 20;
+  // External, meaning favicons for bookmarked pages
+  static constexpr int kExternalIconSize = 18;
+  // Vertical space between sidebar buttons
+  static constexpr int kMargin = 8;
 
   explicit SidebarButtonView(const std::u16string& accessible_name);
   ~SidebarButtonView() override;

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -145,7 +145,7 @@ void BraveToolbarView::Init() {
 
   views::SetHitTestComponent(container_view, HTCAPTION);
 
-  // For non-normal mode, we don't have to more.
+  // For non-normal mode, we don't have to do any more work.
   if (display_mode_ != DisplayMode::NORMAL) {
     brave_initialized_ = true;
     return;
@@ -460,7 +460,7 @@ void BraveToolbarView::Layout(PassKey) {
 
   if (!location_bar_is_wide_.GetValue()) {
     ResetLocationBarBounds();
-    ResetButtonBounds();
+    ResetBookmarkButtonBounds();
   }
 }
 
@@ -477,7 +477,7 @@ void BraveToolbarView::ResetLocationBarBounds() {
       location_bar_->width() - margin.width(), location_bar_->height());
 }
 
-void BraveToolbarView::ResetButtonBounds() {
+void BraveToolbarView::ResetBookmarkButtonBounds() {
   DCHECK_EQ(DisplayMode::NORMAL, display_mode_);
 
   int button_right_margin = GetLayoutConstant(TOOLBAR_STANDARD_SPACING);

--- a/browser/ui/views/toolbar/brave_toolbar_view.h
+++ b/browser/ui/views/toolbar/brave_toolbar_view.h
@@ -60,7 +60,7 @@ class BraveToolbarView : public ToolbarView,
 
   void LoadImages() override;
   void ResetLocationBarBounds();
-  void ResetButtonBounds();
+  void ResetBookmarkButtonBounds();
   void UpdateBookmarkVisibility();
 
   // ProfileAttributesStorage::Observer:

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -339,9 +339,6 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
             container->GetIndexOf(app_menu).value() - 1ul);
 
   // Check avatar button's size.
-  // Sidebar button dimensions are defined in
-  // SidebarButtonView::kSidebarButtonSize and expected to be kept in sync with
-  // the value of TOOLBAR_BUTTON_HEIGHT.
   const int avatar_size = GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT);
   EXPECT_EQ(gfx::Size(avatar_size, avatar_size), avatar->size());
 }

--- a/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view_browsertest.cc
@@ -339,6 +339,9 @@ IN_PROC_BROWSER_TEST_F(BraveToolbarViewTest,
             container->GetIndexOf(app_menu).value() - 1ul);
 
   // Check avatar button's size.
+  // Sidebar button dimensions are defined in
+  // SidebarButtonView::kSidebarButtonSize and expected to be kept in sync with
+  // the value of TOOLBAR_BUTTON_HEIGHT.
   const int avatar_size = GetLayoutConstant(TOOLBAR_BUTTON_HEIGHT);
   EXPECT_EQ(gfx::Size(avatar_size, avatar_size), avatar->size());
 }

--- a/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.h
@@ -17,10 +17,10 @@
   virtual void SetHighlight
 
 #define kDefaultIconSize \
-  kDefaultIconSize = 18; \
+  kDefaultIconSize = 20; \
   static constexpr int kDefaultIconSize_UnUsed
 #define kDefaultIconSizeChromeRefresh \
-  kDefaultIconSizeChromeRefresh = 18; \
+  kDefaultIconSizeChromeRefresh = 20; \
   static constexpr int kDefaultIconSizeChromeRefresh_UnUsed
 #include "src/chrome/browser/ui/views/toolbar/toolbar_button.h"  // IWYU pragma: export
 #undef kDefaultIconSizeChromeRefresh


### PR DESCRIPTION
Adjusts toolbar button height to 28px and icon size to 20px across the UI. Updates sidebar button dimensions to match toolbar constants. Includes padding/inset adjustments and test fixes. Renames `ResetButtonBounds` to more specific `ResetBookmarkButtonBounds`.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43855

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Launch Brave and verify that icons in the toolbar are 18px by 18px, and their outer dimensions (more easily discernable on hover) are 28px by 28px.