### PR TITLE
Add manifest v2 metric

### DIFF
--- a/browser/misc_metrics/extension_metrics.h
+++ b/browser/misc_metrics/extension_metrics.h
@@ -29,6 +29,8 @@ namespace misc_metrics {
 
 inline constexpr char kAdblockExtensionsHistogramName[] =
     "Brave.Extensions.AdBlock";
+inline constexpr char kManifestV2ExtensionsHistogramName[] =
+    "Brave.Extensions.ManifestV2";
 
 // Monitors installation/uninstallation of third-party extensions
 // and reports relevant metrics via P3A.
@@ -51,10 +53,11 @@ class ExtensionMetrics : public extensions::ExtensionRegistryObserver {
                               const extensions::Extension* extension,
                               extensions::UninstallReason reason) override;
 
-  void ScheduleAdBlockMetricReport();
-  void ReportAdBlockMetric();
+  void ScheduleMetricsReport();
+  void ReportMetrics();
 
   base::flat_set<std::string> adblock_extensions_loaded_;
+  base::flat_set<std::string> manifest_v2_extensions_loaded_;
   raw_ptr<extensions::ExtensionRegistry> extension_registry_;
   base::ScopedObservation<extensions::ExtensionRegistry,
                           ExtensionMetrics>

--- a/components/p3a/metric_names.h
+++ b/components/p3a/metric_names.h
@@ -233,6 +233,7 @@ inline constexpr auto kCollectedSlowHistograms =
     {"Brave.Core.PrimaryLang", MetricConfig{.constellation_only = true}},
     {"Brave.Core.ProfileCount", {}},
     {"Brave.Core.UsageMonthly", {}},
+    {"Brave.Extensions.ManifestV2", {}},
     {"Brave.P3A.TestSlowMetric", {}},
     {"Brave.Playlist.LastUsageTime", {}},
     {"Brave.Rewards.PageViewCount", MetricConfig{.ephemeral = true}},


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44660

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

0. Start with fresh profile, wait 10 seconds, ensure metric value is 0.
1. Install any newer extension. Wait 10 seconds. Ensure metric value is still 0.
2. Install uBO or any older extension. Wait 10 seconds. Ensure metric value is 1.
3. Remove uBO or older extension. Wait 10 seconds. Ensure metric value is 0.