### PR TITLE
fix(wallet): Disable Zcash Transfers While Syncing

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1652,7 +1652,9 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW},
     {"braveWalletAccountBirthdayTooHigh",
      IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH},
-    {"braveWalletBlocksBehind", IDS_BRAVE_WALLET_BLOCKS_BEHIND}};
+    {"braveWalletBlocksBehind", IDS_BRAVE_WALLET_BLOCKS_BEHIND},
+    {"braveWalletAccountIsSyncing", IDS_BRAVE_WALLET_ACCOUNT_IS_SYNCING},
+    {"braveWalletSyncing", IDS_BRAVE_WALLET_SYNCING}};
 
 // 0x swap constants
 inline constexpr char kZeroExBaseAPIURL[] = "https://api.0x.wallet.brave.com";

--- a/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
+++ b/components/brave_wallet_ui/common/hooks/use-pending-transaction.ts
@@ -60,6 +60,7 @@ import {
   defaultQuerySubscriptionOptions,
   querySubscriptionOptions60s
 } from '../slices/constants'
+import { useIsAccountSyncing } from './use_is_account_syncing'
 
 // Constants
 import { BraveWallet, emptyProviderErrorCodeUnion } from '../../constants/types'
@@ -178,6 +179,8 @@ export const usePendingTransactions = () => {
   )
 
   const { account: txAccount } = useAccountQuery(transactionInfo?.fromAccountId)
+
+  const isAccountSyncing = useIsAccountSyncing(txAccount?.accountId)
 
   const {
     data: gasEstimates,
@@ -555,6 +558,10 @@ export const usePendingTransactions = () => {
       : hasEvmFeeEstimatesError
 
   const isConfirmButtonDisabled = React.useMemo(() => {
+    if (isAccountSyncing) {
+      return true
+    }
+
     if (hasFeeEstimatesError || isLoadingGasFee) {
       return true
     }
@@ -575,7 +582,8 @@ export const usePendingTransactions = () => {
     hasFeeEstimatesError,
     isLoadingGasFee,
     insufficientFundsError,
-    insufficientFundsForGasError
+    insufficientFundsForGasError,
+    isAccountSyncing
   ])
 
   const { currentTokenAllowance, isCurrentAllowanceUnlimited } =
@@ -652,6 +660,7 @@ export const usePendingTransactions = () => {
     insufficientFundsError,
     insufficientFundsForGasError,
     isZCashTransaction: isZCashTransaction(transactionInfo),
-    isBitcoinTransaction: isBitcoinTransaction(transactionInfo)
+    isBitcoinTransaction: isBitcoinTransaction(transactionInfo),
+    isAccountSyncing
   }
 }

--- a/components/brave_wallet_ui/common/hooks/use_is_account_syncing.ts
+++ b/components/brave_wallet_ui/common/hooks/use_is_account_syncing.ts
@@ -1,0 +1,71 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { skipToken } from '@reduxjs/toolkit/query/react'
+import getAPIProxy from '../async/bridge'
+
+// Types
+import { BraveWallet } from '../../constants/types'
+
+// Selectors
+import { useSafeWalletSelector } from './use-safe-selector'
+import { WalletSelectors } from '../selectors'
+
+// Hooks
+import { useGetIsSyncInProgressQuery } from '../slices/api.slice'
+
+export const useIsAccountSyncing = (accountId?: BraveWallet.AccountId) => {
+  // State
+  const [syncingId, setSyncingId] = React.useState<
+    string | undefined
+  >()
+
+  // Selectors
+  const isZCashShieldedTransactionsEnabled = useSafeWalletSelector(
+    WalletSelectors.isZCashShieldedTransactionsEnabled
+  )
+
+  // Queries
+  const { data: isSyncAlreadyInProgress } = useGetIsSyncInProgressQuery(
+    isZCashShieldedTransactionsEnabled &&
+      !syncingId &&
+      accountId &&
+      accountId.coin === BraveWallet.CoinType.ZEC
+      ? accountId
+      : skipToken
+  )
+
+  // Effects
+  React.useEffect(() => {
+    const zcashWalletServiceObserver =
+      new BraveWallet.ZCashWalletServiceObserverReceiver({
+        onSyncStart: (id: BraveWallet.AccountId) => {
+          if (accountId && accountId.uniqueKey === id.uniqueKey) {
+            setSyncingId(id.uniqueKey)
+          }
+        },
+        onSyncStop: (id: BraveWallet.AccountId) => {
+          if (accountId && accountId.uniqueKey === id.uniqueKey) {
+            setSyncingId('')
+          }
+        },
+        onSyncStatusUpdate: () => {},
+        onSyncError: () => {}
+      })
+
+    getAPIProxy().zcashWalletService.addObserver(
+      zcashWalletServiceObserver.$.bindNewPipeAndPassRemote()
+    )
+
+    return () => zcashWalletServiceObserver.$.close()
+  }, [accountId])
+
+  return syncingId === undefined
+    ? isSyncAlreadyInProgress
+    : accountId && syncingId === accountId.uniqueKey
+}
+
+export default useIsAccountSyncing

--- a/components/brave_wallet_ui/common/slices/api-base.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api-base.slice.ts
@@ -86,6 +86,7 @@ export function createWalletApiBase() {
       'MeldWidget',
       'ZCashAccountInfo',
       'IsShieldingAvailable',
+      'IsSyncInProgress',
       'ZcashChainTipStatus'
     ],
     endpoints: ({ mutation, query }) => ({})

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -221,6 +221,7 @@ export const {
   useGetIsMetaMaskInstalledQuery,
   useGetIsPrivateWindowQuery,
   useGetIsShieldingAvailableQuery,
+  useGetIsSyncInProgressQuery,
   useGetIsTokenOwnedByUserQuery,
   useGetIsTxSimulationOptInStatusQuery,
   useGetIsWalletBackedUpQuery,

--- a/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
@@ -162,7 +162,7 @@ export const zcashEndpoints = ({
           )
         }
       },
-      invalidatesTags: []
+      invalidatesTags: ['IsSyncInProgress']
     }),
 
     stopShieldSync: mutation<true, BraveWallet.AccountId>({
@@ -191,7 +191,26 @@ export const zcashEndpoints = ({
           )
         }
       },
-      invalidatesTags: ['ZcashChainTipStatus']
+      invalidatesTags: ['ZcashChainTipStatus', 'IsSyncInProgress']
+    }),
+
+    getIsSyncInProgress: query<boolean, BraveWallet.AccountId>({
+      queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {
+        try {
+          const { zcashWalletService } = baseQuery(undefined).data
+          const { result } = await zcashWalletService.isSyncInProgress(args)
+          return {
+            data: result
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Error getting is sync in progress: ',
+            error
+          )
+        }
+      },
+      providesTags: ['IsSyncInProgress']
     })
   }
 }

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/pending_tx_actions_footer.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/common/pending_tx_actions_footer.tsx
@@ -41,6 +41,7 @@ interface Props {
   insufficientFundsError?: boolean
   onReject: () => void
   onConfirm: (() => Promise<void>) | (() => void)
+  isAccountSyncing?: boolean
 }
 
 type Warning = Pick<BraveWallet.BlowfishWarning, 'message' | 'severity'>
