### PR TITLE
[iOS] Ensure onboarding actions remain visible even with large fonts

### DIFF
--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/BlockInterruptionsOnboardingStep.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/BlockInterruptionsOnboardingStep.swift
@@ -21,8 +21,6 @@ struct BlockInterruptionsGraphicView: View {
     .resizable()
     .playing(loopMode: .loop)
     .id(colorScheme)
-    .aspectRatio(contentMode: .fit)
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/DefaultBrowserOnboardingStep.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/DefaultBrowserOnboardingStep.swift
@@ -22,8 +22,6 @@ struct DefaultBrowserGraphicView: View {
     .resizable()
     .playing(loopMode: .loop)
     .id(colorScheme)
-    .aspectRatio(contentMode: .fit)
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }
 

--- a/ios/brave-ios/Sources/Onboarding/WelcomeFocus/P3AOptInOnboardingStep.swift
+++ b/ios/brave-ios/Sources/Onboarding/WelcomeFocus/P3AOptInOnboardingStep.swift
@@ -20,6 +20,7 @@ struct P3AOptInGraphicsView: View {
       Image("focus-product-insight", bundle: .module)
         .resizable()
         .aspectRatio(contentMode: .fit)
+        .frame(maxHeight: 250)
       Spacer()
       Toggle(LocalizedStringKey(Strings.FocusOnboarding.p3aToggleTitle), isOn: $isP3AEnabled)
         .padding(24)


### PR DESCRIPTION
This change moves the onboarding actions into an overlay so that they are always visible at the bottom of the UI and embeds the content above them in a scroll view if required.

Resolves https://github.com/brave/brave-browser/issues/44646

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Verify new onboarding UI across 3 different modes (iPhone fullscreen, iPad portrait, iPad landscape, iPad multitask) with different font sizes