### PR TITLE
[ZCash] Add incoming notes filter

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1643,6 +1643,8 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
      IDS_BRAVE_WALLET_OUT_OF_SYNC_BLOCKS_BEHIND_TITLE},
     {"braveWalletOutOfSyncDescription",
      IDS_BRAVE_WALLET_OUT_OF_SYNC_DESCRIPTION},
+    {"braveWalletZCashPendingBalanceTitle",
+     IDS_BRAVE_WALLET_ZCASH_PENDING_BALANCE_TITLE},
     {"braveWalletSyncAccountButton", IDS_BRAVE_WALLET_SYNC_ACCOUNT_BUTTON},
     {"braveWalletSyncAccountName", IDS_BRAVE_WALLET_SYNC_ACCOUNT_NAME},
     {"braveWalletInitializing", IDS_BRAVE_WALLET_INITIALIZING},

--- a/components/brave_wallet/browser/internal/orchard_test_utils.cc
+++ b/components/brave_wallet/browser/internal/orchard_test_utils.cc
@@ -33,4 +33,10 @@ OrchardCommitmentValue CreateMockCommitmentValue(uint32_t position,
   return orchard::CreateMockCommitmentValue(position, rseed);
 }
 
+OrchardCommitment CreateCommitment(OrchardCommitmentValue value,
+                                   bool marked,
+                                   std::optional<uint32_t> checkpoint_id) {
+  return OrchardCommitment{std::move(value), marked, checkpoint_id};
+}
+
 }  // namespace brave_wallet

--- a/components/brave_wallet/browser/internal/orchard_test_utils.h
+++ b/components/brave_wallet/browser/internal/orchard_test_utils.h
@@ -23,6 +23,10 @@ OrchardBlockScanner::Result CreateResultForTesting(
 OrchardCommitmentValue CreateMockCommitmentValue(uint32_t position,
                                                  uint32_t rseed);
 
+OrchardCommitment CreateCommitment(OrchardCommitmentValue value,
+                                   bool marked,
+                                   std::optional<uint32_t> checkpoint_id);
+
 }  // namespace brave_wallet
 
 #endif  // BRAVE_COMPONENTS_BRAVE_WALLET_BROWSER_INTERNAL_ORCHARD_TEST_UTILS_H_

