### PR TITLE
[CodeHealth] Removing unused `ffmpeg` patcher

### DIFF
--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -34,7 +34,6 @@ async function applyPatches(printPatchFailuresInJson) {
   const v8PatchesPath = path.join(patchesPath, 'v8')
   const catapultPatchesPath = path.join(patchesPath, 'third_party', 'catapult')
   const devtoolsFrontendPatchesPath = path.join(patchesPath, 'third_party', 'devtools-frontend', 'src')
-  const ffmpegPatchesPath = path.join(patchesPath, 'third_party', 'ffmpeg')
   const tflitePatchesPath = path.join(patchesPath, 'third_party', 'tflite', 'src')
   const searchEngineDataPatchesPath =
       path.join(patchesPath, 'third_party', 'search_engines_data', 'resources')
@@ -43,7 +42,6 @@ async function applyPatches(printPatchFailuresInJson) {
   const v8RepoPath = path.join(chromiumRepoPath, 'v8')
   const catapultRepoPath = path.join(chromiumRepoPath, 'third_party', 'catapult')
   const devtoolsFrontendRepoPath = path.join(chromiumRepoPath, 'third_party', 'devtools-frontend', 'src')
-  const ffmpegRepoPath = path.join(chromiumRepoPath, 'third_party', 'ffmpeg')
   const tfliteRepoPath = path.join(chromiumRepoPath, 'third_party', 'tflite', 'src')
   const searchEngineDataRepoPath = path.join(
       chromiumRepoPath, 'third_party', 'search_engines_data', 'resources')
@@ -52,7 +50,6 @@ async function applyPatches(printPatchFailuresInJson) {
   const v8Patcher = new GitPatcher(v8PatchesPath, v8RepoPath)
   const catapultPatcher = new GitPatcher(catapultPatchesPath, catapultRepoPath)
   const devtoolsFrontendPatcher = new GitPatcher(devtoolsFrontendPatchesPath, devtoolsFrontendRepoPath)
-  const ffmpegPatcher = new GitPatcher(ffmpegPatchesPath, ffmpegRepoPath)
   const tflitePatcher = new GitPatcher(tflitePatchesPath, tfliteRepoPath)
   const searchEngineDataPatcher =
       new GitPatcher(searchEngineDataPatchesPath, searchEngineDataRepoPath)
@@ -61,7 +58,6 @@ async function applyPatches(printPatchFailuresInJson) {
   const v8PatchStatus = await v8Patcher.applyPatches()
   const catapultPatchStatus = await catapultPatcher.applyPatches()
   const devtoolsFrontendPatchStatus = await devtoolsFrontendPatcher.applyPatches()
-  const ffmpegPatchStatus = await ffmpegPatcher.applyPatches()
   const tflitePatchStatus = await tflitePatcher.applyPatches()
   const searchEngineDataPatchStatus =
       await searchEngineDataPatcher.applyPatches()
@@ -75,7 +71,7 @@ async function applyPatches(printPatchFailuresInJson) {
     s => s.path = path.join('third_party', 'devtools-frontend', 'src', s.path))
   const allPatchStatus = [
     ...chromiumPatchStatus, ...v8PatchStatus, ...catapultPatchStatus,
-    ...devtoolsFrontendPatchStatus, ...ffmpegPatchStatus, ...tflitePatchStatus,
+    ...devtoolsFrontendPatchStatus, ...tflitePatchStatus,
     ...searchEngineDataPatchStatus
   ];
   if (printPatchFailuresInJson) {

--- a/build/commands/scripts/updatePatches.js
+++ b/build/commands/scripts/updatePatches.js
@@ -29,7 +29,6 @@ module.exports = function RunCommand (options) {
   const v8Dir = path.join(config.srcDir, 'v8')
   const catapultDir = path.join(config.srcDir, 'third_party', 'catapult')
   const devtoolsFrontendDir = path.join(config.srcDir, 'third_party', 'devtools-frontend', 'src')
-  const ffmpegDir = path.join(config.srcDir, 'third_party', 'ffmpeg')
   const tfliteDir = path.join(config.srcDir, 'third_party', 'tflite', 'src')
   const searchEngineDataDir = path.join(
       config.srcDir, 'third_party', 'search_engines_data', 'resources')
@@ -37,7 +36,6 @@ module.exports = function RunCommand (options) {
   const v8PatchDir = path.join(patchDir, 'v8')
   const catapultPatchDir = path.join(patchDir, 'third_party', 'catapult')
   const devtoolsFrontendPatchDir = path.join(patchDir, 'third_party', 'devtools-frontend', 'src')
-  const ffmpegPatchDir = path.join(patchDir, 'third_party', 'ffmpeg')
   const tflitePatchDir = path.join(patchDir, 'third_party', 'tflite', 'src')
   const searchEngineDataPatchDir =
       path.join(patchDir, 'third_party', 'search_engines_data', 'resources')
@@ -51,8 +49,6 @@ module.exports = function RunCommand (options) {
     updatePatches(catapultDir, catapultPatchDir),
     // third_party/devtools-frontend/src
     updatePatches(devtoolsFrontendDir, devtoolsFrontendPatchDir),
-    // third_party/ffmpeg
-    updatePatches(ffmpegDir, ffmpegPatchDir),
     // third_party/tflite/src
     updatePatches(tfliteDir, tflitePatchDir),
     // third_party/search_engines_data


### PR DESCRIPTION
There was some patching being done to `ffmpeg` in the past, but this has been abandoned since `cr124` was merged.

This PR removes the unused patcher, which was generating warnings whenever `update_patches` was being run.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44245

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

