### PR TITLE
[iOS] Use UIMenuBuilder for custom web view menu items

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2510,28 +2510,6 @@ extension BrowserViewController: TabDelegate {
     removeBar(bar, animated: true)
   }
 
-  /// Triggered when "Search with Brave" is selected on selected web text
-  func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String) {
-    let engine = profile.searchEngines.defaultEngine(
-      forType: tab.isPrivate ? .privateMode : .standard
-    )
-
-    guard let url = engine?.searchURLForQuery(selectedText) else {
-      assertionFailure("If this returns nil, investigate why and add proper handling or commenting")
-      return
-    }
-
-    tabManager.addTabAndSelect(
-      URLRequest(url: url),
-      afterTab: tab,
-      isPrivate: tab.isPrivate
-    )
-
-    if !privateBrowsingManager.isPrivateBrowsing {
-      RecentSearch.addItem(type: .text, text: selectedText, websiteUrl: url.absoluteString)
-    }
-  }
-
   func showRequestRewardsPanel(_ tab: Tab) {
     let vc = BraveTalkRewardsOptInViewController()
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabObserver.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabObserver.swift
@@ -9,8 +9,6 @@ import WebKit
 protocol TabObserver: AnyObject {
   func tab(_ tab: Tab, didAddSnackbar bar: SnackBar)
   func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar)
-  /// Triggered when "Search with Brave" is selected on selected web text
-  func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String)
   func tab(_ tab: Tab, didCreateWebView webView: UIView)
   func tab(_ tab: Tab, willDeleteWebView webView: UIView)
 
@@ -39,7 +37,6 @@ protocol TabObserver: AnyObject {
 extension TabObserver {
   func tab(_ tab: Tab, didAddSnackbar bar: SnackBar) {}
   func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {}
-  func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String) {}
   func tab(_ tab: Tab, didCreateWebView webView: UIView) {}
   func tab(_ tab: Tab, willDeleteWebView webView: UIView) {}
 
@@ -63,7 +60,6 @@ class AnyTabObserver: TabObserver, Hashable {
   let id: ObjectIdentifier
   private let _tabDidAddSnackbar: (Tab, SnackBar) -> Void
   private let _tabDidRemoveSnackbar: (Tab, SnackBar) -> Void
-  private let _tabDidSelectSearchWithBraveFor: (Tab, String) -> Void
   private let _tabDidCreateWebView: (Tab, UIView) -> Void
   private let _tabWillDeleteWebView: (Tab, UIView) -> Void
 
@@ -94,9 +90,6 @@ class AnyTabObserver: TabObserver, Hashable {
     id = ObjectIdentifier(observer)
     _tabDidAddSnackbar = { [weak observer] in observer?.tab($0, didAddSnackbar: $1) }
     _tabDidRemoveSnackbar = { [weak observer] in observer?.tab($0, didRemoveSnackbar: $1) }
-    _tabDidSelectSearchWithBraveFor = { [weak observer] in
-      observer?.tab($0, didSelectSearchWithBraveFor: $1)
-    }
     _tabDidCreateWebView = { [weak observer] in observer?.tab($0, didCreateWebView: $1) }
     _tabWillDeleteWebView = { [weak observer] in observer?.tab($0, willDeleteWebView: $1) }
     _tabDidStartNavigation = { [weak observer] in observer?.tabDidStartNavigation($0) }
@@ -126,9 +119,6 @@ class AnyTabObserver: TabObserver, Hashable {
   }
   func tab(_ tab: Tab, didRemoveSnackbar bar: SnackBar) {
     _tabDidRemoveSnackbar(tab, bar)
-  }
-  func tab(_ tab: Tab, didSelectSearchWithBraveFor selectedText: String) {
-    _tabDidSelectSearchWithBraveFor(tab, selectedText)
   }
   func tab(_ tab: Tab, didCreateWebView webView: UIView) {
     _tabDidCreateWebView(tab, webView)

--- a/ios/brave-ios/Sources/Brave/Helpers/MenuHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Helpers/MenuHelper.swift
@@ -64,15 +64,8 @@ open class MenuHelper: NSObject {
       title: Strings.menuItemOpenWebsiteTitle,
       action: MenuHelper.selectorOpenWebsite
     )
-    let searchWithBraveItem = UIMenuItem(
-      title: Strings.searchWithBrave,
-      action: MenuHelper.selectorSearchWithBrave
-    )
-    let forcePaste = UIMenuItem(title: Strings.forcePaste, action: MenuHelper.selectorForcePaste)
-
     UIMenuController.shared.menuItems = [
-      copyItem, forcePaste, revealPasswordItem, hidePasswordItem, openWebsiteItem,
-      searchWithBraveItem,
+      copyItem, revealPasswordItem, hidePasswordItem, openWebsiteItem,
     ]
   }
 }


### PR DESCRIPTION
This change shifts the ownership of custom web view edit menu items away from `TabWebView` & `MenuHelper` (which were using deprecated APIs anyways). This is also required since we dont have access to the underlying `CRWWebView` to handle `canPerformAction`

Resolves https://github.com/brave/brave-browser/issues/44799

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

Long press on a web page and ensure `Force Paste` and `Search with Brave` menu items appear at the end