### PR TITLE
Fixed vpn crash when using newly supported timezone

### DIFF
--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -56,7 +56,10 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterListPref(prefs::kBraveVPNWidgetUsageWeeklyStorage);
 }
 
-// Region name map between v1 and v2.
+// Region name map between v1 and v2. Some region from region list v2
+// uses different name with v1. If previously selected region name
+// uses different with v2, we can't proper region with it. So, map
+// v1 name to v2's.
 constexpr auto kV1ToV2Map =
     base::MakeFixedFlatMap<std::string_view, std::string_view>(
         {{"au-au", "ocn-aus"},      {"eu-at", "eu-at"},
@@ -108,7 +111,13 @@ std::string_view GetMigratedNameIfNeeded(PrefService* local_prefs,
   }
 
   auto it = kV1ToV2Map.find(name);
-  CHECK(it != kV1ToV2Map.end());
+  // |kV1ToV2Map| doesn't include newly supported timezone names.
+  // Use |name| in that case.
+  // TODO(simonhong): Need to check this new name is aligned with
+  // v2 region list data.
+  if (it == kV1ToV2Map.end()) {
+    return name;
+  }
   return it->second;
 }
 

--- a/components/brave_vpn/common/brave_vpn_utils_unittest.cc
+++ b/components/brave_vpn/common/brave_vpn_utils_unittest.cc
@@ -230,6 +230,20 @@ TEST(BraveVPNUtilsUnitTest, InvalidSelectedRegionNameMigration) {
   EXPECT_EQ(2, local_state_pref_service.GetInteger(
                    brave_vpn::prefs::kBraveVPNRegionListVersion));
 }
+
+TEST(BraveVPNUtilsUnitTest, NewTimeZoneName) {
+  TestingPrefServiceSimple local_state_pref_service;
+  brave_vpn::RegisterLocalStatePrefs(local_state_pref_service.registry());
+  EXPECT_EQ(1, local_state_pref_service.GetInteger(
+                   brave_vpn::prefs::kBraveVPNRegionListVersion));
+  brave_vpn::MigrateLocalStatePrefs(&local_state_pref_service);
+  EXPECT_EQ(2, local_state_pref_service.GetInteger(
+                   brave_vpn::prefs::kBraveVPNRegionListVersion));
+
+  // Check passed timezone name is returned if it's not included in V1ToV2Map.
+  EXPECT_EQ("asia-new", brave_vpn::GetMigratedNameIfNeeded(
+                            &local_state_pref_service, "asia-new"));
+}
 #endif
 
 TEST(BraveVPNUtilsUnitTest, VPNPaymentsEnv) {


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/44181

When new region is added to timezone list and it's same with user's timezone, vpn service tries to map it to v2's name via GetMigratedNameIfNeeded(). However, new region is not included in kV1ToV2Map, it causes crash. When it's not in that map, use that name instead.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Set `Asia/Jerusalem` to machine's timezone
2. Launch brave with clean profile
3. Set VPN as purchased state
4. No crash