### PR TITLE
Fix vertical tab perf regressions (uplift to 1.76.x)

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -440,7 +440,7 @@ class VerticalTabStripScrollContentsView : public views::View {
     // Prevent reentrance caused by container_->Layout()
     base::AutoReset<bool> in_preferred_size_change(&in_preferred_size_changed_,
                                                    true);
-    container_->DeprecatedLayoutImmediately();
+    container_->InvalidateLayout();
   }
 
   void OnPaintBackground(gfx::Canvas* canvas) override {

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -392,10 +392,6 @@ void BraveTabContainer::CompleteAnimationAndLayout() {
     return;
   }
 
-  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
-    last_layout_size_ = size();
-  }
-
   TabContainerImpl::CompleteAnimationAndLayout();
 
   // Should force tabs to layout as they might not change bounds, which makes
@@ -442,23 +438,6 @@ void BraveTabContainer::SetTabSlotVisibility() {
   }
 
   TabContainerImpl::SetTabSlotVisibility();
-}
-
-void BraveTabContainer::InvalidateIdealBounds() {
-  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
-    last_layout_size_ = gfx::Size();
-  }
-
-  TabContainerImpl::InvalidateIdealBounds();
-}
-
-void BraveTabContainer::Layout(PassKey) {
-  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()) &&
-      last_layout_size_ == size()) {
-    return;
-  }
-
-  LayoutSuperclass<TabContainerImpl>(this);
 }
 
 std::optional<BrowserRootView::DropIndex> BraveTabContainer::GetDropIndex(

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -50,8 +50,6 @@ class BraveTabContainer : public TabContainerImpl,
   void CompleteAnimationAndLayout() override;
   void PaintChildren(const views::PaintInfo& paint_info) override;
   void SetTabSlotVisibility() override;
-  void InvalidateIdealBounds() override;
-  void Layout(PassKey) override;
 
   // BrowserRootView::DropTarget
   std::optional<BrowserRootView::DropIndex> GetDropIndex(
@@ -143,9 +141,6 @@ class BraveTabContainer : public TabContainerImpl,
   BooleanPrefMember vertical_tabs_collapsed_;
 
   bool layout_locked_ = false;
-
-  // Size we last laid out at.
-  gfx::Size last_layout_size_;
 
   base::ScopedObservation<SplitViewBrowserData, SplitViewBrowserDataObserver>
       split_view_data_observation_{this};

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -4,6 +4,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 #include "base/test/bind.h"
+#include "base/test/run_until.h"
 #include "base/test/scoped_feature_list.h"
 #include "brave/browser/ui/browser_commands.h"
 #include "brave/browser/ui/tabs/brave_tab_menu_model.h"
@@ -527,11 +528,13 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
   AppendTab(browser());
   browser_view()->tabstrip()->StopAnimating(/* layout= */ true);
 
-  // When first tab is added, height should have tab's height plush top & bottom
+  // When first tab is added, height should have tab's height plus top & bottom
   // margin.
   contents_view_height +=
       (tabs::kVerticalTabHeight + tabs::kMarginForVerticalTabContainers * 2);
-  EXPECT_EQ(region_view->contents_view_->height(), contents_view_height);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return region_view->contents_view_->height() == contents_view_height;
+  }));
 
   AppendTab(browser());
   browser_view()->tabstrip()->StopAnimating(/* layout= */ true);
@@ -540,7 +543,9 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest,
   // tab spacing.
   contents_view_height +=
       (tabs::kVerticalTabHeight + tabs::kVerticalTabsSpacing);
-  EXPECT_EQ(region_view->contents_view_->height(), contents_view_height);
+  ASSERT_TRUE(base::test::RunUntil([&]() {
+    return region_view->contents_view_->height() == contents_view_height;
+  }));
 }
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ScrollBarVisibility) {


### PR DESCRIPTION
Uplift of #27665
Resolves https://github.com/brave/brave-browser/issues/43980

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.