### PR TITLE
[AI Chat]: Use favicon2 for fetching favicons

### DIFF
--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -67,8 +67,6 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
       mojo::PendingReceiver<mojom::ConversationHandler> receiver,
       mojo::PendingRemote<mojom::ConversationUI> conversation_ui_handler)
       override;
-  void GetFaviconImageData(const std::string& conversation_id,
-                           GetFaviconImageDataCallback callback) override;
 
   void BindParentUIFrameFromChildFrame(
       mojo::PendingReceiver<mojom::ParentUIFrame> receiver);
@@ -91,18 +89,10 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
   // AIChatTabHelper::Observer
   void OnAssociatedContentNavigated(int new_navigation_id) override;
 
-  void GetFaviconImageDataForAssociatedContent(
-      GetFaviconImageDataCallback callback,
-      mojom::AssociatedContentPtr content_info,
-      bool should_send_page_contents);
-
   raw_ptr<AIChatTabHelper> active_chat_tab_helper_ = nullptr;
   raw_ptr<content::WebContents> owner_web_contents_ = nullptr;
-  raw_ptr<favicon::FaviconService> favicon_service_ = nullptr;
   raw_ptr<Profile> profile_ = nullptr;
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
-
-  base::CancelableTaskTracker favicon_task_tracker_;
 
   base::ScopedObservation<AIChatTabHelper, AIChatTabHelper::Observer>
       chat_tab_helper_observation_{this};

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.cc
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.cc
@@ -131,8 +131,6 @@ AIChatTabHelper::AIChatTabHelper(content::WebContents* web_contents,
           std::move(print_preview_extraction_delegate)),
       page_content_fetcher_delegate_(
           std::make_unique<PageContentFetcher>(web_contents)) {
-  favicon::ContentFaviconDriver::FromWebContents(web_contents)
-      ->AddObserver(this);
   previous_page_title_ = web_contents->GetTitle();
 }
 
@@ -160,8 +158,6 @@ void AIChatTabHelper::OnPDFA11yInfoLoaded() {
 // content::WebContentsObserver
 
 void AIChatTabHelper::WebContentsDestroyed() {
-  favicon::ContentFaviconDriver::FromWebContents(web_contents())
-      ->RemoveObserver(this);
   inner_web_contents_ = nullptr;
 }
 
@@ -250,16 +246,6 @@ void AIChatTabHelper::DidFinishLoad(content::RenderFrameHost* render_frame_host,
       GetPageContent(std::move(pending_get_page_content_callback_), "");
     }
   }
-}
-
-// favicon::FaviconDriverObserver
-void AIChatTabHelper::OnFaviconUpdated(
-    favicon::FaviconDriver* favicon_driver,
-    NotificationIconType notification_icon_type,
-    const GURL& icon_url,
-    bool icon_url_changed,
-    const gfx::Image& image) {
-  OnFaviconImageDataChanged();
 }
 
 // mojom::PageContentExtractorHost

--- a/components/ai_chat/content/browser/ai_chat_tab_helper.h
+++ b/components/ai_chat/content/browser/ai_chat_tab_helper.h
@@ -19,7 +19,6 @@
 #include "brave/components/ai_chat/core/browser/associated_content_driver.h"
 #include "brave/components/ai_chat/core/browser/conversation_handler.h"
 #include "brave/components/ai_chat/core/common/mojom/page_content_extractor.mojom.h"
-#include "components/favicon/core/favicon_driver_observer.h"
 #include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
@@ -29,9 +28,6 @@
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
 #include "url/gurl.h"
 
-namespace favicon {
-class FaviconDriver;
-}  // namespace favicon
 namespace gfx {
 class Image;
 }  // namespace gfx
@@ -60,7 +56,6 @@ class AIChatMetrics;
 class AIChatTabHelper : public content::WebContentsObserver,
                         public content::WebContentsUserData<AIChatTabHelper>,
                         public mojom::PageContentExtractorHost,
-                        public favicon::FaviconDriverObserver,
                         public AssociatedContentDriver {
  public:
   using GetPageContentCallback = ConversationHandler::GetPageContentCallback;
@@ -166,13 +161,6 @@ class AIChatTabHelper : public content::WebContentsObserver,
       content::RenderFrameHost* render_frame_host) override;
   void DidFinishLoad(content::RenderFrameHost* render_frame_host,
                      const GURL& validated_url) override;
-
-  // favicon::FaviconDriverObserver
-  void OnFaviconUpdated(favicon::FaviconDriver* favicon_driver,
-                        NotificationIconType notification_icon_type,
-                        const GURL& icon_url,
-                        bool icon_url_changed,
-                        const gfx::Image& image) override;
 
   // ai_chat::AssociatedContentDriver
   GURL GetPageURL() const override;

--- a/components/ai_chat/core/browser/ai_chat_service_unittest.cc
+++ b/components/ai_chat/core/browser/ai_chat_service_unittest.cc
@@ -135,8 +135,6 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
               (const mojom::AssociatedContentPtr, bool),
               (override));
 
