### PR TITLE
[iOS] - Fix Translation Onboarding on Disabled Pages (uplift to 1.77.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
@@ -325,6 +325,12 @@ class BraveTranslateTabHelper: NSObject {
       state: isTranslationSupported ? .available : .unavailable
     )
 
+    // Translation is not supported on this page, so do not show onboarding
+    // Return immediately
+    if !isTranslationSupported {
+      return
+    }
+
     try Task.checkCancellation()
 
     // Check if the user can view the translation onboarding

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
@@ -86,7 +86,6 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
         action: { popover in
           popover.previewForOrigin = nil
           popover.dismissPopover()
-          completion(nil)
         }
       )
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveTranslateScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveTranslateScript.js
@@ -22,15 +22,15 @@ Object.defineProperty(window.__firefox__, "$<brave_translate_script>", {
       return document.documentElement.outerText;
     }),
     "checkTranslate": (function() {
-      setTimeout(function() {
-        try {
+      try {
+        if ((cr.googleTranslate.libReady || cr.googleTranslate.finished) && !cr.googleTranslate.readyCallback) {
           window.webkit.messageHandlers["$<message_handler>"].postMessage({
             "command": "ready"
-          })
-        } catch (error) {
-          cr.googleTranslate.onTranslateElementError(error);
+          });
         }
-      }, 100);
+      } catch (error) {
+        cr.googleTranslate.onTranslateElementError(error);
+      }
     }),
     "loadTranslateScript": (function() {
       return new Promise((resolve, reject) => {


### PR DESCRIPTION
Uplift of #27836
Resolves https://github.com/brave/brave-browser/issues/44272

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.