### PR TITLE
Fixed split view border is not visible

### DIFF
--- a/browser/speedreader/speedreader_browsertest.cc
+++ b/browser/speedreader/speedreader_browsertest.cc
@@ -1063,8 +1063,8 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SplitView) {
   ASSERT_TRUE(toolbar && secondary_toolbar);
   auto* secondary_location_bar_widget =
       browser_view->split_view()->secondary_location_bar_widget_.get();
-  auto* secondary_contents_web_view =
-      browser_view->split_view()->secondary_contents_web_view();
+  auto* secondary_contents_container =
+      browser_view->split_view()->secondary_contents_container();
 
   // No toolbars.
   EXPECT_FALSE(toolbar->GetVisible());
@@ -1085,7 +1085,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SplitView) {
 
   gfx::Point secondary_web_view_origin;
   secondary_web_view_origin = views::View::ConvertPointToScreen(
-      secondary_contents_web_view, secondary_web_view_origin);
+      secondary_contents_container, secondary_web_view_origin);
   EXPECT_EQ(secondary_web_view_origin,
             secondary_location_bar_widget->GetWindowBoundsInScreen().origin());
 
@@ -1098,7 +1098,7 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SplitView) {
   // Check secondary location bar position when changing active tab
   // between non split view tab and split view tab.
   // Secondary location bar should have same origin with secondary
-  // web view. Otherwise, it could overlap with speedreader toolbar.
+  // contents container.
   chrome::AddTabAt(browser(), GURL(), -1, /*foreground*/ true);
   WaitToolbarVisibility(toolbar, false);
   WaitToolbarVisibility(secondary_toolbar, false);
@@ -1107,9 +1107,9 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SplitView) {
   WaitToolbarVisibility(toolbar, true);
   WaitToolbarVisibility(secondary_toolbar, true);
   secondary_web_view_origin =
-      secondary_contents_web_view->GetLocalBounds().origin();
+      secondary_contents_container->GetLocalBounds().origin();
   secondary_web_view_origin = views::View::ConvertPointToScreen(
-      secondary_contents_web_view, secondary_web_view_origin);
+      secondary_contents_container, secondary_web_view_origin);
   EXPECT_EQ(secondary_web_view_origin,
             secondary_location_bar_widget->GetWindowBoundsInScreen().origin());
 
@@ -1121,9 +1121,9 @@ IN_PROC_BROWSER_TEST_F(SpeedReaderBrowserTest, SplitView) {
   WaitToolbarVisibility(toolbar, true);
   WaitToolbarVisibility(secondary_toolbar, true);
   secondary_web_view_origin =
-      secondary_contents_web_view->GetLocalBounds().origin();
+      secondary_contents_container->GetLocalBounds().origin();
   secondary_web_view_origin = views::View::ConvertPointToScreen(
-      secondary_contents_web_view, secondary_web_view_origin);
+      secondary_contents_container, secondary_web_view_origin);
   EXPECT_EQ(secondary_web_view_origin,
             secondary_location_bar_widget->GetWindowBoundsInScreen().origin());
 

