### PR TITLE
Fixes `webui_resources.grd`'s reserved include IDs (uplift to 1.76.x)

### DIFF
--- a/patches/tools-gritsettings-resource_ids.spec.patch
+++ b/patches/tools-gritsettings-resource_ids.spec.patch
@@ -1,5 +1,5 @@
 diff --git a/tools/gritsettings/resource_ids.spec b/tools/gritsettings/resource_ids.spec
-index 80494b5bb318a9dc4b92b4d2fbb3fab84521d8a9..eb9f4cd8c2fdea53d855cc9d219e4a299facb663 100644
+index 80494b5bb318a9dc4b92b4d2fbb3fab84521d8a9..140c0e4b1ed4b526b37601f80f444ae55c8a7e66 100644
 --- a/tools/gritsettings/resource_ids.spec
 +++ b/tools/gritsettings/resource_ids.spec
 @@ -38,6 +38,9 @@
@@ -45,7 +45,7 @@ index 80494b5bb318a9dc4b92b4d2fbb3fab84521d8a9..eb9f4cd8c2fdea53d855cc9d219e4a29
    },
    "<(SHARED_INTERMEDIATE_DIR)/ui/webui/resources/webui_resources.grd": {
 -    "META": {"sizes": {"includes": [1100]}},
-+    "META": {"sizes": {"includes": [1104]}},
++    "META": {"sizes": {"includes": [1105]}},
      "includes": [10000],
    },
    "weblayer/weblayer_resources.grd": {


### PR DESCRIPTION
Uplift of #27759
Resolves https://github.com/brave/brave-browser/issues/44149

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.