### PR TITLE
Fix "Toggle Vertical Tabs Expanded" command for independent expanded states per window

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -594,19 +594,8 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
   width_animation_.Reset(1.0);
 
   header_view_ = AddChildView(std::make_unique<HeaderView>(
-      base::BindRepeating(
-          [](VerticalTabStripRegionView* container, const ui::Event& event) {
-            // Note that Calling SetValue() doesn't trigger
-            // OnCollapsedPrefChanged() for this view.
-            if (container->state_ == State::kExpanded) {
-              container->collapsed_pref_.SetValue(true);
-              container->SetState(State::kCollapsed);
-            } else {
-              container->collapsed_pref_.SetValue(false);
-              container->SetState(State::kExpanded);
-            }
-          },
-          this),
+      base::BindRepeating(&VerticalTabStripRegionView::ToggleState,
+                          base::Unretained(this)),
       this, browser_));
   contents_view_ =
       AddChildView(std::make_unique<VerticalTabStripScrollContentsView>());
@@ -699,6 +688,16 @@ VerticalTabStripRegionView::~VerticalTabStripRegionView() {
   DCHECK(fullscreen_observation_.IsObserving())
       << "We didn't start to observe FullscreenController from BrowserList's "
          "callback";
+}
+
+void VerticalTabStripRegionView::ToggleState() {
+  if (state_ == State::kExpanded) {
+    collapsed_pref_.SetValue(true);
+    SetState(State::kCollapsed);
+  } else {
+    collapsed_pref_.SetValue(false);
+    SetState(State::kExpanded);
+  }
 }
 
 void VerticalTabStripRegionView::OnWidgetActivationChanged(

--- a/browser/ui/views/frame/vertical_tab_strip_region_view.h
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.h
@@ -72,6 +72,8 @@ class VerticalTabStripRegionView : public views::View,
 
   const Browser* browser() const { return browser_; }
 
+  void ToggleState();
+
   // Expand vertical tabstrip temporarily. When the returned
   // ScopedCallbackRunner is destroyed, the state will be restored to the
   // previous state.

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -27,6 +27,7 @@
 #include "build/build_config.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_command_controller.h"
 #include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
@@ -627,6 +628,12 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripBrowserTest, ExpandedState) {
   EXPECT_EQ(State::kExpanded, region_view_1->state());
   EXPECT_FALSE(prefs->GetBoolean(brave_tabs::kVerticalTabsCollapsed));
   EXPECT_EQ(State::kCollapsed, region_view_2->state());
+
+  // Check expanded state is toggled via command.
+  auto* command_controller = browser()->command_controller();
+  command_controller->ExecuteCommandWithDisposition(
+      IDC_TOGGLE_VERTICAL_TABS_EXPANDED, WindowOpenDisposition::CURRENT_TAB);
+  EXPECT_EQ(State::kCollapsed, region_view_1->state());
 
   // And new browser should follow the preference.
   prefs->SetBoolean(brave_tabs::kVerticalTabsCollapsed, true);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/41074

If "Expand vertical tabs independently per window" is enabled, the "Toggle Vertical Tabs Expanded" shortcut command will properly toggle the expanded state for the browser window currently focused.

Exposed a public `ToggleState()` method in the brave vertical tab strip region view for its state to be changed programmatically beyond the tab strip (toggle button) and preference listeners.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

