### PR TITLE
perf tests: Fix downloading WPR during rebase

### DIFF
--- a/patches/third_party/catapult/telemetry-telemetry-page-shared_page_state.py.patch
+++ b/patches/third_party/catapult/telemetry-telemetry-page-shared_page_state.py.patch
@@ -1,0 +1,12 @@
+diff --git a/telemetry/telemetry/page/shared_page_state.py b/telemetry/telemetry/page/shared_page_state.py
+index 70fbf130a9680248683706786f4ac50602fd5186..162fbd93860a0017767ceef02d91f7c17777a2f2 100644
+--- a/telemetry/telemetry/page/shared_page_state.py
++++ b/telemetry/telemetry/page/shared_page_state.py
+@@ -219,6 +219,7 @@ class SharedPageState(story_module.SharedState):
+     if archive_path is not None and not os.path.isfile(archive_path):
+       logging.warning('WPR archive missing: %s', archive_path)
+       archive_path = None
++      raise Exception('WPR missing %s', archive_path) # Brave: always raise
+     self.platform.network_controller.StartReplay(
+         archive_path, page.make_javascript_deterministic, self._extra_wpr_args)
+ 

--- a/tools/perf/brave_page_sets/brave_perf_utils_pages.py
+++ b/tools/perf/brave_page_sets/brave_perf_utils_pages.py
@@ -94,7 +94,7 @@ class _UpdateProfilePage(page_module.Page):
   def __init__(self, page_set, delay: int):
     EXTRA_BROWSER_ARGUMENTS = ['--enable-brave-features-for-perf-testing']
     self._delay = delay
-    super().__init__(url='chrome://components',
+    super().__init__(url='https://example.com',
                      page_set=page_set,
                      shared_page_state_class=_UpdateProfileSharedPageState,
                      name='UpdateProfile',


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44070

We use chrome://components page now.  The telemetry code considers `chrome://` pages as local, so WPR isn't downloaded despite the page is in the list.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

