### PR TITLE
Handle tab-fullscreen from split view (uplift to 1.77.x)

### DIFF
--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -72,6 +72,12 @@ BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {
       std::make_unique<sidebar::SidebarController>(this, profile());
   sidebar_controller_->SetSidebar(brave_window()->InitSidebar());
 #endif
+
+  // As browser window(BrowserView) is initialized before fullscreen controller
+  // is ready, it's difficult to know when browsr window can listen.
+  // Notify exact timing to do it.
+  CHECK(exclusive_access_manager());
+  brave_window()->ReadyToListenFullscreenChanges();
 }
 
 BraveBrowser::~BraveBrowser() = default;

--- a/browser/ui/brave_browser_window.h
+++ b/browser/ui/brave_browser_window.h
@@ -71,6 +71,7 @@ class BraveBrowserWindow : public BrowserWindow {
 
   // Returns true if all tabs in this window is being dragged.
   virtual bool IsInTabDragging() const;
+  virtual void ReadyToListenFullscreenChanges() {}
 };
 
 #endif  // BRAVE_BROWSER_UI_BRAVE_BROWSER_WINDOW_H_

--- a/browser/ui/views/frame/brave_browser_view.cc
+++ b/browser/ui/views/frame/brave_browser_view.cc
@@ -908,6 +908,12 @@ views::View* BraveBrowserView::GetContentsContainerForLayoutManager() {
                      : BrowserView::GetContentsContainerForLayoutManager();
 }
 
+void BraveBrowserView::ReadyToListenFullscreenChanges() {
+  if (split_view_) {
+    split_view_->ListenFullscreenChanges();
+  }
+}
+
 bool BraveBrowserView::IsSidebarVisible() const {
   return sidebar_container_view_ && sidebar_container_view_->IsSidebarVisible();
 }

--- a/browser/ui/views/frame/brave_browser_view.h
+++ b/browser/ui/views/frame/brave_browser_view.h
@@ -115,6 +115,7 @@ class BraveBrowserView : public BrowserView,
   bool AcceleratorPressed(const ui::Accelerator& accelerator) override;
   bool IsInTabDragging() const override;
   views::View* GetContentsContainerForLayoutManager() override;
+  void ReadyToListenFullscreenChanges() override;
 
 #if defined(USE_AURA)
   views::View* sidebar_host_view() { return sidebar_host_view_; }

--- a/browser/ui/views/split_view/split_view.h
+++ b/browser/ui/views/split_view/split_view.h
@@ -16,6 +16,7 @@
 #include "brave/browser/ui/tabs/split_view_browser_data_observer.h"
 #include "brave/browser/ui/views/split_view/split_view_layout_manager.h"
 #include "brave/components/speedreader/common/buildflags/buildflags.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_observer.h"
 #include "chrome/browser/ui/views/frame/scrim_view.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/gfx/geometry/rounded_corners_f.h"
@@ -38,6 +39,7 @@ class BraveBrowserView;
 class Browser;
 class ContentsWebView;
 class DevToolsContentsResizingStrategy;
+class FullscreenController;
 class SplitViewLayoutManager;
 class SplitViewLocationBar;
 class SplitViewSeparator;
@@ -48,6 +50,7 @@ class SplitView : public views::View,
                   public ReaderModeToolbarView::Delegate,
 #endif
                   public views::WidgetObserver,
+                  public FullscreenObserver,
                   public SplitViewBrowserDataObserver {
   METADATA_HEADER(SplitView, views::View)
  public:
@@ -64,6 +67,8 @@ class SplitView : public views::View,
 
   // true when active tab is in tile.
   bool IsSplitViewActive() const;
+
+  void ListenFullscreenChanges();
 
   // Called before/after BrowserView::OnActiveTabChanged() as we have some
   // jobs such as reducing flickering while active tab changing. See the
@@ -123,6 +128,9 @@ class SplitView : public views::View,
   void OnWidgetWindowModalVisibilityChanged(views::Widget* widget,
                                             bool visible) override;
 
+  // FullscreenObserver:
+  void OnFullscreenStateChanged() override;
+
  private:
   friend class SplitViewBrowserTest;
   friend class SplitViewLocationBarBrowserTest;
@@ -139,6 +147,7 @@ class SplitView : public views::View,
 
   SplitViewLayoutManager* GetSplitViewLayoutManager();
   const SplitViewLayoutManager* GetSplitViewLayoutManager() const;
+  bool ShouldHideSecondaryContentsByTabFullscreen() const;
 
   raw_ref<Browser> browser_;
 
@@ -163,6 +172,8 @@ class SplitView : public views::View,
       split_view_observation_{this};
   base::ScopedObservation<views::Widget, views::WidgetObserver>
       widget_observation_{this};
+  base::ScopedObservation<FullscreenController, FullscreenObserver>
+      fullscreen_observation_{this};
 };
 
 #endif  // BRAVE_BROWSER_UI_VIEWS_SPLIT_VIEW_SPLIT_VIEW_H_

--- a/browser/ui/views/split_view/split_view_browsertest.cc
+++ b/browser/ui/views/split_view/split_view_browsertest.cc
@@ -16,6 +16,8 @@
 #include "brave/browser/ui/views/frame/brave_browser_view.h"
 #include "brave/browser/ui/views/split_view/split_view_layout_manager.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
+#include "chrome/browser/ui/exclusive_access/exclusive_access_manager.h"
+#include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/tabs/tab_strip.h"
@@ -354,4 +356,34 @@ IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewTabPathTest) {
                 GetLayoutConstant(TABSTRIP_TOOLBAR_OVERLAP) -
                 (brave_tabs::kHorizontalSplitViewTabVerticalSpacing * 2),
             mask_region.getBounds().height());
+}
+
+IN_PROC_BROWSER_TEST_F(SplitViewBrowserTest, SplitViewFullscreenTest) {
+  brave::NewSplitViewForTab(browser());
+
+  // In split view tile, both contents are visible and have its border.
+  EXPECT_TRUE(browser_view().contents_container()->GetVisible());
+  EXPECT_TRUE(browser_view().contents_container()->GetBorder());
+  EXPECT_TRUE(secondary_contents_container().GetVisible());
+  EXPECT_TRUE(secondary_contents_container().GetBorder());
+
+  // Simulate tab-fullscreen state change.
+  FullscreenController* fullscreen_controller =
+      browser()->exclusive_access_manager()->fullscreen_controller();
+  fullscreen_controller->set_is_tab_fullscreen_for_testing(true);
+  split_view().OnFullscreenStateChanged();
+
+  // In tab full screen, only primary content is visible w/o border.
+  EXPECT_TRUE(browser_view().contents_container()->GetVisible());
+  EXPECT_FALSE(browser_view().contents_container()->GetBorder());
+  EXPECT_FALSE(secondary_contents_container().GetVisible());
+  EXPECT_FALSE(secondary_contents_container().GetBorder());
+
+  fullscreen_controller->set_is_tab_fullscreen_for_testing(false);
+  split_view().OnFullscreenStateChanged();
+
+  EXPECT_TRUE(browser_view().contents_container()->GetVisible());
+  EXPECT_TRUE(browser_view().contents_container()->GetBorder());
+  EXPECT_TRUE(secondary_contents_container().GetVisible());
+  EXPECT_TRUE(secondary_contents_container().GetBorder());
 }


### PR DESCRIPTION
Uplift of #28104
fix https://github.com/brave/brave-browser/issues/43111

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.