### PR TITLE
Revert "[CodeHealth] Use cxx20's `T::contains` pt.2 (#27709)"

### DIFF
--- a/browser/permissions/permission_origin_lifetime_monitor_impl.cc
+++ b/browser/permissions/permission_origin_lifetime_monitor_impl.cc
@@ -7,6 +7,7 @@
 
 #include <utility>
 
+#include "base/containers/contains.h"
 #include "brave/browser/ephemeral_storage/ephemeral_storage_service_factory.h"
 #include "brave/components/brave_wallet/browser/permission_utils.h"
 #include "brave/components/ephemeral_storage/ephemeral_storage_service.h"
@@ -53,7 +54,7 @@ PermissionOriginLifetimeMonitorImpl::SubscribeToPermissionOriginDestruction(
   }
   std::string storage_domain = net::URLToEphemeralStorageDomain(
       is_sub_request_origin ? sub_request_origin.GetURL() : requesting_origin);
-  if (!active_subscriptions_.contains(storage_domain)) {
+  if (!base::Contains(active_subscriptions_, storage_domain)) {
     active_subscriptions_.insert(storage_domain);
   }
   return storage_domain;

--- a/browser/ui/brave_browser_command_controller.cc
+++ b/browser/ui/brave_browser_command_controller.cc
@@ -6,8 +6,9 @@
 #include "brave/browser/ui/brave_browser_command_controller.h"
 
 #include <optional>
+#include <vector>
 
-#include "base/containers/fixed_flat_set.h"
+#include "base/containers/contains.h"
 #include "base/feature_list.h"
 #include "base/types/to_address.h"
 #include "brave/app/brave_command_ids.h"
@@ -75,11 +76,11 @@ bool IsBraveCommands(int id) {
 }
 
 bool IsBraveOverrideCommands(int id) {
-  static constexpr auto kOverrideCommands = base::MakeFixedFlatSet<int>({
+  static std::vector<int> override_commands({
       IDC_NEW_WINDOW,
       IDC_NEW_INCOGNITO_WINDOW,
   });
-  return kOverrideCommands.contains(id);
+  return base::Contains(override_commands, id);
 }
 
 }  // namespace

--- a/chromium_src/components/sessions/content/content_serialized_navigation_driver.cc
+++ b/chromium_src/components/sessions/content/content_serialized_navigation_driver.cc
@@ -7,7 +7,7 @@
 
 #include <string>
 
-#include "base/containers/fixed_flat_set.h"
+#include "base/containers/contains.h"
 #include "components/sessions/core/serialized_navigation_entry.h"
 #include "content/public/common/url_constants.h"
 
@@ -18,22 +18,18 @@
 
 namespace sessions {
 
-namespace {
-
-// Extension can override below three chrome urls.
-// https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/chrome_url_overrides.idl
-constexpr auto kAllowedChromeUrlsOverridingHostList =
-    base::MakeFixedFlatSet<std::string_view>(
-        {"newtab", "history", "bookmarks"});
-
-}  // namespace
-
 std::string ContentSerializedNavigationDriver::GetSanitizedPageStateForPickle(
     const sessions::SerializedNavigationEntry* navigation) const {
+  // Extension can override below three chrome urls.
+  // https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/chrome_url_overrides.idl
+  constexpr std::array<const char*, 3> kAllowedChromeUrlsOverridingHostList = {
+      "newtab", "history", "bookmarks"};
+
   const auto& virtual_url = navigation->virtual_url();
   if (virtual_url.SchemeIs(content::kChromeUIScheme)) {
     // If empty string is returned, chrome url overriding is ignored.
-    if (kAllowedChromeUrlsOverridingHostList.contains(virtual_url.host())) {
+    if (base::Contains(kAllowedChromeUrlsOverridingHostList,
+                       virtual_url.host())) {
       // chrome url can be re-written when it's restored during the tab but
       // re-written url is ignored when encoded page state is empty.
       // In ContentSerializedNavigationBuilder::ToNavigationEntry(), re-written

--- a/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
+++ b/chromium_src/components/sync_device_info/device_info_sync_bridge.cc
@@ -130,7 +130,7 @@ void DeviceInfoSyncBridge::RefreshLocalDeviceInfoIfNeeded() {
     return;
   }
 
-  if (!all_data_.contains(current_info->guid())) {
+  if (!base::Contains(all_data_, current_info->guid())) {
     // After initiating leave the sync chain `DeleteSpecifics` cleans
     // `all_data_` map.
     // It is possible that user close sync settings page or change the data type

--- a/chromium_src/components/webapps/browser/banners/app_banner_manager.cc
+++ b/chromium_src/components/webapps/browser/banners/app_banner_manager.cc
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+#include "base/containers/contains.h"
 #include "brave/components/constants/webui_url_constants.h"
 
 // Include password_manager constants before override so we don't override the
@@ -12,7 +13,7 @@
 // Add some extra items to WebUI hosts considered valid for PWAs
 #define kChromeUIPasswordManagerHost \
   kChromeUIPasswordManagerHost &&    \
-      !kInstallablePWAWebUIHosts.contains(url.host_piece())
+      !base::Contains(kInstallablePWAWebUIHosts, url.host_piece())
 
 #include "src/components/webapps/browser/banners/app_banner_manager.cc"
 #undef kChromeUIPasswordManagerHost

--- a/chromium_src/third_party/blink/common/origin_trials/origin_trials.cc
+++ b/chromium_src/third_party/blink/common/origin_trials/origin_trials.cc
@@ -7,7 +7,7 @@
 
 #include <string_view>
 
-#include "base/containers/fixed_flat_set.h"
+#include "base/containers/contains.h"
 
 namespace blink::origin_trials {
 bool IsTrialValid_ChromiumImpl(std::string_view trial_name);
@@ -19,33 +19,21 @@ bool IsTrialValid_ChromiumImpl(std::string_view trial_name);
 
 namespace blink::origin_trials {
 
-namespace {
-
-// When updating also update the array in the overload below.
-constexpr auto kBraveDisabledTrialNames =
-    base::MakeFixedFlatSet<std::string_view>({
-        "AdInterestGroupAPI",
-        "DeviceAttributes",
-        "DigitalGoodsV2",
-        "InterestCohortAPI",
-        "FencedFrames",
-        "Fledge",
-        "Parakeet",
-        "SignedExchangeSubresourcePrefetch",
-        "SubresourceWebBundles",
-    });
-
-constexpr auto kBraveDisabledTrialFeatures =
-    base::MakeFixedFlatSet<blink::mojom::OriginTrialFeature>({
-        blink::mojom::OriginTrialFeature::kAdInterestGroupAPI,
-        blink::mojom::OriginTrialFeature::kDigitalGoods,
-        blink::mojom::OriginTrialFeature::kParakeet,
-    });
-
-}  // namespace
-
 bool IsTrialDisabledInBrave(std::string_view trial_name) {
-  if (kBraveDisabledTrialNames.contains(trial_name)) {
+  // When updating also update the array in the overload below.
+  static const char* const kBraveDisabledTrialNames[] = {
+      "AdInterestGroupAPI",
+      "DeviceAttributes",
+      "DigitalGoodsV2",
+      "InterestCohortAPI",
+      "FencedFrames",
+      "Fledge",
+      "Parakeet",
+      "SignedExchangeSubresourcePrefetch",
+      "SubresourceWebBundles",
+  };
+
+  if (base::Contains(kBraveDisabledTrialNames, trial_name)) {
     // Check if this is still a valid trial name in Chromium. If not, it needs
     // to be changed as in Chromium or removed.
     DCHECK(IsTrialValid_ChromiumImpl(trial_name));
@@ -57,7 +45,14 @@ bool IsTrialDisabledInBrave(std::string_view trial_name) {
 
 bool IsTrialDisabledInBrave(blink::mojom::OriginTrialFeature feature) {
   // When updating also update the array in the overload above.
-  return kBraveDisabledTrialFeatures.contains(feature);
+  static const blink::mojom::OriginTrialFeature kBraveDisabledTrialFeatures[] =
+      {
+          blink::mojom::OriginTrialFeature::kAdInterestGroupAPI,
+          blink::mojom::OriginTrialFeature::kDigitalGoods,
+          blink::mojom::OriginTrialFeature::kParakeet,
+      };
+
+  return base::Contains(kBraveDisabledTrialFeatures, feature);
 }
 
 bool IsTrialValid(std::string_view trial_name) {

--- a/components/ai_chat/content/browser/page_content_fetcher.cc
+++ b/components/ai_chat/content/browser/page_content_fetcher.cc
@@ -18,6 +18,7 @@
 
 #include "base/check.h"
 #include "base/containers/checked_iterators.h"
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
@@ -202,7 +203,7 @@ class PageContentFetcherInternal {
       return;
     }
     DVLOG(1) << "OnTabContentResult: " << data.get();
-    const bool is_video = kVideoPageContentTypes.contains(data->type);
+    const bool is_video = base::Contains(kVideoPageContentTypes, data->type);
     DVLOG(1) << "Is video? " << is_video;
     // Handle text mode response
     if (!is_video) {
@@ -455,7 +456,7 @@ void PageContentFetcher::FetchPageContent(std::string_view invalidation_token,
 
   auto url = web_contents_->GetLastCommittedURL();
 #if BUILDFLAG(ENABLE_TEXT_RECOGNITION)
-  if (kScreenshotRetrievalHosts.contains(url.host_piece())) {
+  if (base::Contains(kScreenshotRetrievalHosts, url.host_piece())) {
     content::RenderWidgetHostView* view =
         web_contents_->GetRenderWidgetHostView();
     if (view) {

--- a/components/ai_chat/core/browser/tab_tracker_service.cc
+++ b/components/ai_chat/core/browser/tab_tracker_service.cc
@@ -24,7 +24,7 @@ void TabTrackerService::Bind(
 
 void TabTrackerService::UpdateTab(int32_t tab_id, mojom::TabDataPtr tab) {
   auto allowed_scheme =
-      tab && kAllowedContentSchemes.contains(tab->url.scheme());
+      tab && base::Contains(kAllowedContentSchemes, tab->url.scheme());
 
   auto it = std::ranges::find_if(
       tabs_, [tab_id](const auto& tab) { return tab->id == tab_id; });

--- a/components/ai_chat/renderer/ai_chat_resource_sniffer.cc
+++ b/components/ai_chat/renderer/ai_chat_resource_sniffer.cc
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/functional/callback.h"
 #include "base/macros/if.h"
@@ -50,7 +51,8 @@ std::unique_ptr<AIChatResourceSniffer> AIChatResourceSniffer::MaybeCreate(
   // TODO(petemill): Allow some kind of config to be passed in to determine
   // which hosts and paths to sniff, and how to parse it to a
   // |mojom::PageContent|.
-  if (url.SchemeIsHTTPOrHTTPS() && kYouTubeHosts.contains(url.host_piece()) &&
+  if (url.SchemeIsHTTPOrHTTPS() &&
+      base::Contains(kYouTubeHosts, url.host_piece()) &&
       base::EqualsCaseInsensitiveASCII(url.path_piece(),
                                        kYouTubePlayerAPIPath)) {
     return base::WrapUnique(new AIChatResourceSniffer(std::move(delegate)));

--- a/components/ai_chat/renderer/page_content_extractor.cc
+++ b/components/ai_chat/renderer/page_content_extractor.cc
@@ -23,6 +23,7 @@
 
 #include "base/check.h"
 #include "base/check_op.h"
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/containers/flat_tree.h"
 #include "base/containers/span.h"
@@ -172,7 +173,7 @@ void PageContentExtractor::ExtractPageContent(
 
   if (origin.is_valid()) {
     std::string host = origin.host();
-    if (kYouTubeHosts.contains(host)) {
+    if (base::Contains(kYouTubeHosts, host)) {
       VLOG(1) << "YouTube transcript type";
       // Do Youtube extraction
       v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
@@ -192,7 +193,7 @@ void PageContentExtractor::ExtractPageContent(
           blink::mojom::WantResultOption::kWantResult,
           blink::mojom::PromiseResultOption::kAwait);
       return;
-    } else if (kVideoTrackHosts.contains(host)) {
+    } else if (base::Contains(kVideoTrackHosts, host)) {
       VLOG(1) << "Video track transcript type";
       // Video <track> extraction
       // TODO(petemill): Use heuristics to determine if page's main focus is

--- a/components/ai_chat/renderer/page_text_distilling.cc
+++ b/components/ai_chat/renderer/page_text_distilling.cc
@@ -18,8 +18,8 @@
 #include <vector>
 
 #include "base/compiler_specific.h"
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_map.h"
-#include "base/containers/fixed_flat_set.h"
 #include "base/containers/span.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
@@ -50,18 +50,18 @@ namespace ai_chat {
 
 namespace {
 
-constexpr auto kContentParentRoles = base::MakeFixedFlatSet<ax::mojom::Role>({
+static const ax::mojom::Role kContentParentRoles[]{
     ax::mojom::Role::kMain,
     ax::mojom::Role::kArticle,
-});
+};
 
-constexpr auto kContentRoles = base::MakeFixedFlatSet<ax::mojom::Role>({
+static const ax::mojom::Role kContentRoles[]{
     ax::mojom::Role::kHeading,
     ax::mojom::Role::kParagraph,
     ax::mojom::Role::kNote,
-});
+};
 
-constexpr auto kRolesToSkip = base::MakeFixedFlatSet<ax::mojom::Role>({
+static const ax::mojom::Role kRolesToSkip[]{
     ax::mojom::Role::kAudio,
     ax::mojom::Role::kBanner,
     ax::mojom::Role::kButton,
@@ -83,7 +83,7 @@ constexpr auto kRolesToSkip = base::MakeFixedFlatSet<ax::mojom::Role>({
     ax::mojom::Role::kSlider,
     ax::mojom::Role::kSpinButton,
     ax::mojom::Role::kSearchBox,
-});
+};
 
 void GetContentRootNodes(const ui::AXNode* root,
                          std::vector<const ui::AXNode*>* content_root_nodes) {
@@ -94,7 +94,7 @@ void GetContentRootNodes(const ui::AXNode* root,
     queue.pop();
     // If a main or article node is found, add it to the list of content root
     // nodes and continue. Do not explore children for nested article nodes.
-    if (kContentParentRoles.contains(node->GetRole())) {
+    if (base::Contains(kContentParentRoles, node->GetRole())) {
       content_root_nodes->push_back(node);
       continue;
     }
@@ -107,11 +107,11 @@ void GetContentRootNodes(const ui::AXNode* root,
 
 void AddContentNodesToVector(const ui::AXNode* node,
                              std::vector<const ui::AXNode*>* content_nodes) {
-  if (kContentRoles.contains(node->GetRole())) {
+  if (base::Contains(kContentRoles, node->GetRole())) {
     content_nodes->emplace_back(node);
     return;
   }
-  if (kRolesToSkip.contains(node->GetRole())) {
+  if (base::Contains(kRolesToSkip, node->GetRole())) {
     return;
   }
   for (auto iter = node->UnignoredChildrenBegin();
@@ -124,7 +124,7 @@ void AddTextNodesToVector(const ui::AXNode* node,
                           std::vector<std::u16string>* strings) {
   const ui::AXNodeData& node_data = node->data();
 
-  if (kRolesToSkip.contains(node_data.role)) {
+  if (base::Contains(kRolesToSkip, node_data.role)) {
     return;
   }
 

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor.cc
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor.cc
@@ -11,6 +11,7 @@
 #include <utility>
 
 #include "base/check.h"
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/containers/flat_set.h"
 #include "base/logging.h"
@@ -260,7 +261,8 @@ mojom::CreativeSearchResultAdInfoPtr ExtractMojomEntity(
       return {};
     }
 
-    if (kRequiredCreativeAdPropertyNames.contains(mojom_property->name)) {
+    if (base::Contains(kRequiredCreativeAdPropertyNames,
+                       mojom_property->name)) {
       if (!ExtractCreativeAdMojomProperty(mojom_property,
                                           mojom_creative_ad.get())) {
         VLOG(6) << "Failed to extract creative search result ad property "
@@ -269,8 +271,8 @@ mojom::CreativeSearchResultAdInfoPtr ExtractMojomEntity(
       }
 
       creative_ad_property_names.insert(mojom_property->name);
-    } else if (kCreativeSetConversionPropertyNames.contains(
-                   mojom_property->name)) {
+    } else if (base::Contains(kCreativeSetConversionPropertyNames,
+                              mojom_property->name)) {
       if (!ExtractCreativeSetConversionMojomProperty(
               mojom_property, mojom_creative_set_conversion.get())) {
         VLOG(6) << "Failed to extract creative set conversion property "

--- a/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.cc
+++ b/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.cc
@@ -6,6 +6,7 @@
 #include "brave/components/brave_ads/core/internal/ads_client/ads_client_notifier_for_testing.h"
 
 #include "base/check_op.h"
+#include "base/containers/contains.h"
 #include "url/gurl.h"
 
 namespace brave_ads {
@@ -176,7 +177,7 @@ void AdsClientNotifierForTesting::SimulateOpeningNewTab(
     int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
     int http_status_code) {
-  CHECK(!redirect_chains_.contains(tab_id)) << "Tab already open";
+  CHECK(!base::Contains(redirect_chains_, tab_id)) << "Tab already open";
 
   redirect_chains_[tab_id] = redirect_chain;
 
@@ -189,7 +190,7 @@ void AdsClientNotifierForTesting::SimulateNavigateToURL(
     int32_t tab_id,
     const std::vector<GURL>& redirect_chain,
     int http_status_code) {
-  CHECK(redirect_chains_.contains(tab_id)) << "Tab does not exist";
+  CHECK(base::Contains(redirect_chains_, tab_id)) << "Tab does not exist";
 
   redirect_chains_[tab_id] = redirect_chain;
 
@@ -201,12 +202,12 @@ void AdsClientNotifierForTesting::SimulateNavigateToURL(
 }
 
 void AdsClientNotifierForTesting::SimulateSelectTab(int32_t tab_id) {
-  CHECK(redirect_chains_.contains(tab_id)) << "Tab does not exist";
+  CHECK(base::Contains(redirect_chains_, tab_id)) << "Tab does not exist";
 
   if (visible_tab_id_) {
     // Occlude the previously visible tab.
     CHECK_NE(*visible_tab_id_, tab_id) << "Tab already selected";
-    CHECK(redirect_chains_.contains(*visible_tab_id_));
+    CHECK(base::Contains(redirect_chains_, *visible_tab_id_));
 
     NotifyTabDidChange(*visible_tab_id_, redirect_chains_[*visible_tab_id_],
                        /*is_new_navigation=*/false, /*is_restoring=*/false,
@@ -220,7 +221,7 @@ void AdsClientNotifierForTesting::SimulateSelectTab(int32_t tab_id) {
 }
 
 void AdsClientNotifierForTesting::SimulateClosingTab(int32_t tab_id) {
-  CHECK(redirect_chains_.contains(tab_id)) << "Tab does not exist";
+  CHECK(base::Contains(redirect_chains_, tab_id)) << "Tab does not exist";
 
   NotifyDidCloseTab(tab_id);
 

--- a/components/brave_ads/core/internal/common/test/internal/local_state_pref_storage_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/local_state_pref_storage_test_util_internal.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/common/test/internal/local_state_pref_storage_test_util_internal.h"
 
+#include "base/containers/contains.h"
 #include "base/containers/flat_map.h"
 #include "base/no_destructor.h"
 #include "brave/components/brave_ads/core/internal/common/test/internal/current_test_util_internal.h"
@@ -23,7 +24,7 @@ base::flat_map</*uuid=*/std::string, PrefValueInfo>& LocalStatePrefStorage() {
 
 bool FindLocalStatePref(const std::string& path) {
   const std::string uuid = GetUuidForCurrentTestAndValue(path);
-  return LocalStatePrefStorage().contains(uuid);
+  return base::Contains(LocalStatePrefStorage(), uuid);
 }
 
 PrefValueInfo& LocalStatePref(const std::string& path) {
@@ -32,7 +33,8 @@ PrefValueInfo& LocalStatePref(const std::string& path) {
 }
 
 bool HasLocalStatePref(const std::string& path) {
-  return LocalStatePrefStorage().contains(GetUuidForCurrentTestAndValue(path));
+  return base::Contains(LocalStatePrefStorage(),
+                        GetUuidForCurrentTestAndValue(path));
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_ads/core/internal/common/test/internal/profile_pref_storage_test_util_internal.cc
+++ b/components/brave_ads/core/internal/common/test/internal/profile_pref_storage_test_util_internal.cc
@@ -5,6 +5,7 @@
 
 #include "brave/components/brave_ads/core/internal/common/test/internal/profile_pref_storage_test_util_internal.h"
 
+#include "base/containers/contains.h"
 #include "base/containers/flat_map.h"
 #include "base/no_destructor.h"
 #include "brave/components/brave_ads/core/internal/common/test/internal/current_test_util_internal.h"
@@ -22,7 +23,8 @@ base::flat_map</*uuid=*/std::string, PrefValueInfo>& ProfilePrefStorage() {
 }  // namespace
 
 bool FindProfilePref(const std::string& path) {
-  return ProfilePrefStorage().contains(GetUuidForCurrentTestAndValue(path));
+  return base::Contains(ProfilePrefStorage(),
+                        GetUuidForCurrentTestAndValue(path));
 }
 
 PrefValueInfo& ProfilePref(const std::string& path) {
@@ -31,7 +33,8 @@ PrefValueInfo& ProfilePref(const std::string& path) {
 }
 
 bool HasProfilePref(const std::string& path) {
-  return ProfilePrefStorage().contains(GetUuidForCurrentTestAndValue(path));
+  return base::Contains(ProfilePrefStorage(),
+                        GetUuidForCurrentTestAndValue(path));
 }
 
 }  // namespace brave_ads::test

--- a/components/brave_news/browser/brave_news_pref_manager_unittest.cc
+++ b/components/brave_news/browser/brave_news_pref_manager_unittest.cc
@@ -113,11 +113,11 @@ TEST_F(BraveNewsPrefManagerTest, PublishersDiffIsSane) {
 
   base::flat_set<std::string> distinct_changes(diff.changed);
   EXPECT_EQ(5u, distinct_changes.size());
-  EXPECT_TRUE(distinct_changes.contains("One"));
-  EXPECT_TRUE(distinct_changes.contains("Two"));
-  EXPECT_TRUE(distinct_changes.contains("Four"));
-  EXPECT_TRUE(distinct_changes.contains("Five"));
-  EXPECT_TRUE(distinct_changes.contains(direct_three));
+  EXPECT_TRUE(base::Contains(distinct_changes, "One"));
+  EXPECT_TRUE(base::Contains(distinct_changes, "Two"));
+  EXPECT_TRUE(base::Contains(distinct_changes, "Four"));
+  EXPECT_TRUE(base::Contains(distinct_changes, "Five"));
+  EXPECT_TRUE(base::Contains(distinct_changes, direct_three));
 
   EXPECT_EQ(1u, diff.removed.size());
   EXPECT_TRUE(base::Contains(diff.removed, direct_one));

--- a/components/brave_news/browser/channels_controller_unittest.cc
+++ b/components/brave_news/browser/channels_controller_unittest.cc
@@ -10,6 +10,7 @@
 #include <utility>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/functional/bind.h"
 #include "brave/components/api_request_helper/api_request_helper.h"
 #include "brave/components/brave_news/browser/brave_news_controller.h"
@@ -121,10 +122,10 @@ TEST_F(BraveNewsChannelsControllerTest, CanGetAllChannels) {
 
   auto channels = GetAllChannels();
   EXPECT_EQ(4u, channels.size());
-  EXPECT_TRUE(channels.contains("One"));
-  EXPECT_TRUE(channels.contains("Two"));
-  EXPECT_TRUE(channels.contains("Four"));
-  EXPECT_TRUE(channels.contains("Five"));
+  EXPECT_TRUE(base::Contains(channels, "One"));
+  EXPECT_TRUE(base::Contains(channels, "Two"));
+  EXPECT_TRUE(base::Contains(channels, "Four"));
+  EXPECT_TRUE(base::Contains(channels, "Five"));
 
   // By default, none of these channels should be subscribed.
   for (const auto& it : channels) {

--- a/components/brave_news/browser/feed_generation_info.cc
+++ b/components/brave_news/browser/feed_generation_info.cc
@@ -152,8 +152,8 @@ ArticleInfos GetArticleInfos(const std::string& locale,
         continue;
       }
 
-      const bool discoverable =
-          !non_discoverable_publishers.contains(article->data->publisher_id);
+      const bool discoverable = !base::Contains(non_discoverable_publishers,
+                                                article->data->publisher_id);
 
       auto channels = GetChannelsForPublisher(
           locale, publishers.at(article->data->publisher_id));
@@ -230,7 +230,7 @@ FeedGenerationInfo::GetEligibleContentGroups() {
 
     std::vector<ContentGroup> content_groups;
     for (const auto& channel_id : channels_) {
-      if (available_counts_.contains(channel_id)) {
+      if (base::Contains(available_counts_, channel_id)) {
         content_groups.emplace_back(channel_id, true);
         DVLOG(1) << "Subscribed to channel: " << channel_id;
       } else {
@@ -244,7 +244,7 @@ FeedGenerationInfo::GetEligibleContentGroups() {
     for (const auto& [publisher_id, publisher] : publishers_) {
       if (publisher->user_enabled_status == mojom::UserEnabled::ENABLED ||
           publisher->type == mojom::PublisherType::DIRECT_SOURCE) {
-        if (available_counts_.contains(publisher_id)) {
+        if (base::Contains(available_counts_, publisher_id)) {
           content_groups.emplace_back(publisher_id, false);
           DVLOG(1) << "Subscribed to publisher: " << publisher->publisher_name;
         } else {

--- a/components/brave_news/browser/feed_sampling.h
+++ b/components/brave_news/browser/feed_sampling.h
@@ -14,7 +14,6 @@
 #include <vector>
 
 #include "base/containers/flat_set.h"
-#include "base/containers/span.h"
 #include "base/functional/callback_forward.h"
 #include "base/rand_util.h"
 #include "brave/components/brave_news/common/brave_news.mojom-forward.h"
@@ -71,7 +70,7 @@ using PickArticles =
 using ContentGroup = std::pair<std::string, bool>;
 
 template <typename T>
-T PickRandom(const base::span<T>& items) {
+T PickRandom(const std::vector<T>& items) {
   CHECK(!items.empty());
   // Note: RandInt is inclusive, hence the minus 1
   return items[base::RandInt(0, items.size() - 1)];
@@ -79,7 +78,7 @@ T PickRandom(const base::span<T>& items) {
 
 // Sample across subscribed channels (direct and native) and publishers.
 ContentGroup SampleContentGroup(
-    base::span<const ContentGroup> eligible_content_groups);
+    const std::vector<ContentGroup>& eligible_content_groups);
 
 std::vector<std::string> GetChannelsForPublisher(
     const std::string& locale,

--- a/components/brave_news/browser/feed_sampling_unittest.cc
+++ b/components/brave_news/browser/feed_sampling_unittest.cc
@@ -9,7 +9,7 @@
 #include <tuple>
 #include <vector>
 
-#include "base/containers/fixed_flat_set.h"
+#include "base/containers/contains.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
 #include "brave/components/brave_news/browser/feed_fetcher.h"
@@ -22,19 +22,17 @@ namespace brave_news {
 
 TEST(BraveNewsFeedSampling, CanPickRandomItem) {
   constexpr int iterations = 100;
-  static constexpr auto kInts =
-      base::MakeFixedFlatSet<int>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+  std::vector<int> ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   for (auto i = 0; i < iterations; ++i) {
-    auto result = PickRandom(base::span(kInts));
-    EXPECT_TRUE(kInts.contains(result));
+    auto result = PickRandom(ints);
+    EXPECT_TRUE(base::Contains(ints, result));
   }
 
-  static constexpr auto kStrings =
-      base::MakeFixedFlatSet<std::string_view>({"foo", "bar", "hello"});
+  std::vector<std::string> strings = {"foo", "bar", "hello"};
   for (auto i = 0; i < iterations; ++i) {
-    const auto& result = PickRandom(base::span(kStrings));
-    EXPECT_TRUE(kStrings.contains(result));
+    const auto& result = PickRandom(strings);
+    EXPECT_TRUE(base::Contains(strings, result));
   }
 }
 
@@ -47,16 +45,15 @@ TEST(BraveNewsFeedSampling, CanSampleContentGroupEmpty) {
 
 TEST(BraveNewsFeedSampling, CanSampleContentGroup) {
   constexpr int iterations = 100;
-  static constexpr auto kGroups =
-      base::MakeFixedFlatSet<ContentGroup>({{"publisher_1", false},
-                                            {"publisher_2", false},
-                                            {"channel_1", true},
-                                            {"channel_2", true},
-                                            {"publisher_3", false}});
+  std::vector<ContentGroup> groups = {{"publisher_1", false},
+                                      {"publisher_2", false},
+                                      {"channel_1", true},
+                                      {"channel_2", true},
+                                      {"publisher_3", false}};
 
   for (auto i = 0; i < iterations; ++i) {
-    auto sample = SampleContentGroup(kGroups);
-    EXPECT_TRUE(kGroups.contains(sample));
+    auto sample = SampleContentGroup(groups);
+    EXPECT_TRUE(base::Contains(groups, sample));
   }
 }
 

--- a/components/brave_news/browser/feed_v2_builder.cc
+++ b/components/brave_news/browser/feed_v2_builder.cc
@@ -395,10 +395,9 @@ std::vector<mojom::FeedItemV2Ptr> GenerateClusterBlock(
       feed_generation_info.topics().empty();
 
   if (generate_channel) {
-    auto channel = PickRandom(base::span(channels));
+    auto channel = PickRandom(channels);
     DVLOG(1) << "Cluster Block (channel: " << channel << ")";
-    return GenerateChannelBlock(feed_generation_info,
-                                PickRandom(base::span(channels)));
+    return GenerateChannelBlock(feed_generation_info, PickRandom(channels));
   } else {
     DVLOG(1) << "Cluster Block (topic)";
     return GenerateTopicBlock(feed_generation_info);

--- a/components/brave_news/browser/html_parsing.cc
+++ b/components/brave_news/browser/html_parsing.cc
@@ -9,6 +9,7 @@
 #include <string_view>
 #include <vector>
 
+#include "base/containers/contains.h"
 #include "base/containers/fixed_flat_set.h"
 #include "base/i18n/icu_string_conversions.h"
 #include "base/logging.h"
@@ -63,7 +64,7 @@ std::vector<GURL> GetFeedURLsFromHTMLDocument(const std::string& charset,
       continue;
     }
     // Validate rel
-    if (!base::IsStringASCII(rel) || !kSupportedRels.contains(rel)) {
+    if (!base::IsStringASCII(rel) || !base::Contains(kSupportedRels, rel)) {
       VLOG(1) << "not valid rel: " << rel;
       continue;
     }
@@ -76,7 +77,7 @@ std::vector<GURL> GetFeedURLsFromHTMLDocument(const std::string& charset,
     }
     // Validate type
     if (!base::IsStringASCII(content_type) ||
-        !kSupportedFeedTypes.contains(content_type)) {
+        !base::Contains(kSupportedFeedTypes, content_type)) {
       VLOG(1) << "not valid type: " << content_type;
       continue;
     }

--- a/components/brave_news/browser/peeking_card.cc
+++ b/components/brave_news/browser/peeking_card.cc
@@ -114,7 +114,7 @@ std::optional<size_t> PickPeekingCardWithMax(
       // Boost enabled channels.
     } else if (std::ranges::any_of(article->channels, [&subscribed_channels](
                                                           const auto& channel) {
-                 return subscribed_channels.contains(channel);
+                 return base::Contains(subscribed_channels, channel);
                })) {
       score += kChannelBoost;
     }
@@ -124,7 +124,7 @@ std::optional<size_t> PickPeekingCardWithMax(
       continue;
     }
 
-    if (top_story_urls.contains(article->url.spec())) {
+    if (base::Contains(top_story_urls, article->url.spec())) {
       score *= kTopStoryMultiplier;
     }
 
@@ -211,7 +211,7 @@ std::optional<size_t> PickPeekingCardWithMax(
     return std::nullopt;
   }
 
-  auto [index, score] = PickRandom(base::span(final_candidates));
+  auto [index, score] = PickRandom(final_candidates);
   return index;
 }
 

--- a/components/brave_news/browser/publishers_controller_unittest.cc
+++ b/components/brave_news/browser/publishers_controller_unittest.cc
@@ -170,9 +170,9 @@ TEST_F(BraveNewsPublishersControllerTest, CanReceiveFeeds) {
                                        net::HTTP_OK);
   auto result = GetPublishers();
   ASSERT_EQ(3u, result.size());
-  EXPECT_TRUE(result.contains("111"));
-  EXPECT_TRUE(result.contains("333"));
-  EXPECT_TRUE(result.contains("555"));
+  EXPECT_TRUE(base::Contains(result, "111"));
+  EXPECT_TRUE(base::Contains(result, "333"));
+  EXPECT_TRUE(base::Contains(result, "555"));
 }
 
 TEST_F(BraveNewsPublishersControllerTest, CanGetPublisherBySiteUrl) {


### PR DESCRIPTION
This reverts commit b54f97e3f1ae3a9d3e4e8adb3170e951448e03df.

This PR is being reverted due build failures on x86:

```
 ../../brave/components/brave_news/browser/feed_sampling_unittest.cc(50,25): error: constexpr variable 'kGroups' must be initialized by a constant expression
14:55:44     50 |   static constexpr auto kGroups =
14:55:44        |                         ^
14:55:44     51 |       base::MakeFixedFlatSet<ContentGroup>({{"publisher_1", false},
14:55:44        |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
14:55:44     52 |                                             {"publisher_2", false},
14:55:44        |                                             ~~~~~~~~~~~~~~~~~~~~~~~
14:55:44     53 |                                             {"channel_1", true},
14:55:44        |                                             ~~~~~~~~~~~~~~~~~~~~
14:55:44     54 |                                             {"channel_2", true},
14:55:44        |                                             ~~~~~~~~~~~~~~~~~~~~
14:55:44     55 |                                             {"publisher_3", false}});
14:55:44        |                                             ~~~~~~~~~~~~~~~~~~~~~~~~
14:55:44  ../../brave/components/brave_news/browser/feed_sampling_unittest.cc(50,25): note: pointer to subobject of heap-allocated object is not a constant expression
14:55:44  ../../third_party/libc++/src/include\__memory/allocator.h(103,32): note: heap allocation performed here
14:55:44    103 |       return static_cast<_Tp*>(::operator new(__n * sizeof(_Tp)));
14:55:44        |                                ^
14:55:44  ../../brave/components/brave_news/browser/feed_sampling_unittest.cc(51,7): error: call to consteval function 'base::MakeFixedFlatSet<std::pair<std::string, bool>, std::less<void>, 5U>' is not a constant expression
14:55:44     51 |       base::MakeFixedFlatSet<ContentGroup>({{"publisher_1", false},
14:55:44        |       ^
14:55:44  ../../brave/components/brave_news/browser/feed_sampling_unittest.cc(51,7): note: pointer to subobject of heap-allocated object is not a constant expression
14:55:45  ../../third_party/libc++/src/include\__memory/allocator.h(103,32): note: heap allocation performed here
14:55:45    103 |       return static_cast<_Tp*>(::operator new(__n * sizeof(_Tp)));
14:55:45        |  
```

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

