### PR TITLE
[Reset custom filters]  Remove only records added by the Element blocker

### DIFF
--- a/components/brave_shields/content/browser/BUILD.gn
+++ b/components/brave_shields/content/browser/BUILD.gn
@@ -7,6 +7,8 @@ static_library("browser") {
   sources = [
     "ad_block_custom_filters_provider.cc",
     "ad_block_custom_filters_provider.h",
+    "ad_block_custom_filter_reset_util.cc",
+    "ad_block_custom_filter_reset_util.h",
     "ad_block_engine.cc",
     "ad_block_engine.h",
     "ad_block_localhost_filters_provider.cc",

--- a/components/brave_shields/content/browser/BUILD.gn
+++ b/components/brave_shields/content/browser/BUILD.gn
@@ -5,10 +5,10 @@
 
 static_library("browser") {
   sources = [
-    "ad_block_custom_filters_provider.cc",
-    "ad_block_custom_filters_provider.h",
     "ad_block_custom_filter_reset_util.cc",
     "ad_block_custom_filter_reset_util.h",
+    "ad_block_custom_filters_provider.cc",
+    "ad_block_custom_filters_provider.h",
     "ad_block_engine.cc",
     "ad_block_engine.h",
     "ad_block_localhost_filters_provider.cc",

--- a/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.cc
+++ b/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.cc
@@ -43,8 +43,8 @@ std::optional<std::string> ResetCustomFiltersForHost(
   const auto starts_with_str = base::StrCat({host, "##"});
   base::StringTokenizer tokenizer(custom_filters, "\n");
   while (tokenizer.GetNext()) {
-    std::string token;
-    base::TrimWhitespaceASCII(tokenizer.token(), base::TRIM_ALL, &token);
+    const std::string token{
+        base::TrimWhitespaceASCII(tokenizer.token(), base::TRIM_ALL)};
     if (token.starts_with(starts_with_str) && !IsInAllowList(token)) {
       continue;  // Exclude line from the result
     }

--- a/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.cc
+++ b/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.cc
@@ -21,11 +21,7 @@ constexpr std::array<std::string_view, 16> kCustomFilterPatternsToSkip = {
     ":matches-path(", ":matches-prop(", ":min-text-length(", ":not(",
     ":others(", ":upward(", ":watch-attr(", ":xpath("};
 
-bool IsInWhiteList(const std::string& custom_filter_line) {
-  if (custom_filter_line.empty()) {
-    return true;
-  }
-
+bool IsInAllowList(const std::string& custom_filter_line) {
   for (const auto& pattern : kCustomFilterPatternsToSkip) {
     if (custom_filter_line.find(pattern) != std::string::npos) {
       return true;
@@ -49,7 +45,7 @@ std::optional<std::string> ResetCustomFiltersForHost(
   while (tokenizer.GetNext()) {
     std::string token;
     base::TrimWhitespaceASCII(tokenizer.token(), base::TRIM_ALL, &token);
-    if (token.starts_with(starts_with_str) && !IsInWhiteList(token)) {
+    if (token.starts_with(starts_with_str) && !IsInAllowList(token)) {
       continue;  // Exclude line from the result
     }
     result.append(base::StrCat({token, "\n"}));

--- a/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.cc
+++ b/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.cc
@@ -1,0 +1,60 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h"
+
+#include "base/strings/strcat.h"
+#include "net/http/http_util.h"
+
+namespace brave_shields {
+
+namespace {
+constexpr std::array<std::string_view, 16> kCustomFilterPatternsToSkip = {
+    // Scriptlets
+    "+js(",
+
+    // Procedural cosmetic filters
+    ":has(", ":has-text(", ":matches-attr(", ":matches-css(",
+    ":matches-css-before(", ":matches-css-after(", ":matches-media(",
+    ":matches-path(", ":matches-prop(", ":min-text-length(", ":not(",
+    ":others(", ":upward(", ":watch-attr(", ":xpath("};
+
+bool IsInWhiteList(const std::string& custom_filter_line) {
+  if (custom_filter_line.empty()) {
+    return true;
+  }
+
+  for (const auto& pattern : kCustomFilterPatternsToSkip) {
+    if (custom_filter_line.find(pattern) != std::string::npos) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+std::optional<std::string> ResetCustomFiltersForHost(
+    const std::string& host,
+    const std::string& custom_filters) {
+  if (host.empty() || custom_filters.empty()) {
+    return std::nullopt;
+  }
+
+  std::string result;
+  const auto starts_with_str = base::StrCat({host, "##"});
+  base::StringTokenizer tokenizer(custom_filters, "\n");
+  while (tokenizer.GetNext()) {
+    std::string token;
+    base::TrimWhitespaceASCII(tokenizer.token(), base::TRIM_ALL, &token);
+    if (token.starts_with(starts_with_str) && !IsInWhiteList(token)) {
+      continue;  // Exclude line from the result
+    }
+    result.append(base::StrCat({token, "\n"}));
+  }
+  return result;
+}
+
+}  // namespace brave_shields

--- a/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h
+++ b/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h
@@ -3,17 +3,18 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTERS_RESET_UTIL_H_
-#define BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTERS_RESET_UTIL_H_
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTER_RESET_UTIL_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTER_RESET_UTIL_H_
 
 #include <optional>
 #include <string>
 
 namespace brave_shields {
 
-std::optional<std::string> ResetCustomFiltersForHost(const std::string& host,
-                               const std::string& custom_filters);
+std::optional<std::string> ResetCustomFiltersForHost(
+    const std::string& host,
+    const std::string& custom_filters);
 
 }  // namespace brave_shields
 
-#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTERS_RESET_UTIL_H_
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTER_RESET_UTIL_H_

--- a/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h
+++ b/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTERS_RESET_UTIL_H_
+#define BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTERS_RESET_UTIL_H_
+
+#include <optional>
+#include <string>
+
+namespace brave_shields {
+
+std::optional<std::string> ResetCustomFiltersForHost(const std::string& host,
+                               const std::string& custom_filters);
+
+}  // namespace brave_shields
+
+#endif  // BRAVE_COMPONENTS_BRAVE_SHIELDS_CONTENT_BROWSER_AD_BLOCK_CUSTOM_FILTERS_RESET_UTIL_H_

--- a/components/brave_shields/content/browser/ad_block_custom_filters_provider.cc
+++ b/components/brave_shields/content/browser/ad_block_custom_filters_provider.cc
@@ -10,35 +10,12 @@
 #include <utility>
 #include <vector>
 
-#include "base/strings/strcat.h"
 #include "base/strings/string_tokenizer.h"
 #include "base/task/single_thread_task_runner.h"
+#include "brave/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h"
 #include "brave/components/brave_shields/core/browser/ad_block_filters_provider_manager.h"
 #include "brave/components/brave_shields/core/common/pref_names.h"
 #include "components/prefs/pref_service.h"
-
-namespace {
-
-std::optional<std::string> RemoveFiltersForHost(
-    const std::string& host,
-    const std::string& custom_filters) {
-  if (custom_filters.empty()) {
-    return std::nullopt;
-  }
-
-  std::stringstream result;
-  const auto starts_with_str = base::StrCat({host, "##"});
-  base::StringTokenizer tokenizer(custom_filters, "\n");
-  while (tokenizer.GetNext()) {
-    if (tokenizer.token().starts_with(starts_with_str)) {
-      continue;
-    }
-    result << base::StrCat({tokenizer.token(), "\n"});
-  }
-  return result.str();
-}
-
-}  // namespace
 
 namespace brave_shields {
 
@@ -84,7 +61,7 @@ void AdBlockCustomFiltersProvider::ResetCosmeticFilter(
     return;
   }
 
-  const auto modified_filters = RemoveFiltersForHost(host, GetCustomFilters());
+  const auto modified_filters = ResetCustomFiltersForHost(host, GetCustomFilters());
   if (!modified_filters) {
     return;
   }

--- a/components/brave_shields/content/browser/ad_block_custom_filters_provider.cc
+++ b/components/brave_shields/content/browser/ad_block_custom_filters_provider.cc
@@ -61,7 +61,8 @@ void AdBlockCustomFiltersProvider::ResetCosmeticFilter(
     return;
   }
 
-  const auto modified_filters = ResetCustomFiltersForHost(host, GetCustomFilters());
+  const auto modified_filters =
+      ResetCustomFiltersForHost(host, GetCustomFilters());
   if (!modified_filters) {
     return;
   }

--- a/components/brave_shields/content/test/BUILD.gn
+++ b/components/brave_shields/content/test/BUILD.gn
@@ -33,6 +33,7 @@ source_set("unit_tests") {
     "cosmetic_merge_unittest.cc",
     "csp_merge_unittest.cc",
     "strip_procedural_filters_unittest.cc",
+    "ad_block_custom_filter_reset_util_unittest.cc",
   ]
 
   deps = [

--- a/components/brave_shields/content/test/BUILD.gn
+++ b/components/brave_shields/content/test/BUILD.gn
@@ -27,13 +27,13 @@ source_set("unit_tests") {
   testonly = true
 
   sources = [
+    "ad_block_custom_filter_reset_util_unittest.cc",
     "adblock_stub_response_unittest.cc",
     "brave_farbling_service_unittest.cc",
     "cookie_list_opt_in_service_unittest.cc",
     "cosmetic_merge_unittest.cc",
     "csp_merge_unittest.cc",
     "strip_procedural_filters_unittest.cc",
-    "ad_block_custom_filter_reset_util_unittest.cc",
   ]
 
   deps = [

--- a/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
@@ -100,18 +100,14 @@ void CheckCase(const std::string& host_pos0,
   EXPECT_NE(resetted_cf_list->find(base::StrCat(
                 {host_pos8, R"(##^script:has-text(/[\w\W]{35000}/))"})),
             std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos9,
-           R"(##main [role="region"] > [role="row"])", 
-           R"(:has(span:not(:has-text(/^Promoted by/))))"})),
-      std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos10,
-           R"(##:matches-path(/^/home/) )", 
-           R"([data-testid="primaryColumn"]:others())"})),
-      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {host_pos9, R"(##main [role="region"] > [role="row"])",
+                 R"(:has(span:not(:has-text(/^Promoted by/))))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({host_pos10, R"(##:matches-path(/^/home/) )",
+                              R"([data-testid="primaryColumn"]:others())"})),
+            std::string::npos);
   EXPECT_NE(resetted_cf_list->find(
                 base::StrCat({host_pos11, R"(###pcf #a19 b:upward(2))"})),
             std::string::npos);
@@ -120,12 +116,10 @@ void CheckCase(const std::string& host_pos0,
           {host_pos12,
            R"(##.j-mini-player[class]:watch-attr(class):remove-attr(class))"})),
       std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos13,
-           R"(##:xpath(//div[@id="pagelet"])", 
-           R"(//div[starts-with(@id,"hyperfeed_story_id_")])"})),
-      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {host_pos13, R"(##:xpath(//div[@id="pagelet"])",
+                 R"(//div[starts-with(@id,"hyperfeed_story_id_")])"})),
+            std::string::npos);
   EXPECT_NE(
       resetted_cf_list->find(base::StrCat({host_pos14, "##+js(nobab)\n"})),
       std::string::npos);

--- a/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
@@ -1,0 +1,170 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/components/brave_shields/content/browser/ad_block_custom_filter_reset_util.h"
+
+#include <optional>
+
+#include "base/strings/strcat.h"
+#include "base/strings/stringprintf.h"
+#include "gtest/gtest.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace brave_shields {
+
+namespace {
+
+constexpr std::array<std::string, 2> kCurrentHost = {"current-host.com",
+                                                     "host1.com"};
+
+constexpr char kTestCustomFiltersList[] =
+    R"(%s##main [role="region"] > [role="row"]:has(div:last-of-type span:has-text(/^Promoted by/))
+%s##button:matches-attr(class="/[\w]{7}/")
+    %s##body > div[class]:matches-css(position: absolute)   
+%s##body > div[class]:matches-css-before(position: absolute)
+%s##body > div[class]:matches-css-after(position: absolute)
+%s###target-1 > .target-2:matches-media((min-width: 800px))
+ %s##:matches-path(/shop) p
+%s##div:matches-prop(imanad) 
+%s##^script:has-text(/[\w\W]{35000}/)
+%s##main [role="region"] > [role="row"]:has(div:last-of-type span:not(:has-text(/^Promoted by/)))
+%s##:matches-path(/^/home/) [data-testid="primaryColumn"]:others()
+%s###pcf #a19 b:upward(2)
+%s##.j-mini-player[class]:watch-attr(class):remove-attr(class)
+%s##:xpath(//div[@id="stream_pagelet"]//div[starts-with(@id,"hyperfeed_story_id_")]
+%s##+js(nobab)
+%s##body > div.logged-in.env-production.page-responsive
+%s###post-864297 > div.text > img:nth-child(9)
+)";
+
+void CheckCase(const std::string& host_pos0,
+               const std::string& host_pos1,
+               const std::string& host_pos2,
+               const std::string& host_pos3,
+               const std::string& host_pos4,
+               const std::string& host_pos5,
+               const std::string& host_pos6,
+               const std::string& host_pos7,
+               const std::string& host_pos8,
+               const std::string& host_pos9,
+               const std::string& host_pos10,
+               const std::string& host_pos11,
+               const std::string& host_pos12,
+               const std::string& host_pos13,
+               const std::string& host_pos14,
+               const std::string& host_pos15,
+               const std::string& host_pos16,
+               const std::string& reset_for_host) {
+  const auto custom_filters_current_host = base::StringPrintf(
+      kTestCustomFiltersList, host_pos0, host_pos1, host_pos2, host_pos3,
+      host_pos4, host_pos5, host_pos6, host_pos7, host_pos8, host_pos9,
+      host_pos10, host_pos11, host_pos12, host_pos13, host_pos14, host_pos15,
+      host_pos16);
+  const auto resetted_cf_list =
+      ResetCustomFiltersForHost(reset_for_host, custom_filters_current_host);
+
+  ASSERT_TRUE(resetted_cf_list);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos0,
+           R"(##main [role="region"] > [role="row"]:has(div:last-of-type span:has-text(/^Promoted by/)))"})),
+      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {host_pos1, R"(##button:matches-attr(class="/[\w]{7}/"))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {host_pos2,
+                 R"(##body > div[class]:matches-css(position: absolute))"})),
+            std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos3,
+           R"(##body > div[class]:matches-css-before(position: absolute))"})),
+      std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos4,
+           R"(##body > div[class]:matches-css-after(position: absolute))"})),
+      std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos5,
+           R"(###target-1 > .target-2:matches-media((min-width: 800px)))"})),
+      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({host_pos6, R"(##:matches-path(/shop) p)"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({host_pos7, R"(##div:matches-prop(imanad))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {host_pos8, R"(##^script:has-text(/[\w\W]{35000}/))"})),
+            std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos9,
+           R"(##main [role="region"] > [role="row"]:has(div:last-of-type span:not(:has-text(/^Promoted by/))))"})),
+      std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos10,
+           R"(##:matches-path(/^/home/) [data-testid="primaryColumn"]:others())"})),
+      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({host_pos11, R"(###pcf #a19 b:upward(2))"})),
+            std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos12,
+           R"(##.j-mini-player[class]:watch-attr(class):remove-attr(class))"})),
+      std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos13,
+           R"(##:xpath(//div[@id="stream_pagelet"]//div[starts-with(@id,"hyperfeed_story_id_")])"})),
+      std::string::npos);
+  EXPECT_NE(
+      resetted_cf_list->find(base::StrCat({host_pos14, "##+js(nobab)\n"})),
+      std::string::npos);
+
+  EXPECT_EQ(resetted_cf_list->find(base::StrCat(
+                {host_pos15,
+                 "##body > div.logged-in.env-production.page-responsive\n"})) ==
+                std::string::npos,
+            host_pos15 == reset_for_host);
+  EXPECT_EQ(
+      resetted_cf_list->find(base::StrCat(
+          {host_pos16, "###post-864297 > div.text > img:nth-child(9)\n"})) ==
+          std::string::npos,
+      host_pos16 == reset_for_host);
+}
+
+}  // namespace
+
+using AdBlockCustomFilterResetUtilTest = testing::Test;
+
+TEST_F(AdBlockCustomFilterResetUtilTest, IgnoreScripletAndProcedural) {
+  ASSERT_FALSE(ResetCustomFiltersForHost("", ""));
+  ASSERT_FALSE(ResetCustomFiltersForHost(
+      "", "###post-864297 > div.text > img:nth-child(9)\n"));
+
+  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0]);
+  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[1],
+            kCurrentHost[0], kCurrentHost[0]);
+  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
+            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[1],
+            kCurrentHost[1], kCurrentHost[1]);
+}
+
+}  // namespace brave_shields

