### PR TITLE
[Uplift 1.77.x] [Bookmarks]: Allow bookmarks to be the default match and bump exact title matches

### DIFF
--- a/components/omnibox/browser/brave_bookmark_provider.cc
+++ b/components/omnibox/browser/brave_bookmark_provider.cc
@@ -8,6 +8,7 @@
 #include "base/containers/contains.h"
 #include "brave/components/omnibox/browser/brave_history_quick_provider.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
+#include "components/omnibox/browser/autocomplete_match.h"
 #include "components/omnibox/browser/bookmark_provider.h"
 #include "components/omnibox/browser/omnibox_view.h"
 #include "components/prefs/pref_service.h"
@@ -43,20 +44,14 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
     auto bump_match =
         base::Contains(lower_contents, lower_text) ||
         base::Contains(base::ToLowerASCII(match.description), lower_text);
-    match.allowed_to_be_default_match = bump_match;
     if (!bump_match) {
       continue;
     }
 
+    match.SetAllowedToBeDefault(input);
+
     modified = true;
     match.relevance += kContainsQueryBump;
-
-    // Note: By default the BookmarkProvider will fill the URL from the
-    // bookmark. This is fine upstream as they don't allow bookmarks to be the
-    // default match (it breaks the user editing the input when its default).
-    // We set |fill_into_edit| to the input text so what the user typed is not
-    // modified.
-    match.fill_into_edit = input.text();
   }
 
   // If we modified any matches, notify listeners so the UI updates.

--- a/components/omnibox/browser/brave_bookmark_provider.cc
+++ b/components/omnibox/browser/brave_bookmark_provider.cc
@@ -5,9 +5,11 @@
 
 #include "brave/components/omnibox/browser/brave_bookmark_provider.h"
 
+#include "base/containers/contains.h"
 #include "brave/components/omnibox/browser/brave_history_quick_provider.h"
 #include "brave/components/omnibox/browser/brave_omnibox_prefs.h"
 #include "components/omnibox/browser/bookmark_provider.h"
+#include "components/omnibox/browser/omnibox_view.h"
 #include "components/prefs/pref_service.h"
 
 BraveBookmarkProvider::~BraveBookmarkProvider() = default;
@@ -19,4 +21,46 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
     return;
   }
   BookmarkProvider::Start(input, minimal_changes);
+
+  if (input.text().empty() || matches_.empty()) {
+    return;
+  }
+
+  // We need to bump the relevance of the bookmark if we ever want it to rank
+  // high enough to be the default match.
+  constexpr int kContainsQueryBump = 350;
+  bool modified = false;
+
+  auto lower_text = base::ToLowerASCII(input.text());
+  for (auto& match : matches_) {
+    if (match.from_keyword) {
+      continue;
+    }
+
+    // We only allow the bookmark to be the default match if the input is
+    // literally contained in the title or URL.
+    auto lower_contents = base::ToLowerASCII(match.contents);
+    auto bump_match =
+        base::Contains(lower_contents, lower_text) ||
+        base::Contains(base::ToLowerASCII(match.description), lower_text);
+    match.allowed_to_be_default_match = bump_match;
+    if (!bump_match) {
+      continue;
+    }
+
+    modified = true;
+    match.relevance += kContainsQueryBump;
+
+    // Note: By default the BookmarkProvider will fill the URL from the
+    // bookmark. This is fine upstream as they don't allow bookmarks to be the
+    // default match (it breaks the user editing the input when its default).
+    // We set |fill_into_edit| to the input text so what the user typed is not
+    // modified.
+    match.fill_into_edit = input.text();
+  }
+
+  // If we modified any matches, notify listeners so the UI updates.
+  if (modified) {
+    NotifyListeners(true);
+  }
 }

--- a/components/omnibox/browser/brave_bookmark_provider_unittest.cc
+++ b/components/omnibox/browser/brave_bookmark_provider_unittest.cc
@@ -122,3 +122,29 @@ TEST_F(BraveBookmarkProviderTest, ContainsQueryBumpsRelevance) {
   // Note: 1199 is the max relevance score for a bookmark upstream.
   EXPECT_GT(provider_->matches()[0].relevance, 1199);
 }
+
+TEST_F(BraveBookmarkProviderTest, ExactTitleMatchBumpsRelevance) {
+  prefs()->SetBoolean(omnibox::kBookmarkSuggestionsEnabled, true);
+  client_.GetBookmarkModel()->AddURL(client_.GetBookmarkModel()->other_node(),
+                                     0, u"Hellow",
+                                     GURL("https://example.com/one"));
+  provider_->Start(CreateAutocompleteInput("Hello"), true);
+  EXPECT_EQ(provider_->matches().size(), 2u);
+
+  EXPECT_EQ(provider_->matches()[0].description, u"Hello");
+  EXPECT_TRUE(provider_->matches()[0].allowed_to_be_default_match);
+
+  EXPECT_EQ(provider_->matches()[1].description, u"Hellow");
+  EXPECT_TRUE(provider_->matches()[1].allowed_to_be_default_match);
+
+  EXPECT_GT(provider_->matches()[0].relevance,
+            provider_->matches()[1].relevance);
+}
+
+TEST_F(BraveBookmarkProviderTest, TitleOnlyMatchSetsURL) {
+  prefs()->SetBoolean(omnibox::kBookmarkSuggestionsEnabled, true);
+  provider_->Start(CreateAutocompleteInput("Hello"), true);
+  EXPECT_EQ(provider_->matches().size(), 1u);
+  EXPECT_TRUE(provider_->matches()[0].allowed_to_be_default_match);
+  EXPECT_EQ(provider_->matches()[0].contents, u"example.com");
+}


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/27939
Uplift of https://github.com/brave/brave-core/pull/28041
Uplift of https://github.com/brave/brave-core/pull/28101
Resolves https://github.com/brave/brave-browser/issues/44374
Resolves https://github.com/brave/brave-browser/issues/44535
Resolves https://github.com/brave/brave-browser/issues/44518
Resolves https://github.com/brave/brave-browser/issues/44450