### PR TITLE
feat(wallet): Always Show Zcash Sync Status on Account Details

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1651,7 +1651,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletAccountBirthdayTooLow",
      IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW},
     {"braveWalletAccountBirthdayTooHigh",
-     IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH}};
+     IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH},
+    {"braveWalletBlocksBehind", IDS_BRAVE_WALLET_BLOCKS_BEHIND}};
 
 // 0x swap constants
 inline constexpr char kZeroExBaseAPIURL[] = "https://api.0x.wallet.brave.com";

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -227,10 +227,7 @@ export const Account = () => {
     ? chainTipStatus.chainTip - chainTipStatus.latestScannedBlock
     : 0
 
-  const showSyncWarning =
-    isShieldedAccount &&
-    (blocksBehind > 1000 || chainTipStatus === null) &&
-    !syncWarningDismissed
+  const showSyncWarning = isShieldedAccount && !syncWarningDismissed
 
   // custom hooks & memos
   const scrollIntoView = useScrollIntoView()
@@ -578,16 +575,19 @@ export const Account = () => {
                 ? 'error'
                 : blocksBehind > 3000
                 ? 'warning'
-                : 'info'
+                : blocksBehind > 1000
+                ? 'info'
+                : 'notice'
             }
           >
             <div slot='title'>
               {!chainTipStatus
                 ? getLocale('braveWalletOutOfSyncTitle')
-                : getLocale('braveWalletOutOfSyncBlocksBehindTitle').replace(
-                    '$1',
-                    blocksBehind.toLocaleString()
-                  )}
+                : getLocale(
+                    blocksBehind < 1000
+                      ? 'braveWalletBlocksBehind'
+                      : 'braveWalletOutOfSyncBlocksBehindTitle'
+                  ).replace('$1', blocksBehind.toLocaleString())}
             </div>
             {getLocale('braveWalletOutOfSyncDescription')}
             <Row

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1547,6 +1547,7 @@ provideStrings({
     'Please don’t close this window until sync finishes.',
   braveWalletContinueUsingWallet: 'Continue using wallet in a new tab',
   braveWalletShieldedAccountBirthdayBlock: 'Shielded account birthday block',
-  braveWalletAccountBirthdayToLow: 'Account birthday must be greater than $1',
-  braveWalletAccountBirthdayToHigh: 'Account birthday must be less than $1'
+  braveWalletAccountBirthdayTooLow: 'Account birthday must be greater than $1',
+  braveWalletAccountBirthdayTooHigh: 'Account birthday must be less than $1',
+  braveWalletBlocksBehind: '$1 blocks behind'
 })

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1179,6 +1179,7 @@
   <message name="IDS_BRAVE_WALLET_SHIELDED_ACCOUNT_BIRTHDAY_BLOCK" desc="Shielded account birthday block input label">Shielded account birthday block</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW" desc="Account birthday to low error">Account birthday must be greater than <ph name="BLOCK_NUMBER">$1<ex>1687104</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH" desc="Account birthday to high error">Account birthday must be less than <ph name="BLOCK_NUMBER">$1<ex>7687104</ex></ph></message>
+  <message name="IDS_BRAVE_WALLET_BLOCKS_BEHIND" desc="Blocks behind label for Zcash account sync"><ph name="BLOCKS">$1<ex>12,568</ex></ph> blocks behind</message>  
   <message name="IDS_BRAVE_WALLET_BUTTON_RETRY" desc="Retry an action">Retry</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_PREVIEW_FAILED" desc="Explaination that simulation of a transaction has failed">Transaction preview failed.</message>
   <message name="IDS_BRAVE_WALLET_ESTIMATED_BALANCE_CHANGE" desc="Grouping header for estimated balance changes">Estimated balance change</message>


### PR DESCRIPTION
## Description 

- Adds an additional `Sync` status color warning when an account is less then `1000` blocks behind. 
- Will now always display Zcash account `Sync` status on the `Account Details` page, to allow users to sync whenever needed.

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/44074>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Create a brand new `Profile` and `Wallet` account and then create a `Zcash` account
2. Shield that account with a `birthday` value of `10000` or less then the current block height. You can find the current block height on https://blockexplorer.one/zcash/mainnet
3. You should see the `Out of sync` warning on the `Portfolio` screen when grouped by `Accounts`.
4. Click `Sync account`, you should now see the sync `modal`
5. After it has complete syncing, close the `modal` and `Sync` status should still be visible and will be `Gray` in color. 


![Screenshot 48](https://github.com/user-attachments/assets/ce2266a2-ace1-40eb-bcdb-f4ce20d1323f)