--- a/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
@@ -7,6 +7,7 @@
 
 #include <optional>
 
+#include "base/containers/contains.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -46,69 +47,72 @@ void CheckCase(const std::string& host_pos0,
       ResetCustomFiltersForHost(reset_for_host, custom_filters_current_host);
 
   ASSERT_TRUE(resetted_cf_list);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##main [role="reg"] > )",
-                              R"([role="row"]:has(span:has-text(/^Prom/)))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {R"(host0.com##button:matches-attr(class="/[\w]{7}/"))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##body > div[class])",
-                              R"(:matches-css(position: absolute))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##body > div[class]:matches-css)",
-                              R"(-before(position: absolute))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##body > div[class])",
-                              R"(:matches-css-after(position: absolute))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com###target-1 > .target-2)",
-                              R"(:matches-media((min-width: 800px)))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##:matches-path(/shop) p)"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##div:matches-prop(imanad))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {R"(host0.com##^script:has-text(/[\w\W]{35000}/))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##main [role="reg"] > [role="row"])",
-                              R"(:has(span:not(:has-text(/^Promo/))))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##:matches-path(/^/home/) )",
-                              R"([data-testid="primaryColumn"]:others())"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com###pcf #a19 b:upward(2))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({R"(host0.com##.j-mini-player[class])",
-                              R"(:watch-attr(class):remove-attr(class))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {R"(host0.com##:xpath(//div[@id="pag"])",
-                 R"(//div[starts-with(@id,"hyperfeed_story_id_")])"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat({"host0.com##+js(nobab)\n"})),
-            std::string::npos);
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##main [role="reg"] > )",
+                    R"([role="row"]:has(span:has-text(/^Prom/)))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##button:matches-attr(class="/[\w]{7}/"))"})));
+  EXPECT_TRUE(
+      base::Contains(*resetted_cf_list,
+                     base::StrCat({R"(host0.com##body > div[class])",
+                                   R"(:matches-css(position: absolute))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##body > div[class]:matches-css)",
+                    R"(-before(position: absolute))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##body > div[class])",
+                    R"(:matches-css-after(position: absolute))"})));
+  EXPECT_TRUE(
+      base::Contains(*resetted_cf_list,
+                     base::StrCat({R"(host0.com###target-1 > .target-2)",
+                                   R"(:matches-media((min-width: 800px)))"})));
+  EXPECT_TRUE(
+      base::Contains(*resetted_cf_list,
+                     base::StrCat({R"(host0.com##:matches-path(/shop) p)"})));
+  EXPECT_TRUE(
+      base::Contains(*resetted_cf_list,
+                     base::StrCat({R"(host0.com##div:matches-prop(imanad))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##^script:has-text(/[\w\W]{35000}/))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##main [role="reg"] > [role="row"])",
+                    R"(:has(span:not(:has-text(/^Promo/))))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##:matches-path(/^/home/) )",
+                    R"([data-testid="primaryColumn"]:others())"})));
+  EXPECT_TRUE(
+      base::Contains(*resetted_cf_list,
+                     base::StrCat({R"(host0.com###pcf #a19 b:upward(2))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##.j-mini-player[class])",
+                    R"(:watch-attr(class):remove-attr(class))"})));
+  EXPECT_TRUE(base::Contains(
+      *resetted_cf_list,
+      base::StrCat({R"(host0.com##:xpath(//div[@id="pag"])",
+                    R"(//div[starts-with(@id,"hyperfeed_story_id_")])"})));
+  EXPECT_TRUE(base::Contains(*resetted_cf_list,
+                             base::StrCat({"host0.com##+js(nobab)\n"})));
 
