### PR TITLE
[canary] Add markdown console support to `upgrade.py`

### DIFF
--- a/tools/cr/upgrade.py
+++ b/tools/cr/upgrade.py
@@ -3,23 +3,41 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""Version upgrade command line tool.
+"""**Version upgrade command line tool.**
+
+```
+⠀⠀⠀⠀⠀⢀⣴⣶⣶⣶⣶⣶⣶⣶⣶⣦⡀⠀⠀⠀⠀⠀
+⠀⣀⣤⣤⣶⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣶⣤⣤⣀⠀                              🚀
+⣾⣿⣿⣿⣿⡿⠛⠻⠿⠋⠁⠈⠙⠛⠛⠛⢿⣿⣿⣿⣿⣷                         .
+⢈⣿⣿⣿⠏⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠹⣿⣿⣿⡁                     .
+⣿⣿⣟⠁⠀⠴⣿⣿⣿⡄⠀⠀⢠⣿⣿⣿⠦⠀⠈⣻⣿⣿                .
+⣿⣿⣿⣧⡀⠀⠀⠀⣽⠇⠀⠀⠸⣯⠀⠀⠀⢀⣴⣿⣿⣿             .
+⠸⣿⣿⣿⣿⣄⠀⢼⣯⣀⠀⠀⣀⣽⡧⠀⢠⣾⣿⣿⣿⠇          .
+⠀⣿⣿⣿⣿⡟⠀⠀⠉⢻⣿⣿⡟⠉⠀⠀⢹⣿⣿⣿⣿⠀        .
+⠀⢹⣿⣿⣿⣧⣀⣀⣤⣾⣿⣿⣷⣤⣀⣀⣴⣿⣿⣿⡏⠀      .
+⠀⠈⣿⣿⣿⣿⣿⣿⣿⠛⠋⠙⠛⣿⣿⣿⣿⣿⣿⣿⠁⠀     .
+⠀⠀⠸⣿⣿⣿⣿⣿⣿⣷⣤⣠⣾⣿⣿⣿⣿⣿⣿⠇⠀⠀    .
+⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠟⠋⠀⠀⠀⠀   .
+⠀⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⠟⠋⠀⠀⠀⠀⠀⠀⠀💥
+```
 
 This tool is used to upgrade Brave to a desired version of Chromium. The goal
 is to produce a set of patches for the new chromium base version, that looks
 something like:
 
-1. Update from Chromium [from] to [to].
-2. Conflict-resolved patches from Chromium [from] to [to].
-3. Update patches from Chromium [from] to [to].
-4. Updated strings for Chromium [to].
+ * Update from Chromium [from] to [to].
+ * Conflict-resolved patches from Chromium [from] to [to].
+ * Update patches from Chromium [from] to [to].
+ * Updated strings for Chromium [to].
 
 The process is started by providing a target version to upgrade to. The tool
 uses the current upstream branch for the current branch as the base version,
 although that can be overriden with `--previous`.
 
-  git checkout -b cr135 origin/master
-  tools/cr/upgrade.py --to=135.0.7037.1
+```sh
+git checkout -b cr135 origin/master
+tools/cr/upgrade.py --to=135.0.7037.1
+```
 
 The workflow with this script:
 
@@ -35,7 +53,7 @@ The workflow with this script:
     asked to commit the deleted patches manually, preserving the history of why
     they are deleted.
 5. Having resolved all conflicts, the tool will be run again with the same
-   arguments, and with the added --continue flag.
+   arguments, and with the added `--continue` flag.
 6. This tool will then continue from the point where it stopped, staging all
    patches that were applied, and committing them as conflict-resolved patches.
 7. This tool will then continue to update the patches, and rebase the strings
@@ -44,9 +62,9 @@ The workflow with this script:
 Steps 3-7 may end up being skipped altogether if no failures take place, or in
 part if resolution is possible without manual intervention.
 
-Additionally, this tool can be run with the --update-patches-only flag. This is
-useful to generate the "Update patches" and "Updated strings" commits on their
-own when rebasing branches, regenerating these files as desired.
+Additionally, this tool can be run with the `--update-patches-only` flag. This
+is useful to generate the "Update patches" and "Updated strings" commits on
+their own when rebasing branches, regenerating these files as desired.
 """
 
 import argparse
@@ -54,8 +72,23 @@ from datetime import datetime
 import json
 from pathlib import Path
 import re
+from rich.console import Console
+from rich.markdown import Markdown
 import subprocess
 import sys
+
+
+class RichHelpFormatter(argparse.RawDescriptionHelpFormatter):
+
+    def __init__(self, prog):
+        super().__init__(prog)
+        self.console = Console()
+
+    def format_help(self):
+        self.console.print(Markdown(__doc__))
+        self.console.print('')
+        print(super().format_help())
+        return ""
 
 # This file is updated whenever the version number is updated in package.json
 PINSLIST_TIMESTAMP_FILE = 'chromium_src/net/tools/transport_security_state_generator/input_file_parsers.cc'
@@ -642,9 +675,8 @@ class Upgrade:
 
 def main():
     parser = argparse.ArgumentParser(
-        description=__doc__,
         # Custom formatter to preserve line breaks in the docstring
-        formatter_class=argparse.RawDescriptionHelpFormatter)
+        formatter_class=RichHelpFormatter)
 
     parser.add_argument('--previous',
                         help='The previous version to be shown as base.')


### PR DESCRIPTION
This change adds markdown support to the helper page of `upgrade.py`. This will be useful going forward for better user output, that brings to attention important elements. This change only applies it to the `--help` page.

Additionally, some tooling branding has been introduced.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44513

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

