### PR TITLE
🚀・(UI) Updated Desktop Shields Color (Matched to Figma Design)

### DIFF
--- a/components/brave_shields/resources/panel/components/main-panel/style.ts
+++ b/components/brave_shields/resources/panel/components/main-panel/style.ts
@@ -104,7 +104,7 @@ export const ControlBox = styled.div`
 `
 
 export const ShieldsIcon = styled.i<ShieldsIconProps>`
-  --fill-color: #5E6175;
+  --fill-color: #4541EE;
   width: 100%;
   height: auto;
   grid-column: 1;


### PR DESCRIPTION
I managed to find the Brave Shields notification color, so I matched it to the Figma concept. I hope it will be helpful.

**Before:**
![image](https://github.com/user-attachments/assets/f19deaf9-6a46-4765-bc91-6953fb7c2677)

**After:**
![image](https://github.com/user-attachments/assets/f13d61f1-21d7-4b4e-852b-8511822b22f2)