-  EXPECT_EQ(resetted_cf_list->find(base::StrCat(
-                {host_pos0,
-                 "##body > div.logged-in.env-production.page-responsive\n"})) ==
-                std::string::npos,
-            host_pos0 == reset_for_host);
   EXPECT_EQ(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos1, "###post-864297 > div.text > img:nth-child(9)\n"})) ==
-          std::string::npos,
+      !base::Contains(
+          *resetted_cf_list,
+          base::StrCat(
+              {host_pos0,
+               "##body > div.logged-in.env-production.page-responsive\n"})),
+      host_pos0 == reset_for_host);
+  EXPECT_EQ(
+      !base::Contains(
+          *resetted_cf_list,
+          base::StrCat(
+              {host_pos1, "###post-864297 > div.text > img:nth-child(9)\n"})),
       host_pos1 == reset_for_host);
 }
 

--- a/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
@@ -9,7 +9,6 @@
 
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
-#include "gtest/gtest.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace brave_shields {
@@ -20,20 +19,20 @@ constexpr std::array<std::string, 2> kCurrentHost = {"current-host.com",
                                                      "host1.com"};
 
 constexpr char kTestCustomFiltersList[] =
-    R"(%s##main [role="region"] > [role="row"]:has(div:last-of-type span:has-text(/^Promoted by/))
+    R"(%s##main [role="region"] > [role="row"]:has(span:has-text(/^Promoted/))
 %s##button:matches-attr(class="/[\w]{7}/")
