### PR TITLE
Revert "Fixes build error due to missing dep."

### DIFF
--- a/components/omnibox/browser/sources.gni
+++ b/components/omnibox/browser/sources.gni
@@ -48,7 +48,6 @@ brave_components_omnibox_browser_deps = [
   "//brave/components/resources:strings",
   "//brave/components/vector_icons",
   "//components/prefs",
-  "//components/vector_icons",
   "//url",
 ]
 


### PR DESCRIPTION
Reverts brave/brave-core#27668

This doesn't actually fix the problem and it's the wrong way to attempt to fix it
See https://github.com/brave/brave-core/pull/27747