### PR TITLE
[Perf] Fixes Brave Ads hangs UI thread

### DIFF
--- a/browser/brave_ads/ads_service_delegate.cc
+++ b/browser/brave_ads/ads_service_delegate.cc
@@ -200,8 +200,9 @@ void AdsServiceDelegate::OpenNewTabWithUrl(const GURL& url) {
 #endif
 }
 
-void AdsServiceDelegate::InitNotificationHelper() {
-  NotificationHelper::GetInstance()->InitForProfile(&*profile_);
+void AdsServiceDelegate::InitNotificationHelper(base::OnceClosure callback) {
+  NotificationHelper::GetInstance()->InitForProfile(&*profile_,
+                                                    std::move(callback));
 }
 
 bool AdsServiceDelegate::

--- a/browser/brave_ads/ads_service_delegate.h
+++ b/browser/brave_ads/ads_service_delegate.h
@@ -50,7 +50,7 @@ class AdsServiceDelegate : public AdsService::Delegate {
   base::Value::Dict GetSkus() const;
 
   // AdsService::Delegate:
-  void InitNotificationHelper() override;
+  void InitNotificationHelper(base::OnceClosure callback) override;
   bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() override;
   bool DoesSupportSystemNotifications() override;
   bool CanShowNotifications() override;

--- a/browser/brave_ads/application_state/notification_helper/notification_helper.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper.h
@@ -8,6 +8,7 @@
 
 #include <memory>
 
+#include "base/functional/callback_forward.h"
 #include "base/memory/weak_ptr.h"
 
 class Profile;
@@ -28,7 +29,7 @@ class NotificationHelper final {
 
   static NotificationHelper* GetInstance();
 
-  void InitForProfile(Profile* profile);
+  void InitForProfile(Profile* profile, base::OnceClosure callback);
 
   bool CanShowNotifications();
   bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() const;
@@ -44,7 +45,8 @@ class NotificationHelper final {
 
   ~NotificationHelper();
 
-  void OnSystemNotificationPlatformBridgeReady(bool success);
+  void OnSystemNotificationPlatformBridgeReady(base::OnceClosure callback,
+                                               bool success);
 
   bool does_support_system_notifications_ = true;
 

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl.cc
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl.cc
@@ -5,11 +5,20 @@
 
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h"
 
+#include <utility>
+
+#include "base/functional/callback.h"
+
 namespace brave_ads {
 
 NotificationHelperImpl::NotificationHelperImpl() = default;
 
 NotificationHelperImpl::~NotificationHelperImpl() = default;
+
+void NotificationHelperImpl::InitSystemNotifications(
+    base::OnceClosure callback) {
+  std::move(callback).Run();
+}
 
 bool NotificationHelperImpl::CanShowNotifications() {
   return true;

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_H_
 #define BRAVE_BROWSER_BRAVE_ADS_APPLICATION_STATE_NOTIFICATION_HELPER_NOTIFICATION_HELPER_IMPL_H_
 
+#include "base/functional/callback_forward.h"
+
 namespace brave_ads {
 
 class NotificationHelperImpl {
@@ -14,6 +16,8 @@ class NotificationHelperImpl {
   NotificationHelperImpl& operator=(const NotificationHelperImpl&) = delete;
 
   virtual ~NotificationHelperImpl();
+
+  virtual void InitSystemNotifications(base::OnceClosure callback);
 
   virtual bool CanShowNotifications();
   virtual bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() const;

--- a/browser/brave_ads/application_state/notification_helper/notification_helper_impl_win.h
+++ b/browser/brave_ads/application_state/notification_helper/notification_helper_impl_win.h
@@ -9,8 +9,8 @@
 #include <windows.ui.notifications.h>
 #include <wrl/event.h>
 
-#include <string>
-
+#include "base/functional/callback_forward.h"
+#include "base/memory/weak_ptr.h"
 #include "brave/browser/brave_ads/application_state/notification_helper/notification_helper_impl.h"
 
 namespace brave_ads {
@@ -23,33 +23,28 @@ class NotificationHelperImplWin final : public NotificationHelperImpl {
 
   ~NotificationHelperImplWin() override;
 
+  // NotificationHelperImpl:
+  void InitSystemNotifications(base::OnceClosure callback) override;
+  bool CanShowNotifications() override;
+  bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() const override;
+  bool ShowOnboardingNotification() override;
+
  protected:
   friend class NotificationHelper;
-
   NotificationHelperImplWin();
 
- private:
+  void InitSystemNotificationsCallback(
+      base::OnceClosure callback,
+      Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotifier>
+          toast_notifier);
+
   bool IsFocusAssistEnabled() const;
 
   bool IsNotificationsEnabled();
 
-  std::wstring GetAppId() const;
-
-  HRESULT InitializeToastNotifier();
-
-  template <unsigned int size>
-  HRESULT CreateActivationFactory(wchar_t const (&class_name)[size],
-                                  const IID& iid,
-                                  void** factory) const;
-
   Microsoft::WRL::ComPtr<ABI::Windows::UI::Notifications::IToastNotifier>
       toast_notifier_;
-
-  // NotificationHelperImpl:
-  bool CanShowNotifications() override;
-  bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() const override;
-
-  bool ShowOnboardingNotification() override;
+  base::WeakPtrFactory<NotificationHelperImplWin> weak_factory_{this};
 };
 
 }  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -313,8 +313,12 @@ bool AdsServiceImpl::UserHasOptedInToSearchResultAds() const {
 }
 
 void AdsServiceImpl::InitializeNotificationsForCurrentProfile() {
-  delegate_->InitNotificationHelper();
+  delegate_->InitNotificationHelper(base::BindOnce(
+      &AdsServiceImpl::InitializeNotificationsForCurrentProfileCallback,
+      weak_ptr_factory_.GetWeakPtr()));
+}
 
+void AdsServiceImpl::InitializeNotificationsForCurrentProfileCallback() {
   // Postpone recording P3A to make browser startup smoother.
   content::GetUIThreadTaskRunner({base::TaskPriority::BEST_EFFORT})
       ->PostDelayedTask(

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -115,6 +115,7 @@ class AdsServiceImpl final : public AdsService,
   bool UserHasOptedInToSearchResultAds() const;
 
   void InitializeNotificationsForCurrentProfile();
+  void InitializeNotificationsForCurrentProfileCallback();
 
   void GetDeviceIdAndMaybeStartBatAdsService();
   void GetDeviceIdAndMaybeStartBatAdsServiceCallback(std::string device_id);

--- a/components/brave_ads/core/browser/service/ads_service.h
+++ b/components/brave_ads/core/browser/service/ads_service.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#include "base/functional/callback_forward.h"
 #include "base/observer_list.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/browser/service/ads_service_observer.h"
@@ -33,7 +34,7 @@ class AdsService : public KeyedService {
    public:
     virtual ~Delegate() = default;
 
-    virtual void InitNotificationHelper() = 0;
+    virtual void InitNotificationHelper(base::OnceClosure callback) = 0;
     virtual bool CanShowSystemNotificationsWhileBrowserIsBackgrounded() = 0;
     virtual bool DoesSupportSystemNotifications() = 0;
     virtual bool CanShowNotifications() = 0;


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/43712

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

This fix affects notification ads on Windows platform only.
* Fresh Brave Browser install
* Enable Windows notification
* Enable Focus Assist
* Join Brave Rewards
* Try to trigger notification ad
   EXPECTATION: Notification ads are not served

* Disable Windows notification
* Disable Focus Assist
* Try to trigger notification ad
   EXPECTATION: Notification ads are not served

* Enable Windows notification
* Disable Focus Assist
* Try to trigger notification ad
   EXPECTATION: Notification ad is served
