### PR TITLE
[iOS] - Increase Search Results and Autocomplete performance

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -2337,6 +2337,35 @@ extension BrowserViewController: SettingsDelegate {
     let tabIsPrivate = TabType.of(tabManager.selectedTab).isPrivate
     self.tabManager.addTabsForURLs(urls, zombie: !loadImmediately, isPrivate: tabIsPrivate)
   }
+
+  // QA Stuff
+  func settingsCreateFakeTabs() {
+    let urls = (0..<1000).map { URL(string: "https://search.brave.com/search?q=\($0)")! }
+    let tabIsPrivate = TabType.of(tabManager.selectedTab).isPrivate
+    self.tabManager.addTabsForURLs(urls, zombie: true, isPrivate: tabIsPrivate)
+  }
+
+  func settingsCreateFakeBookmarks() {
+    let urls = (0..<1000).map { URL(string: "https://search.brave.com/search?q=Bookmarks\($0)")! }
+    let tabIsPrivate = TabType.of(tabManager.selectedTab).isPrivate
+    for (index, url) in urls.enumerated() {
+      braveCore.bookmarksAPI.createBookmark(
+        withTitle: "QA-Bookmark - BraveSearch - \(index)",
+        url: url
+      )
+    }
+  }
+
+  func settingsCreateFakeHistory() {
+    let urls = (0..<1000).map { URL(string: "https://search.brave.com/search?q=History\($0)")! }
+    let tabIsPrivate = TabType.of(tabManager.selectedTab).isPrivate
+    for (index, url) in urls.enumerated() {
+      braveCore.bookmarksAPI.createBookmark(
+        withTitle: "QA-History - BraveSearch - \(index)",
+        url: url
+      )
+    }
+  }
 }
 
 extension BrowserViewController: PresentingModalViewControllerDelegate {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/FrequencyQuery.swift
@@ -78,7 +78,7 @@ class FrequencyQuery {
     task?.cancel()
     historyCancellable = nil
 
-    task = Task.delayed(bySeconds: 0.5) { @MainActor [weak self] in
+    task = Task { @MainActor [weak self] in
       guard let self = self else { return }
 
       try Task.checkCancellation()

--- a/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Settings/SettingsViewController.swift
@@ -48,6 +48,10 @@ extension Preferences.AutoCloseTabsOption: RepresentableOptionType {
 protocol SettingsDelegate: AnyObject {
   func settingsOpenURLInNewTab(_ url: URL)
   func settingsOpenURLs(_ urls: [URL], loadImmediately: Bool)
+
+  func settingsCreateFakeTabs()
+  func settingsCreateFakeBookmarks()
+  func settingsCreateFakeHistory()
 }
 
 class SettingsViewController: TableViewController {
@@ -1253,8 +1257,23 @@ class SettingsViewController: TableViewController {
         Row(
           text: "Create 1000 Tabs",
           selection: { [unowned self] in
-            let urls = (0..<1000).map { URL(string: "https://search.brave.com/search?q=\($0)")! }
-            self.settingsDelegate?.settingsOpenURLs(urls, loadImmediately: false)
+            self.settingsDelegate?.settingsCreateFakeTabs()
+            self.dismiss(animated: true)
+          },
+          cellClass: ButtonCell.self
+        ),
+        Row(
+          text: "Create 1000 Bookmark Entries",
+          selection: { [unowned self] in
+            self.settingsDelegate?.settingsCreateFakeBookmarks()
+            self.dismiss(animated: true)
+          },
+          cellClass: ButtonCell.self
+        ),
+        Row(
+          text: "Create 1000 History Entries",
+          selection: { [unowned self] in
+            self.settingsDelegate?.settingsCreateFakeHistory()
             self.dismiss(animated: true)
           },
           cellClass: ButtonCell.self

--- a/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Sync/BraveCore/History/HistoryAPIExtensions.swift
@@ -20,19 +20,6 @@ extension BraveHistoryAPI {
     addHistory(historyNode)
   }
 
-  func suffix(_ maxLength: Int, _ completion: @escaping ([HistoryNode]) -> Void) {
-    let options = HistorySearchOptions(
-      maxCount: UInt(max(20, maxLength)),
-      duplicateHandling: .removePerDay
-    )
-
-    search(
-      withQuery: nil,
-      options: options,
-      completion: completion
-    )
-  }
-
   func byFrequency(
     query: String,
     completion: @escaping ([HistoryNode]) -> Void

--- a/ios/browser/api/bookmarks/BUILD.gn
+++ b/ios/browser/api/bookmarks/BUILD.gn
@@ -20,6 +20,7 @@ source_set("bookmarks") {
     "//base",
     "//components/bookmarks/browser",
     "//components/prefs",
+    "//components/query_parser",
     "//components/undo",
     "//components/user_prefs",
     "//ios/chrome/browser/bookmarks/model",


### PR DESCRIPTION
## Summary

- Add ability to create fake bookmarks and fake history for QA. 
- Fix Bookmark search performance

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44842

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

- Fresh Install
- Use the QA Menu to create 20,000 bookmarks, 20,000 history items, 6000 tabs.
- Search in the URL-Bar for `Brave Search filtering is really slow`
- It should search FAST! and not freeze the keyboard or delay
- Clear the search bar
- Search for `Brave Search 10009`
- It should search FAST! and not freeze the keyboard or delay
- Clear the search bar
- Search for `brave`
- AutoComplete should fill in `.com` instantly without any delay
- Clear the search bar
- Search for `wiki`
- AutoComplete should fill in `pedia.org` instantly without any delay