### PR TITLE
Implement Tab Focus Mode with Leo

### DIFF
--- a/app/brave_generated_resources.grd
+++ b/app/brave_generated_resources.grd
@@ -1373,6 +1373,41 @@ Or change later at <ph name="SETTINGS_EXTENIONS_LINK">$2<ex>brave://settings/ext
       <message name="IDS_BRAVE_FILE_SELECT_SAVE_TITLE_NONSTANDARD_URL_IFRAME" desc="">
         An embedded page on this page wants to save
       </message>
+
+      <!-- Tab Search -->
+      <message name="IDS_BRAVE_ORGANIZE_TAB_TITLE" desc="Title for the tab organizer page">
+        Tab focus
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_SUBTITLE" desc="Subtitle for the tab organizer page">
+        Gather all related tabs into a new window
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_SUGGESTED_TOPICS_SUBTITLE" desc="Subtitle for the suggested topics section">
+        Suggested topics
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_TOPIC_INPUT_PLACEHOLDER" desc="Placeholder text for the input field to enter a topic">
+        Enter a topic to focus on...
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_SUBMIT_BUTTON_LABEL" desc="Label for the submit topic input button">
+        Go
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_UNDO_BUTTON_LABEL" desc="Label for the undo button">
+        Undo
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_WINDOW_CREATED_MESSAGE" desc="Message shown when a new window is created">
+        New window created for <ph name="TOPIC">$1<ex>Social media</ex></ph>
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_SEND_TAB_DATA_MESSAGE" desc="Description of how tab data is shared with Leo">
+        This feature sends data about your open tabs to Leo, Brave's AI-powered browser assistant.
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_LEARN_MORE_LABEL" desc="Text of the learn more link">
+        Learn more
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_GO_PREMIUM_BUTTON_LABEL" desc="Text of go premium button">
+        Go Premium
+      </message>
+      <message name="IDS_BRAVE_ORGANIZE_TAB_DISMISS_BUTTON_LABEL" desc="Text of the dismiss button">
+        Dismiss
+      </message>
       <!--Add new items to the appropriate sections above -->
     </messages>
   </release>

--- a/app/brave_settings_strings.grdp
+++ b/app/brave_settings_strings.grdp
@@ -1523,6 +1523,12 @@
   <message name="IDS_SETTINGS_LEO_ASSISTANT_SHOW_IN_CONTEXT_MENU_DESC" desc="The description for settings option to show Leo in context menu">
     Leo will appear in the context menu when you right-click on a website. This will send context from the current web page to Leo.
   </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_LABEL" desc="The text for settings option to enable tab focus mode">
+    Tab Focus Mode
+  </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_DESC" desc="The description for settings option to enable tab focus mode">
+    Enable tab organization in Tab Search page. When opened, this will automatically send the titles and origins of all non-private tabs to Leo to classify them. <ph name="BEGIN_LINK">&lt;a target="_blank" href="$1"&gt;</ph>Learn more<ph name="END_LINK">&lt;/a&gt;</ph>
+  </message>
   <message name="IDS_SETTINGS_LEO_ASSISTANT_SHOW_SUGGESTED_PROMPTS_LABEL" desc="The text for settings option">
     Show suggested prompts in the conversation
   </message>
@@ -1549,6 +1555,15 @@ Leo AI. This action can't be undone.
   </message>
   <message name="IDS_SETTINGS_AI_CHAT_CLEAR_HISTORY_DATA_SUBLABEL" desc="Label description for checkbox to select AI assistant conversations for deletion when deleting browser data">
     Chat history
+  </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_ABOUT_LEO_LABEL" desc="Label for the about Leo assistant section">
+    About Leo AI
+  </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_ABOUT_LEO_DESC_1" desc="Description for the about Leo assistant section">
+    Brave Leo provides privacy-first AI chat and other AI-powered interfaces in the browser. Leo never learns from your data or uses it for model training. All requests are proxied through an anonymizing server.
+  </message>
+  <message name="IDS_SETTINGS_LEO_ASSISTANT_ABOUT_LEO_DESC_2" desc="Description for learning more about Leo privacy policy">
+    Read more about how Brave protects your use of AI in Leo's privacy policy. <ph name="BEGIN_LINK">&lt;a target="_blank" href="$1"&gt;</ph>Learn more<ph name="END_LINK">&lt;/a&gt;</ph>
   </message>
   <message name="IDS_SETTINGS_LEO_ASSISTANT_MODEL_SELECTION_LABEL" desc="Label for selecting default model">
     Default model for new conversations

--- a/browser/extensions/api/settings_private/brave_prefs_util.cc
+++ b/browser/extensions/api/settings_private/brave_prefs_util.cc
@@ -256,6 +256,8 @@ const PrefsUtil::TypedPrefMap& BravePrefsUtil::GetAllowlistedKeys() {
       settings_api::PrefType::kBoolean;
   (*s_brave_allowlist)[ai_chat::prefs::kBraveAIChatShowToolbarButton] =
       settings_api::PrefType::kBoolean;
+  (*s_brave_allowlist)[ai_chat::prefs::kBraveAIChatTabOrganizationEnabled] =
+      settings_api::PrefType::kBoolean;
 
 #if !BUILDFLAG(USE_GCM_FROM_PLATFORM)
   // Push Messaging Pref

--- a/browser/resources/settings/brave_leo_assistant_page/brave_leo_assistant_page.html
+++ b/browser/resources/settings/brave_leo_assistant_page/brave_leo_assistant_page.html
@@ -34,6 +34,14 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     text-transform: uppercase;
   }
 
+  .header {
+    padding: var(--leo-spacing-2xl);
+  }
+
+  .main-header {
+    font: var(--leo-font-heading-h4);
+  }
+
   leo-dropdown {
     min-width: 240px;
   }
@@ -42,6 +50,17 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
     padding: var(--leo-spacing-m);
   }
 </style>
+
+<div class="settings-box header">
+  <div class="flex">
+    <div class="main-header">$i18n{braveLeoAssistantAboutLeoLabel}</div>
+    <div class="label secondary">
+      <p>$i18n{braveLeoAssistantAboutLeoDesc1}</p>
+      <p>$i18nRaw{braveLeoAssistantAboutLeoDesc2}</p>
+    </div>
+  </div>
+</div>
+
 <settings-toggle-button class="cr-row hr"
   pref="[[itemPref_(leoAssistantShowOnToolbarPref_)]]"
   label="$i18n{braveLeoAssistantShowIconOnToolbarLabel}"
@@ -51,6 +70,12 @@ You can obtain one at https://mozilla.org/MPL/2.0/. -->
   pref="{{prefs.brave.ai_chat.context_menu_enabled}}"
   label="$i18n{braveLeoAssistantShowInContextMenuLabel}"
   sub-label="$i18n{braveLeoAssistantShowInContextMenuDesc}">
+</settings-toggle-button>
+<settings-toggle-button class="cr-row hr"
+  pref="{{prefs.brave.ai_chat.tab_organization_enabled}}"
+  label="$i18n{braveLeoAssistantTabOrganizationLabel}"
+  sub-label-with-link="$i18n{braveLeoAssistantTabOrganizationDesc}"
+  on-sub-label-link-clicked="openTabOrganizationLearnMore_">
 </settings-toggle-button>
 <div class="settings-box">
   <div class="flex cr-padded-text">

--- a/browser/resources/settings/brave_leo_assistant_page/brave_leo_assistant_page.ts
+++ b/browser/resources/settings/brave_leo_assistant_page/brave_leo_assistant_page.ts
@@ -192,6 +192,10 @@ class BraveLeoAssistantPageElement extends BraveLeoAssistantPageBase {
       window.open(this.manageUrl_, "_self", "noopener noreferrer")
     }
 
+    openTabOrganizationLearnMore_() {
+      window.open(loadTimeData.getString('braveLeoAssistantTabOrganizationLearnMoreURL'), "_blank", "noopener noreferrer")
+    }
+
     private onStorageEnabledChange_(event: Event) {
       const target = event.target
       assert(target instanceof SettingsToggleButtonElement);

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -53,8 +53,6 @@ constexpr char kURLLearnMoreAboutStorage[] =
     "32663367857549-How-do-I-use-Chat-History-in-Brave-Leo";
 
 #if !BUILDFLAG(IS_ANDROID)
-constexpr char kURLGoPremium[] =
-    "https://account.brave.com/account/?intent=checkout&product=leo";
 constexpr char kURLManagePremium[] = "https://account.brave.com/";
 #endif
 }  // namespace
@@ -251,7 +249,7 @@ void AIChatUIPageHandler::OpenStorageSupportUrl() {
 
 void AIChatUIPageHandler::GoPremium() {
 #if !BUILDFLAG(IS_ANDROID)
-  OpenURL(GURL(kURLGoPremium));
+  OpenURL(GURL(kLeoGoPremiumUrl));
 #else
   auto* contents_to_navigate = (active_chat_tab_helper_)
                                    ? active_chat_tab_helper_->web_contents()

--- a/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
+++ b/browser/ui/webui/settings/brave_settings_localized_strings_provider.cc
@@ -87,6 +87,13 @@ constexpr char16_t kLeoCustomModelsLearnMoreURL[] =
     u"https://support.brave.com/hc/en-us/articles/"
     u"34070140231821-How-do-I-use-the-Bring-Your-Own-Model-BYOM-with-Brave-Leo";
 
+constexpr char16_t kTabOrganizationLearnMoreURL[] =
+    u"https://support.brave.com/hc/en-us/articles/"
+    u"360000766892-How-to-use-Tab-Focus-Mode";
+
+constexpr char16_t kLeoPrivacyPolicyURL[] =
+    u"https://brave.com/privacy/browser/#brave-leo";
+
 void BraveAddCommonStrings(content::WebUIDataSource* html_source,
                            Profile* profile) {
   webui::LocalizedString localized_strings[] = {
@@ -528,6 +535,8 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_LEO_ASSISTANT_SHOW_IN_CONTEXT_MENU_LABEL},
       {"braveLeoAssistantShowInContextMenuDesc",
        IDS_SETTINGS_LEO_ASSISTANT_SHOW_IN_CONTEXT_MENU_DESC},
+      {"braveLeoAssistantTabOrganizationLabel",
+       IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_LABEL},
       {"braveLeoAssistantHistoryPreferenceLabel",
        IDS_SETTINGS_LEO_ASSISTANT_HISTORY_PREFERENCE_LABEL},
       {"braveLeoAssistantHistoryPreferenceConfirm",
@@ -601,6 +610,10 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
        IDS_SETTINGS_LEO_ASSISTANT_YOUR_MODELS_TITLE},
       {"braveLeoAssistantYourModelsDesc1",
        IDS_SETTINGS_LEO_ASSISTANT_YOUR_MODELS_DESC_1},
+      {"braveLeoAssistantAboutLeoLabel",
+       IDS_SETTINGS_LEO_ASSISTANT_ABOUT_LEO_LABEL},
+      {"braveLeoAssistantAboutLeoDesc1",
+       IDS_SETTINGS_LEO_ASSISTANT_ABOUT_LEO_DESC_1},
       {"braveLeoModelSectionTitle", IDS_CHAT_UI_MENU_TITLE_MODELS},
       {"braveLeoAssistantEndpointInvalidError",
        IDS_SETTINGS_LEO_ASSISTANT_ENDPOINT_INVALID_ERROR},
@@ -953,6 +966,14 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       "braveLeoAssistantInputDefaultContextSize",
       base::NumberToString16(ai_chat::kDefaultCustomModelContextSize));
 
+  html_source->AddString("braveLeoAssistantTabOrganizationDesc",
+                         l10n_util::GetStringFUTF16(
+                             IDS_SETTINGS_LEO_ASSISTANT_TAB_ORGANIZATION_DESC,
+                             kTabOrganizationLearnMoreURL));
+
+  html_source->AddString("braveLeoAssistantTabOrganizationLearnMoreURL",
+                         kTabOrganizationLearnMoreURL);
+
 #if BUILDFLAG(ENABLE_EXTENSIONS)
   html_source->AddString("webDiscoveryLearnMoreURL", kWebDiscoveryLearnMoreUrl);
 #endif
@@ -993,6 +1014,11 @@ void BraveAddCommonStrings(content::WebUIDataSource* html_source,
       "braveLeoAssistantYourModelsDesc2",
       l10n_util::GetStringFUTF16(IDS_SETTINGS_LEO_ASSISTANT_YOUR_MODELS_DESC_2,
                                  kLeoCustomModelsLearnMoreURL));
+
+  html_source->AddString(
+      "braveLeoAssistantAboutLeoDesc2",
+      l10n_util::GetStringFUTF16(IDS_SETTINGS_LEO_ASSISTANT_ABOUT_LEO_DESC_2,
+                                 kLeoPrivacyPolicyURL));
 }  // NOLINT(readability/fn_size)
 
 void BraveAddResources(content::WebUIDataSource* html_source,

--- a/browser/ui/webui/tab_search/BUILD.gn
+++ b/browser/ui/webui/tab_search/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+# Curerntly this target is desktop only because chromium's
+# tab_search_page_handler is desktop only.
+assert(!is_android)
+
+source_set("browser_tests") {
+  testonly = true
+
+  sources = [ "tab_search_page_handler_browsertest.cc" ]
+
+  defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
+
+  deps = [
+    "//base",
+    "//brave/browser/ai_chat",
+    "//brave/components/ai_chat/core/browser",
+    "//brave/components/ai_chat/core/browser:test_support",
+    "//brave/components/resources:strings_grit",
+    "//chrome/browser/ui",
+    "//chrome/browser/ui:browser_navigator_params_headers",
+    "//chrome/test",
+    "//chrome/test:test_support",
+    "//testing/gtest",
+    "//ui/base",
+  ]
+}

--- a/browser/ui/webui/tab_search/tab_search_page_handler_browsertest.cc
+++ b/browser/ui/webui/tab_search/tab_search_page_handler_browsertest.cc
@@ -1,0 +1,211 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "chrome/browser/ui/webui/tab_search/tab_search_page_handler.h"
+
+#include <memory>
+#include <string>
+
+#include "base/memory/raw_ptr.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/utf_string_conversions.h"
+#include "base/test/bind.h"
+#include "base/test/gmock_callback_support.h"
+#include "base/test/mock_callback.h"
+#include "brave/browser/ai_chat/ai_chat_service_factory.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_service.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/engine/mock_engine_consumer.h"
+#include "brave/components/ai_chat/core/browser/types.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/browser/ui/browser_commands.h"
+#include "chrome/browser/ui/browser_list.h"
+#include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/test/test_browser_closed_waiter.h"
+#include "chrome/browser/ui/webui/tab_search/tab_search_ui.h"
+#include "chrome/common/webui_url_constants.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "components/grit/brave_components_strings.h"
+#include "content/public/browser/navigation_controller.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "content/public/test/test_utils.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+namespace {
+
+constexpr char kFooDotComUrl1[] = "https://foo.com/1";
+constexpr char kFooDotComUrl2[] = "https://foo.com/2";
+constexpr char kBarDotComUrl1[] = "https://bar.com/1";
+constexpr char kBarDotComUrl2[] = "https://bar.com/2";
+
+constexpr char kFooDotComTitle1[] = "foo.com 1";
+constexpr char kFooDotComTitle2[] = "foo.com 2";
+constexpr char kBarDotComTitle1[] = "bar.com 1";
+constexpr char kBarDotComTitle2[] = "bar.com 2";
+
+}  // namespace
+
+using testing::_;
+
+class TabSearchPageHandlerBrowserTest : public InProcessBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+    webui_contents_ = content::WebContents::Create(
+        content::WebContents::CreateParams(browser()->profile()));
+
+    webui_contents_->GetController().LoadURLWithParams(
+        content::NavigationController::LoadURLParams(
+            GURL(chrome::kChromeUITabSearchURL)));
+
+    // Finish loading after initializing.
+    ASSERT_TRUE(content::WaitForLoadStop(webui_contents_.get()));
+
+    // Create another browser with the default profile.
+    chrome::NewEmptyWindow(profile1(), false);
+  }
+
+  void TearDownOnMainThread() override {
+    webui_contents_.reset();
+    InProcessBrowserTest::TearDownOnMainThread();
+  }
+
+  TabSearchPageHandler* handler() {
+    return webui_contents_->GetWebUI()
+        ->GetController()
+        ->template GetAs<TabSearchUI>()
+        ->page_handler_for_testing();
+  }
+
+  Profile* profile1() { return browser()->profile(); }
+
+  void AppendTabWithTitle(Browser* browser,
+                          const GURL& url,
+                          const std::string& title) {
+    chrome::AddTabAt(browser, url, -1, true);
+    content::WebContents* web_contents =
+        browser->tab_strip_model()->GetActiveWebContents();
+    web_contents->UpdateTitleForEntry(
+        web_contents->GetController().GetLastCommittedEntry(),
+        base::UTF8ToUTF16(title));
+  }
+
+ protected:
+  std::unique_ptr<content::WebContents> webui_contents_;
+};
+
+IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest, GetFocusTabs) {
+  // Test Engine's GetFocusTabs is called with expected tabs info and topic.
+  auto* ai_chat_service =
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile1());
+  ai_chat_service->SetTabOrganizationEngineForTesting(
+      std::make_unique<ai_chat::MockEngineConsumer>());
+
+  BrowserList* browser_list = BrowserList::GetInstance();
+  ASSERT_EQ(browser_list->size(), 2u);
+  Browser* browser2 = browser_list->get(1);
+
+  // Add tabs in windows with the default profile.
+  AppendTabWithTitle(browser(), GURL(kFooDotComUrl1), kFooDotComTitle1);
+  AppendTabWithTitle(browser(), GURL(kFooDotComUrl2), kFooDotComTitle2);
+  AppendTabWithTitle(browser2, GURL(kBarDotComUrl1), kBarDotComTitle1);
+  AppendTabWithTitle(browser2, GURL(kBarDotComUrl2), kBarDotComTitle2);
+
+  // size is 3 because a blank tab is added by default when creating windows.
+  ASSERT_EQ(browser()->tab_strip_model()->count(), 3);
+  ASSERT_EQ(browser2->tab_strip_model()->count(), 3);
+
+  const int tab_id1 =
+      browser()->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value();
+  const int tab_id2 =
+      browser()->tab_strip_model()->GetTabAtIndex(2)->GetHandle().raw_value();
+  const int tab_id3 =
+      browser2->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value();
+  const int tab_id4 =
+      browser2->tab_strip_model()->GetTabAtIndex(2)->GetHandle().raw_value();
+
+  std::vector<ai_chat::Tab> expected_tabs = {
+      {base::NumberToString(tab_id1), kFooDotComTitle1,
+       url::Origin::Create(GURL(kFooDotComUrl1))},
+      {base::NumberToString(tab_id2), kFooDotComTitle2,
+       url::Origin::Create(GURL(kFooDotComUrl2))},
+      {base::NumberToString(tab_id3), kBarDotComTitle1,
+       url::Origin::Create(GURL(kBarDotComUrl1))},
+      {base::NumberToString(tab_id4), kBarDotComTitle2,
+       url::Origin::Create(GURL(kBarDotComUrl2))},
+  };
+
+  std::vector<std::string> mock_ret_tabs = {base::NumberToString(tab_id1),
+                                            "100", "invalid",
+                                            base::NumberToString(tab_id4)};
+  auto* mock_engine = static_cast<ai_chat::MockEngineConsumer*>(
+      ai_chat_service->GetTabOrganizationEngineForTesting());
+  std::string model_name = ai_chat::kClaudeHaikuModelName;
+  EXPECT_CALL(*mock_engine, GetModelName())
+      .WillOnce(testing::ReturnRef(model_name));
+  EXPECT_CALL(*mock_engine, GetFocusTabs(expected_tabs, "topic", _))
+      .WillOnce(base::test::RunOnceCallback<2>(mock_ret_tabs));
+
+  base::RunLoop run_loop1;
+  handler()->GetFocusTabs("topic", base::BindLambdaForTesting(
+                                       [&](bool new_window_created,
+                                           tab_search::mojom::ErrorPtr error) {
+                                         EXPECT_TRUE(new_window_created);
+                                         EXPECT_FALSE(error);
+                                         run_loop1.Quit();
+                                       }));
+  run_loop1.Run();
+
+  Browser* active_browser = browser_list->GetLastActive();
+  ASSERT_EQ(browser_list->size(), 3u) << "A new window should be created.";
+  ASSERT_EQ(active_browser, browser_list->get(2))
+      << "The new window should be active.";
+  EXPECT_EQ(active_browser->tab_strip_model()->count(), 2)
+      << "The new window should have 2 tabs.";
+  EXPECT_EQ(active_browser->user_title(), "topic");
+
+  // Check the tabs are moved to the new window as expected.
+  EXPECT_EQ(active_browser->tab_strip_model()
+                ->GetTabAtIndex(0)
+                ->GetHandle()
+                .raw_value(),
+            tab_id1);
+  EXPECT_EQ(active_browser->tab_strip_model()
+                ->GetTabAtIndex(1)
+                ->GetHandle()
+                .raw_value(),
+            tab_id4);
+
+  // Test undo.
+  base::RunLoop run_loop2;
+  handler()->UndoFocusTabs(base::BindLambdaForTesting([&]() {
+    // Wait for the new window to be closed.
+    ASSERT_EQ(browser_list->size(), 3u);
+    ASSERT_TRUE(
+        TestBrowserClosedWaiter(browser_list->get(2)).WaitUntilClosed());
+
+    Browser* browser1 = browser_list->get(0);
+    EXPECT_EQ(browser1->tab_strip_model()->count(), 3)
+        << "The tabs should be moved back to the previous active window.";
+    EXPECT_EQ(
+        browser1->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value(),
+        tab_id1);
+    Browser* browser2 = browser_list->get(1);
+    EXPECT_EQ(browser2->tab_strip_model()->count(), 3)
+        << "The tabs should be moved back to the previous active window.";
+    EXPECT_EQ(
+        browser2->tab_strip_model()->GetTabAtIndex(2)->GetHandle().raw_value(),
+        tab_id4);
+    run_loop2.Quit();
+  }));
+
+  run_loop2.Run();
+}