-    %s##body > div[class]:matches-css(position: absolute)   
+    %s##body > div[class]:matches-css(position: absolute)
 %s##body > div[class]:matches-css-before(position: absolute)
 %s##body > div[class]:matches-css-after(position: absolute)
 %s###target-1 > .target-2:matches-media((min-width: 800px))
  %s##:matches-path(/shop) p
-%s##div:matches-prop(imanad) 
+%s##div:matches-prop(imanad)
 %s##^script:has-text(/[\w\W]{35000}/)
-%s##main [role="region"] > [role="row"]:has(div:last-of-type span:not(:has-text(/^Promoted by/)))
+%s##main [role="region"] > [role="row"]:has(span:not(:has-text(/^Promoted by/)))
 %s##:matches-path(/^/home/) [data-testid="primaryColumn"]:others()
 %s###pcf #a19 b:upward(2)
 %s##.j-mini-player[class]:watch-attr(class):remove-attr(class)
-%s##:xpath(//div[@id="stream_pagelet"]//div[starts-with(@id,"hyperfeed_story_id_")]
+%s##:xpath(//div[@id="pagelet"]//div[starts-with(@id,"hyperfeed_story_id_")]
 %s##+js(nobab)
 %s##body > div.logged-in.env-production.page-responsive
 %s###post-864297 > div.text > img:nth-child(9)
