### PR TITLE
Update Custom Distillation Approach, Enable by Default

### DIFF
--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -49,7 +49,7 @@ bool IsAIChatHistoryEnabled() {
 
 BASE_FEATURE(kCustomSiteDistillerScripts,
              "CustomSiteDistillerScripts",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 bool IsCustomSiteDistillerScriptsEnabled() {
   return base::FeatureList::IsEnabled(features::kCustomSiteDistillerScripts);

--- a/components/ai_chat/renderer/page_text_distilling.h
+++ b/components/ai_chat/renderer/page_text_distilling.h
@@ -11,8 +11,9 @@
 #include <string>
 #include <utility>
 
+#include "base/containers/fixed_flat_map.h"
 #include "base/functional/callback_forward.h"
-#include "url/gurl.h"
+#include "brave/components/ai_chat/resources/custom_site_distiller_scripts/grit/custom_site_distiller_scripts_generated.h"
 
 namespace content {
 class RenderFrame;
@@ -27,6 +28,16 @@ void DistillPageText(
     int32_t global_world_id,
     int32_t isolated_world_id,
     base::OnceCallback<void(const std::optional<std::string>&)>);
+
+// A map of hostnames to the corresponding custom site distiller script.
+// The value is a pair consisting of the resource ID of the script, and a
+// boolean indicating if the script is intended for the main world or not.
+inline constexpr auto kHostToScriptResource =
+    base::MakeFixedFlatMap<std::string_view, std::pair<int, bool>>({
+        {"github.com",
+         {IDR_CUSTOM_SITE_DISTILLER_SCRIPTS_GITHUB_COM_BUNDLE_JS, false}},
+        {"x.com", {IDR_CUSTOM_SITE_DISTILLER_SCRIPTS_X_COM_BUNDLE_JS, true}},
+    });
 
 // Attempts to retrieve a a custom site distiller script for the given host.
 // Returns a pair consisting of the script content, and a boolean indicating if

--- a/components/ai_chat/resources/custom_site_distiller_scripts/BUILD.gn
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/BUILD.gn
@@ -12,14 +12,17 @@ transpile_web_ui("custom_site_distiller_scripts") {
   entry_points = [
     [
       "x_com",
-      rebase_path("scripts/x.com/index.ts"),
+      rebase_path("scripts/x.com/distiller.ts"),
     ],
     [
       "github_com",
-      rebase_path("scripts/github.com/index.ts"),
+      rebase_path("scripts/github.com/distiller.ts"),
     ],
   ]
-  output_module = true
+
+  # Distillation scripts are provided a `return` statement and IIFE by
+  # ai_chat::DistillPageTextViaSiteScript in page_text_distilling.cc
+  no_iife = true
 }
 
 pack_web_resources("generated_resources") {

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/github.com/distiller.ts
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/github.com/distiller.ts
@@ -7,13 +7,13 @@ import { LEO_DISTILLATION_LEVEL } from '../distillation'
 import { distillBranches } from './branches'
 import { GetPageType, SupportedPage } from './utils'
 
-let _DISTILLATION_LEVEL = LEO_DISTILLATION_LEVEL.LOW
+let _DISTILLATION_LEVEL = LEO_DISTILLATION_LEVEL.FULL
 
 export function getDistillationLevel() {
   return _DISTILLATION_LEVEL
 }
 
-export default function distill(level = LEO_DISTILLATION_LEVEL.LOW) {
+export default function distill(level = LEO_DISTILLATION_LEVEL.FULL) {
   _DISTILLATION_LEVEL = level
 
   switch (GetPageType(document)) {

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/github.com/distiller.ts
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/github.com/distiller.ts
@@ -13,7 +13,7 @@ export function getDistillationLevel() {
   return _DISTILLATION_LEVEL
 }
 
-export default function distill(level: LEO_DISTILLATION_LEVEL) {
+export default function distill(level = LEO_DISTILLATION_LEVEL.LOW) {
   _DISTILLATION_LEVEL = level
 
   switch (GetPageType(document)) {

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/github.com/index.ts
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/github.com/index.ts
@@ -1,8 +1,0 @@
-/* Copyright (c) 2024 The Brave Authors. All rights reserved.
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-import distill from './distiller'
-
-export { distill }

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/tsconfig.json
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/tsconfig.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../../../tsconfig",
-  "include": [
-    "**/*.ts",
-    "**/*.tsx",
-    "**/*.d.ts",
-    "../../definitions/*.d.ts"
-  ]
-}

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/x.com/distiller.ts
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/x.com/distiller.ts
@@ -10,13 +10,13 @@ import { distillPostElement } from './post'
 import { distillSeenUsers } from './user'
 import { LEO_DISTILLATION_LEVEL } from '../distillation'
 
-let _DISTILLATION_LEVEL = LEO_DISTILLATION_LEVEL.LOW
+let _DISTILLATION_LEVEL = LEO_DISTILLATION_LEVEL.FULL
 
 export function getDistillationLevel() {
   return _DISTILLATION_LEVEL
 }
 
-export default function distill(distillLevel = LEO_DISTILLATION_LEVEL.LOW) {
+export default function distill(distillLevel = LEO_DISTILLATION_LEVEL.FULL) {
   if (!isSupportedPage(document)) {
     return null
   }

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/x.com/index.ts
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/x.com/index.ts
@@ -1,8 +1,0 @@
-/* Copyright (c) 2024 The Brave Authors. All rights reserved.
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this file,
- * You can obtain one at https://mozilla.org/MPL/2.0/. */
-
-import distill from './distiller'
-
-export { distill }

--- a/components/ai_chat/resources/custom_site_distiller_scripts/scripts/x.com/utils.ts
+++ b/components/ai_chat/resources/custom_site_distiller_scripts/scripts/x.com/utils.ts
@@ -96,9 +96,8 @@ export function msToMinutesAndSeconds(ms: number) {
 
 export function getDateString(date: any) {
   const dateObject = new Date(date)
-  const distillLevel = getDistillationLevel()
 
-  if (distillLevel < LEO_DISTILLATION_LEVEL.MEDIUM) {
+  if (getDistillationLevel() < LEO_DISTILLATION_LEVEL.MEDIUM) {
     return dateObject.toISOString().substring(0, 10)
   }
 

--- a/components/common/typescript.gni
+++ b/components/common/typescript.gni
@@ -91,6 +91,8 @@ brave_common_web_compile_inputs = [
 #   sync_wasm
 #     Synchronous WASM loading (experiments.syncWebAssembly - deprecated).
 #     If not used, we default to asynchronous WASM loading (experiments.asyncWebAssembly).
+#   no_iife
+#     If true, the resulting bundle will not be wrapped in an IIFE.
 template("transpile_web_ui") {
   if (defined(invoker.rust_packages)) {
     rust_to_wasm("build_rust_packages") {
@@ -113,6 +115,7 @@ template("transpile_web_ui") {
       # generated
       "//brave/components/webpack:generate_tsconfig",
     ]
+
     if (defined(invoker.deps)) {
       # If there are any mojo js bindings deps make sure to build mojo js
       # bindings first
@@ -212,6 +215,10 @@ template("transpile_web_ui") {
 
     if (defined(invoker.sync_wasm) && invoker.sync_wasm) {
       args += [ "--sync_wasm" ]
+    }
+
+    if (defined(invoker.no_iife) && invoker.no_iife) {
+      args += [ "--no_iife" ]
     }
 
     forward_variables_from(invoker,

--- a/components/webpack/webpack.config.js
+++ b/components/webpack/webpack.config.js
@@ -69,14 +69,17 @@ module.exports = async function (env, argv) {
   }
 
   const output = {
+    iife: !env.no_iife,
     path: process.env.TARGET_GEN_DIR,
     filename: '[name].bundle.js',
     chunkFilename: '[name].chunk.js',
     publicPath: '/'
   }
+
   if (env.output_module) {
     output.library = { type: 'module' }
   }
+
   if (env.output_public_path) {
     output.publicPath = env.output_public_path
   }

--- a/script/transpile-web-ui.py
+++ b/script/transpile-web-ui.py
@@ -42,7 +42,8 @@ def main():
                              output_module=args.output_module,
                              extra_modules=args.extra_modules,
                              public_asset_path=args.public_asset_path,
-                             sync_wasm=args.sync_wasm)
+                             sync_wasm=args.sync_wasm,
+                             no_iife=args.no_iife)
     transpile_web_uis(transpile_options)
     generate_grd(output_path_absolute, args.grd_name[0], args.resource_name[0],
                  resource_path_prefix)
@@ -79,6 +80,7 @@ def parse_args():
                         required=False,
                         default=[])
     parser.add_argument('--sync_wasm', action='store_true')
+    parser.add_argument('--no_iife', action='store_true')
 
     args = parser.parse_args()
     # validate args
@@ -130,6 +132,11 @@ def transpile_web_uis(options):
 
     if options['sync_wasm']:
         args.append("--env=sync_wasm")
+
+    # Webpack will by default wrap the output in an IIFE, which is not
+    # desirable for some bundles.
+    if options['no_iife']:
+        args.append("--env=no_iife")
 
     # We should use webpack-cli env param to not pollute environment
     env["ROOT_GEN_DIR"] = options['root_gen_dir']


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44357
Builds on previous PR: https://github.com/brave/brave-core/pull/25722

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

For x.com:

1. Navigate to, and authenticate with x.com
2. Navigate to x.com/home
3. Ask Leo which accounts are represented, and who has the most followers.
4. Verify by hovering over a few accounts to reveal true follower numbers

![image](https://github.com/user-attachments/assets/6b1793a8-fd36-4794-b1a8-c1f80354af43)