### PR TITLE
[ads] Fix RichNTT content is un-clickable when the browser window is narrow

### DIFF
--- a/components/brave_new_tab_ui/components/default/page/index.tsx
+++ b/components/brave_new_tab_ui/components/default/page/index.tsx
@@ -49,6 +49,15 @@ function getItemRowCount(p: PageProps): number {
   return Math.max(left, right) + 1 // extra 1 for footer
 }
 
+const pointerEventPassthrough = css`
+ // Allow clicks to pass through to background.
+ pointer-events: none;
+ // Restore click events for child elements.
+ & > * {
+  pointer-events: auto;
+ }
+`
+
 const StyledPage = styled('div') <PageProps>`
   /* Increase the explicit row count when adding new widgets
      so that the footer goes in the correct location always,
@@ -110,14 +119,7 @@ const StyledPage = styled('div') <PageProps>`
     align-items: center;
   }
 
-  ${p => p.hasSponsoredRichMediaBackground && css`
-    // Allow clicks to pass through to background.
-    pointer-events: none;
-    // Restore click events for child elements.
-    & > * {
-      pointer-events: auto;
-    }
-  `};
+  ${p => p.hasSponsoredRichMediaBackground && pointerEventPassthrough}
 `
 
 export const Page: React.FunctionComponent<React.PropsWithChildren<PageProps>> = (props) => {
@@ -180,12 +182,14 @@ export const Page: React.FunctionComponent<React.PropsWithChildren<PageProps>> =
 export const GridItemStats = styled('section')`
   grid-column: 1 / span 2;
   ${singleColumnSmallViewport}
+  ${pointerEventPassthrough}
 `
 
 export const GridItemClock = styled('section')`
   grid-column: 3;
   justify-self: center;
   ${singleColumnSmallViewport}
+  ${pointerEventPassthrough}
 `
 
 export const GridItemWidgetStack = styled('section')`
@@ -199,6 +203,7 @@ export const GridItemWidgetStack = styled('section')`
 export const GridItemTopSites = styled('section')`
   grid-column: 1;
   ${singleColumnSmallViewport}
+  ${pointerEventPassthrough}
 `
 
 export const GridItemSponsoredImageClickArea = styled.section<{ otherWidgetsHidden: boolean }>`
@@ -269,7 +274,7 @@ export const BrandedWallpaperNotification = styled('div')`
 `
 
 export const GridItemNavigation = styled('section')`
-  grid-column: 2 / span 2;
+  grid-column: 3;
   grid-row: -2 / span 1;
   align-self: end;
   margin: 0 24px 24px 0;
@@ -308,6 +313,8 @@ export const Footer = styled('footer') <{}>`
     flex-direction: row;
     align-items: flex-end;
   }
+
+  ${pointerEventPassthrough}
 `
 
 export const FooterContent = styled('div')`


### PR DESCRIPTION
The PR changes some items in NTP grid to pass clicks through to make background RichNTT clickable.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44438

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

* Fresh install with dev component updater
* Open NTP until RichNTT is shown
  EXPECTATION:
  Area which is not covered by Stats, Favorites, Cards and Search widget is clickable
* Hide card button
* Narrow window to half of the screen
  EXPECTATION:
  Area between Favorites and Search widget is clickable