@@ -66,11 +65,10 @@ void CheckCase(const std::string& host_pos0,
       ResetCustomFiltersForHost(reset_for_host, custom_filters_current_host);
 
   ASSERT_TRUE(resetted_cf_list);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos0,
-           R"(##main [role="region"] > [role="row"]:has(div:last-of-type span:has-text(/^Promoted by/)))"})),
-      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {host_pos0, R"(##main [role="region"] > )",
+                 R"([role="row"]:has(span:has-text(/^Promoted/)))"})),
+            std::string::npos);
   EXPECT_NE(resetted_cf_list->find(base::StrCat(
                 {host_pos1, R"(##button:matches-attr(class="/[\w]{7}/"))"})),
             std::string::npos);
@@ -105,12 +103,14 @@ void CheckCase(const std::string& host_pos0,
   EXPECT_NE(
       resetted_cf_list->find(base::StrCat(
           {host_pos9,
-           R"(##main [role="region"] > [role="row"]:has(div:last-of-type span:not(:has-text(/^Promoted by/))))"})),
+           R"(##main [role="region"] > [role="row"])", 
+           R"(:has(span:not(:has-text(/^Promoted by/))))"})),
       std::string::npos);
   EXPECT_NE(
       resetted_cf_list->find(base::StrCat(
           {host_pos10,
-           R"(##:matches-path(/^/home/) [data-testid="primaryColumn"]:others())"})),
+           R"(##:matches-path(/^/home/) )", 
+           R"([data-testid="primaryColumn"]:others())"})),
       std::string::npos);
   EXPECT_NE(resetted_cf_list->find(
                 base::StrCat({host_pos11, R"(###pcf #a19 b:upward(2))"})),
@@ -123,7 +123,8 @@ void CheckCase(const std::string& host_pos0,
   EXPECT_NE(
       resetted_cf_list->find(base::StrCat(
           {host_pos13,
-           R"(##:xpath(//div[@id="stream_pagelet"]//div[starts-with(@id,"hyperfeed_story_id_")])"})),
+           R"(##:xpath(//div[@id="pagelet"])", 
+           R"(//div[starts-with(@id,"hyperfeed_story_id_")])"})),
       std::string::npos);
   EXPECT_NE(
       resetted_cf_list->find(base::StrCat({host_pos14, "##+js(nobab)\n"})),

--- a/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
+++ b/components/brave_shields/content/test/ad_block_custom_filter_reset_util_unittest.cc
@@ -15,125 +15,101 @@ namespace brave_shields {
 
 namespace {
 
-constexpr std::array<std::string, 2> kCurrentHost = {"current-host.com",
-                                                     "host1.com"};
+constexpr std::array<std::string, 2> kCurrentHost = {"host0.com", "host1.com"};
 
 constexpr char kTestCustomFiltersList[] =
-    R"(%s##main [role="region"] > [role="row"]:has(span:has-text(/^Promoted/))
-%s##button:matches-attr(class="/[\w]{7}/")
-    %s##body > div[class]:matches-css(position: absolute)
-%s##body > div[class]:matches-css-before(position: absolute)
-%s##body > div[class]:matches-css-after(position: absolute)
-%s###target-1 > .target-2:matches-media((min-width: 800px))
- %s##:matches-path(/shop) p
-%s##div:matches-prop(imanad)
-%s##^script:has-text(/[\w\W]{35000}/)
-%s##main [role="region"] > [role="row"]:has(span:not(:has-text(/^Promoted by/)))
-%s##:matches-path(/^/home/) [data-testid="primaryColumn"]:others()
-%s###pcf #a19 b:upward(2)
-%s##.j-mini-player[class]:watch-attr(class):remove-attr(class)
-%s##:xpath(//div[@id="pagelet"]//div[starts-with(@id,"hyperfeed_story_id_")]
-%s##+js(nobab)
+    R"(host0.com##main [role="reg"] > [role="row"]:has(span:has-text(/^Prom/))
+host0.com##button:matches-attr(class="/[\w]{7}/")
+    host0.com##body > div[class]:matches-css(position: absolute)
+host0.com##body > div[class]:matches-css-before(position: absolute)
+host0.com##body > div[class]:matches-css-after(position: absolute)
+host0.com###target-1 > .target-2:matches-media((min-width: 800px))
+ host0.com##:matches-path(/shop) p
+host0.com##div:matches-prop(imanad)
+host0.com##^script:has-text(/[\w\W]{35000}/)
+host0.com##main [role="reg"] > [role="row"]:has(span:not(:has-text(/^Promo/)))
+host0.com##:matches-path(/^/home/) [data-testid="primaryColumn"]:others()
+host0.com###pcf #a19 b:upward(2)
+host0.com##.j-mini-player[class]:watch-attr(class):remove-attr(class)
+host0.com##:xpath(//div[@id="pag"]//div[starts-with(@id,"hyperfeed_story_id_")]
+host0.com##+js(nobab)
 %s##body > div.logged-in.env-production.page-responsive
 %s###post-864297 > div.text > img:nth-child(9)
 )";
 
 void CheckCase(const std::string& host_pos0,
                const std::string& host_pos1,
-               const std::string& host_pos2,
-               const std::string& host_pos3,
-               const std::string& host_pos4,
-               const std::string& host_pos5,
-               const std::string& host_pos6,
-               const std::string& host_pos7,
-               const std::string& host_pos8,
-               const std::string& host_pos9,
-               const std::string& host_pos10,
-               const std::string& host_pos11,
-               const std::string& host_pos12,
-               const std::string& host_pos13,
-               const std::string& host_pos14,
-               const std::string& host_pos15,
-               const std::string& host_pos16,
                const std::string& reset_for_host) {
-  const auto custom_filters_current_host = base::StringPrintf(
-      kTestCustomFiltersList, host_pos0, host_pos1, host_pos2, host_pos3,
-      host_pos4, host_pos5, host_pos6, host_pos7, host_pos8, host_pos9,
-      host_pos10, host_pos11, host_pos12, host_pos13, host_pos14, host_pos15,
-      host_pos16);
+  const auto custom_filters_current_host =
+      base::StringPrintf(kTestCustomFiltersList, host_pos0, host_pos1);
   const auto resetted_cf_list =
       ResetCustomFiltersForHost(reset_for_host, custom_filters_current_host);
 
   ASSERT_TRUE(resetted_cf_list);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {host_pos0, R"(##main [role="region"] > )",
-                 R"([role="row"]:has(span:has-text(/^Promoted/)))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {host_pos1, R"(##button:matches-attr(class="/[\w]{7}/"))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {host_pos2,
-                 R"(##body > div[class]:matches-css(position: absolute))"})),
-            std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos3,
-           R"(##body > div[class]:matches-css-before(position: absolute))"})),
-      std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos4,
-           R"(##body > div[class]:matches-css-after(position: absolute))"})),
-      std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos5,
-           R"(###target-1 > .target-2:matches-media((min-width: 800px)))"})),
-      std::string::npos);
   EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({host_pos6, R"(##:matches-path(/shop) p)"})),
