### PR TITLE
Revert "[cr134][WIP] Fix `TabDragController` tab dragging calculation"

### DIFF
--- a/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -262,6 +262,66 @@ void TabDragController::DetachAndAttachToNewContext(
   }
 }
 
+gfx::Rect TabDragController::CalculateNonMaximizedDraggedBrowserBounds(
+    views::Widget* widget,
+    const gfx::Point& point_in_screen) {
+  // This method is called when dragging all tabs and moving window.
+  auto bounds =
+      TabDragControllerChromium::CalculateNonMaximizedDraggedBrowserBounds(
+          widget, point_in_screen);
+#if BUILDFLAG(IS_MAC)
+  // According to what's been observed, this only needed on Mac. Per platform,
+  // window management mechanism is different so this could happen.
+  if (is_showing_vertical_tabs_) {
+    bounds.Offset(GetVerticalTabStripWidgetOffset());
+  }
+#endif
+
+  if (is_showing_vertical_tabs_) {
+    bounds.set_size(widget->GetTopLevelWidget()->GetRestoredBounds().size());
+  }
+
+  return bounds;
+}
+
+gfx::Rect TabDragController::CalculateDraggedBrowserBounds(
+    TabDragContext* source,
+    const gfx::Point& point_in_screen,
+    std::vector<gfx::Rect>* drag_bounds) {
+  // This method is called when creating new browser by detaching tabs and
+  // when dragging all tabs in maximized window.
+  auto bounds = TabDragControllerChromium::CalculateDraggedBrowserBounds(
+      source, point_in_screen, drag_bounds);
+  if (is_showing_vertical_tabs_) {
+    // Revert back coordinate adjustment done by Chromium impl.
+    bounds.set_origin(point_in_screen);
+
+    // Adjust coordinate so that dragged tabs are under cursor.
+    DCHECK(!drag_bounds->empty());
+    bounds.Offset(-(mouse_offset_.OffsetFromOrigin()));
+    bounds.Offset({-drag_bounds->front().x(), 0});
+    bounds.Offset({-GetXCoordinateAdjustmentForMultiSelectedTabs(
+                       attached_views_, source_view_index_),
+                   0});
+
+    auto* browser_view = static_cast<BraveBrowserView*>(
+        BrowserView::GetBrowserViewForNativeWindow(
+            GetAttachedBrowserWidget()->GetNativeWindow()));
+    DCHECK(browser_view);
+
+    auto* widget_delegate_view =
+        browser_view->vertical_tab_strip_widget_delegate_view();
+    DCHECK(widget_delegate_view);
+
+    bounds.Offset(GetVerticalTabStripWidgetOffset());
+    bounds.Offset(-widget_delegate_view->vertical_tab_strip_region_view()
+                       ->GetOffsetForDraggedTab());
+    bounds.set_size(browser_view->GetRestoredBounds().size());
+  }
+
+  return bounds;
+}
+
 [[nodiscard]] TabDragController::Liveness TabDragController::ContinueDragging(
     const gfx::Point& point_in_screen) {
   auto* browser_widget = GetAttachedBrowserWidget();

--- a/browser/ui/views/tabs/dragging/tab_drag_controller.h
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.h
@@ -42,6 +42,13 @@ class TabDragController : public TabDragControllerChromium {
   void DetachAndAttachToNewContext(ReleaseCapture release_capture,
                                    TabDragContext* target_context) override;
 
+  gfx::Rect CalculateNonMaximizedDraggedBrowserBounds(
+      views::Widget* widget,
+      const gfx::Point& point_in_screen) override;
+  gfx::Rect CalculateDraggedBrowserBounds(
+      TabDragContext* source,
+      const gfx::Point& point_in_screen,
+      std::vector<gfx::Rect>* drag_bounds) override;
   [[nodiscard]] Liveness ContinueDragging(
       const gfx::Point& point_in_screen) override;
 

--- a/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -15,6 +15,12 @@
 
 #define TabDragController TabDragControllerChromium
 
+// Wraps function calls so that they can work with a child NativeWindow as well.
+#define non_client_view()                                    \
+  non_client_view()                                          \
+      ? source->GetWidget()->non_client_view()->frame_view() \
+      : source->GetWidget()->GetTopLevelWidget()->non_client_view()
+
 // Remove drag threshold when it's vertical tab strip
 #define GetHorizontalDragThreshold()                          \
   GetHorizontalDragThreshold() -                              \
@@ -27,6 +33,7 @@
 
 #include "src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.cc"
 
+#undef non_client_view
 #undef GetHorizontalDragThreshold
 #undef GetBrowserViewForNativeWindow
 #undef TabDragController

--- a/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h
@@ -31,11 +31,16 @@ using TabDragControllerBrave = TabDragController;
   virtual views::Widget* GetAttachedBrowserWidget
 #define GetLocalProcessWindow virtual GetLocalProcessWindow
 #define DetachAndAttachToNewContext virtual DetachAndAttachToNewContext
+#define CalculateNonMaximizedDraggedBrowserBounds \
+  virtual CalculateNonMaximizedDraggedBrowserBounds
+#define CalculateDraggedBrowserBounds virtual CalculateDraggedBrowserBounds
 #define ContinueDragging virtual ContinueDragging
 
 #include "src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h"  // IWYU pragma: export
 
 #undef ContinueDragging
+#undef CalculateDraggedBrowserBounds
+#undef CalculateNonMaximizedDraggedBrowserBounds
 #undef DetachAndAttachToNewContext
 #undef GetLocalProcessWindow
 #undef GetAttachedBrowserWidget


### PR DESCRIPTION
This reverts commit 4d6e57f4fa6f44ef8bd2584860d37af569eadaf0.

Revert reason: This change was added for handling https://chromium-review.googlesource.com/c/chromium/src/+/6160815 but it's reverted by https://chromium-review.googlesource.com/c/chromium/src/+/6234751

By reverting this, we could avoid invalid `non_client_view()` access that causes https://github.com/brave/brave-browser/issues/44362.
Also can get proper dragged tab under cursor that fixes https://github.com/brave/brave-browser/issues/44282

fix https://github.com/brave/brave-browser/issues/44362
fix https://github.com/brave/brave-browser/issues/44282

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.