### PR TITLE
Ensure shields settings always exist in worker.

### DIFF
--- a/browser/content_settings/sources.gni
+++ b/browser/content_settings/sources.gni
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_browser_content_settings_deps = [
+  "//brave/components/brave_shields/content/browser",
+  "//components/user_prefs",
+]

--- a/chromium_src/chrome/browser/content_settings/DEPS
+++ b/chromium_src/chrome/browser/content_settings/DEPS
@@ -1,3 +1,5 @@
 include_rules = [
+  "+brave/components/brave_shields/content/browser",
+  "+brave/components/brave_shields/core/common",
   "+brave/components/content_settings/core/browser",
 ]

--- a/chromium_src/chrome/browser/content_settings/content_settings_manager_delegate.cc
+++ b/chromium_src/chrome/browser/content_settings/content_settings_manager_delegate.cc
@@ -1,0 +1,57 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/chrome/browser/content_settings/content_settings_manager_delegate.cc"
+
+#include "brave/components/brave_shields/content/browser/brave_shields_util.h"
+#include "brave/components/brave_shields/core/common/shields_settings.mojom-shared.h"
+#include "chrome/browser/content_settings/host_content_settings_map_factory.h"
+#include "components/user_prefs/user_prefs.h"
+
+namespace {
+
+brave_shields::mojom::ShieldsSettingsPtr GetBraveShieldsSettingsOnUI(
+    const content::GlobalRenderFrameHostToken& frame_token) {
+  content::RenderFrameHost* rfh =
+      content::RenderFrameHost::FromFrameToken(frame_token);
+  if (!rfh) {
+    return brave_shields::mojom::ShieldsSettings::New();
+  }
+  content::RenderFrameHost* top_frame_rfh = rfh->GetOutermostMainFrame();
+  if (!top_frame_rfh) {
+    return brave_shields::mojom::ShieldsSettings::New();
+  }
+
+  const GURL& top_frame_url = top_frame_rfh->GetLastCommittedURL();
+
+  content::BrowserContext* browser_context = rfh->GetBrowserContext();
+  const brave_shields::mojom::FarblingLevel farbling_level =
+      brave_shields::GetFarblingLevel(
+          HostContentSettingsMapFactory::GetForProfile(browser_context),
+          top_frame_url);
+  const base::Token farbling_token =
+      farbling_level != brave_shields::mojom::FarblingLevel::OFF
+          ? brave_shields::GetFarblingToken(
+                HostContentSettingsMapFactory::GetForProfile(browser_context),
+                top_frame_url)
+          : base::Token();
+
+  PrefService* pref_service = user_prefs::UserPrefs::Get(browser_context);
+
+  return brave_shields::mojom::ShieldsSettings::New(
+      farbling_level, farbling_token, std::vector<std::string>(),
+      brave_shields::IsReduceLanguageEnabledForProfile(pref_service));
+}
+
+}  // namespace
+
+void ContentSettingsManagerDelegate::GetBraveShieldsSettings(
+    const content::GlobalRenderFrameHostToken& frame_token,
+    content_settings::mojom::ContentSettingsManager::
+        GetBraveShieldsSettingsCallback callback) {
+  content::GetUIThreadTaskRunner({})->PostTaskAndReplyWithResult(
+      FROM_HERE, base::BindOnce(&GetBraveShieldsSettingsOnUI, frame_token),
+      std::move(callback));
+}

--- a/chromium_src/chrome/browser/content_settings/content_settings_manager_delegate.h
+++ b/chromium_src/chrome/browser/content_settings/content_settings_manager_delegate.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_CONTENT_SETTINGS_CONTENT_SETTINGS_MANAGER_DELEGATE_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_CONTENT_SETTINGS_CONTENT_SETTINGS_MANAGER_DELEGATE_H_
+
+#include "components/content_settings/browser/content_settings_manager_impl.h"
+
+#define GetCookieSettings(...)                                \
+  GetCookieSettings(__VA_ARGS__) override;                    \
+  void GetBraveShieldsSettings(                               \
+      const content::GlobalRenderFrameHostToken& frame_token, \
+      content_settings::mojom::ContentSettingsManager::       \
+          GetBraveShieldsSettingsCallback callback)
+
+#include "src/chrome/browser/content_settings/content_settings_manager_delegate.h"  // IWYU pragma: export
+
+#undef GetCookieSettings
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_CONTENT_SETTINGS_CONTENT_SETTINGS_MANAGER_DELEGATE_H_

--- a/chromium_src/chrome/renderer/worker_content_settings_client.h
+++ b/chromium_src/chrome/renderer/worker_content_settings_client.h
@@ -40,6 +40,8 @@ class WorkerContentSettingsClient_BraveImpl
   WorkerContentSettingsClient_BraveImpl(
       const WorkerContentSettingsClient_BraveImpl& other);
 
