### PR TITLE
[ZCash] Ui tweaks

### DIFF
--- a/components/brave_wallet_ui/common/hooks/use_is_account_syncing.ts
+++ b/components/brave_wallet_ui/common/hooks/use_is_account_syncing.ts
@@ -17,7 +17,8 @@ import { WalletSelectors } from '../selectors'
 // Hooks
 import {
   useGetIsSyncInProgressQuery,
-  useClearChainTipStatusCacheMutation
+  useClearChainTipStatusCacheMutation,
+  useClearZCashBalanceCacheMutation
 } from '../slices/api.slice'
 
 export const useIsAccountSyncing = (accountId?: BraveWallet.AccountId) => {
@@ -26,6 +27,7 @@ export const useIsAccountSyncing = (accountId?: BraveWallet.AccountId) => {
     string | undefined
   >()
   const [clearChainTipStatusCache] = useClearChainTipStatusCacheMutation()
+  const [clearZCashBalanceCache] = useClearZCashBalanceCacheMutation()
 
   // Selectors
   const isZCashShieldedTransactionsEnabled = useSafeWalletSelector(
@@ -53,6 +55,7 @@ export const useIsAccountSyncing = (accountId?: BraveWallet.AccountId) => {
         },
         onSyncStop: (id: BraveWallet.AccountId) => {
           clearChainTipStatusCache()
+          clearZCashBalanceCache()
           if (accountId && accountId.uniqueKey === id.uniqueKey) {
             setSyncingId('')
           }
@@ -66,7 +69,7 @@ export const useIsAccountSyncing = (accountId?: BraveWallet.AccountId) => {
     )
 
     return () => zcashWalletServiceObserver.$.close()
-  }, [accountId, clearChainTipStatusCache])
+  }, [accountId, clearChainTipStatusCache, clearZCashBalanceCache])
 
   return syncingId === undefined
     ? isSyncAlreadyInProgress

--- a/components/brave_wallet_ui/common/slices/api.slice.ts
+++ b/components/brave_wallet_ui/common/slices/api.slice.ts
@@ -348,6 +348,7 @@ export const {
   useStartShieldSyncMutation,
   useStopShieldSyncMutation,
   useClearChainTipStatusCacheMutation,
+  useClearZCashBalanceCacheMutation,
   useTransactionStatusChangedMutation,
   useUnapprovedTxUpdatedMutation,
   useUnlockWalletMutation,

--- a/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
+++ b/components/brave_wallet_ui/common/slices/endpoints/zcash.endpoints.ts
@@ -56,7 +56,8 @@ export const zcashEndpoints = ({
           )
         }
       },
-      invalidatesTags: ['ZCashAccountInfo', 'IsShieldingAvailable']
+      invalidatesTags: ['ZCashAccountInfo', 'IsShieldingAvailable',
+                        'ZcashChainTipStatus']
     }),
     getZCashAccountInfo: query<
       BraveWallet.ZCashAccountInfo | null,
@@ -201,6 +202,14 @@ export const zcashEndpoints = ({
           }
       },
       invalidatesTags: ['ZcashChainTipStatus']
+    }),
+    clearZCashBalanceCache: mutation<true, void>({
+      queryFn: async (_args, { endpoint }, _extraOptions, baseQuery) => {
+          return {
+            data: true
+          }
+      },
+      invalidatesTags: ['ZCashBalance']
     }),
     stopShieldSync: mutation<true, BraveWallet.AccountId>({
       queryFn: async (args, { endpoint }, _extraOptions, baseQuery) => {


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/44615

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:
1) Upgrade account to shielded with custom account birthday (- 30000 from the current chain tip) 
2) Check out of sync banner is shown at the account details page

1) Deposit shielded funds to the account
2) After 5 blocks make a sync
3) Check pending balance is shown at the account details page
