### PR TITLE
Add an option to allow users to take screenshots in private mode

### DIFF
--- a/android/java/org/chromium/base/BraveFeatureList.java
+++ b/android/java/org/chromium/base/BraveFeatureList.java
@@ -40,4 +40,5 @@ public abstract class BraveFeatureList {
     public static final String BRAVE_SHIELDS_ELEMENT_PICKER = "BraveShieldsElementPicker";
     public static final String BRAVE_WEB_DISCOVERY_NATIVE = "BraveWebDiscoveryNative";
     public static final String NEW_REWARDS_UI_FEATURE = "BraveRewardsNewRewardsUI";
+    public static final String BRAVE_INCOGNITO_SCREENSHOT = "incognito-screenshot";
 }

--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
@@ -49,6 +49,8 @@ import org.chromium.mojo.system.MojoException;
 import org.chromium.ui.text.ChromeClickableSpan;
 import org.chromium.ui.text.SpanApplier;
 import org.chromium.webcompat_reporter.mojom.WebcompatReporterHandler;
+import org.chromium.chrome.browser.BraveFeatureUtil;
+import org.chromium.chrome.browser.BraveRelaunchUtils;
 
 /** Fragment to keep track of the all the brave privacy related preferences. */
 public class BravePrivacySettings extends PrivacySettings implements ConnectionErrorHandler {
@@ -67,6 +69,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
     private static final String PREF_PRIVACY_SANDBOX = "privacy_sandbox";
     private static final String PREF_HTTPS_FIRST_MODE_LEGACY = "https_first_mode_legacy";
     private static final String PREF_HTTPS_FIRST_MODE = "https_first_mode";
+    private static final String PREF_INCOGNITO_SCREENSHOT = "incognito_screenshot";
     private static final String PREF_INCOGNITO_LOCK = "incognito_lock";
     private static final String PREF_PHONE_AS_A_SECURITY_KEY = "phone_as_a_security_key";
     private static final String PREF_FINGERPRINT_LANGUAGE = "fingerprint_language";
@@ -152,6 +155,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         PREF_APP_LINKS,
         PREF_WEBRTC_POLICY,
         PREF_SAFE_BROWSING,
+        PREF_INCOGNITO_SCREENSHOT,
         PREF_INCOGNITO_LOCK,
         PREF_CAN_MAKE_PAYMENT,
         PREF_UNSTOPPABLE_DOMAINS,
@@ -204,6 +208,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
     private ChromeSwitchPreference mSocialBlockingTwitter;
     private ChromeSwitchPreference mSocialBlockingLinkedin;
     private ChromeSwitchPreference mAppLinks;
+    private ChromeSwitchPreference mIncognitoScreenshot;
     private ChromeBasePreference mWebrtcPolicy;
     private ChromeSwitchPreference mClearBrowsingDataOnExit;
     private Preference mUstoppableDomains;
@@ -411,10 +416,12 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
 
         mAppLinks = (ChromeSwitchPreference) findPreference(PREF_APP_LINKS);
         mAppLinks.setOnPreferenceChangeListener(this);
-
         boolean isAppLinksAllowed =
                 ChromeSharedPreferences.getInstance().readBoolean(PREF_APP_LINKS, true);
         mAppLinks.setChecked(isAppLinksAllowed);
+
+        mIncognitoScreenshot = (ChromeSwitchPreference) findPreference(PREF_INCOGNITO_SCREENSHOT);
+        mIncognitoScreenshot.setOnPreferenceChangeListener(this);
 
         mWebrtcPolicy = (ChromeBasePreference) findPreference(PREF_WEBRTC_POLICY);
 
@@ -623,6 +630,10 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
             sharedPreferencesEditor.putBoolean(PREF_APP_LINKS, (boolean) newValue);
             ChromeSharedPreferences.getInstance()
                     .writeBoolean(BravePrivacySettings.PREF_APP_LINKS_RESET, false);
+        } else if (PREF_INCOGNITO_SCREENSHOT.equals(key)) {
+            BraveFeatureUtil.enableFeature(
+                    BraveFeatureList.BRAVE_INCOGNITO_SCREENSHOT, (boolean) newValue, false);
+                BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_BLOCK_TRACKERS_ADS.equals(key)) {
             if (newValue instanceof String) {
                 final String newStringValue = String.valueOf(newValue);

--- a/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
+++ b/android/java/org/chromium/chrome/browser/privacy/settings/BravePrivacySettings.java
@@ -20,7 +20,9 @@ import org.chromium.brave_shields.mojom.FilterListAndroidHandler;
 import org.chromium.brave_shields.mojom.FilterListConstants;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.BraveConfig;
+import org.chromium.chrome.browser.BraveFeatureUtil;
 import org.chromium.chrome.browser.BraveLocalState;
+import org.chromium.chrome.browser.BraveRelaunchUtils;
 import org.chromium.chrome.browser.browsing_data.BraveClearBrowsingDataFragment;
 import org.chromium.chrome.browser.flags.ChromeFeatureList;
 import org.chromium.chrome.browser.metrics.ChangeMetricsReportingStateCalledFrom;
@@ -49,8 +51,6 @@ import org.chromium.mojo.system.MojoException;
 import org.chromium.ui.text.ChromeClickableSpan;
 import org.chromium.ui.text.SpanApplier;
 import org.chromium.webcompat_reporter.mojom.WebcompatReporterHandler;
-import org.chromium.chrome.browser.BraveFeatureUtil;
-import org.chromium.chrome.browser.BraveRelaunchUtils;
 
 /** Fragment to keep track of the all the brave privacy related preferences. */
 public class BravePrivacySettings extends PrivacySettings implements ConnectionErrorHandler {
@@ -633,7 +633,7 @@ public class BravePrivacySettings extends PrivacySettings implements ConnectionE
         } else if (PREF_INCOGNITO_SCREENSHOT.equals(key)) {
             BraveFeatureUtil.enableFeature(
                     BraveFeatureList.BRAVE_INCOGNITO_SCREENSHOT, (boolean) newValue, false);
-                BraveRelaunchUtils.askForRelaunch(getActivity());
+            BraveRelaunchUtils.askForRelaunch(getActivity());
         } else if (PREF_BLOCK_TRACKERS_ADS.equals(key)) {
             if (newValue instanceof String) {
                 final String newStringValue = String.valueOf(newValue);

--- a/android/java/res/xml/brave_privacy_preferences.xml
+++ b/android/java/res/xml/brave_privacy_preferences.xml
@@ -133,6 +133,12 @@
             android:title="@string/settings_webrtc_policy_label"
             android:persistent="false"/>
         <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
+            android:key="incognito_screenshot"
+            android:order="25"
+            android:title="@string/incognito_screenshot_title"
+            android:summary="@string/incognito_screenshot_summary"
+            android:defaultValue="false" />
+        <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
             android:key="close_tabs_on_exit"
             android:order="25"
             defaultValue="false"

--- a/android/java/res/xml/brave_privacy_preferences.xml
+++ b/android/java/res/xml/brave_privacy_preferences.xml
@@ -135,8 +135,8 @@
         <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
             android:key="incognito_screenshot"
             android:order="25"
-            android:title="@string/incognito_screenshot_title"
-            android:summary="@string/incognito_screenshot_summary"
+            android:title="@string/private_tab_screenshot_title"
+            android:summary="@string/private_tab_screenshot_summary"
             android:defaultValue="false" />
         <org.chromium.components.browser_ui.settings.ChromeSwitchPreference
             android:key="close_tabs_on_exit"

--- a/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java
+++ b/android/javatests/org/chromium/chrome/browser/privacy/settings/BravePrivacySettingsTest.java
@@ -45,7 +45,7 @@ public class BravePrivacySettingsTest {
     private static final String PREF_PHONE_AS_A_SECURITY_KEY = "phone_as_a_security_key";
     private static final String PREF_PASSWORD_LEAK_DETECTION = "password_leak_detection";
 
-    private static final int BRAVE_PRIVACY_SETTINGS_NUMBER_OF_ITEMS = 29;
+    private static final int BRAVE_PRIVACY_SETTINGS_NUMBER_OF_ITEMS = 30;
 
     private int mItemsLeft;
 

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -4125,7 +4125,7 @@ If you don't accept this request, VPN will not reconnect and your internet conne
       Show Safe Browsing errors
     </message>
     <message name="IDS_INCOGNITO_SCREENSHOT_TITLE" desc="A title to show incognito screenshot">
-      Private tab Screenshot
+      Private tab screenshots
     </message>
     <message name="IDS_INCOGNITO_SCREENSHOT_SUMMARY" desc="A summary to show incognito screenshot">
       Enables Private tab screenshots.

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -4124,11 +4124,11 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_SAFEBROWSING_ERRORS_PREF" desc="A preferences to show Safe Browsing errors">
       Show Safe Browsing errors
     </message>
-    <message name="IDS_INCOGNITO_SCREENSHOT_TITLE" desc="A title to show incognito screenshot">
-      Private tab screenshots
+    <message name="IDS_PRIVATE_TAB_SCREENSHOT_TITLE" desc="A title to show private tab screenshot">
+      Allow screenshots in private tabs
     </message>
-    <message name="IDS_INCOGNITO_SCREENSHOT_SUMMARY" desc="A summary to show incognito screenshot">
-      Enables Private tab screenshots.
+    <message name="IDS_PRIVATE_TAB_SCREENSHOT_SUMMARY" desc="A summary to show private tab screenshot">
+      If allowed, private tabs will also be visible when multiple apps are open.
     </message>
   </messages>
   </release>

--- a/browser/ui/android/strings/android_brave_strings.grd
+++ b/browser/ui/android/strings/android_brave_strings.grd
@@ -4124,6 +4124,12 @@ If you don't accept this request, VPN will not reconnect and your internet conne
     <message name="IDS_SAFEBROWSING_ERRORS_PREF" desc="A preferences to show Safe Browsing errors">
       Show Safe Browsing errors
     </message>
+    <message name="IDS_INCOGNITO_SCREENSHOT_TITLE" desc="A title to show incognito screenshot">
+      Private tab Screenshot
+    </message>
+    <message name="IDS_INCOGNITO_SCREENSHOT_SUMMARY" desc="A summary to show incognito screenshot">
+      Enables Private tab screenshots.
+    </message>
   </messages>
   </release>
 </grit>


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/35242
Security/Privacy review : https://github.com/brave/reviews/issues/1889

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
![Screenshot_2025-03-14-12-23-45-84_f47e22bfa97b97281975892054dd50a9](https://github.com/user-attachments/assets/c7143a02-39a2-4558-9ab6-fdc5182638f9)
By default, this option will be disabled and can be found under Settings → Brave Privacy & Security.
Test plan 1 : 
1. Open private tab
2. Try to take the screenshot, it should show the error message or an empty screenshot depending on the OS version
3. Enable the flag `Allow screenshots in private tabs`
4. Try to take the screenshot in private tab
