### PR TITLE
[iOS] - Add VPN SmartProxyIcon for Region with Smart Proxy Routing Enabled. 

### DIFF
--- a/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc77e6f3629107d5cbe6c6faf6f01675cae9b1794b1b3b2a5a58fad817ae819c",
+  "originHash" : "ae19e081abd4f13d64c011a8cec25fa3a66a2b25bfffd2b41efd7b5ef1053818",
   "pins" : [
     {
       "identity" : "feedkit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "37885b13b0712be902e7abacccb50f0c00456914",
-        "version" : "2.0.1"
+        "revision" : "936dc60748c75c113c461bf52a48ab430cf05d8d",
+        "version" : "2.1.0"
       }
     },
     {

--- a/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/brave-ios/App/Client.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ae19e081abd4f13d64c011a8cec25fa3a66a2b25bfffd2b41efd7b5ef1053818",
+  "originHash" : "55298de62e194f1056de109272e0eb934369549f068e3b06c6a81b9b46dab634",
   "pins" : [
     {
       "identity" : "feedkit",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GuardianFirewall/GuardianConnect",
       "state" : {
-        "revision" : "936dc60748c75c113c461bf52a48ab430cf05d8d",
-        "version" : "2.1.0"
+        "revision" : "706cd111bd1c894c75d0f32b7f749451b8aab5ee",
+        "version" : "2.1.1"
       }
     },
     {

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -73,7 +73,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.3.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "2.0.1"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "2.1.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(
       url: "https://github.com/venmo/Static",

--- a/ios/brave-ios/Package.swift
+++ b/ios/brave-ios/Package.swift
@@ -73,7 +73,7 @@ var package = Package(
     .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     .package(url: "https://github.com/devxoul/Then", from: "2.7.0"),
     .package(url: "https://github.com/mkrd/Swift-BigInt", from: "2.3.0"),
-    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "2.1.0"),
+    .package(url: "https://github.com/GuardianFirewall/GuardianConnect", exact: "2.1.1"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "0.6.0"),
     .package(
       url: "https://github.com/venmo/Static",

--- a/ios/brave-ios/Sources/BraveUI/SwiftUI/BravePopover.swift
+++ b/ios/brave-ios/Sources/BraveUI/SwiftUI/BravePopover.swift
@@ -1,0 +1,179 @@
+// Copyright 2024 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+import Shared
+import SwiftUI
+import UIKit
+
+public struct BravePopoverViewModifier<PopoverContent: View>: ViewModifier {
+  @Binding var isPresented: Bool
+  var arrowDirection: UIPopoverArrowDirection = [.any]
+  let content: () -> PopoverContent
+
+  public func body(content: Content) -> some View {
+    content
+      .background(
+        BravePopoverView(
+          isPresented: self.$isPresented,
+          arrowDirection: self.arrowDirection,
+          content: self.content
+        )
+      )
+  }
+}
+
+extension View {
+  public func bravePopover<Content>(
+    isPresented: Binding<Bool>,
+    arrowDirection: UIPopoverArrowDirection = [.any],
+    @ViewBuilder content: @escaping () -> Content
+  ) -> some View where Content: View {
+    self.modifier(
+      BravePopoverViewModifier(
+        isPresented: isPresented,
+        arrowDirection: arrowDirection,
+        content: content
+      )
+    )
+  }
+}
+
+public struct BravePopoverView<Content: View>: UIViewControllerRepresentable {
+  @Binding var isPresented: Bool
+  private var arrowDirection: UIPopoverArrowDirection
+  private var content: Content
+
+  public init(
+    isPresented: Binding<Bool>,
+    arrowDirection: UIPopoverArrowDirection,
+    @ViewBuilder content: () -> Content
+  ) {
+    self._isPresented = isPresented
+    self.arrowDirection = arrowDirection
+    self.content = content()
+  }
+
+  public func makeUIViewController(context: Context) -> UIViewController {
+    return .init()
+  }
+
+  public func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+    context.coordinator.updateView(content)
+
+    if isPresented {
+      guard uiViewController.presentedViewController == nil
+      else {
+        DispatchQueue.main.async {
+          context.coordinator.dismiss()
+        }
+        return
+      }
+
+      if !uiViewController.isBeingDismissed {
+        context.coordinator.prepareForPresentation(
+          on: uiViewController,
+          arrowDirections: arrowDirection
+        )
+
+        DispatchQueue.main.async {
+          if let presentedViewController = uiViewController.presentedViewController {
+            presentedViewController.dismiss(animated: true) {
+              context.coordinator.present(on: uiViewController)
+            }
+          } else {
+            context.coordinator.present(on: uiViewController)
+          }
+        }
+      }
+    } else {
+      if context.coordinator.isPresentedOn(uiViewController) {
+        context.coordinator.dismiss()
+      }
+    }
+  }
+
+  public func makeCoordinator() -> Coordinator {
+    Coordinator(self, content: content)
+  }
+
+  public class Coordinator: NSObject, UIPopoverPresentationControllerDelegate {
+    private let parent: BravePopoverView
+    private var host: UIHostingController<SelfSizingView>?
+
+    init(_ parent: BravePopoverView, content: Content) {
+      self.parent = parent
+      super.init()
+
+      host = UIHostingController(
+        rootView: SelfSizingView(view: content, coordinator: .init(self))
+      )
+    }
+
+    public func updateView(_ content: Content) {
+      host?.rootView = SelfSizingView(view: content, coordinator: .init(self))
+    }
+
+    public func isPresentedOn(_ controller: UIViewController) -> Bool {
+      return host == controller.presentedViewController
+    }
+
+    public func prepareForPresentation(
+      on controller: UIViewController,
+      arrowDirections: UIPopoverArrowDirection
+    ) {
+      guard let host = host else { return }
+      host.modalPresentationStyle = .popover
+      host.popoverPresentationController?.delegate = self
+      host.popoverPresentationController?.sourceView = controller.view
+      host.popoverPresentationController?.sourceRect = controller.view.bounds
+      host.popoverPresentationController?.permittedArrowDirections = arrowDirections
+    }
+
+    public func present(on controller: UIViewController) {
+      if let host = host {
+        controller.present(host, animated: true)
+      }
+    }
+
+    public func dismiss() {
+      host?.dismiss(animated: true)
+    }
+
+    public func setPreferredContentSize(_ size: CGSize) {
+      host?.preferredContentSize = size
+    }
+
+    public func popoverPresentationControllerDidDismissPopover(
+      _ popoverPresentationController: UIPopoverPresentationController
+    ) {
+      parent.isPresented = false
+    }
+
+    public func adaptivePresentationStyle(
+      for controller: UIPresentationController
+    ) -> UIModalPresentationStyle {
+      return .none
+    }
+  }
+
+  private struct SelfSizingView: View {
+    @State
+    var size: CGSize = .zero
+
+    let view: Content
+    let coordinator: WeakRef<Coordinator>
+
+    var body: some View {
+      view.onGeometryChange(
+        for: CGSize.self,
+        of: { $0.size },
+        action: {
+          coordinator.wrappedValue?.setPreferredContentSize($0)
+        }
+      )
+    }
+  }
+}

--- a/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
+++ b/ios/brave-ios/Sources/BraveVPN/BraveVPN.swift
@@ -403,18 +403,13 @@ public class BraveVPN {
     if !shouldProcessVPNAlerts() { return }
 
     Task {
-      let (data, success, error) = await GRDGatewayAPI().events()
+      let (alertsData, success, error) = await GRDGatewayAPI().events()
       if !success {
         Logger.module.error("VPN getEvents call failed")
         if let error = error {
           Logger.module.warning("\(error)")
         }
 
-        return
-      }
-
-      guard let alertsData = data["alerts"] else {
-        Logger.module.error("Failed to unwrap json for vpn alerts")
         return
       }
 

--- a/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionDetailsView.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionDetailsView.swift
@@ -69,6 +69,7 @@ struct BraveRegionDetailsView: View {
         BraveVPNCityRegion(
           displayName: $0.displayName,
           regionName: $0.regionName,
+          smartRoutingProxyState: $0.smartRoutingProxyState,
           serverCount: Int(truncating: $0.serverCount)
         )
       }

--- a/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionListView.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionListView.swift
@@ -5,6 +5,7 @@
 
 import BraveShared
 import BraveStrings
+import BraveUI
 import GuardianConnect
 import SwiftUI
 
@@ -110,65 +111,22 @@ public struct BraveVPNRegionListView: View {
     }
   }
 
-  private func infoButtonView(index: Int) -> some View {
-    Button(
-      action: {
-        guard !isLoading else {
-          return
-        }
-
-        isRegionDetailsPresented = true
-        if let designatedRegion = allRegions[safe: index],
-          let desiredRegion = allRegions[safe: index]
-        {
-          selectedRegion = desiredRegion
-          selectedRegionCities = designatedRegion.cities
-        }
-      },
-      label: {
-        Image(braveSystemName: "leo.info.ios-only")
-          .foregroundStyle(Color(braveSystemName: .iconInteractive))
-      }
-    )
-    .buttonStyle(.plain)
-  }
-
   @ViewBuilder
   private func countryRegionItem(at index: Int, region: GRDRegion) -> some View {
-    let isSelectedRegion =
-      self.isVPNEnabled && region.countryISOCode == BraveVPN.activatedRegion?.countryISOCode
-
-    Button {
+    BraveVPNCountryRegionView(region: region) {
       selectDesignatedVPNRegion(at: index)
-    } label: {
-      HStack {
-        region.countryISOCode.regionFlag ?? Image(braveSystemName: "leo.globe")
-        VStack(alignment: .leading) {
-          Text("\(region.displayName)")
-            .font(.body)
-            .foregroundStyle(
-              isSelectedRegion
-                ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textPrimary)
-            )
-          Text(generateServerCountDetails(for: region))
-            .font(.footnote)
-            .foregroundStyle(
-              isSelectedRegion
-                ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textSecondary)
-            )
-        }
-        Spacer()
-        if isSelectedRegion {
-          Text(Strings.VPN.connectedRegionDescription)
-            .font(.body)
-            .foregroundStyle(Color(braveSystemName: .textSecondary))
-        }
-        infoButtonView(index: index)
-          .hidden()
+    } onInfoButtonPressed: {
+      guard !isLoading else {
+        return
       }
-    }
-    .overlay(alignment: .trailing) {
-      infoButtonView(index: index)
+
+      isRegionDetailsPresented = true
+      if let designatedRegion = allRegions[safe: index],
+        let desiredRegion = allRegions[safe: index]
+      {
+        selectedRegion = desiredRegion
+        selectedRegionCities = designatedRegion.cities
+      }
     }
   }
 
@@ -193,23 +151,6 @@ public struct BraveVPNRegionListView: View {
     .foregroundStyle(Color(braveSystemName: .textPrimary))
     .tint(.accentColor)
     .listRowBackground(Color(braveSystemName: .iosBrowserElevatedIos))
-  }
-
-  private func generateServerCountDetails(for region: GRDRegion) -> String {
-    let cityCount = region.cities.count
-    let serverCount = Int(truncating: region.serverCount)
-
-    let cityCountTitle =
-      cityCount > 1
-      ? String(format: Strings.VPN.multipleCityCountTitle, cityCount)
-      : String(format: Strings.VPN.cityCountTitle, cityCount)
-
-    let serverCountTitle =
-      serverCount > 1
-      ? String(format: Strings.VPN.multipleServerCountTitle, serverCount)
-      : String(format: Strings.VPN.serverCountTitle, serverCount)
-
-    return "\(cityCountTitle) - \(serverCountTitle)"
   }
 
   private func enableAutomaticServer(_ enabled: Bool) {
@@ -270,6 +211,106 @@ public struct BraveVPNRegionListView: View {
     // Invalidate the modification timer if it is still running
     regionModificationTimer?.invalidate()
     regionModificationTimer = nil
+  }
+}
+
+private struct BraveVPNCountryRegionView: View {
+  @State
+  private var showPopover = false
+
+  let region: GRDRegion
+  let onRegionSelected: () -> Void
+  let onInfoButtonPressed: () -> Void
+
+  var body: some View {
+    let isSelectedRegion = region.countryISOCode == BraveVPN.activatedRegion?.countryISOCode
+
+    Button {
+      onRegionSelected()
+    } label: {
+      HStack {
+        region.countryISOCode.regionFlag ?? Image(braveSystemName: "leo.globe")
+        VStack(alignment: .leading) {
+          HStack {
+            Text("\(region.displayName)")
+              .font(.body)
+              .foregroundStyle(
+                isSelectedRegion
+                  ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textPrimary)
+              )
+
+            Button {
+              showPopover.toggle()
+            } label: {
+              Label {
+                Text(Strings.VPN.smartProxyPopoverTitle)
+              } icon: {
+                Image(braveSystemName: "leo.smart.proxy-routing")
+                  .foregroundStyle(Color(braveSystemName: .iconDefault))
+                  .padding(4.0)
+                  .background(Color(braveSystemName: .containerHighlight))
+                  .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+              }
+              .labelStyle(.iconOnly)
+            }
+            .bravePopover(isPresented: $showPopover, arrowDirection: [.down]) {
+              Text(Strings.VPN.smartProxyPopoverTitle)
+                .font(.subheadline)
+                .foregroundStyle(Color(braveSystemName: .textTertiary))
+                .fixedSize(horizontal: false, vertical: true)
+                .padding()
+            }
+          }
+          Text(generateServerCountDetails(for: region))
+            .font(.footnote)
+            .foregroundStyle(
+              isSelectedRegion
+                ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textSecondary)
+            )
+        }
+        Spacer()
+        if isSelectedRegion {
+          Text(Strings.VPN.connectedRegionDescription)
+            .font(.body)
+            .foregroundStyle(Color(braveSystemName: .textSecondary))
+        }
+        infoButtonView()
+          .hidden()
+      }
+    }
+    .overlay(alignment: .trailing) {
+      infoButtonView()
+    }
+  }
+
+  private func infoButtonView() -> some View {
+    Button(
+      action: {
+        onInfoButtonPressed()
+      },
+      label: {
+        Image(systemName: "info.circle")
+          .foregroundStyle(Color(braveSystemName: .iconInteractive))
+      }
+    )
+    .buttonStyle(.plain)
+  }
+
+  private func generateServerCountDetails(for region: GRDRegion) -> String {
+    let cityCount = region.cities.count
+    let serverCount = Int(truncating: region.serverCount)
+
+    let cityCountTitle =
+      cityCount > 1
+      ? String(format: Strings.VPN.multipleCityCountTitle, cityCount)
+      : String(format: Strings.VPN.cityCountTitle, cityCount)
+
+    let serverCountTitle =
+      serverCount > 1
+      ? String(format: Strings.VPN.multipleServerCountTitle, serverCount)
+      : String(format: Strings.VPN.serverCountTitle, serverCount)
+
+    return "\(cityCountTitle) - \(serverCountTitle)"
   }
 }
 

--- a/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionListView.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Region/BraveVPNRegionListView.swift
@@ -239,28 +239,31 @@ private struct BraveVPNCountryRegionView: View {
                   ? Color(braveSystemName: .iconInteractive) : Color(braveSystemName: .textPrimary)
               )
 
-            Button {
-              showPopover.toggle()
-            } label: {
-              Label {
-                Text(Strings.VPN.smartProxyPopoverTitle)
-              } icon: {
-                Image(braveSystemName: "leo.smart.proxy-routing")
-                  .foregroundStyle(Color(braveSystemName: .iconDefault))
-                  .padding(4.0)
-                  .background(Color(braveSystemName: .containerHighlight))
-                  .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+            if region.smartRoutingProxyState != kGRDRegionSmartRoutingProxyNone {
+              Button {
+                showPopover.toggle()
+              } label: {
+                Label {
+                  Text(Strings.VPN.smartProxyPopoverTitle)
+                } icon: {
+                  Image(braveSystemName: "leo.smart.proxy-routing")
+                    .foregroundStyle(Color(braveSystemName: .iconDefault))
+                    .padding(4.0)
+                    .background(Color(braveSystemName: .containerHighlight))
+                    .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+                }
+                .labelStyle(.iconOnly)
               }
-              .labelStyle(.iconOnly)
-            }
-            .bravePopover(isPresented: $showPopover, arrowDirection: [.down]) {
-              Text(Strings.VPN.smartProxyPopoverTitle)
-                .font(.subheadline)
-                .foregroundStyle(Color(braveSystemName: .textTertiary))
-                .fixedSize(horizontal: false, vertical: true)
-                .padding()
+              .bravePopover(isPresented: $showPopover, arrowDirection: [.down]) {
+                Text(Strings.VPN.smartProxyPopoverTitle)
+                  .font(.subheadline)
+                  .foregroundStyle(Color(braveSystemName: .textTertiary))
+                  .fixedSize(horizontal: false, vertical: true)
+                  .padding()
+              }
             }
           }
+
           Text(generateServerCountDetails(for: region))
             .font(.footnote)
             .foregroundStyle(

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -307,8 +307,8 @@ public class BraveVPNSettingsViewController: TableViewController {
           },
           image: BraveVPN.serverLocation.isoCode?.regionFlagImage
             ?? UIImage(braveSystemNamed: "leo.globe"),
-          accessory: .disclosureIndicator,
-          cellClass: MultilineSubtitleCell.self,
+          accessory: .view(BraveVPNSmartProxyCellView(settingsController: self)),
+          cellClass: BraveVPNSmartProxyCell.self,
           uuid: locationCellId
         ),
         Row(

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSettingsViewController.swift
@@ -290,6 +290,8 @@ public class BraveVPNSettingsViewController: TableViewController {
 
     let locationCity = BraveVPN.serverLocationDetailed.city ?? "-"
     let locationCountry = BraveVPN.serverLocationDetailed.country ?? hostname
+    let smartProxyAvailable =
+      BraveVPN.activatedRegion?.smartRoutingProxyState != kGRDRegionSmartRoutingProxyNone
 
     let userPreferredTunnelProtocol = GRDTransportProtocol.getUserPreferredTransportProtocol()
     let transportProtocol = GRDTransportProtocol.prettyTransportProtocolString(
@@ -309,6 +311,7 @@ public class BraveVPNSettingsViewController: TableViewController {
             ?? UIImage(braveSystemNamed: "leo.globe"),
           accessory: .view(BraveVPNSmartProxyCellView(settingsController: self)),
           cellClass: BraveVPNSmartProxyCell.self,
+          context: ["isSmartProxyAvailable": smartProxyAvailable],
           uuid: locationCellId
         ),
         Row(
@@ -405,10 +408,13 @@ public class BraveVPNSettingsViewController: TableViewController {
         .indexPath(rowUUID: protocolCellId, sectionUUID: serverSectionId)
     else { return }
 
+    let locationCity = BraveVPN.serverLocationDetailed.city ?? "-"
+    let locationCountry = BraveVPN.serverLocationDetailed.country ?? hostname
+
     dataSource.sections[locationIndexPath.section].rows[locationIndexPath.row]
-      .text = BraveVPN.serverLocationDetailed.city ?? "-"
+      .text = locationCity
     dataSource.sections[locationIndexPath.section].rows[locationIndexPath.row]
-      .detailText = BraveVPN.serverLocationDetailed.country ?? hostname
+      .detailText = locationCountry
     dataSource.sections[locationIndexPath.section].rows[locationIndexPath.row]
       .image =
       BraveVPN.serverLocation.isoCode?.regionFlagImage ?? UIImage(braveSystemNamed: "leo.globe")

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSmartProxyCell.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSmartProxyCell.swift
@@ -1,0 +1,150 @@
+// Copyright 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import BraveUI
+import Shared
+import Static
+import SwiftUI
+import UIKit
+
+class BraveVPNSmartProxyCellView: UIView {
+  weak var settingsController: BraveVPNSettingsViewController?
+
+  init(settingsController: BraveVPNSettingsViewController) {
+    self.settingsController = settingsController
+    super.init(frame: .zero)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+class BraveVPNSmartProxyCell: UITableViewCell, Cell {
+
+  private let hostingController = UIHostingController(
+    rootView: VPNSmartProxyView(countryFlagIcon: nil, title: "", subtitle: "")
+  ).then {
+    $0.view.backgroundColor = .clear
+  }
+
+  public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+    super.init(style: .default, reuseIdentifier: reuseIdentifier)
+    contentView.addSubview(hostingController.view)
+    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+    NSLayoutConstraint.activate([
+      hostingController.view.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16.0),
+      hostingController.view.bottomAnchor.constraint(
+        equalTo: contentView.bottomAnchor,
+        constant: -16.0
+      ),
+      hostingController.view.leadingAnchor.constraint(
+        equalTo: contentView.leadingAnchor,
+        constant: 16.0
+      ),
+      hostingController.view.trailingAnchor.constraint(
+        equalTo: contentView.trailingAnchor,
+        constant: -16.0
+      ),
+    ])
+  }
+
+  public required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  public func configure(row: Row) {
+    guard case .view(let view) = row.accessory,
+      let parentController = (view as? BraveVPNSmartProxyCellView)?.settingsController
+    else {
+      assertionFailure("row.accessory must be of type: BraveVPNSmartProxyCellView")
+      return
+    }
+
+    if hostingController.parent != parentController {
+      if hostingController.parent != nil {
+        hostingController.willMove(toParent: nil)
+        hostingController.view.removeFromSuperview()
+        hostingController.removeFromParent()
+      }
+
+      parentController.addChild(hostingController)
+      hostingController.didMove(toParent: parentController)
+    }
+
+    self.accessoryType = .disclosureIndicator
+    hostingController.rootView = VPNSmartProxyView(
+      countryFlagIcon: row.image,
+      title: row.text ?? "",
+      subtitle: row.detailText ?? ""
+    )
+  }
+
+  override func prepareForReuse() {
+    super.prepareForReuse()
+
+    if hostingController.parent != nil {
+      hostingController.willMove(toParent: nil)
+      hostingController.view.removeFromSuperview()
+      hostingController.removeFromParent()
+    }
+  }
+
+  private struct VPNSmartProxyView: View {
+    let countryFlagIcon: UIImage?
+    let title: String
+    let subtitle: String
+
+    @State
+    private var showPopover = false
+
+    public var body: some View {
+      HStack {
+        if let countryFlagIcon {
+          Image(uiImage: countryFlagIcon)
+        }
+
+        VStack {
+          HStack {
+            Text(title)
+              .font(.body)
+              .foregroundStyle(Color(braveSystemName: .textPrimary))
+              .fixedSize(horizontal: false, vertical: true)
+
+            Button {
+              showPopover.toggle()
+            } label: {
+              Label {
+                Text(Strings.VPN.smartProxyPopoverTitle)
+              } icon: {
+                Image(braveSystemName: "leo.smart.proxy-routing")
+                  .foregroundStyle(Color(braveSystemName: .iconDefault))
+                  .padding(4.0)
+                  .background(Color(braveSystemName: .containerHighlight))
+                  .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+              }
+              .labelStyle(.iconOnly)
+            }
+            .bravePopover(isPresented: $showPopover, arrowDirection: [.down]) {
+              Text(Strings.VPN.smartProxyPopoverTitle)
+                .font(.subheadline)
+                .foregroundStyle(Color(braveSystemName: .textTertiary))
+                .fixedSize(horizontal: false, vertical: true)
+                .padding()
+            }
+          }
+          .frame(maxWidth: .infinity, alignment: .leading)
+
+          Text(subtitle)
+            .font(.footnote)
+            .foregroundStyle(Color(braveSystemName: .textSecondary))
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+      }
+    }
+  }
+}

--- a/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSmartProxyCell.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Settings/BraveVPNSmartProxyCell.swift
@@ -25,31 +25,18 @@ class BraveVPNSmartProxyCellView: UIView {
 class BraveVPNSmartProxyCell: UITableViewCell, Cell {
 
   private let hostingController = UIHostingController(
-    rootView: VPNSmartProxyView(countryFlagIcon: nil, title: "", subtitle: "")
+    rootView: VPNSmartProxyView(
+      countryFlagIcon: nil,
+      title: "",
+      subtitle: "",
+      isSmartProxyAvailable: false
+    )
   ).then {
     $0.view.backgroundColor = .clear
   }
 
   public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
     super.init(style: .default, reuseIdentifier: reuseIdentifier)
-    contentView.addSubview(hostingController.view)
-    hostingController.view.translatesAutoresizingMaskIntoConstraints = false
-
-    NSLayoutConstraint.activate([
-      hostingController.view.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16.0),
-      hostingController.view.bottomAnchor.constraint(
-        equalTo: contentView.bottomAnchor,
-        constant: -16.0
-      ),
-      hostingController.view.leadingAnchor.constraint(
-        equalTo: contentView.leadingAnchor,
-        constant: 16.0
-      ),
-      hostingController.view.trailingAnchor.constraint(
-        equalTo: contentView.trailingAnchor,
-        constant: -16.0
-      ),
-    ])
   }
 
   public required init?(coder aDecoder: NSCoder) {
@@ -73,13 +60,33 @@ class BraveVPNSmartProxyCell: UITableViewCell, Cell {
 
       parentController.addChild(hostingController)
       hostingController.didMove(toParent: parentController)
+
+      contentView.addSubview(hostingController.view)
+      hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+      NSLayoutConstraint.activate([
+        hostingController.view.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 16.0),
+        hostingController.view.bottomAnchor.constraint(
+          equalTo: contentView.bottomAnchor,
+          constant: -16.0
+        ),
+        hostingController.view.leadingAnchor.constraint(
+          equalTo: contentView.leadingAnchor,
+          constant: 16.0
+        ),
+        hostingController.view.trailingAnchor.constraint(
+          equalTo: contentView.trailingAnchor,
+          constant: -16.0
+        ),
+      ])
     }
 
     self.accessoryType = .disclosureIndicator
     hostingController.rootView = VPNSmartProxyView(
       countryFlagIcon: row.image,
       title: row.text ?? "",
-      subtitle: row.detailText ?? ""
+      subtitle: row.detailText ?? "",
+      isSmartProxyAvailable: row.context?["smartRoutingProxyState"] as? Bool ?? false
     )
   }
 
@@ -97,6 +104,7 @@ class BraveVPNSmartProxyCell: UITableViewCell, Cell {
     let countryFlagIcon: UIImage?
     let title: String
     let subtitle: String
+    let isSmartProxyAvailable: Bool
 
     @State
     private var showPopover = false
@@ -114,26 +122,28 @@ class BraveVPNSmartProxyCell: UITableViewCell, Cell {
               .foregroundStyle(Color(braveSystemName: .textPrimary))
               .fixedSize(horizontal: false, vertical: true)
 
-            Button {
-              showPopover.toggle()
-            } label: {
-              Label {
-                Text(Strings.VPN.smartProxyPopoverTitle)
-              } icon: {
-                Image(braveSystemName: "leo.smart.proxy-routing")
-                  .foregroundStyle(Color(braveSystemName: .iconDefault))
-                  .padding(4.0)
-                  .background(Color(braveSystemName: .containerHighlight))
-                  .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+            if isSmartProxyAvailable {
+              Button {
+                showPopover.toggle()
+              } label: {
+                Label {
+                  Text(Strings.VPN.smartProxyPopoverTitle)
+                } icon: {
+                  Image(braveSystemName: "leo.smart.proxy-routing")
+                    .foregroundStyle(Color(braveSystemName: .iconDefault))
+                    .padding(4.0)
+                    .background(Color(braveSystemName: .containerHighlight))
+                    .clipShape(RoundedRectangle(cornerRadius: 8.0, style: .continuous))
+                }
+                .labelStyle(.iconOnly)
               }
-              .labelStyle(.iconOnly)
-            }
-            .bravePopover(isPresented: $showPopover, arrowDirection: [.down]) {
-              Text(Strings.VPN.smartProxyPopoverTitle)
-                .font(.subheadline)
-                .foregroundStyle(Color(braveSystemName: .textTertiary))
-                .fixedSize(horizontal: false, vertical: true)
-                .padding()
+              .bravePopover(isPresented: $showPopover, arrowDirection: [.down]) {
+                Text(Strings.VPN.smartProxyPopoverTitle)
+                  .font(.subheadline)
+                  .foregroundStyle(Color(braveSystemName: .textTertiary))
+                  .fixedSize(horizontal: false, vertical: true)
+                  .padding()
+              }
             }
           }
           .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios/brave-ios/Sources/BraveVPN/Components/Subscription/BraveVPN+Subscription.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Components/Subscription/BraveVPN+Subscription.swift
@@ -39,9 +39,9 @@ extension BraveVPN {
     }
 
     switch productId {
-    case BraveStoreProduct.vpnMonthly.rawValue:
+    case BraveStoreProduct.vpnMonthly.rawValue, BraveStoreProduct.vpnMonthly.itemSKU:
       return Strings.VPN.vpnSettingsMonthlySubName
-    case BraveStoreProduct.vpnYearly.rawValue:
+    case BraveStoreProduct.vpnYearly.rawValue, BraveStoreProduct.vpnYearly.itemSKU:
       return Strings.VPN.vpnSettingsYearlySubName
     default:
       assertionFailure("Can't get product id")

--- a/ios/brave-ios/Sources/BraveVPN/Models/BraveVPNRegion.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Models/BraveVPNRegion.swift
@@ -16,6 +16,7 @@ struct BraveVPNCityRegion: Identifiable, Equatable {
   let id = UUID()
   let displayName: String
   let regionName: String
+  var smartRoutingProxyState: String
   var serverCount: Int = 0
   var isAutomatic = false
 }
@@ -25,6 +26,7 @@ class VPNCityRegionDetail: ObservableObject {
     BraveVPNCityRegion(
       displayName: Strings.VPN.vpnCityRegionOptimalTitle,
       regionName: BraveVPNCityRegion.optimalCityRegionName,
+      smartRoutingProxyState: kGRDRegionSmartRoutingProxyNone,
       isAutomatic: true
     )
   ]

--- a/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
+++ b/ios/brave-ios/Sources/BraveVPN/Resources/BraveVPNStrings.swift
@@ -1165,6 +1165,14 @@ extension Strings {
       comment: "Text indicating how many server is used for that region used as Ex: '2 Servers'"
     )
 
+    public static let smartProxyPopoverTitle = NSLocalizedString(
+      "vpn.smartProxyPopoverTitle",
+      bundle: .module,
+      value: "Smart Proxy routing available",
+      comment:
+        "Text in the smart proxy popover, that lets the user know the server supports smart proxy routing"
+    )
+
     public static let connectedRegionDescription = NSLocalizedString(
       "vpn.connectedRegionDescription",
       bundle: .module,

--- a/ios/nala/BUILD.gn
+++ b/ios/nala/BUILD.gn
@@ -211,6 +211,7 @@ nala_icons = [
   "leo.smartphone.laptop.svg",
   "leo.smartphone.svg",
   "leo.smartphone.tablet-portrait.svg",
+  "leo.smart.proxy-routing.svg",
   "leo.sort.desc.svg",
   "leo.stack.svg",
   "leo.star.outline.svg",


### PR DESCRIPTION
## Security Review
- https://github.com/brave/reviews/issues/2034

## Summary
- Adds the VPN Smart Proxy button/icon to the VPN server cells
- Tapping the icon shows a popover

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44122
Resolves https://github.com/brave/brave-browser/issues/49108

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

<img width="219" alt="image" src="https://github.com/user-attachments/assets/43eb08b8-38de-4fe7-9426-bf4c86c3f04e" />
