### PR TITLE
[iOS] - Update the Brave Translate Onboarding

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
@@ -285,17 +285,6 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
   }
 
   @MainActor
-  func setupOnboarding() async throws {
-    guard let tab = tab, let delegate = delegate else {
-      return
-    }
-
-    if delegate.canShowTranslateOnboarding(tab: tab) {
-      await detectLanguage()
-    }
-  }
-
-  @MainActor
   func beginSetup() async throws {
     guard tab != nil else {
       return
@@ -339,11 +328,9 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
     // Check if the user can view the translation onboarding
     guard delegate.canShowTranslateOnboarding(tab: tab) else {
-      let translateEnabled = Preferences.Translate.translateEnabled.value == true
-
       delegate.updateTranslateURLBar(
         tab: tab,
-        state: translateEnabled ? .available : .unavailable
+        state: Preferences.Translate.translateEnabled.value ? .available : .unavailable
       )
 
       return
@@ -360,16 +347,13 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
 
     delegate.updateTranslateURLBar(
       tab: tab,
-      state: translateEnabled == true ? .available : .unavailable
+      state: translateEnabled ? .available : .unavailable
     )
 
     // User enabled translation via onboarding
-    if translateEnabled == true {
+    if translateEnabled {
       // Load the translate script manually
       try await loadTranslateScript()
-
-      // Automatically translate
-      startTranslation(canShowToast: true)
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -100,7 +100,7 @@ extension BrowserViewController {
     if FeatureList.kBraveTranslateEnabled.enabled,
       let translationState = tab?.translationState,
       translationState != .unavailable,
-      Preferences.Translate.translateEnabled.value != false
+      Preferences.Translate.translateEnabled.value
     {
       activities.append(
         BasicMenuActivity(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Translate.swift
@@ -25,15 +25,14 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
       return false
     }
 
-    return Preferences.Translate.translateEnabled.value == nil
+    return Preferences.Translate.translateEnabled.value
       && !topToolbar.inOverlayMode
       && topToolbar.secureContentState == .secure
       && Preferences.Translate.translateURLBarOnboardingCount.value < 2
       && shouldShowTranslationOnboardingThisSession && presentedViewController == nil
   }
 
-  func showTranslateOnboarding(tab: Tab, completion: @escaping (_ translateEnabled: Bool?) -> Void)
-  {
+  func showTranslateOnboarding(tab: Tab, completion: @escaping (_ translateEnabled: Bool) -> Void) {
     topToolbar.layoutIfNeeded()
     view.layoutIfNeeded()
 
@@ -44,34 +43,14 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
       // Do NOT show the translate onboarding popup if the tab isn't visible
       guard self.canShowTranslateOnboarding(tab: tab)
       else {
-        completion(nil)
+        completion(Preferences.Translate.translateEnabled.value)
         return
       }
 
       Preferences.Translate.translateURLBarOnboardingCount.value += 1
 
       let popover = PopoverController(
-        content: OnboardingTranslateView(
-          onContinueButtonPressed: { [weak self, weak tab] in
-            guard let tab = tab, let self = self else { return }
-
-            self.topToolbar.locationView.translateButton.setOnboardingState(enabled: false)
-            Preferences.Translate.translateEnabled.value = true
-
-            tab.translateHelper?.presentUI(on: self)
-            completion(true)
-          },
-          onDisableFeature: { [weak self, weak tab] in
-            guard let tab = tab, let self = self else { return }
-
-            self.topToolbar.locationView.translateButton.setOnboardingState(enabled: false)
-
-            Preferences.Translate.translateEnabled.value = false
-            tab.translationState = .unavailable
-            self.topToolbar.updateTranslateButtonState(.unavailable)
-            completion(false)
-          }
-        ),
+        content: OnboardingTranslateView(),
         autoLayoutConfiguration: .phoneWidth
       )
 
@@ -90,7 +69,7 @@ extension BrowserViewController: BraveTranslateScriptHandlerDelegate {
 
       popover.popoverDidDismiss = { [weak self] _ in
         self?.topToolbar.locationView.translateButton.setOnboardingState(enabled: false)
-        completion(nil)
+        completion(Preferences.Translate.translateEnabled.value)
       }
       popover.present(from: self.topToolbar.locationView.translateButton, on: self)
       self.shouldShowTranslationOnboardingThisSession = false

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -3106,7 +3106,7 @@ extension BrowserViewController: PreferencesObserver {
     case Preferences.Translate.translateEnabled.key:
       tabManager.selectedTab?.translationState = .unavailable
       tabManager.selectedTab?.setScripts(scripts: [
-        .braveTranslate: Preferences.Translate.translateEnabled.value != false
+        .braveTranslate: Preferences.Translate.translateEnabled.value
       ])
       // Only reload the tab if the setting was changed from the settings controller
       if presentedViewController is SettingsNavigationController {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -625,7 +625,7 @@ class Tab: NSObject {
         .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
         .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value,
         .nightMode: Preferences.General.nightModeEnabled.value,
-        .braveTranslate: Preferences.Translate.translateEnabled.value != false,
+        .braveTranslate: Preferences.Translate.translateEnabled.value,
       ]
 
       userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Translate/BraveTranslateSettingsView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Translate/BraveTranslateSettingsView.swift
@@ -16,9 +16,7 @@ struct BraveTranslateSettingsView: View {
   var body: some View {
     Form {
       Section {
-        Toggle(
-          isOn: .init(get: { translateEnabled.value == true }, set: { translateEnabled.value = $0 })
-        ) {
+        Toggle(isOn: $translateEnabled.value) {
           Text(Strings.BraveTranslate.settingsTranslateEnabledOptionTitle)
         }
         .tint(Color.accentColor)

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -382,9 +382,8 @@ extension Preferences {
     /// Determines whether Brave Translate is enabled
     /// - true = Enabled
     /// - false = Disabled
-    /// - nil = Onboarding dismissed, state unknown
     public static let translateEnabled =
-      Option<Bool?>(key: "brave-translate.enabled", default: nil)
+      Option<Bool>(key: "brave-translate.enabled", default: true)
 
     /// Determines whether to show Brave Translate onboarding.
     public static let translateURLBarOnboardingCount =

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveTranslateScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveTranslateScriptHandler.swift
@@ -13,7 +13,7 @@ import os.log
 protocol BraveTranslateScriptHandlerDelegate: NSObject {
   func updateTranslateURLBar(tab: Tab, state: TranslateURLBarButton.TranslateState)
   func canShowTranslateOnboarding(tab: Tab) -> Bool
-  func showTranslateOnboarding(tab: Tab, completion: @escaping (_ translateEnabled: Bool?) -> Void)
+  func showTranslateOnboarding(tab: Tab, completion: @escaping (_ translateEnabled: Bool) -> Void)
   func presentTranslateToast(tab: Tab, languageInfo: BraveTranslateLanguageInfo)
   func presentTranslateError(tab: Tab)
 }
@@ -83,7 +83,7 @@ class BraveTranslateScriptHandler: NSObject, TabContentScript {
       return
     }
 
-    if Preferences.Translate.translateEnabled.value == false {
+    if !Preferences.Translate.translateEnabled.value {
       Logger.module.debug("Translation Disabled")
       replyHandler(nil, BraveTranslateError.translateDisabled.rawValue)
       return
@@ -121,7 +121,7 @@ class BraveTranslateScriptHandler: NSObject, TabContentScript {
     body: [String: Any]
   ) async throws -> (Any?, String?) {
     if command == "load_brave_translate_script" {
-      if Preferences.Translate.translateEnabled.value == true {
+      if Preferences.Translate.translateEnabled.value {
         if let script = Self.elementScript {
           return (script, nil)
         }
@@ -130,7 +130,6 @@ class BraveTranslateScriptHandler: NSObject, TabContentScript {
         return (Self.elementScript, nil)
       }
 
-      try await tab.translateHelper?.setupOnboarding()
       return (nil, BraveTranslateError.translateDisabled.rawValue)
     }
 

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -28,6 +28,7 @@ public class Migration {
     Preferences.migrateHTTPSUpgradeLevel()
     Preferences.migrateBackgroundSponsoredImages()
     Preferences.migrateBookmarksButtonInToolbar()
+    Preferences.migrateTranslateEnabled()
 
     if Preferences.General.isFirstLaunch.value {
       if UIDevice.current.userInterfaceIdiom == .phone {
@@ -260,6 +261,11 @@ extension Preferences {
       key: "migration.bookmarks-button-in-toolbar",
       default: false
     )
+
+    static let migratedTranslateEnabledCompleted = Option<Bool>(
+      key: "migration.translate-enabled-completed",
+      default: false
+    )
   }
 
   /// Migrate a given key from `Prefs` into a specific option
@@ -424,6 +430,12 @@ extension Preferences {
     }
 
     Migration.migratedBookmarksButtonInToolbar.value = true
+  }
+
+  fileprivate class func migrateTranslateEnabled() {
+    guard !Migration.migratedTranslateEnabledCompleted.value else { return }
+    Preferences.Translate.translateEnabled.value = true
+    Migration.migratedTranslateEnabledCompleted.value = true
   }
 }
 

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -28,7 +28,6 @@ public class Migration {
     Preferences.migrateHTTPSUpgradeLevel()
     Preferences.migrateBackgroundSponsoredImages()
     Preferences.migrateBookmarksButtonInToolbar()
-    Preferences.migrateTranslateEnabled()
 
     if Preferences.General.isFirstLaunch.value {
       if UIDevice.current.userInterfaceIdiom == .phone {
@@ -261,11 +260,6 @@ extension Preferences {
       key: "migration.bookmarks-button-in-toolbar",
       default: false
     )
-
-    static let migratedTranslateEnabledCompleted = Option<Bool>(
-      key: "migration.translate-enabled-completed",
-      default: false
-    )
   }
 
   /// Migrate a given key from `Prefs` into a specific option
@@ -430,12 +424,6 @@ extension Preferences {
     }
 
     Migration.migratedBookmarksButtonInToolbar.value = true
-  }
-
-  fileprivate class func migrateTranslateEnabled() {
-    guard !Migration.migratedTranslateEnabledCompleted.value else { return }
-    Preferences.Translate.translateEnabled.value = true
-    Migration.migratedTranslateEnabledCompleted.value = true
   }
 }
 

--- a/ios/brave-ios/Sources/Onboarding/Callouts/OnboardingTranslateView.swift
+++ b/ios/brave-ios/Sources/Onboarding/Callouts/OnboardingTranslateView.swift
@@ -11,67 +11,21 @@ import Strings
 import SwiftUI
 
 public struct OnboardingTranslateView: View {
-  @Environment(\.dismiss) private var dismiss
 
-  private var onContinueButtonPressed: (() -> Void)?
-  private var onDisableFeature: (() -> Void)?
-
-  public init(onContinueButtonPressed: (() -> Void)? = nil, onDisableFeature: (() -> Void)? = nil) {
-    self.onContinueButtonPressed = onContinueButtonPressed
-    self.onDisableFeature = onDisableFeature
-  }
+  public init() {}
 
   public var body: some View {
     ScrollView(.vertical) {
-      VStack(spacing: 0.0) {
+      VStack(spacing: 16.0) {
         Image("translate-onboarding-icon", bundle: .module)
-          .padding(.vertical, 24.0)
 
         Text(Strings.BraveTranslateOnboarding.translateTitle)
           .font(.callout.weight(.semibold))
           .foregroundColor(Color(braveSystemName: .textPrimary))
-          .padding(.bottom)
 
         Text(Strings.BraveTranslateOnboarding.translateDescription)
           .font(.callout)
           .foregroundColor(Color(braveSystemName: .textSecondary))
-          .padding(.bottom, 24.0)
-
-        Button(
-          action: {
-            dismiss()
-            onContinueButtonPressed?()
-          },
-          label: {
-            Text(Strings.OBContinueButton)
-              .font(.body.weight(.semibold))
-              .padding()
-              .frame(maxWidth: .infinity)
-              .foregroundStyle(Color(braveSystemName: .schemesOnPrimary))
-              .background(
-                ContainerRelativeShape()
-                  .fill(Color(braveSystemName: .buttonBackground))
-              )
-              .containerShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
-          }
-        )
-        .buttonStyle(.plain)
-        .padding(.bottom)
-
-        Button(
-          action: {
-            dismiss()
-            onDisableFeature?()
-          },
-          label: {
-            Text(Strings.BraveTranslateOnboarding.disableTranslateButtonTitle)
-              .font(.body.weight(.semibold))
-              .padding()
-              .frame(maxWidth: .infinity)
-              .foregroundStyle(Color(braveSystemName: .textSecondary))
-          }
-        )
-        .buttonStyle(.plain)
       }
       .padding(24.0)
     }


### PR DESCRIPTION
## Summary
- Translate is on by default
- Removed buttons from translate onboarding
- Update code to accommodate new onboarding

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44650

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

