### PR TITLE
[iOS] - Change AboutHomeHandler to use a proper background colour format

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -488,6 +488,7 @@ var braveTarget: PackageDescription.Target = .target(
   ],
   resources: [
     .copy("Assets/About/Licenses.html"),
+    .copy("Assets/About/AboutHome.html"),
     .copy("Assets/__firefox__.js"),
     .copy("Assets/AllFramesAtDocumentEnd.js"),
     .copy("Assets/AllFramesAtDocumentEndSandboxed.js"),

--- a/ios/brave-ios/Sources/Brave/Assets/About/AboutHome.html
+++ b/ios/brave-ios/Sources/Brave/Assets/About/AboutHome.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About Home</title>
+    <style>
+      body {
+        transition: background-color 0.1s, color 0.1s;
+      }
+
+      body.light-mode {
+        background-color: #LIGHT_MODE_COLOUR;
+        color: black;
+      }
+
+      body.dark-mode {
+        background-color: #DARK_MODE_COLOUR;
+        color: white;
+      }
+    </style>
+  </head>
+  <body>
+    <script>
+      function applyTheme() {
+        if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+          document.body.classList.remove("light-mode");
+          document.body.classList.add('dark-mode');
+        } else {
+          document.body.classList.remove("dark-mode");
+          document.body.classList.add("light-mode");
+        }
+      }
+
+      applyTheme();
+
+      let themeMatch = window.matchMedia("(prefers-color-scheme: dark)");
+      if (themeMatch) {
+        themeMatch.addEventListener("change", (event) => {
+          applyTheme();
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/ios/brave-ios/Sources/Brave/Assets/About/AboutHome.html
+++ b/ios/brave-ios/Sources/Brave/Assets/About/AboutHome.html
@@ -9,37 +9,19 @@
         transition: background-color 0.1s, color 0.1s;
       }
 
-      body.light-mode {
-        background-color: #LIGHT_MODE_COLOUR;
+      .theme {
         color: black;
+        background-color: #LIGHT_MODE_COLOUR;
       }
 
-      body.dark-mode {
-        background-color: #DARK_MODE_COLOUR;
-        color: white;
+      @media (prefers-color-scheme: dark) {
+        .theme {
+          color: white;
+          background-color: #DARK_MODE_COLOUR;
+        }
       }
     </style>
   </head>
-  <body>
-    <script>
-      function applyTheme() {
-        if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-          document.body.classList.remove("light-mode");
-          document.body.classList.add('dark-mode');
-        } else {
-          document.body.classList.remove("dark-mode");
-          document.body.classList.add("light-mode");
-        }
-      }
-
-      applyTheme();
-
-      let themeMatch = window.matchMedia("(prefers-color-scheme: dark)");
-      if (themeMatch) {
-        themeMatch.addEventListener("change", (event) => {
-          applyTheme();
-        });
-      }
-    </script>
+  <body class="theme">
   </body>
 </html>

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
@@ -17,10 +17,10 @@ public class AboutHomeHandler: InternalSchemeResponse {
     let bg = UIColor.braveBackground.toHexString()
     // Blank page with a color matching the background of the panels which is displayed for a split-second until the panel shows.
     let html = """
-          <!DOCTYPE html>
-          <html>
-            <body style='background-color:\(bg)'></body>
-          </html>
+      <!DOCTYPE html>
+      <html>
+        <body style='background-color: #\(bg)'></body>
+      </html>
       """
     let data = Data(html.utf8)
     return (response, data)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
@@ -15,10 +15,10 @@ public class AboutHomeHandler: InternalSchemeResponse {
     guard let url = request.url else { return nil }
     let response = InternalSchemeHandler.response(forUrl: url)
 
-    let lightModeColour = UIColor.braveBackground.resolvedColor(
+    let lightModeColour = UIColor(braveSystemName: .containerBackground).resolvedColor(
       with: .init(userInterfaceStyle: .light)
     ).toHexString()
-    let darkModeColour = UIColor.braveBackground.resolvedColor(
+    let darkModeColour = UIColor(braveSystemName: .containerBackground).resolvedColor(
       with: .init(userInterfaceStyle: .dark)
     ).toHexString()
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
@@ -14,14 +14,24 @@ public class AboutHomeHandler: InternalSchemeResponse {
   public func response(forRequest request: URLRequest) async -> (URLResponse, Data)? {
     guard let url = request.url else { return nil }
     let response = InternalSchemeHandler.response(forUrl: url)
-    let bg = UIColor.braveBackground.toHexString()
+
+    let lightModeColour = UIColor.braveBackground.resolvedColor(
+      with: .init(userInterfaceStyle: .light)
+    ).toHexString()
+    let darkModeColour = UIColor.braveBackground.resolvedColor(
+      with: .init(userInterfaceStyle: .dark)
+    ).toHexString()
+
     // Blank page with a color matching the background of the panels which is displayed for a split-second until the panel shows.
-    let html = """
-      <!DOCTYPE html>
-      <html>
-        <body style='background-color: #\(bg)'></body>
-      </html>
-      """
+    guard let asset = Bundle.module.url(forResource: "AboutHome", withExtension: "html"),
+      var html = await AsyncFileManager.default.utf8Contents(at: asset)
+    else {
+      return nil
+    }
+
+    html = html.replacingOccurrences(of: "LIGHT_MODE_COLOUR", with: lightModeColour)
+      .replacingOccurrences(of: "DARK_MODE_COLOUR", with: darkModeColour)
+
     let data = Data(html.utf8)
     return (response, data)
   }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44270

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable Dark-Mode (NOT night-mode)
2. Open a brand new tab
3. Visit `ign.com`
4. Page should should dark, then IGN should load in Dark-Mode.

---

1. Enable Dark-Mode (NOT night-mode)
2. Open a brand new tab
3. Switch to Light-Mode
5. Visit `ign.com`
6. Page should load white, then IGN should load in Light-Mode.

---

1. Enable Light-Mode
2. Open a brand new tab
3. Switch to Dark-Mode (NOT night-mode)
5. Visit `ign.com`
6. Page should load dark, then IGN should load in Dark-Mode.