+                base::StrCat({R"(host0.com##main [role="reg"] > )",
+                              R"([role="row"]:has(span:has-text(/^Prom/)))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {R"(host0.com##button:matches-attr(class="/[\w]{7}/"))"})),
             std::string::npos);
   EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({host_pos7, R"(##div:matches-prop(imanad))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {host_pos8, R"(##^script:has-text(/[\w\W]{35000}/))"})),
-            std::string::npos);
-  EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {host_pos9, R"(##main [role="region"] > [role="row"])",
-                 R"(:has(span:not(:has-text(/^Promoted by/))))"})),
+                base::StrCat({R"(host0.com##body > div[class])",
+                              R"(:matches-css(position: absolute))"})),
             std::string::npos);
   EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({host_pos10, R"(##:matches-path(/^/home/) )",
+                base::StrCat({R"(host0.com##body > div[class]:matches-css)",
+                              R"(-before(position: absolute))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com##body > div[class])",
+                              R"(:matches-css-after(position: absolute))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com###target-1 > .target-2)",
+                              R"(:matches-media((min-width: 800px)))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com##:matches-path(/shop) p)"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com##div:matches-prop(imanad))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat(
+                {R"(host0.com##^script:has-text(/[\w\W]{35000}/))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com##main [role="reg"] > [role="row"])",
+                              R"(:has(span:not(:has-text(/^Promo/))))"})),
+            std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com##:matches-path(/^/home/) )",
                               R"([data-testid="primaryColumn"]:others())"})),
             std::string::npos);
   EXPECT_NE(resetted_cf_list->find(
-                base::StrCat({host_pos11, R"(###pcf #a19 b:upward(2))"})),
+                base::StrCat({R"(host0.com###pcf #a19 b:upward(2))"})),
             std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat(
-          {host_pos12,
-           R"(##.j-mini-player[class]:watch-attr(class):remove-attr(class))"})),
-      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(
+                base::StrCat({R"(host0.com##.j-mini-player[class])",
+                              R"(:watch-attr(class):remove-attr(class))"})),
+            std::string::npos);
   EXPECT_NE(resetted_cf_list->find(base::StrCat(
-                {host_pos13, R"(##:xpath(//div[@id="pagelet"])",
+                {R"(host0.com##:xpath(//div[@id="pag"])",
                  R"(//div[starts-with(@id,"hyperfeed_story_id_")])"})),
             std::string::npos);
-  EXPECT_NE(
-      resetted_cf_list->find(base::StrCat({host_pos14, "##+js(nobab)\n"})),
-      std::string::npos);
+  EXPECT_NE(resetted_cf_list->find(base::StrCat({"host0.com##+js(nobab)\n"})),
+            std::string::npos);
 
   EXPECT_EQ(resetted_cf_list->find(base::StrCat(
-                {host_pos15,
+                {host_pos0,
                  "##body > div.logged-in.env-production.page-responsive\n"})) ==
                 std::string::npos,
-            host_pos15 == reset_for_host);
+            host_pos0 == reset_for_host);
   EXPECT_EQ(
       resetted_cf_list->find(base::StrCat(
-          {host_pos16, "###post-864297 > div.text > img:nth-child(9)\n"})) ==
+          {host_pos1, "###post-864297 > div.text > img:nth-child(9)\n"})) ==
           std::string::npos,
