### PR TITLE
[iOS] - Fix Translate Crash on iPad (Uplift to 1.77.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
@@ -209,12 +209,12 @@ class BraveTranslateTabHelper: NSObject {
     // Cache CSS and JS requests
     Self.requestCache[request.url] = (data, response)
 
-    if isTranslationRequest && canShowToast {
-      canShowToast = false
+    if isTranslationRequest {
+      delegate?.updateTranslateURLBar(tab: tab, state: .active)
 
-      Task { @MainActor in
-        self.delegate?.updateTranslateURLBar(tab: tab, state: .active)
-        self.delegate?.presentToast(tab: tab, languageInfo: currentLanguageInfo)
+      if canShowToast {
+        canShowToast = false
+        delegate?.presentToast(tab: tab, languageInfo: currentLanguageInfo)
       }
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
@@ -74,10 +74,11 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
             completion(false)
           }
         ),
-        autoLayoutConfiguration: .init(preferredWidth: self.view.bounds.width - (32.0 * 2.0))
+        autoLayoutConfiguration: .phoneWidth
       )
 
       popover.arrowDistance = 10.0
+      popover.outerMargins = UIEdgeInsets(equalInset: 16.0)
 
       popover.previewForOrigin = .init(
         view: self.topToolbar.locationView.translateButton.then {


### PR DESCRIPTION
Uplift of #27857
Resolves https://github.com/brave/brave-browser/issues/43870
Resolves https://github.com/brave/brave-browser/issues/43869

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.