### PR TITLE
Improve vpn device region setting

### DIFF
--- a/components/brave_vpn/browser/brave_vpn_service_unittest.cc
+++ b/components/brave_vpn/browser/brave_vpn_service_unittest.cc
@@ -399,56 +399,67 @@ class BraveVPNServiceTest : public testing::Test {
         {
           "continent": "europe",
           "name": "eu-es",
+          "country-iso-code": "ES",
           "name-pretty": "Spain"
         },
         {
           "continent": "south-america",
           "name": "sa-br",
+          "country-iso-code": "BR",
           "name-pretty": "Brazil"
         },
         {
           "continent": "europe",
           "name": "eu-ch",
+          "country-iso-code": "CH",
           "name-pretty": "Switzerland"
         },
         {
           "continent": "europe",
           "name": "eu-de",
+          "country-iso-code": "DE",
           "name-pretty": "Germany"
         },
         {
           "continent": "asia",
           "name": "asia-sg",
+          "country-iso-code": "SG",
           "name-pretty": "Singapore"
         },
         {
           "continent": "north-america",
           "name": "ca-east",
+          "country-iso-code": "CA",
           "name-pretty": "Canada"
         },
         {
           "continent": "asia",
           "name": "asia-jp",
+          "country-iso-code": "JP",
           "name-pretty": "Japan"
         },
         {
           "continent": "europe",
           "name": "eu-en",
+          "country-iso-code": "GB",
           "name-pretty": "United Kingdom"
         },
         {
           "continent": "europe",
           "name": "eu-nl",
+          "country-iso-code": "NL",
           "name-pretty": "Netherlands"
         },
         {
           "continent": "north-america",
           "name": "us-central",
+          "country-iso-code": "US",
           "name-pretty": "USA - Central"
         },
         {
           "continent": "oceania",
           "name": "au-au",
+          "country-iso-code": "AU",
           "name-pretty": "Australia"
         }
       ])";
@@ -459,6 +470,7 @@ class BraveVPNServiceTest : public testing::Test {
         {
           "continent": "north-america",
           "name": "na-usa",
+          "country-iso-code": "US",
           "name-pretty": "USA - Central"
         }
       ])";
