### PR TITLE
Handle tab-fullscreen from split view

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -72,6 +72,12 @@ BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {
       std::make_unique<sidebar::SidebarController>(this, profile());
   sidebar_controller_->SetSidebar(brave_window()->InitSidebar());
 #endif
+
+  // As browser window(BrowserView) is initialized before fullscreen controller
+  // is ready, it's difficult to know when browsr window can listen.
+  // Notify exact timing to do it.
+  CHECK(exclusive_access_manager());
+  brave_window()->ReadyToListenFullscreenChanges();
 }
 
 BraveBrowser::~BraveBrowser() = default;

--- a/browser/ui/brave_browser_window.h
+++ b/browser/ui/brave_browser_window.h
@@ -71,6 +71,7 @@ class BraveBrowserWindow : public BrowserWindow {
 
   // Returns true if all tabs in this window is being dragged.
   virtual bool IsInTabDragging() const;
+  virtual void ReadyToListenFullscreenChanges() {}
 };
 
 #endif  // BRAVE_BROWSER_UI_BRAVE_BROWSER_WINDOW_H_

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -917,6 +917,12 @@ views::View* BraveBrowserView::GetContentsContainerForLayoutManager() {
                      : BrowserView::GetContentsContainerForLayoutManager();
 }
 
+void BraveBrowserView::ReadyToListenFullscreenChanges() {
+  if (split_view_) {
+    split_view_->ListenFullscreenChanges();
+  }
+}
+
 bool BraveBrowserView::IsSidebarVisible() const {
   return sidebar_container_view_ && sidebar_container_view_->IsSidebarVisible();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -118,6 +118,7 @@ class BraveBrowserView : public BrowserView,
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
   bool IsInTabDragging() const override;
   views::View* GetContentsContainerForLayoutManager() override;
+  void ReadyToListenFullscreenChanges() override;
 
 #if defined(USE_AURA)
   views::View* sidebar_host_view() { return sidebar_host_view_; }

--- a/browser/ui/views/split_view/split_view.h
+++ b/browser/ui/views/split_view/split_view.h
@@ -16,6 +16,7 @@
 #include "brave/browser/ui/tabs/split_view_browser_data_observer.h"
 #include "brave/browser/ui/views/split_view/split_view_layout_manager.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_observer.h"
 #include "chrome/browser/ui/views/frame/scrim_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/gfx/geometry/rounded_corners_f.h"
@@ -38,6 +39,7 @@ class BraveBrowserView;
 class Browser;
 class ContentsWebView;
 class DevToolsContentsResizingStrategy;
+class FullscreenController;
 class SplitViewLayoutManager;
 class SplitViewLocationBar;
 class SplitViewSeparator;
@@ -48,6 +50,7 @@ class SplitView : public views::View,
                   public ReaderModeToolbarView::Delegate,
 #endif
                   public views::WidgetObserver,
+                  public FullscreenObserver,
                   public SplitViewBrowserDataObserver {
   METADATA_HEADER(SplitView, views::View)
  public:
@@ -64,6 +67,8 @@ class SplitView : public views::View,
 
   // true when active tab is in tile.
   bool IsSplitViewActive() const;
+
+  void ListenFullscreenChanges();
 
   // Called before/after BrowserView::OnActiveTabChanged() as we have some
   // jobs such as reducing flickering while active tab changing. See the
@@ -123,6 +128,9 @@ class SplitView : public views::View,
   void OnWidgetWindowModalVisibilityChanged(views::Widget* widget,
                                             bool visible) override;
 
+  // FullscreenObserver:
+  void OnFullscreenStateChanged() override;
+
  private:
   friend class SplitViewBrowserTest;
   friend class SplitViewLocationBarBrowserTest;
@@ -139,6 +147,7 @@ class SplitView : public views::View,
 
   SplitViewLayoutManager* GetSplitViewLayoutManager();
   const SplitViewLayoutManager* GetSplitViewLayoutManager() const;
+  bool ShouldHideSecondaryContentsByTabFullscreen() const;
 
   raw_ref<Browser> browser_;
 
@@ -163,6 +172,8 @@ class SplitView : public views::View,
       split_view_observation_{this};
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
+  base::ScopedObservation<FullscreenController, FullscreenObserver>
+      fullscreen_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_H_

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -16,6 +16,8 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/split_view/split_view_layout_manager.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -354,4 +356,34 @@ IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewTabPathTest) {
                 GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP) -
                 (brave_tabs::kHorizontalSplitViewTabVerticalSpacing * 2),
             mask_region.getBounds().height());
+}
+
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewFullscreenTest) {
+  brave::NewSplitViewForTab(browser());
+
+  // In split view tile, both contents are visible and have its border.
+  EXPECT_TRUE(browser_view().contents_container()->GetVisible());
+  EXPECT_TRUE(browser_view().contents_container()->GetBorder());
+  EXPECT_TRUE(secondary_contents_container().GetVisible());
+  EXPECT_TRUE(secondary_contents_container().GetBorder());
+
+  // Simulate tab-fullscreen state change.
+  FullscreenController* fullscreen_controller =
+      browser()->exclusive_access_manager()->fullscreen_controller();
+  fullscreen_controller->set_is_tab_fullscreen_for_testing(true);
+  split_view().OnFullscreenStateChanged();
+
+  // In tab full screen, only primary content is visible w/o border.
+  EXPECT_TRUE(browser_view().contents_container()->GetVisible());
+  EXPECT_FALSE(browser_view().contents_container()->GetBorder());
+  EXPECT_FALSE(secondary_contents_container().GetVisible());
+  EXPECT_FALSE(secondary_contents_container().GetBorder());
+
+  fullscreen_controller->set_is_tab_fullscreen_for_testing(false);
+  split_view().OnFullscreenStateChanged();
+
+  EXPECT_TRUE(browser_view().contents_container()->GetVisible());
+  EXPECT_TRUE(browser_view().contents_container()->GetBorder());
+  EXPECT_TRUE(secondary_contents_container().GetVisible());
+  EXPECT_TRUE(secondary_contents_container().GetBorder());
 }


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/43111

When active tab initiates tab-fullscreen from split view, it should occupy whole screen.


https://github.com/user-attachments/assets/b9daac26-946c-4179-88b7-593d6c283214



<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SplitViewBrowserTest.SplitViewFullscreenTest`

See the linked issue for manual test