### PR TITLE
Fixed vertical tab regressions

### DIFF
--- a/browser/ui/views/frame/vertical_tab_strip_region_view.cc
+++ b/browser/ui/views/frame/vertical_tab_strip_region_view.cc
@@ -420,9 +420,7 @@ END_METADATA
 class VerticalTabStripScrollContentsView : public views::View {
   METADATA_HEADER(VerticalTabStripScrollContentsView, views::View)
  public:
-  VerticalTabStripScrollContentsView(VerticalTabStripRegionView* container,
-                                     TabStrip* tab_strip)
-      : container_(container), tab_strip_(tab_strip) {
+  VerticalTabStripScrollContentsView() {
     SetLayoutManager(std::make_unique<views::FillLayout>());
   }
   ~VerticalTabStripScrollContentsView() override = default;
@@ -433,25 +431,12 @@ class VerticalTabStripScrollContentsView : public views::View {
       return;
     }
 
-    if (in_preferred_size_changed_) {
-      return;
-    }
-
-    // Prevent reentrance caused by container_->Layout()
-    base::AutoReset<bool> in_preferred_size_change(&in_preferred_size_changed_,
-                                                   true);
-    container_->InvalidateLayout();
+    PreferredSizeChanged();
   }
 
   void OnPaintBackground(gfx::Canvas* canvas) override {
     canvas->DrawColor(GetColorProvider()->GetColor(kColorToolbar));
   }
-
- private:
-  raw_ptr<VerticalTabStripRegionView> container_ = nullptr;
-  raw_ptr<TabStrip> tab_strip_ = nullptr;
-
-  bool in_preferred_size_changed_ = false;
 };
 
 BEGIN_METADATA(VerticalTabStripScrollContentsView)
@@ -627,8 +612,7 @@ VerticalTabStripRegionView::VerticalTabStripRegionView(
           this),
       this, browser_));
   contents_view_ =
-      AddChildView(std::make_unique<VerticalTabStripScrollContentsView>(
-          this, original_region_view_->tab_strip_));
+      AddChildView(std::make_unique<VerticalTabStripScrollContentsView>());
   header_view_->toggle_button()->SetHighlighted(state_ == State::kExpanded);
   separator_ = AddChildView(std::make_unique<views::View>());
   separator_->SetBackground(

--- a/browser/ui/views/tabs/brave_tab_container.cc
+++ b/browser/ui/views/tabs/brave_tab_container.cc
@@ -392,6 +392,10 @@ void BraveTabContainer::CompleteAnimationAndLayout() {
     return;
   }
 
+  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
+    last_layout_size_ = size();
+  }
+
   TabContainerImpl::CompleteAnimationAndLayout();
 
   // Should force tabs to layout as they might not change bounds, which makes
@@ -438,6 +442,23 @@ void BraveTabContainer::SetTabSlotVisibility() {
   }
 
   TabContainerImpl::SetTabSlotVisibility();
+}
+
+void BraveTabContainer::InvalidateIdealBounds() {
+  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser())) {
+    last_layout_size_ = gfx::Size();
+  }
+
+  TabContainerImpl::InvalidateIdealBounds();
+}
+
+void BraveTabContainer::Layout(PassKey) {
+  if (tabs::utils::ShouldShowVerticalTabs(tab_slot_controller_->GetBrowser()) &&
+      last_layout_size_ == size()) {
+    return;
+  }
+
+  LayoutSuperclass<TabContainerImpl>(this);
 }
 
 std::optional<BrowserRootView::DropIndex> BraveTabContainer::GetDropIndex(

--- a/browser/ui/views/tabs/brave_tab_container.h
+++ b/browser/ui/views/tabs/brave_tab_container.h
@@ -50,6 +50,8 @@ class BraveTabContainer : public TabContainerImpl,
   void CompleteAnimationAndLayout() override;
   void PaintChildren(const views::PaintInfo& paint_info) override;
   void SetTabSlotVisibility() override;
+  void InvalidateIdealBounds() override;
+  void Layout(PassKey) override;
 
   // BrowserRootView::DropTarget
   std::optional<BrowserRootView::DropIndex> GetDropIndex(
@@ -141,6 +143,9 @@ class BraveTabContainer : public TabContainerImpl,
   BooleanPrefMember vertical_tabs_collapsed_;
 
   bool layout_locked_ = false;
+
+  // Size we last laid out at.
+  gfx::Size last_layout_size_;
 
   base::ScopedObservation<SplitViewBrowserData, SplitViewBrowserDataObserver>
       split_view_data_observation_{this};

--- a/browser/ui/views/tabs/brave_tab_strip.cc
+++ b/browser/ui/views/tabs/brave_tab_strip.cc
@@ -428,6 +428,10 @@ void BraveTabStrip::UpdateTabContainer() {
     // In order to update shadow state, call ActiveStateChanged().
     tab_at(active_index.value())->ActiveStateChanged();
   }
+
+  // Called only at startup or vertical tab mode changed.
+  // To make initial tabs layout properly.
+  DeprecatedLayoutImmediately();
 }
 
 bool BraveTabStrip::ShouldShowVerticalTabs() const {


### PR DESCRIPTION
fix brave/brave-browser#44050
fix brave/brave-browser#44032
fix brave/brave-browser#44276

When dragging, vertical tab is invalidated and it causes layout of BraveTabContainer.
As preferred size changes notification occurs even its preferred size is not changed during the runtime,
we don't need to layout BraveTabContainer when its size is not changed.
Also do forced layout of tab strip at startup or vertical tab mode changed to get proper initial layout state.

This PR includes https://github.com/brave/brave-core/pull/27665/ changes.
At that time, tab container's preferred size is changed whenever dragging but not anymore.
So, layout value caching works well now.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

See the linked issue.