@@ -468,6 +480,7 @@ class BraveVPNServiceTest : public testing::Test {
     return R"([
         {
           "name": "us-central",
+          "country-iso-code": "US",
           "timezones": [
             "America/Guatemala",
             "America/Guayaquil",
@@ -477,6 +490,7 @@ class BraveVPNServiceTest : public testing::Test {
         },
         {
           "name": "eu-es",
+          "country-iso-code": "ES",
           "timezones": [
             "Europe/Madrid",
             "Europe/Gibraltar",
@@ -486,12 +500,14 @@ class BraveVPNServiceTest : public testing::Test {
         },
         {
           "name": "eu-ch",
+          "country-iso-code": "CH",
           "timezones": [
             "Europe/Zurich"
           ]
         },
         {
           "name": "eu-nl",
+          "country-iso-code": "NL",
           "timezones": [
             "Europe/Amsterdam",
             "Europe/Brussels"
@@ -499,6 +515,7 @@ class BraveVPNServiceTest : public testing::Test {
         },
         {
           "name": "asia-sg",
+          "country-iso-code": "SG",
           "timezones": [
             "Asia/Aden",
             "Asia/Almaty",
@@ -507,6 +524,7 @@ class BraveVPNServiceTest : public testing::Test {
         },
         {
           "name": "asia-jp",
+          "country-iso-code": "JP",
           "timezones": [
             "Pacific/Guam",
             "Pacific/Saipan",

--- a/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.h
+++ b/components/brave_vpn/browser/connection/brave_vpn_region_data_manager.h
@@ -54,6 +54,7 @@ class BraveVPNRegionDataManager {
   friend class BraveVPNServiceTest;
   friend class SystemVPNConnectionAPIUnitTest;
 
+  std::string GetCountryRegionNameFrom(const std::string& country_iso) const;
   void SetDeviceRegion(std::string_view name);
 
   void SetFallbackDeviceRegion();

--- a/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_unittest.cc
+++ b/components/brave_vpn/browser/connection/ikev2/system_vpn_connection_api_unittest.cc
@@ -99,6 +99,7 @@ class SystemVPNConnectionAPIUnitTest : public testing::Test {
     return R"([
         {
           "name": "us-central",
+          "country-iso-code": "US",
           "timezones": [
             "America/Guatemala",
             "America/Guayaquil",
@@ -108,6 +109,7 @@ class SystemVPNConnectionAPIUnitTest : public testing::Test {
         },
         {
           "name": "eu-es",
+          "country-iso-code": "ES",
           "timezones": [
             "Europe/Madrid",
             "Europe/Gibraltar",
@@ -117,12 +119,14 @@ class SystemVPNConnectionAPIUnitTest : public testing::Test {
         },
         {
           "name": "eu-ch",
+          "country-iso-code": "CH",
           "timezones": [
             "Europe/Zurich"
           ]
         },
         {
           "name": "eu-nl",
+          "country-iso-code": "NL",
           "timezones": [
             "Europe/Amsterdam",
             "Europe/Brussels"
@@ -130,6 +134,7 @@ class SystemVPNConnectionAPIUnitTest : public testing::Test {
         },
         {
           "name": "asia-sg",
+          "country-iso-code": "SG",
           "timezones": [
             "Asia/Aden",
             "Asia/Almaty",
@@ -138,6 +143,7 @@ class SystemVPNConnectionAPIUnitTest : public testing::Test {
         },
         {
           "name": "asia-jp",
+          "country-iso-code": "JP",
           "timezones": [
             "Pacific/Guam",
             "Pacific/Saipan",

--- a/components/brave_vpn/common/brave_vpn_utils.cc
+++ b/components/brave_vpn/common/brave_vpn_utils.cc
@@ -56,6 +56,7 @@ void RegisterVPNLocalStatePrefs(PrefRegistrySimple* registry) {
   registry->RegisterListPref(prefs::kBraveVPNWidgetUsageWeeklyStorage);
 }
 
+#if !BUILDFLAG(IS_ANDROID)
 // Region name map between v1 and v2. Some region from region list v2
 // uses different name with v1. If previously selected region name
 // uses different with v2, we can't proper region with it. So, map
@@ -80,7 +81,6 @@ constexpr auto kV1ToV2Map =
          {"us-west", "na-usa"},     {"eu-ua", "eu-ua"},
          {"eu-en", "eu-en"}});
 
-#if !BUILDFLAG(IS_ANDROID)
 void MigrateFromV1ToV2(PrefService* local_prefs) {
   const auto selected_region_v1 =
       local_prefs->GetString(prefs::kBraveVPNSelectedRegion);
@@ -103,23 +103,6 @@ void MigrateFromV1ToV2(PrefService* local_prefs) {
 #endif
 
 }  // namespace
-
-std::string_view GetMigratedNameIfNeeded(PrefService* local_prefs,
-                                         const std::string& name) {
-  if (local_prefs->GetInteger(prefs::kBraveVPNRegionListVersion) == 1) {
-    return name;
-  }
-
-  auto it = kV1ToV2Map.find(name);
-  // |kV1ToV2Map| doesn't include newly supported timezone names.
-  // Use |name| in that case.
-  // TODO(simonhong): Need to check this new name is aligned with
-  // v2 region list data.
-  if (it == kV1ToV2Map.end()) {
-    return name;
-  }
-  return it->second;
-}
 
 bool IsBraveVPNWireguardEnabled(PrefService* local_state) {
   if (!IsBraveVPNFeatureEnabled()) {

--- a/components/brave_vpn/common/brave_vpn_utils.h
+++ b/components/brave_vpn/common/brave_vpn_utils.h
@@ -40,8 +40,6 @@ std::string GetSubscriberCredential(PrefService* local_prefs);
 bool HasValidSkusCredential(PrefService* local_prefs);
 std::string GetSkusCredential(PrefService* local_prefs);
 bool IsBraveVPNWireguardEnabled(PrefService* local_state);
-std::string_view GetMigratedNameIfNeeded(PrefService* local_prefs,
-                                         const std::string& name);
 GURL GetManageURLForUIType(mojom::ManageURLType type, const GURL& manage_url);
 
 #if BUILDFLAG(IS_WIN)

--- a/components/brave_vpn/common/brave_vpn_utils_unittest.cc
+++ b/components/brave_vpn/common/brave_vpn_utils_unittest.cc
@@ -230,20 +230,6 @@ TEST(BraveVPNUtilsUnitTest, InvalidSelectedRegionNameMigration) {
   EXPECT_EQ(2, local_state_pref_service.GetInteger(
                    brave_vpn::prefs::kBraveVPNRegionListVersion));
 }
-
-TEST(BraveVPNUtilsUnitTest, NewTimeZoneName) {
-  TestingPrefServiceSimple local_state_pref_service;
-  brave_vpn::RegisterLocalStatePrefs(local_state_pref_service.registry());
-  EXPECT_EQ(1, local_state_pref_service.GetInteger(
-                   brave_vpn::prefs::kBraveVPNRegionListVersion));
-  brave_vpn::MigrateLocalStatePrefs(&local_state_pref_service);
-  EXPECT_EQ(2, local_state_pref_service.GetInteger(
-                   brave_vpn::prefs::kBraveVPNRegionListVersion));
-
-  // Check passed timezone name is returned if it's not included in V1ToV2Map.
-  EXPECT_EQ("asia-new", brave_vpn::GetMigratedNameIfNeeded(
-                            &local_state_pref_service, "asia-new"));
-}
 #endif
 
 TEST(BraveVPNUtilsUnitTest, VPNPaymentsEnv) {


### PR DESCRIPTION
We don't need to use V1ToV2Map to get default(device) region for timezone.
With timezone's iso code, we could proper region name from region list.

fix https://github.com/brave/brave-browser/issues/44365

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.