### PR TITLE
[ads] Fix metric reporting placement and creative instance identifiers (uplift to 1.77.x)

### DIFF
--- a/components/brave_new_tab_ui/containers/newTab/index.tsx
+++ b/components/brave_new_tab_ui/containers/newTab/index.tsx
@@ -707,8 +707,8 @@ class NewTabPage extends React.Component<Props, State> {
                 }
 
                 getNTPBrowserAPI().sponsoredRichMediaAdEventHandler.reportRichMediaAdEvent(
-                  this.sponsoredRichMediaBackgroundInfo.creativeInstanceId,
                   this.sponsoredRichMediaBackgroundInfo.placementId,
+                  this.sponsoredRichMediaBackgroundInfo.creativeInstanceId,
                   adEventType)
 
                 if (adEventType === BraveAds.NewTabPageAdEventType.kClicked) {


### PR DESCRIPTION
Uplift of #28048
Resolves https://github.com/brave/brave-browser/issues/44544

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.