### PR TITLE
[iOS] Fix crash when sync chain contains a device syncing tab groups (uplift to 1.76.x)

### DIFF
--- a/chromium_src/ios/chrome/browser/shared/public/features/features.mm
+++ b/chromium_src/ios/chrome/browser/shared/public/features/features.mm
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#import "ios/chrome/browser/shared/public/features/features.h"
+
+#define IsTabGroupSyncEnabled IsTabGroupSyncEnabled_ChromiumImpl
+#include "src/ios/chrome/browser/shared/public/features/features.mm"
+#undef IsTabGroupSyncEnabled
+
+bool IsTabGroupSyncEnabled() {
+  return false;
+}


### PR DESCRIPTION
Uplift of #28113
Resolves https://github.com/brave/brave-browser/issues/44380

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.