### PR TITLE
Default 'Automatically open tab groups from other devices' to false (uplift to 1.77.x)

### DIFF
--- a/chromium_src/components/saved_tab_groups/public/pref_names.cc
+++ b/chromium_src/components/saved_tab_groups/public/pref_names.cc
@@ -1,0 +1,25 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/saved_tab_groups/public/pref_names.h"
+
+#include "components/pref_registry/pref_registry_syncable.h"
+
+#define RegisterProfilePrefs RegisterProfilePrefs_ChromiumImpl
+#include "src/components/saved_tab_groups/public/pref_names.cc"
+#undef RegisterProfilePrefs
+
+namespace tab_groups::prefs {
+
+void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
+  RegisterProfilePrefs_ChromiumImpl(registry);
+
+#if BUILDFLAG(IS_ANDROID)
+  registry->SetDefaultPrefValue(prefs::kAutoOpenSyncedTabGroups,
+                                base::Value(false));
+#endif  // BUILDFLAG(IS_ANDROID)
+}
+
+}  // namespace tab_groups::prefs


### PR DESCRIPTION
Uplift of #28220
Resolves https://github.com/brave/brave-browser/issues/44264

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.