### PR TITLE
[cr135 follow up] Fixes showing download button in toolbar.

### DIFF
--- a/browser/resources/settings/brave_overrides/appearance_page.ts
+++ b/browser/resources/settings/brave_overrides/appearance_page.ts
@@ -38,6 +38,13 @@ RegisterPolymerTemplateModifications({
         `)
     }
 
+    const customizeToolbar = templateContent.getElementById('customizeToolbar')
+    if (!customizeToolbar) {
+        console.error(`[Settings] Couldn't find #customizeToolbar`)
+    } else {
+        customizeToolbar.setAttribute('hidden', 'true')
+    }
+
     // Super-referral
     // W/o super referral, we don't need to themes link option with themes sub
     // page.

--- a/browser/ui/views/toolbar/brave_toolbar_view.cc
+++ b/browser/ui/views/toolbar/brave_toolbar_view.cc
@@ -33,7 +33,6 @@
 #include "chrome/browser/ui/layout_constants.h"
 #include "chrome/browser/ui/ui_features.h"
 #include "chrome/browser/ui/views/bookmarks/bookmark_bubble_view.h"
-#include "chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h"
 #include "chrome/browser/ui/views/toolbar/toolbar_view.h"
 #include "components/bookmarks/common/bookmark_pref_names.h"
 #include "components/prefs/pref_service.h"
@@ -283,16 +282,6 @@ void BraveToolbarView::Init() {
 
   brave_initialized_ = true;
   UpdateHorizontalPadding();
-
-  // We want to hide pin action buttons(side panel's pin button) in toolbar.
-  // As toolbar is shared for different types of windows, this action button
-  // container could be null. So Upstream code has assumption that
-  // |pinned_toolbar_actions_container_| could be null.
-  // If it's changed, we should check again.
-  if (pinned_toolbar_actions_container_) {
-    RemoveChildView(pinned_toolbar_actions_container_.get());
-    pinned_toolbar_actions_container_ = nullptr;
-  }
 }
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)

--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h"
+
+#include "src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.cc"
+
+bool PinnedActionToolbarButton::ShouldShowMenu() {
+  return false;
+}

--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_ACTION_TOOLBAR_BUTTON_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_ACTION_TOOLBAR_BUTTON_H_
+
+// We don't want to show context menu for pinned container buttons. For now we
+// only allow downloads button and we don't want to show any customization UI
+// elements yet.
+#define ShouldShowEphemerallyInToolbar(...)    \
+  ShouldShowEphemerallyInToolbar(__VA_ARGS__); \
+  bool ShouldShowMenu() override
+
+#include "src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h"  // IWYU pragma: export
+#undef ShouldShowEphemerallyInToolbar
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_ACTION_TOOLBAR_BUTTON_H_

--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h"
+
+#define UpdateActionState UpdateActionState_UnUsed
+#define ShowActionEphemerallyInToolbar \
+  ShowActionEphemerallyInToolbar_ChromiumImpl
+
+#include "src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc"
+#undef ShowActionEphemerallyInToolbar
+#undef UpdateActionState
+
+void PinnedToolbarActionsContainer::UpdateActionState(actions::ActionId id,
+                                                      bool is_active) {
+  // We don't want anything pinned. Downloads button is shown ephemerally on
+  // download status change.
+  return;
+}
+
+void PinnedToolbarActionsContainer::ShowActionEphemerallyInToolbar(
+    actions::ActionId id,
+    bool show) {
+  if (id != kActionShowDownloads) {
+    return;
+  }
+  PinnedToolbarActionsContainer::ShowActionEphemerallyInToolbar_ChromiumImpl(
+      id, show);
+}

--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h
@@ -1,0 +1,23 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_TOOLBAR_ACTIONS_CONTAINER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_TOOLBAR_ACTIONS_CONTAINER_H_
+
+// We only want to allow the downloads button to be show in the pinned toolbar
+// container for now.
+#define UpdateActionState(...)           \
+  UpdateActionState_UnUsed(__VA_ARGS__); \
+  void UpdateActionState(__VA_ARGS__)
+
+#define ShowActionEphemerallyInToolbar(...)                 \
+  ShowActionEphemerallyInToolbar_ChromiumImpl(__VA_ARGS__); \
+  void ShowActionEphemerallyInToolbar(__VA_ARGS__)
+
+#include "src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h"  // IWYU pragma: export
+#undef ShowActionEphemerallyInToolbar
+#undef UpdateActionState
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_TOOLBAR_ACTIONS_CONTAINER_H_

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1968,51 +1968,22 @@
 # not expect
 -FullscreenTabSearchBubbleDialogTest.InvokeUi_default
 
