### PR TITLE
Optimize HashPrefixStore

### DIFF
--- a/components/brave_rewards/core/engine/BUILD.gn
+++ b/components/brave_rewards/core/engine/BUILD.gn
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import("//third_party/flatbuffers/flatbuffer.gni")
 import("//third_party/protobuf/proto_library.gni")
 
 import("//brave/components/brave_rewards/core/engine/config.gni")
@@ -90,6 +91,10 @@ proto_library("publishers_proto") {
     "publisher/protos/channel_response.proto",
     "publisher/protos/publisher_prefix_list.proto",
   ]
+}
+
+flatbuffer("publishers_flatbuffers") {
+  sources = [ "publisher/flat/prefix_storage.fbs" ]
 }
 
 static_library("engine") {
@@ -444,6 +449,7 @@ static_library("engine") {
   ]
 
   deps = [
+    ":publishers_flatbuffers",
     ":publishers_proto",
     "//base",
     "//brave/components/brave_private_cdn",
@@ -460,6 +466,7 @@ static_library("engine") {
     "//third_party/abseil-cpp:absl",
     "//third_party/boringssl",
     "//third_party/brotli:dec",
+    "//third_party/flatbuffers:flatbuffers",
     "//third_party/protobuf:protobuf_lite",
     "//third_party/re2",
     "//url",

--- a/components/brave_rewards/core/engine/DEPS
+++ b/components/brave_rewards/core/engine/DEPS
@@ -1,6 +1,7 @@
 include_rules = [
   "+crypto",
   "+third_party/brotli",
+  "+third_party/flatbuffers",
   "+third_party/re2",
   "+sql",
 ]

--- a/components/brave_rewards/core/engine/hash_prefix_store.h
+++ b/components/brave_rewards/core/engine/hash_prefix_store.h
@@ -8,7 +8,6 @@
 
 #include <memory>
 #include <string>
-#include <string_view>
 
 #include "base/files/file_path.h"
 #include "base/files/memory_mapped_file.h"
@@ -18,6 +17,7 @@ namespace brave_rewards::internal {
 
 // Responsible for storage and retrieval of a sorted hash prefix list. The
 // operations of this class will block the current thread on IO.
+// See flat/prefix_storage.fbs for the format of the hash prefix file.
 class HashPrefixStore {
  public:
   explicit HashPrefixStore(base::FilePath path);
@@ -41,9 +41,8 @@ class HashPrefixStore {
 
  private:
   const base::FilePath file_path_;
+
   std::unique_ptr<base::MemoryMappedFile> mapped_file_;
-  std::string_view prefixes_;
-  size_t prefix_size_ = 0;
   bool open_called_ = false;
 
   SEQUENCE_CHECKER(sequence_checker_);

--- a/components/brave_rewards/core/engine/publisher/flat/prefix_storage.fbs
+++ b/components/brave_rewards/core/engine/publisher/flat/prefix_storage.fbs
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+namespace rewards.flat;
+
+// A structure to store a set of prefixes.
+// Each prefix is considered as the first 2 bytes (are used as index) + suffix.
+// Prefixes are stored as a collection where the first 2 bytes are used as an
+// index into the 'offsets' array (size 256*256 for all possible 2-byte values).
+// Each offset points to the position in 'all_suffixes' where the suffixes
+// for that prefix index begin.
+// Suffixes are stored contiguously for efficient binary search lookup.
+//
+// Memory usage = Header + 256 *256 * 4 (256KB) + N * (prefix_size - 2).
+
+table PrefixStorage {
+  magic: uint32;
+  prefix_size: uint32; // 4..32
+
+  offsets: [uint32]; // size = 256 * 256
+  all_suffixes: [ubyte]; // size = N * (prefix_size - 2)
+}
+
+root_type PrefixStorage;

--- a/components/brave_rewards/core/engine/test/BUILD.gn
+++ b/components/brave_rewards/core/engine/test/BUILD.gn
@@ -80,12 +80,14 @@ source_set("test") {
   deps = [
     "//base/test:test_support",
     "//brave/components/brave_rewards/core/engine",
+    "//brave/components/brave_rewards/core/engine:publishers_flatbuffers",
     "//brave/components/brave_rewards/core/engine:publishers_proto",
     "//brave/components/brave_rewards/core/mojom:engine",
     "//brave/components/challenge_bypass_ristretto",
     "//brave/third_party/rapidjson",
     "//net:net",
     "//sql:sql",
+    "//third_party/flatbuffers",
     "//url:url",
   ]
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
The PR:
* reduces the size of rewards publisher prefix storage by using another 
* uses flatbuffers as a container.

The structure:
Each prefix is considered as the first 2 bytes (are used as index) + suffix.
Prefixes are stored as a collection where the first 2 bytes are used as an
index into the 'offsets' array (size 256*256 for all possible 2-byte values).
Each offset points to the position in 'all_suffixes' where the suffixes
for that prefix index begin.
Suffixes are stored contiguously for efficient binary search lookup.

Memory usage before = 1.7M * 4 = 6.5 MB
Memory usage after = Header + 256KB (offsets) + 1.7M * 2 (prefix_count * (prefix_size - 2)) = 3.5MB

When this version is installed the old `RewardsCreators.db` will be dropped, the prefixes will be re-downloaded.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