--- a/browser/ui/tabs/brave_tab_color_mixer.cc
+++ b/browser/ui/tabs/brave_tab_color_mixer.cc
@@ -74,7 +74,8 @@ void AddBraveTabThemeColorMixer(ui::ColorProvider* provider,
   mixer[kColorBraveSharedPinnedTabDummyViewTitle] = {nala::kColorTextPrimary};
   mixer[kColorBraveSharedPinnedTabDummyViewBackground] = {
       nala::kColorContainerBackground};
-  mixer[kColorBraveSplitViewInactiveWebViewBorder] = {kColorToolbar};
+  mixer[kColorBraveSplitViewInactiveWebViewBorder] = {
+      nala::kColorDesktopbrowserToolbarButtonOutline};
 }
 
 void AddBraveTabPrivateThemeColorMixer(ui::ColorProvider* provider,

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -84,6 +84,7 @@ class BraveBrowserView : public BrowserView,
   void CloseWalletBubble();
   WalletButton* GetWalletButton();
   views::View* GetWalletButtonAnchorView();
+  void UpdateContentsSeparatorVisibility();
 
   // Triggers layout of web modal dialogs
   void NotifyDialogPositionRequiresUpdate();

--- a/browser/ui/views/frame/brave_contents_layout_manager.cc
+++ b/browser/ui/views/frame/brave_contents_layout_manager.cc
@@ -7,6 +7,12 @@
 
 #include "ui/views/view.h"
 
+// static
+BraveContentsLayoutManager* BraveContentsLayoutManager::GetLayoutManagerForView(
+    views::View* host) {
+  return static_cast<BraveContentsLayoutManager*>(host->GetLayoutManager());
+}
+
 BraveContentsLayoutManager::BraveContentsLayoutManager(
     views::View* devtools_view,
     views::View* contents_view,
@@ -26,6 +32,12 @@ BraveContentsLayoutManager::BraveContentsLayoutManager(
 
 BraveContentsLayoutManager::~BraveContentsLayoutManager() = default;
 
+void BraveContentsLayoutManager::SetWebContentsBorderInsets(
+    const gfx::Insets& insets) {
+  border_insets_ = insets;
+  InvalidateHost(true);
+}
+
 views::ProposedLayout BraveContentsLayoutManager::CalculateProposedLayout(
     const views::SizeBounds& size_bounds) const {
   views::ProposedLayout layouts =
@@ -35,6 +47,8 @@ views::ProposedLayout BraveContentsLayoutManager::CalculateProposedLayout(
   if (!contents_layout) {
     return layouts;
   }
+
+  contents_layout->bounds.Inset(border_insets_);
 
   if (reader_mode_toolbar_->GetVisible()) {
     gfx::Rect toolbar_bounds = contents_layout->bounds;

--- a/browser/ui/views/frame/brave_contents_layout_manager.h
+++ b/browser/ui/views/frame/brave_contents_layout_manager.h
@@ -10,6 +10,8 @@
 
 class BraveContentsLayoutManager : public ContentsLayoutManager {
  public:
+  static BraveContentsLayoutManager* GetLayoutManagerForView(views::View* host);
+
   BraveContentsLayoutManager(views::View* devtools_view,
                              views::View* contents_view,
                              views::View* scrim_view,
@@ -17,6 +19,12 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
                              views::View* watermark_view,
                              views::View* reader_mode_toolbar);
   ~BraveContentsLayoutManager() override;
+
+  // We want to set a contents container border for split view.
+  // However, upstream ContentsLayoutManager doesn't consider host view's
+  // border when layout web contents. So, adjust its border when calculating
+  // proposed layout with |border_insets_|.
+  void SetWebContentsBorderInsets(const gfx::Insets& insets);
 
  protected:
   // ContentsLayoutManager:
@@ -26,6 +34,7 @@ class BraveContentsLayoutManager : public ContentsLayoutManager {
  private:
   raw_ptr<views::View> contents_view_ = nullptr;
   raw_ptr<views::View> reader_mode_toolbar_ = nullptr;
+  gfx::Insets border_insets_;
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_FRAME_BRAVE_CONTENTS_LAYOUT_MANAGER_H_

--- a/browser/ui/views/speedreader/reader_mode_toolbar_view.h
+++ b/browser/ui/views/speedreader/reader_mode_toolbar_view.h
@@ -12,10 +12,10 @@
 #include "ui/views/controls/webview/webview.h"
 
 namespace content {
+class BrowserContext;
 class WebContents;
-}
+}  // namespace content
 
-class Browser;
 class ReaderModeToolbarView : public views::View {
   METADATA_HEADER(ReaderModeToolbarView, views::View)
  public:
@@ -24,7 +24,8 @@ class ReaderModeToolbarView : public views::View {
     virtual void OnReaderModeToolbarActivate(ReaderModeToolbarView* toolbar) {}
   };
 
-  explicit ReaderModeToolbarView(Browser* browser);
+  ReaderModeToolbarView(content::BrowserContext* browser_context,
+                        bool use_rounded_corners);
   ~ReaderModeToolbarView() override;
 
   ReaderModeToolbarView(const ReaderModeToolbarView&) = delete;
@@ -50,6 +51,7 @@ class ReaderModeToolbarView : public views::View {
   void OnBoundsChanged(const gfx::Rect& previous_bounds) override;
   bool OnMousePressed(const ui::MouseEvent& event) override;
 
+  bool use_rounded_corners_ = false;
   std::unique_ptr<views::WebView> toolbar_;
   std::unique_ptr<content::WebContents> toolbar_contents_;
   raw_ptr<Delegate> delegate_ = nullptr;

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -390,9 +390,7 @@ void SplitView::UpdateContentsWebViewBorder() {
       return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
                  base::to_address(browser_))
                  ? views::CreateThemedRoundedRectBorder(
-                       kBorderThickness,
-                       BraveContentsViewUtil::kBorderRadius +
-                           kBorderThickness / 2,
+                       kBorderThickness, BraveContentsViewUtil::kBorderRadius,
                        color_id)
                  : views::CreateThemedSolidBorder(kBorderThickness, color_id);
     };

--- a/browser/ui/views/split_view/split_view.cc
+++ b/browser/ui/views/split_view/split_view.cc
@@ -25,6 +25,7 @@
 #include "chrome/browser/ui/views/frame/contents_layout_manager.h"
 #include "chrome/browser/ui/views/frame/contents_web_view.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
+#include "ui/compositor/layer.h"
 #include "ui/views/background.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/webview/webview.h"
@@ -105,7 +106,11 @@ SplitView::SplitView(Browser& browser,
 
 #if BUILDFLAG(ENABLE_SPEEDREADER)
   secondary_reader_mode_toolbar_ = secondary_contents_container_->AddChildView(
-      std::make_unique<ReaderModeToolbarView>(base::to_address(browser_)));
+      std::make_unique<ReaderModeToolbarView>(
+          browser_->profile(),
+          BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
+              base::to_address(browser_))));
+
   secondary_reader_mode_toolbar_->SetDelegate(this);
 
   secondary_contents_container_->SetLayoutManager(
@@ -125,6 +130,12 @@ SplitView::SplitView(Browser& browser,
 }
 
 SplitView::~SplitView() = default;
+
+bool SplitView::IsSplitViewActive() const {
+  auto* split_view_browser_data =
+      SplitViewBrowserData::FromBrowser(base::to_address(browser_));
+  return split_view_browser_data->GetTile(GetActiveTabHandle()).has_value();
+}
 
 void SplitView::WillChangeActiveWebContents(
     BrowserViewKey,
@@ -217,11 +228,6 @@ void SplitView::SetSecondaryContentsResizingStrategy(
       ->SetContentsResizingStrategy(strategy);
 }
 
-void SplitView::OnThemeChanged() {
-  View::OnThemeChanged();
-  UpdateContentsWebViewBorder();
-}
-
 void SplitView::Layout(PassKey key) {
   LayoutSuperclass<views::View>(this);
 
@@ -254,6 +260,11 @@ void SplitView::OnTileTabs(const TabTile& tile) {
     return;
   }
 
+  // Update separator visibility first before starting split view layout
+  // to give their final position.
+  static_cast<BraveBrowserView*>(browser_->window())
+      ->UpdateContentsSeparatorVisibility();
+
   UpdateContentsWebViewVisual();
 }
 
@@ -261,6 +272,11 @@ void SplitView::OnDidBreakTile(const TabTile& tile) {
   if (!IsActiveWebContentsTiled(tile)) {
     return;
   }
+
+  // Update separator visibility first before starting split view layout
+  // to give their final position.
+  static_cast<BraveBrowserView*>(browser_->window())
+      ->UpdateContentsSeparatorVisibility();
 
   UpdateContentsWebViewVisual();
 }
@@ -370,29 +386,37 @@ void SplitView::UpdateContentsWebViewBorder() {
   DCHECK(split_view_browser_data);
 
   if (split_view_browser_data->GetTile(GetActiveTabHandle())) {
-    auto create_border = [this](SkColor color) {
-      constexpr int kBorderThickness = 2;
+    auto create_border = [this](int color_id) {
       return BraveBrowser::ShouldUseBraveWebViewRoundedCorners(
                  base::to_address(browser_))
-                 ? views::CreateRoundedRectBorder(
+                 ? views::CreateThemedRoundedRectBorder(
                        kBorderThickness,
                        BraveContentsViewUtil::kBorderRadius +
                            kBorderThickness / 2,
-                       color)
-                 : views::CreateSolidBorder(kBorderThickness, color);
+                       color_id)
+                 : views::CreateThemedSolidBorder(kBorderThickness, color_id);
     };
+    contents_container_->SetBorder(
+        create_border(kColorBraveSplitViewActiveWebViewBorder));
+    BraveContentsLayoutManager::GetLayoutManagerForView(contents_container_)
+        ->SetWebContentsBorderInsets(gfx::Insets(kBorderThickness));
 
-    if (auto* cp = GetColorProvider()) {
-      contents_web_view_->SetBorder(
-          create_border(cp->GetColor(nala::kColorPrimitivePrimary70)));
-
-      secondary_contents_web_view_->SetBorder(create_border(
-          cp->GetColor(kColorBraveSplitViewInactiveWebViewBorder)));
-    }
+    secondary_contents_container_->SetBorder(
+        create_border(kColorBraveSplitViewInactiveWebViewBorder));
+    BraveContentsLayoutManager::GetLayoutManagerForView(
+        secondary_contents_container_)
+        ->SetWebContentsBorderInsets(gfx::Insets(kBorderThickness));
   } else {
-    contents_web_view_->SetBorder(nullptr);
-    secondary_contents_web_view_->SetBorder(nullptr);
+    contents_container_->SetBorder(nullptr);
+    BraveContentsLayoutManager::GetLayoutManagerForView(contents_container_)
+        ->SetWebContentsBorderInsets({});
+
+    secondary_contents_container_->SetBorder(nullptr);
+    BraveContentsLayoutManager::GetLayoutManagerForView(
+        secondary_contents_container_)
+        ->SetWebContentsBorderInsets({});
   }
+  SchedulePaint();
 }
 
 void SplitView::UpdateSecondaryContentsWebViewVisibility() {
@@ -462,6 +486,7 @@ void SplitView::UpdateSecondaryContentsWebViewVisibility() {
 }
 
 void SplitView::UpdateCornerRadius(const gfx::RoundedCornersF& corners) {
+  secondary_contents_web_view_->layer()->SetRoundedCornerRadius(corners);
   secondary_contents_web_view_->holder()->SetCornerRadii(corners);
   secondary_devtools_web_view_->holder()->SetCornerRadii(corners);
 }
@@ -521,15 +546,6 @@ void SplitView::UpdateSecondaryReaderModeToolbar() {
   }
 }
 #endif
-
-gfx::Point SplitView::GetSplitViewLocationBarOffset() const {
-#if BUILDFLAG(ENABLE_SPEEDREADER)
-  if (secondary_reader_mode_toolbar_->GetVisible()) {
-    return {0, secondary_reader_mode_toolbar_->GetPreferredSize().height()};
-  }
-#endif
-  return {};
-}
 
 void SplitView::UpdateSecondaryDevtoolsLayoutAndVisibility() {
   DevToolsContentsResizingStrategy strategy;

--- a/browser/ui/views/split_view/split_view.h
+++ b/browser/ui/views/split_view/split_view.h
@@ -52,11 +52,17 @@ class SplitView : public views::View,
   METADATA_HEADER(SplitView, views::View)
  public:
   using BrowserViewKey = base::PassKey<BraveBrowserView>;
+
+  static constexpr int kBorderThickness = 1;
+
   SplitView(Browser& browser,
             views::View* contents_container,
             ContentsWebView* contents_web_view);
 
   ~SplitView() override;
+
+  // true when active tab is in tile.
+  bool IsSplitViewActive() const;
 
   // Called before/after BrowserView::OnActiveTabChanged() as we have some
   // jobs such as reducing flickering while active tab changing. See the
@@ -78,8 +84,6 @@ class SplitView : public views::View,
 
   // Update dev tools
   void UpdateSecondaryDevtoolsLayoutAndVisibility();
-
-  gfx::Point GetSplitViewLocationBarOffset() const;
 
   views::View* secondary_contents_container() {
     return secondary_contents_container_;
@@ -105,7 +109,6 @@ class SplitView : public views::View,
       const DevToolsContentsResizingStrategy& strategy);
 
   // views::View:
-  void OnThemeChanged() override;
   void Layout(PassKey) override;
   void AddedToWidget() override;
 

--- a/browser/ui/views/split_view/split_view_location_bar.cc
+++ b/browser/ui/views/split_view/split_view_location_bar.cc
@@ -160,7 +160,7 @@ void SplitViewLocationBar::OnPaintBorder(gfx::Canvas* canvas) {
   flags.setColor(cp->GetColor(kColorBraveSplitViewInactiveWebViewBorder));
   flags.setAntiAlias(true);
   flags.setStyle(cc::PaintFlags::kStroke_Style);
-  flags.setStrokeWidth(2);
+  flags.setStrokeWidth(SplitView::kBorderThickness);
   canvas->DrawPath(path, flags);
 }
 
@@ -215,9 +215,6 @@ void SplitViewLocationBar::UpdateBounds() {
   }
 
   gfx::Point point;
-  if (split_view_) {
-    point = split_view_->GetSplitViewLocationBarOffset();
-  }
   views::View::ConvertPointToWidget(view, &point);
 
   auto* widget = GetWidget();

--- a/browser/ui/views/split_view/split_view_separator.cc
+++ b/browser/ui/views/split_view/split_view_separator.cc
@@ -29,6 +29,7 @@
 #include "ui/views/background.h"
 #include "ui/views/border.h"
 #include "ui/views/controls/button/image_button.h"
+#include "ui/views/controls/highlight_path_generator.h"
 #include "ui/views/controls/resize_area.h"
 #include "ui/views/layout/fill_layout.h"
 #include "ui/views/widget/widget.h"
@@ -42,7 +43,7 @@ class MenuButtonDelegate : public views::WidgetDelegateView,
  public:
   explicit MenuButtonDelegate(Browser* browser) {
     SetLayoutManager(std::make_unique<views::FillLayout>());
-    constexpr auto kCornerRadius = 8;
+    constexpr auto kCornerRadius = 4;
     constexpr auto kBorderThickness = 1;
     SetBackground(views::CreateThemedRoundedRectBackground(
         kColorBraveSplitViewMenuButtonBackground, kCornerRadius,
@@ -63,6 +64,8 @@ class MenuButtonDelegate : public views::WidgetDelegateView,
     for (auto state : views::Button::kButtonStates) {
       image_button->SetImageModel(state, image_model);
     }
+    views::InstallRoundRectHighlightPathGenerator(image_button, gfx::Insets(),
+                                                  kCornerRadius);
 
     image_button->SetImageHorizontalAlignment(views::ImageButton::ALIGN_CENTER);
     image_button->SetImageVerticalAlignment(views::ImageButton::ALIGN_MIDDLE);
@@ -113,7 +116,7 @@ class MenuButtonDelegate : public views::WidgetDelegateView,
     gfx::Transform transform;
     transform.Translate(width() / 2, height() / 2);
     transform.Scale(gfx::Tween::DoubleValueBetween(
-                        background_animation_.GetCurrentValue(), 0.4, 1),
+                        background_animation_.GetCurrentValue(), 0.57, 1),
                     1);
     transform.Translate(-width() / 2, -height() / 2);
     canvas->Transform(transform);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/44146

Previously, we set split view focus border to `ContentsWebView` control
but we can't do it anymore because it uses solid color layer for background.
Instead, use border for its container. So, focus border includes reader mode toolbar also.
And changed inactive tab's focus border color and miniurl bar's border also uses same border color.

In non-rounded corner mode, contents separator is disabled when split view is used.
If not, top focus border seems thicker as focus border is rendered right after the contents separator. 
See https://github.com/brave/brave-core/pull/27775#pullrequestreview-2636988051

and focus border uses 1px thickness.
In design, focus border's thickness is 2px and inactive border's thickness is 1px.
However, it causes re-layout whenever active tab changes because different border
thickness means different contents bounds.

Menu handle update:
![image](https://github.com/user-attachments/assets/48de5aaa-755c-4d05-a199-eb5c7064a99c)


rounded corners mode on: (below images are captured w/o above handle changes)
<img width="876" alt="Screenshot 2025-02-26 at 2 54 03 PM" src="https://github.com/user-attachments/assets/279aa60d-ec86-4207-821c-3846a0960a32" />
<img width="874" alt="Screenshot 2025-02-26 at 2 54 11 PM" src="https://github.com/user-attachments/assets/4d011b07-cb39-4b74-939c-c8bc550cee3f" />
<img width="874" alt="Screenshot 2025-02-26 at 2 55 11 PM" src="https://github.com/user-attachments/assets/5db2569c-36dd-4c12-95fe-07c8f14e6eec" />
<img width="877" alt="Screenshot 2025-02-26 at 2 55 20 PM" src="https://github.com/user-attachments/assets/328136a8-b9a4-4714-b95d-344fd1c2114d" />

rounded corners mode off:
<img width="867" alt="Screenshot 2025-02-26 at 2 58 03 PM" src="https://github.com/user-attachments/assets/ba6298a3-cc68-4367-8776-c6260ed43145" />
<img width="868" alt="Screenshot 2025-02-26 at 2 58 11 PM" src="https://github.com/user-attachments/assets/cdf78878-1b54-4a64-ba05-efdfb673838e" />
<img width="872" alt="Screenshot 2025-02-26 at 2 58 44 PM" src="https://github.com/user-attachments/assets/cb9f73fa-5772-4c1d-a697-635b92687959" />
<img width="869" alt="Screenshot 2025-02-26 at 2 58 51 PM" src="https://github.com/user-attachments/assets/b60d054d-7419-46f2-bc6d-af6541cb4faf" />


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Launch browser with `--enable-features=BraveSplitView` or `--enable-features=BraveSplitView,brave-web-view-rounded-corners` to check split view border with or w/o roudned corners mode