-# This test fails because we remove toolbar's panel pin button container.
-# When extension side panel is opened, usptream shows close button in toolbar
-# for closing it. However, it's not shown if panel pin button container is not
-# exited. See SidePanelCoordinator::NotifyPinnedContainerOfActiveStateChange().
--ExtensionSidePanelBrowserTest.CloseSidePanelButtonVisibleWhenExtensionsSidePanelOpen
-
-# These tests crash because ToolbarView tries to access
-# |pinned_toolbar_actions_container_| (typically from
-# ToolbarView::GetAnchorView(), but sometimes elsewhere). But we made that
-# container null as we don't want the panel pin button container. In production,
-# this crash doesn't happen because that code path is only effective if
-# features::IsToolbarPinningEnabled(). That feature is disabled by default.
--BrowserActionsBrowserTest.ShowAddressesBubbleOrPage
--BrowserActionsBrowserTest.ShowPaymentsBubbleOrPage
--BrowserCommandControllerBrowserTestToolbarPinningOnly.ShowTranslateStatusFrenchPage
--CastBrowserControllerTest.PausedIcon
--CastBrowserControllerTest.UpdateIssues
+# These tests fail because we only allow adding downloads button to the pinned
+# toolbar buttons container.
 -ChromeLabsMultipleFeaturesUiTest.InvokeUi_default
 -ChromeLabsUiTest.InvokeUi_default
--DownloadExtensionBubbleEnabledTest.SetUiOptions
--DownloadExtensionBubbleEnabledTest.SetUiOptionsBeforeDownloadStart
--DownloadExtensionBubbleEnabledTest.SetUiOptionsMultipleExtensions
--DownloadExtensionBubbleEnabledTest.SetUiOptionsOffTheRecord
--DownloadToolbarUIControllerBrowserTest.ButtonPressWithNoRecentDownloads
--DownloadToolbarUIControllerBrowserTest.ButtonPressWithRecentDownloads
--DownloadToolbarUIControllerBrowserTest.ButtonShowsForDownloadingItems
--DownloadToolbarUIControllerBrowserTest.ButtonShowsInNewBrowserWithRecentDownload
--DownloadToolbarUIControllerBrowserTest.ControllerUpdatesButtonEnabledState
--DownloadToolbarUIControllerBrowserTest.DialogAutoCloses
--DownloadToolbarUIControllerBrowserTest.HideDoesNotRemoveButtonIfPinned
--DownloadToolbarUIControllerBrowserTest.ImageBadgeDoesNotShowForSingleDownload
--DownloadToolbarUIControllerBrowserTest.ImageBadgeShowsForMultipleDownloads
--DownloadToolbarUIControllerBrowserTest.OpenPrimaryDialog
--DownloadToolbarUIControllerBrowserTest.OpenSecurityDialog
--DownloadToolbarUIControllerBrowserTest.ProgressRingDormantState
--DownloadToolbarUIControllerBrowserTest.ProgressRingVisibleDuringDownload
--DownloadToolbarUIControllerBrowserTest.ShowHide
--PinnedToolbarActionsContainerBrowserTest.*
+-RecentActivityBubbleDialogViewActionBrowserTest.HandlesActionFocusTab
+-RecentActivityBubbleDialogViewActionBrowserTest.HandlesActionReopenTab
 -SendTabToSelfBubbleTest.BubbleTriggersCorrectlyWhenPinned
--SendTabToSelfBubbleTest.InvokeUi_ShowDeviceList
--SendTabToSelfBubbleTest.InvokeUi_ShowNoTargetDevicePromo
--SendTabToSelfBubbleTest.InvokeUi_ShowSigninPromo
 -SendTabToSelfToolbarIconControllerTest.DisplayNewEntry
 -SendTabToSelfToolbarIconControllerTest.ReplaceExistingEntry
--SendTabToSelfToolbarIconControllerTest.StorePendingNewEntry*
+-SendTabToSelfToolbarIconControllerTest.StorePendingNewEntryFromIncognitoBrowser
+-SendTabToSelfToolbarIconControllerTest.StorePendingNewEntryFromWebApp
+
+# This test fails in CanvasImageSource::CreatePadded when checking
+# DCHECK(clip_rect.Contains(gfx::Rect(size_in_pixel))); when both clip_rect
+# and size_in_pixel are (0,0). Have not investigated any further.
+-DownloadToolbarUIControllerBrowserTest.ImageBadgeShowsForMultipleDownloads
 
 # These tests fail because we stub captions::IsLiveCaptionFeatureSuppported to
 # always return false


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44825

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