-      host_pos16 == reset_for_host);
+      host_pos1 == reset_for_host);
 }
 
 }  // namespace
@@ -145,21 +121,9 @@ TEST_F(AdBlockCustomFilterResetUtilTest, IgnoreScripletAndProcedural) {
   ASSERT_FALSE(ResetCustomFiltersForHost(
       "", "###post-864297 > div.text > img:nth-child(9)\n"));
 
-  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0]);
-  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[1],
-            kCurrentHost[0], kCurrentHost[0]);
-  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[0],
-            kCurrentHost[0], kCurrentHost[0], kCurrentHost[0], kCurrentHost[1],
-            kCurrentHost[1], kCurrentHost[1]);
+  CheckCase(kCurrentHost[0], kCurrentHost[0], kCurrentHost[0]);
+  CheckCase(kCurrentHost[1], kCurrentHost[0], kCurrentHost[0]);
+  CheckCase(kCurrentHost[1], kCurrentHost[1], kCurrentHost[1]);
 }
 
 }  // namespace brave_shields

--- a/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
+++ b/components/cosmetic_filters/renderer/cosmetic_filters_js_handler.cc
@@ -13,7 +13,6 @@
 #include "base/json/json_writer.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/no_destructor.h"
-#include "base/ranges/algorithm.h"
 #include "base/strings/stringprintf.h"
 #include "base/trace_event/trace_event.h"
 #include "base/values.h"


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43812

