### PR TITLE
Treat .onion as a secure context for insecure form warnings and autofill

### DIFF
--- a/chromium_src/components/autofill/core/browser/autofill_browser_util.cc
+++ b/chromium_src/components/autofill/core/browser/autofill_browser_util.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#define IsFormMixedContent IsFormMixedContent_ChromiumImpl
+#include "src/components/autofill/core/browser/autofill_browser_util.cc"
+#undef IsFormMixedContent
+
+namespace {
+constexpr char kOnionDomain[] = "onion";
+}  // namespace
+
+namespace autofill {
+
+bool IsFormMixedContent(const AutofillClient& client, const FormData& form) {
+  if (IsFormMixedContent_ChromiumImpl(client, form)) {
+    return true;
+  }
+
+  return client.GetLastCommittedPrimaryMainFrameOrigin().DomainIs(
+             kOnionDomain) &&
+         (form.action().is_valid() &&
+          security_interstitials::IsInsecureFormAction(form.action()));
+}
+
+}  // namespace autofill

--- a/chromium_src/components/autofill/core/browser/autofill_browser_util.cc
+++ b/chromium_src/components/autofill/core/browser/autofill_browser_util.cc
@@ -7,9 +7,7 @@
 #include "src/components/autofill/core/browser/autofill_browser_util.cc"
 #undef IsFormMixedContent
 
-namespace {
-constexpr char kOnionDomain[] = "onion";
-}  // namespace
+#include "net/base/url_util.h"
 
 namespace autofill {
 
@@ -18,8 +16,7 @@ bool IsFormMixedContent(const AutofillClient& client, const FormData& form) {
     return true;
   }
 
-  return client.GetLastCommittedPrimaryMainFrameOrigin().DomainIs(
-             kOnionDomain) &&
+  return net::IsOnion(client.GetLastCommittedPrimaryMainFrameOrigin()) &&
          (form.action().is_valid() &&
           security_interstitials::IsInsecureFormAction(form.action()));
 }

--- a/chromium_src/components/autofill/core/browser/autofill_browser_util.cc
+++ b/chromium_src/components/autofill/core/browser/autofill_browser_util.cc
@@ -16,6 +16,8 @@ bool IsFormMixedContent(const AutofillClient& client, const FormData& form) {
     return true;
   }
 
+  // We only need to handle top-level .onion pages since nested cases
+  // are already handled correctly in Chromium.
   return net::IsOnion(client.GetLastCommittedPrimaryMainFrameOrigin()) &&
          (form.action().is_valid() &&
           security_interstitials::IsInsecureFormAction(form.action()));

--- a/chromium_src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc
+++ b/chromium_src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc
@@ -1,0 +1,70 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc"
+
+namespace autofill {
+namespace {
+
+// Test that if a form is mixed content we show a warning instead of any
+// suggestions.
+TEST_F(BrowserAutofillManagerTest, Onion_MixedForm1) {
+  // Set up our form data.
+  FormData form;
+  form.set_name(u"MyForm");
+  form.set_url(GURL("https://myform.onion/form.html"));
+  form.set_action(GURL("http://myform.com/submit.html"));
+  form.set_fields({CreateTestFormField("Name on Card", "nameoncard", "",
+                                       FormControlType::kInputText)});
+
+  OnAskForValuesToFill(form, form.fields()[0]);
+
+  // Test that we sent the right values to the external delegate.
+  external_delegate()->CheckSuggestions(
+      form.fields().back().global_id(),
+      {Suggestion(l10n_util::GetStringUTF8(IDS_AUTOFILL_WARNING_MIXED_FORM), "",
+                  Suggestion::Icon::kNoIcon,
+                  SuggestionType::kMixedFormMessage)});
+}
+
+// Test that if a form is mixed content we show a warning instead of any
+// suggestions. A .onion hostname is considered secure.
+TEST_F(BrowserAutofillManagerTest, Onion_MixedForm2) {
+  // Set up our form data.
+  FormData form;
+  form.set_name(u"MyForm");
+  form.set_url(GURL("http://myform.onion/form.html"));
+  form.set_action(GURL("http://myform.com/submit.html"));
+  form.set_fields({CreateTestFormField("Name on Card", "nameoncard", "",
+                                       FormControlType::kInputText)});
+
+  OnAskForValuesToFill(form, form.fields()[0]);
+
+  // Test that we sent the right values to the external delegate.
+  external_delegate()->CheckSuggestions(
+      form.fields().back().global_id(),
+      {Suggestion(l10n_util::GetStringUTF8(IDS_AUTOFILL_WARNING_MIXED_FORM), "",
+                  Suggestion::Icon::kNoIcon,
+                  SuggestionType::kMixedFormMessage)});
+}
+
+// Test that if a form is not mixed content we show suggestions.
+TEST_F(BrowserAutofillManagerTest, Onion_NonMixedForm) {
+  // Set up our form data.
+  FormData form;
+  form.set_name(u"MyForm");
+  form.set_url(GURL("http://myform.onion/form.html"));
+  form.set_action(GURL("https://myform.com/submit.html"));
+  form.set_fields({CreateTestFormField("Name on Card", "nameoncard", "",
+                                       FormControlType::kInputText)});
+
+  OnAskForValuesToFill(form, form.fields()[0]);
+
+  // Check there is no warning.
+  EXPECT_FALSE(external_delegate()->on_suggestions_returned_seen());
+}
+
+}  // namespace
+}  // namespace autofill

