### PR TITLE
[iOS] Fix url & progress displayed when https upgrade falls back

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -24,7 +24,7 @@ extension BrowserViewController: TabObserver {
       // didCommit is called and it will cause url bar be empty in that period
       // To fix this when tab display url is empty, webview url is used
       if tab === tabManager.selectedTab, tab.url?.displayURL == nil {
-        if let url = tab.url, !url.isLocal, !InternalURL.isValid(url: url) {
+        if let url = tab.visibleURL, !url.isLocal, !InternalURL.isValid(url: url) {
           updateToolbarCurrentURL(url.displayURL)
         }
       } else if tab === tabManager.selectedTab, tab.url?.displayURL?.scheme == "about",
@@ -55,7 +55,7 @@ extension BrowserViewController: TabObserver {
 
     // Update the estimated progress when the URL changes. Estimated progress may update to 0.1 when the url
     // is still an internal URL even though a request may be pending for a web page.
-    if tab === tabManager.selectedTab, let url = tab.url,
+    if tab === tabManager.selectedTab, let url = tab.visibleURL,
       !InternalURL.isValid(url: url), tab.estimatedProgress > 0
     {
       topToolbar.updateProgressBar(Float(tab.estimatedProgress))
@@ -71,7 +71,7 @@ extension BrowserViewController: TabObserver {
 
   func tabDidChangeLoadProgress(_ tab: Tab) {
     guard tab === tabManager.selectedTab else { return }
-    if let url = tab.url, !InternalURL.isValid(url: url) {
+    if let url = tab.visibleURL, !InternalURL.isValid(url: url) {
       topToolbar.updateProgressBar(Float(tab.estimatedProgress))
     } else {
       topToolbar.hideProgressBar()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebNavigationDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebNavigationDelegate.swift
@@ -8,6 +8,7 @@ import BraveWallet
 import Foundation
 import OSLog
 import Preferences
+import Shared
 
 /// A protocol that tells an object about web navigation related events happening
 ///
@@ -216,7 +217,11 @@ extension BrowserViewController: TabWebNavigationDelegate {
       tab.upgradeHTTPSTimeoutTimer = nil
 
       if tab === tabManager.selectedTab {
-        updateToolbarCurrentURL(tab.url?.displayURL)
+        if let displayURL = tab.url?.displayURL {
+          updateToolbarCurrentURL(displayURL)
+        } else if let url = tab.visibleURL, !url.isLocal, !InternalURL.isValid(url: url) {
+          updateToolbarCurrentURL(url.displayURL)
+        }
         updateWebViewPageZoom(tab: tab)
       }
       return true

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -320,6 +320,14 @@ class Tab: NSObject {
   /// The previous url that was set before `comittedURL` was set again
   private(set) var previousComittedURL: URL?
 
+  /// The URL that is loaded by the web view, but has not committed yet
+  var visibleURL: URL? {
+    if let webView {
+      return webView.url
+    }
+    return url
+  }
+
   private(set) var url: URL? {
     didSet {
       if let _url = url, let internalUrl = InternalURL(_url), internalUrl.isAuthorized {
@@ -598,10 +606,7 @@ class Tab: NSObject {
       url = newURL
       notifyObservers = true
     } else {
-      // If navigation will start from NTP, tab display url will be nil until
-      // didCommit is called and it will cause url bar be empty in that period
-      // To fix this when tab display url is empty, webview url is used
-      if isTabVisible() || url?.displayURL?.scheme == "about", !loading {
+      if isTabVisible(), url?.displayURL != nil, url?.displayURL?.scheme == "about", !loading {
         if let newURL {
           url = newURL
           notifyObservers = true


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