-  MOCK_METHOD(void, OnFaviconImageDataChanged, (), (override));
-
   MOCK_METHOD(void, OnConversationDeleted, (), (override));
 
  private:

--- a/components/ai_chat/core/browser/associated_content_driver.cc
+++ b/components/ai_chat/core/browser/associated_content_driver.cc
@@ -267,12 +267,6 @@ AssociatedContentDriver::ParseSearchQuerySummaryResponse(
   return entries;
 }
 
-void AssociatedContentDriver::OnFaviconImageDataChanged() {
-  for (auto& conversation : associated_conversations_) {
-    conversation->OnFaviconImageDataChanged();
-  }
-}
-
 void AssociatedContentDriver::OnTitleChanged() {
   for (auto& conversation : associated_conversations_) {
     conversation->OnAssociatedContentTitleChanged();

--- a/components/ai_chat/core/browser/associated_content_driver.h
+++ b/components/ai_chat/core/browser/associated_content_driver.h
@@ -107,9 +107,6 @@ class AssociatedContentDriver
       ConversationHandler::GetPageContentCallback callback,
       std::string_view invalidation_token) = 0;
 
-  // Implementer should call this when the favicon for the content changes
-  void OnFaviconImageDataChanged();
-
   // Implementer should call this when the title is updated
   void OnTitleChanged();
 

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -1108,13 +1108,6 @@ void ConversationHandler::AddSubmitSelectedTextError(
   SetAPIError(error);
 }
 
-void ConversationHandler::OnFaviconImageDataChanged() {
-  for (const mojo::Remote<mojom::ConversationUI>& client :
-       conversation_ui_handlers_) {
-    client->OnFaviconImageDataChanged();
-  }
-}
-
 void ConversationHandler::OnAssociatedContentTitleChanged() {
   OnAssociatedContentInfoChanged();
 }
@@ -1760,15 +1753,6 @@ void ConversationHandler::OnConversationUIConnectionChanged(
 void ConversationHandler::OnSelectedLanguageChanged(
     const std::string& selected_language) {
   selected_language_ = selected_language;
-}
-
-void ConversationHandler::OnAssociatedContentFaviconImageDataChanged() {
-  for (auto& client : conversation_ui_handlers_) {
-    client->OnFaviconImageDataChanged();
-  }
-  for (auto& client : untrusted_conversation_ui_handlers_) {
-    client->OnFaviconImageDataChanged();
-  }
 }
 
 void ConversationHandler::OnSuggestedQuestionsChanged() {

--- a/components/ai_chat/core/browser/conversation_handler.h
+++ b/components/ai_chat/core/browser/conversation_handler.h
@@ -288,7 +288,6 @@ class ConversationHandler : public mojom::ConversationHandler,
                                   mojom::ActionType action_type,
                                   mojom::APIError error);
   void OnAssociatedContentTitleChanged();
-  void OnFaviconImageDataChanged();
   void OnUserOptedIn();
   size_t GetConversationHistorySize() override;
 
@@ -428,7 +427,6 @@ class ConversationHandler : public mojom::ConversationHandler,
   void OnConversationTitleChanged(std::string_view title);
   void OnConversationUIConnectionChanged(mojo::RemoteSetElementId id);
   void OnSelectedLanguageChanged(const std::string& selected_language);
-  void OnAssociatedContentFaviconImageDataChanged();
   void OnAPIRequestInProgressChanged();
   void OnStateForConversationEntriesChanged();
 

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -111,8 +111,6 @@ class MockConversationHandlerClient : public mojom::ConversationUI {
               (const mojom::AssociatedContentPtr, bool),
               (override));
 
-  MOCK_METHOD(void, OnFaviconImageDataChanged, (), (override));
-
   MOCK_METHOD(void, OnConversationDeleted, (), (override));
 
  private:

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -405,11 +405,6 @@ interface AIChatUIHandler {
   // be bound to the associated conversation, if this UI has a target
   NewConversation(pending_receiver<ConversationHandler> conversation,
       pending_remote<ConversationUI> conversation_ui);
-
-  // TODO(petemill): WebUI clients won't need this when they can
-  // request via FaviconSource URLs via trusted webui.
-  GetFaviconImageData(string conversation_uuid) => (
-      array<uint8>? favicon_image_data);
 };
 
 // UI-side handler for messages from the browser WebUI
@@ -531,7 +526,6 @@ interface UntrustedConversationUI {
   // to the most recent entry.
   OnConversationHistoryUpdate();
   OnEntriesUIStateChanged(ConversationEntriesState state);
-  OnFaviconImageDataChanged();
 };
 
 interface ConversationUI {
@@ -553,7 +547,6 @@ interface ConversationUI {
   // Associated page information has changed. If there is none then |associated_content|
   // will be |null|.
   OnAssociatedContentInfoChanged(AssociatedContent? associated_content, bool should_send_page_contents);
-  OnFaviconImageDataChanged();
   OnConversationDeleted();
 };
 

--- a/components/ai_chat/resources/page/components/attachments/index.tsx
+++ b/components/ai_chat/resources/page/components/attachments/index.tsx
@@ -21,7 +21,7 @@ function TabItem({ tab }: { tab: TabData }) {
         aiChat.uiHandler?.associateTab(tab, conversationUuid!)
     }}>
         <span className={styles.title}>{tab.title}</span>
-        <img className={styles.icon} src={`chrome://favicon2/?size=20&pageUrl=${encodeURIComponent(tab.url.url)}`} />
+        <img key={tab.contentId} className={styles.icon} src={`chrome://favicon2/?size=20&pageUrl=${encodeURIComponent(tab.url.url)}`} />
     </RadioButton>
 }
 

--- a/components/ai_chat/resources/page/components/site_title/index.tsx
+++ b/components/ai_chat/resources/page/components/site_title/index.tsx
@@ -13,7 +13,7 @@ interface SiteTitleProps {
 
 function SiteTitle(props: SiteTitleProps) {
   const context = useConversation()
-
+  const url = context.associatedContentInfo?.url.url
   return (
     <div
       className={classnames({
@@ -27,7 +27,7 @@ function SiteTitle(props: SiteTitleProps) {
           [styles.favIconContainerSm]: props.size === 'small'
         })}
       >
-        { context.faviconUrl && <img src={context.faviconUrl} /> }
+        {url && <img src={`chrome://favicon2?size=64&pageUrl=${encodeURIComponent(url)}`} />}
       </div>
       <div
         className={classnames({

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -32,8 +32,6 @@ export type ConversationContext = SendFeedbackState & CharCountContext & {
   suggestedQuestions: string[]
   isGenerating: boolean
   suggestionStatus: Mojom.SuggestionGenerationStatus
-  faviconUrl?: string
-  faviconCacheKey?: string
   currentError: Mojom.APIError | undefined
   apiHasError: boolean
   shouldDisableUserInput: boolean
@@ -291,13 +289,6 @@ export function ConversationContextProvider(props: React.PropsWithChildren) {
     )
     listenerIds.push(id)
 
-    id = callbackRouter.onFaviconImageDataChanged.addListener(() =>
-      setPartialContext({
-        faviconCacheKey: new Date().getTime().toFixed(0)
-      })
-    )
-    listenerIds.push(id)
-
     id = callbackRouter.onConversationDeleted.addListener(() => {
       // TODO(petemill): Show deleted UI
       console.debug('DELETED')
@@ -311,23 +302,6 @@ export function ConversationContextProvider(props: React.PropsWithChildren) {
       }
     }
   }, [conversationHandler, callbackRouter])
-
-  // Update favicon
-  React.useEffect(() => {
-    if (!context.conversationUuid || !aiChatContext.uiHandler) {
-      return
-    }
-    aiChatContext.uiHandler.getFaviconImageData(context.conversationUuid)
-      .then(({ faviconImageData }) => {
-        if (!faviconImageData) {
-          return
-        }
-        const blob = new Blob([new Uint8Array(faviconImageData)], { type: 'image/*' })
-        setPartialContext({
-          faviconUrl: URL.createObjectURL(blob)
-        })
-      })
-  }, [context.conversationUuid, context.faviconCacheKey])
 
   // Update the location when the visible conversation changes
   const isVisible = useIsConversationVisible(context.conversationUuid)

--- a/ios/browser/api/ai_chat/conversation_client.h
+++ b/ios/browser/api/ai_chat/conversation_client.h
@@ -46,7 +46,6 @@ class ConversationClient : public mojom::ConversationUI,
   void OnAssociatedContentInfoChanged(
       const mojom::AssociatedContentPtr site_info,
       bool should_send_content) override;
-  void OnFaviconImageDataChanged() override;
   void OnConversationDeleted() override;
 
   // mojom::ServiceObserver

--- a/ios/browser/api/ai_chat/conversation_client.mm
+++ b/ios/browser/api/ai_chat/conversation_client.mm
@@ -76,8 +76,6 @@ void ConversationClient::OnAssociatedContentInfoChanged(
           shouldSendContent:should_send_content];
 }
 
-void ConversationClient::OnFaviconImageDataChanged() {}
-
 void ConversationClient::OnConversationDeleted() {
   // TODO(petemill): UI should bind to a new conversation. This only
   // needs to be handled when the AIChatStorage feature is enabled, which


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44384

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Favicon should be correct on a new chat related to a page
![image](https://github.com/user-attachments/assets/77bdcc1d-c33b-4d04-84e2-c58e09bd8a10)

2. Favicon should update when changing between chats
![image](https://github.com/user-attachments/assets/18708cc3-8115-47d1-83f9-5c71a0c2e761)

3. Favicons should change when creating a full page chat and changing the associated content with the attachment picker.
![image](https://github.com/user-attachments/assets/699d3bd2-1ef8-4e29-a15d-b212eb58a1b5)


4. Favicons should also update in the bottom `Use this page` tooltip:
![image](https://github.com/user-attachments/assets/f54f4bb8-f819-4e36-a31b-a53736a1fc8a)