--- a/chromium_src/chrome/browser/resources/tab_search/auto_tab_groups/auto_tab_groups_page.css
+++ b/chromium_src/chrome/browser/resources/tab_search/auto_tab_groups/auto_tab_groups_page.css
@@ -1,0 +1,168 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+/* #css_wrapper_metadata_start
+ * #type=style-lit
+ * #css_wrapper_metadata_end */
+
+#brave-tab-focus {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.auto-tab-groups-header {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  padding: var(--leo-spacing-xl);
+  gap: var(--leo-spacing-l);
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--leo-color-divider-subtle);
+}
+
+.title-row {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  gap: var(--leo-spacing-m);
+  box-sizing: border-box;
+}
+
+.title-column {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: var(--leo-spacing-s);
+}
+
+.input-row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  gap: var(--leo-spacing-m);
+}
+
+.title {
+  font: var(--leo-font-heading-h4);
+  color: var(--leo-color-text-primary);
+  text-align: left;
+}
+
+.subtitle {
+  font: var(--leo-font-default-regular);
+  color: var(--leo-color-text-secondary);
+  text-align: left;
+}
+
+.topics-title {
+  font: var(--leo-font-default-semibold);
+  color: var(--leo-color-text-secondary);
+  text-align: left;
+}
+
+.topic-input {
+  width: 100%;
+}
+
+.topics-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  padding: var(--leo-spacing-xl) var(--leo-spacing-xl) 0px var(--leo-spacing-xl);
+  gap: var(--leo-spacing-m);
+  box-sizing: border-box;
+}
+
+.topics-button {
+  --leo-button-padding: 3px;
+  --leo-button-radius: var(--leo-radius-m);
+  width: 100%;
+  container-type: inline-size;
+  --leo-button-color: var(--leo-color-divider-subtle);
+}
+
+.topic-description {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100cqw;
+  gap: var(--leo-spacing-m);
+  color: var(--leo-color-text-secondary);
+  font: var(--leo-font-default-regular);
+  padding: 0 calc(var(--leo-button-padding) + var(--border-width));
+  text-align: left;
+}
+
+.emoji-wrapper {
+  display: flex;
+  flex-shrink: 0;
+  align-self: stretch;
+  min-height: 32px;
+  width: 32px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--leo-color-neutral-10);
+  padding: var(--leo-spacing-s);
+  font-size: 20px;
+  border-radius: var(--leo-radius-s);
+  margin-left: 4px;
+}
+
+.loading-ring {
+  --leo-progressring-color: var(--leo-color-icon-default);
+  --leo-progressring-size: 20px;
+}
+
+.empty-state {
+  display: flex;
+  width: 100%;
+  height: 24px;
+  background-color: var(--leo-color-neutral-10);
+  border-radius: var(--leo-radius-s);
+  margin-right: var(--leo-spacing-m);
+}
+
+.footer {
+  display: flex;
+  padding: var(--leo-spacing-xl);
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--leo-spacing-s);
+  align-self: stretch;
+  color: var(--leo-color-text-tertiary);
+}
+
+.learn-more-link {
+  color: var(--leo-color-text-tertiary);
+  font-feature-settings: 'ss03' on;
+  text-decoration-line: underline;
+  text-decoration-style: solid;
+  text-decoration-skip-ink: none;
+  text-decoration-thickness: auto;
+  text-underline-offset: auto;
+}
+
+.error-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  padding: var(--leo-spacing-l);
+  box-sizing: border-box;
+}

--- a/chromium_src/chrome/browser/resources/tab_search/auto_tab_groups/auto_tab_groups_page.html.ts
+++ b/chromium_src/chrome/browser/resources/tab_search/auto_tab_groups/auto_tab_groups_page.html.ts
@@ -1,0 +1,157 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { html } from '//resources/lit/v3_0/lit.rollup.js'
+import type { AutoTabGroupsPageElement } from './auto_tab_groups_page.js'
+
+function getUndoFocusTabsHtml(this:  AutoTabGroupsPageElement) {
+  return this.undoTopic_ !== '' ? html`
+    <leo-alert
+      id="undo"
+      type="success"
+      hideIcon={true}
+    >
+      ${this.getWindowCreatedMessage_()}
+      <leo-button
+        id="undoButton"
+        kind="plain-faint"
+        size="tiny"
+        @click="${this.onUndoClicked_}"
+      >
+        ${this.getUndoButtonLabel_()}
+      </leo-button>
+    </leo-alert>
+  ` : ''
+}
+
+function getTopicsHtml(this:  AutoTabGroupsPageElement) {
+  return this.isLoadingTopics
+  ? [1, 2, 3, 4, 5].map((key) => html`
+    <leo-button
+      key=${key}
+      class="topics-button"
+      size="small"
+      kind="outline"
+      isDisabled={true}
+    >
+      <div class="topic-description">
+        <div class="emoji-wrapper">
+          <leo-progressring class="loading-ring"></leo-progressring>
+        </div>
+        <div class="empty-state"></div>
+      </div>
+    </leo-button>
+  `)
+  : this.topics_.map((entry, index) => html`
+      <leo-button
+        id="${this.getTopicId_(index)}"
+        class="topics-button"
+        size="small"
+        kind="outline"
+        @click="${() => this.onTopicClicked_(index)}"
+      >
+        <div class="topic-description">
+          <div class="emoji-wrapper">
+            ${this.getTopicEmoji_(entry)}
+          </div>
+          ${this.getTopicWithoutEmoji_(entry)}
+        </div>
+      </leo-button>
+  `)
+}
+
+export function getHtml(this:  AutoTabGroupsPageElement) {
+  return html`<!--_html_template_start_-->
+    <div id="brave-tab-focus" class="brave-tab-focus">
+      <div
+        id="header"
+        class="auto-tab-groups-header"
+        aria-live="polite"
+        aria-relevant="all"
+      >
+        <div class='title-row'>
+          ${this.showBackButton ? html`
+            <leo-button
+              size="medium"
+              kind="plain-faint"
+              fab
+              @click=${this.onBackClick_}
+            >
+              <leo-icon name="arrow-left"></leo-icon>
+            </leo-button>
+          ` : ''}
+          <div class='title-column'>
+            <div class="title">${this.getTitle_()}</div>
+            <div class="subtitle">${this.getSubtitle_()}</div>
+          </div>
+        </div>
+        <div class="input-row">
+          <leo-input
+            id="topic-input"
+            class="topic-input"
+            placeholder="${this.getTopicInputPlaceholder_()}"
+            type="text"
+            value=${this.topic}
+            @input=${this.onTopicInputChanged_}
+            ?disabled=${this.errorMessage !== ''}>
+          </leo-input>
+          <leo-button
+            id="submitButton"
+            size="medium"
+            fab
+            @click=${this.onFocusTabsClicked_}
+            ?isDisabled=${this.errorMessage !== ''}
+          >
+            ${this.getSubmitButtonLabel_()}
+          </leo-button>
+        </div>
+        ${getUndoFocusTabsHtml.bind(this)()}
+      </div>
+      ${this.errorMessage === '' ? html`
+        <div class="topics-wrapper">
+          <div class="topics-title">${this.getSuggestedTopicsSubtitle_()}</div>
+          ${getTopicsHtml.bind(this)()}
+        </div>
+      ` : html`
+          <div class="error-wrapper">
+            <leo-alert
+              id="error"
+              type="error"
+            >
+              ${this.errorMessage}
+              ${this.needsPremium ? html`
+                <div slot="actions">
+                  <leo-button
+                    id="premiumButton"
+                    kind="filled"
+                    size="medium"
+                    @click="${this.onGoPremiumClicked_}"
+                  >
+                    ${this.getGoPremiumButtonLabel_()}
+                  </leo-button>
+                  <leo-button
+                    id="dismissButton"
+                    kind="plain-faint"
+                    size="medium"
+                    @click="${this.onDismissErrorClicked_}"
+                  >
+                    ${this.getDismissButtonLabel_()}
+                  </leo-button>
+                </div>
+              ` : ''}
+            </leo-alert>
+          </div>
+      `}
+      ${this.errorMessage === '' ? html`
+      <div class="footer">
+        ${this.getFooterMessage_()}
+        <span class="learn-more-link" @click=${this.onLearnMoreClicked_}>
+          ${this.getLearnMoreLabel_()}
+        </span>
+      </div>
+      ` : ''}
+    </div>
+    <!--_html_template_end_-->`
+}