@@ -56,7 +57,8 @@ export function PendingTransactionActionsFooter({
   insufficientFundsForGasError,
   insufficientFundsError,
   onReject,
-  onConfirm
+  onConfirm,
+  isAccountSyncing
 }: Props) {
   // state
   const [isWarningDismissed, setIsWarningDismissed] = React.useState(false)
@@ -124,7 +126,9 @@ export function PendingTransactionActionsFooter({
           isDisabled={isConfirmButtonDisabled}
           isLoading={transactionConfirmed}
         >
-          {getLocale('braveWalletAllowSpendConfirmButton')}
+          {isAccountSyncing
+            ? getLocale('braveWalletSyncing')
+            : getLocale('braveWalletAllowSpendConfirmButton')}
         </LeoSquaredButton>
       ),
       rejectButton: (
@@ -143,7 +147,8 @@ export function PendingTransactionActionsFooter({
     onClickConfirmTransaction,
     isConfirmButtonDisabled,
     transactionConfirmed,
-    onReject
+    onReject,
+    isAccountSyncing
   ])
 
   // computed

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -142,7 +142,8 @@ export const ConfirmTransactionPanel = ({
     isLoadingGasFee,
     rejectAllTransactions,
     isConfirmButtonDisabled,
-    isSolanaDappTransaction
+    isSolanaDappTransaction,
+    isAccountSyncing
   } = usePendingTransactions()
 
   // queries
@@ -505,6 +506,7 @@ export const ConfirmTransactionPanel = ({
           insufficientFundsError={insufficientFundsError}
           isWarningCollapsed={isWarningCollapsed}
           setIsWarningCollapsed={setIsWarningCollapsed}
+          isAccountSyncing={isAccountSyncing}
         />
       </Column>
       {showSimulationNotSupportedMessage && (

--- a/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
+++ b/components/brave_wallet_ui/page/screens/send/send_screen/send_screen.tsx
@@ -64,6 +64,9 @@ import {
 import {
   useAccountFromAddressQuery //
 } from '../../../../common/slices/api.slice.extra'
+import {
+  useIsAccountSyncing //
+} from '../../../../common/hooks/use_is_account_syncing'
 
 // Styled Components
 import { InputRow, ToText, ToRow } from './send.style'
@@ -215,6 +218,8 @@ export const SendScreen = React.memo((props: Props) => {
           }
         : skipToken
     )
+
+  const isAccountSyncing = useIsAccountSyncing(accountFromParams?.accountId)
 
   // memos & computed
   const sendAmountValidationError: AmountValidationErrorType | undefined =
@@ -626,13 +631,15 @@ export const SendScreen = React.memo((props: Props) => {
                     parseFloat(sendAmount) === 0 ||
                     Boolean(sendAmountValidationError) ||
                     (tokenFromParams?.coin === BraveWallet.CoinType.BTC &&
-                      !isWarningAcknowledged)
+                      !isWarningAcknowledged) ||
+                    isAccountSyncing
                   }
                 >
                   {getLocale(
                     getReviewButtonText(
                       sendAmountValidationError,
-                      insufficientFundsError
+                      insufficientFundsError,
+                      isAccountSyncing
                     )
                   ).replace('$1', CoinTypesMap[networkFromParams?.coin ?? 0])}
                 </LeoSquaredButton>
@@ -684,13 +691,17 @@ function ethToWeiAmount(
 
 function getReviewButtonText(
   sendAmountValidationError: string | undefined,
-  insufficientFundsError: boolean
+  insufficientFundsError: boolean,
+  isAccountSyncing?: boolean
 ) {
   if (sendAmountValidationError) {
     return 'braveWalletDecimalPlacesError'
   }
   if (insufficientFundsError) {
     return 'braveWalletNotEnoughFunds'
+  }
+  if (isAccountSyncing) {
+    return 'braveWalletAccountIsSyncing'
   }
 
   return 'braveWalletReviewSend'

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1549,5 +1549,7 @@ provideStrings({
   braveWalletShieldedAccountBirthdayBlock: 'Shielded account birthday block',
   braveWalletAccountBirthdayTooLow: 'Account birthday must be greater than $1',
   braveWalletAccountBirthdayTooHigh: 'Account birthday must be less than $1',
-  braveWalletBlocksBehind: '$1 blocks behind'
+  braveWalletBlocksBehind: '$1 blocks behind',
+  braveWalletAccountIsSyncing: 'Account is syncing',
+  braveWalletSyncing: 'Syncing'
 })

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1179,7 +1179,9 @@
   <message name="IDS_BRAVE_WALLET_SHIELDED_ACCOUNT_BIRTHDAY_BLOCK" desc="Shielded account birthday block input label">Shielded account birthday block</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_LOW" desc="Account birthday to low error">Account birthday must be greater than <ph name="BLOCK_NUMBER">$1<ex>1687104</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_BIRTHDAY_TOO_HIGH" desc="Account birthday to high error">Account birthday must be less than <ph name="BLOCK_NUMBER">$1<ex>7687104</ex></ph></message>
-  <message name="IDS_BRAVE_WALLET_BLOCKS_BEHIND" desc="Blocks behind label for Zcash account sync"><ph name="BLOCKS">$1<ex>12,568</ex></ph> blocks behind</message>  
+  <message name="IDS_BRAVE_WALLET_BLOCKS_BEHIND" desc="Blocks behind label for Zcash account sync"><ph name="BLOCKS">$1<ex>12,568</ex></ph> blocks behind</message>
+  <message name="IDS_BRAVE_WALLET_ACCOUNT_IS_SYNCING" desc="Account is syncing label">Account is syncing</message>
+  <message name="IDS_BRAVE_WALLET_SYNCING" desc="Syncing label">Syncing</message>
   <message name="IDS_BRAVE_WALLET_BUTTON_RETRY" desc="Retry an action">Retry</message>
   <message name="IDS_BRAVE_WALLET_TRANSACTION_PREVIEW_FAILED" desc="Explaination that simulation of a transaction has failed">Transaction preview failed.</message>
   <message name="IDS_BRAVE_WALLET_ESTIMATED_BALANCE_CHANGE" desc="Grouping header for estimated balance changes">Estimated balance change</message>


### PR DESCRIPTION
## Description 

Disables `Zcash` transfers while it's account is `Syncing`

<!-- Add brave-browser issue bellow that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/44147>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Go to your `Shielded` Zcash account and click `Sync account`
2. The `Sync Account Status` modal should popup and start syncing.
3. Click on `Continue using wallet in a new tab` button and and go to the `Send` screen in the new tab
4. Select to send `Zcash` and then select the `Account` that is syncing
5. The `Review send` button should be disabled and say `Account is syncing`
6. Go back to the other tab an pause the `Sync`, now go back to the `Send` tab and the `Review send` button should not be disabled.
7. Also test creating a `Pending` Zcash transaction for that account and start the `Sync`
8. Open the `Panel` to view the `Pending` transaction, the `Confirm` button should be disabled and say `Syncing`.

https://github.com/user-attachments/assets/15fa7adb-208e-43d3-8e5c-3da81fed6d20