Added the ability to skip procedural cosmetic filters and scriptlet during the reset operation of custom filters.
The next records should be skipped for reset:
- procedural cosmetic filters : https://github.com/gorhill/uBlock/wiki/Procedural-cosmetic-filters#list-of-available-operators
- scriptlet: https://github.com/gorhill/uBlock/wiki/Procedural-cosmetic-filters#list-of-available-operators


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

**On Android:**
1. Open Android Brave browser
2. Open `webpage1` you want to block any HTML element
3. Open `Brave Shields menu` -> `Advanced controls`
4. Click `Block elements` and make sure that `Element Picker` appears
7. Click any HTML element you want to block on the `webpage1` and press button `Block Element`, and make sure element blocked
8. Open `Settings` -> `Brave Shields & privacy` -> `Content Filtering` -> `Create custom filters`, make sure that new line for blocked element appeared there.
9. Add some custom rule with using any procedural cosmetic filter or scriptlet (Ex.: `<webpage1's host>##span:has-text(/^Post/)`, according to element you want to block)
10. Refresh the `webpage1` and make sure that both of elements are blocked
11. Open `Brave Shields menu` -> `Advanced controls` -> `Block elements` and click Reset button.
12. Make sure that only rule added in the step `#7` has been removed


**On Desktop:**
1. Open Brave browser
2. Open `webpage1` you want to block any HTML element
3. Open for the page: `Context menu` -> `Block elements`
4. Click any HTML element you want to block on the `webpage1` and press button `Block Element`, and make sure element blocked and new rule on the `brave://settings/shields/filters` has been added
5. On the `brave://settings/shields/filters` add some custom rule with using any procedural cosmetic filter or scriptlet (Ex.: `<webpage1's host>##span:has-text(/^Post/)`, according to element you want to block)
6. Refresh the `webpage1` and make sure that both of elements are blocked
7. Open for the page: `Context menu` -> `Block elements` and click Reset button
8. Make sure that only rule added in the step `#4` has been removed

