### PR TITLE
Fixed vpn crash when using newly supported timezone (uplift to 1.76.x)

### DIFF
--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -56,7 +56,10 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterListPref(prefs::kBraveVPNWidgetUsageWeeklyStorage);
 }
 
-// Region name map between v1 and v2.
+// Region name map between v1 and v2. Some region from region list v2
+// uses different name with v1. If previously selected region name
+// uses different with v2, we can't proper region with it. So, map
+// v1 name to v2's.
 constexpr auto kV1ToV2Map =
     base::MakeFixedFlatMap<std::string_view, std::string_view>(
         {{"au-au", "ocn-aus"},      {"eu-at", "eu-at"},
@@ -108,7 +111,13 @@ std::string_view GetMigratedNameIfNeeded(PrefService* local_prefs,
   }
 
   auto it = kV1ToV2Map.find(name);
-  CHECK(it != kV1ToV2Map.end());
+  // |kV1ToV2Map| doesn't include newly supported timezone names.
+  // Use |name| in that case.
+  // TODO(simonhong): Need to check this new name is aligned with
+  // v2 region list data.
+  if (it == kV1ToV2Map.end()) {
+    return name;
+  }
   return it->second;
 }
 

--- a/components/brave_vpn/common/brave_vpn_utils_unittest.cc
+++ b/components/brave_vpn/common/brave_vpn_utils_unittest.cc
@@ -226,6 +226,20 @@ TEST(BraveVPNUtilsUnitTest, InvalidSelectedRegionNameMigration) {
   EXPECT_EQ(2, local_state_pref_service.GetInteger(
                    brave_vpn::prefs::kBraveVPNRegionListVersion));
 }
+
+TEST(BraveVPNUtilsUnitTest, NewTimeZoneName) {
+  TestingPrefServiceSimple local_state_pref_service;
+  brave_vpn::RegisterLocalStatePrefs(local_state_pref_service.registry());
+  EXPECT_EQ(1, local_state_pref_service.GetInteger(
+                   brave_vpn::prefs::kBraveVPNRegionListVersion));
+  brave_vpn::MigrateLocalStatePrefs(&local_state_pref_service);
+  EXPECT_EQ(2, local_state_pref_service.GetInteger(
+                   brave_vpn::prefs::kBraveVPNRegionListVersion));
+
+  // Check passed timezone name is returned if it's not included in V1ToV2Map.
+  EXPECT_EQ("asia-new", brave_vpn::GetMigratedNameIfNeeded(
+                            &local_state_pref_service, "asia-new"));
+}
 #endif
 
 TEST(BraveVPNUtilsUnitTest, VPNPaymentsEnv) {


### PR DESCRIPTION
Uplift of #27791
fix https://github.com/brave/brave-browser/issues/44181

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.