### PR TITLE
[iOS] Fix usage of find in page when using CWVWebView

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -349,13 +349,10 @@ extension BrowserViewController: TopToolbarDelegate {
     controller.webView.load(URLRequest(url: url))
     controller.title = url.host?.capitalizeFirstLetter
     let webView = controller.webView
-    // TODO: brave-browser#44346 Using CWVFindInPageController will DCHECK on deinit, use when fixed
-    webView.internalWebView?.isFindInteractionEnabled = true
     controller.navigationItem.rightBarButtonItem = UIBarButtonItem(
       systemItem: .search,
       primaryAction: .init { [weak webView] _ in
-        webView?.internalWebView?.findInteraction?.searchText = ""
-        webView?.internalWebView?.findInteraction?.presentFindNavigator(showingReplace: false)
+        webView?.findInPageController.startFindInPage()
       }
     )
     let container = UINavigationController(rootViewController: controller)

--- a/patches/ios-web_view-internal-cwv_find_in_page_controller.mm.patch
+++ b/patches/ios-web_view-internal-cwv_find_in_page_controller.mm.patch
@@ -1,0 +1,14 @@
+diff --git a/ios/web_view/internal/cwv_find_in_page_controller.mm b/ios/web_view/internal/cwv_find_in_page_controller.mm
+index 57db8d366294f0b0ed060535dfdd0149e2112dfe..256d52d776cfbb43108b67835714a66c35b4092c 100644
+--- a/ios/web_view/internal/cwv_find_in_page_controller.mm
++++ b/ios/web_view/internal/cwv_find_in_page_controller.mm
+@@ -32,6 +32,9 @@
+     _findInPageManager = web::FindInPageManager::FromWebState(webState);
+ 
+     _webState = webState->GetWeakPtr();
++    _webStateObserverBridge =
++        std::make_unique<web::WebStateObserverBridge>(self);
++    _webState->AddObserver(_webStateObserverBridge.get());
+   }
+   return self;
+ }


### PR DESCRIPTION
This introduces an upstreamed patch that fixes a DCHECK that occurs when using `CWVFindInPageController` (https://chromium-review.googlesource.com/c/chromium/src/+/6316988)

Resolves https://github.com/brave/brave-browser/issues/44346

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

