### PR TITLE
[canary] Provide exclusion file for `update_patches` (uplift to 1.77.x)

### DIFF
--- a/build/update_patches_exclusions.cfg
+++ b/build/update_patches_exclusions.cfg
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+buildtools/reclient_cfgs/*
+chrome/app/theme/default/*
+chrome/app/theme/brave/*
+chrome/app/theme/chromium/*
+third_party/win_build_output/midl/chrome/elevation_service/*
+third_party/win_build_output/midl/google_update/*
+*.png
+*.xtb
+*.grd
+*.grdp
+*.svg
+*new_tab_page_view.xml
+*channel_constants.xml
+chrome/VERSION
+ui/webui/resources/css/text_defaults_md.css


### PR DESCRIPTION
Uplift of #28252

Resolves https://github.com/brave/brave-browser/issues/44881

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.