### PR TITLE
[iOS] - Add more unit tests. Add more robust formatting. Format origin only

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TabLocationView.swift
@@ -534,7 +534,8 @@ class TabLocationView: UIView {
         var urlString = url.absoluteString
 
         // For the web schemes, format the origin instead of the full url
-        if url.isWebPage(includeDataURIs: false), let origin = url.origin.url?.absoluteString {
+        let isWebPage = url.isWebPage(includeDataURIs: false) || url.scheme == "blob"
+        if isWebPage, let origin = url.origin.url?.absoluteString {
           urlString = origin
         }
 
@@ -566,7 +567,6 @@ class TabLocationView: UIView {
           isLTR = true
         }
 
-        let isWebPage = url.isWebPage(includeDataURIs: false) || url.scheme == "blob"
         urlDisplayLabel.isLeftToRight = !isWebPage || !isLTR
       }
     } else {

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/AutocompleteTextField.swift
@@ -63,12 +63,13 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
     }
 
     set(newValue) {
-      if let text = newValue, let url = URL(string: text) {
+      if let text = newValue, URL.isValidURLWithoutEncoding(text: text, scheme: "blob"),
+        let url = URL(string: text)
+      {
         super.text = url.strippingBlobURLAuth.absoluteString
       } else {
         super.text = text
       }
-
       self.textDidChange(self)
     }
   }
@@ -370,7 +371,7 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
   }
 
   func setTextWithoutSearching(_ text: String) {
-    if let url = URL(string: text) {
+    if URL.isValidURLWithoutEncoding(text: text, scheme: "blob"), let url = URL(string: text) {
       super.text = url.strippingBlobURLAuth.absoluteString
     } else {
       super.text = text
@@ -426,5 +427,4 @@ public class AutocompleteTextField: UITextField, UITextFieldDelegate {
     applyCompletion()
     super.touchesBegan(touches, with: event)
   }
-
 }

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -237,14 +237,21 @@ extension URL {
   // Returns true if a string is a valid URL, with the specified optional scheme,
   // without percent encoding, idn encoding, or modifying the URL in any way.
   public static func isValidURLWithoutEncoding(text: String, scheme: String? = nil) -> Bool {
-    if let components = URLComponents(string: text),
-      !(scheme ?? "").isEmpty ? components.scheme == scheme : true,
-      !(components.host ?? components.path).isEmpty
-    {
-      return true
+    guard let components = URLComponents(string: text) else {
+      return false
     }
 
-    return false
+    // If a scheme was specified, check if it matches
+    if let scheme = scheme, !scheme.isEmpty, components.scheme != scheme {
+      return false
+    }
+
+    // A valid URL must have a non-empty host or path
+    if (components.host ?? components.path).isEmpty {
+      return false
+    }
+
+    return true
   }
 }
 

--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -233,6 +233,19 @@ extension URL {
     }
     return self
   }
+
+  // Returns true if a string is a valid URL, with the specified optional scheme,
+  // without percent encoding, idn encoding, or modifying the URL in any way.
+  public static func isValidURLWithoutEncoding(text: String, scheme: String? = nil) -> Bool {
+    if let components = URLComponents(string: text),
+      !(scheme ?? "").isEmpty ? components.scheme == scheme : true,
+      !(components.host ?? components.path).isEmpty
+    {
+      return true
+    }
+
+    return false
+  }
 }
 
 extension InternalURL {

--- a/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
+++ b/ios/brave-ios/Tests/BraveSharedTests/URLExtensionTests.swift
@@ -247,6 +247,21 @@ class URLExtensionTests: XCTestCase {
     url = URL(string: "https://brave.github.io/")!
     XCTAssertEqual(url.strippingBlobURLAuth.absoluteString, "https://brave.github.io/")
   }
+
+  private func testURLComponentsEncoding() {
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "Дом.com"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "Дoм.com"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "https://Дом.com"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "https://Дoм.com"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "https://google.ca/"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "https://google.ca/search?q=hello"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "https://google.ca/search?q=hello%20world"))
+    XCTAssertTrue(URL.isValidURLWithoutEncoding(text: "https://google.ca/", scheme: "https"))
+    XCTAssertFalse(URL.isValidURLWithoutEncoding(text: "https://google.ca/", scheme: "blob"))
+    XCTAssertFalse(URL.isValidURLWithoutEncoding(text: "https://google.ca/search?q=hello + world"))
+    XCTAssertFalse(URL.isValidURLWithoutEncoding(text: "https://google.ca/search?q=hello world"))
+    XCTAssertFalse(URL.isValidURLWithoutEncoding(text: "hello world"))
+  }
 }
 
 private class NavigationDelegate: NSObject, WKNavigationDelegate {


### PR DESCRIPTION
## Summary
- Add more unit tests. 
- Add more robust formatting. 
- Format blob origin only

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43921

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Visit: https://frozzipies.github.io/blobspoof.html
2. URL-Bar should display: `frozzipies.github.io`
3. Tap on the URL-Bar. Should display `blob:https://frozzipies.github.io/`

---

1. Visit: https://syarifmsajjad.github.io/test-spoofing/bs.html
2. Tap on the "Spoof" URL on the page.
3. URL-Bar should display: `syarifmsajjad.github.io`.
4. Tap on the URL-Bar. Should display `blob:https://syarifmsajjad.github.io/e2937c6b-9707-4f94-9c94-27ac0bc84012` (the UUID can be different).