+  void EnsureShieldsSettings();
+
   brave_shields::mojom::ShieldsSettingsPtr shields_settings_;
 };
 

--- a/chromium_src/components/content_settings/browser/DEPS
+++ b/chromium_src/components/content_settings/browser/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
+  "+brave/components/brave_shields/core/common",
   "+components/content_settings/common",
 ]

--- a/chromium_src/components/content_settings/browser/content_settings_manager_impl.cc
+++ b/chromium_src/components/content_settings/browser/content_settings_manager_impl.cc
@@ -3,9 +3,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#include "components/content_settings/browser/content_settings_manager_impl.h"
+
 #include <optional>
 
-#include "components/content_settings/browser/content_settings_manager_impl.h"
 #include "src/components/content_settings/browser/content_settings_manager_impl.cc"
 
 namespace content_settings {
@@ -16,12 +17,22 @@ void ContentSettingsManagerImpl::AllowEphemeralStorageAccess(
     const net::SiteForCookies& site_for_cookies,
     const url::Origin& top_frame_origin,
     AllowEphemeralStorageAccessCallback callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   url::Origin storage_origin;
   const bool should_use = cookie_settings_->ShouldUseEphemeralStorage(
       origin, site_for_cookies, top_frame_origin, storage_origin);
   std::move(callback).Run(should_use
                               ? std::make_optional<url::Origin>(storage_origin)
                               : std::nullopt);
+}
+
+void ContentSettingsManagerImpl::GetBraveShieldsSettings(
+    const blink::LocalFrameToken& frame_token,
+    GetBraveShieldsSettingsCallback callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  delegate_->GetBraveShieldsSettings(
+      content::GlobalRenderFrameHostToken(render_process_id_, frame_token),
+      std::move(callback));
 }
 
 }  // namespace content_settings

--- a/chromium_src/components/content_settings/browser/content_settings_manager_impl.h
+++ b/chromium_src/components/content_settings/browser/content_settings_manager_impl.h
@@ -7,8 +7,17 @@
 #define BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_BROWSER_CONTENT_SETTINGS_MANAGER_IMPL_H_
 
 #include "base/containers/flat_map.h"
+#include "brave/components/brave_shields/core/common/shields_settings.mojom.h"
 #include "components/content_settings/common/content_settings_manager.mojom.h"
 
+// Extend ContentSettingsManagerImpl::Delegate.
+#define GetCookieSettings(...)                                \
+  GetCookieSettings(__VA_ARGS__) = 0;                         \
+  virtual void GetBraveShieldsSettings(                       \
+      const content::GlobalRenderFrameHostToken& frame_token, \
+      GetBraveShieldsSettingsCallback callback)
+
+// Extend ContentSettingsManagerImpl.
 #define OnContentBlocked                                                    \
   NotUsed() {}                                                              \
   void AllowEphemeralStorageAccess(                                         \
@@ -16,10 +25,14 @@
       const net::SiteForCookies& site_for_cookies,                          \
       const url::Origin& top_frame_origin,                                  \
       AllowEphemeralStorageAccessCallback callback) override;               \
+  void GetBraveShieldsSettings(const blink::LocalFrameToken& frame_token,   \
+                               GetBraveShieldsSettingsCallback callback)    \
+      override;                                                             \
   void OnContentBlocked
 
 #include "src/components/content_settings/browser/content_settings_manager_impl.h"  // IWYU pragma: export
 
 #undef OnContentBlocked
+#undef GetCookieSettings
 
 #endif  // BRAVE_CHROMIUM_SRC_COMPONENTS_CONTENT_SETTINGS_BROWSER_CONTENT_SETTINGS_MANAGER_IMPL_H_

--- a/chromium_src/components/content_settings/common/content_settings_manager.mojom
+++ b/chromium_src/components/content_settings/common/content_settings_manager.mojom
@@ -19,6 +19,11 @@ interface ContentSettingsManager {
       network.mojom.SiteForCookies site_for_cookies,
       url.mojom.Origin top_frame_origin) => (url.mojom.Origin? storage_origin);
 
+  // Returns the shields settings for the given frame token. This is required in
+  // some scenarios when ContentSettings are not available in the worker
+  // context. It is unclear why these settings are randomly absent (most likely
+  // Chromium issue needs to be investigated), so this is added to ensure that
+  // shields settings are always available.
   [Sync]
   GetBraveShieldsSettings(
       blink.mojom.LocalFrameToken frame_token) => (brave_shields.mojom.ShieldsSettings shields_settings);

--- a/chromium_src/components/content_settings/common/content_settings_manager.mojom
+++ b/chromium_src/components/content_settings/common/content_settings_manager.mojom
@@ -5,6 +5,7 @@
 
 module content_settings.mojom;
 
