### PR TITLE
[iOS] Move non-web navigation related Tab data into its own container

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Rewards/Panel/BraveRewardsViewController.swift
@@ -88,7 +88,7 @@ class BraveRewardsViewController: UIViewController, PopoverContentComponent {
           from: url,
           faviconURL: nil,
           publisherBlob: nil,
-          tabId: UInt64(self.browserTab.rewardsId)
+          tabId: UInt64(self.browserTab.rewardsId ?? 0)
         )
       } else {
         self.rewardsView.publisherView.isHidden = true
@@ -127,7 +127,7 @@ class BraveRewardsViewController: UIViewController, PopoverContentComponent {
         observer.fetchedPanelPublisher = { [weak self] publisher, tabId in
           guard let self = self else { return }
           DispatchQueue.main.async {
-            if tabId == self.browserTab.rewardsId {
+            if UInt32(tabId) == self.browserTab.rewardsId {
               self.publisher = publisher
             }
           }

--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
@@ -111,7 +111,7 @@ class BraveTranslateTabHelper: NSObject, TabObserver {
         throw BraveTranslateError.invalidLanguage
       }
 
-      let previousState = tab.translationState
+      let previousState = tab.translationState ?? .unavailable
       delegate.updateTranslateURLBar(tab: tab, state: .pending)
 
       // TranslateAgent::TranslateFrame

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+KeyCommands.swift
@@ -21,14 +21,14 @@ extension BrowserViewController {
   @objc private func goBackKeyCommand() {
     if let tab = tabManager.selectedTab, tab.canGoBack, favoritesController == nil {
       tab.goBack()
-      tab.resetExternalAlertProperties()
+      tab.browserData?.resetExternalAlertProperties()
     }
   }
 
   @objc private func goForwardKeyCommand() {
     if let tab = tabManager.selectedTab, tab.canGoForward {
       tab.goForward()
-      tab.resetExternalAlertProperties()
+      tab.browserData?.resetExternalAlertProperties()
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -139,14 +139,14 @@ extension BrowserViewController {
   }
 }
 
-extension Tab {
+extension TabBrowserData {
   func reportPageLoad(to rewards: BraveRewards, redirectChain: [URL]) {
-    guard let url = redirectChain.last, !url.isLocal, !isPrivate
+    guard let tab, let url = redirectChain.last, !url.isLocal, !tab.isPrivate
     else {
       return
     }
 
-    if self.displayFavicon == nil {
+    if tab.displayFavicon == nil {
       adsRewardsLog.warning("No favicon found in \(self) to report to rewards panel")
     }
 
@@ -163,7 +163,7 @@ extension Tab {
       // Only utilized for verifiable conversions, which requires the user to have
       // joined Brave Rewards.
       group.enter()
-      evaluateSafeJavaScript(
+      tab.evaluateSafeJavaScript(
         functionName: "new XMLSerializer().serializeToString",
         args: ["document"],
         contentWorld: WKContentWorld.defaultClient,
@@ -177,7 +177,7 @@ extension Tab {
       // joined Brave Rewards. Desktop requires the user to have opted into
       // notification ads, however we do not have access to that pref at this time.
       group.enter()
-      evaluateSafeJavaScript(
+      tab.evaluateSafeJavaScript(
         functionName: "document?.body?.innerText",
         contentWorld: .defaultClient,
         asFunction: false
@@ -189,7 +189,7 @@ extension Tab {
 
     group.notify(queue: .main) {
       rewards.reportLoadedPage(
-        tab: self,
+        tab: tab,
         htmlContent: htmlContent,
         textContent: textContent
       )

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Rewards.swift
@@ -131,7 +131,7 @@ extension BrowserViewController {
     rewardsObserver.fetchedPanelPublisher = { [weak self] publisher, tabId in
       DispatchQueue.main.async {
         guard let self = self, self.isViewLoaded, let tab = self.tabManager.selectedTab,
-          tab.rewardsId == tabId
+          tab.rewardsId == UInt32(tabId)
         else { return }
         self.publisher = publisher
       }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ShareActivity.swift
@@ -83,7 +83,7 @@ extension BrowserViewController {
     // Toogle Reader Mode Activity
     // If the reader mode button is occluded due to a secure content state warning add it as an activity
     if let tab = tabManager.selectedTab, tab.lastKnownSecureContentState.shouldDisplayWarning {
-      if tab.readerModeAvailableOrActive {
+      if tab.readerModeAvailableOrActive == true {
         activities.append(
           BasicMenuActivity(
             activityType: .toggleReaderMode,

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+SnackBarTabHelperDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+SnackBarTabHelperDelegate.swift
@@ -1,0 +1,40 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import UIKit
+
+extension BrowserViewController: SnackBarTabHelperDelegate {
+  func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {
+    showBar(bar, animated: true)
+  }
+
+  func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {
+    removeBar(bar, animated: true)
+  }
+
+  func showBar(_ bar: SnackBar, animated: Bool) {
+    view.layoutIfNeeded()
+    UIView.animate(
+      withDuration: animated ? 0.25 : 0,
+      animations: {
+        self.alertStackView.insertArrangedSubview(bar, at: 0)
+        self.view.layoutIfNeeded()
+      }
+    )
+  }
+
+  func removeBar(_ bar: SnackBar, animated: Bool) {
+    UIView.animate(
+      withDuration: animated ? 0.25 : 0,
+      animations: {
+        bar.removeFromSuperview()
+      }
+    )
+  }
+
+  func removeAllBars() {
+    alertStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabDownloadDelegate.swift
@@ -23,7 +23,7 @@ extension UTType {
 
 extension BrowserViewController: TabDownloadDelegate {
   func tab(_ tab: Tab, didCreateDownload download: Download) {
-    guard tab.isTabVisible() else {
+    guard tab.browserData?.isTabVisible() == true else {
       download.cancel()
       return
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -196,7 +196,7 @@ extension BrowserViewController: TabManagerDelegate {
     tab.removePolicyDecider(self)
 
     if !privateBrowsingManager.isPrivateBrowsing {
-      rewards.reportTabClosed(tabId: Int(tab.rewardsId))
+      rewards.reportTabClosed(tabId: Int(tab.rewardsId ?? 0))
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabManagerDelegate.swift
@@ -16,6 +16,11 @@ import WebKit
 import os.log
 
 extension BrowserViewController: TabManagerDelegate {
+  func attachTabHelpers(to tab: Tab) {
+    tab.browserData = .init(tab: tab, tabGeneratorAPI: braveCore.tabGeneratorAPI)
+    SnackBarTabHelper.create(for: tab)
+  }
+
   func tabManager(_ tabManager: TabManager, didSelectedTabChange selected: Tab?, previous: Tab?) {
     // Remove the old accessibilityLabel. Since this webview shouldn't be visible, it doesn't need it
     // and having multiple views with the same label confuses tests.
@@ -93,7 +98,7 @@ extension BrowserViewController: TabManagerDelegate {
     updateStatusBarOverlayColor()
 
     removeAllBars()
-    if let bars = selected?.bars {
+    if let bars = selected.flatMap(SnackBarTabHelper.from)?.bars {
       for bar in bars {
         showBar(bar, animated: true)
       }
@@ -111,7 +116,9 @@ extension BrowserViewController: TabManagerDelegate {
 
     let shouldShowPlaylistURLBarButton = selected?.url?.isPlaylistSupportedSiteURL == true
 
-    if let readerMode = selected?.getContentScript(name: ReaderModeScriptHandler.scriptName)
+    if let readerMode = selected?.browserData?.getContentScript(
+      name: ReaderModeScriptHandler.scriptName
+    )
       as? ReaderModeScriptHandler,
       !shouldShowPlaylistURLBarButton
     {
@@ -134,10 +141,10 @@ extension BrowserViewController: TabManagerDelegate {
     if FeatureList.kBraveTranslateEnabled.enabled, let selectedTab = selected,
       selectedTab.translateHelper != nil
     {
-      updateTranslateURLBar(tab: selectedTab, state: selectedTab.translationState)
+      updateTranslateURLBar(tab: selectedTab, state: selectedTab.translationState ?? .unavailable)
       updatePlaylistURLBar(
         tab: selectedTab,
-        state: selectedTab.playlistItemState,
+        state: selectedTab.playlistItemState ?? .none,
         item: selectedTab.playlistItem
       )
     } else {
@@ -167,6 +174,9 @@ extension BrowserViewController: TabManagerDelegate {
     tab.webDelegate = self
     tab.downloadDelegate = self
     tab.certStore = profile.certStore
+    attachTabHelpers(to: tab)
+
+    SnackBarTabHelper.from(tab: tab)?.delegate = self
 
     tab.walletKeyringService = BraveWallet.KeyringServiceFactory.get(privateMode: tab.isPrivate)
     updateTabsBarVisibility()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -66,6 +66,12 @@ extension BrowserViewController: TabObserver {
     tab.upgradeHTTPSTimeoutTimer?.invalidate()
     tab.upgradeHTTPSTimeoutTimer = nil
 
+    // Clear the current request url and the redirect source url
+    // We don't need these values after the request has been comitted
+    tab.currentRequestURL = nil
+    tab.redirectSourceURL = nil
+    tab.isInternalRedirect = false
+
     // Need to evaluate Night mode script injection after url is set inside the Tab
     tab.nightMode = Preferences.General.nightModeEnabled.value
     tab.browserData?.clearSolanaConnectedAccounts()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabObserver.swift
@@ -11,7 +11,7 @@ import Shared
 
 extension BrowserViewController: TabObserver {
   func tabDidStartNavigation(_ tab: Tab) {
-    tab.contentBlocker.clearPageStats()
+    tab.contentBlocker?.clearPageStats()
 
     let visibleURL = tab.url
 
@@ -42,7 +42,7 @@ extension BrowserViewController: TabObserver {
       // new site has a different origin, hide wallet icon.
       tabManager.selectedTab?.isWalletIconVisible = false
       // new site, reset connected addresses
-      tabManager.selectedTab?.clearSolanaConnectedAccounts()
+      tabManager.selectedTab?.browserData?.clearSolanaConnectedAccounts()
       // close wallet panel if it's open
       if let popoverController = self.presentedViewController as? PopoverController,
         popoverController.contentController is WalletPanelHostingController
@@ -68,7 +68,7 @@ extension BrowserViewController: TabObserver {
 
     // Need to evaluate Night mode script injection after url is set inside the Tab
     tab.nightMode = Preferences.General.nightModeEnabled.value
-    tab.clearSolanaConnectedAccounts()
+    tab.browserData?.clearSolanaConnectedAccounts()
 
     // Dismiss any alerts that are showing on page navigation.
     if let alert = tab.shownPromptAlert {
@@ -78,22 +78,24 @@ extension BrowserViewController: TabObserver {
     // Providers need re-initialized when changing origin to align with desktop in
     // `BraveContentBrowserClient::RegisterBrowserInterfaceBindersForFrame`
     // https://github.com/brave/brave-core/blob/1.52.x/browser/brave_content_browser_client.cc#L608
-    if let provider = braveCore.braveWalletAPI.ethereumProvider(
-      with: tab,
-      isPrivateBrowsing: tab.isPrivate
-    ) {
-      // The Ethereum provider will fetch allowed accounts from it's delegate (the tab)
-      // on initialization. Fetching allowed accounts requires the origin; so we need to
-      // initialize after `commitedURL` / `url` are updated above
-      tab.walletEthProvider = provider
-      tab.walletEthProvider?.initialize(eventsListener: tab)
-    }
-    if let provider = braveCore.braveWalletAPI.solanaProvider(
-      with: tab,
-      isPrivateBrowsing: tab.isPrivate
-    ) {
-      tab.walletSolProvider = provider
-      tab.walletSolProvider?.initialize(eventsListener: tab)
+    if let browserData = tab.browserData {
+      if let provider = braveCore.braveWalletAPI.ethereumProvider(
+        with: browserData,
+        isPrivateBrowsing: tab.isPrivate
+      ) {
+        // The Ethereum provider will fetch allowed accounts from it's delegate (the tab)
+        // on initialization. Fetching allowed accounts requires the origin; so we need to
+        // initialize after `commitedURL` / `url` are updated above
+        tab.walletEthProvider = provider
+        tab.walletEthProvider?.initialize(eventsListener: browserData)
+      }
+      if let provider = braveCore.braveWalletAPI.solanaProvider(
+        with: browserData,
+        isPrivateBrowsing: tab.isPrivate
+      ) {
+        tab.walletSolProvider = provider
+        tab.walletSolProvider?.initialize(eventsListener: browserData)
+      }
     }
 
     // Notify of tab changes after navigation completes but before notifying that
@@ -152,14 +154,14 @@ extension BrowserViewController: TabObserver {
       isSelected: tabManager.selectedTab == tab,
       isPrivate: privateBrowsingManager.isPrivateBrowsing
     )
-    tab.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
+    tab.browserData?.reportPageLoad(to: rewards, redirectChain: tab.redirectChain)
     // Reset `rewardsReportingState` tab property so that listeners
     // can be notified of tab changes when a new navigation happens.
     tab.rewardsReportingState = RewardsTabChangeReportingState()
 
     Task {
-      await tab.updateEthereumProperties()
-      await tab.updateSolanaProperties()
+      await tab.browserData?.updateEthereumProperties()
+      await tab.browserData?.updateSolanaProperties()
     }
 
     if tab.url?.isLocal == false {
@@ -168,7 +170,7 @@ extension BrowserViewController: TabObserver {
     }
 
     if tab.walletEthProvider != nil {
-      tab.emitEthereumEvent(.connect)
+      tab.browserData?.emitEthereumEvent(.connect)
     }
 
     if let lastCommittedURL = tab.committedURL {
@@ -216,7 +218,7 @@ extension BrowserViewController: TabObserver {
   }
 
   func tabDidUpdateURL(_ tab: Tab) {
-    if tab === tabManager.selectedTab && !tab.restoring {
+    if tab === tabManager.selectedTab && !tab.isRestoring {
       updateUIForReaderHomeStateForTab(tab)
     }
 
@@ -237,12 +239,14 @@ extension BrowserViewController: TabObserver {
       } else if tab === tabManager.selectedTab, tab.url?.displayURL?.scheme == "about",
         !tab.loading
       {
-        if !tab.restoring {
+        if !tab.isRestoring {
           updateUIForReaderHomeStateForTab(tab)
         }
 
         navigateInTab(tab: tab)
-      } else if tab === tabManager.selectedTab, tab.isDisplayingBasicAuthPrompt {
+      } else if tab === tabManager.selectedTab, let tabData = tab.browserData,
+        tabData.isDisplayingBasicAuthPrompt
+      {
         updateToolbarCurrentURL(
           URL(string: "\(InternalURL.baseUrl)/\(InternalURL.Path.basicAuth.rawValue)")
         )
@@ -256,7 +260,7 @@ extension BrowserViewController: TabObserver {
         let rewardsURL = tab.rewardsXHRLoadURL,
         url.host == rewardsURL.host
       {
-        tab.reportPageLoad(to: rewards, redirectChain: [url])
+        tab.browserData?.reportPageLoad(to: rewards, redirectChain: [url])
       }
     }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
@@ -710,7 +710,7 @@ extension BrowserViewController {
     if let request = request.stripQueryParams(
       initiatorURL: tab.committedURL,
       redirectSourceURL: tab.redirectSourceURL,
-      isInternalRedirect: tab.isInternalRedirect
+      isInternalRedirect: tab.isInternalRedirect == true
     ) {
       Logger.module.debug(
         "Stripping query params for `\(requestURL.absoluteString)`"

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
@@ -148,7 +148,7 @@ extension BrowserViewController: TabWebPolicyDecider {
           domain: domain,
           isDeAmpEnabled: braveCore.deAmpPrefs.isDeAmpEnabled
         ) ?? []
-      tab.setCustomUserScript(scripts: scriptTypes)
+      tab.browserData?.setCustomUserScript(scripts: scriptTypes)
     }
 
     if let responseURL = responseURL,
@@ -156,7 +156,7 @@ extension BrowserViewController: TabWebPolicyDecider {
     {
       let internalUrl = InternalURL(responseURL)
 
-      tab.rewardsReportingState.httpStatusCode = response.statusCode
+      tab.rewardsReportingState?.httpStatusCode = response.statusCode
     }
 
     let request = response.url.flatMap { pendingRequests[$0.absoluteString] }
@@ -196,6 +196,8 @@ extension BrowserViewController: TabWebPolicyDecider {
       tab.externalAppPopupContinuation = nil
       tab.externalAppPopup = nil
     }
+
+    tab.rewardsReportingState?.wasRestored = tab.isRestoring
 
     // Handle internal:// urls
     if InternalURL.isValid(url: requestURL) {
@@ -317,7 +319,7 @@ extension BrowserViewController: TabWebPolicyDecider {
       }
     }
 
-    tab.rewardsReportingState.isNewNavigation =
+    tab.rewardsReportingState?.isNewNavigation =
       requestInfo.navigationType != .backForward && requestInfo.navigationType != .reload
     tab.currentRequestURL = requestURL
 
@@ -389,7 +391,7 @@ extension BrowserViewController: TabWebPolicyDecider {
 
       // Set some additional user scripts
       if requestInfo.isMainFrame {
-        tab.setScripts(scripts: [
+        tab.browserData?.setScripts(scripts: [
           // Add de-amp script
           // The user script manager will take care to not reload scripts if this value doesn't change
           .deAmp: braveCore.deAmpPrefs.isDeAmpEnabled,
@@ -422,7 +424,7 @@ extension BrowserViewController: TabWebPolicyDecider {
             domain: domainForMainFrame,
             isDeAmpEnabled: braveCore.deAmpPrefs.isDeAmpEnabled
           ) ?? []
-        tab.setCustomUserScript(scripts: scriptTypes)
+        tab.browserData?.setCustomUserScript(scripts: scriptTypes)
       }
 
       // Brave Search logic.
@@ -515,7 +517,7 @@ extension BrowserViewController: TabWebPolicyDecider {
 
       if requestInfo.isMainFrame,
         let etldP1 = requestURL.baseDomain,
-        tab.proceedAnywaysDomainList.contains(etldP1) == false
+        tab.proceedAnywaysDomainList?.contains(etldP1) == false
       {
         let domain = Domain.getOrCreate(forUrl: requestURL, persistent: !isPrivateBrowsing)
 
@@ -554,11 +556,14 @@ extension BrowserViewController: TabWebPolicyDecider {
 
         // Load rule lists
         let ruleLists = await AdBlockGroupsManager.shared.ruleLists(for: domainForShields)
-        tab.contentBlocker.set(ruleLists: ruleLists)
+        tab.contentBlocker?.set(ruleLists: ruleLists)
       }
 
       // Cookie Blocking code below
-      tab.setScript(script: .cookieBlocking, enabled: Preferences.Privacy.blockAllCookies.value)
+      tab.browserData?.setScript(
+        script: .cookieBlocking,
+        enabled: Preferences.Privacy.blockAllCookies.value
+      )
 
       // Reset the block alert bool on new host.
       if let newHost: String = requestURL.host, let oldHost: String = tab.url?.host,
@@ -585,9 +590,11 @@ extension BrowserViewController: TabWebPolicyDecider {
 
       // Do not show error message for JS navigated links or redirect
       // as it's not the result of a user action.
-      if !shouldOpen, requestInfo.navigationType == .linkActivated && !isSyntheticClick {
+      if let tabData = tab.browserData, !shouldOpen,
+        requestInfo.navigationType == .linkActivated && !isSyntheticClick
+      {
         if self.presentedViewController == nil && self.presentingViewController == nil
-          && !tab.isExternalAppAlertPresented && !tab.isExternalAppAlertSuppressed
+          && !tabData.isExternalAppAlertPresented && !tabData.isExternalAppAlertSuppressed
         {
           return await withCheckedContinuation { continuation in
             // This alert does not need to be a BrowserAlertController because we return a policy
@@ -839,12 +846,14 @@ extension BrowserViewController {
     tab.externalAppURLDomain = tab.url?.baseDomain
 
     // Do not try to present over existing warning
-    if tab.isExternalAppAlertPresented || tab.isExternalAppAlertSuppressed {
+    if let tabData = tab.browserData,
+      tabData.isExternalAppAlertPresented || tabData.isExternalAppAlertSuppressed
+    {
       return false
     }
 
     // External dialog should not be shown for non-active tabs #6687 - #7835
-    let isVisibleTab = tab.isTabVisible()
+    let isVisibleTab = tab.browserData?.isTabVisible() == true
 
     if !isVisibleTab {
       return false
@@ -949,7 +958,7 @@ extension BrowserViewController {
       return isTopController && isTopWindow
     }
 
-    tab.externalAppAlertCounter += 1
+    tab.browserData?.externalAppAlertCounter += 1
 
     return await withTaskCancellationHandler {
       return await withCheckedContinuation { [weak tab] continuation in
@@ -958,7 +967,7 @@ extension BrowserViewController {
           return
         }
         tab.externalAppPopupContinuation = continuation
-        showExternalSchemeAlert(for: tab, isSuppressActive: tab.externalAppAlertCounter > 2) {
+        showExternalSchemeAlert(for: tab, isSuppressActive: tab.externalAppAlertCounter ?? 0 > 2) {
           [weak tab] in
           tab?.externalAppPopupContinuation = nil
           continuation.resume(with: .success($0))

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -475,7 +475,7 @@ extension BrowserViewController: TopToolbarDelegate {
         if $0.url?.baseDomain == currentDomain {
           $0.reload()
           // Domain specific shield setting changed, reset selectors cache.
-          $0.contentBlocker.resetSelectorsCache()
+          $0.contentBlocker?.resetSelectorsCache()
         }
       }
     }
@@ -676,12 +676,15 @@ extension BrowserViewController: TopToolbarDelegate {
   }
 
   func topToolbarDidTapWalletButton(_ urlBar: TopToolbarView) {
-    guard let selectedTab = tabManager.selectedTab else {
+    guard let selectedTab = tabManager.selectedTab,
+      let origin = selectedTab.browserData?.getOrigin(),
+      let tabDappStore = selectedTab.tabDappStore
+    else {
       return
     }
     // System components sit on top so we want to dismiss it
     selectedTab.dismissFindInteraction()
-    presentWalletPanel(from: selectedTab.getOrigin(), with: selectedTab.tabDappStore)
+    presentWalletPanel(from: origin, with: tabDappStore)
   }
 
   private func hideSearchController() {
@@ -1004,7 +1007,7 @@ extension BrowserViewController: ToolbarDelegate {
 
   func tabToolbarDidPressBack(_ tabToolbar: ToolbarProtocol, button: UIButton) {
     tabManager.selectedTab?.goBack()
-    tabManager.selectedTab?.resetExternalAlertProperties()
+    tabManager.selectedTab?.browserData?.resetExternalAlertProperties()
     recordNavigationActionP3A(isNavigationActionForward: false)
   }
 
@@ -1015,7 +1018,7 @@ extension BrowserViewController: ToolbarDelegate {
 
   func tabToolbarDidPressForward(_ tabToolbar: ToolbarProtocol, button: UIButton) {
     tabManager.selectedTab?.goForward()
-    tabManager.selectedTab?.resetExternalAlertProperties()
+    tabManager.selectedTab?.browserData?.resetExternalAlertProperties()
     recordNavigationActionP3A(isNavigationActionForward: true)
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2489,7 +2489,6 @@ extension BrowserViewController: TabDelegate {
     webView.removeFromSuperview()
   }
 
-
   func showRequestRewardsPanel(_ tab: Tab) {
     let vc = BraveTalkRewardsOptInViewController()
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -401,7 +401,7 @@ public class BrowserViewController: UIViewController {
     braveCore.adblockService.registerFilterListChanges { [weak self] _ in
       // Filter lists updated, reset selectors cache(s).
       self?.tabManager.allTabs.forEach {
-        $0.contentBlocker.resetSelectorsCache()
+        $0.contentBlocker?.resetSelectorsCache()
       }
     }
 
@@ -410,7 +410,7 @@ public class BrowserViewController: UIViewController {
       .sink { [weak self] _ in
         // Filter lists selections changed, reset selectors cache(s).
         self?.tabManager.allTabs.forEach {
-          $0.contentBlocker.resetSelectorsCache()
+          $0.contentBlocker?.resetSelectorsCache()
         }
       }
       .store(in: &cancellables)
@@ -465,7 +465,7 @@ public class BrowserViewController: UIViewController {
     }
 
     for tab in tabManager.tabsForCurrentMode where tab.id != tabManager.selectedTab?.id {
-      tab.newTabPageViewController = nil
+      tab.browserData?.newTabPageViewController = nil
     }
   }
 
@@ -1322,7 +1322,7 @@ public class BrowserViewController: UIViewController {
 
   public func showQueuedAlertIfAvailable() {
     if let selectedTab = tabManager.selectedTab,
-      let queuedAlertInfo = selectedTab.dequeueJavascriptAlertPrompt()
+      let queuedAlertInfo = selectedTab.browserData?.dequeueJavascriptAlertPrompt()
     {
       let alertController = queuedAlertInfo.alertController()
       alertController.delegate = self
@@ -1593,13 +1593,16 @@ public class BrowserViewController: UIViewController {
 
         // Refresh the reading view toolbar since the article record may have changed
         if let tab = self.tabManager.selectedTab,
-          let readerMode = tab.getContentScript(name: ReaderModeScriptHandler.scriptName)
+          let readerMode = tab.browserData?.getContentScript(
+            name: ReaderModeScriptHandler.scriptName
+          )
             as? ReaderModeScriptHandler,
           readerMode.state == .active,
-          isReaderModeURL
+          isReaderModeURL,
+          let state = tab.playlistItemState
         {
           self.showReaderModeBar(animated: false)
-          self.updatePlaylistURLBar(tab: tab, state: tab.playlistItemState, item: tab.playlistItem)
+          self.updatePlaylistURLBar(tab: tab, state: state, item: tab.playlistItem)
         }
       }
     )
@@ -1784,7 +1787,7 @@ public class BrowserViewController: UIViewController {
       return
     }
     let scriptHandler =
-      tab.getContentScript(name: Web3NameServiceScriptHandler.scriptName)
+      tab.browserData?.getContentScript(name: Web3NameServiceScriptHandler.scriptName)
       as? Web3NameServiceScriptHandler
     scriptHandler?.originalURL = originalURL
 
@@ -1797,7 +1800,7 @@ public class BrowserViewController: UIViewController {
       return true
     } else if let selectedTab = tabManager.selectedTab, selectedTab.canGoBack {
       selectedTab.goBack()
-      selectedTab.resetExternalAlertProperties()
+      selectedTab.browserData?.resetExternalAlertProperties()
       return true
     }
     return false
@@ -1835,7 +1838,7 @@ public class BrowserViewController: UIViewController {
 
       updateInContentHomePanel(url as URL)
       updateScreenTimeUrl(url)
-      updatePlaylistURLBar(tab: tab, state: tab.playlistItemState, item: tab.playlistItem)
+      updatePlaylistURLBar(tab: tab, state: tab.playlistItemState ?? .none, item: tab.playlistItem)
     }
   }
 
@@ -2108,7 +2111,9 @@ public class BrowserViewController: UIViewController {
   }
 
   func navigateInTab(tab: Tab) {
-    tabManager.expireSnackbars()
+    for tab in tabManager.allTabs {
+      SnackBarTabHelper.from(tab: tab)?.expireSnackbars()
+    }
 
     if let url = tab.url {
       // Whether to show search icon or + icon
@@ -2203,7 +2208,7 @@ public class BrowserViewController: UIViewController {
 
   func toggleReaderMode() {
     guard let tab = tabManager.selectedTab else { return }
-    if let readerMode = tab.getContentScript(name: ReaderModeScriptHandler.scriptName)
+    if let readerMode = tab.browserData?.getContentScript(name: ReaderModeScriptHandler.scriptName)
       as? ReaderModeScriptHandler
     {
       switch readerMode.state {
@@ -2412,10 +2417,14 @@ extension BrowserViewController: TabDelegate {
       YoutubeQualityScriptHandler(tab: tab),
       BraveLeoScriptHandler(),
       BraveSkusScriptHandler(),
-
-      tab.contentBlocker,
-      tab.requestBlockingContentHelper,
     ]
+
+    if let contentBlocker = tab.contentBlocker {
+      injectedScripts.append(contentBlocker)
+    }
+    if let requestBlockingContentHelper = tab.requestBlockingContentHelper {
+      injectedScripts.append(requestBlockingContentHelper)
+    }
 
     #if canImport(BraveTalk)
     injectedScripts.append(
@@ -2450,20 +2459,22 @@ extension BrowserViewController: TabDelegate {
     // tab.addHelper(spotlightHelper, name: SpotlightHelper.name())
 
     injectedScripts.forEach {
-      tab.addContentScript(
+      tab.browserData?.addContentScript(
         $0,
         name: type(of: $0).scriptName,
         contentWorld: type(of: $0).scriptSandbox
       )
     }
 
-    (tab.getContentScript(name: ReaderModeScriptHandler.scriptName) as? ReaderModeScriptHandler)?
+    (tab.browserData?.getContentScript(name: ReaderModeScriptHandler.scriptName)
+      as? ReaderModeScriptHandler)?
       .delegate = self
-    (tab.getContentScript(name: PlaylistScriptHandler.scriptName) as? PlaylistScriptHandler)?
+    (tab.browserData?.getContentScript(name: PlaylistScriptHandler.scriptName)
+      as? PlaylistScriptHandler)?
       .delegate = self
-    (tab.getContentScript(name: PlaylistFolderSharingScriptHandler.scriptName)
+    (tab.browserData?.getContentScript(name: PlaylistFolderSharingScriptHandler.scriptName)
       as? PlaylistFolderSharingScriptHandler)?.delegate = self
-    (tab.getContentScript(name: Web3NameServiceScriptHandler.scriptName)
+    (tab.browserData?.getContentScript(name: Web3NameServiceScriptHandler.scriptName)
       as? Web3NameServiceScriptHandler)?.delegate = self
 
     // Translate Helper
@@ -2471,44 +2482,13 @@ extension BrowserViewController: TabDelegate {
   }
 
   func tab(_ tab: Tab, willDeleteWebView webView: UIView) {
-    tab.cancelQueuedAlerts()
+    tab.browserData?.cancelQueuedAlerts()
     if let scrollView = tab.webScrollView {
       toolbarVisibilityViewModel.endScrollViewObservation(scrollView)
     }
     webView.removeFromSuperview()
   }
 
-  func showBar(_ bar: SnackBar, animated: Bool) {
-    view.layoutIfNeeded()
-    UIView.animate(
-      withDuration: animated ? 0.25 : 0,
-      animations: {
-        self.alertStackView.insertArrangedSubview(bar, at: 0)
-        self.view.layoutIfNeeded()
-      }
-    )
-  }
-
-  func removeBar(_ bar: SnackBar, animated: Bool) {
-    UIView.animate(
-      withDuration: animated ? 0.25 : 0,
-      animations: {
-        bar.removeFromSuperview()
-      }
-    )
-  }
-
-  func removeAllBars() {
-    alertStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
-  }
-
-  func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {
-    showBar(bar, animated: true)
-  }
-
-  func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {
-    removeBar(bar, animated: true)
-  }
 
   func showRequestRewardsPanel(_ tab: Tab) {
     let vc = BraveTalkRewardsOptInViewController()
@@ -2559,12 +2539,12 @@ extension BrowserViewController: TabDelegate {
   func showWalletNotification(_ tab: Tab, origin: URLOrigin) {
     // only display notification when BVC is front and center
     guard presentedViewController == nil,
-      Preferences.Wallet.displayWeb3Notifications.value
+      Preferences.Wallet.displayWeb3Notifications.value,
+      let origin = tab.browserData?.getOrigin(),
+      let tabDappStore = tab.tabDappStore
     else {
       return
     }
-    let origin = tab.getOrigin()
-    let tabDappStore = tab.tabDappStore
     let walletNotificaton = WalletNotification(
       priority: .low,
       origin: origin,
@@ -2973,7 +2953,7 @@ extension BrowserViewController: PreferencesObserver {
       recordGlobalAdBlockShieldsP3A()
       // Global shield setting changed, reset selectors cache.
       tabManager.allTabs.forEach({
-        $0.contentBlocker.resetSelectorsCache()
+        $0.contentBlocker?.resetSelectorsCache()
       })
     case Preferences.Shields.fingerprintingProtection.key:
       tabManager.reloadSelectedTab()
@@ -3007,7 +2987,7 @@ extension BrowserViewController: PreferencesObserver {
       Preferences.Rewards.rewardsToggledOnce.key:
       updateRewardsButtonState()
     case Preferences.General.mediaAutoBackgrounding.key:
-      tabManager.selectedTab?.setScripts(scripts: [
+      tabManager.selectedTab?.browserData?.setScripts(scripts: [
         .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value
       ])
       tabManager.reloadSelectedTab()
@@ -3083,8 +3063,8 @@ extension BrowserViewController: PreferencesObserver {
       }
     case Preferences.Translate.translateEnabled.key:
       tabManager.selectedTab?.translationState = .unavailable
-      tabManager.selectedTab?.setScripts(scripts: [
-        .braveTranslate: Preferences.Translate.translateEnabled.value
+      tabManager.selectedTab?.browserData?.setScripts(scripts: [
+        .braveTranslate: Preferences.Translate.translateEnabled.value != false
       ])
       // Only reload the tab if the setting was changed from the settings controller
       if presentedViewController is SettingsNavigationController {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/FingerprintingProtection.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/FingerprintingProtection.swift
@@ -34,8 +34,9 @@ class FingerprintingProtection: TabContentScript {
     replyHandler: (Any?, String?) -> Void
   ) {
     defer { replyHandler(nil, nil) }
-    let stats = tab.contentBlocker.stats
-    tab.contentBlocker.stats = stats.adding(fingerprintingCount: 1)
+    guard let tabData = tab.browserData else { return }
+    let stats = tabData.contentBlocker.stats
+    tabData.contentBlocker.stats = stats.adding(fingerprintingCount: 1)
     BraveGlobalShieldStats.shared.fpProtection += 1
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -62,7 +62,7 @@ class ScreenshotHelper {
   }
 
   func takePendingScreenshots(_ tabs: [Tab]) {
-    for tab in tabs where tab.pendingScreenshot {
+    for tab in tabs where tab.pendingScreenshot == true {
       tab.pendingScreenshot = false
       takeDelayedScreenshot(tab)
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -21,24 +21,24 @@ class ScreenshotHelper {
   func takeScreenshot(_ tab: Tab) {
     guard let url = tab.url else {
       Logger.module.error("Tab webView or url is nil")
-      tab.setScreenshot(nil)
+      tab.browserData?.setScreenshot(nil)
       return
     }
 
     if InternalURL(url)?.isAboutHomeURL == true {
       if let homePanel = tabManager?.selectedTab?.newTabPageViewController {
         let screenshot = homePanel.view.screenshot(quality: UIConstants.activeScreenshotQuality)
-        tab.setScreenshot(screenshot)
+        tab.browserData?.setScreenshot(screenshot)
       } else {
-        tab.setScreenshot(nil)
+        tab.browserData?.setScreenshot(nil)
       }
     } else {
       tab.takeSnapshot { [weak tab] image in
         if let image = image {
-          tab?.setScreenshot(image)
+          tab?.browserData?.setScreenshot(image)
         } else {
           Logger.module.error("Cannot snapshot Tab Screenshot - No error description")
-          tab?.setScreenshot(nil)
+          tab?.browserData?.setScreenshot(nil)
         }
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/SnackBarTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/SnackBarTabHelper.swift
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+extension TabDataValues {
+  struct SnackBarTabHelperKey: TabDataKey {
+    static var defaultValue: SnackBarTabHelper?
+  }
+  var snackBars: SnackBarTabHelper? {
+    self[SnackBarTabHelperKey.self]
+  }
+  fileprivate var _snackBars: SnackBarTabHelper? {
+    get { self[SnackBarTabHelperKey.self] }
+    set { self[SnackBarTabHelperKey.self] = newValue }
+  }
+}
+
+protocol SnackBarTabHelperDelegate: AnyObject {
+  func tab(_ tab: Tab, didAddSnackbar bar: SnackBar)
+  func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar)
+}
+
+final class SnackBarTabHelper {
+  weak var tab: Tab?
+  weak var delegate: SnackBarTabHelperDelegate?
+
+  var bars = [SnackBar]()
+
+  init(tab: Tab) {
+    self.tab = tab
+  }
+
+  func addSnackbar(_ bar: SnackBar) {
+    guard let tab else { return }
+    bars.append(bar)
+    delegate?.tab(tab, didAddSnackbar: bar)
+  }
+
+  func removeSnackbar(_ bar: SnackBar) {
+    guard let tab else { return }
+    if let index = bars.firstIndex(of: bar) {
+      bars.remove(at: index)
+      delegate?.tab(tab, didRemoveSnackbar: bar)
+    }
+  }
+
+  func removeAllSnackbars() {
+    // Enumerate backwards here because we'll remove items from the list as we go.
+    bars.reversed().forEach { removeSnackbar($0) }
+  }
+
+  func expireSnackbars() {
+    guard let tab else { return }
+    // Enumerate backwards here because we may remove items from the list as we go.
+    bars.reversed().filter({ !$0.shouldPersist(tab) }).forEach({ removeSnackbar($0) })
+  }
+}
+
+extension SnackBarTabHelper: TabHelper {
+  static var keyPath: WritableKeyPath<TabDataValues, SnackBarTabHelper?> { \._snackBars }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -77,6 +77,8 @@ class TabBrowserData: NSObject, TabObserver {
     }
   }
 
+  let rewardsId: UInt32 = .random(in: 1...UInt32.max)
+
   fileprivate(set) var screenshot: UIImage?
   func setScreenshot(_ screenshot: UIImage?) {
     self.screenshot = screenshot

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -277,6 +277,10 @@ class TabBrowserData: NSObject, TabObserver {
   /// A list of domains that we want to proceed to anyways regardless of any ad-blocking
   var proceedAnywaysDomainList: Set<String> = []
 
+  /// When viewing a non-HTML content type in the webview (like a PDF document), this URL will
+  /// point to a tempfile containing the content so it can be shared to external applications.
+  var temporaryDocument: TemporaryDocument?
+
   func addContentScript(_ helper: TabContentScript, name: String, contentWorld: WKContentWorld) {
     guard let tab else { return }
     contentScriptManager.addContentScript(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -79,6 +79,7 @@ class TabBrowserData: NSObject, TabObserver {
 
   let rewardsId: UInt32 = .random(in: 1...UInt32.max)
 
+  var pendingScreenshot = false
   fileprivate(set) var screenshot: UIImage?
   func setScreenshot(_ screenshot: UIImage?) {
     self.screenshot = screenshot
@@ -168,6 +169,21 @@ class TabBrowserData: NSObject, TabObserver {
   /// If the upgrade hasn't completed within 3s, it is cancelled
   /// and we fallback to HTTP or cancel the request (strict vs. standard)
   var upgradeHTTPSTimeoutTimer: Timer?
+
+  /// This is the url for the current request
+  var currentRequestURL: URL? {
+    willSet {
+      // Lets push the value as a redirect value
+      redirectSourceURL = currentRequestURL
+    }
+  }
+
+  /// This tells us if we internally redirected while navigating (i.e. debounce or query stripping)
+  var isInternalRedirect: Bool = false
+
+  // If the current reqest wasn't comitted and a new one was set
+  // we were redirected and therefore this is set
+  var redirectSourceURL: URL?
 
   /// The tabs new tab page controller.
   ///

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -1,0 +1,529 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveCore
+import BraveUI
+import BraveWallet
+import Data
+import Foundation
+import Preferences
+import Shared
+import Storage
+
+extension TabDataValues {
+  private struct TabBrowserDataKey: TabDataKey {
+    static var defaultValue: TabBrowserData? { nil }
+  }
+
+  var browserData: TabBrowserData? {
+    get { self[TabBrowserDataKey.self] }
+    set { self[TabBrowserDataKey.self] = newValue }
+  }
+}
+
+/// A broad container of assorted data that was previously stored in Tab
+///
+/// DO NOT ADD NEW PROPERTIES TO THIS TYPE
+///
+/// This is a temporary container to shift non-web navigation related properties out of Tab,
+/// any additional properties or changes to data in this should be pulled out and placed in its own
+/// type such as a tab helper.
+class TabBrowserData: NSObject, TabObserver {
+  weak var tab: Tab?
+
+  init(
+    tab: Tab,
+    tabGeneratorAPI: BraveTabGeneratorAPI? = nil
+  ) {
+    self.tab = tab
+    _syncTab = tabGeneratorAPI?.createBraveSyncTab(isOffTheRecord: tab.isPrivate)
+
+    if let syncTab = _syncTab {
+      _faviconDriver = FaviconDriver(webState: syncTab.webState).then {
+        $0.setMaximumFaviconImageSize(CGSize(width: 1024, height: 1024))
+      }
+    } else {
+      _faviconDriver = nil
+    }
+
+    nightMode = Preferences.General.nightModeEnabled.value
+
+    super.init()
+
+    tab.addObserver(self)
+    contentScriptManager.tab = tab
+  }
+
+  deinit {
+    deleteNewTabPageController()
+    contentScriptManager.helpers.removeAll()
+
+    // A number of mojo-powered core objects have to be deconstructed on the same
+    // thread they were constructed
+    var mojoObjects: [Any?] = [
+      _faviconDriver,
+      _syncTab,
+      _walletEthProvider,
+      _walletSolProvider,
+      _walletKeyringService,
+    ]
+
+    DispatchQueue.main.async {
+      // Reference inside to retain it, supress warnings by reading/writing
+      _ = mojoObjects
+      mojoObjects = []
+    }
+  }
+
+  fileprivate(set) var screenshot: UIImage?
+  func setScreenshot(_ screenshot: UIImage?) {
+    self.screenshot = screenshot
+    onScreenshotUpdated?()
+  }
+  var onScreenshotUpdated: (() -> Void)?
+  var rewardsEnabledCallback: ((Bool) -> Void)?
+
+  var alertShownCount: Int = 0
+  var blockAllAlerts: Bool = false
+
+  var redirectChain = [URL]()
+  var responses = [URL: URLResponse]()
+
+  private var _syncTab: BraveSyncTab?
+  private var _faviconDriver: FaviconDriver?
+  private var _walletEthProvider: BraveWalletEthereumProvider?
+  private var _walletSolProvider: BraveWalletSolanaProvider?
+  private var _walletKeyringService: BraveWalletKeyringService? {
+    didSet {
+      _walletKeyringService?.addObserver(self)
+    }
+  }
+
+  weak var syncTab: BraveSyncTab? {
+    _syncTab
+  }
+
+  weak var faviconDriver: FaviconDriver? {
+    _faviconDriver
+  }
+
+  weak var walletEthProvider: BraveWalletEthereumProvider? {
+    get { _walletEthProvider }
+    set { _walletEthProvider = newValue }
+  }
+
+  weak var walletSolProvider: BraveWalletSolanaProvider? {
+    get { _walletSolProvider }
+    set { _walletSolProvider = newValue }
+  }
+
+  weak var walletKeyringService: BraveWalletKeyringService? {
+    get { _walletKeyringService }
+    set { _walletKeyringService = newValue }
+  }
+
+  var tabDappStore: TabDappStore = .init()
+  var isWalletIconVisible: Bool = false {
+    didSet {
+      tab?.tabDelegate?.updateURLBarWalletButton()
+    }
+  }
+
+  // PageMetadata is derived from the page content itself, and as such lags behind the
+  // rest of the tab.
+  var pageMetadata: PageMetadata?
+
+  var userActivity: NSUserActivity?
+
+  var isDisplayingBasicAuthPrompt = false
+
+  // This variable is used to keep track of current page. It is used to detect
+  // and report same document navigations to Brave Rewards library.
+  var rewardsXHRLoadURL: URL?
+
+  /// This object holds on to information regarding the current web page
+  ///
+  /// The page data is cleared when the user leaves the page (i.e. when the main frame url changes)
+  @MainActor var currentPageData: PageData?
+
+  var isEditing = false
+
+  var playlistItem: PlaylistInfo?
+  var playlistItemState: PlaylistItemAddedState = .none
+  var translationState: TranslateURLBarButton.TranslateState = .unavailable
+
+  /// The rewards reporting state which is filled during a page navigation.
+  // It is reset to initial values when the page navigation is finished.
+  var rewardsReportingState = RewardsTabChangeReportingState()
+
+  /// This is the request that was upgraded to HTTPS
+  /// This allows us to rollback the upgrade when we encounter a 4xx+
+  var upgradedHTTPSRequest: URLRequest?
+
+  /// This is a timer that's started on HTTPS upgrade
+  /// If the upgrade hasn't completed within 3s, it is cancelled
+  /// and we fallback to HTTP or cancel the request (strict vs. standard)
+  var upgradeHTTPSTimeoutTimer: Timer?
+
+  /// The tabs new tab page controller.
+  ///
+  /// Should be setup in BVC then assigned here for future use.
+  var newTabPageViewController: NewTabPageViewController? {
+    willSet {
+      if newValue == nil {
+        deleteNewTabPageController()
+      }
+    }
+  }
+
+  private func deleteNewTabPageController() {
+    guard let controller = newTabPageViewController, controller.parent != nil else { return }
+    controller.willMove(toParent: nil)
+    controller.removeFromParent()
+    controller.view.removeFromSuperview()
+  }
+
+  // There is no 'available macro' on props, we currently just need to store ownership.
+  lazy var contentBlocker = ContentBlockerHelper(tab: tab)
+  let requestBlockingContentHelper = RequestBlockingContentScriptHandler()
+
+  var readerModeAvailableOrActive: Bool {
+    if let readerMode = getContentScript(name: ReaderModeScriptHandler.scriptName)
+      as? ReaderModeScriptHandler
+    {
+      return readerMode.state != .unavailable
+    }
+    return false
+  }
+
+  var webStateDebounceTimer: Timer?
+  var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
+
+  fileprivate let contentScriptManager = TabContentScriptManager()
+  private var userScripts = Set<UserScriptManager.ScriptType>()
+  private var customUserScripts = Set<UserScriptType>()
+
+  /// Any time a tab tries to make requests to display a Javascript Alert and we are not the active
+  /// tab instance, queue it for later until we become foregrounded.
+  fileprivate var alertQueue = [JSAlertInfo]()
+  weak var shownPromptAlert: UIAlertController?
+
+  var nightMode: Bool {
+    didSet {
+      var isNightModeEnabled = false
+
+      if let fetchedTabURL = tab?.fetchedURL, nightMode,
+        !DarkReaderScriptHandler.isNightModeBlockedURL(fetchedTabURL)
+      {
+        isNightModeEnabled = true
+      }
+
+      if let tab = tab {
+        if isNightModeEnabled {
+          DarkReaderScriptHandler.enable(for: tab)
+        } else {
+          DarkReaderScriptHandler.disable(for: tab)
+        }
+      }
+
+      self.setScript(script: .nightMode, enabled: isNightModeEnabled)
+    }
+  }
+
+  var translateHelper: BraveTranslateTabHelper?
+  private(set) lazy var leoTabHelper = BraveLeoScriptTabHelper(tab: tab)
+
+  /// Boolean tracking custom url-scheme alert presented
+  var isExternalAppAlertPresented = false
+  var externalAppPopup: AlertPopupView?
+  var externalAppPopupContinuation: CheckedContinuation<Bool, Never>?
+  var externalAppAlertCounter = 0
+  var isExternalAppAlertSuppressed = false
+  var externalAppURLDomain: String?
+
+  func resetExternalAlertProperties() {
+    externalAppAlertCounter = 0
+    isExternalAppAlertPresented = false
+    isExternalAppAlertSuppressed = false
+    externalAppURLDomain = nil
+  }
+
+  /// A helper property that handles native to Brave Search communication.
+  var braveSearchManager: BraveSearchManager?
+
+  /// A helper property that handles Brave Search Result Ads.
+  var braveSearchResultAdManager: BraveSearchResultAdManager?
+
+  /// A list of domains that we want to proceed to anyways regardless of any ad-blocking
+  var proceedAnywaysDomainList: Set<String> = []
+
+  func addContentScript(_ helper: TabContentScript, name: String, contentWorld: WKContentWorld) {
+    guard let tab else { return }
+    contentScriptManager.addContentScript(
+      helper,
+      name: name,
+      forTab: tab,
+      contentWorld: contentWorld
+    )
+  }
+
+  func removeContentScript(name: String, forTab tab: Tab, contentWorld: WKContentWorld) {
+    contentScriptManager.removeContentScript(name: name, forTab: tab, contentWorld: contentWorld)
+  }
+
+  func replaceContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
+    contentScriptManager.replaceContentScript(helper, name: name, forTab: tab)
+  }
+
+  func getContentScript(name: String) -> TabContentScript? {
+    return contentScriptManager.getContentScript(name)
+  }
+
+  func queueJavascriptAlertPrompt(_ alert: JSAlertInfo) {
+    alertQueue.append(alert)
+  }
+
+  func dequeueJavascriptAlertPrompt() -> JSAlertInfo? {
+    guard !alertQueue.isEmpty else {
+      return nil
+    }
+    return alertQueue.removeFirst()
+  }
+
+  func cancelQueuedAlerts() {
+    alertQueue.forEach { alert in
+      alert.cancel()
+    }
+  }
+
+  func addTabInfoToSyncedSessions(url: URL, displayTitle: String) {
+    syncTab?.setURL(url)
+    syncTab?.setTitle(displayTitle)
+  }
+
+  func setScript(script: UserScriptManager.ScriptType, enabled: Bool) {
+    setScripts(scripts: [script: enabled])
+  }
+
+  func setScripts(scripts: Set<UserScriptManager.ScriptType>, enabled: Bool) {
+    var scriptMap = [UserScriptManager.ScriptType: Bool]()
+    scripts.forEach({ scriptMap[$0] = enabled })
+    setScripts(scripts: scriptMap)
+  }
+
+  func setScripts(scripts: [UserScriptManager.ScriptType: Bool]) {
+    var scriptsToAdd = Set<UserScriptManager.ScriptType>()
+    var scriptsToRemove = Set<UserScriptManager.ScriptType>()
+
+    for (script, enabled) in scripts {
+      let scriptExists = userScripts.contains(script)
+
+      if !scriptExists && enabled {
+        scriptsToAdd.insert(script)
+      } else if scriptExists && !enabled {
+        scriptsToRemove.insert(script)
+      }
+    }
+
+    if scriptsToAdd.isEmpty && scriptsToRemove.isEmpty {
+      // Scripts already enabled or disabled
+      return
+    }
+
+    userScripts.formUnion(scriptsToAdd)
+    userScripts.subtract(scriptsToRemove)
+    updateInjectedScripts()
+  }
+
+  func setCustomUserScript(scripts: Set<UserScriptType>) {
+    if customUserScripts != scripts {
+      customUserScripts = scripts
+      updateInjectedScripts()
+    }
+  }
+
+  private func updateInjectedScripts() {
+    guard let tab else { return }
+    UserScriptManager.shared.loadCustomScripts(
+      into: tab,
+      userScripts: userScripts,
+      customScripts: customUserScripts
+    )
+  }
+
+  // MARK: - TabObserver
+
+  func tabDidStartNavigation(_ tab: Tab) {
+    resetExternalAlertProperties()
+    nightMode = Preferences.General.nightModeEnabled.value
+  }
+
+  func tabDidChangeTitle(_ tab: Tab) {
+    syncTab?.setTitle(tab.displayTitle)
+  }
+
+  func tabDidUpdateURL(_ tab: Tab) {
+    if let url = tab.url, !tab.isPrivate, !url.isLocal, !InternalURL.isValid(url: url),
+      !url.isInternalURL(for: .readermode)
+    {
+      syncTab?.setURL(url)
+    }
+  }
+
+  func tab(_ tab: Tab, didCreateWebView webView: UIView) {
+    let scriptPreferences: [UserScriptManager.ScriptType: Bool] = [
+      .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
+      .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value,
+      .nightMode: Preferences.General.nightModeEnabled.value,
+      .braveTranslate: Preferences.Translate.translateEnabled.value != false,
+    ]
+
+    userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))
+    self.updateInjectedScripts()
+    nightMode = Preferences.General.nightModeEnabled.value
+  }
+
+  func tab(_ tab: Tab, willDeleteWebView webView: UIView) {
+    contentScriptManager.helpers.removeAll()
+    contentScriptManager.uninstall(from: tab)
+    translateHelper = nil
+  }
+
+  func tabWillBeDestroyed(_ tab: Tab) {
+    tab.removeObserver(self)
+  }
+}
+
+private class TabContentScriptManager: NSObject, WKScriptMessageHandlerWithReply {
+  fileprivate var helpers = [String: TabContentScript]()
+  weak var tab: Tab?
+
+  func uninstall(from tab: Tab) {
+    helpers.forEach {
+      let name = type(of: $0.value).messageHandlerName
+      tab.configuration.userContentController.removeScriptMessageHandler(forName: name)
+    }
+  }
+
+  func userContentController(
+    _ userContentController: WKUserContentController,
+    didReceive message: WKScriptMessage,
+    replyHandler: @escaping (Any?, String?) -> Void
+  ) {
+    guard let tab,
+      let helper = helpers.values.first(where: {
+        type(of: $0).messageHandlerName == message.name
+      })
+    else {
+      replyHandler(nil, nil)
+      return
+    }
+    helper.tab(tab, receivedScriptMessage: message, replyHandler: replyHandler)
+  }
+
+  func addContentScript(
+    _ helper: TabContentScript,
+    name: String,
+    forTab tab: Tab,
+    contentWorld: WKContentWorld
+  ) {
+    if let _ = helpers[name] {
+      assertionFailure("Duplicate helper added: \(name)")
+    }
+
+    helpers[name] = helper
+
+    // If this helper handles script messages, then get the handler name and register it. The Tab
+    // receives all messages and then dispatches them to the right TabHelper.
+    let scriptMessageHandlerName = type(of: helper).messageHandlerName
+    tab.configuration.userContentController.addScriptMessageHandler(
+      self,
+      contentWorld: contentWorld,
+      name: scriptMessageHandlerName
+    )
+  }
+
+  func removeContentScript(name: String, forTab tab: Tab, contentWorld: WKContentWorld) {
+    if let helper = helpers[name] {
+      let scriptMessageHandlerName = type(of: helper).messageHandlerName
+      tab.configuration.userContentController.removeScriptMessageHandler(
+        forName: scriptMessageHandlerName,
+        contentWorld: contentWorld
+      )
+      helpers[name] = nil
+    }
+  }
+
+  func replaceContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
+    if helpers[name] != nil {
+      helpers[name] = helper
+    }
+  }
+
+  func getContentScript(_ name: String) -> TabContentScript? {
+    return helpers[name]
+  }
+}
+
+/// Computed variables based on TabBrowserData
+extension Tab {
+  var canonicalURL: URL? {
+    if let string = self.pageMetadata?.siteURL,
+      let siteURL = URL(string: string)
+    {
+      return siteURL
+    }
+    return self.url
+  }
+
+  /// The URL that should be shared when requested by the user via the share sheet
+  ///
+  /// If the canonical URL of the page points to a different base domain entirely, this will result in
+  /// sharing the canonical URL. This is to ensure pages such as Google's AMP share the correct URL while
+  /// also ensuring single page applications which don't update their canonical URLs on navigation share
+  /// the current pages URL
+  var shareURL: URL? {
+    guard let url = url else { return nil }
+    if let canonicalURL = canonicalURL, canonicalURL.baseDomain != url.baseDomain {
+      return canonicalURL
+    }
+    return url
+  }
+}
+
+/// Allows fetching directly from TabBrowserData directly from Tab using dynamic member lookup
+///
+/// DO NOT REPLICATE FOR OTHER TYPES
+///
+/// Tab will retain dynamic member lookup only one layer deep into TabDataValues, this is only
+/// here to avoid more significant refactors
+extension Tab {
+  subscript<Value>(dynamicMember member: KeyPath<TabBrowserData, Value>) -> Value? {
+    return data.browserData?[keyPath: member]
+  }
+  subscript<Value>(dynamicMember member: KeyPath<TabBrowserData, Value?>) -> Value? {
+    return data.browserData?[keyPath: member]
+  }
+  subscript<Value>(dynamicMember member: WritableKeyPath<TabBrowserData, Value>) -> Value? {
+    get {
+      return data.browserData?[keyPath: member]
+    }
+    set {
+      if let newValue {
+        data.browserData?[keyPath: member] = newValue
+      }
+    }
+  }
+  subscript<Value>(dynamicMember member: WritableKeyPath<TabBrowserData, Value?>) -> Value? {
+    get {
+      return data.browserData?[keyPath: member]
+    }
+    set {
+      if let newValue {
+        data.browserData?[keyPath: member] = newValue
+      }
+    }
+  }
+}

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/LinkPreviewViewController.swift
@@ -33,8 +33,7 @@ class LinkPreviewViewController: UIViewController {
 
     currentTab = Tab(
       configuration: parentTab.configuration,
-      type: parentTab.isPrivate ? .private : .regular,
-      tabGeneratorAPI: nil
+      type: parentTab.isPrivate ? .private : .regular
     ).then {
       $0.tabDelegate = browserController
       $0.createWebview()

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Playlist/Managers & Cache/PlaylistCacheLoader.swift
@@ -37,7 +37,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
     type: .private
   ).then {
     $0.createWebview()
-    $0.setScript(
+    $0.browserData?.setScript(
       script: .playlistMediaSource,
       enabled: true
     )
@@ -88,7 +88,7 @@ class LivePlaylistWebLoader: UIView, PlaylistWebLoader {
       browserViewController.tab(tab, didCreateWebView: webContentView)
 
       tab.addObserver(self)
-      tab.replaceContentScript(
+      tab.browserData?.replaceContentScript(
         PlaylistWebLoaderContentHelper(self),
         name: PlaylistWebLoaderContentHelper.scriptName,
         forTab: tab

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -230,7 +230,6 @@ class Tab: NSObject {
   var lastExecutedTime: Timestamp?
   fileprivate var lastRequest: URLRequest?
   var isRestoring: Bool = false
-  var pendingScreenshot = false
 
   /// The url set after a successful navigation. This will also set the `url` property.
   ///
@@ -240,12 +239,6 @@ class Tab: NSObject {
     willSet {
       url = newValue
       previousComittedURL = committedURL
-
-      // Clear the current request url and the redirect source url
-      // We don't need these values after the request has been comitted
-      currentRequestURL = nil
-      redirectSourceURL = nil
-      isInternalRedirect = false
     }
     didSet {
       observers.forEach {
@@ -266,21 +259,6 @@ class Tab: NSObject {
       }
     }
   }
-
-  /// This is the url for the current request
-  var currentRequestURL: URL? {
-    willSet {
-      // Lets push the value as a redirect value
-      redirectSourceURL = currentRequestURL
-    }
-  }
-
-  /// This tells us if we internally redirected while navigating (i.e. debounce or query stripping)
-  var isInternalRedirect: Bool = false
-
-  // If the current reqest wasn't comitted and a new one was set
-  // we were redirected and therefore this is set
-  var redirectSourceURL: URL?
 
   /// The previous url that was set before `comittedURL` was set again
   private(set) var previousComittedURL: URL?

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -201,8 +201,6 @@ class Tab: NSObject {
 
   var sslPinningError: Error?
 
-  var userActivity: NSUserActivity?
-
   private var webView: TabWebView?
   // Should only be used by internal Tab code, will be removed in the future when Tab can live
   // in its own SPM target

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -82,15 +82,24 @@ enum TabSecureContentState: String {
   }
 }
 
+@dynamicMemberLookup
 class Tab: NSObject {
   let id: UUID
   let rewardsId: UInt32
 
-  var onScreenshotUpdated: (() -> Void)?
-  var rewardsEnabledCallback: ((Bool) -> Void)?
+  var data: TabDataValues {
+    get { _data.withLock { $0 } }
+    set { _data.withLock { $0 = newValue } }
+  }
+  private var _data: OSAllocatedUnfairLock<TabDataValues> = .init(uncheckedState: .init())
 
-  var alertShownCount: Int = 0
-  var blockAllAlerts: Bool = false
+  subscript<Value>(dynamicMember member: KeyPath<TabDataValues, Value>) -> Value {
+    return data[keyPath: member]
+  }
+  subscript<Value>(dynamicMember member: WritableKeyPath<TabDataValues, Value>) -> Value {
+    get { data[keyPath: member] }
+    set { data[keyPath: member] = newValue }
+  }
 
   private(set) var type: TabType = .regular
 
@@ -193,73 +202,6 @@ class Tab: NSObject {
 
   var sslPinningError: Error?
 
-  private let _syncTab: BraveSyncTab?
-  private let _faviconDriver: FaviconDriver?
-  private var _walletEthProvider: BraveWalletEthereumProvider?
-  private var _walletSolProvider: BraveWalletSolanaProvider?
-  private var _walletKeyringService: BraveWalletKeyringService? {
-    didSet {
-      _walletKeyringService?.addObserver(self)
-    }
-  }
-
-  private weak var syncTab: BraveSyncTab? {
-    _syncTab
-  }
-
-  weak var faviconDriver: FaviconDriver? {
-    _faviconDriver
-  }
-
-  weak var walletEthProvider: BraveWalletEthereumProvider? {
-    get { _walletEthProvider }
-    set { _walletEthProvider = newValue }
-  }
-
-  weak var walletSolProvider: BraveWalletSolanaProvider? {
-    get { _walletSolProvider }
-    set { _walletSolProvider = newValue }
-  }
-
-  weak var walletKeyringService: BraveWalletKeyringService? {
-    get { _walletKeyringService }
-    set { _walletKeyringService = newValue }
-  }
-
-  var tabDappStore: TabDappStore = .init()
-  var isWalletIconVisible: Bool = false {
-    didSet {
-      tabDelegate?.updateURLBarWalletButton()
-    }
-  }
-
-  // PageMetadata is derived from the page content itself, and as such lags behind the
-  // rest of the tab.
-  var pageMetadata: PageMetadata?
-
-  var canonicalURL: URL? {
-    if let string = pageMetadata?.siteURL,
-      let siteURL = URL(string: string)
-    {
-      return siteURL
-    }
-    return self.url
-  }
-
-  /// The URL that should be shared when requested by the user via the share sheet
-  ///
-  /// If the canonical URL of the page points to a different base domain entirely, this will result in
-  /// sharing the canonical URL. This is to ensure pages such as Google's AMP share the correct URL while
-  /// also ensuring single page applications which don't update their canonical URLs on navigation share
-  /// the current pages URL
-  var shareURL: URL? {
-    guard let url = url else { return nil }
-    if let canonicalURL = canonicalURL, canonicalURL.baseDomain != url.baseDomain {
-      return canonicalURL
-    }
-    return url
-  }
-
   var userActivity: NSUserActivity?
 
   private var webView: TabWebView?
@@ -285,22 +227,11 @@ class Tab: NSObject {
     webView?.sampledPageTopColor
   }
   var tabDelegate: TabDelegate?
-  var bars = [SnackBar]()
   var favicon: Favicon
   var lastExecutedTime: Timestamp?
   fileprivate var lastRequest: URLRequest?
-  var restoring: Bool = false
+  var isRestoring: Bool = false
   var pendingScreenshot = false
-  var isDisplayingBasicAuthPrompt = false
-
-  // This variable is used to keep track of current page. It is used to detect
-  // and report same document navigations to Brave Rewards library.
-  var rewardsXHRLoadURL: URL?
-
-  /// This object holds on to information regarding the current web page
-  ///
-  /// The page data is cleared when the user leaves the page (i.e. when the main frame url changes)
-  @MainActor var currentPageData: PageData?
 
   /// The url set after a successful navigation. This will also set the `url` property.
   ///
@@ -369,7 +300,7 @@ class Tab: NSObject {
         url = URL(string: internalUrl.stripAuthorization)
       }
 
-      if isDisplayingBasicAuthPrompt {
+      if data.browserData?.isDisplayingBasicAuthPrompt == true {
         url = URL(string: "\(InternalURL.baseUrl)/\(InternalURL.Path.basicAuth.rawValue)")
       }
 
@@ -377,7 +308,7 @@ class Tab: NSObject {
       if let url = url, !isPrivate, !url.isLocal, !InternalURL.isValid(url: url),
         !url.isInternalURL(for: .readermode)
       {
-        syncTab?.setURL(url)
+        data.browserData?.syncTab?.setURL(url)
       }
     }
   }
@@ -393,49 +324,10 @@ class Tab: NSObject {
   }
 
   var mimeType: String?
-  var isEditing = false
-  var playlistItem: PlaylistInfo?
-  var playlistItemState: PlaylistItemAddedState = .none
-  var translationState: TranslateURLBarButton.TranslateState = .unavailable
-
-  /// The rewards reporting state which is filled during a page navigation.
-  // It is reset to initial values when the page navigation is finished.
-  var rewardsReportingState = RewardsTabChangeReportingState()
-
-  /// This is the request that was upgraded to HTTPS
-  /// This allows us to rollback the upgrade when we encounter a 4xx+
-  var upgradedHTTPSRequest: URLRequest?
-
-  /// This is a timer that's started on HTTPS upgrade
-  /// If the upgrade hasn't completed within 3s, it is cancelled
-  /// and we fallback to HTTP or cancel the request (strict vs. standard)
-  var upgradeHTTPSTimeoutTimer: Timer?
-
-  /// The tabs new tab page controller.
-  ///
-  /// Should be setup in BVC then assigned here for future use.
-  var newTabPageViewController: NewTabPageViewController? {
-    willSet {
-      if newValue == nil {
-        deleteNewTabPageController()
-      }
-    }
-  }
-
-  private func deleteNewTabPageController() {
-    guard let controller = newTabPageViewController, controller.parent != nil else { return }
-    controller.willMove(toParent: nil)
-    controller.removeFromParent()
-    controller.view.removeFromSuperview()
-  }
 
   /// When viewing a non-HTML content type in the webview (like a PDF document), this URL will
   /// point to a tempfile containing the content so it can be shared to external applications.
   var temporaryDocument: TemporaryDocument?
-
-  // There is no 'available macro' on props, we currently just need to store ownership.
-  lazy var contentBlocker = ContentBlockerHelper(tab: self)
-  let requestBlockingContentHelper = RequestBlockingContentScriptHandler()
 
   /// The last title shown by this tab. Used by the tab tray to show titles for zombie tabs.
   var lastTitle: String?
@@ -458,77 +350,15 @@ class Tab: NSObject {
   /// Each tab has separate list of website overrides.
   private var userAgentOverrides: [String: Bool] = [:]
 
-  var readerModeAvailableOrActive: Bool {
-    if let readerMode = self.getContentScript(name: ReaderModeScriptHandler.scriptName)
-      as? ReaderModeScriptHandler
-    {
-      return readerMode.state != .unavailable
-    }
-    return false
-  }
-
-  fileprivate(set) var screenshot: UIImage?
-
-  var webStateDebounceTimer: Timer?
-  var onPageReadyStateChanged: ((ReadyState.State) -> Void)?
-
   // If this tab has been opened from another, its parent will point to the tab from which it was opened
   weak var parent: Tab?
 
-  fileprivate let contentScriptManager = TabContentScriptManager()
-  private var userScripts = Set<UserScriptManager.ScriptType>()
-  private var customUserScripts = Set<UserScriptType>()
-
   private(set) var configuration: WKWebViewConfiguration
-
-  /// Any time a tab tries to make requests to display a Javascript Alert and we are not the active
-  /// tab instance, queue it for later until we become foregrounded.
-  fileprivate var alertQueue = [JSAlertInfo]()
-  weak var shownPromptAlert: UIAlertController?
-
-  var nightMode: Bool {
-    didSet {
-      var isNightModeEnabled = false
-
-      if let fetchedTabURL = fetchedURL, nightMode,
-        !DarkReaderScriptHandler.isNightModeBlockedURL(fetchedTabURL)
-      {
-        isNightModeEnabled = true
-      }
-
-      if isNightModeEnabled {
-        DarkReaderScriptHandler.enable(for: self)
-      } else {
-        DarkReaderScriptHandler.disable(for: self)
-      }
-
-      self.setScript(script: .nightMode, enabled: isNightModeEnabled)
-    }
-  }
-
-  var translateHelper: BraveTranslateTabHelper?
-  private(set) lazy var leoTabHelper = BraveLeoScriptTabHelper(tab: self)
-
-  /// Boolean tracking custom url-scheme alert presented
-  var isExternalAppAlertPresented = false
-  var externalAppPopup: AlertPopupView?
-  var externalAppPopupContinuation: CheckedContinuation<Bool, Never>?
-  var externalAppAlertCounter = 0
-  var isExternalAppAlertSuppressed = false
-  var externalAppURLDomain: String?
-
-  func resetExternalAlertProperties() {
-    externalAppAlertCounter = 0
-    isExternalAppAlertPresented = false
-    isExternalAppAlertSuppressed = false
-    externalAppURLDomain = nil
-  }
 
   init(
     configuration: WKWebViewConfiguration,
     id: UUID = UUID(),
-    type: TabType = .regular,
-    tabGeneratorAPI: BraveTabGeneratorAPI? = nil
+    type: TabType = .regular
   ) {
     self.configuration = configuration
     self.id = id
@@ -536,29 +366,11 @@ class Tab: NSObject {
 
     self.favicon = Favicon.default
     rewardsId = UInt32.random(in: 1...UInt32.max)
-    nightMode = Preferences.General.nightModeEnabled.value
-    _syncTab = tabGeneratorAPI?.createBraveSyncTab(isOffTheRecord: type == .private)
-
-    if let syncTab = _syncTab {
-      _faviconDriver = FaviconDriver(webState: syncTab.webState).then {
-        $0.setMaximumFaviconImageSize(CGSize(width: 1024, height: 1024))
-      }
-    } else {
-      _faviconDriver = nil
-    }
-
     super.init()
 
-    self.contentScriptManager.tab = self
     self.navigationHandler = TabWKNavigationHandler(tab: self)
     self.uiHandler = TabWKUIHandler(tab: self)
   }
-
-  /// A helper property that handles native to Brave Search communication.
-  var braveSearchManager: BraveSearchManager?
-
-  /// A helper property that handles Brave Search Result Ads.
-  var braveSearchResultAdManager: BraveSearchResultAdManager?
 
   private lazy var refreshControl = UIRefreshControl().then {
     $0.addTarget(self, action: #selector(reload), for: .valueChanged)
@@ -617,17 +429,6 @@ class Tab: NSObject {
       observers.forEach {
         $0.tab(self, didCreateWebView: webView)
       }
-
-      let scriptPreferences: [UserScriptManager.ScriptType: Bool] = [
-        .cookieBlocking: Preferences.Privacy.blockAllCookies.value,
-        .mediaBackgroundPlay: Preferences.General.mediaAutoBackgrounding.value,
-        .nightMode: Preferences.General.nightModeEnabled.value,
-        .braveTranslate: Preferences.Translate.translateEnabled.value,
-      ]
-
-      userScripts = Set(scriptPreferences.filter({ $0.value }).map({ $0.key }))
-      self.updateInjectedScripts()
-      nightMode = Preferences.General.nightModeEnabled.value
     }
   }
 
@@ -646,7 +447,9 @@ class Tab: NSObject {
       url = newURL
       notifyObservers = true
     } else {
-      if isTabVisible(), url?.displayURL != nil, url?.displayURL?.scheme == "about", !loading {
+      if tabDelegate?.isTabVisible(self) == true, url?.displayURL != nil,
+        url?.displayURL?.scheme == "about", !loading
+      {
         if let newURL {
           url = newURL
           notifyObservers = true
@@ -844,7 +647,6 @@ class Tab: NSObject {
   func resetWebView(config: WKWebViewConfiguration) {
     configuration = config
     deleteWebView()
-    contentScriptManager.helpers.removeAll()
   }
 
   func clearHistory(config: WKWebViewConfiguration) {
@@ -899,11 +701,9 @@ class Tab: NSObject {
     // we extract the information needed to restore the tabs and create a NSURLRequest with the custom session restore URL
     // to trigger the session restore via custom handlers
     if let sessionInfo = restorationData {
-      restoring = true
+      isRestoring = true
       lastTitle = sessionInfo.title
       webView.interactionState = sessionInfo.interactionState
-      restoring = false
-      rewardsReportingState.wasRestored = true
     } else if let request = lastRequest {
       webView.load(request)
     } else {
@@ -918,10 +718,9 @@ class Tab: NSObject {
     requestRestorationData: (title: String, request: URLRequest)?
   ) {
     if let sessionInfo = requestRestorationData {
-      restoring = true
+      isRestoring = true
       lastTitle = sessionInfo.title
       webView.load(sessionInfo.request)
-      restoring = false
     } else if let request = lastRequest {
       webView.load(request)
     } else {
@@ -932,9 +731,6 @@ class Tab: NSObject {
   }
 
   func deleteWebView() {
-    contentScriptManager.uninstall(from: self)
-    translateHelper = nil
-
     if let webView = webView {
       observers.forEach {
         $0.tab(self, willDeleteWebView: webView)
@@ -945,28 +741,9 @@ class Tab: NSObject {
   }
 
   deinit {
+    deleteWebView()
     observers.forEach {
       $0.tabWillBeDestroyed(self)
-    }
-
-    deleteWebView()
-    deleteNewTabPageController()
-    contentScriptManager.helpers.removeAll()
-
-    // A number of mojo-powered core objects have to be deconstructed on the same
-    // thread they were constructed
-    var mojoObjects: [Any?] = [
-      _faviconDriver,
-      _syncTab,
-      _walletEthProvider,
-      _walletSolProvider,
-      _walletKeyringService,
-    ]
-
-    DispatchQueue.main.async {
-      // Reference inside to retain it, supress warnings by reading/writing
-      _ = mojoObjects
-      mojoObjects = []
     }
   }
 
@@ -992,42 +769,35 @@ class Tab: NSObject {
 
   var displayTitle: String {
     if let displayTabTitle = fetchDisplayTitle(using: url, title: title) {
-      syncTab?.setTitle(displayTabTitle)
       return displayTabTitle
     }
 
     // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
     // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
-    if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, !restoring {
-      syncTab?.setTitle(Strings.Hotkey.newTabTitle)
+    if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, !isRestoring {
       return Strings.Hotkey.newTabTitle
     }
 
     if let url = self.url, !InternalURL.isValid(url: url),
       let shownUrl = url.displayURL?.absoluteString, webView != nil
     {
-      syncTab?.setTitle(shownUrl)
       return shownUrl
     }
 
     guard let lastTitle = lastTitle, !lastTitle.isEmpty else {
       // FF uses url?.displayURL?.absoluteString ??  ""
       if let title = url?.absoluteString {
-        syncTab?.setTitle(title)
         return title
       } else if let tab = SessionTab.from(tabId: id) {
         if tab.title.isEmpty {
           return Strings.Hotkey.newTabTitle
         }
-        syncTab?.setTitle(tab.title)
         return tab.title
       }
 
-      syncTab?.setTitle("")
       return ""
     }
 
-    syncTab?.setTitle(lastTitle)
     return lastTitle
   }
 
@@ -1045,9 +815,6 @@ class Tab: NSObject {
     }
     return favicon
   }
-
-  /// A list of domains that we want to proceed to anyways regardless of any ad-blocking
-  var proceedAnywaysDomainList: Set<String> = []
 
   var canGoBack: Bool {
     return webView?.canGoBack ?? false
@@ -1087,7 +854,6 @@ class Tab: NSObject {
         displayTitle = ""
       }
 
-      syncTab?.setTitle(displayTitle)
       return displayTitle
     }
 
@@ -1150,8 +916,6 @@ class Tab: NSObject {
       }
     }
 
-    resetExternalAlertProperties()
-
     // If the current page is an error page, and the reload button is tapped, load the original URL
     if let url = webView?.url, let internalUrl = InternalURL(url),
       let page = internalUrl.originalURLFromErrorPage
@@ -1161,7 +925,6 @@ class Tab: NSObject {
     }
 
     if let _ = webView?.reloadFromOrigin() {
-      nightMode = Preferences.General.nightModeEnabled.value
       Logger.module.debug("reloaded zombified tab from origin")
       return
     }
@@ -1186,27 +949,6 @@ class Tab: NSObject {
 
     let desktopMode = userAgentOverrides[baseDomain] ?? UserAgent.shouldUseDesktopMode()
     webView.customUserAgent = desktopMode ? UserAgent.desktop : UserAgent.mobile
-  }
-
-  func addContentScript(_ helper: TabContentScript, name: String, contentWorld: WKContentWorld) {
-    contentScriptManager.addContentScript(
-      helper,
-      name: name,
-      forTab: self,
-      contentWorld: contentWorld
-    )
-  }
-
-  func removeContentScript(name: String, forTab tab: Tab, contentWorld: WKContentWorld) {
-    contentScriptManager.removeContentScript(name: name, forTab: tab, contentWorld: contentWorld)
-  }
-
-  func replaceContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-    contentScriptManager.replaceContentScript(helper, name: name, forTab: tab)
-  }
-
-  func getContentScript(name: String) -> TabContentScript? {
-    return contentScriptManager.getContentScript(name)
   }
 
   func hideContent(_ animated: Bool = false) {
@@ -1237,37 +979,6 @@ class Tab: NSObject {
     }
   }
 
-  func addSnackbar(_ bar: SnackBar) {
-    bars.append(bar)
-    observers.forEach {
-      $0.tab(self, didAddSnackbar: bar)
-    }
-  }
-
-  func removeSnackbar(_ bar: SnackBar) {
-    if let index = bars.firstIndex(of: bar) {
-      bars.remove(at: index)
-      observers.forEach {
-        $0.tab(self, didRemoveSnackbar: bar)
-      }
-    }
-  }
-
-  func removeAllSnackbars() {
-    // Enumerate backwards here because we'll remove items from the list as we go.
-    bars.reversed().forEach { removeSnackbar($0) }
-  }
-
-  func expireSnackbars() {
-    // Enumerate backwards here because we may remove items from the list as we go.
-    bars.reversed().filter({ !$0.shouldPersist(self) }).forEach({ removeSnackbar($0) })
-  }
-
-  func setScreenshot(_ screenshot: UIImage?) {
-    self.screenshot = screenshot
-    onScreenshotUpdated?()
-  }
-
   /// Switches user agent Desktop -> Mobile or Mobile -> Desktop.
   func switchUserAgent() {
     if let urlString = webView?.url?.baseDomain {
@@ -1283,23 +994,6 @@ class Tab: NSObject {
     reload()
   }
 
-  func queueJavascriptAlertPrompt(_ alert: JSAlertInfo) {
-    alertQueue.append(alert)
-  }
-
-  func dequeueJavascriptAlertPrompt() -> JSAlertInfo? {
-    guard !alertQueue.isEmpty else {
-      return nil
-    }
-    return alertQueue.removeFirst()
-  }
-
-  func cancelQueuedAlerts() {
-    alertQueue.forEach { alert in
-      alert.cancel()
-    }
-  }
-
   func updatePullToRefreshVisibility() {
     guard let url = webView?.url, let webView = webView else { return }
     webView.scrollView.refreshControl =
@@ -1312,11 +1006,6 @@ class Tab: NSObject {
 
   func stopMediaPlayback() {
     tabDelegate?.stopMediaPlayback(self)
-  }
-
-  func addTabInfoToSyncedSessions(url: URL, displayTitle: String) {
-    syncTab?.setURL(url)
-    syncTab?.setTitle(displayTitle)
   }
 
   private func resolvedPolicyDecision(
@@ -1396,77 +1085,6 @@ class Tab: NSObject {
     observers.forEach {
       $0.tab(self, didFailNavigationWithError: error)
     }
-  }
-}
-
-private class TabContentScriptManager: NSObject, WKScriptMessageHandlerWithReply {
-  fileprivate var helpers = [String: TabContentScript]()
-  weak var tab: Tab?
-
-  func uninstall(from tab: Tab) {
-    helpers.forEach {
-      let name = type(of: $0.value).messageHandlerName
-      tab.configuration.userContentController.removeScriptMessageHandler(forName: name)
-    }
-  }
-
-  func userContentController(
-    _ userContentController: WKUserContentController,
-    didReceive message: WKScriptMessage,
-    replyHandler: @escaping (Any?, String?) -> Void
-  ) {
-    guard let tab,
-      let helper = helpers.values.first(where: {
-        type(of: $0).messageHandlerName == message.name
-      })
-    else {
-      replyHandler(nil, nil)
-      return
-    }
-    helper.tab(tab, receivedScriptMessage: message, replyHandler: replyHandler)
-  }
-
-  func addContentScript(
-    _ helper: TabContentScript,
-    name: String,
-    forTab tab: Tab,
-    contentWorld: WKContentWorld
-  ) {
-    if let _ = helpers[name] {
-      assertionFailure("Duplicate helper added: \(name)")
-    }
-
-    helpers[name] = helper
-
-    // If this helper handles script messages, then get the handler name and register it. The Tab
-    // receives all messages and then dispatches them to the right TabHelper.
-    let scriptMessageHandlerName = type(of: helper).messageHandlerName
-    tab.configuration.userContentController.addScriptMessageHandler(
-      self,
-      contentWorld: contentWorld,
-      name: scriptMessageHandlerName
-    )
-  }
-
-  func removeContentScript(name: String, forTab tab: Tab, contentWorld: WKContentWorld) {
-    if let helper = helpers[name] {
-      let scriptMessageHandlerName = type(of: helper).messageHandlerName
-      tab.configuration.userContentController.removeScriptMessageHandler(
-        forName: scriptMessageHandlerName,
-        contentWorld: contentWorld
-      )
-      helpers[name] = nil
-    }
-  }
-
-  func replaceContentScript(_ helper: TabContentScript, name: String, forTab tab: Tab) {
-    if helpers[name] != nil {
-      helpers[name] = helper
-    }
-  }
-
-  func getContentScript(_ name: String) -> TabContentScript? {
-    return helpers[name]
   }
 }
 
@@ -1589,14 +1207,14 @@ extension Tab {
 
         var queryResult = "null"
 
-        if let url = self.webView?.url,
+        if let url = self.url,
           BraveSearchManager.isValidURL(url),
           let result = self.braveSearchManager?.fallbackQueryResult
         {
           queryResult = result
         }
 
-        self.webView?.evaluateSafeJavaScript(
+        self.evaluateSafeJavaScript(
           functionName: "window.onFetchedBackupResults",
           args: [queryResult],
           contentWorld: BraveSearchScriptHandler.scriptSandbox,
@@ -1613,7 +1231,7 @@ extension Tab {
 // MARK: - Brave SKU
 extension Tab {
   func injectLocalStorageItem(key: String, value: String) {
-    self.webView?.evaluateSafeJavaScript(
+    self.evaluateSafeJavaScript(
       functionName: "localStorage.setItem",
       args: [key, value],
       contentWorld: BraveSkusScriptHandler.scriptSandbox
@@ -1623,54 +1241,6 @@ extension Tab {
 
 // MARK: Script Injection
 extension Tab {
-  func setScript(script: UserScriptManager.ScriptType, enabled: Bool) {
-    setScripts(scripts: [script: enabled])
-  }
-
-  func setScripts(scripts: Set<UserScriptManager.ScriptType>, enabled: Bool) {
-    var scriptMap = [UserScriptManager.ScriptType: Bool]()
-    scripts.forEach({ scriptMap[$0] = enabled })
-    setScripts(scripts: scriptMap)
-  }
-
-  func setScripts(scripts: [UserScriptManager.ScriptType: Bool]) {
-    var scriptsToAdd = Set<UserScriptManager.ScriptType>()
-    var scriptsToRemove = Set<UserScriptManager.ScriptType>()
-
-    for (script, enabled) in scripts {
-      let scriptExists = userScripts.contains(script)
-
-      if !scriptExists && enabled {
-        scriptsToAdd.insert(script)
-      } else if scriptExists && !enabled {
-        scriptsToRemove.insert(script)
-      }
-    }
-
-    if scriptsToAdd.isEmpty && scriptsToRemove.isEmpty {
-      // Scripts already enabled or disabled
-      return
-    }
-
-    userScripts.formUnion(scriptsToAdd)
-    userScripts.subtract(scriptsToRemove)
-    updateInjectedScripts()
-  }
-
-  func setCustomUserScript(scripts: Set<UserScriptType>) {
-    if customUserScripts != scripts {
-      customUserScripts = scripts
-      updateInjectedScripts()
-    }
-  }
-
-  private func updateInjectedScripts() {
-    UserScriptManager.shared.loadCustomScripts(
-      into: self,
-      userScripts: userScripts,
-      customScripts: customUserScripts
-    )
-  }
 }
 
 // Find In Page interaction
@@ -1894,5 +1464,48 @@ extension Tab {
       in: frame,
       contentWorld: contentWorld
     )
+  }
+}
+
+struct TabDataValues {
+  private var storage: [AnyHashable: Any] = [:]
+
+  public subscript<Key: TabDataKey>(key: Key.Type) -> Key.Value? {
+    get {
+      guard let helper = storage[ObjectIdentifier(key)] as? Key.Value else {
+        return Key.defaultValue
+      }
+      return helper
+    }
+    set {
+      storage[ObjectIdentifier(key)] = newValue
+    }
+  }
+}
+
+protocol TabDataKey {
+  associatedtype Value
+  static var defaultValue: Value? { get }
+}
+
+protocol TabHelper {
+  init(tab: Tab)
+  static var keyPath: WritableKeyPath<TabDataValues, Self?> { get }
+  static func create(for tab: Tab)
+  static func remove(from tab: Tab)
+  static func from(tab: Tab) -> Self?
+}
+
+extension TabHelper {
+  static func create(for tab: Tab) {
+    if tab.data[keyPath: keyPath] == nil {
+      tab.data[keyPath: keyPath] = Self(tab: tab)
+    }
+  }
+  static func remove(from tab: Tab) {
+    tab.data[keyPath: keyPath] = nil
+  }
+  static func from(tab: Tab) -> Self? {
+    tab.data[keyPath: keyPath]
   }
 }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -85,7 +85,6 @@ enum TabSecureContentState: String {
 @dynamicMemberLookup
 class Tab: NSObject {
   let id: UUID
-  let rewardsId: UInt32
 
   var data: TabDataValues {
     get { _data.withLock { $0 } }
@@ -365,7 +364,6 @@ class Tab: NSObject {
     self.type = type
 
     self.favicon = Favicon.default
-    rewardsId = UInt32.random(in: 1...UInt32.max)
     super.init()
 
     self.navigationHandler = TabWKNavigationHandler(tab: self)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Tab.swift
@@ -300,10 +300,6 @@ class Tab: NSObject {
 
   var mimeType: String?
 
-  /// When viewing a non-HTML content type in the webview (like a PDF document), this URL will
-  /// point to a tempfile containing the content so it can be shared to external applications.
-  var temporaryDocument: TemporaryDocument?
-
   /// The last title shown by this tab. Used by the tab tray to show titles for zombie tabs.
   var lastTitle: String?
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabObserver.swift
@@ -7,8 +7,6 @@ import Foundation
 import WebKit
 
 protocol TabObserver: AnyObject {
-  func tab(_ tab: Tab, didAddSnackbar bar: SnackBar)
-  func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar)
   func tab(_ tab: Tab, didCreateWebView webView: UIView)
   func tab(_ tab: Tab, willDeleteWebView webView: UIView)
 
@@ -35,8 +33,6 @@ protocol TabObserver: AnyObject {
 }
 
 extension TabObserver {
-  func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {}
-  func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {}
   func tab(_ tab: Tab, didCreateWebView webView: UIView) {}
   func tab(_ tab: Tab, willDeleteWebView webView: UIView) {}
 
@@ -58,8 +54,6 @@ extension TabObserver {
 
 class AnyTabObserver: TabObserver, Hashable {
   let id: ObjectIdentifier
-  private let _tabDidAddSnackbar: (Tab, SnackBar) -> Void
-  private let _tabDidRemoveSnackbar: (Tab, SnackBar) -> Void
   private let _tabDidCreateWebView: (Tab, UIView) -> Void
   private let _tabWillDeleteWebView: (Tab, UIView) -> Void
 
@@ -88,8 +82,6 @@ class AnyTabObserver: TabObserver, Hashable {
 
   init(_ observer: some TabObserver) {
     id = ObjectIdentifier(observer)
-    _tabDidAddSnackbar = { [weak observer] in observer?.tab($0, didAddSnackbar: $1) }
-    _tabDidRemoveSnackbar = { [weak observer] in observer?.tab($0, didRemoveSnackbar: $1) }
     _tabDidCreateWebView = { [weak observer] in observer?.tab($0, didCreateWebView: $1) }
     _tabWillDeleteWebView = { [weak observer] in observer?.tab($0, willDeleteWebView: $1) }
     _tabDidStartNavigation = { [weak observer] in observer?.tabDidStartNavigation($0) }
@@ -114,12 +106,6 @@ class AnyTabObserver: TabObserver, Hashable {
     _tabWillBeDestroyed = { [weak observer] in observer?.tabWillBeDestroyed($0) }
   }
 
-  func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {
-    _tabDidAddSnackbar(tab, bar)
-  }
-  func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {
-    _tabDidRemoveSnackbar(tab, bar)
-  }
   func tab(_ tab: Tab, didCreateWebView webView: UIView) {
     _tabDidCreateWebView(tab, webView)
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabWKNavigationHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabWKNavigationHandler.swift
@@ -310,6 +310,7 @@ class TabWKNavigationHandler: NSObject, WKNavigationDelegate {
 
     // Set the committed url which will also set tab.url
     tab.committedURL = webView.url
+    tab.isRestoring = false
 
     tab.didCommitNavigation()
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/Reader/ReadabilityService.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Reader/ReadabilityService.swift
@@ -35,12 +35,13 @@ class ReadabilityOperation: Operation {
     DispatchQueue.main.async {
       let configuration = WKWebViewConfiguration()
       self.tab = Tab(configuration: configuration)
+      self.tab.browserData = .init(tab: self.tab, tabGeneratorAPI: nil)
       self.tab.createWebview()
       self.tab.addObserver(self)
 
       let readerMode = ReaderModeScriptHandler()
       readerMode.delegate = self
-      self.tab.addContentScript(
+      self.tab.browserData?.addContentScript(
         readerMode,
         name: ReaderModeScriptHandler.scriptName,
         contentWorld: ReaderModeScriptHandler.scriptSandbox

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -213,7 +213,7 @@ public class BraveRewards: PreferencesObserver {
     }
 
     ads.notifyTabDidChange(
-      Int(tab.rewardsId),
+      Int(tab.rewardsId ?? 0),
       redirectChain: tab.redirectChain,
       isNewNavigation: reportingState.isNewNavigation,
       isRestoring: reportingState.wasRestored,
@@ -232,7 +232,7 @@ public class BraveRewards: PreferencesObserver {
     }
 
     ads.notifyTabDidLoad(
-      Int(tab.rewardsId),
+      Int(tab.rewardsId ?? 0),
       httpStatusCode: reportingState.httpStatusCode
     )
   }
@@ -261,7 +261,7 @@ public class BraveRewards: PreferencesObserver {
       return
     }
 
-    let tabId = Int(tab.rewardsId)
+    let tabId = Int(tab.rewardsId ?? 0)
     if isSelected {
       tabRetrieved(tabId, url: url, html: nil)
     }
@@ -279,7 +279,7 @@ public class BraveRewards: PreferencesObserver {
       return
     }
 
-    let tabId = Int(tab.rewardsId)
+    let tabId = Int(tab.rewardsId ?? 0)
 
     tabRetrieved(tabId, url: url, html: htmlContent)
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Rewards/BraveRewards.swift
@@ -204,7 +204,9 @@ public class BraveRewards: PreferencesObserver {
     tab: Tab,
     isSelected: Bool
   ) {
-    guard !tab.redirectChain.isEmpty, !tab.isPrivate, ads.isServiceRunning() else {
+    guard !tab.redirectChain.isEmpty, !tab.isPrivate, ads.isServiceRunning(),
+      let reportingState = tab.rewardsReportingState
+    else {
       // Don't notify `DidChange` for tabs that haven't finished loading, private tabs,
       // or when the ads service is not running.
       return
@@ -213,15 +215,17 @@ public class BraveRewards: PreferencesObserver {
     ads.notifyTabDidChange(
       Int(tab.rewardsId),
       redirectChain: tab.redirectChain,
-      isNewNavigation: tab.rewardsReportingState.isNewNavigation,
-      isRestoring: tab.rewardsReportingState.wasRestored,
+      isNewNavigation: reportingState.isNewNavigation,
+      isRestoring: reportingState.wasRestored,
       isSelected: isSelected
     )
   }
 
   /// Notifies Brave Ads that the given tab did load
   func maybeNotifyTabDidLoad(tab: Tab) {
-    guard !tab.redirectChain.isEmpty, !tab.isPrivate, ads.isServiceRunning() else {
+    guard !tab.redirectChain.isEmpty, !tab.isPrivate, ads.isServiceRunning(),
+      let reportingState = tab.rewardsReportingState
+    else {
       // Don't notify `DidLoad` for tabs that haven't finished loading, private tabs,
       // or when the ads service is not running.
       return
@@ -229,7 +233,7 @@ public class BraveRewards: PreferencesObserver {
 
     ads.notifyTabDidLoad(
       Int(tab.rewardsId),
-      httpStatusCode: tab.rewardsReportingState.httpStatusCode
+      httpStatusCode: reportingState.httpStatusCode
     )
   }
 
@@ -281,13 +285,13 @@ public class BraveRewards: PreferencesObserver {
 
     // Don't notify about content changes if the ads service is not available, the
     // tab was restored, was a previously committed navigation, or an error page was displayed.
-    if ads.isServiceRunning() {
+    if ads.isServiceRunning(), let tabData = tab.browserData {
       let kHttpClientErrorResponseStatusCodeClass = 4
       let kHttpServerErrorResponseStatusCodeClass = 5
-      let responseStatusCodeClass = tab.rewardsReportingState.httpStatusCode / 100
+      let responseStatusCodeClass = tabData.rewardsReportingState.httpStatusCode / 100
 
-      if !tab.rewardsReportingState.wasRestored
-        && tab.rewardsReportingState.isNewNavigation
+      if !tabData.rewardsReportingState.wasRestored
+        && tabData.rewardsReportingState.isNewNavigation
         && responseStatusCodeClass != kHttpClientErrorResponseStatusCodeClass
         && responseStatusCodeClass != kHttpServerErrorResponseStatusCodeClass
       {

--- a/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsSettingsViewModel.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Shields/ShieldsSettingsViewModel.swift
@@ -56,10 +56,10 @@ class ShieldsSettingsViewModel: ObservableObject {
       .fpProtection,
       considerAllShieldsOption: true
     )
-    self.stats = tab.contentBlocker.stats
+    self.stats = tab.contentBlocker?.stats ?? .init()
 
-    tab.contentBlocker.statsDidChange = { [weak self] _ in
-      self?.stats = tab.contentBlocker.stats
+    tab.contentBlocker?.statsDidChange = { [weak self, weak tab] _ in
+      self?.stats = tab?.contentBlocker?.stats ?? .init()
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/BlockedDomainScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Internal/BlockedDomainScriptHandler.swift
@@ -52,7 +52,7 @@ class BlockedDomainScriptHandler: TabContentScript {
     }
 
     let request = URLRequest(url: url)
-    tab.proceedAnywaysDomainList.insert(etldP1)
+    tab.proceedAnywaysDomainList?.insert(etldP1)
     tab.loadRequest(request)
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/CosmeticFiltersScriptHandler.swift
@@ -89,7 +89,7 @@ class CosmeticFiltersScriptHandler: TabContentScript {
 
         // cache blocked selectors
         if let url = tab.url {
-          tab.contentBlocker.cacheSelectors(
+          tab.contentBlocker?.cacheSelectors(
             for: url,
             standardSelectors: standardSelectors,
             aggressiveSelectors: aggressiveSelectors

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/EthereumProviderScriptHandler.swift
@@ -100,7 +100,7 @@ class EthereumProviderScriptHandler: TabContentScript {
     ) {
       Task { @MainActor in
         if updateJSProperties {
-          await tab.updateEthereumProperties()
+          await tab.browserData?.updateEthereumProperties()
         }
 
         if reject {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -330,7 +330,9 @@ extension PlaylistScriptHandler {
 
 extension PlaylistScriptHandler {
   static func updatePlaylistTab(tab: Tab, item: PlaylistInfo?) {
-    if let handler = tab.getContentScript(name: Self.scriptName) as? PlaylistScriptHandler {
+    if let handler = tab.browserData?.getContentScript(name: Self.scriptName)
+      as? PlaylistScriptHandler
+    {
       Self.processPlaylistInfo(tab: tab, handler: handler, item: item)
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RequestBlockingContentScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/RequestBlockingContentScriptHandler.swift
@@ -103,13 +103,16 @@ class RequestBlockingContentScriptHandler: TabContentScript {
           )
         }
 
-        if shouldBlock
-          && !tab.contentBlocker.blockedRequests.contains(where: { $0.requestURL == requestURL })
+        if let tabData = tab.browserData,
+          shouldBlock
+            && !tabData.contentBlocker.blockedRequests.contains(where: {
+              $0.requestURL == requestURL
+            })
         {
           BraveGlobalShieldStats.shared.adblock += 1
-          let stats = tab.contentBlocker.stats
-          tab.contentBlocker.stats = stats.adding(adCount: 1)
-          tab.contentBlocker.blockedRequests.append(
+          let stats = tabData.contentBlocker.stats
+          tab.contentBlocker?.stats = stats.adding(adCount: 1)
+          tab.contentBlocker?.blockedRequests.append(
             .init(
               requestURL: requestURL,
               sourceURL: windowOriginURL,

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/SolanaProviderScriptHandler.swift
@@ -134,7 +134,7 @@ class SolanaProviderScriptHandler: TabContentScript {
         if method == Keys.connect.rawValue, let publicKey = result as? String {
           await emitConnectEvent(tab: tab, publicKey: publicKey)
         } else if method == Keys.disconnect.rawValue {
-          tab.emitSolanaEvent(.disconnect)
+          tab.browserData?.emitSolanaEvent(.disconnect)
         }
       case .signTransaction:
         let (result, error) = await signTransaction(tab: tab, args: body.args)
@@ -163,7 +163,7 @@ class SolanaProviderScriptHandler: TabContentScript {
     guard status == .success else {
       return (nil, buildErrorJson(status: status, errorMessage: errorMessage))
     }
-    await tab.updateSolanaProperties()
+    await tab.browserData?.updateSolanaProperties()
     return (publicKey, nil)
   }
 
@@ -256,7 +256,7 @@ class SolanaProviderScriptHandler: TabContentScript {
     if method == Keys.connect.rawValue,
       let publicKey = result[Keys.publicKey.rawValue]?.stringValue
     {
-      await tab.updateSolanaProperties()
+      await tab.browserData?.updateSolanaProperties()
       return (publicKey, nil)
     } else {
       guard let encodedResult = MojoBase.Value(dictionaryValue: result).jsonObject else {

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/AdsMediaReportingScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/AdsMediaReportingScriptHandler.swift
@@ -39,9 +39,9 @@ class AdsMediaReportingScriptHandler: TabContentScript {
 
     if let isPlaying = body["data"] as? Bool {
       if isPlaying {
-        rewards.reportMediaStarted(tabId: Int(tab.rewardsId))
+        rewards.reportMediaStarted(tabId: Int(tab.rewardsId ?? 0))
       } else {
-        rewards.reportMediaStopped(tabId: Int(tab.rewardsId))
+        rewards.reportMediaStopped(tabId: Int(tab.rewardsId ?? 0))
       }
     }
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveLeoScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/BraveLeoScriptHandler.swift
@@ -54,7 +54,7 @@ class BraveLeoScriptHandler: NSObject, TabContentScript {
 class BraveLeoScriptTabHelper: AIChatWebDelegate {
   weak var tab: Tab?
 
-  init(tab: Tab) {
+  init(tab: Tab?) {
     self.tab = tab
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/LoginsScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/LoginsScriptHandler.swift
@@ -150,10 +150,11 @@ class LoginsScriptHandler: TabContentScript {
     guard let username = login.usernameValue else {
       return
     }
+    let snackBarTabHelper = SnackBarTabHelper.from(tab: tab)
 
     // Remove the existing prompt
     if let existingPrompt = self.snackBar {
-      tab.removeSnackbar(existingPrompt)
+      snackBarTabHelper?.removeSnackbar(existingPrompt)
     }
 
     let promptMessage = String(
@@ -174,7 +175,7 @@ class LoginsScriptHandler: TabContentScript {
         ? Strings.loginsHelperDontUpdateButtonTitle : Strings.loginsHelperDontSaveButtonTitle,
       accessibilityIdentifier: "UpdateLoginPrompt.dontSaveUpdateButton"
     ) { [unowned self] bar in
-      tab.removeSnackbar(bar)
+      snackBarTabHelper?.removeSnackbar(bar)
       self.snackBar = nil
       return
     }
@@ -184,7 +185,7 @@ class LoginsScriptHandler: TabContentScript {
         ? Strings.loginsHelperUpdateButtonTitle : Strings.loginsHelperSaveLoginButtonTitle,
       accessibilityIdentifier: "UpdateLoginPrompt.saveUpdateButton"
     ) { [unowned self] bar in
-      tab.removeSnackbar(bar)
+      snackBarTabHelper?.removeSnackbar(bar)
       self.snackBar = nil
 
       completion()
@@ -194,7 +195,7 @@ class LoginsScriptHandler: TabContentScript {
     snackBar?.addButton(saveORUpdate)
 
     if let bar = snackBar {
-      tab.addSnackbar(bar)
+      snackBarTabHelper?.addSnackbar(bar)
     }
   }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Sandboxed/SiteStateListenerScriptHandler.swift
@@ -75,7 +75,7 @@ class SiteStateListenerScriptHandler: TabContentScript {
           var cachedStandardSelectors: Set<String> = .init()
           var cachedAggressiveSelectors: Set<String> = .init()
           if let url = tab.url,
-            let (standard, aggressive) = tab.contentBlocker.cachedSelectors(for: url)
+            let (standard, aggressive) = tab.contentBlocker?.cachedSelectors(for: url)
           {
             cachedStandardSelectors = standard
             cachedAggressiveSelectors = aggressive

--- a/ios/brave-ios/Sources/Brave/Frontend/Widgets/SnackBar.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Widgets/SnackBar.swift
@@ -215,29 +215,6 @@ class TimerSnackBar: SnackBar {
     fatalError("init(coder:) has not been implemented")
   }
 
-  static func showAppStoreConfirmationBar(forTab tab: Tab, appStoreURL: URL) {
-    let bar = TimerSnackBar(
-      text: Strings.externalLinkAppStoreConfirmationTitle,
-      img: Favicon.defaultImage
-    )
-    let openAppStore = SnackButton(
-      title: Strings.OKString,
-      accessibilityIdentifier: "ConfirmOpenInAppStore"
-    ) { bar in
-      tab.removeSnackbar(bar)
-      UIApplication.shared.open(appStoreURL)
-    }
-    let cancelButton = SnackButton(
-      title: Strings.cancelButtonTitle,
-      accessibilityIdentifier: "CancelOpenInAppStore"
-    ) { bar in
-      tab.removeSnackbar(bar)
-    }
-    bar.addButton(openAppStore)
-    bar.addButton(cancelButton)
-    tab.addSnackbar(bar)
-  }
-
   override func show() {
     self.timer = Timer(
       timeInterval: timeout,

--- a/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
+++ b/ios/brave-ios/Sources/Brave/WebFilters/ContentBlocker/ContentBlockerHelper.swift
@@ -87,7 +87,7 @@ class ContentBlockerHelper: ObservableObject {
   /// Cached aggressive selectors. Key is the URL's `baseDomain`.
   private var hiddenAggressiveSelectors: [String: Set<String>] = [:]
 
-  init(tab: Tab) {
+  init(tab: Tab?) {
     self.tab = tab
   }
 

--- a/ios/brave-ios/Tests/ClientTests/SolanaProviderScriptHandlerTests.swift
+++ b/ios/brave-ios/Tests/ClientTests/SolanaProviderScriptHandlerTests.swift
@@ -12,6 +12,12 @@ import XCTest
 
 @MainActor class SolanaProviderScriptHandlerTests: XCTestCase {
 
+  private func testTab() -> Tab {
+    let tab = Tab(configuration: .init())
+    tab.browserData = .init(tab: tab)
+    return tab
+  }
+
   /// Test `connect()`, given no parameters, the error flow will return a tuple `(result: Any?, error: String?)`
   /// with the error populated as the given error dictionary
   func testConnectFailure() async {
@@ -19,7 +25,7 @@ import XCTest
     provider._connect = { params, completion in
       completion(.internalError, Strings.Wallet.internalErrorMessage, "")
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -43,7 +49,7 @@ import XCTest
     provider._connect = { [kTestPublicKey] params, completion in
       completion(.success, "", kTestPublicKey)
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -69,7 +75,7 @@ import XCTest
       XCTAssertNotNil(params)  // onlyIfTrusted provided as an arg, should be non-nil
       completion(.success, "", kTestPublicKey)
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -100,7 +106,7 @@ import XCTest
     provider._signAndSendTransaction = { signTransactionParam, sendOptions, completion in
       completion(.internalError, Strings.Wallet.internalErrorMessage, [:])
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -143,7 +149,7 @@ import XCTest
         ]
       )
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -185,7 +191,7 @@ import XCTest
         ]
       )
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -214,7 +220,7 @@ import XCTest
     provider._signMessage = { _, _, completion in
       completion(.internalError, Strings.Wallet.internalErrorMessage, [:])
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -254,7 +260,7 @@ import XCTest
         ]
       )
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -299,7 +305,7 @@ import XCTest
         ]
       )
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -340,7 +346,7 @@ import XCTest
     provider._signTransaction = { _, completion in
       completion(.internalError, Strings.Wallet.internalErrorMessage, [], .legacy)
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -379,7 +385,7 @@ import XCTest
     provider._signTransaction = { [kSerializedTx] _, completion in
       completion(.success, "", kSerializedTx.map(NSNumber.init(value:)), .legacy)
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -418,7 +424,7 @@ import XCTest
     provider._signTransaction = { [kSerializedTx] _, completion in
       completion(.success, "", kSerializedTx.map(NSNumber.init(value:)), .V0)
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -457,7 +463,7 @@ import XCTest
     provider._signAllTransactions = { _, completion in
       completion(.internalError, Strings.Wallet.internalErrorMessage, [], [])
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -501,7 +507,7 @@ import XCTest
         [NSNumber(value: BraveWallet.SolanaMessageVersion.legacy.rawValue)]
       )
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 
@@ -547,7 +553,7 @@ import XCTest
         [NSNumber(value: BraveWallet.SolanaMessageVersion.V0.rawValue)]
       )
     }
-    let tab = Tab(configuration: .init())
+    let tab = testTab()
     let solProviderHelper = SolanaProviderScriptHandler()
     tab.walletSolProvider = provider
 


### PR DESCRIPTION
This change introduces very basic support for storing arbitrary data in Tab similar to `base::SupportsUserData` using a type-safe SwiftUI Environment style API and then shifts all a majority of the properties currently stored in Tab into a temporary type. This type should eventually be deleted when individual tab helpers for each feature are created

Resolves https://github.com/brave/brave-browser/issues/44722

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

TBD, basically sanity test every Brave feature that relies on tab state: translate, alert prompts, rewards/ads, playlist, NTP, wallet, sync...