### PR TITLE
Unlock multiple images upload in aichat

### DIFF
--- a/browser/ai_chat/upload_file_helper.h
+++ b/browser/ai_chat/upload_file_helper.h
@@ -38,6 +38,8 @@ class UploadFileHelper : public ui::SelectFileDialog::Listener {
  private:
   // ui::SelectFileDialog::Listener
   void FileSelected(const ui::SelectedFileInfo& file, int index) override;
+  void MultiFilesSelected(
+      const std::vector<ui::SelectedFileInfo>& files) override;
   void FileSelectionCanceled() override;
 
   void OnImageRead(

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.cc
@@ -172,8 +172,7 @@ void AIChatUIPageHandler::ShowSoftKeyboard() {
 #endif
 }
 
-void AIChatUIPageHandler::UploadImage(const std::string& conversation_uuid,
-                                      UploadImageCallback callback) {
+void AIChatUIPageHandler::UploadImage(UploadImageCallback callback) {
   if (!upload_file_helper_) {
     upload_file_helper_ =
         std::make_unique<UploadFileHelper>(owner_web_contents_, profile_);

--- a/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
+++ b/browser/ui/webui/ai_chat/ai_chat_ui_page_handler.h
@@ -55,8 +55,7 @@ class AIChatUIPageHandler : public mojom::AIChatUIHandler,
   void ManagePremium() override;
   void HandleVoiceRecognition(const std::string& conversation_uuid) override;
   void ShowSoftKeyboard() override;
-  void UploadImage(const std::string& conversation_uuid,
-                   UploadImageCallback callback) override;
+  void UploadImage(UploadImageCallback callback) override;
   void CloseUI() override;
   void SetChatUI(mojo::PendingRemote<mojom::ChatUI> chat_ui,
                  SetChatUICallback callback) override;

--- a/components/ai_chat/core/browser/constants.h
+++ b/components/ai_chat/core/browser/constants.h
@@ -48,10 +48,6 @@ inline constexpr float kMaxContentLengthThreshold = 0.6f;
 inline constexpr size_t kReservedTokensForPrompt = 300;
 inline constexpr size_t kReservedTokensForMaxNewTokens = 400;
 
-// Model key for Claude Haiku model.
-inline constexpr char kClaudeHaikuModelKey[] = "chat-claude-haiku";
-// Model key for Claude Sonnet model.
-inline constexpr char kClaudeSonnetModelKey[] = "chat-claude-sonnet";
 // Model name to send to the server for Claude Haiku model.
 inline constexpr char kClaudeHaikuModelName[] = "claude-3-haiku";
 // Model name to send to the server for Claude Sonnet model.

--- a/components/ai_chat/core/browser/conversation_handler.cc
+++ b/components/ai_chat/core/browser/conversation_handler.cc
@@ -664,7 +664,9 @@ void ConversationHandler::SubmitHumanConversationEntry(
                                      ? model_service_->GetDefaultModelKey()
                                      : metadata_->model_key.value());
     if (!current_model->vision_support) {
-      ChangeModel(features::kAIModelsVisionDefaultKey.Get());
+      ChangeModel(ai_chat_service_->IsPremiumStatus()
+                      ? features::kAIModelsPremiumVisionDefaultKey.Get()
+                      : features::kAIModelsVisionDefaultKey.Get());
     }
   }
   mojom::ConversationTurnPtr turn = mojom::ConversationTurn::New(

--- a/components/ai_chat/core/browser/engine/conversation_api_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.cc
@@ -128,7 +128,17 @@ base::Value::List ConversationEventsToList(
     CHECK(type_it != kTypeMap->end());
     event_dict.Set("type", type_it->second);
 
-    event_dict.Set("content", event.content);
+    if (event.content.empty()) {
+      event_dict.Set("content", "");
+    } else if (event.content.size() == 1) {
+      event_dict.Set("content", event.content.front());
+    } else {
+      base::Value::List content_list;
+      for (const auto& content : event.content) {
+        content_list.Append(content);
+      }
+      event_dict.Set("content", std::move(content_list));
+    }
 
     if (event.type == ConversationEventType::GetFocusTabsForTopic) {
       event_dict.Set("topic", event.topic);
@@ -167,6 +177,20 @@ GURL GetEndpointUrl(bool premium, const std::string& path) {
 }
 
 }  // namespace
+
+ConversationAPIClient::ConversationEvent::ConversationEvent(
+    mojom::CharacterType role,
+    ConversationEventType type,
+    const std::vector<std::string>& content,
+    const std::string& topic)
+    : role(role), type(type), content(content), topic(topic) {}
+ConversationAPIClient::ConversationEvent::ConversationEvent() = default;
+ConversationAPIClient::ConversationEvent::~ConversationEvent() = default;
+ConversationAPIClient::ConversationEvent::ConversationEvent(
+    const ConversationEvent&) = default;
+ConversationAPIClient::ConversationEvent&
+ConversationAPIClient::ConversationEvent::operator=(const ConversationEvent&) =
+    default;
 
 ConversationAPIClient::ConversationAPIClient(
     const std::string& model_name,

--- a/components/ai_chat/core/browser/engine/conversation_api_client.h
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.h
@@ -78,8 +78,17 @@ class ConversationAPIClient {
   struct ConversationEvent {
     mojom::CharacterType role;
     ConversationEventType type;
-    std::string content;
+    std::vector<std::string> content;
     std::string topic;  // Used in GetFocusTabsForTopic event.
+
+    ConversationEvent(mojom::CharacterType,
+                      ConversationEventType,
+                      const std::vector<std::string>&,
+                      const std::string& = "");
+    ConversationEvent();
+    ~ConversationEvent();
+    ConversationEvent(const ConversationEvent&);
+    ConversationEvent& operator=(const ConversationEvent&);
   };
 
   ConversationAPIClient(

--- a/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client_unittest.cc
@@ -73,20 +73,31 @@ GetMockEventsAndExpectedEventsBody() {
       std::vector<ConversationAPIClient::ConversationEvent>, std::string>>
       mock_events_and_expected_events_body{
           std::vector<ConversationAPIClient::ConversationEvent>{
-              {mojom::CharacterType::HUMAN, ConversationAPIClient::PageText,
-               "This is a page about The Mandalorian."},
-              {mojom::CharacterType::HUMAN, ConversationAPIClient::PageExcerpt,
-               "The Mandalorian"},
-              {mojom::CharacterType::HUMAN, ConversationAPIClient::ChatMessage,
-               "Est-ce lié à une série plus large?"},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::PageText,
+               {"This is a page about The Mandalorian."}},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::PageExcerpt,
+               {"The Mandalorian"}},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::ChatMessage,
+               {"Est-ce lié à une série plus large?"}},
               {mojom::CharacterType::HUMAN,
                ConversationAPIClient::GetSuggestedTopicsForFocusTabs,
-               "GetSuggestedTopicsForFocusTabs"},
-              {mojom::CharacterType::HUMAN, ConversationAPIClient::DedupeTopics,
-               "DedupeTopics"},
+               {"GetSuggestedTopicsForFocusTabs"}},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::DedupeTopics,
+               {"DedupeTopics"}},
               {mojom::CharacterType::HUMAN,
                ConversationAPIClient::GetFocusTabsForTopic,
-               "GetFocusTabsForTopics", "C++"},
+               {"GetFocusTabsForTopics"},
+               "C++"},
+              {mojom::CharacterType::HUMAN,
+               ConversationAPIClient::UploadImage,
+               {"data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///"
+                "yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                "data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///"
+                "yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"}},
           },
           R"([
       {"role": "user", "type": "pageText", "content": "This is a page about The Mandalorian."},
@@ -94,7 +105,11 @@ GetMockEventsAndExpectedEventsBody() {
       {"role": "user", "type": "chatMessage", "content": "Est-ce lié à une série plus large?"},
       {"role": "user", "type": "suggestFocusTopics", "content": "GetSuggestedTopicsForFocusTabs"},
       {"role": "user", "type": "dedupeFocusTopics", "content": "DedupeTopics"},
-      {"role": "user", "type": "classifyTabs", "content": "GetFocusTabsForTopics", "topic": "C++"}
+      {"role": "user", "type": "classifyTabs", "content": "GetFocusTabsForTopics", "topic": "C++"},
+      {"role": "user", "type": "uploadImage",
+       "content": ["data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7",
+                   "data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"]
+      }
     ])"};
 
   return *mock_events_and_expected_events_body;

--- a/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
+++ b/components/ai_chat/core/browser/engine/engine_consumer_conversation_api_unittest.cc
@@ -182,7 +182,7 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_BasicMessage) {
         EXPECT_EQ(conversation.size(), 2u);
         EXPECT_EQ(conversation[0].role, mojom::CharacterType::HUMAN);
         // Page content should be truncated
-        EXPECT_EQ(conversation[0].content, expected_page_content);
+        EXPECT_EQ(conversation[0].content[0], expected_page_content);
         EXPECT_EQ(conversation[0].type, ConversationAPIClient::PageText);
         EXPECT_EQ(conversation[1].role, mojom::CharacterType::HUMAN);
         // Match entire structure
@@ -487,12 +487,12 @@ TEST_F(EngineConsumerConversationAPIUnitTest, GenerateEvents_UploadImage) {
         ASSERT_EQ(conversation.size(), 2u);
         EXPECT_EQ(conversation[0].role, mojom::CharacterType::HUMAN);
         EXPECT_EQ(
-            conversation[0].content,
+            conversation[0].content[0],
             base::StrCat({"data:image/png;base64,",
                           base::Base64Encode(uploaded_images[0]->image_data)}));
         EXPECT_EQ(conversation[0].type, ConversationAPIClient::UploadImage);
         EXPECT_EQ(conversation[1].role, mojom::CharacterType::HUMAN);
-        EXPECT_EQ(conversation[1].content, kTestPrompt);
+        EXPECT_EQ(conversation[1].content[0], kTestPrompt);
         EXPECT_EQ(conversation[1].type, ConversationAPIClient::ChatMessage);
         std::move(callback).Run(kAssistantResponse);
       });

--- a/components/ai_chat/core/browser/model_service.cc
+++ b/components/ai_chat/core/browser/model_service.cc
@@ -36,6 +36,7 @@
 #include "brave/components/ai_chat/core/browser/engine/engine_consumer_oai.h"
 #include "brave/components/ai_chat/core/browser/model_validator.h"
 #include "brave/components/ai_chat/core/browser/utils.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "brave/components/ai_chat/core/common/features.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom-shared.h"
 #include "brave/components/ai_chat/core/common/mojom/ai_chat.mojom.h"
@@ -133,7 +134,7 @@ const std::vector<mojom::ModelPtr>& GetLeoModels() {
       auto model = mojom::Model::New();
       model->key = kClaudeHaikuModelKey;
       model->display_name = "Claude Haiku";
-      model->vision_support = false;
+      model->vision_support = true;
       model->options =
           mojom::ModelOptions::NewLeoModelOptions(std::move(options));
 
@@ -203,6 +204,7 @@ const std::vector<mojom::ModelPtr>& GetLeoModels() {
       auto model = mojom::Model::New();
       model->key = "chat-qwen";
       model->display_name = "Qwen 14B";
+      model->vision_support = false;
       model->options =
           mojom::ModelOptions::NewLeoModelOptions(std::move(options));
 

--- a/components/ai_chat/core/common/constants.h
+++ b/components/ai_chat/core/common/constants.h
@@ -19,6 +19,11 @@ inline constexpr auto kAllowedContentSchemes =
         {url::kHttpsScheme, url::kHttpScheme, url::kFileScheme,
          url::kDataScheme});
 
+// Model key for Claude Haiku model.
+inline constexpr char kClaudeHaikuModelKey[] = "chat-claude-haiku";
+// Model key for Claude Sonnet model.
+inline constexpr char kClaudeSonnetModelKey[] = "chat-claude-sonnet";
+
 }  // namespace ai_chat
 
 #endif  // BRAVE_COMPONENTS_AI_CHAT_CORE_COMMON_CONSTANTS_H_

--- a/components/ai_chat/core/common/features.cc
+++ b/components/ai_chat/core/common/features.cc
@@ -9,6 +9,7 @@
 
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "brave/components/ai_chat/core/common/constants.h"
 #include "build/build_config.h"
 
 namespace ai_chat::features {
@@ -19,7 +20,9 @@ const base::FeatureParam<std::string> kAIModelsDefaultKey{
 const base::FeatureParam<std::string> kAIModelsPremiumDefaultKey{
     &kAIChat, "default_premium_model", "chat-leo-expanded"};
 const base::FeatureParam<std::string> kAIModelsVisionDefaultKey{
-    &kAIChat, "default_vision_model", "chat-vision-basic"};
+    &kAIChat, "default_vision_model", kClaudeHaikuModelKey};
+const base::FeatureParam<std::string> kAIModelsPremiumVisionDefaultKey{
+    &kAIChat, "default_vision_model", kClaudeSonnetModelKey};
 const base::FeatureParam<bool> kFreemiumAvailable(&kAIChat,
                                                   "is_freemium_available",
                                                   true);

--- a/components/ai_chat/core/common/features.h
+++ b/components/ai_chat/core/common/features.h
@@ -21,6 +21,8 @@ COMPONENT_EXPORT(AI_CHAT_COMMON)
 extern const base::FeatureParam<std::string> kAIModelsPremiumDefaultKey;
 COMPONENT_EXPORT(AI_CHAT_COMMON)
 extern const base::FeatureParam<std::string> kAIModelsVisionDefaultKey;
+COMPONENT_EXPORT(AI_CHAT_COMMON)
+extern const base::FeatureParam<std::string> kAIModelsPremiumVisionDefaultKey;
 
 // If true, certain freemium models are available to non-premium users. If
 // false, those models are premium-only.

--- a/components/ai_chat/core/common/mojom/ai_chat.mojom
+++ b/components/ai_chat/core/common/mojom/ai_chat.mojom
@@ -409,7 +409,7 @@ interface AIChatUIHandler {
   ManagePremium();
   HandleVoiceRecognition(string conversation_uuid);
   ShowSoftKeyboard();
-  UploadImage(string conversation_uuid) => (UploadedImage? uploaded_image);
+  UploadImage() => (array<UploadedImage>? uploaded_images);
 
   // This might be a no-op if the UI isn't closeable
   CloseUI();

--- a/components/ai_chat/resources/common/constants.ts
+++ b/components/ai_chat/resources/common/constants.ts
@@ -1,0 +1,6 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+export const MAX_IMAGES = 64

--- a/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
@@ -15,12 +15,9 @@ import { getLocale } from '$web-common/locale'
 // Styles
 import styles from './style.module.scss'
 
-type Props = Pick<ConversationContext, 'uploadImage' | 'conversationHistory'>
+type Props = Pick<ConversationContext, 'uploadImage'>
 
 export default function AttachmentButtonMenu(props: Props) {
-  const isMenuDisabled = props.conversationHistory.some(
-    (turn) => turn.uploadedImages
-  )
   return (
     <>
       <ButtonMenu>
@@ -29,7 +26,6 @@ export default function AttachmentButtonMenu(props: Props) {
             fab
             kind='plain-faint'
             title={getLocale('attachmentMenuButtonLabel')}
-            isDisabled={isMenuDisabled}
           >
             <Icon name='attachment' />
           </Button>

--- a/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
+++ b/components/ai_chat/resources/page/components/attachment_button_menu/index.tsx
@@ -8,6 +8,7 @@ import ButtonMenu from '@brave/leo/react/buttonMenu'
 import Button from '@brave/leo/react/button'
 import Icon from '@brave/leo/react/icon'
 import { ConversationContext } from '../../state/conversation_context'
+import { MAX_IMAGES } from '../../../common/constants'
 
 // Utils
 import { getLocale } from '$web-common/locale'
@@ -15,9 +16,16 @@ import { getLocale } from '$web-common/locale'
 // Styles
 import styles from './style.module.scss'
 
-type Props = Pick<ConversationContext, 'uploadImage'>
+type Props = Pick<ConversationContext, 'uploadImage' | 'conversationHistory'>
 
 export default function AttachmentButtonMenu(props: Props) {
+  const totalUploadedImages = props.conversationHistory.reduce(
+    (total, turn) => total + (turn.uploadedImages?.length || 0),
+    0
+  )
+
+  const isMenuDisabled = totalUploadedImages >= MAX_IMAGES
+
   return (
     <>
       <ButtonMenu>
@@ -26,6 +34,7 @@ export default function AttachmentButtonMenu(props: Props) {
             fab
             kind='plain-faint'
             title={getLocale('attachmentMenuButtonLabel')}
+            isDisabled={isMenuDisabled}
           >
             <Icon name='attachment' />
           </Button>

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -175,7 +175,6 @@ function InputBox(props: InputBoxProps) {
           )}
           <AttachmentButtonMenu
             uploadImage={props.context.uploadImage}
-            conversationHistory={props.context.conversationHistory}
           />
         </div>
         <div>

--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -175,6 +175,7 @@ function InputBox(props: InputBoxProps) {
           )}
           <AttachmentButtonMenu
             uploadImage={props.context.uploadImage}
+            conversationHistory={props.context.conversationHistory}
           />
         </div>
         <div>

--- a/components/ai_chat/resources/page/state/conversation_context.tsx
+++ b/components/ai_chat/resources/page/state/conversation_context.tsx
@@ -507,30 +507,34 @@ export function ConversationContextProvider(props: React.PropsWithChildren) {
   }
 
   const uploadImage = () => {
-    if (!context.conversationUuid) {
-      console.error('No conversationUuid found')
-      return
-    }
-    // For now we only allow uploading 1 image per conversation.
-    if (context.pendingMessageImages) {
-      setPartialContext({
-        pendingMessageImages: null
-      })
-    }
-    aiChatContext.uiHandler?.uploadImage(context.conversationUuid)
-    .then(({uploadedImage}) => {
-      if (uploadedImage) {
+    aiChatContext.uiHandler?.uploadImage()
+    .then(({uploadedImages}) => {
+      if (uploadedImages) {
         setPartialContext({
-          pendingMessageImages: [uploadedImage]
+          pendingMessageImages: context.pendingMessageImages
+            ? [...context.pendingMessageImages, ...uploadedImages]
+            : [...uploadedImages]
         })
       }
     })
   }
 
   const removeImage = (index: number) => {
-    setPartialContext({
-      pendingMessageImages: null
-    })
+    if (!context.pendingMessageImages || context.pendingMessageImages.length === 0) {
+      return
+    }
+
+    if (context.pendingMessageImages.length === 1) {
+      setPartialContext({
+        pendingMessageImages: null
+      })
+    } else {
+      const updatedImages = [...context.pendingMessageImages]
+      updatedImages.splice(index, 1)
+      setPartialContext({
+        pendingMessageImages: updatedImages
+      })
+    }
   }
 
   const store: ConversationContext = {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44844

- [ ] **https://github.com/brave/aichat/pull/468 needs to be merged to prod before merging this PR**

- We no longer have one image per conversation limit, users can upload multiple images per turn and multiple turns with images in a conversation.
- data image url will be sent to server as a string if it is a single image and a list of string if there are multiple images
- Change default vision model to freemium: Claude Haiku and premium: Claude Sonnet because they perform better than llama vision regarding multiple image input

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [x] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [x] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
### Multiple image selection dialog
1. Click "Upload Image" from Leo attachment
2. Should be able to select multiple images and display in staging area
<img width="663" alt="Screenshot 2025-03-20 at 16 09 45" src="https://github.com/user-attachments/assets/7a015c84-cf42-4dcb-b56e-9cb697428940" />

3. Single image selection should still work

### Turns with images
1. We can submit images in different turns like
<img width="738" alt="Screenshot 2025-03-20 at 16 08 31" src="https://github.com/user-attachments/assets/2f42fe0e-91c5-42f0-9f0b-3a69ba5e6d2d" />

2. And ask questions like "how many images have you seen so far?"
<img width="637" alt="Screenshot 2025-03-20 at 16 12 35" src="https://github.com/user-attachments/assets/9e3684db-aef5-4933-9d29-c179509b6093" />

###  Default vision model
1. Set default model to Llama 3.1 8B
2. And ask a question with image attach
3. When the answer is submitted, freemium users should be switched to Haiku and premium users to Sonnet