--- a/chromium_src/chrome/browser/resources/tab_search/auto_tab_groups/auto_tab_groups_page.ts
+++ b/chromium_src/chrome/browser/resources/tab_search/auto_tab_groups/auto_tab_groups_page.ts
@@ -1,0 +1,260 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import '//resources/cr_elements/cr_button/cr_button.js'
+import '//resources/cr_elements/cr_input/cr_input.js'
+
+import {loadTimeData} from '//resources/js/load_time_data.js'
+import {CrLitElement} from '//resources/lit/v3_0/lit.rollup.js'
+
+import {BraveTabSearchApiProxy, TabSearchApiProxyImpl} from '../tab_search_api_proxy.js'
+import type {TabOrganizationSession} from '../tab_search.mojom-webui.js'
+
+import {getHtml} from './auto_tab_groups_page.html.js'
+import {getCss} from './auto_tab_groups_page.css.js'
+
+export class AutoTabGroupsPageElement extends CrLitElement {
+  static get is() {
+    return 'auto-tab-groups-page'
+  }
+
+  protected topics_: string[] = []
+  protected topic = ''
+  protected undoTopic_ = ''
+
+  private apiProxy_: BraveTabSearchApiProxy =
+      TabSearchApiProxyImpl.getInstance() as BraveTabSearchApiProxy
+
+  private visibilityChangedListener_: () => void
+  private elementVisibilityChangedListener_: IntersectionObserver
+  private isElementVisible_ = false
+
+  static override get properties() {
+    return {
+      availableHeight: {type: Number},
+      showBackButton: {type: Boolean},
+      topic: {type: String},
+      topics_: {type: Array},
+      undoTopic_: {type: String},
+      isLoadingTopics: {type: Boolean},
+      errorMessage: {type: String},
+      needsPremium: {type: Boolean},
+    }
+  }
+
+  availableHeight = 0
+  showBackButton = false
+  isLoadingTopics = false
+  errorMessage = ''
+  needsPremium = false
+
+  static override get styles() {
+    return getCss()
+  }
+
+  constructor() {
+    super()
+
+    this.visibilityChangedListener_ = this.maybeUpdateSuggestedTopics_
+
+    this.elementVisibilityChangedListener_ =
+        new IntersectionObserver((entries, _observer) => {
+          this.onElementVisibilityChanged_((entries[0]?.intersectionRatio ?? 0) > 0);
+        }, {root: document.documentElement})
+
+  }
+
+  protected onTopicInputChanged_(e: any) {
+    this.topic = e.value
+  }
+
+  protected onFocusTabsClicked_() {
+    this.getFocusTabs_(this.topic)
+  }
+
+  protected onUndoClicked_() {
+    this.apiProxy_.undoFocusTabs().then(() => {
+      this.undoTopic_ = ''
+    })
+  }
+
+  private getFocusTabs_(topic: string) {
+    this.undoTopic_ = ''
+    this.apiProxy_.getFocusTabs(topic).then(({windowCreated, error}) => {
+      if (error) {
+        this.errorMessage = error.message
+        if (error.rateLimitedInfo) {
+          this.needsPremium = !error.rateLimitedInfo.isPremium
+        }
+        return
+      }
+      this.errorMessage = ''
+      if (windowCreated) {
+        this.undoTopic_ = topic
+      }
+    })
+  }
+
+  private maybeUpdateSuggestedTopics_ = () => {
+    // Don't update if it's already loading topics or when it's not visible.
+    if (this.isLoadingTopics ||
+        document.visibilityState !== 'visible' ||
+        !this.isElementVisible_) {
+      return
+    }
+
+    this.isLoadingTopics = true
+    this.apiProxy_.getSuggestedTopics().then(({topics, error}) => {
+      this.isLoadingTopics = false
+      if (error) {
+        this.errorMessage = error.message
+        if (error.rateLimitedInfo) {
+          this.needsPremium = !error.rateLimitedInfo.isPremium
+        }
+        return
+      }
+      this.onSuggestTopicsUpdated(topics)
+      this.errorMessage = ''
+    })
+  }
+
+  private onSuggestTopicsUpdated(topics: string[]) {
+    this.topics_ = topics
+  }
+
+  protected getTopicId_(index: number): string {
+    return 'topicId' + index
+  }
+
+  protected getTopicWithoutEmoji_(topic: string): string {
+    return topic.replace(/[^\x20-\x7F]/g, '').trimStart()
+  }
+
+  protected getTopicEmoji_(topic: string): string {
+    return topic.match(/^\p{Emoji}/u)![0]
+  }
+
+  protected onTopicClicked_(index: number) {
+    if (this.topics_[index]) {
+      this.getFocusTabs_(this.topics_[index])
+    }
+  }
+
+  override render() {
+    return getHtml.bind(this)()
+  }
+
+  override connectedCallback() {
+    super.connectedCallback()
+
+    document.addEventListener('visibilitychange',
+                              this.visibilityChangedListener_)
+    this.elementVisibilityChangedListener_.observe(this)
+
+    this.maybeUpdateSuggestedTopics_()
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback()
+
+    document.removeEventListener('visibilitychange',
+                                 this.visibilityChangedListener_)
+    this.elementVisibilityChangedListener_.disconnect()
+  }
+
+  protected getTitle_(): string {
+    return loadTimeData.getString('tabOrganizationTitle')
+  }
+
+  protected getSubtitle_(): string {
+    return loadTimeData.getString('tabOrganizationSubtitle')
+  }
+
+  protected getSuggestedTopicsSubtitle_(): string {
+    return loadTimeData.getString('tabOrganizationSuggestedTopicsSubtitle')
+  }
+
+  protected getBackButtonAriaLabel_(): string {
+    return loadTimeData.getStringF('backButtonAriaLabel', this.getTitle_())
+  }
+
+  protected getSubmitButtonLabel_(): string {
+    return loadTimeData.getString('tabOrganizationSubmitButtonLabel')
+  }
+
+  protected getUndoButtonLabel_(): string {
+    return loadTimeData.getString('tabOrganizationUndoButtonLabel')
+  }
+
+  protected getWindowCreatedMessage_(): string {
+    return loadTimeData.getStringF('tabOrganizationWindowCreatedMessage', this.undoTopic_)
+  }
+
+  protected getTopicInputPlaceholder_(): string {
+    return loadTimeData.getString('tabOrganizationTopicInputPlaceholder')
+  }
+
+  protected getFooterMessage_(): string {
+    return loadTimeData.getStringF('tabOrganizationSendTabDataMessage')
+  }
+
+  protected getLearnMoreLabel_(): string {
+    return loadTimeData.getString('tabOrganizationLearnMoreLabel')
+  }
+
+  protected getGoPremiumButtonLabel_(): string {
+    return loadTimeData.getString('tabOrganizationGoPremiumButtonLabel')
+  }
+
+  protected getDismissButtonLabel_(): string {
+    return loadTimeData.getString('tabOrganizationDismissButtonLabel')
+  }
+
+  protected onLearnMoreClicked_() {
+    this.apiProxy_.openHelpPage()
+  }
+
+  protected onGoPremiumClicked_() {
+    this.apiProxy_.openLeoGoPremiumPage()
+  }
+
+  protected onDismissErrorClicked_() {
+    this.errorMessage = ''
+  }
+
+  override focus() {
+    if (this.showBackButton) {
+      const backButton = this.shadowRoot!.querySelector('cr-icon-button')!
+      backButton.focus()
+    } else {
+      super.focus()
+    }
+  }
+
+  protected onBackClick_() {
+    this.fire('back-click')
+  }
+
+  private onElementVisibilityChanged_(visible: boolean) {
+    if (this.isElementVisible_ === visible) {
+      return
+    }
+
+    this.isElementVisible_ = visible
+    this.maybeUpdateSuggestedTopics_()
+  }
+
+  // Shim for Chromium auto_tab_groups_page test.
+  setSessionForTesting(_session: TabOrganizationSession) {
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'auto-tab-groups-page': AutoTabGroupsPageElement
+  }
+}
+
+customElements.define(AutoTabGroupsPageElement.is, AutoTabGroupsPageElement)

--- a/chromium_src/chrome/browser/resources/tab_search/tab_search_api_proxy.ts
+++ b/chromium_src/chrome/browser/resources/tab_search/tab_search_api_proxy.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { TabSearchApiProxy, TabSearchApiProxyImpl } from './tab_search_api_proxy-chromium.js'
+
+import type { Error } from './tab_search.mojom-webui.js'
+
+export interface BraveTabSearchApiProxy extends TabSearchApiProxy {
+  getSuggestedTopics: () => Promise<{ topics: string[], error: Error | null }>
+  getFocusTabs: (topic: string) => Promise<{ windowCreated: boolean, error: Error | null }>
+  undoFocusTabs: () => Promise<void>
+  openLeoGoPremiumPage: () => void
+}
+
+export class BraveTabSearchApiProxyImpl extends TabSearchApiProxyImpl implements BraveTabSearchApiProxy {
+  getSuggestedTopics() {
+    return this.handler.getSuggestedTopics()
+  }
+
+  getFocusTabs(topic: string) {
+    return this.handler.getFocusTabs(topic)
+  }
+
+  undoFocusTabs() {
+    return this.handler.undoFocusTabs()
+  }
+
+  openLeoGoPremiumPage() {
+    this.handler.openLeoGoPremiumPage()
+  }
+}
+
+TabSearchApiProxyImpl.getInstance = () => {
+  return braveInstance || (braveInstance = new BraveTabSearchApiProxyImpl())
+}
+
+let braveInstance: BraveTabSearchApiProxy | null = null
+
+export * from './tab_search_api_proxy-chromium.js'

