### PR TITLE
[iOS] - Block tabs from showing popups when switched AFTER the system popup

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebDelegate.swift
@@ -293,7 +293,9 @@ extension BrowserViewController: TabWebDelegate {
     _ tab: Tab,
     requestMediaCapturePermissionsFor type: WebMediaCaptureType
   ) async -> WebPermissionDecision {
-    guard let origin = tab.committedURL?.origin else { return .deny }
+    guard let origin = tab.committedURL?.origin, tab === tabManager.selectedTab else {
+      return .deny
+    }
 
     let presentAlert: (CheckedContinuation<WebPermissionDecision, Never>) -> Void = {
       [weak self] contination in
@@ -356,7 +358,9 @@ extension BrowserViewController: TabWebDelegate {
   }
 
   func tab(_ tab: Tab, runJavaScriptAlertPanelWithMessage message: String, pageURL: URL) async {
-    guard case let origin = pageURL.origin, !origin.isOpaque else { return }
+    guard case let origin = pageURL.origin, !origin.isOpaque, tab === tabManager.selectedTab else {
+      return
+    }
     await withCheckedContinuation { continuation in
       let completionHandler: () -> Void = {
         continuation.resume()
@@ -378,7 +382,9 @@ extension BrowserViewController: TabWebDelegate {
     runJavaScriptConfirmPanelWithMessage message: String,
     pageURL: URL
   ) async -> Bool {
-    guard case let origin = pageURL.origin, !origin.isOpaque else { return false }
+    guard case let origin = pageURL.origin, !origin.isOpaque, tab === tabManager.selectedTab else {
+      return false
+    }
     return await withCheckedContinuation { continuation in
       let completionHandler: (Bool) -> Void = { result in
         continuation.resume(returning: result)
@@ -401,7 +407,9 @@ extension BrowserViewController: TabWebDelegate {
     defaultText: String?,
     pageURL: URL
   ) async -> String? {
-    guard case let origin = pageURL.origin, !origin.isOpaque else { return nil }
+    guard case let origin = pageURL.origin, !origin.isOpaque, tab === tabManager.selectedTab else {
+      return nil
+    }
     return await withCheckedContinuation { continuation in
       let completionHandler: (String?) -> Void = { result in
         continuation.resume(returning: result)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -369,7 +369,9 @@ extension BrowserViewController: WKUIDelegate {
     type: WKMediaCaptureType,
     decisionHandler: @escaping (WKPermissionDecision) -> Void
   ) {
-    guard let tab = tabManager[webView], let captureType = WebMediaCaptureType(type) else {
+    guard let tab = tabManager[webView], let captureType = WebMediaCaptureType(type),
+      tab === tabManager.selectedTab
+    else {
       decisionHandler(.deny)
       return
     }
@@ -401,7 +403,8 @@ extension BrowserViewController: WKUIDelegate {
     initiatedByFrame frame: WKFrameInfo,
     completionHandler: @escaping () -> Void
   ) {
-    guard let tab = tabManager[webView], let url = frame.origin?.url else {
+    guard let tab = tabManager[webView], let url = frame.origin?.url, tab === tabManager.selectedTab
+    else {
       completionHandler()
       return
     }
@@ -417,7 +420,8 @@ extension BrowserViewController: WKUIDelegate {
     initiatedByFrame frame: WKFrameInfo,
     completionHandler: @escaping (Bool) -> Void
   ) {
-    guard let tab = tabManager[webView], let url = frame.origin?.url else {
+    guard let tab = tabManager[webView], let url = frame.origin?.url, tab === tabManager.selectedTab
+    else {
       completionHandler(false)
       return
     }
@@ -434,7 +438,8 @@ extension BrowserViewController: WKUIDelegate {
     initiatedByFrame frame: WKFrameInfo,
     completionHandler: @escaping (String?) -> Void
   ) {
-    guard let tab = tabManager[webView], let url = frame.origin?.url else {
+    guard let tab = tabManager[webView], let url = frame.origin?.url, tab === tabManager.selectedTab
+    else {
       completionHandler(nil)
       return
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -369,8 +369,7 @@ extension BrowserViewController: WKUIDelegate {
     type: WKMediaCaptureType,
     decisionHandler: @escaping (WKPermissionDecision) -> Void
   ) {
-    guard let tab = tabManager[webView], let captureType = WebMediaCaptureType(type),
-      tab === tabManager.selectedTab
+    guard let tab = tabManager[webView], let captureType = WebMediaCaptureType(type)
     else {
       decisionHandler(.deny)
       return
@@ -403,8 +402,7 @@ extension BrowserViewController: WKUIDelegate {
     initiatedByFrame frame: WKFrameInfo,
     completionHandler: @escaping () -> Void
   ) {
-    guard let tab = tabManager[webView], let url = frame.origin?.url, tab === tabManager.selectedTab
-    else {
+    guard let tab = tabManager[webView], let url = frame.origin?.url else {
       completionHandler()
       return
     }
@@ -420,8 +418,7 @@ extension BrowserViewController: WKUIDelegate {
     initiatedByFrame frame: WKFrameInfo,
     completionHandler: @escaping (Bool) -> Void
   ) {
-    guard let tab = tabManager[webView], let url = frame.origin?.url, tab === tabManager.selectedTab
-    else {
+    guard let tab = tabManager[webView], let url = frame.origin?.url else {
       completionHandler(false)
       return
     }
@@ -438,8 +435,7 @@ extension BrowserViewController: WKUIDelegate {
     initiatedByFrame frame: WKFrameInfo,
     completionHandler: @escaping (String?) -> Void
   ) {
-    guard let tab = tabManager[webView], let url = frame.origin?.url, tab === tabManager.selectedTab
-    else {
+    guard let tab = tabManager[webView], let url = frame.origin?.url else {
       completionHandler(nil)
       return
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+WKNavigationDelegate.swift
@@ -369,8 +369,7 @@ extension BrowserViewController: WKUIDelegate {
     type: WKMediaCaptureType,
     decisionHandler: @escaping (WKPermissionDecision) -> Void
   ) {
-    guard let tab = tabManager[webView], let captureType = WebMediaCaptureType(type)
-    else {
+    guard let tab = tabManager[webView], let captureType = WebMediaCaptureType(type) else {
       decisionHandler(.deny)
       return
     }


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44419

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

