### PR TITLE
Only check if main frame requests should be blocked / show blocked do…

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
@@ -521,7 +521,8 @@ extension BrowserViewController: TabWebPolicyDecider {
     if ["http", "https", "data", "blob", "file"].contains(requestURL.scheme) {
       pendingRequests[requestURL.absoluteString] = request
 
-      if let etldP1 = requestURL.baseDomain,
+      if requestInfo.isMainFrame,
+        let etldP1 = requestURL.baseDomain,
         tab.proceedAnywaysDomainList.contains(etldP1) == false
       {
         let domain = Domain.getOrCreate(forUrl: requestURL, persistent: !isPrivateBrowsing)


### PR DESCRIPTION
- Previously, we only showed blocked domain interstitial for requests received from the main-frame: https://github.com/brave/brave-core/blob/e5c42e5766c4e7bd1bd2cc1c10cc9842e04cac62/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC%2BWKNavigationDelegate.swift#L525-L551
- With the refactor in #27746, the main frame check was missed: https://github.com/brave/brave-core/pull/27746/files#diff-348b0ca220f2c6c15e6acd06769d042b9eb7d26355cfb397bb4bc6bab53c8c17R99-L551
    - Since Github hides the large diff, it's in `BVC+WKNavigationDelegate.swift` around line 525.
- Fix is restoring the main frame check before determining if we should display the interstitial, which is provided by the new `requestInfo: WebRequestInfo` property.

Resolves https://github.com/brave/brave-browser/issues/44343

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Enable Shields aggressive mode 
2. Visit [linkedin.com](http://linkedin.com/) (signed in)
3. Request desktop site
4. Wait 10-20 seconds
5. Verify blocked domain interstitial is not shown
6. Open a new tab
7. Enter `https://radar.cedexis.com/1/11326/radar.html`
8. Verify blocked domain interstitial IS shown.