### PR TITLE
[iOS] Remove WKWebView references in AIChat component

### DIFF
--- a/ios/brave-ios/Sources/AIChat/ModelView/AIChatJavaScript.swift
+++ b/ios/brave-ios/Sources/AIChat/ModelView/AIChatJavaScript.swift
@@ -6,20 +6,6 @@
 import Foundation
 import WebKit
 
-public protocol AIChatJavascript {
-  @MainActor
-  static func getPageContentType(webView: WKWebView) async -> String?
-
-  @MainActor
-  static func getMainArticle(webView: WKWebView) async -> String?
-
-  @MainActor
-  static func getPDFDocument(webView: WKWebView) async -> String?
-
-  @MainActor
-  static func getPrintViewPDF(webView: WKWebView) async -> Data
-}
-
 public protocol AIChatBraveTalkJavascript {
   @MainActor
   func getTranscript() async -> String?

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3672,12 +3672,11 @@ extension BrowserViewController {
       return
     }
 
-    let webView = (query == nil) ? tabManager.selectedTab?.webView : nil
+    let webDelegate = (query == nil) ? tabManager.selectedTab?.leoTabHelper : nil
 
     let model = AIChatViewModel(
       braveCore: braveCore,
-      webView: webView,
-      script: BraveLeoScriptHandler.self,
+      webDelegate: webDelegate,
       braveTalkScript: self.braveTalkJitsiCoordinator,
       querySubmited: query
     )

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -431,6 +431,7 @@ class Tab: NSObject {
   }
 
   var translateHelper: BraveTranslateTabHelper?
+  private(set) lazy var leoTabHelper = BraveLeoScriptTabHelper(tab: self)
 
   /// Boolean tracking custom url-scheme alert presented
   var isExternalAppAlertPresented = false

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -853,8 +853,7 @@ class SettingsViewController: TableViewController {
       selection: { [unowned self] in
         let model = AIChatViewModel(
           braveCore: self.braveCore,
-          webView: self.tabManager.selectedTab?.webView,
-          script: BraveLeoScriptHandler.self,
+          webDelegate: self.tabManager.selectedTab?.leoTabHelper,
           braveTalkScript: nil
         )
 


### PR DESCRIPTION
This change adjusts the AIChatViewModel & related delegates from referencing WKWebView directly in preparation for using Chromium web views

Resolves https://github.com/brave/brave-browser/issues/44194

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Sanity test basic Leo web page context integrations such as: summarizing articles, summarizing/asking questions on a PDF document