### PR TITLE
Fixed wrong cursor position when dragging window by tab grab

### DIFF
--- a/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -119,6 +119,23 @@ gfx::Point TabDragController::GetAttachedDragPoint(
   return {x, y};
 }
 
+gfx::Vector2d TabDragController::CalculateWindowDragOffset() {
+  gfx::Vector2d offset = TabDragControllerChromium::CalculateWindowDragOffset();
+  if (!is_showing_vertical_tabs_) {
+    return offset;
+  }
+
+  // Re-calculate offset as above result is based on vertical tab widget.
+  // Convert it based on browser window widget(top level widget).
+  gfx::Point new_offset(offset.x(), offset.y());
+  views::View::ConvertPointFromWidget(attached_context_, &new_offset);
+  views::View::ConvertPointToScreen(attached_context_, &new_offset);
+  views::View::ConvertPointFromScreen(
+      attached_context_->GetWidget()->GetTopLevelWidget()->GetRootView(),
+      &new_offset);
+  return new_offset.OffsetFromOrigin();
+}
+
 void TabDragController::MoveAttached(const gfx::Point& point_in_screen,
                                      bool just_attached) {
   TabDragControllerChromium::MoveAttached(point_in_screen, just_attached);

--- a/browser/ui/views/tabs/dragging/tab_drag_controller.h
+++ b/browser/ui/views/tabs/dragging/tab_drag_controller.h
@@ -34,6 +34,7 @@ class TabDragController : public TabDragControllerChromium {
   void MoveAttached(const gfx::Point& point_in_screen,
                     bool just_attached) override;
   views::Widget* GetAttachedBrowserWidget() override;
+  gfx::Vector2d CalculateWindowDragOffset() override;
 
   Liveness GetLocalProcessWindow(const gfx::Point& screen_point,
                                  bool exclude_dragged_view,

--- a/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
+++ b/browser/ui/views/tabs/vertical_tab_strip_browsertest.cc
@@ -956,7 +956,11 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripDragAndDropBrowserTest,
 // TODO(sko) On Linux test environment, the test doesn't work well
 // TODO(sko) On Windows CI, SendMouse() doesn't work.
 // TODO(sko) As of Dec, 2023 this test is flaky on Mac CI.
+#if BUILDFLAG(IS_WIN)
+#define MAYBE_DragTabToDetach DragTabToDetach
+#else
 #define MAYBE_DragTabToDetach DISABLED_DragTabToDetach
+#endif
 
 IN_PROC_BROWSER_TEST_F(VerticalTabStripDragAndDropBrowserTest,
                        MAYBE_DragTabToDetach) {
@@ -979,8 +983,16 @@ IN_PROC_BROWSER_TEST_F(VerticalTabStripDragAndDropBrowserTest,
                           std::ranges::count_if(*browser_list, [&](Browser* b) {
                             return b->profile() == browser()->profile();
                           }));
-                ReleaseMouse();
                 auto* new_browser = browser_list->GetLastActive();
+                auto* browser_view =
+                    BrowserView::GetBrowserViewForBrowser(new_browser);
+                auto* tab = browser_view->tabstrip()->tab_at(0);
+                ASSERT_TRUE(tab);
+                // During the tab detaching, mouse should be over the dragged
+                // tab.
+                EXPECT_TRUE(tab->IsMouseHovered());
+                EXPECT_TRUE(tab->dragging());
+                ReleaseMouse();
                 new_browser->window()->Close();
               }));
 }

--- a/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.cc
@@ -37,9 +37,11 @@
 // StackAtTop() should be called vertical tab widget's top level widget.
 // This also works in horizontal tab mode because it's already top level window.
 #define StackAtTop GetTopLevelWidget()->StackAtTop
+#define GetWindowBoundsInScreen GetTopLevelWidget()->GetWindowBoundsInScreen
 
 #include "src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.cc"
 
+#undef GetWindowBoundsInScreen
 #undef StackAtTop
 #undef GetHorizontalDragThreshold
 #undef GetBrowserViewForNativeWindow

--- a/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h
+++ b/chromium_src/chrome/browser/ui/views/tabs/dragging/tab_drag_controller.h
@@ -29,6 +29,13 @@ using TabDragControllerBrave = TabDragController;
     return {};                        \
   }                                   \
   virtual views::Widget* GetAttachedBrowserWidget
+
+#define CalculateWindowDragOffset      \
+  CalculateWindowDragOffset_Unused() { \
+    return {};                         \
+  }                                    \
+  virtual gfx::Vector2d CalculateWindowDragOffset
+
 #define GetLocalProcessWindow virtual GetLocalProcessWindow
 #define DetachAndAttachToNewContext virtual DetachAndAttachToNewContext
 #define ContinueDragging virtual ContinueDragging
@@ -38,6 +45,7 @@ using TabDragControllerBrave = TabDragController;
 #undef ContinueDragging
 #undef DetachAndAttachToNewContext
 #undef GetLocalProcessWindow
+#undef CalculateWindowDragOffset
 #undef GetAttachedBrowserWidget
 #undef TabDragController
 #undef InitDragData


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/44393

This is f/u fix as https://github.com/brave/brave-core/pull/27909
is reverted in cr135.

We adjusted window offset while dragging in vertical tab mode
because TabDragController refers widget from TabDraggingContext but
that widget is vertical tab widget not browser window widget.
However, upstream refactored TabDragController so we need to adjust
based on latest code again.

Upstream changes - https://chromium-review.googlesource.com/c/chromium/src/+/6160815
Our previous offset adjust - https://github.com/brave/brave-core/pull/27909

Enabled tab detach browser test again(VerticalTabStripDragAndDropBrowserTest.DragTabToDetach)
to check mouse cursor is located over the dragged tab properly during
the dragging. But not sure it works well on CI.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

