### PR TITLE
[canary] Adopting 🚀Brockit! as the util name

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -3,7 +3,7 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
-"""**Version upgrade command line tool.**
+"""**🚀Brockit! Guide**
 
 ```
 ⠀⠀⠀⠀⠀⢀⣴⣶⣶⣶⣶⣶⣶⣶⣶⣦⡀⠀⠀⠀⠀⠀
@@ -21,8 +21,9 @@
 ⠀⠀⠀⠀⠀⠀⠀⠙⠻⣿⣿⣿⣿⠟⠋⠀⠀⠀⠀⠀⠀⠀💥
 ```
 
-This tool is used to upgrade Brave to a newer Chromium base version, resulting
-in some or all of the following changes being produced:
+This is *🚀Brockit!* (Brave Rocket? Brave Rock it? Broke it?): a tool to help
+upgrade Brave to a newer Chromium base version. The main goal is to produce
+use it to commit the following changes:
 
  * Update from Chromium [from] to [to].
  * Conflict-resolved patches from Chromium [from] to [to].
@@ -34,49 +35,50 @@ either by providing a `--previous` argument, or by having an upstream branch to
 to your current branch.
 
 ```sh
-tools/cr/upgrade.py --to=135.0.7037.1 --previous=origin/master
+tools/cr/brockit.py --to=135.0.7037.1 --previous=origin/master
 ```
 
 Using upstream:
 
 ```sh
 git branch --set-upstream-to=origin/master
-tools/cr/upgrade.py --to=135.0.7037.1
+tools/cr/brockit.py --to=135.0.7037.1
 ```
 
 The following steps will take place:
 
-1. A "Update from Chromium [from] to [to]" commit will be created. This commit
+1. A *Update from Chromium [from] to [to]* commit will be created. This commit
    contains changes to `package.json` and to the pinlist timestamp file.
 2. `npm run init` will be run with the newer version.
 3. For any patches that fail to apply during `init`, there will be another
    attempt to apply them using `--3way`.
 4. If any patches still fail to apply, the process will stop. A summary of
    files with conflicts will be provided for resolution.
-5. Deleted patches will also cause the  tool to stop. The user is expected to
-   provide separate commits for deleted patches, explaining the reason.
-6. Having resolved all conflicts. Restart the tool with the same arguments as
-   before, but with the `--continue` flag.
-7. This tool will then continue from the point where it stopped, updating all
-   patches, staging all patches that were applied, and committing them as
-   "Conflict-resolved patches from Chromium [from] to [to]".
-8. "Update patches from Chromium [from] to [to]" will be committed.
-9. "Updated strings for Chromium [to]" will be committed.
+5. Deleted patches will also cause the  *🚀Brockit!* to stop . The user is
+   expected to provide separate commits for deleted patches, explaining the
+   reason.
+6. Having resolved all conflicts. Restart *🚀Brockit!* with the same arguments
+   as before, but add `--continue` as well.
+7. *🚀Brockit!* will pick up from where it stopped, possibly running
+  `npm run update_patches`, staging all patches, and committing the under
+  *Conflict-resolved patches from Chromium [from] to [to].*
+8. *Update patches from Chromium [from] to [to]* will be committed.
+9. *Updated strings for Chromium [to]* will be committed.
 
 Steps 3-7 may end up being skipped altogether if no failures take place, or in
 part if resolution is possible without manual intervention.
 
-Additionally, this tool can be run with the `--update-patches-only` flag. This
+Additionally, *🚀Brockit!* can be run with the `--update-patches-only` flag. This
 is useful to generate the "Update patches" and "Updated strings" commits on
 their own when rebasing branches, regenerating these files as desired.
 
 **Github support**
 
 Upgrade runs can also be accompanied by github tasks, by passing
-`--with-github` when running the this tool.
+`--with-github` when running *🚀Brockit!*.
 
 ```sh
-tools/cr/upgrade.py --to=135.0.7037.1 --with-github
+tools/cr/brockit.py --to=135.0.7037.1 --with-github
 ```
 
 This will attempt to create/update the github issue for the run as part of
@@ -793,7 +795,7 @@ class Upgrade:
                     if resolver.requires_conflict_resolution() is True:
                         # Manual resolution required.
                         console.log(
-                            '👋 (Once all conflicts are resolved ready, rerun this tool with [bold cyan]--continue[/])'
+                            '👋 (Once all conflicts are resolved ready, rerun *🚀Brockit!* with [bold cyan]--continue[/])'
                         )
                         return False
 
@@ -962,7 +964,7 @@ def main():
     args = parser.parse_args()
     upgrade = Upgrade(args.previous, args.to)
 
-    console.log('🚀')
+    console.log('[italic]🚀 Brockit!')
     if args.update_patches_only:
         upgrade.generate_patches()
     elif args.github_issue_only:


### PR DESCRIPTION
This utility is being given a unique name, to allow discussions around its use to be a bit less ambigious, and to give it a little bit more of a character.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

