### PR TITLE
[Omnibox]: Additional bump for exact title matches

### DIFF
--- a/components/omnibox/browser/brave_bookmark_provider.cc
+++ b/components/omnibox/browser/brave_bookmark_provider.cc
@@ -51,8 +51,28 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
       continue;
     }
 
+    // By default |contents| is the folder the bookmark is in if there are no
+    // matches in the URL. Instead, we want to should show the URL that will be
+    // opened so the user knows what will happen when they select the result.
+    // Note: Bookmark paths are prefixed with a "/" to indicate they are
+    // relative to the bookmark root.
+    if (match.contents.starts_with(u"/")) {
+      // This is the same formatting used on Bookmark URLs normally.
+      match.contents = url_formatter::FormatUrl(
+          match.destination_url,
+          url_formatter::kFormatUrlOmitHTTPS |
+              url_formatter::kFormatUrlOmitDefaults |
+              url_formatter::kFormatUrlOmitTrivialSubdomains,
+          base::UnescapeRule::SPACES, nullptr, nullptr, nullptr);
+      // In this scenario we're matching the title, so its okay to display no
+      // matches on the URL.
+      match.contents_class = {
+          ACMatchClassification(0, ACMatchClassification::URL)};
+    }
+
     // Additional bump if the title is an exact match - this helps people with
-    // short bookmark titles for jumping to pages (like "sa" for "chrome://settings/appearance")
+    // short bookmark titles for jumping to pages (like "sa" for
+    // "chrome://settings/appearance")
     if (lower_description == lower_text) {
       match.relevance += kExactTitleBump;
     }

--- a/components/omnibox/browser/brave_bookmark_provider_unittest.cc
+++ b/components/omnibox/browser/brave_bookmark_provider_unittest.cc
@@ -137,5 +137,14 @@ TEST_F(BraveBookmarkProviderTest, ExactTitleMatchBumpsRelevance) {
   EXPECT_EQ(provider_->matches()[1].description, u"Hellow");
   EXPECT_TRUE(provider_->matches()[1].allowed_to_be_default_match);
 
-  EXPECT_GT(provider_->matches()[0].relevance, provider_->matches()[1].relevance);
+  EXPECT_GT(provider_->matches()[0].relevance,
+            provider_->matches()[1].relevance);
+}
+
+TEST_F(BraveBookmarkProviderTest, TitleOnlyMatchSetsURL) {
+  prefs()->SetBoolean(omnibox::kBookmarkSuggestionsEnabled, true);
+  provider_->Start(CreateAutocompleteInput("Hello"), true);
+  EXPECT_EQ(provider_->matches().size(), 1u);
+  EXPECT_TRUE(provider_->matches()[0].allowed_to_be_default_match);
+  EXPECT_EQ(provider_->matches()[0].contents, u"example.com");
 }

--- a/components/omnibox/browser/brave_bookmark_provider_unittest.cc
+++ b/components/omnibox/browser/brave_bookmark_provider_unittest.cc
@@ -122,3 +122,20 @@ TEST_F(BraveBookmarkProviderTest, ContainsQueryBumpsRelevance) {
   // Note: 1199 is the max relevance score for a bookmark upstream.
   EXPECT_GT(provider_->matches()[0].relevance, 1199);
 }
+
+TEST_F(BraveBookmarkProviderTest, ExactTitleMatchBumpsRelevance) {
+  prefs()->SetBoolean(omnibox::kBookmarkSuggestionsEnabled, true);
+  client_.GetBookmarkModel()->AddURL(client_.GetBookmarkModel()->other_node(),
+                                     0, u"Hellow",
+                                     GURL("https://example.com/one"));
+  provider_->Start(CreateAutocompleteInput("Hello"), true);
+  EXPECT_EQ(provider_->matches().size(), 2u);
+
+  EXPECT_EQ(provider_->matches()[0].description, u"Hello");
+  EXPECT_TRUE(provider_->matches()[0].allowed_to_be_default_match);
+
+  EXPECT_EQ(provider_->matches()[1].description, u"Hellow");
+  EXPECT_TRUE(provider_->matches()[1].allowed_to_be_default_match);
+
+  EXPECT_GT(provider_->matches()[0].relevance, provider_->matches()[1].relevance);
+}


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44450

[Screencast From 2025-03-12 13-29-51.webm](https://github.com/user-attachments/assets/327a1066-4167-4ca5-a056-3d96e4424eca)

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Create a bookmark for `chrome://settings/appearance` with the title `sa`
2. Close the tab
3. In a new tab, enter `sa` into the omnibox and press enter
4. chrome://settings/appearance should be opened.