### PR TITLE
Browser test for crash with unset NetworkTimeHelper::ui_task_runner_

### DIFF
--- a/browser/sync/BUILD.gn
+++ b/browser/sync/BUILD.gn
@@ -16,3 +16,18 @@ source_set("sync") {
     "//components/sync_device_info",
   ]
 }
+
+source_set("browser_tests") {
+  testonly = true
+  sources = [ "network_time_helper_browsertest.cc" ]
+
+  deps = [
+    "//base",
+    "//base/test:test_support",
+    "//brave/components/brave_sync:prefs",
+    "//chrome/browser",
+    "//chrome/test:test_support",
+  ]
+
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+}

--- a/browser/sync/network_time_helper_browsertest.cc
+++ b/browser/sync/network_time_helper_browsertest.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_sync/brave_sync_prefs.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/test/base/platform_browser_test.h"
+#include "components/keyed_service/content/browser_context_dependency_manager.h"
+#include "components/sync/base/command_line_switches.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/test/browser_test.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace {
+
+constexpr char kValidSyncCode[] =
+    "fringe digital begin feed equal output proof cheap "
+    "exotic ill sure question trial squirrel glove celery "
+    "awkward push jelly logic broccoli almost grocery drift";
+
+}  // namespace
+
+// This test ensures that the browser doesn't crashes as it is described at
+// https://github.com/brave/brave-browser/issues/43727
+// The conditions for the crash were:
+//    1. Sync chain is set up
+//    2. Command line has --sync-deferred-startup-timeout-seconds=0
+
+class BraveSyncNetworkTimeHelperBrowserTest : public PlatformBrowserTest {
+ public:
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    PlatformBrowserTest::SetUpCommandLine(command_line);
+    command_line->AppendSwitchASCII(syncer::kSyncDeferredStartupTimeoutSeconds,
+                                    "0");
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    PlatformBrowserTest::SetUpInProcessBrowserTestFixture();
+    create_services_subscription_ =
+        BrowserContextDependencyManager::GetInstance()
+            ->RegisterCreateServicesCallbackForTesting(
+                base::BindRepeating(&BraveSyncNetworkTimeHelperBrowserTest ::
+                                        OnWillCreateBrowserContextServices,
+                                    base::Unretained(this)));
+  }
+
+  void OnWillCreateBrowserContextServices(content::BrowserContext* context) {
+    // At this point profile and preferences are created, but sync service is
+    // not yet. Pretend we have a configured sync chain by setting up the sync
+    // code. This along with --sync-deferred-startup-timeout-seconds=0 will
+    // cause SyncServiceImpl::Initialize() immediately post
+    // SyncServiceImpl::TryStartImpl() and this would crash without
+    // brave-core/pull/27499
+
+    brave_sync::Prefs brave_sync_refs(
+        static_cast<Profile*>(context)->GetPrefs());
+    brave_sync_refs.SetSeed(kValidSyncCode);
+  }
+
+  base::CallbackListSubscription create_services_subscription_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveSyncNetworkTimeHelperBrowserTest, DidntCrash) {
+  // The actual test is the fact we didn't crashed at
+  //    brave_sync::NetworkTimeHelper::GetNetworkTime()
+  //    syncer::BraveSyncAuthManager::RequestAccessToken()
+  //    syncer::SyncAuthManager::ConnectionOpened()
+  //    syncer::SyncServiceImpl::TryStartImpl()
+  // because NetworkTimeHelper::ui_task_runner_ wasn't set at the time.
+  // You can see the test crash failure by reverting commit
+  // 92c41053e2da9d5931ed44036f7594b69559fa66
+
+  EXPECT_TRUE(true);
+}

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1162,6 +1162,7 @@ test("brave_browser_tests") {
       "//brave/browser/brave_search:browser_tests",
       "//brave/browser/password_manager:browser_tests",
       "//brave/browser/sharing_hub:browser_tests",
+      "//brave/browser/sync:browser_tests",
       "//brave/browser/ui/ai_rewriter:browsertest",
       "//brave/browser/ui/geolocation:browser_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_browser_tests",


### PR DESCRIPTION
This is a follow-up for https://github.com/brave/brave-core/pull/27499

 This test ensures that the browser doesn't crashes as it is described at
 https://github.com/brave/brave-browser/issues/43727
 The conditions for the crash were:
    1. Sync chain is set up
    2. Command line has `--sync-deferred-startup-timeout-seconds=0`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44190

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
The steps are rather for devs 
1. `git revert 92c41053e2da9d5931ed44036f7594b69559fa66`
2. `npm run test  -- brave_browser_tests --filter=BraveSyncNetworkTimeHelperBrowserTest.*` - should crash at 
```
[1891420:1891420:0225/185225.132900:FATAL:scoped_refptr.h(292)] Check failed: ptr_. 
#0 0x776170d05c82 base::debug::CollectStackTrace()
#1 0x776170ce22b0 base::debug::StackTrace::StackTrace()
#2 0x776170bafc1a logging::LogMessage::Flush()
#3 0x776170bafb01 logging::LogMessage::~LogMessage()
#4 0x776170b88341 logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage()
#5 0x776170b87a83 logging::CheckError::~CheckError()
#6 0x62993a684093 brave_sync::NetworkTimeHelper::GetNetworkTime()
#7 0x62993a4795cb syncer::BraveSyncAuthManager::RequestAccessToken()
#8 0x62993a463cd0 syncer::SyncAuthManager::ConnectionOpened()
#9 0x62993a456704 syncer::SyncServiceImpl::TryStartImpl()
#10 0x776170b83a51 base::OnceCallback<>::Run()
#11 0x776170c3c9dd base::TaskAnnotator::RunTaskImpl()
#12 0x776170c7740b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl()
#13 0x776170c7679b base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#14 0x776170c77ba5 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork()
#15 0x776170d2a7d9 base::MessagePumpGlib::Run()
#16 0x776170c78571 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run()
#17 0x776170c0ca96 base::RunLoop::Run()
#18 0x629939631c24 SessionRestoreImpl::Restore()
#19 0x6299396313fe SessionRestore::RestoreSession()
#20 0x629939742588 StartupBrowserCreatorImpl::RestoreOrCreateBrowser()
#21 0x629939740b9f StartupBrowserCreatorImpl::DetermineURLsAndLaunch()
#22 0x629939740164 StartupBrowserCreatorImpl::Launch()
#23 0x62993973a835 BraveStartupBrowserCreatorImpl::Launch()
#24 0x62993973c156 StartupBrowserCreator::LaunchBrowser()
#25 0x62993973ccaa StartupBrowserCreator::LaunchBrowserForLastProfiles()
#26 0x62993973bb5c StartupBrowserCreator::ProcessCmdLineImpl()
#27 0x62993973aa6e StartupBrowserCreator::Start()
#28 0x6299390118aa ChromeBrowserMainParts_ChromiumImpl::PreMainMessageLoopRunImpl()
#29 0x629939010dea ChromeBrowserMainParts_ChromiumImpl::PreMainMessageLoopRun()
#30 0x77617217a687 content::BrowserMainLoop::PreMainMessageLoopRun()
#31 0x776171fb84c1 base::OnceCallback<>::Run()
#32 0x776172ab6769 content::StartupTaskRunner::RunAllTasksNow()
#33 0x77617217a1ac content::BrowserMainLoop::CreateStartupTasks()
#34 0x77617217d7b1 content::BrowserMainRunnerImpl::Initialize()
#35 0x7761721777d7 content::BrowserMain()
#36 0x77617318d388 content::RunBrowserProcessMain()
#37 0x77617318fd64 content::ContentMainRunnerImpl::RunBrowser()
#38 0x77617318f551 content::ContentMainRunnerImpl::Run()
#39 0x77617318be87 content::RunContentProcess()
#40 0x77617318c022 content::ContentMain()
#41 0x62993baafa70 content::BrowserTestBase::SetUp()
#42 0x629939f48d41 InProcessBrowserTest::SetUp()
#43 0x629938b8d7d0 testing::Test::Run()
#44 0x629938b8e512 testing::TestInfo::Run()
#45 0x629938b8f037 testing::TestSuite::Run()
#46 0x629938b9c667 testing::internal::UnitTestImpl::RunAllTests()
#47 0x629938b9c0ff testing::UnitTest::Run()
#48 0x62993ba610ca base::TestSuite::Run()
#49 0x629939f46c76 ChromeTestSuiteRunner::RunTestSuite()
#50 0x629939f46faf ChromeTestLauncherDelegate::RunTestSuite()
#51 0x62993badca71 content::LaunchTestsInternal()
#52 0x62993badd055 content::LaunchTests()
#53 0x629939f4722a LaunchChromeTests()
#54 0x629938d108e5 main

```