+import "brave/components/brave_shields/core/common/shields_settings.mojom";
 import "services/network/public/mojom/site_for_cookies.mojom";
 import "url/mojom/origin.mojom";
 import "third_party/blink/public/mojom/tokens/tokens.mojom";
@@ -17,4 +18,8 @@ interface ContentSettingsManager {
       url.mojom.Origin origin,
       network.mojom.SiteForCookies site_for_cookies,
       url.mojom.Origin top_frame_origin) => (url.mojom.Origin? storage_origin);
+
+  [Sync]
+  GetBraveShieldsSettings(
+      blink.mojom.LocalFrameToken frame_token) => (brave_shields.mojom.ShieldsSettings shields_settings);
 };

--- a/chromium_src/components/content_settings/core/browser/cookie_settings.h
+++ b/chromium_src/components/content_settings/core/browser/cookie_settings.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "base/containers/flat_map.h"
+#include "brave/components/brave_shields/core/common/shields_settings.mojom.h"
 #include "components/content_settings/core/browser/content_settings_provider.h"
 #include "components/content_settings/core/browser/host_content_settings_map.h"
 #include "components/keyed_service/core/refcounted_keyed_service.h"
@@ -24,6 +25,8 @@
       url::Origin& storage_origin);                                           \
   std::vector<url::Origin> TakeEphemeralStorageOpaqueOrigins(                 \
       const std::string& ephemeral_storage_domain);                           \
+  brave_shields::mojom::ShieldsSettingsPtr GetBraveShieldsSettings(           \
+      const url::Origin& origin, const url::Origin& top_frame_origin);        \
                                                                               \
  private:                                                                     \
   /* Ephemeral storage domain to non_opaque->opaque origins map. */           \

--- a/components/content_settings/renderer/brave_content_settings_agent_impl_autoplay_browsertest.cc
+++ b/components/content_settings/renderer/brave_content_settings_agent_impl_autoplay_browsertest.cc
@@ -47,6 +47,10 @@ class MockContentSettingsManagerImpl : public mojom::ContentSettingsManager {
       const ::url::Origin& top_frame_origin,
       AllowEphemeralStorageAccessCallback callback) override {}
 
+  void GetBraveShieldsSettings(
+      const blink::LocalFrameToken& frame_token,
+      GetBraveShieldsSettingsCallback callback) override {}
+
   void OnContentBlocked(const blink::LocalFrameToken& frame_token,
                         ContentSettingsType type) override {
     ++log_->on_content_blocked_count;

--- a/components/content_settings/sources.gni
+++ b/components/content_settings/sources.gni
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_components_content_settings_common_mojom_deps =
+    [ "//brave/components/brave_shields/core/common:mojom" ]

--- a/patches/chrome-browser-content_settings-BUILD.gn.patch
+++ b/patches/chrome-browser-content_settings-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/content_settings/BUILD.gn b/chrome/browser/content_settings/BUILD.gn
+index c236e757f0bca1edc6b51c0a7441e175ee61b840..910031d15379ac63b47a3bff6c286beef7852cab 100644
+--- a/chrome/browser/content_settings/BUILD.gn
++++ b/chrome/browser/content_settings/BUILD.gn
+@@ -110,6 +110,7 @@ source_set("impl") {
+   if (enable_pdf) {
+     deps += [ "//chrome/browser/pdf" ]
+   }
++  import("//brave/browser/content_settings/sources.gni") deps += brave_browser_content_settings_deps
+ }
+ 
+ # Fixes circular deps with different components. For example -

--- a/patches/components-content_settings-common-BUILD.gn.patch
+++ b/patches/components-content_settings-common-BUILD.gn.patch
@@ -1,0 +1,10 @@
+diff --git a/components/content_settings/common/BUILD.gn b/components/content_settings/common/BUILD.gn
+index 04c77e73d6817ad6f1d77cc3f89630d273535574..9ad65d0e080caabe40becf9385052363b94f449a 100644
+--- a/components/content_settings/common/BUILD.gn
++++ b/components/content_settings/common/BUILD.gn
+@@ -19,4 +19,5 @@ mojom("mojom") {
+     "//url/mojom:url_mojom_gurl",
+     "//url/mojom:url_mojom_origin",
+   ]
++  import("//brave/components/content_settings/sources.gni") deps += brave_components_content_settings_common_mojom_deps
+ }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Chromium occasionally fails to provide ContentSettings in web workers, an issue that consistently affects a percentage of our users. While I don't have a clear reproduction case for why ContentSettings becomes unavailable, this PR adds an explicit shields settings request to ensure proper Shields functionality.

Resolves https://github.com/brave/brave-browser/issues/44154

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

