### PR TITLE
Fix build failure on iOS caused by incorrect deps (uplift to 1.77.x)

### DIFF
--- a/chromium_src/ui/base/sources.gni
+++ b/chromium_src/ui/base/sources.gni
@@ -3,5 +3,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
-brave_chromium_src_ui_base_deps =
-    [ "//brave/components/resources:static_resources_grit" ]
+brave_chromium_src_ui_base_deps = [ "//brave/components/resources:strings" ]

--- a/patches/ui-base-BUILD.gn.patch
+++ b/patches/ui-base-BUILD.gn.patch
@@ -1,12 +1,12 @@
-diff --git a/ui/base/BUILD.gn b/ui/base/BUILD.gn
-index 5ca4c8fc961d24985aa4e0459dc2c42003a5346f..b764434560dbeec56cdf26df46e56617df4b4c8e 100644
---- a/ui/base/BUILD.gn
-+++ b/ui/base/BUILD.gn
-@@ -548,6 +548,7 @@ component("base") {
-       "//ui/events",
-       "//ui/events/devices",
-     ]
-+    import("//brave/chromium_src/ui/base/sources.gni") deps += brave_chromium_src_ui_base_deps
-     public_deps += [ "//ui/color:color_headers" ]
-   }
+diff --git i/ui/base/BUILD.gn w/ui/base/BUILD.gn
+index 5ca4c8fc961d2..8e957b64ff517 100644
+--- i/ui/base/BUILD.gn
++++ w/ui/base/BUILD.gn
+@@ -513,6 +513,7 @@ component("base") {
+     "//ui/webui/resources:resources_grit",
+     "//url",
+   ]
++  import("//brave/chromium_src/ui/base/sources.gni") deps += brave_chromium_src_ui_base_deps
  
+   if (is_debug || dcheck_always_on) {
+     deps += [ "//third_party/re2" ]


### PR DESCRIPTION
Uplift of #27829
Resolves https://github.com/brave/brave-browser/issues/44263

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.