### PR TITLE
Cleanup SidebarItem

### DIFF
--- a/browser/net/brave_network_audit_browsertest.cc
+++ b/browser/net/brave_network_audit_browsertest.cc
@@ -184,7 +184,7 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkAuditTest, BasicTests) {
   for (int i = 0; i < item_num; ++i) {
     auto item = all_items[i];
     // Load all builtin panel items.
-    if (sidebar::IsBuiltInType(item) && item.open_in_panel) {
+    if (item.is_built_in_type() && item.open_in_panel) {
       builtin_panel_item_count++;
       sidebar_controller->ActivateItemAt(i);
       WaitForTimeout(kMaxTimeoutPerLoadedURL);

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -941,7 +941,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {
   for (const auto& item : model->GetAllSidebarItems()) {
     // Check disabled builtin items are not included in guest browser's items
     // list.
-    if (IsBuiltInType(item)) {
+    if (item.is_built_in_type()) {
       EXPECT_FALSE(IsDisabledItemForGuest(item.built_in_item_type));
     }
   }
@@ -953,7 +953,7 @@ IN_PROC_BROWSER_TEST_F(SidebarBrowserTest, DisabledItemsTest) {
   for (const auto& item : model->GetAllSidebarItems()) {
     // Check disabled builtin items are not included in private browser's items
     // list.
-    if (IsBuiltInType(item)) {
+    if (item.is_built_in_type()) {
       EXPECT_FALSE(IsDisabledItemForPrivate(item.built_in_item_type));
     }
   }

--- a/browser/ui/sidebar/sidebar_controller.cc
+++ b/browser/ui/sidebar/sidebar_controller.cc
@@ -69,7 +69,7 @@ bool SidebarController::IsActiveIndex(std::optional<size_t> index) const {
 bool SidebarController::DoesBrowserHaveOpenedTabForItem(
     const SidebarItem& item) const {
   // This method is only for builtin item's icon state updating.
-  DCHECK(sidebar::IsBuiltInType(item));
+  DCHECK(item.is_built_in_type());
   DCHECK(!item.open_in_panel);
 
   const std::vector<Browser*> browsers =
@@ -118,7 +118,7 @@ void SidebarController::ActivateItemAt(std::optional<size_t> index,
   }
 
   // Iterate whenever builtin shortcut type item icon clicks.
-  if (IsBuiltInType(item)) {
+  if (item.is_built_in_type()) {
     IterateOrLoadAtActiveTab(item.url);
     return;
   }

--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -97,8 +97,9 @@ void SidebarModel::AddItem(const SidebarItem& item,
   }
 
   // Web type uses site favicon as button's image.
-  if (sidebar::IsWebType(item))
+  if (item.is_web_type()) {
     FetchFavicon(item);
+  }
 }
 
 void SidebarModel::OnItemAdded(const SidebarItem& item, size_t index) {
@@ -155,8 +156,9 @@ void SidebarModel::OnURLVisited(history::HistoryService* history_service,
                                 const history::VisitRow& new_visit) {
   for (const auto& item : GetAllSidebarItems()) {
     // Don't try to update builtin items image. It uses bundled one.
-    if (IsBuiltInType(item))
+    if (item.is_built_in_type()) {
       continue;
+    }
 
     // If same url is added to history service, try to fetch favicon to update
     // for item.
@@ -214,7 +216,7 @@ std::optional<size_t> SidebarModel::GetIndexOf(
     SidebarItem::BuiltInItemType type) const {
   const auto items = GetAllSidebarItems();
   const auto iter = std::ranges::find_if(items, [&type](const auto& i) {
-    return IsBuiltInType(i) && (type == i.built_in_item_type);
+    return i.is_built_in_type() && (type == i.built_in_item_type);
   });
   if (iter == items.end()) {
     return std::nullopt;

--- a/browser/ui/views/sidebar/sidebar_items_contents_view.cc
+++ b/browser/ui/views/sidebar/sidebar_items_contents_view.cc
@@ -123,7 +123,7 @@ void SidebarItemsContentsView::OnThemeChanged() {
 
   for (size_t item_index = 0; item_index < items_num; ++item_index) {
     const auto item = items[item_index];
-    if (!sidebar::IsWebType(item)) {
+    if (!item.is_web_type()) {
       continue;
     }
 
@@ -147,7 +147,7 @@ void SidebarItemsContentsView::UpdateAllBuiltInItemsViewState() {
   const size_t items_num = items.size();
   for (size_t item_index = 0; item_index < items_num; ++item_index) {
     const auto item = items[item_index];
-    if (!sidebar::IsBuiltInType(item)) {
+    if (!item.is_built_in_type()) {
       continue;
     }
 
@@ -294,7 +294,7 @@ void SidebarItemsContentsView::AddItemView(const sidebar::SidebarItem& item,
                           base::Unretained(this), item_view));
   item_view->set_drag_controller(drag_controller_);
 
-  if (sidebar::IsWebType(item)) {
+  if (item.is_web_type()) {
     SetDefaultImageFor(item);
   }
 
@@ -377,7 +377,7 @@ void SidebarItemsContentsView::ShowItemAddedFeedbackBubble(
 
 bool SidebarItemsContentsView::IsBuiltInTypeItemView(views::View* view) const {
   auto index = GetIndexOf(view);
-  return sidebar::IsBuiltInType(sidebar_model_->GetAllSidebarItems()[*index]);
+  return sidebar_model_->GetAllSidebarItems()[*index].is_built_in_type();
 }
 
 void SidebarItemsContentsView::SetImageForItem(const sidebar::SidebarItem& item,
@@ -489,7 +489,7 @@ void SidebarItemsContentsView::UpdateItemViewStateAt(size_t index,
     item_view->SetActiveState(active);
   }
 
-  if (sidebar::IsBuiltInType(item)) {
+  if (item.is_built_in_type()) {
     for (const auto state : views::Button::kButtonStates) {
       auto color_state = state;
       if (active && state != views::Button::STATE_DISABLED) {

--- a/components/sidebar/browser/sidebar_item.cc
+++ b/components/sidebar/browser/sidebar_item.cc
@@ -45,25 +45,19 @@ bool SidebarItem::operator==(const SidebarItem& item) const {
          open_in_panel == item.open_in_panel;
 }
 
-bool IsBuiltInType(const SidebarItem& item) {
-  return item.type == SidebarItem::Type::kTypeBuiltIn;
-}
-
-bool IsWebType(const SidebarItem& item) {
-  return item.type == SidebarItem::Type::kTypeWeb;
-}
-
-bool IsValidItem(const SidebarItem& item) {
+bool SidebarItem::IsValidItem() const {
   // Any type should have valid title.
-  if (item.title.empty())
+  if (title.empty()) {
     return false;
+  }
 
-  if (item.type == SidebarItem::Type::kTypeBuiltIn)
-    return item.built_in_item_type != SidebarItem::BuiltInItemType::kNone;
+  if (type == SidebarItem::Type::kTypeBuiltIn) {
+    return built_in_item_type != SidebarItem::BuiltInItemType::kNone;
+  }
 
   // WebType
-  return item.url.is_valid() &&
-         item.built_in_item_type == SidebarItem::BuiltInItemType::kNone;
+  return url.is_valid() &&
+         built_in_item_type == SidebarItem::BuiltInItemType::kNone;
 }
 
 }  // namespace sidebar

--- a/components/sidebar/browser/sidebar_item.h
+++ b/components/sidebar/browser/sidebar_item.h
@@ -49,6 +49,12 @@ struct SidebarItem {
   SidebarItem& operator=(SidebarItem&&);
   ~SidebarItem();
 
+  bool is_built_in_type() const {
+    return type == SidebarItem::Type::kTypeBuiltIn;
+  }
+  bool is_web_type() const { return type == SidebarItem::Type::kTypeWeb; }
+  bool IsValidItem() const;
+
   bool operator==(const SidebarItem& item) const;
 
   GURL url;
@@ -58,10 +64,6 @@ struct SidebarItem {
   // Set false to open this item in new tab.
   bool open_in_panel = false;
 };
-
-bool IsBuiltInType(const SidebarItem& item);
-bool IsWebType(const SidebarItem& item);
-bool IsValidItem(const SidebarItem& item);
 
 }  // namespace sidebar
 

--- a/components/sidebar/browser/sidebar_service.cc
+++ b/components/sidebar/browser/sidebar_service.cc
@@ -277,8 +277,8 @@ void SidebarService::MigratePrefSidebarBuiltInItemsToHidden() {
 }
 
 void SidebarService::AddItem(const SidebarItem& item) {
-  DCHECK(IsValidItem(item));
-  if (IsWebType(item)) {
+  DCHECK(item.IsValidItem());
+  if (item.is_web_type()) {
     items_.push_back(item);
     for (Observer& obs : observers_) {
       // Index starts at zero.
@@ -428,7 +428,7 @@ std::vector<SidebarItem::BuiltInItemType>
 SidebarService::GetCurrentlyPresentBuiltInTypes() const {
   std::vector<SidebarItem::BuiltInItemType> items;
   std::ranges::for_each(items_, [&items](const auto& item) {
-    if (IsBuiltInType(item)) {
+    if (item.is_built_in_type()) {
       items.push_back(item.built_in_item_type);
     }
   });
@@ -464,7 +464,7 @@ std::optional<SidebarItem> SidebarService::GetDefaultPanelItem() const {
 
 bool SidebarService::IsEditableItemAt(size_t index) const {
   DCHECK(index < items_.size());
-  return sidebar::IsWebType(items_[index]);
+  return items_[index].is_web_type();
 }
 
 void SidebarService::SetSidebarShowOption(ShowSidebarOption show_options) {
@@ -712,7 +712,7 @@ size_t SidebarService::GetBuiltInItemIndexToInsert(
   auto find_prev_builtin_in_items = [&]() {
     return std::find_if(items.cbegin(), items.cend(),
                         [&prev_builtin_item](const SidebarItem& item) {
-                          return IsBuiltInType(item) &&
+                          return item.is_built_in_type() &&
                                  item.built_in_item_type == prev_builtin_item;
                         });
   };

--- a/components/sidebar/browser/sidebar_service_unittest.cc
+++ b/components/sidebar/browser/sidebar_service_unittest.cc
@@ -258,7 +258,7 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
 
   // Cache 1st item to compare after removing.
   const SidebarItem item = service_->items()[0];
-  EXPECT_TRUE(IsBuiltInType(item));
+  EXPECT_TRUE(item.is_built_in_type());
 
   EXPECT_CALL(observer_, OnWillRemoveItem(item, 0)).Times(1);
   EXPECT_CALL(observer_, OnItemRemoved(item, 0)).Times(1);
@@ -279,7 +279,7 @@ TEST_F(SidebarServiceTest, AddRemoveItems) {
   const SidebarItem item2 = SidebarItem::Create(
       GURL("https://www.brave.com/"), u"brave software",
       SidebarItem::Type::kTypeWeb, SidebarItem::BuiltInItemType::kNone, false);
-  EXPECT_TRUE(IsWebType(item2));
+  EXPECT_TRUE(item2.is_web_type());
   EXPECT_CALL(observer_, OnItemAdded(item2, default_item_count)).Times(1);
   service_->AddItem(item2);
   testing::Mock::VerifyAndClearExpectations(&observer_);
@@ -324,31 +324,31 @@ TEST_F(SidebarServiceTest, MoveItem) {
 
 TEST(SidebarItemTest, SidebarItemValidation) {
   SidebarItem builtin_item;
-  EXPECT_FALSE(IsValidItem(builtin_item));
+  EXPECT_FALSE(builtin_item.IsValidItem());
 
   builtin_item.type = SidebarItem::Type::kTypeBuiltIn;
   builtin_item.title = u"title";
   builtin_item.built_in_item_type = SidebarItem::BuiltInItemType::kNone;
 
   // builtin item should have have specific builtin item type.
-  EXPECT_FALSE(IsValidItem(builtin_item));
+  EXPECT_FALSE(builtin_item.IsValidItem());
   builtin_item.built_in_item_type = SidebarItem::BuiltInItemType::kBookmarks;
-  EXPECT_TRUE(IsValidItem(builtin_item));
+  EXPECT_TRUE(builtin_item.IsValidItem());
 
   // Invalid if title is empty.
   builtin_item.title = u"";
-  EXPECT_FALSE(IsValidItem(builtin_item));
+  EXPECT_FALSE(builtin_item.IsValidItem());
   builtin_item.title = u"title";
-  EXPECT_TRUE(IsValidItem(builtin_item));
+  EXPECT_TRUE(builtin_item.IsValidItem());
 
   SidebarItem web_item;
   web_item.type = SidebarItem::Type::kTypeWeb;
   web_item.built_in_item_type = SidebarItem::BuiltInItemType::kNone;
   web_item.url = GURL("https://abcd.com/");
   web_item.title = u"title";
-  EXPECT_TRUE(IsValidItem(web_item));
+  EXPECT_TRUE(web_item.IsValidItem());
   web_item.built_in_item_type = SidebarItem::BuiltInItemType::kBookmarks;
-  EXPECT_FALSE(IsValidItem(web_item));
+  EXPECT_FALSE(web_item.IsValidItem());
 }
 
 TEST_F(SidebarServiceTest, UpdateItem) {
@@ -357,7 +357,7 @@ TEST_F(SidebarServiceTest, UpdateItem) {
   // Added webtype item at last.
   int last_item_index = service_->items().size() - 1;
   // Builtin type is not editable.
-  EXPECT_TRUE(IsBuiltInType(service_->items()[last_item_index]));
+  EXPECT_TRUE(service_->items()[last_item_index].is_built_in_type());
   EXPECT_FALSE(service_->IsEditableItemAt(last_item_index));
 
   SidebarItem brave_item;


### PR DESCRIPTION
fix https://github.com/brave/brave-browser/issues/44896

Global methods in `sidebar_item.h` could be `SidebarItem`'s method.

This cleanup was included in brave/brave-core#21081.
But it could be done in separated PR as this cleanup is not directly related with sidebar mobile view feature.
And it helps reducing original PR's size.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

No functional changes.