### PR TITLE
[canary] Handle missing sources when applying patches

### DIFF
--- a/build/commands/lib/gitPatcher.test.js
+++ b/build/commands/lib/gitPatcher.test.js
@@ -147,6 +147,22 @@ describe('Apply Patches', function () {
     expect(status[0]).toHaveProperty('reason', GitPatcher.patchApplyReasons.PATCH_REMOVED)
   })
 
+  test('handles missing file when patch file is still present', async function () {
+    validate()
+    // apply once
+    await gitPatcher.applyPatches()
+    // remove target file
+    await fs.unlink(testFile1Path)
+    await runGitAsyncWithErrorLog(repoPath, ['rm', testFile1Path])
+    await runGitAsyncWithErrorLog(repoPath, ['commit', '-a', '-m', '"remove target"'])
+    // apply again
+    const status = await gitPatcher.applyPatches()
+    expect(status).toHaveLength(1)
+    expect(status[0]).toHaveProperty('patchPath', testFile1PatchPath)
+    expect(status[0]).toHaveProperty('error')
+    expect(status[0]).toHaveProperty('reason', GitPatcher.patchApplyReasons.SRC_REMOVED)
+  })
+
   test('handles bad patch file', async function () {
     validate()
     // Create an invalid patch

--- a/build/commands/lib/logging.js
+++ b/build/commands/lib/logging.js
@@ -130,13 +130,16 @@ function printFailedPatchesInJsonFormat(allPatchStatus, bravePath) {
     return;
   }
 
-  const patchFailuresOutput = failedPatches.map(({path, patchPath}) => {
+  const GitPatcher = require('./gitPatcher')
+
+  const patchFailuresOutput = failedPatches.map(({path, patchPath, reason}) => {
     return {
       // Trimming the patch path to be relative to the brave core repo. We skip
       // the first character to avoid the trailing slash from the absolute
       // path.
       patchPath:
         patchPath.replace(bravePath, '').substring(1),
+      reason: GitPatcher.getReasonName(reason),
       path: path
     }
   })


### PR DESCRIPTION
When running `apply_patches` and a patch fails to apply because the source file it was created for is gone from Chromium, the tool usually emits the following error:

```
[Error: ENOENT: no such file or directory, open '/home/redacted/dev/brave-dev/src/build/util/action_remote.py'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/home/redacted/dev/brave-dev/src/build/util/action_remote.py'
}
```

This error is not ideal as this interrupts the execution of the tool, and it requires the patch to be deleted first, before a proper run of `apply_patches` with error reporting can be finished.

This change adds an extra reason why patches can fail, and it flags that reason whenever a patch is not present.

This change also corrects an existing bug where `apply_patches` adds to the reset list a file that is already gone. That causes all the files listed after to not be reset, which leads to patch deletions when running `update_patches` after.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves: https://github.com/brave/brave-browser/issues/44285

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