--- a/chromium_src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc
+++ b/chromium_src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc
@@ -3,7 +3,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc"
+#include "src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc"
 
 namespace autofill {
 namespace {
@@ -29,13 +29,30 @@ TEST_F(BrowserAutofillManagerTest, Onion_MixedForm1) {
                   SuggestionType::kMixedFormMessage)});
 }
 
-// Test that if a form is mixed content we show a warning instead of any
-// suggestions. A .onion hostname is considered secure.
 TEST_F(BrowserAutofillManagerTest, Onion_MixedForm2) {
   // Set up our form data.
   FormData form;
   form.set_name(u"MyForm");
   form.set_url(GURL("http://myform.onion/form.html"));
+  form.set_action(GURL("http://myform.com/submit.html"));
+  form.set_fields({CreateTestFormField("Name on Card", "nameoncard", "",
+                                       FormControlType::kInputText)});
+
+  OnAskForValuesToFill(form, form.fields()[0]);
+
+  // Test that we sent the right values to the external delegate.
+  external_delegate()->CheckSuggestions(
+      form.fields().back().global_id(),
+      {Suggestion(l10n_util::GetStringUTF8(IDS_AUTOFILL_WARNING_MIXED_FORM), "",
+                  Suggestion::Icon::kNoIcon,
+                  SuggestionType::kMixedFormMessage)});
+}
+
+TEST_F(BrowserAutofillManagerTest, Onion_MixedForm3) {
+  // Set up our form data.
+  FormData form;
+  form.set_name(u"MyForm");
+  form.set_url(GURL("http://a.myform.onion/form.html"));
   form.set_action(GURL("http://myform.com/submit.html"));
   form.set_fields({CreateTestFormField("Name on Card", "nameoncard", "",
                                        FormControlType::kInputText)});

--- a/chromium_src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc
+++ b/chromium_src/components/autofill/core/browser/foundations/browser_autofill_manager_unittest.cc
@@ -10,7 +10,7 @@ namespace {
 
 // Test that if a form is mixed content we show a warning instead of any
 // suggestions.
-TEST_F(BrowserAutofillManagerTest, Onion_MixedForm1) {
+TEST_F(BrowserAutofillManagerTest, Onion_MixedFormHttps) {
   // Set up our form data.
   FormData form;
   form.set_name(u"MyForm");
@@ -29,7 +29,7 @@ TEST_F(BrowserAutofillManagerTest, Onion_MixedForm1) {
                   SuggestionType::kMixedFormMessage)});
 }
 
-TEST_F(BrowserAutofillManagerTest, Onion_MixedForm2) {
+TEST_F(BrowserAutofillManagerTest, Onion_MixedFormHttp) {
   // Set up our form data.
   FormData form;
   form.set_name(u"MyForm");
@@ -48,7 +48,7 @@ TEST_F(BrowserAutofillManagerTest, Onion_MixedForm2) {
                   SuggestionType::kMixedFormMessage)});
 }
 
