### PR TITLE
[ads] Fixes Search Result Ad Clicked InfoBar keeps showing (uplift to 1.75.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
@@ -29,9 +29,8 @@ class BraveSearchResultAdManager: NSObject {
     placementId: String,
     searchResultAd: BraveAds.CreativeSearchResultAdInfo
   ) {
-    rewards.ads.triggerSearchResultAdEvent(
+    rewards.ads.triggerSearchResultAdViewedEvent(
       searchResultAd,
-      eventType: .viewedImpression,
       completion: { _ in }
     )
   }

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -72,7 +72,7 @@ OBJC_EXPORT
 
 /// Returns `true` if the privacy notice infobar should be displayed when a user
 /// clicks on a search result ad. This should be called before calling
-/// `triggerSearchResultAdEvent` for the click.
+/// `triggerSearchResultAdClickedEvent`.
 - (BOOL)shouldShowSearchResultAdClickedInfoBar;
 
 /// Used to notify the ads service that the user has opted-in/opted-out to
@@ -135,10 +135,9 @@ OBJC_EXPORT
 - (void)triggerSearchResultAdClickedEvent:(NSString*)placementId
                                completion:(void (^)(BOOL success))completion;
 
-- (void)triggerSearchResultAdEvent:
+- (void)triggerSearchResultAdViewedEvent:
             (BraveAdsCreativeSearchResultAdInfo*)searchResultAd
-                         eventType:(BraveAdsSearchResultAdEventType)eventType
-                        completion:(void (^)(BOOL success))completion;
+                              completion:(void (^)(BOOL success))completion;
 
 - (void)purgeOrphanedAdEventsForType:(BraveAdsAdType)adType
                           completion:(void (^)(BOOL success))completion;


### PR DESCRIPTION
Uplift of #27627
Resolves https://github.com/brave/brave-browser/issues/43922

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.