### PR TITLE
[iOS] - Fix iPad Translate with Page History Navigation

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
@@ -67,6 +67,8 @@ class BraveTranslateTabHelper: NSObject {
           self.url = url
           self.isTranslationReady = false
           self.canShowToast = false
+          self.currentLanguageInfo = BraveTranslateLanguageInfo()
+          self.translationTask = nil
           self.delegate?.updateTranslateURLBar(tab: self.tab, state: .unavailable)
         }
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
@@ -51,7 +51,7 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
     // Ensure url bar is expanded before presenting a popover on it
     toolbarVisibilityViewModel.toolbarState = .expanded
 
-    DispatchQueue.main.async {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
       let popover = PopoverController(
         content: OnboardingTranslateView(
           onContinueButtonPressed: { [weak self, weak tab] in

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveTranslateScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveTranslateScript.js
@@ -21,9 +21,27 @@ Object.defineProperty(window.__firefox__, "$<brave_translate_script>", {
     "getRawPageSource": (function() {
       return document.documentElement.outerText;
     }),
+    "hasNoTranslate": (function() {
+      for (const metaTag of document.getElementsByTagName('meta')) {
+        if (metaTag.name === 'google') {
+          if (metaTag.content === 'notranslate' ||
+              metaTag.getAttribute('value') === 'notranslate') {
+            return true;
+          }
+        }
+      }
+      return false;
+    }),
+    "isSameLanguage": (function() {
+      let userLanguage = (navigator.language || navigator.userLanguage).split('-')[0];
+      let pageLanguage = document.documentElement.lang
+      return userLanguage == pageLanguage;
+    }),
     "checkTranslate": (function() {
       try {
-        if ((cr.googleTranslate.libReady || cr.googleTranslate.finished) && !cr.googleTranslate.readyCallback) {
+        if ((cr.googleTranslate.libReady || cr.googleTranslate.finished) &&
+            !cr.googleTranslate.readyCallback &&
+            !window.__firefox__.$<brave_translate_script>.isSameLanguage()) {
           window.webkit.messageHandlers["$<message_handler>"].postMessage({
             "command": "ready"
           });

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveTranslateScript.js
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/Scripts/Sandboxed/BraveTranslateScript.js
@@ -151,10 +151,10 @@ try {
       }
   };
 
-  const emptySvgDataUrl = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg"/>');
-
   // Make replacements in loading .js files.
   function processJavascript(text) {
+      const emptySvgDataUrl = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg"/>');
+    
       // Replace gen204 telemetry requests with loading an empty svg.
       text = text.replaceAll('"//"+po+"/gen204?"+Bo(b)', '"' + emptySvgDataUrl + '"');
 
@@ -166,6 +166,8 @@ try {
 
   // Make replacements in loading .css files.
   function processCSS(text) {
+      const emptySvgDataUrl = 'data:image/svg+xml;base64,' + btoa('<svg xmlns="http://www.w3.org/2000/svg"/>');
+    
       // Used in the injected elements, that are currently not visible. Replace it
       // to hide the loading error in devtools (because of CSP).
       text = text.replaceAll('//www.gstatic.com/images/branding/product/2x/translate_24dp.png', emptySvgDataUrl);
@@ -309,17 +311,17 @@ try {
       xhr.send();
   }
 
-  // The styles to hide root elements that are injected by the scripts in the DOM.
-  // Currently they are always invisible. The styles are added in case of changes
-  // in future versions.
-  const braveExtraStyles = `.goog-te-spinner-pos, #goog-gt-tt {display: none;}`
-
   // An overridden version of onLoadCSS from translate.js.
   // The differences:
   // 1. change url via rewriteUrl();
   // 2. process the loaded styles via processCSS().
   // 3. Add braveExtraStyles in the end.
   cr.googleTranslate.onLoadCSS = function(url) {
+      // The styles to hide root elements that are injected by the scripts in the DOM.
+      // Currently they are always invisible. The styles are added in case of changes
+      // in future versions.
+      const braveExtraStyles = `.goog-te-spinner-pos, #goog-gt-tt {display: none;}`
+    
       const xhr = new XMLHttpRequest();
       xhr.open('GET', rewriteUrl(url), true);
       xhr.onreadystatechange = function() {


### PR DESCRIPTION
## Summary
- When you use the back-forth buttons on iPad, WebKit caches the page history AND the javascript variables, so JS does not execute again. We manually execute the JS like we do for Reader-Mode, but we need to now check if the page is already translated
- Fix translate on iPad when in Desktop User-Agent and History changes with Page Cache

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43869

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

