### PR TITLE
[iOS] - Change AboutHomeHandler to use a proper background colour format (uplift to 1.77.x)

### DIFF
--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -488,6 +488,7 @@ var braveTarget: PackageDescription.Target = .target(
   ],
   resources: [
     .copy("Assets/About/Licenses.html"),
+    .copy("Assets/About/AboutHome.html"),
     .copy("Assets/__firefox__.js"),
     .copy("Assets/AllFramesAtDocumentEnd.js"),
     .copy("Assets/AllFramesAtDocumentEndSandboxed.js"),

--- a/ios/brave-ios/Sources/Brave/Assets/About/AboutHome.html
+++ b/ios/brave-ios/Sources/Brave/Assets/About/AboutHome.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About Home</title>
+    <style>
+      body {
+        transition: background-color 0.1s, color 0.1s;
+      }
+
+      .theme {
+        color: black;
+        background-color: #LIGHT_MODE_COLOUR;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .theme {
+          color: white;
+          background-color: #DARK_MODE_COLOUR;
+        }
+      }
+    </style>
+  </head>
+  <body class="theme">
+  </body>
+</html>

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Handlers/AboutHomeHandler.swift
@@ -14,14 +14,24 @@ public class AboutHomeHandler: InternalSchemeResponse {
   public func response(forRequest request: URLRequest) async -> (URLResponse, Data)? {
     guard let url = request.url else { return nil }
     let response = InternalSchemeHandler.response(forUrl: url)
-    let bg = UIColor.braveBackground.toHexString()
+
+    let lightModeColour = UIColor(braveSystemName: .containerBackground).resolvedColor(
+      with: .init(userInterfaceStyle: .light)
+    ).toHexString()
+    let darkModeColour = UIColor(braveSystemName: .containerBackground).resolvedColor(
+      with: .init(userInterfaceStyle: .dark)
+    ).toHexString()
+
     // Blank page with a color matching the background of the panels which is displayed for a split-second until the panel shows.
-    let html = """
-          <!DOCTYPE html>
-          <html>
-            <body style='background-color:\(bg)'></body>
-          </html>
-      """
+    guard let asset = Bundle.module.url(forResource: "AboutHome", withExtension: "html"),
+      var html = await AsyncFileManager.default.utf8Contents(at: asset)
+    else {
+      return nil
+    }
+
+    html = html.replacingOccurrences(of: "LIGHT_MODE_COLOUR", with: lightModeColour)
+      .replacingOccurrences(of: "DARK_MODE_COLOUR", with: darkModeColour)
+
     let data = Data(html.utf8)
     return (response, data)
   }


### PR DESCRIPTION
Uplift of #27833
Resolves https://github.com/brave/brave-browser/issues/44270

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.