--- a/chromium_src/chrome/browser/ui/webui/DEPS
+++ b/chromium_src/chrome/browser/ui/webui/DEPS
@@ -8,6 +8,7 @@ include_rules = [
   "+brave/components/brave_private_cdn",
   "+brave/components/brave_vpn/common",
   "+brave/components/playlist/common",
+  "+brave/components/ai_chat/core/browser",
   "+brave/components/ai_chat/core/common",
   "+brave/components/brave_education/buildflags.h",
 ]

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search.mojom
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search.mojom
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+module tab_search.mojom;
+
+[BraveAdd]
+struct RateLimitedInfo {
+  // Provide premium status for front end to determine if we need to show
+  // premium purchase button.
+  bool is_premium;
+};
+
+[BraveAdd]
+struct Error {  // Error struct to propagate error to tab organization UI.
+  string message;
+  // Extra information used for rate limited error, will be non-null if the
+  // error is rate limited.
+  RateLimitedInfo? rate_limited_info;
+};
+
+[BraveExtend]
+interface PageHandler {
+  // APIs for tab organization feature using Leo.
+  // GetSuggestedTopics get all tabs (HTTPS/HTTP only) in the same profile
+  // (regular only), send them (ID, title, origin) to Leo, and get back a list
+  // of suggested topics for user to focus on.
+  GetSuggestedTopics() => (array<string> topics, Error? error);
+  // GetFocusTabs get all tabs (HTTPS/HTTP only) in the same profile (regular
+  // only), send them (ID, title, origin) along with the topic to Leo. Leo will
+  // return a list of tabs that should be focused on, these tabs would be moved
+  // to a newly created window.
+  GetFocusTabs(string topic) => (bool window_created, Error? error);
+  // UndoFocusTabs will undo the last focused tabs action.
+  UndoFocusTabs() => ();
+  // Open a new tab for purchasing Leo premium.
+  OpenLeoGoPremiumPage();
+};

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.cc
@@ -1,0 +1,248 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/webui/tab_search/tab_search_page_handler.h"
+
+#include "base/check.h"
+#include "brave/browser/ai_chat/ai_chat_service_factory.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_service.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
+#include "brave/components/ai_chat/core/browser/types.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
+#include "brave/components/ai_chat/core/common/pref_names.h"
+#include "chrome/browser/ui/browser_finder.h"
+#include "chrome/browser/ui/browser_navigator_params.h"
+#include "chrome/browser/ui/tabs/tab_strip_model.h"
+#include "components/grit/brave_components_strings.h"
+#include "components/sessions/core/session_id.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "ui/base/page_transition_types.h"
+#include "ui/base/window_open_disposition.h"
+#include "url/origin.h"
+
+#define TabSearchPageHandler TabSearchPageHandler_ChromiumImpl
+#include "src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.cc"
+#undef TabSearchPageHandler
+
+TabSearchPageHandler::TabSearchPageHandler(
+    mojo::PendingReceiver<tab_search::mojom::PageHandler> receiver,
+    mojo::PendingRemote<tab_search::mojom::Page> page,
+    content::WebUI* web_ui,
+    TopChromeWebUIController* webui_controller,
+    MetricsReporter* metrics_reporter)
+    : TabSearchPageHandler_ChromiumImpl(std::move(receiver),
+                                        std::move(page),
+                                        web_ui,
+                                        webui_controller,
+                                        metrics_reporter) {
+  pref_change_registrar_.Add(
+      ai_chat::prefs::kBraveAIChatTabOrganizationEnabled,
+      base::BindRepeating(
+          &TabSearchPageHandler::OnTabOrganizationFeaturePrefChanged,
+          base::Unretained(this), Profile::FromWebUI(web_ui_)));
+}
+
+void TabSearchPageHandler::OnTabOrganizationFeaturePrefChanged(
+    Profile* profile) {
+  page_->TabOrganizationEnabledChanged(
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile) &&
+      ai_chat::features::IsTabOrganizationEnabled() &&
+      profile->GetPrefs()->GetBoolean(
+          ai_chat::prefs::kBraveAIChatTabOrganizationEnabled));
+}
+
+TabSearchPageHandler::~TabSearchPageHandler() = default;
+
+std::vector<ai_chat::Tab> TabSearchPageHandler::GetTabsForAIEngine() {
+  std::vector<ai_chat::Tab> tabs;
+  auto profile_data = CreateProfileData();
+  for (const auto& window : profile_data->windows) {
+    for (const auto& tab : window->tabs) {
+      if (!tab->url.SchemeIsHTTPOrHTTPS()) {
+        continue;
+      }
+
+      // It should be safe to use url::Origin::Create() here as we are only
+      // handling HTTP/HTTPS tab URLs.
+      tabs.push_back(ai_chat::Tab(base::NumberToString(tab->tab_id), tab->title,
+                                  url::Origin::Create(tab->url)));
+    }
+  }
+
+  return tabs;
+}
+
+tab_search::mojom::ErrorPtr TabSearchPageHandler::GetError(
+    ai_chat::mojom::APIError api_error) {
+  Profile* profile = Profile::FromWebUI(web_ui_);
+  ai_chat::AIChatService* ai_chat_service =
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile);
+  CHECK(ai_chat_service);
+
+  tab_search::mojom::ErrorPtr error = tab_search::mojom::Error::New();
+  if (api_error == ai_chat::mojom::APIError::RateLimitReached) {
+    bool is_premium = ai_chat_service->IsPremiumStatus();
+    error->message =
+        is_premium
+            ? l10n_util::GetStringUTF8(IDS_CHAT_UI_ERROR_RATE_LIMIT)
+            : l10n_util::GetStringUTF8(IDS_CHAT_UI_RATE_LIMIT_REACHED_DESC);
+    error->rate_limited_info =
+        tab_search::mojom::RateLimitedInfo::New(is_premium);
+  } else if (api_error == ai_chat::mojom::APIError::ConnectionIssue) {
+    error->message = l10n_util::GetStringUTF8(IDS_CHAT_UI_ERROR_NETWORK);
+  } else {
+    error->message = l10n_util::GetStringUTF8(IDS_CHAT_UI_ERROR_INTERNAL);
+  }
+
+  return error;
+}
+
+void TabSearchPageHandler::GetSuggestedTopics(
+    GetSuggestedTopicsCallback callback) {
+  std::vector<ai_chat::Tab> tabs = GetTabsForAIEngine();
+  ai_chat::AIChatService* ai_chat_service =
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(
+          Profile::FromWebUI(web_ui_));
+  // Must be available as related UI is only shown if the service is
+  // available.
+  CHECK(ai_chat_service);
+  ai_chat_service->GetSuggestedTopics(
+      tabs,
+      base::BindOnce(&TabSearchPageHandler::OnGetSuggestedTopics,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void TabSearchPageHandler::OnGetSuggestedTopics(
+    GetSuggestedTopicsCallback callback,
+    base::expected<std::vector<std::string>, ai_chat::mojom::APIError> result) {
+  if (!result.has_value()) {
+    std::move(callback).Run({}, GetError(result.error()));
+    return;
+  }
+
+  std::move(callback).Run(*result, nullptr);
+}
+
+void TabSearchPageHandler::GetFocusTabs(const std::string& topic,
+                                        GetFocusTabsCallback callback) {
+  original_tabs_info_by_window_.clear();
+
+  ai_chat::AIChatService* ai_chat_service =
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(
+          Profile::FromWebUI(web_ui_));
+  // Must be available as related UI is only shown if the service is
+  // available.
+  CHECK(ai_chat_service);
+  std::vector<ai_chat::Tab> tabs = GetTabsForAIEngine();
+  ai_chat_service->GetFocusTabs(
+      tabs, topic,
+      base::BindOnce(&TabSearchPageHandler::OnGetFocusTabs,
+                     weak_ptr_factory_.GetWeakPtr(), topic,
+                     std::move(callback)));
+}
+
+void TabSearchPageHandler::OnGetFocusTabs(
+    const std::string& topic,
+    GetFocusTabsCallback callback,
+    base::expected<std::vector<std::string>, ai_chat::mojom::APIError> result) {
+  if (!result.has_value()) {
+    std::move(callback).Run(false, GetError(result.error()));
+    return;
+  }
+
+  // Move all tabs from normal browser window to a new window.
+  std::vector<TabDetails> tab_details_before_move;
+  for (const auto& tab_id_str : *result) {
+    int tab_id = 0;
+    if (!base::StringToInt(tab_id_str, &tab_id)) {
+      continue;
+    }
+
+    std::optional<TabDetails> details = GetTabDetails(tab_id);
+    if (!details) {
+      continue;
+    }
+
+    // Store all details before move to preserve the index.
+    tab_details_before_move.push_back(*details);
+    // Store old window ID (session ID), tab ID, and tab strip index for
+    // undo.
+    original_tabs_info_by_window_[details->browser->session_id()].push_back(
+        {tab_id, details->GetIndex()});
+  }
+
+  if (tab_details_before_move.empty()) {
+    std::move(callback).Run(false, nullptr);
+    return;
+  }
+
+  auto create_params = Browser::CreateParams(Profile::FromWebUI(web_ui_), true);
+  create_params.user_title = topic;
+  Browser* new_browser = Browser::Create(create_params);
+  for (const auto& details : tab_details_before_move) {
+    std::unique_ptr<tabs::TabModel> tab =
+        details.browser->tab_strip_model()->DetachTabAtForInsertion(
+            details.GetIndex());
+    new_browser->tab_strip_model()->AppendTab(std::move(tab),
+                                              false /* foreground */);
+  }
+  new_browser->window()->Show();
+
+  std::move(callback).Run(true, nullptr);
+}
+
+void TabSearchPageHandler::UndoFocusTabs(UndoFocusTabsCallback callback) {
+  for (auto& iter : original_tabs_info_by_window_) {
+    // Find the browser with the session ID (key).
+    Browser* target = nullptr;
+    for (Browser* browser : *BrowserList::GetInstance()) {
+      if (!ShouldTrackBrowser(browser)) {
+        continue;
+      }
+
+      if (browser->session_id() == iter.first) {
+        target = browser;
+        break;
+      }
+    }
+
+    if (!target) {
+      continue;
+    }
+
+    // Sort the tabs info by index in ascending order to ensure tabs are
+    // inserted in the correct order.
+    std::ranges::sort(iter.second, [](const TabInfo& a, const TabInfo& b) {
+      return a.index < b.index;
+    });
+
+    for (const auto& tab_info : iter.second) {
+      // Find the moved tab.
+      std::optional<TabDetails> details = GetTabDetails(tab_info.tab_id);
+      if (!details) {
+        continue;
+      }
+
+      std::unique_ptr<tabs::TabModel> tab =
+          details->browser->tab_strip_model()->DetachTabAtForInsertion(
+              details->GetIndex());
+      target->tab_strip_model()->InsertDetachedTabAt(
+          tab_info.index, std::move(tab), AddTabTypes::ADD_NONE);
+    }
+  }
+
+  original_tabs_info_by_window_.clear();
+  std::move(callback).Run();
+}
+
+void TabSearchPageHandler::OpenLeoGoPremiumPage() {
+  NavigateParams params(Profile::FromWebUI(web_ui_),
+                        GURL(ai_chat::kLeoGoPremiumUrl),
+                        ui::PageTransition::PAGE_TRANSITION_LINK);
+  params.disposition = WindowOpenDisposition::NEW_FOREGROUND_TAB;
+  Navigate(&params);
+}

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.h
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_TAB_SEARCH_TAB_SEARCH_PAGE_HANDLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_TAB_SEARCH_TAB_SEARCH_PAGE_HANDLER_H_
+
+#include "base/memory/weak_ptr.h"
+#include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
+
+class SessionID;
+
+class TabSearchPageHandler;
+using TabSearchPageHandler_BraveImpl = TabSearchPageHandler;
+
+#define TabSearchPageHandler TabSearchPageHandler_ChromiumImpl
+#define MaybeShowUI                      \
+  NotUsed();                             \
+  friend TabSearchPageHandler_BraveImpl; \
+  void MaybeShowUI
+
+#include "src/chrome/browser/ui/webui/tab_search/tab_search_page_handler.h"  // IWYU pragma: export
+
+#undef TabSearchPageHandler
+#undef MaybeShowUI
+
+namespace ai_chat {
+struct Tab;
+namespace mojom {
+enum class APIError;
+}  // namespace mojom
+}  // namespace ai_chat
+
+// Overrides TabSearchPageHandler to provide Brave-specific functionality.
+// See tab_search.mojom in chromium_src for our extended interface. Currently
+// it provides APIs needed for our tab organization feature using Leo.
+class TabSearchPageHandler : public TabSearchPageHandler_ChromiumImpl {
+ public:
+  // Used to store info for undo focus tabs.
+  struct TabInfo {
+    int tab_id;
+    int index;
+  };
+
+  TabSearchPageHandler(
+      mojo::PendingReceiver<tab_search::mojom::PageHandler> receiver,
+      mojo::PendingRemote<tab_search::mojom::Page> page,
+      content::WebUI* web_ui,
+      TopChromeWebUIController* webui_controller,
+      MetricsReporter* metrics_reporter);
+  ~TabSearchPageHandler() override;
+  TabSearchPageHandler(const TabSearchPageHandler&) = delete;
+  TabSearchPageHandler& operator=(const TabSearchPageHandler&) = delete;
+
+  // tab_search::mojom::PageHandler:
+  void GetSuggestedTopics(GetSuggestedTopicsCallback callback) override;
+  void GetFocusTabs(const std::string& topic,
+                    GetFocusTabsCallback callback) override;
+  void UndoFocusTabs(UndoFocusTabsCallback callback) override;
+  void OpenLeoGoPremiumPage() override;
+
+  void SetOriginalTabsInfoByWindowForTesting(
+      const base::flat_map<SessionID, std::vector<TabInfo>>&
+          original_tabs_info_by_window) {
+    original_tabs_info_by_window_ = original_tabs_info_by_window;
+  }
+
+ private:
+  void OnGetFocusTabs(const std::string& topic,
+                      GetFocusTabsCallback callback,
+                      base::expected<std::vector<std::string>,
+                                     ai_chat::mojom::APIError> result);
+  void OnGetSuggestedTopics(GetSuggestedTopicsCallback callback,
+                            base::expected<std::vector<std::string>,
+                                           ai_chat::mojom::APIError> result);
+  void OnTabOrganizationFeaturePrefChanged(Profile* profile);
+  tab_search::mojom::ErrorPtr GetError(ai_chat::mojom::APIError error);
+
+  std::vector<ai_chat::Tab> GetTabsForAIEngine();
+
+  // Map from window ID (session ID serves as a unique window ID here as this is
+  // only used within a single session) to the list of original tab info for
+  // undo last focus tabs action. This is used to move the focus tabs back to
+  // their original positions.
+  base::flat_map<SessionID, std::vector<TabInfo>> original_tabs_info_by_window_;
+
+  base::WeakPtrFactory<TabSearchPageHandler> weak_ptr_factory_{this};
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_TAB_SEARCH_TAB_SEARCH_PAGE_HANDLER_H_

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
@@ -1,0 +1,369 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/webui/tab_search/tab_search_page_handler.h"
+
+#include "base/test/bind.h"
+#include "base/test/gmock_callback_support.h"
+#include "base/test/mock_callback.h"
+#include "brave/browser/ai_chat/ai_chat_service_factory.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
+#include "brave/components/ai_chat/core/browser/ai_chat_service.h"
+#include "brave/components/ai_chat/core/browser/constants.h"
+#include "brave/components/ai_chat/core/browser/engine/mock_engine_consumer.h"
+#include "brave/components/ai_chat/core/browser/types.h"
+#include "components/grit/brave_components_strings.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "ui/base/l10n/l10n_util.h"
+#include "url/gurl.h"
+#include "url/origin.h"
+
+#include "src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc"
+
+namespace {
+
+constexpr char kFooDotComUrl1[] = "https://foo.com/1";
+constexpr char kFooDotComUrl2[] = "https://foo.com/2";
+constexpr char kBarDotComUrl1[] = "https://bar.com/1";
+constexpr char kBarDotComUrl2[] = "https://bar.com/2";
+constexpr char kCatDotComUrl1[] = "https://cat.com/1";
+constexpr char kCatDotComUrl2[] = "https://cat.com/2";
+
+constexpr char kFooDotComTitle1[] = "foo.com 1";
+constexpr char kFooDotComTitle2[] = "foo.com 2";
+constexpr char kBarDotComTitle1[] = "bar.com 1";
+constexpr char kBarDotComTitle2[] = "bar.com 2";
+constexpr char kCatDotComTitle1[] = "cat.com 1";
+constexpr char kCatDotComTitle2[] = "cat.com 2";
+
+class MockAIChatCredentialManager : public ai_chat::AIChatCredentialManager {
+ public:
+  using ai_chat::AIChatCredentialManager::AIChatCredentialManager;
+  MOCK_METHOD(void,
+              GetPremiumStatus,
+              (ai_chat::mojom::Service::GetPremiumStatusCallback callback),
+              (override));
+};
+
+}  // namespace
+
+TEST_F(TabSearchPageHandlerTest, GetSuggestedTopics) {
+  auto* ai_chat_service =
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile());
+  ai_chat_service->SetTabOrganizationEngineForTesting(
+      std::make_unique<testing::NiceMock<ai_chat::MockEngineConsumer>>());
+
+  ai_chat_service->SetCredentialManagerForTesting(
+      std::make_unique<testing::NiceMock<MockAIChatCredentialManager>>(
+          base::NullCallback(), nullptr));
+
+  auto* mock_credential_manager = static_cast<MockAIChatCredentialManager*>(
+      ai_chat_service->GetCredentialManagerForTesting());
+  ON_CALL(*mock_credential_manager, GetPremiumStatus(_))
+      .WillByDefault(
+          [&](ai_chat::mojom::Service::GetPremiumStatusCallback callback) {
+            ai_chat::mojom::PremiumInfoPtr premium_info =
+                ai_chat::mojom::PremiumInfo::New();
+            std::move(callback).Run(ai_chat::mojom::PremiumStatus::Inactive,
+                                    std::move(premium_info));
+          });
+
+  // Create multiple tabs in different windows and verify GetSuggestedTopics is
+  // called with expected tabs info.
+  // Browser with the same profile but not normal type.
+  AddTabWithTitle(browser5(), GURL(kFooDotComUrl1), kFooDotComTitle1);
+  // Browser with a different profile of the default browser.
+  AddTabWithTitle(browser4(), GURL(kFooDotComUrl2), kFooDotComTitle2);
+  // Browser with incognito profile.
+  AddTabWithTitle(browser3(), GURL(kBarDotComUrl1), kBarDotComTitle1);
+  // Browser with the same profile of the default browser.
+  AddTabWithTitle(browser2(), GURL(kBarDotComUrl2), kBarDotComTitle2);
+  // The default browser.
+  AddTabWithTitle(browser1(), GURL(kCatDotComUrl2), kCatDotComTitle2);
+  AddTabWithTitle(browser1(), GURL(kCatDotComUrl1), kCatDotComTitle1);
+
+  // Tab with kCatDotComUrl1 and kCatDotComTitle1.
+  const int tab_id1 =
+      browser1()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  // Tab with kCatDotComUrl2 and kCatDotComTitle2.
+  const int tab_id2 =
+      browser1()->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value();
+  // Tab with kBarDotComUrl2 and kBarDotComTitle2.
+  const int tab_id3 =
+      browser2()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+
+  std::vector<ai_chat::Tab> expected_tabs = {
+      {base::NumberToString(tab_id1), kCatDotComTitle1,
+       url::Origin::Create(GURL(kCatDotComUrl1))},
+      {base::NumberToString(tab_id2), kCatDotComTitle2,
+       url::Origin::Create(GURL(kCatDotComUrl2))},
+      {base::NumberToString(tab_id3), kBarDotComTitle2,
+       url::Origin::Create(GURL(kBarDotComUrl2))},
+  };
+
+  std::vector<std::string> expected_topics = {"topic1", "topic2", "topic3",
+                                              "topic4", "topic5"};
+  auto* mock_engine = static_cast<ai_chat::MockEngineConsumer*>(
+      ai_chat_service->GetTabOrganizationEngineForTesting());
+  std::string model_name = ai_chat::kClaudeHaikuModelName;
+  EXPECT_CALL(*mock_engine, GetModelName())
+      .WillRepeatedly(testing::ReturnRef(model_name));
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(expected_tabs, _))
+      .WillOnce(base::test::RunOnceCallback<1>(expected_topics));
+
+  // Uninteresting calls from upstream.
+  EXPECT_CALL(page_, TabsChanged(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabUpdated(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabsRemoved(_)).Times(testing::AnyNumber());
+
+  handler()->GetSuggestedTopics(
+      base::BindLambdaForTesting([&](const std::vector<std::string>& topics,
+                                     tab_search::mojom::ErrorPtr error) {
+        EXPECT_EQ(topics, expected_topics);
+        EXPECT_FALSE(error);
+      }));
+
+  testing::Mock::VerifyAndClearExpectations(mock_engine);
+
+  EXPECT_CALL(*mock_engine, GetModelName())
+      .WillOnce(testing::ReturnRef(model_name));
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(expected_tabs, _))
+      .WillOnce(base::test::RunOnceCallback<1>(
+          base::unexpected(ai_chat::mojom::APIError::RateLimitReached)));
+
+  handler()->GetSuggestedTopics(
+      base::BindLambdaForTesting([&](const std::vector<std::string>& topics,
+                                     tab_search::mojom::ErrorPtr error) {
+        EXPECT_TRUE(topics.empty());
+        auto rate_limited_info =
+            tab_search::mojom::RateLimitedInfo::New(false /* is_premium */);
+        EXPECT_EQ(
+            error,
+            tab_search::mojom::Error::New(
+                l10n_util::GetStringUTF8(IDS_CHAT_UI_RATE_LIMIT_REACHED_DESC),
+                std::move(rate_limited_info)));
+      }));
+
+  // Uninteresting calls from upstream.
+  EXPECT_CALL(page_, TabsChanged(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabUpdated(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabsRemoved(_)).Times(testing::AnyNumber());
+
+  testing::Mock::VerifyAndClearExpectations(mock_engine);
+
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(expected_tabs, _))
+      .WillOnce(base::test::RunOnceCallback<1>(
+          base::unexpected(ai_chat::mojom::APIError::ConnectionIssue)));
+  EXPECT_CALL(*mock_engine, GetModelName())
+      .WillOnce(testing::ReturnRef(model_name));
+
+  handler()->GetSuggestedTopics(
+      base::BindLambdaForTesting([&](const std::vector<std::string>& topics,
+                                     tab_search::mojom::ErrorPtr error) {
+        EXPECT_TRUE(topics.empty());
+        EXPECT_EQ(
+            error,
+            tab_search::mojom::Error::New(
+                l10n_util::GetStringUTF8(IDS_CHAT_UI_ERROR_NETWORK), nullptr));
+      }));
+
+  // Uninteresting calls from upstream.
+  EXPECT_CALL(page_, TabsChanged(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabUpdated(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabsRemoved(_)).Times(testing::AnyNumber());
+
+  testing::Mock::VerifyAndClearExpectations(mock_engine);
+}
+
+TEST_F(TabSearchPageHandlerTest, GetFocusTabs) {
+  auto* ai_chat_service =
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile());
+  ai_chat_service->SetTabOrganizationEngineForTesting(
+      std::make_unique<testing::NiceMock<ai_chat::MockEngineConsumer>>());
+
+  ai_chat_service->SetCredentialManagerForTesting(
+      std::make_unique<testing::NiceMock<MockAIChatCredentialManager>>(
+          base::NullCallback(), nullptr));
+  auto* mock_credential_manager = static_cast<MockAIChatCredentialManager*>(
+      ai_chat_service->GetCredentialManagerForTesting());
+  ON_CALL(*mock_credential_manager, GetPremiumStatus(_))
+      .WillByDefault(
+          [&](ai_chat::mojom::Service::GetPremiumStatusCallback callback) {
+            ai_chat::mojom::PremiumInfoPtr premium_info =
+                ai_chat::mojom::PremiumInfo::New();
+            std::move(callback).Run(ai_chat::mojom::PremiumStatus::Inactive,
+                                    std::move(premium_info));
+          });
+
+  // Create multiple tabs in different windows and verify GetFocusTabs is called
+  // with expected tabs info.
+  // Browser with the same profile but not normal type.
+  AddTabWithTitle(browser5(), GURL(kFooDotComUrl1), kFooDotComTitle1);
+  // Browser with a different profile of the default browser.
+  AddTabWithTitle(browser4(), GURL(kFooDotComUrl2), kFooDotComTitle2);
+  // Browser with incognito profile.
+  AddTabWithTitle(browser3(), GURL(kBarDotComUrl1), kBarDotComTitle1);
+  // Browser with the same profile of the default browser.
+  AddTabWithTitle(browser2(), GURL(kBarDotComUrl2), kBarDotComTitle2);
+  // The default browser.
+  AddTabWithTitle(browser1(), GURL(kCatDotComUrl1), kCatDotComTitle1);
+
+  const int tab_id1 =
+      browser1()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  const int tab_id2 =
+      browser2()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  const int tab_id3 =
+      browser3()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  const int tab_id4 =
+      browser4()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  const int tab_id5 =
+      browser5()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+
+  // Only tabs from the same profile and normal window are expected.
+  std::vector<ai_chat::Tab> expected_tabs = {
+      {base::NumberToString(tab_id1), kCatDotComTitle1,
+       url::Origin::Create(GURL(kCatDotComUrl1))},
+      {base::NumberToString(tab_id2), kBarDotComTitle2,
+       url::Origin::Create(GURL(kBarDotComUrl2))},
+  };
+
+  // Only covers the case where the returned tab ID is invalid.
+  // 1) Tab ID is not found.
+  // 2) Tab in the incognito window.
+  // 3) Tab in the non-normal window.
+  // 4) Tab in another profile.
+  // This tests the error handling in OnGetFocusTabs. The valid case is covered
+  // in TabSearchPageHandlerBrowserTest so a real browser window can be created.
+  std::vector<std::string> mock_ret_tabs = {
+      "100", "invalid", base::NumberToString(tab_id3),
+      base::NumberToString(tab_id4), base::NumberToString(tab_id5)};
+  auto* mock_engine = static_cast<ai_chat::MockEngineConsumer*>(
+      ai_chat_service->GetTabOrganizationEngineForTesting());
+  std::string model_name = ai_chat::kClaudeHaikuModelName;
+  EXPECT_CALL(*mock_engine, GetModelName())
+      .WillOnce(testing::ReturnRef(model_name));
+  EXPECT_CALL(*mock_engine, GetFocusTabs(expected_tabs, "topic", _))
+      .WillOnce(base::test::RunOnceCallback<2>(mock_ret_tabs));
+
+  handler()->GetFocusTabs("topic", base::BindLambdaForTesting(
+                                       [&](bool new_window_created,
+                                           tab_search::mojom::ErrorPtr error) {
+                                         EXPECT_FALSE(new_window_created);
+                                         // We just do nothing in this case.
+                                         EXPECT_FALSE(error);
+                                       }));
+
+  // Uninteresting calls from upstream.
+  EXPECT_CALL(page_, TabsChanged(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabUpdated(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabsRemoved(_)).Times(testing::AnyNumber());
+
+  testing::Mock::VerifyAndClearExpectations(mock_engine);
+
+  // Test error.
+  EXPECT_CALL(*mock_engine, GetModelName())
+      .WillOnce(testing::ReturnRef(model_name));
+  EXPECT_CALL(*mock_engine, GetFocusTabs(expected_tabs, "topic", _))
+      .WillOnce(base::test::RunOnceCallback<2>(
+          base::unexpected(ai_chat::mojom::APIError::RateLimitReached)));
+
+  handler()->GetFocusTabs(
+      "topic",
+      base::BindLambdaForTesting(
+          [&](bool new_window_created, tab_search::mojom::ErrorPtr error) {
+            EXPECT_FALSE(new_window_created);
+            auto rate_limited_info =
+                tab_search::mojom::RateLimitedInfo::New(false /* is_premium */);
+            EXPECT_EQ(error, tab_search::mojom::Error::New(
+                                 l10n_util::GetStringUTF8(
+                                     IDS_CHAT_UI_RATE_LIMIT_REACHED_DESC),
+                                 std::move(rate_limited_info)));
+          }));
+
+  // Uninteresting calls from upstream.
+  EXPECT_CALL(page_, TabsChanged(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabUpdated(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabsRemoved(_)).Times(testing::AnyNumber());
+
+  testing::Mock::VerifyAndClearExpectations(mock_engine);
+}
+
+TEST_F(TabSearchPageHandlerTest, UndoFocusTabs) {
+  // Add tabs in windows with the default profile.
+  AddTabWithTitle(browser1(), GURL(kFooDotComUrl2), kFooDotComTitle2);
+  AddTabWithTitle(browser1(), GURL(kFooDotComUrl1), kFooDotComTitle1);
+  AddTabWithTitle(browser2(), GURL(kCatDotComUrl2), kCatDotComTitle2);
+  AddTabWithTitle(browser2(), GURL(kCatDotComUrl1), kCatDotComTitle1);
+  AddTabWithTitle(browser2(), GURL(kBarDotComUrl2), kBarDotComTitle2);
+  AddTabWithTitle(browser2(), GURL(kBarDotComUrl1), kBarDotComTitle1);
+
+  ASSERT_EQ(browser1()->tab_strip_model()->count(), 2);
+  ASSERT_EQ(browser2()->tab_strip_model()->count(), 4);
+
+  const int tab_id1 =
+      browser1()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  const int tab_id2 =
+      browser1()->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value();
+  const int tab_id3 =
+      browser2()->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value();
+  const int tab_id4 =
+      browser2()->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value();
+  const int tab_id5 =
+      browser2()->tab_strip_model()->GetTabAtIndex(2)->GetHandle().raw_value();
+  const int tab_id6 =
+      browser2()->tab_strip_model()->GetTabAtIndex(3)->GetHandle().raw_value();
+
+  // Close tab_id6 to have a non-existing tab ID inside, for example, tab is
+  // closed in the new window.
+  browser2()->tab_strip_model()->CloseWebContentsAt(3,
+                                                    TabCloseTypes::CLOSE_NONE);
+
+  base::flat_map<SessionID, std::vector<TabSearchPageHandler::TabInfo>>
+      original_tabs_info;
+  // Use browser1's session ID to mock that these tabs were moved from browser1.
+  original_tabs_info[browser1()->session_id()] = {
+      {tab_id3, 2},
+      {tab_id4, 1},
+      // Index 5 is bigger than the last index after restored, this can happen
+      // when a tab in the original window is closed before undo.
+      {tab_id5, 5},
+      {tab_id6, 6},
+      {100, 5},
+  };
+  handler()->SetOriginalTabsInfoByWindowForTesting(original_tabs_info);
+  handler()->UndoFocusTabs(base::BindLambdaForTesting([&]() {
+    BrowserList* browser_list = BrowserList::GetInstance();
+    Browser* browser1 = browser_list->get(0);
+    EXPECT_EQ(browser1->tab_strip_model()->count(), 5)
+        << "The tabs should be moved back to the window stored.";
+    EXPECT_EQ(
+        browser1->tab_strip_model()->GetTabAtIndex(0)->GetHandle().raw_value(),
+        tab_id1);
+    EXPECT_EQ(
+        browser1->tab_strip_model()->GetTabAtIndex(1)->GetHandle().raw_value(),
+        tab_id4);
+    EXPECT_EQ(
+        browser1->tab_strip_model()->GetTabAtIndex(2)->GetHandle().raw_value(),
+        tab_id3);
+    EXPECT_EQ(
+        browser1->tab_strip_model()->GetTabAtIndex(3)->GetHandle().raw_value(),
+        tab_id2);
+    EXPECT_EQ(
+        browser1->tab_strip_model()->GetTabAtIndex(4)->GetHandle().raw_value(),
+        tab_id5);
+
+    // We do not wait for the window to be closed and only verify the tabs are
+    // moved out here, it is covered in TabSearchPageHandlerBrowserTest.
+    ASSERT_TRUE(browser_list->size() > 1);
+    Browser* browser2 = browser_list->get(1);
+    EXPECT_EQ(browser2->tab_strip_model()->count(), 0)
+        << "The tabs should be moved back to the window stored.";
+  }));
+
+  // Uninteresting calls from upstream.
+  EXPECT_CALL(page_, TabsChanged(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabUpdated(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(page_, TabsRemoved(_)).Times(testing::AnyNumber());
+}

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_ui.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_ui.cc
@@ -1,0 +1,77 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/webui/tab_search/tab_search_ui.h"
+
+#include "brave/browser/ai_chat/ai_chat_service_factory.h"
+#include "brave/components/ai_chat/core/common/features.h"
+#include "brave/components/ai_chat/core/common/pref_names.h"
+#include "brave/grit/brave_generated_resources.h"
+
+#define TabSearchUI TabSearchUI_ChromiumImpl
+#include "src/chrome/browser/ui/webui/tab_search/tab_search_ui.cc"
+#undef TabSearchUI
+
+TabSearchUI::TabSearchUI(content::WebUI* web_ui)
+    : TabSearchUI_ChromiumImpl(web_ui) {
+  Profile* profile = Profile::FromWebUI(web_ui);
+  base::Value::Dict update_data;
+
+  update_data.Set(
+      "tabOrganizationEnabled",
+      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile) &&
+          ai_chat::features::IsTabOrganizationEnabled() &&
+          profile->GetPrefs()->GetBoolean(
+              ai_chat::prefs::kBraveAIChatTabOrganizationEnabled));
+
+  update_data.Set("autoTabGroupsSelectorHeading",
+                  l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_TITLE));
+
+  update_data.Set("tabOrganizationTitle",
+                  l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_TITLE));
+
+  update_data.Set("tabOrganizationSubtitle",
+                  l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_SUBTITLE));
+
+  update_data.Set("tabOrganizationSuggestedTopicsSubtitle",
+                  l10n_util::GetStringUTF16(
+                      IDS_BRAVE_ORGANIZE_TAB_SUGGESTED_TOPICS_SUBTITLE));
+
+  update_data.Set("tabOrganizationTopicInputPlaceholder",
+                  l10n_util::GetStringUTF16(
+                      IDS_BRAVE_ORGANIZE_TAB_TOPIC_INPUT_PLACEHOLDER));
+
+  update_data.Set(
+      "tabOrganizationSubmitButtonLabel",
+      l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_SUBMIT_BUTTON_LABEL));
+  update_data.Set(
+      "tabOrganizationUndoButtonLabel",
+      l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_UNDO_BUTTON_LABEL));
+
+  update_data.Set(
+      "tabOrganizationWindowCreatedMessage",
+      l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_WINDOW_CREATED_MESSAGE));
+
+  update_data.Set(
+      "tabOrganizationSendTabDataMessage",
+      l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_SEND_TAB_DATA_MESSAGE));
+
+  update_data.Set(
+      "tabOrganizationLearnMoreLabel",
+      l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_LEARN_MORE_LABEL));
+
+  update_data.Set("tabOrganizationGoPremiumButtonLabel",
+                  l10n_util::GetStringUTF16(
+                      IDS_BRAVE_ORGANIZE_TAB_GO_PREMIUM_BUTTON_LABEL));
+
+  update_data.Set(
+      "tabOrganizationDismissButtonLabel",
+      l10n_util::GetStringUTF16(IDS_BRAVE_ORGANIZE_TAB_DISMISS_BUTTON_LABEL));
+
+  content::WebUIDataSource::Update(profile, chrome::kChromeUITabSearchHost,
+                                   std::move(update_data));
+}
+
+TabSearchUI::~TabSearchUI() = default;

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_ui.h
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_ui.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_TAB_SEARCH_TAB_SEARCH_UI_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_TAB_SEARCH_TAB_SEARCH_UI_H_
+
+#define TabSearchUI TabSearchUI_ChromiumImpl
+#define TabSearchUIConfig TabSearchUIConfig_Unused
+
+#include "src/chrome/browser/ui/webui/tab_search/tab_search_ui.h"  // IWYU pragma: export
+
+#undef TabSearchUI
+#undef TabSearchUIConfig
+
+class TabSearchUI : public TabSearchUI_ChromiumImpl {
+ public:
+  // To update WebUIDataSource for TabSearchUI with Brave specific resources.
+  // Also override tab organization enabled boolean value with our own feature
+  // flags.
+  explicit TabSearchUI(content::WebUI* web_ui);
+  ~TabSearchUI() override;
+};
+
+// Re-define TabSearchUIConfig so it will be using TabSearchUI instead of
+// TabSearchUI_ChromiumImpl.
+class TabSearchUIConfig : public DefaultTopChromeWebUIConfig<TabSearchUI> {
+ public:
+  TabSearchUIConfig();
+
+  // DefaultTopChromeWebUIConfig:
+  bool ShouldAutoResizeHost() override;
+  bool IsPreloadable() override;
+  std::optional<int> GetCommandIdForTesting() override;
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_WEBUI_TAB_SEARCH_TAB_SEARCH_UI_H_

--- a/chromium_src/chrome/common/url_constants.h
+++ b/chromium_src/chrome/common/url_constants.h
@@ -466,7 +466,8 @@ inline constexpr char kWallpaperSearchLearnMorePageManagedURL[] =
 
 // The URL for the "Learn more" page for Tab Organization.
 inline constexpr char kTabOrganizationLearnMorePageURL[] =
-    "https://support.brave.com/";
+    "https://support.brave.com/hc/en-us/articles/"
+    "360000766892-How-to-use-Tab-Focus-Mode";
 
 // The URL for the "Learn more" page for Tab Organization for managed users.
 inline constexpr char kTabOrganizationLearnMorePageManagedURL[] =

--- a/chromium_src/chrome/test/data/webui/tab_search/auto_tab_groups_page_test.ts
+++ b/chromium_src/chrome/test/data/webui/tab_search/auto_tab_groups_page_test.ts
@@ -1,0 +1,12 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// This override is needed to avoid build time TS error from
+// upstream unit_tests target complaining some child components might be null
+// because we do not have them in our implementation.
+// We replaced the whole auto_tab_groups_page from upstream, so upstream test
+// here is not relevant to us. Currently we do not run TabSearchFocusTest
+// which runs tests for auto_tab_groups_page either. It should be fairly safe to
+// ignore this file.

--- a/chromium_src/chrome/test/sources.gni
+++ b/chromium_src/chrome/test/sources.gni
@@ -11,6 +11,7 @@ brave_chromium_src_chrome_test_test_support_sources = [
 ]
 
 brave_chromium_src_chrome_test_test_support_deps = [
+  "//brave/components/ai_chat/core/browser:test_support",
   "//brave/components/brave_shields/content/browser",
   "//brave/components/brave_shields/content/browser:test_support",
   "//brave/components/brave_vpn/common/buildflags",

--- a/chromium_src/ui/webui/resources/cr_elements/cr_icon/cr_icon.ts
+++ b/chromium_src/ui/webui/resources/cr_elements/cr_icon/cr_icon.ts
@@ -91,6 +91,7 @@ const iconMap: { [key: string]: string } = {
     'cr:print': 'print',
     'settings:download': 'download',
     'settings:performance': 'cpu-chip',
+    'tab-search:auto-tab-groups': 'product-brave-leo',  // tab organization
 }
 
 injectStyle(CrIconElement, css`:host {

--- a/components/ai_chat/core/browser/ai_chat_credential_manager.cc
+++ b/components/ai_chat/core/browser/ai_chat_credential_manager.cc
@@ -61,6 +61,13 @@ void AIChatCredentialManager::GetPremiumStatus(
   base::Time now = base::Time::Now();
   // First check for a valid credential in the cache.
   bool credential_in_cache = false;
+
+  // |pref_service_| can be null in tests.
+  if (!prefs_service_) {
+    std::move(callback).Run(mojom::PremiumStatus::Inactive, nullptr);
+    return;
+  }
+
   const auto& cached_creds_dict =
       prefs_service_->GetDict(prefs::kBraveChatPremiumCredentialCache);
   for (const auto [credential, expires_at_value] : cached_creds_dict) {

--- a/components/ai_chat/core/browser/ai_chat_service.cc
+++ b/components/ai_chat/core/browser/ai_chat_service.cc
@@ -909,8 +909,12 @@ bool AIChatService::IsPremiumStatus() {
 }
 
 std::unique_ptr<EngineConsumer> AIChatService::GetDefaultAIEngine() {
-  return model_service_->GetEngineForModel(model_service_->GetDefaultModelKey(),
-                                           url_loader_factory_,
+  return GetEngineForModel(model_service_->GetDefaultModelKey());
+}
+
+std::unique_ptr<EngineConsumer> AIChatService::GetEngineForModel(
+    const std::string& model_key) {
+  return model_service_->GetEngineForModel(model_key, url_loader_factory_,
                                            credential_manager_.get());
 }
 
@@ -982,4 +986,63 @@ void AIChatService::AssociateContent(
   MaybeAssociateContentWithConversation(conversation, content->GetContentId(),
                                         content->GetWeakPtr());
 }
+
+void AIChatService::GetSuggestedTopics(const std::vector<Tab>& tabs,
+                                       GetSuggestedTopicsCallback callback) {
+  GetEngineForTabOrganization(base::BindOnce(
+      &AIChatService::GetSuggestedTopicsWithEngine,
+      weak_ptr_factory_.GetWeakPtr(), tabs, std::move(callback)));
+}
+
+void AIChatService::GetFocusTabs(const std::vector<Tab>& tabs,
+                                 const std::string& topic,
+                                 GetFocusTabsCallback callback) {
+  GetEngineForTabOrganization(base::BindOnce(
+      &AIChatService::GetFocusTabsWithEngine, weak_ptr_factory_.GetWeakPtr(),
+      tabs, topic, std::move(callback)));
+}
+
+void AIChatService::GetEngineForTabOrganization(base::OnceClosure callback) {
+  GetPremiumStatus(
+      base::BindOnce(&AIChatService::ContinueGetEngineForTabOrganization,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void AIChatService::ContinueGetEngineForTabOrganization(
+    base::OnceClosure callback,
+    mojom::PremiumStatus status,
+    mojom::PremiumInfoPtr info) {
+  bool is_premium = IsPremiumStatus();
+  if (tab_organization_engine_) {
+    // Check if model name matches the current premium status.
+    if ((is_premium &&
+         tab_organization_engine_->GetModelName() != kClaudeSonnetModelName) ||
+        (!is_premium &&
+         tab_organization_engine_->GetModelName() != kClaudeHaikuModelName)) {
+      tab_organization_engine_.reset();
+    }
+  }
+
+  if (!tab_organization_engine_) {
+    tab_organization_engine_ = GetEngineForModel(
+        is_premium ? kClaudeSonnetModelKey : kClaudeHaikuModelKey);
+  }
+
+  std::move(callback).Run();
+}
+
+void AIChatService::GetSuggestedTopicsWithEngine(
+    const std::vector<Tab>& tabs,
+    GetSuggestedTopicsCallback callback) {
+  CHECK(tab_organization_engine_);
+  tab_organization_engine_->GetSuggestedTopics(tabs, std::move(callback));
+}
+
+void AIChatService::GetFocusTabsWithEngine(const std::vector<Tab>& tabs,
+                                           const std::string& topic,
+                                           GetFocusTabsCallback callback) {
+  CHECK(tab_organization_engine_);
+  tab_organization_engine_->GetFocusTabs(tabs, topic, std::move(callback));
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/ai_chat_service.h
+++ b/components/ai_chat/core/browser/ai_chat_service.h
@@ -14,11 +14,13 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "base/callback_list.h"
 #include "base/functional/callback.h"
 #include "base/functional/callback_helpers.h"
+#include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
@@ -63,6 +65,10 @@ class AIChatService : public KeyedService,
  public:
   using SkusServiceGetter =
       base::RepeatingCallback<mojo::PendingRemote<skus::mojom::SkusService>()>;
+  using GetSuggestedTopicsCallback = base::OnceCallback<void(
+      base::expected<std::vector<std::string>, mojom::APIError>)>;
+  using GetFocusTabsCallback = base::OnceCallback<void(
+      base::expected<std::vector<std::string>, mojom::APIError>)>;
 
   AIChatService(
       ModelService* model_service,
@@ -140,6 +146,12 @@ class AIChatService : public KeyedService,
   void AssociateContent(ConversationHandler::AssociatedContentDelegate* content,
                         const std::string& conversation_uuid);
 
+  void GetFocusTabs(const std::vector<Tab>& tabs,
+                    const std::string& topic,
+                    GetFocusTabsCallback callback);
+  void GetSuggestedTopics(const std::vector<Tab>& tabs,
+                          GetSuggestedTopicsCallback callback);
+
   // mojom::Service
   void MarkAgreementAccepted() override;
   void EnableStoragePref() override;
@@ -171,7 +183,15 @@ class AIChatService : public KeyedService,
   bool IsAIChatHistoryEnabled();
 
   std::unique_ptr<EngineConsumer> GetDefaultAIEngine();
+  std::unique_ptr<EngineConsumer> GetEngineForModel(
+      const std::string& model_key);
 
+  std::unique_ptr<EngineConsumer> GetEngineForTabOrganization();
+
+  void SetCredentialManagerForTesting(
+      std::unique_ptr<AIChatCredentialManager> credential_manager) {
+    credential_manager_ = std::move(credential_manager);
+  }
   AIChatCredentialManager* GetCredentialManagerForTesting() {
     return credential_manager_.get();
   }
@@ -179,7 +199,18 @@ class AIChatService : public KeyedService,
 
   size_t GetInMemoryConversationCountForTesting();
 
+  EngineConsumer* GetTabOrganizationEngineForTesting() {
+    return tab_organization_engine_.get();
+  }
+
+  void SetTabOrganizationEngineForTesting(
+      std::unique_ptr<EngineConsumer> engine) {
+    tab_organization_engine_ = std::move(engine);
+  }
+
  private:
+  friend class AIChatServiceUnitTest;
+
   // Key is uuid
   using ConversationMap =
       std::map<std::string, mojom::ConversationPtr, std::less<>>;
@@ -225,6 +256,16 @@ class AIChatService : public KeyedService,
   mojom::ServiceStatePtr BuildState();
   void OnStateChanged();
 
+  void GetEngineForTabOrganization(base::OnceClosure callback);
+  void ContinueGetEngineForTabOrganization(base::OnceClosure callback,
+                                           mojom::PremiumStatus status,
+                                           mojom::PremiumInfoPtr info);
+  void GetSuggestedTopicsWithEngine(const std::vector<Tab>& tabs,
+                                    GetSuggestedTopicsCallback callback);
+  void GetFocusTabsWithEngine(const std::vector<Tab>& tabs,
+                              const std::string& topic,
+                              GetFocusTabsCallback callback);
+
   raw_ptr<ModelService> model_service_;
   raw_ptr<PrefService> profile_prefs_;
   raw_ptr<AIChatMetrics> ai_chat_metrics_;
@@ -234,6 +275,9 @@ class AIChatService : public KeyedService,
 
   std::unique_ptr<AIChatFeedbackAPI> feedback_api_;
   std::unique_ptr<AIChatCredentialManager> credential_manager_;
+
+  // Engine for tab organization, created on demand and owned by AIChatService.
+  std::unique_ptr<ai_chat::EngineConsumer> tab_organization_engine_;
 
   base::FilePath profile_path_;
 

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -34,6 +34,9 @@ inline constexpr char kLeoModelSupportUrl[] =
     "https://support.brave.com/hc/en-us/articles/26727364100493-"
     "What-are-the-differences-between-Leo-s-AI-Models";
 
+inline constexpr char kLeoGoPremiumUrl[] =
+    "https://account.brave.com/account/?intent=checkout&product=leo";
+
 // Upon registering a custom model, users have the ability to explicitly
 // provide a context size (in tokens). When present, we'll use this value to
 // determine the max associated content length (in chars). We will assume 4
@@ -44,6 +47,15 @@ inline constexpr size_t kDefaultCharsPerToken = 4;
 inline constexpr float kMaxContentLengthThreshold = 0.6f;
 inline constexpr size_t kReservedTokensForPrompt = 300;
 inline constexpr size_t kReservedTokensForMaxNewTokens = 400;
+
+// Model key for Claude Haiku model.
+inline constexpr char kClaudeHaikuModelKey[] = "chat-claude-haiku";
+// Model key for Claude Sonnet model.
+inline constexpr char kClaudeSonnetModelKey[] = "chat-claude-sonnet";
+// Model name to send to the server for Claude Haiku model.
+inline constexpr char kClaudeHaikuModelName[] = "claude-3-haiku";
+// Model name to send to the server for Claude Sonnet model.
+inline constexpr char kClaudeSonnetModelName[] = "claude-3-sonnet";
 
 }  // namespace ai_chat
 

--- a/components/ai_chat/core/browser/engine/conversation_api_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.cc
@@ -200,6 +200,10 @@ base::Value::List ConversationEventsToList(
            {ConversationEventType::RequestSuggestedActions,
             "requestSuggestedActions"},
            {ConversationEventType::SuggestedActions, "suggestedActions"},
+           {ConversationEventType::GetSuggestedTopicsForFocusTabs,
+            "suggestFocusTopics"},
+           {ConversationEventType::DedupeTopics, "dedupeFocusTopics"},
+           {ConversationEventType::GetFocusTabsForTopic, "classifyTabs"},
            {ConversationEventType::UploadImage, "uploadImage"}});
 
   base::Value::List events;
@@ -217,6 +221,11 @@ base::Value::List ConversationEventsToList(
     event_dict.Set("type", type_it->second);
 
     event_dict.Set("content", event.content);
+
+    if (event.type == ConversationEventType::GetFocusTabsForTopic) {
+      event_dict.Set("topic", event.topic);
+    }
+
     events.Append(std::move(event_dict));
   }
   return events;

--- a/components/ai_chat/core/browser/engine/conversation_api_client.h
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.h
@@ -64,6 +64,9 @@ class ConversationAPIClient {
     RequestRewrite,
     SuggestedActions,
     UploadImage,
+    GetSuggestedTopicsForFocusTabs,
+    DedupeTopics,
+    GetFocusTabsForTopic,
     // TODO(petemill):
     // - Search in-progress?
     // - Sources?
@@ -76,6 +79,7 @@ class ConversationAPIClient {
     mojom::CharacterType role;
     ConversationEventType type;
     std::string content;
+    std::string topic;  // Used in GetFocusTabsForTopic event.
   };
 
   ConversationAPIClient(

--- a/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
@@ -64,6 +64,44 @@ using Ticket = api_request_helper::APIRequestHelper::Ticket;
 
 namespace ai_chat {
 
+namespace {
+
+const std::pair<std::vector<ConversationAPIClient::ConversationEvent>,
+                std::string>&
+GetMockEventsAndExpectedEventsBody() {
+  static base::NoDestructor<std::pair<
+      std::vector<ConversationAPIClient::ConversationEvent>, std::string>>
+      mock_events_and_expected_events_body{
+          std::vector<ConversationAPIClient::ConversationEvent>{
+              {mojom::CharacterType::HUMAN, ConversationAPIClient::PageText,
+               "This is a page about The Mandalorian."},
+              {mojom::CharacterType::HUMAN, ConversationAPIClient::PageExcerpt,
+               "The Mandalorian"},
+              {mojom::CharacterType::HUMAN, ConversationAPIClient::ChatMessage,
+               "Est-ce lié à une série plus large?"},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::GetSuggestedTopicsForFocusTabs,
+               "GetSuggestedTopicsForFocusTabs"},
+              {mojom::CharacterType::HUMAN, ConversationAPIClient::DedupeTopics,
+               "DedupeTopics"},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::GetFocusTabsForTopic,
+               "GetFocusTabsForTopics", "C++"},
+          },
+          R"([
+      {"role": "user", "type": "pageText", "content": "This is a page about The Mandalorian."},
+      {"role": "user", "type": "pageExcerpt", "content": "The Mandalorian"},
+      {"role": "user", "type": "chatMessage", "content": "Est-ce lié à une série plus large?"},
+      {"role": "user", "type": "suggestFocusTopics", "content": "GetSuggestedTopicsForFocusTabs"},
+      {"role": "user", "type": "dedupeFocusTopics", "content": "DedupeTopics"},
+      {"role": "user", "type": "classifyTabs", "content": "GetFocusTabsForTopics", "topic": "C++"}
+    ])"};
+
+  return *mock_events_and_expected_events_body;
+}
+
+}  // namespace
+
 using ConversationEvent = ConversationAPIClient::ConversationEvent;
 
 class MockCallbacks {
@@ -198,18 +236,10 @@ TEST_F(ConversationAPIUnitTest, PerformRequest_PremiumHeaders) {
   //  - ConversationEvent is correctly formatted into JSON
   //  - completion response is parsed and passed through to the callbacks
   std::string expected_crediential = "unit_test_credential";
-  std::vector<ConversationAPIClient::ConversationEvent> events = {
-      {mojom::CharacterType::HUMAN, ConversationAPIClient::PageText,
-       "This is a page about The Mandalorian."},
-      {mojom::CharacterType::HUMAN, ConversationAPIClient::PageExcerpt,
-       "The Mandalorian"},
-      {mojom::CharacterType::HUMAN, ConversationAPIClient::ChatMessage,
-       "Est-ce lié à une série plus large?"}};
-  std::string expected_events_body = R"([
-    {"role": "user", "type": "pageText", "content": "This is a page about The Mandalorian."},
-    {"role": "user", "type": "pageExcerpt", "content": "The Mandalorian"},
-    {"role": "user", "type": "chatMessage", "content": "Est-ce lié à une série plus large?"}
-  ])";
+  const std::vector<ConversationAPIClient::ConversationEvent>& events =
+      GetMockEventsAndExpectedEventsBody().first;
+  const std::string& expected_events_body =
+      GetMockEventsAndExpectedEventsBody().second;
   std::string expected_system_language = "en_KY";
   const brave_l10n::test::ScopedDefaultLocale scoped_default_locale(
       expected_system_language);
@@ -406,18 +436,10 @@ TEST_F(ConversationAPIUnitTest, PerformRequest_NonPremium) {
   //  - ConversationEvent is correctly formatted into JSON
   //  - completion response is parsed and passed through to the callbacks
   std::string expected_crediential = "unit_test_credential";
-  std::vector<ConversationAPIClient::ConversationEvent> events = {
-      {mojom::CharacterType::HUMAN, ConversationAPIClient::PageText,
-       "This is a page about The Mandalorian."},
-      {mojom::CharacterType::HUMAN, ConversationAPIClient::PageExcerpt,
-       "The Mandalorian"},
-      {mojom::CharacterType::HUMAN, ConversationAPIClient::ChatMessage,
-       "Est-ce lié à une série plus large?"}};
-  std::string expected_events_body = R"([
-    {"role": "user", "type": "pageText", "content": "This is a page about The Mandalorian."},
-    {"role": "user", "type": "pageExcerpt", "content": "The Mandalorian"},
-    {"role": "user", "type": "chatMessage", "content": "Est-ce lié à une série plus large?"}
-  ])";
+  const std::vector<ConversationAPIClient::ConversationEvent>& events =
+      GetMockEventsAndExpectedEventsBody().first;
+  const std::string& expected_events_body =
+      GetMockEventsAndExpectedEventsBody().second;
   std::string expected_system_language = "en_KY";
   const brave_l10n::test::ScopedDefaultLocale scoped_default_locale(
       expected_system_language);

--- a/components/ai_chat/core/browser/engine/engine_consumer.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer.cc
@@ -49,4 +49,8 @@ bool EngineConsumer::CanPerformCompletionRequest(
   return true;
 }
 
+const std::string& EngineConsumer::GetModelName() const {
+  return model_name_;
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer.h
@@ -16,6 +16,7 @@
 #include "base/functional/callback_forward.h"
 #include "base/types/expected.h"
 #include "brave/components/ai_chat/core/browser/engine/remote_completion_client.h"
+#include "brave/components/ai_chat/core/browser/types.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-forward.h"
 
 namespace ai_chat {
@@ -42,6 +43,11 @@ class EngineConsumer {
       base::OnceCallback<void(GenerationResult)>;
 
   using ConversationHistory = std::vector<mojom::ConversationTurnPtr>;
+
+  using GetSuggestedTopicsCallback = base::OnceCallback<void(
+      base::expected<std::vector<std::string>, mojom::APIError>)>;
+  using GetFocusTabsCallback = base::OnceCallback<void(
+      base::expected<std::vector<std::string>, mojom::APIError>)>;
 
   static std::string GetPromptForEntry(const mojom::ConversationTurnPtr& entry);
 
@@ -86,6 +92,16 @@ class EngineConsumer {
 
   virtual void UpdateModelOptions(const mojom::ModelOptions& options) = 0;
 
+  // Given a list of tabs, return a list of suggested topics from the server.
+  virtual void GetSuggestedTopics(const std::vector<Tab>& tabs,
+                                  GetSuggestedTopicsCallback callback) = 0;
+  // Given a list of tabs and a specific topic, return a list of tabs to be
+  // focused on from the server.
+  virtual void GetFocusTabs(const std::vector<Tab>& tabs,
+                            const std::string& topic,
+                            GetFocusTabsCallback callback) = 0;
+  virtual const std::string& GetModelName() const;
+
   void SetMaxAssociatedContentLengthForTesting(
       uint32_t max_associated_content_length) {
     max_associated_content_length_ = max_associated_content_length;
@@ -100,6 +116,7 @@ class EngineConsumer {
   bool CanPerformCompletionRequest(
       const ConversationHistory& conversation_history) const;
   uint32_t max_associated_content_length_ = 0;
+  std::string model_name_ = "";
 };
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.cc
@@ -171,6 +171,7 @@ EngineConsumerClaudeRemote::EngineConsumerClaudeRemote(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager) {
   DCHECK(!model_options.name.empty());
+  model_name_ = model_options.name;
   base::flat_set<std::string_view> stop_sequences(kStopSequences.begin(),
                                                   kStopSequences.end());
   api_ = std::make_unique<RemoteCompletionClient>(
@@ -299,6 +300,18 @@ void EngineConsumerClaudeRemote::SanitizeInput(std::string& input) {
   base::ReplaceSubstringsAfterOffset(&input, 0, "</question>", "");
   base::ReplaceSubstringsAfterOffset(&input, 0, "<excerpt>", "");
   base::ReplaceSubstringsAfterOffset(&input, 0, "</excerpt>", "");
+}
+
+void EngineConsumerClaudeRemote::GetSuggestedTopics(
+    const std::vector<Tab>& tabs,
+    GetSuggestedTopicsCallback callback) {
+  std::move(callback).Run(base::unexpected(mojom::APIError::InternalError));
+}
+
+void EngineConsumerClaudeRemote::GetFocusTabs(const std::vector<Tab>& tabs,
+                                              const std::string& topic,
+                                              GetFocusTabsCallback callback) {
+  std::move(callback).Run(base::unexpected(mojom::APIError::InternalError));
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_claude.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_claude.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
@@ -70,6 +71,11 @@ class EngineConsumerClaudeRemote : public EngineConsumer {
       GenerationCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
+  void GetSuggestedTopics(const std::vector<Tab>& tabs,
+                          GetSuggestedTopicsCallback callback) override;
+  void GetFocusTabs(const std::vector<Tab>& tabs,
+                    const std::string& topic,
+                    GetFocusTabsCallback callback) override;
 
   void SetAPIForTesting(
       std::unique_ptr<RemoteCompletionClient> api_for_testing) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.cc
@@ -5,24 +5,31 @@
 
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer_conversation_api.h"
 
+#include <algorithm>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <vector>
 
+#include "base/barrier_callback.h"
 #include "base/check.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/functional/callback_helpers.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/numerics/clamped_math.h"
 #include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "base/time/time.h"
 #include "base/types/expected.h"
+#include "base/values.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "third_party/re2/src/re2/re2.h"
 
 namespace ai_chat {
 
@@ -31,6 +38,9 @@ namespace {
 using ConversationEvent = ConversationAPIClient::ConversationEvent;
 using ConversationEventType = ConversationAPIClient::ConversationEventType;
 
+constexpr size_t kChunkSize = 75;
+constexpr char kArrayPattern[] = R"((\[.*?\]))";
+
 }  // namespace
 
 EngineConsumerConversationAPI::EngineConsumerConversationAPI(
@@ -38,6 +48,7 @@ EngineConsumerConversationAPI::EngineConsumerConversationAPI(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager) {
   DCHECK(!model_options.name.empty());
+  model_name_ = model_options.name;
   api_ = std::make_unique<ConversationAPIClient>(
       model_options.name, url_loader_factory, credential_manager);
   max_associated_content_length_ = model_options.max_associated_content_length;
@@ -47,6 +58,70 @@ EngineConsumerConversationAPI::~EngineConsumerConversationAPI() = default;
 
 void EngineConsumerConversationAPI::ClearAllQueries() {
   api_->ClearAllQueries();
+}
+
+// static
+base::expected<std::vector<std::string>, mojom::APIError>
+EngineConsumerConversationAPI::GetStrArrFromTabOrganizationResponses(
+    std::vector<EngineConsumer::GenerationResult>& results) {
+  // Rust implementation of JSON reader is required to parse the response
+  // safely. This function currently is only called on Desktop which uses a
+  // rust JSON reader. Chromium is in progress of making all platforms use the
+  // rust JSON reader and updating the rule of 2 documentation to explicitly
+  // point out that JSON parser in base is considered safe.
+  if (!base::JSONReader::UsingRust()) {
+    return base::unexpected(mojom::APIError::InternalError);
+  }
+
+  // Use RE2 to extract the array from the response, then use rust JSON::Reader
+  // to safely parse the array.
+  std::vector<std::string> str_arr;
+  mojom::APIError error = mojom::APIError::None;
+  for (auto& result : results) {
+    // Fail the operation if server returns an error, such as rate limiting.
+    // On the other hand, ignore the result which cannot be parsed as expected.
+    if (!result.has_value()) {
+      error = result.error();
+      break;
+    }
+
+    // Skip empty results.
+    if (result->empty()) {
+      continue;
+    }
+
+    std::string strArr = "";
+    if (!RE2::PartialMatch(*result, kArrayPattern, &strArr)) {
+      continue;
+    }
+    auto value = base::JSONReader::Read(strArr, base::JSON_PARSE_RFC);
+    if (!value) {
+      continue;
+    }
+
+    auto* list = value->GetIfList();
+    if (!list) {
+      continue;
+    }
+
+    for (const auto& item : *list) {
+      auto* str = item.GetIfString();
+      if (!str || str->empty()) {
+        continue;
+      }
+      str_arr.push_back(*str);
+    }
+  }
+
+  if (error != mojom::APIError::None) {
+    return base::unexpected(error);
+  }
+
+  if (str_arr.empty()) {
+    return base::unexpected(mojom::APIError::InternalError);
+  }
+
+  return str_arr;
 }
 
 void EngineConsumerConversationAPI::GenerateRewriteSuggestion(
@@ -181,6 +256,108 @@ EngineConsumerConversationAPI::GetAssociatedContentConversationEvent(
   event.type = is_video ? ConversationEventType::VideoTranscript
                         : ConversationEventType::PageText;
   return event;
+}
+
+void EngineConsumerConversationAPI::DedupeTopics(
+    base::expected<std::vector<std::string>, mojom::APIError> topics_result,
+    GetSuggestedTopicsCallback callback) {
+  if (!topics_result.has_value() || topics_result->empty()) {
+    std::move(callback).Run(topics_result);
+    return;
+  }
+
+  base::Value::List topic_list;
+  for (const auto& topic : *topics_result) {
+    topic_list.Append(topic);
+  }
+  std::vector<ConversationEvent> conversation;
+  conversation.push_back({mojom::CharacterType::HUMAN,
+                          ConversationEventType::DedupeTopics,
+                          base::WriteJson(topic_list).value_or(std::string())});
+  api_->PerformRequest(
+      std::move(conversation), "" /* selected_language */,
+      base::NullCallback() /* data_received_callback */,
+      base::BindOnce(
+          [](GetSuggestedTopicsCallback callback,
+             EngineConsumer::GenerationResult result) {
+            // Return deduped topics from the response.
+            std::vector<EngineConsumer::GenerationResult> results = {result};
+            std::move(callback).Run(
+                EngineConsumerConversationAPI::
+                    GetStrArrFromTabOrganizationResponses(results));
+          },
+          std::move(callback)));
+}
+
+void EngineConsumerConversationAPI::ProcessTabChunks(
+    const std::vector<Tab>& tabs,
+    ConversationEventType event_type,
+    base::OnceCallback<void(std::vector<GenerationResult>)> merge_callback,
+    const std::string& topic) {
+  CHECK(event_type == ConversationEventType::GetSuggestedTopicsForFocusTabs ||
+        event_type == ConversationEventType::GetFocusTabsForTopic);
+
+  // Split tab into chunks of 75
+  size_t num_chunks = (tabs.size() + kChunkSize - 1) / kChunkSize;
+  const auto barrier_callback = base::BarrierCallback<GenerationResult>(
+      num_chunks, std::move(merge_callback));
+
+  for (size_t chunk = 0; chunk < num_chunks; ++chunk) {
+    base::Value::List tab_value_list;
+    for (size_t i = chunk * kChunkSize;
+         i < std::min((chunk + 1) * kChunkSize, tabs.size()); ++i) {
+      tab_value_list.Append(base::Value::Dict()
+                                .Set("id", tabs[i].id)
+                                .Set("title", tabs[i].title)
+                                .Set("url", tabs[i].origin.Serialize()));
+    }
+
+    std::vector<ConversationEvent> conversation;
+    conversation.push_back(
+        {mojom::CharacterType::HUMAN, event_type,
+         base::WriteJson(tab_value_list).value_or(std::string()), topic});
+
+    api_->PerformRequest(std::move(conversation), "" /* selected_language */,
+                         base::NullCallback() /* data_received_callback */,
+                         barrier_callback /* data_completed_callback */);
+  }
+}
+
+void EngineConsumerConversationAPI::MergeSuggestTopicsResults(
+    GetSuggestedTopicsCallback callback,
+    std::vector<GenerationResult> results) {
+  // Merge the result and send another request to dedupe topics.
+  DedupeTopics(GetStrArrFromTabOrganizationResponses(results),
+               std::move(callback));
+}
+
+void EngineConsumerConversationAPI::GetSuggestedTopics(
+    const std::vector<Tab>& tabs,
+    GetSuggestedTopicsCallback callback) {
+  ProcessTabChunks(
+      tabs, ConversationEventType::GetSuggestedTopicsForFocusTabs,
+      base::BindOnce(&EngineConsumerConversationAPI::MergeSuggestTopicsResults,
+                     weak_ptr_factory_.GetWeakPtr(), std::move(callback)),
+      "" /* topic */);
+}
+
+void EngineConsumerConversationAPI::GetFocusTabs(
+    const std::vector<Tab>& tabs,
+    const std::string& topic,
+    EngineConsumer::GetFocusTabsCallback callback) {
+  ProcessTabChunks(
+      tabs, ConversationEventType::GetFocusTabsForTopic,
+      base::BindOnce(
+          [](EngineConsumer::GetFocusTabsCallback callback,
+             std::vector<GenerationResult> results) {
+            // Merge the results and call callback with tab IDs or
+            // error.
+            std::move(callback).Run(
+                EngineConsumerConversationAPI::
+                    GetStrArrFromTabOrganizationResponses(results));
+          },
+          std::move(callback)),
+      topic);
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.cc
@@ -339,6 +339,7 @@ EngineConsumerLlamaRemote::EngineConsumerLlamaRemote(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     AIChatCredentialManager* credential_manager) {
   DCHECK(!model_options.name.empty());
+  model_name_ = model_options.name;
   base::flat_set<std::string_view> stop_sequences(kStopSequences.begin(),
                                                   kStopSequences.end());
   api_ = std::make_unique<RemoteCompletionClient>(
@@ -490,6 +491,18 @@ void EngineConsumerLlamaRemote::SanitizeInput(std::string& input) {
   base::ReplaceSubstringsAfterOffset(&input, 0, "</excerpt>", "");
   base::ReplaceSubstringsAfterOffset(&input, 0, kSelectedTextPromptPlaceholder,
                                      "");
+}
+
+void EngineConsumerLlamaRemote::GetSuggestedTopics(
+    const std::vector<Tab>& tabs,
+    GetSuggestedTopicsCallback callback) {
+  std::move(callback).Run(base::unexpected(mojom::APIError::InternalError));
+}
+
+void EngineConsumerLlamaRemote::GetFocusTabs(const std::vector<Tab>& tabs,
+                                             const std::string& topic,
+                                             GetFocusTabsCallback callback) {
+  std::move(callback).Run(base::unexpected(mojom::APIError::InternalError));
 }
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_llama.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_llama.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
@@ -70,6 +71,11 @@ class EngineConsumerLlamaRemote : public EngineConsumer {
       GenerationCompletedCallback completed_callback) override;
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
+  void GetSuggestedTopics(const std::vector<Tab>& tabs,
+                          GetSuggestedTopicsCallback callback) override;
+  void GetFocusTabs(const std::vector<Tab>& tabs,
+                    const std::string& topic,
+                    GetFocusTabsCallback callback) override;
 
   void SetAPIForTesting(
       std::unique_ptr<RemoteCompletionClient> api_for_testing) {

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.cc
@@ -299,4 +299,16 @@ void EngineConsumerOAIRemote::GenerateAssistantResponse(
 
 void EngineConsumerOAIRemote::SanitizeInput(std::string& input) {}
 
+void EngineConsumerOAIRemote::GetSuggestedTopics(
+    const std::vector<Tab>& tabs,
+    GetSuggestedTopicsCallback callback) {
+  std::move(callback).Run(base::unexpected(mojom::APIError::InternalError));
+}
+
+void EngineConsumerOAIRemote::GetFocusTabs(const std::vector<Tab>& tabs,
+                                           const std::string& topic,
+                                           GetFocusTabsCallback callback) {
+  std::move(callback).Run(base::unexpected(mojom::APIError::InternalError));
+}
+
 }  // namespace ai_chat

--- a/components/ai_chat/core/browser/engine/engine_consumer_oai.h
+++ b/components/ai_chat/core/browser/engine/engine_consumer_oai.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "base/memory/weak_ptr.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_credential_manager.h"
@@ -63,6 +64,11 @@ class EngineConsumerOAIRemote : public EngineConsumer {
   void SanitizeInput(std::string& input) override;
   void ClearAllQueries() override;
   bool SupportsDeltaTextResponses() const override;
+  void GetSuggestedTopics(const std::vector<Tab>& tabs,
+                          GetSuggestedTopicsCallback callback) override;
+  void GetFocusTabs(const std::vector<Tab>& tabs,
+                    const std::string& topic,
+                    GetFocusTabsCallback callback) override;
 
   void SetAPIForTesting(std::unique_ptr<OAIAPIClient> api_for_testing) {
     api_ = std::move(api_for_testing);

--- a/components/ai_chat/core/browser/engine/mock_engine_consumer.h
+++ b/components/ai_chat/core/browser/engine/mock_engine_consumer.h
@@ -7,6 +7,7 @@
 #define BRAVE_COMPONENTS_AI_CHAT_CORE_BROWSER_ENGINE_MOCK_ENGINE_CONSUMER_H_
 
 #include <string>
+#include <vector>
 
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -51,6 +52,18 @@ class MockEngineConsumer : public EngineConsumer {
   MOCK_METHOD(void, SanitizeInput, (std::string & input), (override));
 
   MOCK_METHOD(void, ClearAllQueries, (), (override));
+
+  MOCK_METHOD(void,
+              GetSuggestedTopics,
+              (const std::vector<Tab>&, GetSuggestedTopicsCallback),
+              (override));
+  MOCK_METHOD(void,
+              GetFocusTabs,
+              (const std::vector<Tab>&,
+               const std::string&,
+               GetFocusTabsCallback),
+              (override));
+  MOCK_METHOD(const std::string&, GetModelName, (), (const, override));
 
   bool SupportsDeltaTextResponses() const override {
     return supports_delta_text_responses_;

--- a/components/ai_chat/core/browser/model_service.cc
+++ b/components/ai_chat/core/browser/model_service.cc
@@ -121,7 +121,7 @@ const std::vector<mojom::ModelPtr>& GetLeoModels() {
     {
       auto options = mojom::LeoModelOptions::New();
       options->display_maker = "Anthropic";
-      options->name = "claude-3-haiku";
+      options->name = kClaudeHaikuModelName;
       options->category = mojom::ModelCategory::CHAT;
       options->access = kFreemiumAccess;
       options->engine_type =
@@ -131,7 +131,7 @@ const std::vector<mojom::ModelPtr>& GetLeoModels() {
       options->long_conversation_warning_character_limit = 320000;
 
       auto model = mojom::Model::New();
-      model->key = "chat-claude-haiku";
+      model->key = kClaudeHaikuModelKey;
       model->display_name = "Claude Haiku";
       model->vision_support = false;
       model->options =
@@ -143,7 +143,7 @@ const std::vector<mojom::ModelPtr>& GetLeoModels() {
     {
       auto options = mojom::LeoModelOptions::New();
       options->display_maker = "Anthropic";
-      options->name = "claude-3-sonnet";
+      options->name = kClaudeSonnetModelName;
       options->category = mojom::ModelCategory::CHAT;
       options->access = mojom::ModelAccess::PREMIUM;
       options->engine_type =
@@ -153,7 +153,7 @@ const std::vector<mojom::ModelPtr>& GetLeoModels() {
       options->long_conversation_warning_character_limit = 320000;
 
       auto model = mojom::Model::New();
-      model->key = "chat-claude-sonnet";
+      model->key = kClaudeSonnetModelKey;
       model->display_name = "Claude Sonnet";
       model->vision_support = true;
       model->options =
@@ -314,7 +314,7 @@ ModelService::ModelService(PrefService* prefs_service)
     // First set to an equivalent model that is available to all users. When
     // we are told about premium status, we can switch to the premium
     // equivalent.
-    SetDefaultModelKey("chat-claude-haiku");
+    SetDefaultModelKey(kClaudeHaikuModelKey);
     is_migrating_claude_instant_ = true;
   }
 }

--- a/components/ai_chat/core/browser/types.h
+++ b/components/ai_chat/core/browser/types.h
@@ -8,6 +8,8 @@
 
 #include <string>
 
+#include "url/origin.h"
+
 namespace ai_chat {
 
 struct SearchQuerySummary {
@@ -15,6 +17,14 @@ struct SearchQuerySummary {
   std::string summary;
 
   bool operator==(const SearchQuerySummary& other) const = default;
+};
+
+struct Tab {
+  std::string id;
+  std::string title;
+  url::Origin origin;
+
+  bool operator==(const Tab& other) const = default;
 };
 
 }  // namespace ai_chat

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -13,10 +13,7 @@
 
 namespace ai_chat::features {
 
-BASE_FEATURE(kAIChat,
-             "AIChat",
-             base::FEATURE_ENABLED_BY_DEFAULT
-);
+BASE_FEATURE(kAIChat, "AIChat", base::FEATURE_ENABLED_BY_DEFAULT);
 const base::FeatureParam<std::string> kAIModelsDefaultKey{
     &kAIChat, "default_model", "chat-leo-expanded"};
 const base::FeatureParam<std::string> kAIModelsPremiumDefaultKey{
@@ -98,6 +95,14 @@ BASE_FEATURE(kPageContextEnabledInitially,
 
 bool IsPageContextEnabledInitially() {
   return base::FeatureList::IsEnabled(features::kPageContextEnabledInitially);
+}
+
+BASE_FEATURE(kTabOrganization,
+             "BraveTabOrganization",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
+bool IsTabOrganizationEnabled() {
+  return base::FeatureList::IsEnabled(features::kTabOrganization);
 }
 
 }  // namespace ai_chat::features

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -65,6 +65,10 @@ COMPONENT_EXPORT(AI_CHAT_COMMON)
 BASE_DECLARE_FEATURE(kPageContextEnabledInitially);
 COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsPageContextEnabledInitially();
 
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+BASE_DECLARE_FEATURE(kTabOrganization);
+COMPONENT_EXPORT(AI_CHAT_COMMON) bool IsTabOrganizationEnabled();
+
 }  // namespace ai_chat::features
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_FEATURES_H_

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -17,6 +17,7 @@ enum CharacterType {
 
 enum APIError {
   None,
+  InternalError,
   ConnectionIssue,
   RateLimitReached,
   ContextLimitReached,

--- a/components/ai_chat/core/common/pref_names.cc
+++ b/components/ai_chat/core/common/pref_names.cc
@@ -31,6 +31,7 @@ void RegisterProfilePrefs(PrefRegistrySimple* registry) {
 #endif
     registry->RegisterBooleanPref(kBraveAIChatContextMenuEnabled, true);
     registry->RegisterBooleanPref(kBraveAIChatShowToolbarButton, true);
+    registry->RegisterBooleanPref(kBraveAIChatTabOrganizationEnabled, false);
   }
   registry->RegisterBooleanPref(kEnabledByPolicy, true);
 }

--- a/components/ai_chat/core/common/pref_names.h
+++ b/components/ai_chat/core/common/pref_names.h
@@ -93,6 +93,9 @@ inline constexpr char kEnabledByPolicy[] = "brave.ai_chat.enabled_by_policy";
 inline constexpr char kObseleteBraveChatAutoGenerateQuestions[] =
     "brave.ai_chat.auto_generate_questions";
 
+inline constexpr char kBraveAIChatTabOrganizationEnabled[] =
+    "brave.ai_chat.tab_organization_enabled";
+
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 void RegisterProfilePrefs(PrefRegistrySimple* registry);
 

--- a/components/resources/ai_chat_ui_strings.grdp
+++ b/components/resources/ai_chat_ui_strings.grdp
@@ -45,6 +45,9 @@
   <message name="IDS_CHAT_UI_PAGE_CONTENT_WARNING" desc="Description about page content being sent to a remote LLM">
      Disconnect to stop sending this page content to Leo, and start a new conversation
   </message>
+  <message name="IDS_CHAT_UI_ERROR_INTERNAL" desc="A general error message for processing user requests">
+    Something went wrong while processing your request. Please try again later.
+  </message>
   <message name="IDS_CUSTOM_MODEL_ENDPOINT_INVALID_ERROR" desc="An error presented when the model endpoint is invalid">
     This model has an invalid endpoint. Please check your configuration and try again.
   </message>

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -1162,6 +1162,7 @@ test("brave_browser_tests") {
       "//brave/browser/ui/ai_rewriter:browsertest",
       "//brave/browser/ui/geolocation:browser_tests",
       "//brave/browser/ui/toolbar:brave_app_menu_browser_tests",
+      "//brave/browser/ui/webui/tab_search:browser_tests",
       "//brave/browser/ui/whats_new:browser_test",
       "//brave/browser/url_sanitizer:browser_tests",
       "//brave/components/brave_wallet/browser:test_support",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44679
Security and privacy review: https://github.com/brave/reviews/issues/1890
Server PR: https://github.com/brave/aichat/pull/421
UI changes is co-authored with @Douglashdaniel, I'll tag him in the commit message before merging.

https://github.com/user-attachments/assets/4006f72c-7691-4f78-8f34-a5796f2e871b

Setting to enable tab organization: (default to off)
<img width="1288" alt="Screenshot 2025-03-14 at 3 03 26 PM" src="https://github.com/user-attachments/assets/0732eba0-e161-46d0-b969-82ea5b8b4648" />

Loading suggested topics:
<img width="318" alt="Screenshot 2025-03-14 at 2 58 51 PM" src="https://github.com/user-attachments/assets/09009b6b-891c-4223-84f6-408953df6b54" />

Finish loading suggested topics:
<img width="319" alt="Screenshot 2025-03-14 at 2 59 53 PM" src="https://github.com/user-attachments/assets/81c18514-55b2-42c6-9c6d-2a61eefed910" />

With undo:
<img width="318" alt="Screenshot 2025-03-14 at 2 25 19 PM" src="https://github.com/user-attachments/assets/bc4c6dec-6af8-4f13-bae7-617439d67906" />

Selector shown if chromium's declutter feature flag is enabled (default is off atm):
<img width="324" alt="Screenshot 2025-03-14 at 2 21 59 PM" src="https://github.com/user-attachments/assets/4dc0139a-1a62-4eba-964b-a95df87d7bc2" />
Note that Chromium choose to align button text in the center, this can be updated in the follow-up to match our design (align: left).

Rate limit reached:
<img width="315" alt="Screenshot 2025-03-14 at 3 27 55 PM" src="https://github.com/user-attachments/assets/b500226b-d895-4c7c-b1d2-a4a52d93c617" />

Rate limit reached (premium user):
<img width="321" alt="Screenshot 2025-03-14 at 3 22 52 PM" src="https://github.com/user-attachments/assets/581ad765-15a4-46d0-879a-ff273e9a3219" />

Connection issue:
<img width="309" alt="Screenshot 2025-03-14 at 4 04 19 PM" src="https://github.com/user-attachments/assets/42b267f3-12a3-4502-976c-25657976b519" />


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1. Open various tabs in different topics and URLs.
2. Open Tab Search UI without enabling the new setting added for this feature, no Tab Organization UI should be seen.
3. Enable the feature setting added in this PR.
4. Open Tab Search UI and go to Tab Organization sub-tab.
5. Verify suggested topics would be loaded when this UI is shown.
6. Clicking on one of the suggested topics, verify a new window with related tabs will be created.
7. Go back to the original window and open Tab Search UI again to test `undo`, which will move tabs in the new window back.
8. Manually enter a topic to focus on and verify related tabs are moved to a new window.
(Note that the result from AI agent may not be a good one sometimes during tests, which is not really in the scope of this PR.)