-TEST_F(BrowserAutofillManagerTest, Onion_MixedForm3) {
+TEST_F(BrowserAutofillManagerTest, Onion_MixedFormHttpSubdomain) {
   // Set up our form data.
   FormData form;
   form.set_name(u"MyForm");

--- a/chromium_src/components/security_interstitials/core/insecure_form_util.cc
+++ b/chromium_src/components/security_interstitials/core/insecure_form_util.cc
@@ -9,15 +9,13 @@
 #include "src/components/security_interstitials/core/insecure_form_util.cc"
 #undef IsInsecureFormActionOnSecureSource
 
-namespace {
-constexpr char kOnionDomain[] = "onion";
-}  // namespace
+#include "net/base/url_util.h"
 
 namespace security_interstitials {
 
 bool IsInsecureFormActionOnSecureSource(const url::Origin& source_origin,
                                         const GURL& action_url) {
-  if (source_origin.DomainIs(kOnionDomain)) {
+  if (net::IsOnion(source_origin)) {
     return IsInsecureFormAction(action_url);
   }
 

--- a/chromium_src/components/security_interstitials/core/insecure_form_util.cc
+++ b/chromium_src/components/security_interstitials/core/insecure_form_util.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#define IsInsecureFormActionOnSecureSource \
+  IsInsecureFormActionOnSecureSource_ChromiumImpl
+
+#include "src/components/security_interstitials/core/insecure_form_util.cc"
+#undef IsInsecureFormActionOnSecureSource
+
+namespace {
+constexpr char kOnionDomain[] = "onion";
+}  // namespace
+
+namespace security_interstitials {
+
+bool IsInsecureFormActionOnSecureSource(const url::Origin& source_origin,
+                                        const GURL& action_url) {
+  if (source_origin.DomainIs(kOnionDomain)) {
+    return IsInsecureFormAction(action_url);
+  }
+
+  return IsInsecureFormActionOnSecureSource_ChromiumImpl(source_origin,
+                                                         action_url);
+}
+
+}  // namespace security_interstitials

--- a/chromium_src/components/security_interstitials/core/insecure_form_util_unittest.cc
+++ b/chromium_src/components/security_interstitials/core/insecure_form_util_unittest.cc
@@ -1,0 +1,16 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/security_interstitials/core/insecure_form_util_unittest.cc"
+
+TEST_F(InsecureFormUtilTest, IsInsecureFormActionOnOnionSource) {
+  EXPECT_TRUE(IsInsecureFormActionOnSecureSource(
+      url::Origin::Create(GURL("http://foo.onion")),
+      GURL("http://example.com")));
+
+  EXPECT_TRUE(IsInsecureFormActionOnSecureSource(
+      url::Origin::Create(GURL("https://foo.onion")),
+      GURL("http://example.com")));
+}

--- a/chromium_src/components/security_interstitials/core/insecure_form_util_unittest.cc
+++ b/chromium_src/components/security_interstitials/core/insecure_form_util_unittest.cc
@@ -3,14 +3,32 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "components/security_interstitials/core/insecure_form_util_unittest.cc"
+#include "src/components/security_interstitials/core/insecure_form_util_unittest.cc"
 
 TEST_F(InsecureFormUtilTest, IsInsecureFormActionOnOnionSource) {
+  // Should work even without special-casing .onion
+  EXPECT_TRUE(IsInsecureFormActionOnSecureSource(
+      url::Origin::Create(GURL("https://foo.onion")),
+      GURL("http://example.com")));
+  EXPECT_FALSE(IsInsecureFormActionOnSecureSource(
+      url::Origin::Create(GURL("http://foo.onion")),
+      GURL("https://example.com")));
+
+  // Basic case
   EXPECT_TRUE(IsInsecureFormActionOnSecureSource(
       url::Origin::Create(GURL("http://foo.onion")),
       GURL("http://example.com")));
 
+  // Subdomains
   EXPECT_TRUE(IsInsecureFormActionOnSecureSource(
-      url::Origin::Create(GURL("https://foo.onion")),
+      url::Origin::Create(GURL("http://foo.bar.onion")),
+      GURL("http://example.com")));
+
+  // Non-onion URLs
+  EXPECT_FALSE(IsInsecureFormActionOnSecureSource(
+      url::Origin::Create(GURL("http://foo.onion.com")),
+      GURL("http://example.com")));
+  EXPECT_FALSE(IsInsecureFormActionOnSecureSource(
+      url::Origin::Create(GURL("http://foo.baronion")),
       GURL("http://example.com")));
 }

--- a/chromium_src/net/base/url_util.cc
+++ b/chromium_src/net/base/url_util.cc
@@ -35,6 +35,10 @@ bool IsOnion(const GURL& url) {
   return url.DomainIs(kOnionDomain);
 }
 
+bool IsOnion(const url::Origin& origin) {
+  return origin.DomainIs(kOnionDomain);
+}
+
 bool IsLocalhostOrOnion(const GURL& url) {
   return IsLocalhost(url) || IsOnion(url);
 }

--- a/chromium_src/net/base/url_util.cc
+++ b/chromium_src/net/base/url_util.cc
@@ -32,7 +32,8 @@ std::string URLToEphemeralStorageDomain(const GURL& url) {
 }
 
 bool IsOnion(const GURL& url) {
-  return url.DomainIs(kOnionDomain);
+  return (url.SchemeIsWSOrWSS() || url.SchemeIsHTTPOrHTTPS()) &&
+         url.DomainIs(kOnionDomain);
 }
 
 bool IsOnion(const url::Origin& origin) {

--- a/chromium_src/net/base/url_util.h
+++ b/chromium_src/net/base/url_util.h
@@ -19,6 +19,8 @@ NET_EXPORT std::string URLToEphemeralStorageDomain(const GURL& url);
 
 NET_EXPORT bool IsOnion(const GURL& url);
 
+NET_EXPORT bool IsOnion(const url::Origin& origin);
+
 NET_EXPORT bool IsLocalhostOrOnion(const GURL& url);
 
 }  // namespace net

--- a/chromium_src/net/base/url_util_unittest.cc
+++ b/chromium_src/net/base/url_util_unittest.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "src/net/base/url_util_unittest.cc"
+
+namespace net {
+namespace {
+
+TEST(UrlUtilTest, IsOnionOrigin) {
+  EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("https://foo.onion/"))));
+  EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("https://foo.onion:20000/"))));
+  EXPECT_TRUE(IsOnion(url::Origin::Create(GURL("https://foo.bar.onion/"))));
+  EXPECT_FALSE(IsOnion(url::Origin::Create(GURL("https://foo.onion.com/"))));
+  EXPECT_FALSE(IsOnion(url::Origin::Create(GURL("https://foo.com/b.onion"))));
+}
+
+TEST(UrlUtilTest, IsOnionUrlSchemes) {
+  EXPECT_TRUE(IsOnion(GURL("https://foo.onion/")));
+  EXPECT_TRUE(IsOnion(GURL("Http://foo.bar.onion/")));
+  EXPECT_TRUE(IsOnion(GURL("wSs://foo.onion/bar")));
+  EXPECT_TRUE(IsOnion(GURL("WS://foo.onion/bar")));
+  EXPECT_FALSE(IsOnion(GURL("file:///foo.onion/bar")));
+  EXPECT_FALSE(IsOnion(GURL("ftp://foo.onion/")));
+  EXPECT_FALSE(IsOnion(GURL("data:,foo.onion")));
+  EXPECT_FALSE(IsOnion(GURL("chrome://onion/")));
+}
+
+}  // namespace
+}  // namespace net


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#44802

Security review: https://github.com/brave/reviews/issues/1893

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

1. Open <http://ixrdj3iwwhkuau5tby5jh3a536a2rdhpbdbu6ldhng43r47kim7a3lid.onion/test/onion-mixed.html> (note the `http` scheme) in a **Tor private window**
2. Confirm that the image is blocked: 
![Screenshot from 2025-03-19 15-21-57](https://github.com/user-attachments/assets/788b10a1-2466-490a-9b3f-4c4b473eb9e3)
3. Click on the text field and confirm that the warning is present: 
![Screenshot from 2025-03-19 15-21-12](https://github.com/user-attachments/assets/817e36e8-dfa8-4199-a936-4ea64ded599b)
4. Type some text in the text field and click Submit.
5. Confirm that an interstitial is shown:
![Screenshot from 2025-03-19 15-22-17](https://github.com/user-attachments/assets/7562d58d-4180-470a-8f4e-810c3f1bda10)