--- a/components/brave_wallet/browser/zcash/zcash_action_context.cc
+++ b/components/brave_wallet/browser/zcash/zcash_action_context.cc
@@ -10,12 +10,14 @@ namespace brave_wallet {
 ZCashActionContext::ZCashActionContext(
     ZCashRpc& zcash_rpc,
 #if BUILDFLAG(ENABLE_ORCHARD)
+    const std::optional<OrchardAddrRawPart>& account_internal_addr,
     base::SequenceBound<OrchardSyncState>& sync_state,
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
     const mojom::AccountIdPtr& account_id,
     const std::string& chain_id)
     : zcash_rpc(zcash_rpc),
 #if BUILDFLAG(ENABLE_ORCHARD)
+      account_internal_addr(account_internal_addr),
       sync_state(sync_state),
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
       account_id(account_id.Clone()),

--- a/components/brave_wallet/browser/zcash/zcash_action_context.h
+++ b/components/brave_wallet/browser/zcash/zcash_action_context.h
@@ -12,23 +12,27 @@
 #include "base/threading/sequence_bound.h"
 #include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/buildflags.h"
+#include "brave/components/brave_wallet/common/zcash_utils.h"
 
 namespace brave_wallet {
 
-class ZCashRpc;
 class OrchardSyncState;
+class ZCashRpc;
 
 // Basic context required by most orchard-related operations.
 struct ZCashActionContext {
-  ZCashActionContext(ZCashRpc& zcash_rpc,
+  ZCashActionContext(
+      ZCashRpc& zcash_rpc,
 #if BUILDFLAG(ENABLE_ORCHARD)
-                     base::SequenceBound<OrchardSyncState>& sync_state,
+      const std::optional<OrchardAddrRawPart>& account_internal_addr,
+      base::SequenceBound<OrchardSyncState>& sync_state,
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
-                     const mojom::AccountIdPtr& account_id,
-                     const std::string& chain_id);
+      const mojom::AccountIdPtr& account_id,
+      const std::string& chain_id);
   ~ZCashActionContext();
   raw_ref<ZCashRpc> zcash_rpc;
 #if BUILDFLAG(ENABLE_ORCHARD)
+  std::optional<OrchardAddrRawPart> account_internal_addr;
   raw_ref<base::SequenceBound<OrchardSyncState>> sync_state;
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
   ZCashActionContext(ZCashActionContext&) = delete;

--- a/components/brave_wallet/browser/zcash/zcash_complete_transaction_task.h
+++ b/components/brave_wallet/browser/zcash/zcash_complete_transaction_task.h
@@ -50,10 +50,6 @@ class ZCashCompleteTransactionTask {
       base::expected<zcash::mojom::BlockIDPtr, std::string> result);
 
 #if BUILDFLAG(ENABLE_ORCHARD)
-  void GetMaxCheckpointedHeight();
-  void OnGetMaxCheckpointedHeight(
-      base::expected<std::optional<uint32_t>, OrchardStorage::Error> result);
-
   void CalculateWitness();
   void OnWitnessCalulcateResult(
       base::expected<std::vector<OrchardInput>, OrchardStorage::Error> result);
@@ -81,7 +77,6 @@ class ZCashCompleteTransactionTask {
 
 #if BUILDFLAG(ENABLE_ORCHARD)
   std::optional<std::vector<OrchardInput>> witness_inputs_;
-  std::optional<uint32_t> anchor_block_height_;
   std::optional<zcash::mojom::TreeStatePtr> anchor_tree_state_;
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
 

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
@@ -8,6 +8,7 @@
 #include <utility>
 
 #include "base/numerics/checked_math.h"
+#include "brave/components/brave_wallet/common/brave_wallet.mojom.h"
 #include "brave/components/brave_wallet/common/hex_utils.h"
 #include "components/grit/brave_components_strings.h"
 #include "ui/base/l10n/l10n_util.h"
@@ -70,28 +71,42 @@ void ZCashCreateOrchardToOrchardTransactionTask::WorkOnTask() {
 }
 
 void ZCashCreateOrchardToOrchardTransactionTask::GetSpendableNotes() {
+  if (!context_.account_internal_addr) {
+    error_ = "No internal address provided";
+    ScheduleWorkOnTask();
+    return;
+  }
   context_.sync_state->AsyncCall(&OrchardSyncState::GetSpendableNotes)
-      .WithArgs(context_.account_id.Clone())
+      .WithArgs(context_.account_id.Clone(),
+                context_.account_internal_addr.value())
       .Then(base::BindOnce(
           &ZCashCreateOrchardToOrchardTransactionTask::OnGetSpendableNotes,
           weak_ptr_factory_.GetWeakPtr()));
 }
 
 void ZCashCreateOrchardToOrchardTransactionTask::OnGetSpendableNotes(
-    base::expected<std::vector<OrchardNote>, OrchardStorage::Error> result) {
+    base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
+                   OrchardStorage::Error> result) {
   if (!result.has_value()) {
     error_ = result.error().message;
     ScheduleWorkOnTask();
     return;
   }
 
-  spendable_notes_ = result.value();
+  if (!result.value()) {
+    error_ = "No spendable notes";
+    ScheduleWorkOnTask();
+    return;
+  }
+
+  spendable_notes_ = std::move(**result);
   ScheduleWorkOnTask();
 }
 
 void ZCashCreateOrchardToOrchardTransactionTask::CreateTransaction() {
   CHECK(spendable_notes_);
-  auto pick_result = PickZCashOrchardInputs(spendable_notes_.value(), amount_);
+  auto pick_result =
+      PickZCashOrchardInputs(spendable_notes_->spendable_notes, amount_);
   if (!pick_result) {
     error_ = "Can't pick inputs";
     ScheduleWorkOnTask();
@@ -106,22 +121,24 @@ void ZCashCreateOrchardToOrchardTransactionTask::CreateTransaction() {
   }
   zcash_transaction.set_fee(pick_result->fee);
 
+  if (!context_.account_internal_addr) {
+    error_ = "Internal address error";
+    ScheduleWorkOnTask();
+    return;
+  }
+
+  if (!spendable_notes_->anchor_block_id) {
+    error_ = "Failed to select anchor";
+    ScheduleWorkOnTask();
+    return;
+  }
+
   // Create shielded change
   if (pick_result->change != 0) {
     OrchardOutput& orchard_output =
         zcash_transaction.orchard_part().outputs.emplace_back();
     orchard_output.value = pick_result->change;
-    auto change_addr =
-        zcash_wallet_service_->keyring_service_->GetOrchardRawBytes(
-            context_.account_id.Clone(),
-            mojom::ZCashKeyId::New(context_.account_id->account_index,
-                                   1 /* internal */, 0));
-    if (!change_addr) {
-      error_ = l10n_util::GetStringUTF8(IDS_WALLET_INTERNAL_ERROR);
-      ScheduleWorkOnTask();
-      return;
-    }
-    orchard_output.addr = *change_addr;
+    orchard_output.addr = context_.account_internal_addr.value();
   }
 
   // Create shielded output
@@ -133,6 +150,8 @@ void ZCashCreateOrchardToOrchardTransactionTask::CreateTransaction() {
   orchard_output.value = value.ValueOrDie();
   orchard_output.addr = receiver_;
   orchard_output.memo = memo_;
+  zcash_transaction.orchard_part().anchor_block_height =
+      spendable_notes_->anchor_block_id.value();
 
   auto orchard_unified_addr = GetOrchardUnifiedAddress(
       receiver_, context_.chain_id == mojom::kZCashTestnet);

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.cc
@@ -99,7 +99,7 @@ void ZCashCreateOrchardToOrchardTransactionTask::OnGetSpendableNotes(
     return;
   }
 
-  spendable_notes_ = std::move(**result);
+  spendable_notes_ = std::move(*result.value());
   ScheduleWorkOnTask();
 }
 

--- a/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.h
+++ b/components/brave_wallet/browser/zcash/zcash_create_orchard_to_orchard_transaction_task.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "brave/components/brave_wallet/browser/internal/orchard_sync_state.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_action_context.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_transaction_utils.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_wallet_service.h"
@@ -43,11 +44,9 @@ class ZCashCreateOrchardToOrchardTransactionTask {
 
   void GetSpendableNotes();
   void OnGetSpendableNotes(
-      base::expected<std::vector<OrchardNote>, OrchardStorage::Error> result);
+      base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
+                     OrchardStorage::Error> result);
   void CreateTransaction();
-
-  void GetAnchor();
-  void OnGetAnchor();
 
   void CalculateWitness();
   void OnWittnessCalculated();
@@ -62,7 +61,7 @@ class ZCashCreateOrchardToOrchardTransactionTask {
   bool started_ = false;
 
   std::optional<std::string> error_;
-  std::optional<std::vector<OrchardNote>> spendable_notes_;
+  std::optional<OrchardSyncState::SpendableNotesBundle> spendable_notes_;
   std::optional<PickOrchardInputsResult> picked_notes_;
   std::optional<OrchardSpendsBundle> spends_bundle_;
   std::optional<ZCashTransaction> transaction_;

--- a/components/brave_wallet/browser/zcash/zcash_create_transparent_to_orchard_transaction_task.h
+++ b/components/brave_wallet/browser/zcash/zcash_create_transparent_to_orchard_transaction_task.h
@@ -14,6 +14,7 @@
 
 #include "base/memory/raw_ref.h"
 #include "brave/components/brave_wallet/browser/internal/orchard_bundle_manager.h"
+#include "brave/components/brave_wallet/browser/internal/orchard_sync_state.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_action_context.h"
 #include "brave/components/brave_wallet/browser/zcash/zcash_wallet_service.h"
 #include "brave/components/brave_wallet/common/zcash_utils.h"
@@ -46,11 +47,14 @@ class ZCashCreateTransparentToOrchardTransactionTask {
 
   void GetAllUtxos();
   void GetChangeAddress();
+  void GetLatestBlock();
 
   void OnGetChangeAddress(
       base::expected<mojom::ZCashAddressPtr, std::string> result);
   void OnGetUtxos(
       base::expected<ZCashWalletService::UtxoMap, std::string> utxo_map);
+  void OnGetLatestBlockHeight(
+      base::expected<zcash::mojom::BlockIDPtr, std::string> result);
 
   void SetError(const std::string& error_string) { error_ = error_string; }
 
@@ -67,6 +71,7 @@ class ZCashCreateTransparentToOrchardTransactionTask {
   std::optional<std::string> error_;
 
   std::optional<ZCashWalletService::UtxoMap> utxo_map_;
+  std::optional<uint32_t> chain_tip_height_;
   mojom::ZCashAddressPtr change_address_;
 
   std::optional<ZCashTransaction> transaction_;

--- a/components/brave_wallet/browser/zcash/zcash_get_chaintip_status_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_get_chaintip_status_task_unittest.cc
@@ -138,7 +138,7 @@ class ZCashGetChainTipStatusTaskTest : public testing::Test {
   }
 
   ZCashActionContext CreateContext() {
-    return ZCashActionContext(zcash_rpc_, sync_state_, account_id_,
+    return ZCashActionContext(zcash_rpc_, {}, sync_state_, account_id_,
                               mojom::kZCashMainnet);
   }
 

--- a/components/brave_wallet/browser/zcash/zcash_resolve_balance_task.h
+++ b/components/brave_wallet/browser/zcash/zcash_resolve_balance_task.h
@@ -25,8 +25,7 @@ class ZCashResolveBalanceTask {
       base::expected<mojom::ZCashBalancePtr, std::string>)>;
   ZCashResolveBalanceTask(base::PassKey<ZCashWalletService> pass_key,
                           ZCashWalletService& zcash_wallet_service,
-                          const std::string& chain_id,
-                          mojom::AccountIdPtr account_id,
+                          ZCashActionContext context,
                           ZCashResolveBalanceTaskCallback callback);
   ~ZCashResolveBalanceTask();
 
@@ -44,15 +43,15 @@ class ZCashResolveBalanceTask {
 
 #if BUILDFLAG(ENABLE_ORCHARD)
   void OnGetSpendableNotes(
-      base::expected<std::vector<OrchardNote>, OrchardStorage::Error> result);
+      base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
+                     OrchardStorage::Error> result);
 
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
 
   void CreateBalance();
 
   const raw_ref<ZCashWalletService> zcash_wallet_service_;  // Owns this
-  std::string chain_id_;
-  mojom::AccountIdPtr account_id_;
+  ZCashActionContext context_;
   ZCashResolveBalanceTaskCallback callback_;
 
   bool started_ = false;
@@ -63,7 +62,7 @@ class ZCashResolveBalanceTask {
   std::optional<mojom::ZCashBalancePtr> result_;
 
 #if BUILDFLAG(ENABLE_ORCHARD)
-  std::optional<std::vector<OrchardNote>> orchard_notes_;
+  std::optional<OrchardSyncState::SpendableNotesBundle> spendable_notes_result_;
 #endif  // BUILDFLAG(ENABLE_ORCHARD)
 
   base::WeakPtrFactory<ZCashResolveBalanceTask> weak_ptr_factory_{this};

--- a/components/brave_wallet/browser/zcash/zcash_resolve_transaction_status_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_resolve_transaction_status_task_unittest.cc
@@ -121,7 +121,7 @@ class ZCashResolveTransactionStatusTaskTest : public testing::Test {
   ZCashActionContext CreateContext() {
     return ZCashActionContext(zcash_rpc_,
 #if BUILDFLAG(ENABLE_ORCHARD)
-                              sync_state_,
+                              {}, sync_state_,
 #endif
                               account_id_, mojom::kZCashMainnet);
   }

--- a/components/brave_wallet/browser/zcash/zcash_shield_sync_service.h
+++ b/components/brave_wallet/browser/zcash/zcash_shield_sync_service.h
@@ -141,7 +141,8 @@ class ZCashShieldSyncService {
   void UpdateSpendableNotes(const ScanRangeResult& scan_range_result);
   void OnGetSpendableNotes(
       const ScanRangeResult& scan_range_result,
-      base::expected<std::vector<OrchardNote>, OrchardStorage::Error> result);
+      base::expected<std::optional<OrchardSyncState::SpendableNotesBundle>,
+                     OrchardStorage::Error> result);
 
   void StartBlockScanning();
   void OnScanRangeResult(
@@ -173,7 +174,7 @@ class ZCashShieldSyncService {
   std::optional<ScanRangeResult> latest_scanned_block_result_;
 
   // Local cache of spendable notes to fast check on discovered nullifiers
-  std::optional<std::vector<OrchardNote>> spendable_notes_;
+  std::optional<OrchardSyncState::SpendableNotesBundle> spendable_notes_bundle_;
   std::optional<Error> error_;
 
   mojom::ZCashShieldSyncStatusPtr current_sync_status_;

--- a/components/brave_wallet/browser/zcash/zcash_transaction.cc
+++ b/components/brave_wallet/browser/zcash/zcash_transaction.cc
@@ -289,6 +289,11 @@ base::Value::Dict ZCashTransaction::ToValue() const {
     orchard_outputs_value.Append(orchard_output.ToValue());
   }
 
+  if (orchard_part_.anchor_block_height) {
+    dict.Set("anchor_block_height",
+             base::NumberToString(orchard_part_.anchor_block_height.value()));
+  }
+
   dict.Set("locktime", base::NumberToString(locktime_));
   dict.Set("to", to_);
   dict.Set("amount", base::NumberToString(amount_));
@@ -368,6 +373,16 @@ std::optional<ZCashTransaction> ZCashTransaction::FromValue(
         return std::nullopt;
       }
       result.orchard_part_.outputs.push_back(std::move(*output_opt));
+    }
+  }
+
+  auto* anchor = value.Find("anchor_block_height");
+  if (anchor) {
+    uint32_t anchor_block_height = 0;
+    if (ReadUint32StringTo(value, "anchor_block_height", anchor_block_height)) {
+      result.orchard_part().anchor_block_height = anchor_block_height;
+    } else {
+      return std::nullopt;
     }
   }
 

--- a/components/brave_wallet/browser/zcash/zcash_transaction.h
+++ b/components/brave_wallet/browser/zcash/zcash_transaction.h
@@ -114,6 +114,7 @@ class ZCashTransaction {
 
     std::vector<OrchardInput> inputs;
     std::vector<OrchardOutput> outputs;
+    std::optional<uint32_t> anchor_block_height;
     std::optional<std::array<uint8_t, kZCashDigestSize>> digest;
     std::optional<std::vector<uint8_t>> raw_tx;
   };

--- a/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task_unittest.cc
+++ b/components/brave_wallet/browser/zcash/zcash_verify_chain_state_task_unittest.cc
@@ -143,7 +143,7 @@ class ZCashVerifyChainStateTaskTest : public testing::Test {
   }
 
   ZCashActionContext CreateContext() {
-    return ZCashActionContext(zcash_rpc_, sync_state_, account_id_,
+    return ZCashActionContext(zcash_rpc_, {}, sync_state_, account_id_,
                               mojom::kZCashMainnet);
   }
 

--- a/components/brave_wallet/common/brave_wallet.mojom
+++ b/components/brave_wallet/common/brave_wallet.mojom
@@ -1861,6 +1861,7 @@ struct ZCashBalance {
   uint64 total_balance;
   uint64 transparent_balance;
   uint64 shielded_balance;
+  uint64 shielded_pending_balance;
   // Transparent balances
   map<string, uint64> balances;  // address -> balance of that address(sum of all related utxos)
 };

--- a/components/brave_wallet_ui/common/slices/api-base.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api-base.slice.ts
@@ -87,7 +87,8 @@ export function createWalletApiBase() {
       'ZCashAccountInfo',
       'IsShieldingAvailable',
       'IsSyncInProgress',
-      'ZcashChainTipStatus'
+      'ZcashChainTipStatus',
+      'ZCashBalance'
     ],
     endpoints: ({ mutation, query }) => ({})
   })

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -263,6 +263,7 @@ export const {
   useGetUserTokensRegistryQuery,
   useGetWalletsToImportQuery,
   useGetZCashAccountInfoQuery,
+  useGetZCashBalanceQuery,
   useHideNetworksMutation,
   useImportEthAccountFromJsonMutation,
   useImportEthAccountMutation,

--- a/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
@@ -16,6 +16,11 @@ type MakeAccountShieldedPayloadType = {
   accountBirthdayBlock: number
 }
 
+type GetZCashBalancePayloadType = {
+  chainId: string
+  accountId: BraveWallet.AccountId
+}
+
 export const zcashEndpoints = ({
   query,
   mutation
@@ -77,6 +82,31 @@ export const zcashEndpoints = ({
         }
       },
       providesTags: ['ZCashAccountInfo']
+    }),
+    getZCashBalance: query<
+    BraveWallet.ZCashBalance | null,
+    GetZCashBalancePayloadType
+    >({
+      queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {
+        try {
+          const { zcashWalletService } = baseQuery(undefined).data
+
+          const { balance } = await zcashWalletService.getBalance(
+            args.chainId, args.accountId
+          )
+
+          return {
+            data: balance
+          }
+        } catch (error) {
+          return handleEndpointError(
+            endpoint,
+            'Error getting ZCash balance info: ',
+            error
+          )
+        }
+      },
+      providesTags: ['ZCashBalance']
     }),
     getIsShieldingAvailable: query<boolean, BraveWallet.AccountId[]>({
       queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {

--- a/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
+++ b/components/brave_wallet_ui/components/desktop/views/accounts/account.tsx
@@ -222,7 +222,7 @@ export const Account = () => {
 
   const { data: zcashBalance } =
     useGetZCashBalanceQuery(isShieldedAccount && selectedAccount ? {
-        chainId: BraveWallet.Z_CASH_MAINNET, 
+        chainId: BraveWallet.Z_CASH_MAINNET,
         accountId: selectedAccount.accountId
       } : skipToken)
 
@@ -608,7 +608,7 @@ export const Account = () => {
             </div>
             <div>
               {(accountsTokensList && zcashBalance &&
-                zcashBalance.shieldedPendingBalance > 0) && 
+                zcashBalance.shieldedPendingBalance > 0) &&
                 getLocale('braveWalletZCashPendingBalanceTitle').replace('$1',
                   formatTokenBalanceWithSymbol(
                     (zcashBalance?.shieldedPendingBalance || 0).toString(),
@@ -632,7 +632,7 @@ export const Account = () => {
                   slot='icon-before'
                 />
                 {getLocale('braveWalletSyncAccountButton')}
-              </Button>              
+              </Button>
               <Button
                 size='small'
                 kind='plain-faint'

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1539,7 +1539,7 @@ provideStrings({
   braveWalletOutOfSyncDescription:
     'Sync your account to access the latest transactions and balance.',
   braveWalletZCashPendingBalanceTitle:
-    'Pending balance(requires more confirmations): $1',
+    'Pending balance (more confirmations required): $1',
   braveWalletSyncAccountButton: 'Sync account',
   braveWalletSyncAccountName: 'Sync $1',
   braveWalletInitializing: 'Initializing...',

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1538,6 +1538,8 @@ provideStrings({
   braveWalletOutOfSyncBlocksBehindTitle: 'Out of sync ($1 blocks behind)',
   braveWalletOutOfSyncDescription:
     'Sync your account to access the latest transactions and balance.',
+  braveWalletZCashPendingBalanceTitle:
+    'Pending balance(requires more confirmations): $1',
   braveWalletSyncAccountButton: 'Sync account',
   braveWalletSyncAccountName: 'Sync $1',
   braveWalletInitializing: 'Initializing...',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1168,7 +1168,7 @@
   <message name="IDS_BRAVE_WALLET_TRANSPARENT" desc="Transparent label">Transparent</message>
   <message name="IDS_BRAVE_WALLET_OUT_OF_SYNC_TITLE" desc="Warning title for when an account is out of sync.">Out of sync</message>
   <message name="IDS_BRAVE_WALLET_OUT_OF_SYNC_BLOCKS_BEHIND_TITLE" desc="Warning title for when an account is out of sync with blocks behind.">Out of sync (<ph name="BLOCKS">$1<ex>12,568</ex></ph> blocks behind)</message>
-  <message name="IDS_BRAVE_WALLET_ZCASH_PENDING_BALANCE_TITLE" desc="Warning title for when an account has shielded funds that need more blocks to be synced.">Pending balance(more confirmations required): <ph name="FUNDS">$1<ex>12,568</ex></ph></message>
+  <message name="IDS_BRAVE_WALLET_ZCASH_PENDING_BALANCE_TITLE" desc="Warning title for when an account has shielded funds that need more blocks to be synced.">Pending balance (more confirmations required): <ph name="FUNDS">$1<ex>12,568</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_OUT_OF_SYNC_DESCRIPTION" desc="Warning description for when an account is out of sync.">Sync your account to access the latest transactions and balance.</message>
   <message name="IDS_BRAVE_WALLET_SYNC_ACCOUNT_BUTTON" desc="Sync account button label.">Sync account</message>
   <message name="IDS_BRAVE_WALLET_SYNC_ACCOUNT_NAME" desc="Sync account name title on sync dialog.">Sync <ph name="ACCOUNT">$1<ex>Zcash Account 1</ex></ph></message>

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1168,6 +1168,7 @@
   <message name="IDS_BRAVE_WALLET_TRANSPARENT" desc="Transparent label">Transparent</message>
   <message name="IDS_BRAVE_WALLET_OUT_OF_SYNC_TITLE" desc="Warning title for when an account is out of sync.">Out of sync</message>
   <message name="IDS_BRAVE_WALLET_OUT_OF_SYNC_BLOCKS_BEHIND_TITLE" desc="Warning title for when an account is out of sync with blocks behind.">Out of sync (<ph name="BLOCKS">$1<ex>12,568</ex></ph> blocks behind)</message>
+  <message name="IDS_BRAVE_WALLET_ZCASH_PENDING_BALANCE_TITLE" desc="Warning title for when an account has shielded funds that need more blocks to be synced.">Pending balance(more confirmations required): <ph name="FUNDS">$1<ex>12,568</ex></ph></message>
   <message name="IDS_BRAVE_WALLET_OUT_OF_SYNC_DESCRIPTION" desc="Warning description for when an account is out of sync.">Sync your account to access the latest transactions and balance.</message>
   <message name="IDS_BRAVE_WALLET_SYNC_ACCOUNT_BUTTON" desc="Sync account button label.">Sync account</message>
   <message name="IDS_BRAVE_WALLET_SYNC_ACCOUNT_NAME" desc="Sync account name title on sync dialog.">Sync <ph name="ACCOUNT">$1<ex>Zcash Account 1</ex></ph></message>


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/44249

Anchor selection logic is refactored. Now spendable notes bundle is returned along with suggested anchor block id.
Spendable notes are filtered by the confirmations count to the latest scanned block.
Added pending balance message to the sync banner.
![image](https://github.com/user-attachments/assets/0615df70-670b-448d-a6da-4aea90e0b69c)


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

