### PR TITLE
fix(privacy): Cached content blocker rule list version comparison on iOS

### DIFF
--- a/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerManager.swift
@@ -624,6 +624,16 @@ import os.log
   }
 }
 
+#if DEBUG
+extension ContentBlockerManager {
+  /// Assigns the given value to `cachedRuleLists` for testing with the `hasRuleList` functionality
+  /// NOTE: This should only be used in unit testing.
+  func setTestingCachedRuleLists(_ ruleLists: [String: CompileResult]) {
+    self.cachedRuleLists = ruleLists
+  }
+}
+#endif
+
 extension ShieldLevel {
   var preferredBlockingModes: Set<ContentBlockerManager.BlockingMode> {
     if isAggressive {


### PR DESCRIPTION
On iOS we cache the compiled rule lists for the Content Blocker. When caching, we store the cached version to the app preferences. We then use this cached version value to compare to the version when lists update to determine if we need to re-compile the `WKContentRuleList`. Unfortunately there was a bug with this version comparison. The version is stored as a `String` in 3 possible formats:

1. Date timestamp, ex. `"2025-01-23T19:55:25Z"`
2. Date timestamp + version, ex. `"2025-03-08T18:43:06Z,1.0.71"`
3. Version format, ex `"1.0.7341"`
    
The comparison for to determine if the existing (cached) version was older was incorrectly using String's `<` overload, which could fail for versions in the 3rd format - ex `"1.0.7341"` - resulting in us failing to recompile the `WKContentRuleList` with the updated list.

For example, consider these values where the new version has an extra character/digit:
```
let existingVersion = "1.0.999"
let newVersion = "1.0.1234"
```
If we use the `<` String overload, we fail to detect that the `existingVersion` is older than the `newVersion` because of String comparison and the extra character:
```existingVersion < newVersion == false```
This PR updates this version comparison to use [compare(_,options:range:locale:)](https://developer.apple.com/documentation/foundation/nsstring/1414561-compare) with `.numeric` option so version formats are compared as expected, and adds unit tests to verify.

<img width="729" alt="new digit in build number" src="https://github.com/user-attachments/assets/ca8cc90e-a3bf-4ad3-803b-90f39c8587af" /> | <img width="729" alt="same digits in build number" src="https://github.com/user-attachments/assets/ea415a49-3bde-4cad-8af8-0e53dfe549fe" />
--|--


Resolves https://github.com/brave/brave-browser/issues/44156

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This one is tricky to test as it requires a much older build of Brave installed (or use an exported App Container + set some user preference values in code). 
On the older build of Brave, attempt to load https://www.vejdirektoratet.dk/nyhed/2023/beslutning-om-igangsaettelse-af-kalundborgmotorvejens-3-etape. If you see ```Application error: a client-side exception has occurred (see the browser console for more information).``` you will be able to test this PR. For uplift verification, this must be a TestFlight Nightly build.

1. Load https://www.vejdirektoratet.dk/nyhed/2023/beslutning-om-igangsaettelse-af-kalundborgmotorvejens-3-etape
2. Verify you see error on site page:```Application error: a client-side exception has occurred (see the browser console for more information).```
<img src="https://github.com/user-attachments/assets/359877f2-9814-4c74-8829-8c8273822014" width="250">

3. Update to build containing this fix 
4. Go to Settings -> Shields & Privacy -> Content Filtering -> Update Lists
5. Reload https://www.vejdirektoratet.dk/nyhed/2023/beslutning-om-igangsaettelse-af-kalundborgmotorvejens-3-etape
6. Verify site displays, no more error.

### Developer testing:
1. Switch to `master` branch
2. Set a breakpoint at start of `application(_:willFinishLaunchingWithOptions:)`. 
3. In `ContentBlockerManager.swift`, in the initializer update the `self.versions` assignment to:
```
    self.versions = Preferences.Option(
      key: "content-blocker.versions",
      default: [
        "filter-list-group-standard-standard": "2025-03-07T18:43:06Z,1.0.71",
        "filter-list-group-standard-aggressive": "2025-03-07T18:43:06Z,1.0.71",
        "filter-list-bfpgedeaaibpoidldhjcknekahbikncb-aggressive": "1.0.9715",
        "filter-list-cdbbhgbmjhfnhnmgeddbliobbofkgdhe-aggressive": "1.0.7341",
        "filter-list-adcocjohghhfpidemphmcmlmhnfgikei-aggressive": "1.0.316",
        "stored-type-block-trackers": "2025-01-23T19:55:25Z",
        "stored-type-mixed-content-upgrade": "2025-01-23T19:55:25Z",
        "stored-type-block-cookies": "2025-01-23T19:55:25Z",
      ],
      container: container
    )
```
(This is required because we use a group for `UserDefaults`, so the preference values aren't included in the app container / `.xcappdata` file.)

4. Build & run on device, when you hit the breakpoint stop execution.
5. In Xcode, go to Window -> Devices & Simulators
6. In devices panel, find Brave install and replace the app container with: https://drive.google.com/file/d/1-wYnUvUyux9mkcX7MexLXqtZ_pq9-CKC/view?usp=drive_link
7. Launch the app on device.
8. Load https://www.vejdirektoratet.dk/nyhed/2023/beslutning-om-igangsaettelse-af-kalundborgmotorvejens-3-etape
9. You should see an error on the page:
```Application error: a client-side exception has occurred (see the browser console for more information).```
<img src="https://github.com/user-attachments/assets/359877f2-9814-4c74-8829-8c8273822014" width="250">

10. Checkout this branch `bugfix/ios-content-blocker-version-comparison`
11. Perform step 3 on this new branch.
12. Build & run
13. Go to Settings -> Shields & Privacy -> Content Filtering -> Update Lists
14. Reload https://www.vejdirektoratet.dk/nyhed/2023/beslutning-om-igangsaettelse-af-kalundborgmotorvejens-3-etape
15. Verify site displays, no more error.