### PR TITLE
[Rewards] Do not show Rewards 3 UI for unsupported regions (uplift to 1.76.x)

### DIFF
--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -125,7 +125,8 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
                  profile->GetPrefs(),
                  brave_rewards::IsSupportedOptions::kSkipRegionCheck)) {
     if (base::FeatureList::IsEnabled(
-            brave_rewards::features::kNewRewardsUIFeature)) {
+            brave_rewards::features::kNewRewardsUIFeature) &&
+        brave_rewards::IsSupportedForProfile(profile)) {
       return new brave_rewards::RewardsPageUI(web_ui, url.host());
     }
     return new BraveRewardsPageUI(web_ui, url.host());


### PR DESCRIPTION
Uplift of #27987
Resolves https://github.com/brave/brave-browser/issues/44459

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.