### PR TITLE
Revert "Don't disable toolbar pinning" (uplift to 1.77.x)

### DIFF
--- a/app/feature_defaults_unittest.cc
+++ b/app/feature_defaults_unittest.cc
@@ -134,6 +134,9 @@ TEST(FeatureDefaultsTest, DisabledFeatures) {
       &feature_engagement::kIPHGMCCastStartStopFeature,
       &feature_engagement::kIPHPasswordsManagementBubbleAfterSaveFeature,
 #endif
+#if !BUILDFLAG(IS_ANDROID)
+      &features::kToolbarPinning,
+#endif
       &features::kBookmarkTriggerForPrerender2,
       &features::kChromeStructuredMetrics,
       &features::kCookieDeprecationFacilitatedTesting,

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -888,7 +888,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, TabSpecificAndGlobalPanelsTest) {
   tab_model()->ActivateTabAt(1);
   EXPECT_FALSE(panel_ui->IsSidePanelShowing());
 
-  // Open global panel when active tab index is 1.
+  // Open global panel when active tab indext is 1.
   panel_ui->Show(SidePanelEntryId::kBookmarks);
   WaitUntil(base::BindLambdaForTesting([&]() {
     return panel_ui->GetCurrentEntryId() == SidePanelEntryId::kBookmarks;

--- a/chromium_src/chrome/browser/ui/ui_features.cc
+++ b/chromium_src/chrome/browser/ui/ui_features.cc
@@ -15,6 +15,9 @@ OVERRIDE_FEATURE_DEFAULT_STATES({{
     {kFewerUpdateConfirmations, base::FEATURE_DISABLED_BY_DEFAULT},
 #endif
     {kTabHoverCardImages, base::FEATURE_DISABLED_BY_DEFAULT},
+#if !defined(ANDROID)
+    {kToolbarPinning, base::FEATURE_DISABLED_BY_DEFAULT},
+#endif
 }});
 
 }  // namespace features

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1536,6 +1536,10 @@
 -NewTabPageUtilDisableFlagBrowserTest.DisableDriveByFlag
 -NewTabPageUtilEnableFlagBrowserTest.EnableDriveByFlag
 
+# These tests fail because we don't support the search companion.
+-CompanionPage*
+-SidePanelCompanion2BrowserEnabledTest.FeatureEnabled
+
 # These tests fail because we provide our own override of the side panel which
 # does not enable this feature
 -All/LensOverlayControllerBrowserPDFContextualizationTest.Histograms/*
@@ -1930,14 +1934,7 @@
 # exited. See SidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange().
 -ExtensionSidePanelBrowserTest.CloseSidePanelButtonVisibleWhenExtensionsSidePanelOpen
 
-# These tests crash because ToolbarView tries to access
-# |pinned_toolbar_actions_container_| (typically from
-# ToolbarView::GetAnchorView(), but sometimes elsewhere). But we made that
-# container null as we don't want the panel pin button container. In production,
-# this crash doesn't happen because that code path is only effective if
-# features::IsToolbarPinningEnabled(). That feature is disabled by default.
--BrowserActionsBrowserTest.ShowAddressesBubbleOrPage
--BrowserActionsBrowserTest.ShowPaymentsBubbleOrPage
+# These test fail because kToolbarPinning is disabled
 -BrowserCommandControllerBrowserTestToolbarPinningOnly.ShowTranslateStatusFrenchPage
 -CastBrowserControllerTest.PausedIcon
 -CastBrowserControllerTest.UpdateIssues
@@ -1959,12 +1956,10 @@
 -DownloadToolbarUIControllerBrowserTest.ShowHide
 -PinnedToolbarActionsContainerBrowserTest.*
 -SendTabToSelfBubbleTest.BubbleTriggersCorrectlyWhenPinned
--SendTabToSelfBubbleTest.InvokeUi_ShowDeviceList
--SendTabToSelfBubbleTest.InvokeUi_ShowNoTargetDevicePromo
--SendTabToSelfBubbleTest.InvokeUi_ShowSigninPromo
 -SendTabToSelfToolbarIconControllerTest.DisplayNewEntry
 -SendTabToSelfToolbarIconControllerTest.ReplaceExistingEntry
--SendTabToSelfToolbarIconControllerTest.StorePendingNewEntry*
+-SendTabToSelfToolbarIconControllerTest.StorePendingNewEntryFromIncognitoBrowser
+-SendTabToSelfToolbarIconControllerTest.StorePendingNewEntryFromWebApp
 
 # These tests fail because we stub captions::IsLiveCaptionFeatureSuppported to
 # always return false
@@ -2129,6 +2124,7 @@
 -CredentialManagerBrowserTest.*
 -CriticalClientHintsBrowserTest.*
 -CrossProfileDebuggerApiTest.GetTargets
+-CustomizeChromeSidePanelBrowserTest.*
 -DataSaverBrowserTest.*
 -DataSaverWebAPIsBrowserTest.*
 -DebuggerApiTest.*
@@ -2366,6 +2362,7 @@
 -PageInfoBubbleViewAboutThisSiteBrowserTest.*
 -PageInfoBubbleViewAboutThisSiteDialogBrowserTest.*
 -PageInfoBubbleViewAboutThisSiteDisabledBrowserTest.*
+-PageInfoBubbleViewAboutThisSiteWithoutSidePanelBrowserTest.*
 -PageInfoBubbleViewIsolatedWebAppBrowserTest.InvokeUi_AppNameIsDisplayedInsteadOfOriginForIsolatedWebApps_REV2
 -PageInfoBubbleViewSyncBrowserTest.*
 -PageLoadMetricsBrowserTest.*


### PR DESCRIPTION
Uplift of #28017
Resolves https://github.com/brave/brave-browser/issues/44486

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.