### PR TITLE
[Rewards] Optimize Ads history item rendering

### DIFF
--- a/components/brave_rewards/resources/rewards_page/components/home/ads_history_modal.style.ts
+++ b/components/brave_rewards/resources/rewards_page/components/home/ads_history_modal.style.ts
@@ -84,10 +84,39 @@ export const style = scoped.css`
     }
   }
 
-  leo-menu-item {
-    --leo-icon-size: 16px;
+  .more {
+    position: relative;
+  }
+
+  .more-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 1;
+
+    padding: 4px;
+    border-radius: 8px;
+    border: solid 1px ${color.divider.subtle};
+    background: ${color.container.background};
+    box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.05);
     display: flex;
-    gap: 8px;
-    align-items: center;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 180px;
+
+    button {
+      --leo-icon-size: 20px;
+
+      padding: 8px;
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      white-space: nowrap;
+
+      &:hover, &.highlight {
+        background: ${color.container.highlight};
+      }
+    }
   }
 `

--- a/components/brave_rewards/resources/rewards_page/stories/storybook_model.ts
+++ b/components/brave_rewards/resources/rewards_page/stories/storybook_model.ts
@@ -16,6 +16,14 @@ function delay(ms: number) {
   })
 }
 
+function repeat<T>(array: T[], times: number) {
+  const result = []
+  for (let i = 0; i < times; ++i) {
+    result.push(...array)
+  }
+  return result
+}
+
 export function createModel(): AppModel {
   const locale = createLocaleContextForTesting(localeStrings)
   const stateManager = createStateManager<AppState>({
@@ -219,7 +227,7 @@ export function createModel(): AppModel {
     },
 
     async getAdsHistory() {
-      return [
+      return repeat([
         {
           createdAt: Date.now(),
           id: '123',
@@ -240,7 +248,7 @@ export function createModel(): AppModel {
           likeStatus: 'liked',
           inappropriate: false
         }
-      ]
+      ], 500)
     },
 
     async removeRecurringContribution(id) {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44753

Currently, the Ads history item "more" action menu is slow to render due to `ButtonMenu` position calculations. This change replaces the menu with vanilla JS. In the future, we may want to optimize the UI further with paging, incremental rendering, or collapsing the date groups.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [ ] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [ ] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [ ] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [ ] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [ ] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [ ] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

