### PR TITLE
Update default search in JP - phase 2

### DIFF
--- a/browser/search_engines/normal_window_search_engine_provider_service.cc
+++ b/browser/search_engines/normal_window_search_engine_provider_service.cc
@@ -5,12 +5,20 @@
 
 #include "brave/browser/search_engines/normal_window_search_engine_provider_service.h"
 
+#include <string>
+
 #include "base/functional/bind.h"
+#include "brave/browser/search_engines/pref_names.h"
 #include "brave/browser/search_engines/search_engine_provider_util.h"
+#include "brave/components/l10n/common/country_code_util.h"
+#include "brave/components/search_engines/brave_prepopulated_engines.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
+#include "chrome/common/pref_names.h"
+#include "components/country_codes/country_codes.h"
 #include "components/search_engines/search_engines_pref_names.h"
+#include "components/search_engines/template_url_prepopulate_data.h"
 #include "components/search_engines/template_url_service.h"
 
 NormalWindowSearchEngineProviderService::
@@ -26,7 +34,7 @@ NormalWindowSearchEngineProviderService::
 
   auto* service = TemplateURLServiceFactory::GetForProfile(profile_);
   if (service->loaded()) {
-    PrepareInitialPrivateSearchProvider();
+    OnTemplateURLServiceLoaded();
     return;
   }
 
@@ -48,6 +56,7 @@ void NormalWindowSearchEngineProviderService::Shutdown() {
 void NormalWindowSearchEngineProviderService::OnTemplateURLServiceLoaded() {
   template_url_service_subscription_ = {};
   PrepareInitialPrivateSearchProvider();
+  MigrateSearchEnginePrefsInJP();
 }
 
 void NormalWindowSearchEngineProviderService::
@@ -57,4 +66,49 @@ void NormalWindowSearchEngineProviderService::
 
 void NormalWindowSearchEngineProviderService::OnPreferenceChanged() {
   brave::UpdateDefaultPrivateSearchProviderData(*profile_);
+}
+
+void NormalWindowSearchEngineProviderService::MigrateSearchEnginePrefsInJP() {
+  auto* prefs = profile_->GetPrefs();
+  if (prefs->GetBoolean(kMigratedSearchDefaultInJP)) {
+    return;
+  }
+
+  prefs->SetBoolean(kMigratedSearchDefaultInJP, true);
+
+  const std::string country_string =
+      brave_l10n::GetCountryCode(g_browser_process->local_state());
+  if (country_string != "JP") {
+    return;
+  }
+
+  auto* preference =
+      prefs->FindPreference(prefs::kSyncedDefaultSearchProviderGUID);
+  if (preference->HasUserSetting()) {
+    return;
+  }
+
+  auto* service = TemplateURLServiceFactory::GetForProfile(profile_);
+  if (!service->loaded()) {
+    return;
+  }
+
+  if (service->GetDefaultSearchProvider()->prepopulate_id() ==
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_YAHOO_JP) {
+    return;
+  }
+
+  auto data = TemplateURLPrepopulateData::GetPrepopulatedEngine(
+      *prefs, country_codes::CountryStringToCountryID(country_string),
+      TemplateURLPrepopulateData::PREPOPULATED_ENGINE_ID_YAHOO_JP);
+  if (!data) {
+    return;
+  }
+
+  TemplateURL url(*data);
+  service->SetUserSelectedDefaultSearchProvider(&url);
+
+  if (prefs->GetBoolean(prefs::kSearchSuggestEnabled)) {
+    prefs->SetBoolean(prefs::kSearchSuggestEnabled, false);
+  }
 }

--- a/browser/search_engines/normal_window_search_engine_provider_service.h
+++ b/browser/search_engines/normal_window_search_engine_provider_service.h
@@ -38,6 +38,7 @@ class NormalWindowSearchEngineProviderService : public KeyedService {
   void OnTemplateURLServiceLoaded();
   void PrepareInitialPrivateSearchProvider();
   void OnPreferenceChanged();
+  void MigrateSearchEnginePrefsInJP();
 
   raw_ptr<Profile> profile_ = nullptr;
   StringPrefMember private_search_provider_guid_;

--- a/browser/search_engines/pref_names.h
+++ b/browser/search_engines/pref_names.h
@@ -10,4 +10,8 @@
 inline constexpr char kEnableSearchSuggestionsByDefault[] =
     "brave.enable_search_suggestions_by_default";
 
+// Profile prefs
+inline constexpr char kMigratedSearchDefaultInJP[] =
+    "brave.migrated_search_default_in_jp";
+
 #endif  // BRAVE_BROWSER_SEARCH_ENGINES_PREF_NAMES_H_

--- a/browser/search_engines/search_engine_provider_service_factory.cc
+++ b/browser/search_engines/search_engine_provider_service_factory.cc
@@ -23,6 +23,7 @@
 #include "brave/browser/search_engines/private_window_search_engine_provider_service_android.h"
 #else
 #include "brave/browser/search_engines/normal_window_search_engine_provider_service.h"
+#include "brave/browser/search_engines/pref_names.h"
 #include "brave/browser/search_engines/private_window_search_engine_provider_service.h"
 #include "brave/browser/search_engines/tor_window_search_engine_provider_service.h"
 #endif
@@ -99,6 +100,7 @@ void SearchEngineProviderServiceFactory::RegisterProfilePrefs(
 #if !BUILDFLAG(IS_ANDROID)
   registry->RegisterBooleanPref(prefs::kDefaultSearchProviderByExtension,
                                 false);
+  registry->RegisterBooleanPref(kMigratedSearchDefaultInJP, false);
   registry->RegisterStringPref(prefs::kSyncedDefaultPrivateSearchProviderGUID,
                                std::string(),
                                user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/44769

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`MigrateSearchEnginePrefsInJPTest.*`

_Note: `1.78.45` is the version that has yahoo JP phase 1 changes._

**Test 1 (default search provider is changed to yahoo after this update if user didn't touch settings)**
1. Set JP to system region
2. Launch browser older than `1.78.45` with clean profile
3. Check there is no yahoo jp in default search provider list
4. Launch newer browser version w/o this PR's change(maybe `1.78.45`)
5. Check there is yahoo jp in default search provider list
6. Check google is default search provider
7. Launch latest browser that has this PR's change
8. Check yahoo jp is default search provider

**Test 2 (default search provider is not changed to yahoo after this update if user touched settings already)**
1. Set JP to system region
2. Launch browser older than `1.78.45` with clean profile
3. Check there is no yahoo jp in default search provider list
4. Launch newer browser version w/o this PR's change(maybe `1.78.45`)
5. Check there is yahoo jp in default search provider list
6. Check google is default search provider
7. Change brave as a default search provider
8. Launch latest browser that has this PR's change
9. Check default search provider is not changed(brave)

**Test 3 (search suggestions are disabled when default search provider is changed to yahoo after update)**
1. Set JP to system region
2. Launch browser older than `1.78.45` with clean profile
3. Check there is no yahoo jp in default search provider list
4. Enable search suggestions
5. Launch newer browser version w/o this PR's change(maybe `1.78.45`)
6. Check there is yahoo jp in default search provider list
7. Check google is default search provider
8. Launch latest browser that has this PR's change
9. Check yahoo jp is default search provider
10. Check search suggestions option is off

**Test 4 (search suggestion is not changed if yahoo jp was set already)**
1. Set JP to system region
2. Launch `1.78.45` browser with clean profile
3. Check yahho is default search provider
4. Enable search suggestions option
8. Launch latest browser that has this PR's change
9. Check yahoo jp is still default search provider
10. Check search suggestions option is also still enabled