### PR TITLE
Sidebar mobile view panel (1/2) (non-ui)

### DIFF
--- a/browser/ai_chat/BUILD.gn
+++ b/browser/ai_chat/BUILD.gn
@@ -99,6 +99,7 @@ source_set("browser_tests") {
       "//brave/app:generate_command_metadata",
       "//brave/browser/ai_chat",
       "//brave/browser/misc_metrics",
+      "//brave/browser/ui/sidebar",
       "//brave/components/ai_chat/content/browser",
       "//brave/components/ai_chat/core/browser",
       "//brave/components/ai_chat/core/browser:test_support",

--- a/browser/brave_wallet/BUILD.gn
+++ b/browser/brave_wallet/BUILD.gn
@@ -230,6 +230,7 @@ source_set("browser_tests") {
       "//base/test:test_support",
       "//brave/app:command_ids",
       "//brave/browser",
+      "//brave/browser/ui/sidebar",
       "//brave/components/brave_wallet/browser:pref_names",
       "//brave/components/brave_wallet/common",
       "//brave/components/brave_wallet/common:pref_names",

--- a/browser/playlist/test/BUILD.gn
+++ b/browser/playlist/test/BUILD.gn
@@ -17,14 +17,18 @@ source_set("browser_tests") {
     "playlist_media_discovery_browsertests.cc",
   ]
 
+  deps = []
+
   if (enable_playlist_webui) {
     sources += [
       "playlist_active_tab_tracker_browsertest.cc",
       "playlist_browsertest.cc",
     ]
+
+    deps += [ "//brave/browser/ui/sidebar" ]
   }
 
-  deps = [
+  deps += [
     "//base",
     "//brave/components/playlist/browser",
     "//chrome/app:command_ids",

--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -228,9 +228,7 @@ source_set("ui") {
       "side_panel/ai_chat/ai_chat_side_panel_utils.h",
       "sidebar/sidebar.h",
       "sidebar/sidebar_controller.cc",
-      "sidebar/sidebar_controller.h",
       "sidebar/sidebar_model.cc",
-      "sidebar/sidebar_model.h",
       "sidebar/sidebar_service_factory.cc",
       "sidebar/sidebar_service_factory.h",
       "sidebar/sidebar_tab_helper.cc",
@@ -353,6 +351,7 @@ source_set("ui") {
       "//base",
       "//brave/browser/ntp_background",
       "//brave/browser/profiles:util",
+      "//brave/browser/ui/sidebar",
       "//brave/browser/ui/tabs:split_view",
       "//brave/common",
       "//brave/components/constants",
@@ -638,6 +637,7 @@ source_set("ui") {
 
     deps += [
       "//brave/browser/ui/side_panel",
+      "//brave/browser/ui/views/side_panel",
       "//chrome/browser:shell_integration",
       "//chrome/browser/devtools",
       "//chrome/browser/enterprise/watermark:watermark_view_lib",

--- a/browser/ui/DEPS
+++ b/browser/ui/DEPS
@@ -5,5 +5,6 @@ include_rules += [
   "+chrome/browser/ui",
   "+brave/components/vector_icons",
   "+brave/components/query_filter",
+  "+brave/components/sidebar/common",
   "+brave/components/text_recognition/common/buildflags",
 ]

--- a/browser/ui/brave_browser.cc
+++ b/browser/ui/brave_browser.cc
@@ -62,6 +62,8 @@ bool BraveBrowser::ShouldUseBraveWebViewRoundedCorners(Browser* browser) {
 
 BraveBrowser::BraveBrowser(const CreateParams& params) : Browser(params) {
   if (sidebar::CanUseSidebar(this)) {
+    // TODO(simonhong): Remove this constraint -
+    // https://github.com/brave/brave-browser/issues/45138.
     // Below call order is important.
     // When reaches here, Sidebar UI is setup in BraveBrowserView but
     // not initialized. It's just empty because sidebar controller/model is not

--- a/browser/ui/browser_window/BUILD.gn
+++ b/browser/ui/browser_window/BUILD.gn
@@ -28,6 +28,7 @@ source_set("impl") {
     "//brave/components/brave_vpn/common/buildflags",
     "//brave/components/sidebar/common",
     "//chrome/browser/ui/browser_window",
+    "//chrome/browser/ui/views/side_panel",
   ]
 
   if (enable_brave_vpn) {

--- a/browser/ui/browser_window/BUILD.gn
+++ b/browser/ui/browser_window/BUILD.gn
@@ -24,7 +24,9 @@ source_set("impl") {
     "//base",
     "//brave/browser/ui:brave_tab_features",
     "//brave/browser/ui/tabs:split_view",
+    "//brave/browser/ui/views/side_panel",
     "//brave/components/brave_vpn/common/buildflags",
+    "//brave/components/sidebar/common",
     "//chrome/browser/ui/browser_window",
   ]
 

--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -12,6 +12,7 @@
 #include "brave/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "brave/components/sidebar/common/features.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
 #include "brave/browser/ui/brave_vpn/brave_vpn_controller.h"
@@ -55,11 +56,6 @@ void BrowserWindowFeatures::Init(
     split_view_browser_data_ =
         std::make_unique<SplitViewBrowserData>(browser_window_interface);
   }
-
-  if (base::FeatureList::IsEnabled(sidebar::features::kSidebarMobileView)) {
-    mobile_view_side_panel_manager_ =
-        std::make_unique<MobileViewSidePanelManager>(*browser_window_interface);
-  }
 }
 
 void BrowserWindowFeatures::InitPostBrowserViewConstruction(
@@ -70,6 +66,12 @@ void BrowserWindowFeatures::InitPostBrowserViewConstruction(
 #if BUILDFLAG(ENABLE_BRAVE_VPN)
   brave_vpn_controller_ = std::make_unique<BraveVPNController>(browser_view);
 #endif
+
+  if (base::FeatureList::IsEnabled(sidebar::features::kSidebarMobileView)) {
+    mobile_view_side_panel_manager_ =
+        std::make_unique<MobileViewSidePanelManager>(
+            *side_panel_coordinator()->GetWindowRegistry());
+  }
 }
 
 void BrowserWindowFeatures::TearDownPreBrowserViewDestruction() {

--- a/browser/ui/browser_window/browser_window_features.cc
+++ b/browser/ui/browser_window/browser_window_features.cc
@@ -58,7 +58,7 @@ void BrowserWindowFeatures::Init(
 
   if (base::FeatureList::IsEnabled(sidebar::features::kSidebarMobileView)) {
     mobile_view_side_panel_manager_ =
-        std::make_unique<MobileViewSidePanelManager>(browser_window_interface);
+        std::make_unique<MobileViewSidePanelManager>(*browser_window_interface);
   }
 }
 
@@ -73,7 +73,7 @@ void BrowserWindowFeatures::InitPostBrowserViewConstruction(
 }
 
 void BrowserWindowFeatures::TearDownPreBrowserViewDestruction() {
-  // Destroy before upstream's |side_panel_coordinator_| as this panal manager
+  // Destroy before upstream's |side_panel_coordinator_| as this panel manager
   // depends on it.
   mobile_view_side_panel_manager_.reset();
 

--- a/browser/ui/browser_window/public/browser_window_features.h
+++ b/browser/ui/browser_window/public/browser_window_features.h
@@ -9,6 +9,7 @@
 #include <memory>
 
 class BraveVPNController;
+class MobileViewSidePanelManager;
 class SplitViewBrowserData;
 
 // This file doesn't include header file for BrowserWindowFeatures_ChromiumImpl
@@ -24,12 +25,16 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
       BrowserWindowFeaturesFactory factory);
 
   // BrowserWindowFeatures_ChromiumImpl:
-  void Init(BrowserWindowInterface* browser) override;
+  void Init(BrowserWindowInterface* browser_window_interface) override;
   void InitPostBrowserViewConstruction(BrowserView* browser_view) override;
+  void TearDownPreBrowserViewDestruction() override;
 
   BraveVPNController* brave_vpn_controller();
   SplitViewBrowserData* split_view_browser_data() {
     return split_view_browser_data_.get();
+  }
+  MobileViewSidePanelManager* mobile_view_side_panel_manager() {
+    return mobile_view_side_panel_manager_.get();
   }
 
  protected:
@@ -38,6 +43,7 @@ class BrowserWindowFeatures : public BrowserWindowFeatures_ChromiumImpl {
  private:
   std::unique_ptr<BraveVPNController> brave_vpn_controller_;
   std::unique_ptr<SplitViewBrowserData> split_view_browser_data_;
+  std::unique_ptr<MobileViewSidePanelManager> mobile_view_side_panel_manager_;
 };
 
 #endif  // BRAVE_BROWSER_UI_BROWSER_WINDOW_PUBLIC_BROWSER_WINDOW_FEATURES_H_

--- a/browser/ui/sidebar/BUILD.gn
+++ b/browser/ui/sidebar/BUILD.gn
@@ -8,6 +8,20 @@ import("//extensions/buildflags/buildflags.gni")
 
 assert(toolkit_views)
 
+source_set("sidebar") {
+  sources = [
+    "sidebar_controller.h",
+    "sidebar_model.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/components/sidebar/browser",
+    "//components/history/core/browser",
+    "//ui/base",
+  ]
+}
+
 source_set("browser_tests") {
   testonly = true
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]
@@ -18,9 +32,11 @@ source_set("browser_tests") {
   ]
 
   deps = [
+    ":sidebar",
     "//base",
     "//brave/app:command_ids",
     "//brave/browser/ui/tabs:split_view",
+    "//brave/browser/ui/views/side_panel",
     "//brave/components/ai_chat/core/common",
     "//brave/components/playlist/common",
     "//brave/components/sidebar/browser",
@@ -46,6 +62,7 @@ source_set("unit_tests") {
   sources = [ "sidebar_unittest.cc" ]
 
   deps = [
+    ":sidebar",
     "//base",
     "//brave/common",
     "//brave/components/playlist/common",

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -1351,7 +1351,7 @@ class SidebarBrowserTestWithMobileViewFeature
       public SidebarBrowserTest {
  public:
   SidebarBrowserTestWithMobileViewFeature() {
-    if (GetParam()) {
+    if (FeatureEnabled()) {
       feature_list_.InitAndEnableFeature(features::kSidebarMobileView);
 
     } else {
@@ -1362,6 +1362,7 @@ class SidebarBrowserTestWithMobileViewFeature
 
   bool FeatureEnabled() const { return GetParam(); }
 
+ protected:
   base::test::ScopedFeatureList feature_list_;
 };
 

--- a/browser/ui/sidebar/sidebar_browsertest.cc
+++ b/browser/ui/sidebar/sidebar_browsertest.cc
@@ -1353,9 +1353,6 @@ class SidebarBrowserTestWithMobileViewFeature
   SidebarBrowserTestWithMobileViewFeature() {
     if (FeatureEnabled()) {
       feature_list_.InitAndEnableFeature(features::kSidebarMobileView);
-
-    } else {
-      feature_list_.InitAndDisableFeature(features::kSidebarMobileView);
     }
   }
   ~SidebarBrowserTestWithMobileViewFeature() override = default;

--- a/browser/ui/sidebar/sidebar_model.cc
+++ b/browser/ui/sidebar/sidebar_model.cc
@@ -145,6 +145,10 @@ void SidebarModel::OnItemUpdated(const SidebarItem& item,
 void SidebarModel::OnWillRemoveItem(const SidebarItem& item, size_t index) {
   if (index == active_index_)
     UpdateActiveIndexAndNotify(std::nullopt);
+
+  for (Observer& obs : observers_) {
+    obs.OnWillRemoveItem(item);
+  }
 }
 
 void SidebarModel::OnItemRemoved(const SidebarItem& item, size_t index) {

--- a/browser/ui/sidebar/sidebar_model.h
+++ b/browser/ui/sidebar/sidebar_model.h
@@ -57,6 +57,7 @@ class SidebarModel : public SidebarService::Observer,
                              size_t index,
                              bool user_gesture) {}
     virtual void OnItemMoved(const SidebarItem& item, size_t from, size_t to) {}
+    virtual void OnWillRemoveItem(const SidebarItem& item) {}
     virtual void OnItemRemoved(size_t index) {}
     virtual void OnActiveIndexChanged(std::optional<size_t> old_index,
                                       std::optional<size_t> new_index) {}

--- a/browser/ui/sidebar/sidebar_unittest.cc
+++ b/browser/ui/sidebar/sidebar_unittest.cc
@@ -46,6 +46,7 @@ class MockSidebarModelObserver : public SidebarModel::Observer {
               OnItemMoved,
               (const SidebarItem& item, size_t from, size_t to),
               (override));
+  MOCK_METHOD(void, OnWillRemoveItem, (const SidebarItem& item), (override));
   MOCK_METHOD(void, OnItemRemoved, (size_t index), (override));
   MOCK_METHOD(void,
               OnActiveIndexChanged,
@@ -170,6 +171,30 @@ TEST_F(SidebarModelTest, ItemsChangedTest) {
   service()->MoveItem(3, 0);
   testing::Mock::VerifyAndClearExpectations(&observer_);
   EXPECT_THAT(model()->active_index(), Optional(3u));
+}
+
+TEST_F(SidebarModelTest, ItemRemoveTest) {
+  auto built_in_items_size = service()->items().size();
+
+  model()->Init(nullptr);
+
+  EXPECT_THAT(model()->active_index(), Eq(std::nullopt));
+
+  // Add one more item to test with 5 items.
+  SidebarItem new_item = SidebarItem::Create(
+      GURL("https://www.brave.com/"), u"brave software",
+      SidebarItem::Type::kTypeWeb, SidebarItem::BuiltInItemType::kNone, false);
+
+  service()->AddItem(new_item);
+  const auto items_count = built_in_items_size + 1;
+  EXPECT_EQ(items_count, service()->items().size());
+
+  const auto last_item_index = items_count - 1;
+  // Remove last item.
+  EXPECT_CALL(observer_, OnWillRemoveItem(new_item)).Times(1);
+  EXPECT_CALL(observer_, OnItemRemoved(last_item_index)).Times(1);
+  service()->RemoveItemAt(last_item_index);
+  testing::Mock::VerifyAndClearExpectations(&observer_);
 }
 
 TEST_F(SidebarModelTest, CanUseNotAddedBuiltInItemInsteadOfTest) {

--- a/browser/ui/views/side_panel/BUILD.gn
+++ b/browser/ui/views/side_panel/BUILD.gn
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+source_set("side_panel") {
+  sources = [
+    "mobile_view/mobile_view_side_panel_coordinator.cc",
+    "mobile_view/mobile_view_side_panel_coordinator.h",
+    "mobile_view/mobile_view_side_panel_manager.cc",
+    "mobile_view/mobile_view_side_panel_manager.h",
+  ]
+
+  deps = [
+    "//base",
+    "//brave/browser/ui/sidebar",
+    "//brave/components/sidebar/browser",
+    "//chrome/browser/ui/browser_window",
+    "//chrome/browser/ui/views/side_panel",
+    "//ui/views",
+    "//url",
+  ]
+}

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.cc
@@ -5,22 +5,19 @@
 
 #include "brave/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h"
 
-#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
-#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
-#include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
 #include "chrome/browser/ui/views/side_panel/side_panel_registry.h"
 #include "url/gurl.h"
 
 MobileViewSidePanelCoordinator::MobileViewSidePanelCoordinator(
-    BrowserWindowInterface& browser_window_interface,
+    SidePanelRegistry& window_registry,
     const GURL& url)
-    : browser_window_interface_(browser_window_interface), url_(url) {
+    : window_registry_(window_registry), url_(url) {
   CHECK(url_.is_valid());
 
   // Using Unretained() here is safe becuase this coordinator
   // will be destroyed by MobileViewSidePanelManager
   // while SidePanelCoordinator() lives. It owns this registry.
-  GetWindowRegistry()->Register(std::make_unique<SidePanelEntry>(
+  window_registry_->Register(std::make_unique<SidePanelEntry>(
       GetEntryKey(),
       base::BindRepeating(&MobileViewSidePanelCoordinator::CreateView,
                           base::Unretained(this))));
@@ -33,6 +30,7 @@ MobileViewSidePanelCoordinator::~MobileViewSidePanelCoordinator() {
 std::unique_ptr<views::View> MobileViewSidePanelCoordinator::CreateView(
     SidePanelEntryScope& scope) {
   // TODO(simonhong): Implement UI.
+  // https://github.com/brave/brave-browser/issues/34597
   NOTREACHED();
 }
 
@@ -42,11 +40,5 @@ SidePanelEntry::Key MobileViewSidePanelCoordinator::GetEntryKey() const {
 }
 
 void MobileViewSidePanelCoordinator::DeregisterEntry() {
-  GetWindowRegistry()->Deregister(GetEntryKey());
-}
-
-SidePanelRegistry* MobileViewSidePanelCoordinator::GetWindowRegistry() {
-  return browser_window_interface_->GetFeatures()
-      .side_panel_coordinator()
-      ->GetWindowRegistry();
+  window_registry_->Deregister(GetEntryKey());
 }

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.cc
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.cc
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "brave/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h"
+
+#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_coordinator.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_registry.h"
+#include "url/gurl.h"
+
+MobileViewSidePanelCoordinator::MobileViewSidePanelCoordinator(
+    BrowserWindowInterface& browser_window_interface,
+    const GURL& url)
+    : browser_window_interface_(browser_window_interface), url_(url) {
+  CHECK(url_.is_valid());
+
+  // Using Unretained() here is safe becuase this coordinator
+  // will be destroyed by MobileViewSidePanelManager
+  // while SidePanelCoordinator() lives. It owns this registry.
+  GetWindowRegistry()->Register(std::make_unique<SidePanelEntry>(
+      GetEntryKey(),
+      base::BindRepeating(&MobileViewSidePanelCoordinator::CreateView,
+                          base::Unretained(this))));
+}
+
+MobileViewSidePanelCoordinator::~MobileViewSidePanelCoordinator() {
+  DeregisterEntry();
+}
+
+std::unique_ptr<views::View> MobileViewSidePanelCoordinator::CreateView(
+    SidePanelEntryScope& scope) {
+  // TODO(simonhong): Implement UI.
+  NOTREACHED();
+}
+
+SidePanelEntry::Key MobileViewSidePanelCoordinator::GetEntryKey() const {
+  return SidePanelEntry::Key(SidePanelEntry::Id::kMobileView,
+                             sidebar::MobileViewId(url_.spec()));
+}
+
+void MobileViewSidePanelCoordinator::DeregisterEntry() {
+  GetWindowRegistry()->Deregister(GetEntryKey());
+}
+
+SidePanelRegistry* MobileViewSidePanelCoordinator::GetWindowRegistry() {
+  return browser_window_interface_->GetFeatures()
+      .side_panel_coordinator()
+      ->GetWindowRegistry();
+}

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h
@@ -12,7 +12,6 @@
 #include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
 #include "url/gurl.h"
 
-class BrowserWindowInterface;
 class SidePanelRegistry;
 
 namespace views {
@@ -20,12 +19,13 @@ class View;
 }  // namespace views
 
 // Handles the creation and registration of the mobile view panel
-// SidePanelEntry.
+// SidePanelEntry. Mobile view is another type of side panel that can
+// load any url. As different url can be loaded in different panel,
+// each panel should have its own panel coordinator.
 class MobileViewSidePanelCoordinator {
  public:
-  MobileViewSidePanelCoordinator(
-      BrowserWindowInterface& browser_window_interface,
-      const GURL& url);
+  MobileViewSidePanelCoordinator(SidePanelRegistry& window_registry,
+                                 const GURL& url);
   virtual ~MobileViewSidePanelCoordinator();
   MobileViewSidePanelCoordinator(const MobileViewSidePanelCoordinator&) =
       delete;
@@ -35,10 +35,9 @@ class MobileViewSidePanelCoordinator {
  private:
   std::unique_ptr<views::View> CreateView(SidePanelEntryScope& scope);
   SidePanelEntry::Key GetEntryKey() const;
-  SidePanelRegistry* GetWindowRegistry();
   void DeregisterEntry();
 
-  raw_ref<BrowserWindowInterface> browser_window_interface_;
+  raw_ref<SidePanelRegistry> window_registry_;
   const GURL url_;
 };
 

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_MOBILE_VIEW_MOBILE_VIEW_SIDE_PANEL_COORDINATOR_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_MOBILE_VIEW_MOBILE_VIEW_SIDE_PANEL_COORDINATOR_H_
+
+#include <memory>
+
+#include "base/memory/raw_ref.h"
+#include "chrome/browser/ui/views/side_panel/side_panel_entry.h"
+#include "url/gurl.h"
+
+class BrowserWindowInterface;
+class SidePanelRegistry;
+
+namespace views {
+class View;
+}  // namespace views
+
+// Handles the creation and registration of the mobile view panel
+// SidePanelEntry.
+class MobileViewSidePanelCoordinator {
+ public:
+  MobileViewSidePanelCoordinator(
+      BrowserWindowInterface& browser_window_interface,
+      const GURL& url);
+  virtual ~MobileViewSidePanelCoordinator();
+  MobileViewSidePanelCoordinator(const MobileViewSidePanelCoordinator&) =
+      delete;
+  MobileViewSidePanelCoordinator& operator=(
+      const MobileViewSidePanelCoordinator&) = delete;
+
+ private:
+  std::unique_ptr<views::View> CreateView(SidePanelEntryScope& scope);
+  SidePanelEntry::Key GetEntryKey() const;
+  SidePanelRegistry* GetWindowRegistry();
+  void DeregisterEntry();
+
+  raw_ref<BrowserWindowInterface> browser_window_interface_;
+  const GURL url_;
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_MOBILE_VIEW_MOBILE_VIEW_SIDE_PANEL_COORDINATOR_H_

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.cc
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.cc
@@ -8,12 +8,11 @@
 #include <utility>
 
 #include "brave/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h"
-#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
 #include "ui/views/view.h"
 
 MobileViewSidePanelManager::MobileViewSidePanelManager(
-    BrowserWindowInterface& browser_window_interface)
-    : browser_window_interface_(browser_window_interface) {}
+    SidePanelRegistry& window_registry)
+    : window_registry_(window_registry) {}
 
 MobileViewSidePanelManager::~MobileViewSidePanelManager() = default;
 
@@ -26,7 +25,7 @@ void MobileViewSidePanelManager::CreateMobileViewSidePanelCoordinator(
     const sidebar::SidebarItem& item) {
   coordinators_.emplace(sidebar::MobileViewId(item.url.spec()),
                         std::make_unique<MobileViewSidePanelCoordinator>(
-                            browser_window_interface_.get(), item.url));
+                            window_registry_.get(), item.url));
 }
 
 void MobileViewSidePanelManager::OnItemAdded(const sidebar::SidebarItem& item,

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.cc
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.cc
@@ -12,8 +12,8 @@
 #include "ui/views/view.h"
 
 MobileViewSidePanelManager::MobileViewSidePanelManager(
-    BrowserWindowInterface* browser_window_interface)
-    : browser_window_interface_(*browser_window_interface) {}
+    BrowserWindowInterface& browser_window_interface)
+    : browser_window_interface_(browser_window_interface) {}
 
 MobileViewSidePanelManager::~MobileViewSidePanelManager() = default;
 

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.cc
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.cc
@@ -1,0 +1,47 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h"
+
+#include <utility>
+
+#include "brave/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_coordinator.h"
+#include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+#include "ui/views/view.h"
+
+MobileViewSidePanelManager::MobileViewSidePanelManager(
+    BrowserWindowInterface* browser_window_interface)
+    : browser_window_interface_(*browser_window_interface) {}
+
+MobileViewSidePanelManager::~MobileViewSidePanelManager() = default;
+
+void MobileViewSidePanelManager::Init(sidebar::SidebarModel* model) {
+  CHECK(model);
+  sidebar_model_observation_.Observe(model);
+}
+
+void MobileViewSidePanelManager::CreateMobileViewSidePanelCoordinator(
+    const sidebar::SidebarItem& item) {
+  coordinators_.emplace(sidebar::MobileViewId(item.url.spec()),
+                        std::make_unique<MobileViewSidePanelCoordinator>(
+                            browser_window_interface_.get(), item.url));
+}
+
+void MobileViewSidePanelManager::OnItemAdded(const sidebar::SidebarItem& item,
+                                             size_t index,
+                                             bool user_gesture) {
+  if (item.IsMobileViewItem()) {
+    CHECK(!coordinators_.contains(sidebar::MobileViewId(item.url.spec())));
+    CreateMobileViewSidePanelCoordinator(item);
+  }
+}
+
+void MobileViewSidePanelManager::OnWillRemoveItem(
+    const sidebar::SidebarItem& item) {
+  if (item.IsMobileViewItem()) {
+    CHECK(coordinators_.contains(sidebar::MobileViewId(item.url.spec())));
+    coordinators_.erase(sidebar::MobileViewId(item.url.spec()));
+  }
+}

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h
@@ -15,8 +15,8 @@
 #include "brave/browser/ui/sidebar/sidebar_model.h"
 #include "brave/components/sidebar/browser/mobile_view_id.h"
 
-class BrowserWindowInterface;
 class MobileViewSidePanelCoordinator;
+class SidePanelRegistry;
 
 namespace sidebar {
 FORWARD_DECLARE_TEST(SidebarBrowserTestWithMobileViewFeature,
@@ -27,8 +27,7 @@ FORWARD_DECLARE_TEST(SidebarBrowserTestWithMobileViewFeature,
 // Create/Remove it with item add/remove state.
 class MobileViewSidePanelManager : public sidebar::SidebarModel::Observer {
  public:
-  explicit MobileViewSidePanelManager(
-      BrowserWindowInterface& browser_window_interface);
+  explicit MobileViewSidePanelManager(SidePanelRegistry& window_registry);
 
   MobileViewSidePanelManager(const MobileViewSidePanelManager&) = delete;
   MobileViewSidePanelManager& operator=(const MobileViewSidePanelManager&) =
@@ -52,7 +51,7 @@ class MobileViewSidePanelManager : public sidebar::SidebarModel::Observer {
   base::flat_map<sidebar::MobileViewId,
                  std::unique_ptr<MobileViewSidePanelCoordinator>>
       coordinators_;
-  base::raw_ref<BrowserWindowInterface> browser_window_interface_;
+  base::raw_ref<SidePanelRegistry> window_registry_;
   base::ScopedObservation<sidebar::SidebarModel,
                           sidebar::SidebarModel::Observer>
       sidebar_model_observation_{this};

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_MOBILE_VIEW_MOBILE_VIEW_SIDE_PANEL_MANAGER_H_
+#define BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_MOBILE_VIEW_MOBILE_VIEW_SIDE_PANEL_MANAGER_H_
+
+#include <memory>
+
+#include "base/containers/flat_map.h"
+#include "base/gtest_prod_util.h"
+#include "base/memory/raw_ref.h"
+#include "base/scoped_observation.h"
+#include "brave/browser/ui/sidebar/sidebar_model.h"
+#include "brave/components/sidebar/browser/mobile_view_id.h"
+
+class BrowserWindowInterface;
+class MobileViewSidePanelCoordinator;
+
+namespace sidebar {
+FORWARD_DECLARE_TEST(SidebarBrowserTestWithMobileViewFeature,
+                     SimpleItemAddRemoveTest);
+}  // namespace sidebar
+
+// Manage each mobile view panel item's coordinator by observing SidebarModel.
+// Create/Remove it with item add/remove state.
+class MobileViewSidePanelManager : public sidebar::SidebarModel::Observer {
+ public:
+  explicit MobileViewSidePanelManager(
+      BrowserWindowInterface* browser_window_interface);
+
+  MobileViewSidePanelManager(const MobileViewSidePanelManager&) = delete;
+  MobileViewSidePanelManager& operator=(const MobileViewSidePanelManager&) =
+      delete;
+  ~MobileViewSidePanelManager() override;
+
+  void Init(sidebar::SidebarModel* model);
+
+ private:
+  FRIEND_TEST_ALL_PREFIXES(sidebar::SidebarBrowserTestWithMobileViewFeature,
+                           SimpleItemAddRemoveTest);
+
+  // SidebarModel::Observer overrides:
+  void OnItemAdded(const sidebar::SidebarItem& item,
+                   size_t index,
+                   bool user_gesture) override;
+  void OnWillRemoveItem(const sidebar::SidebarItem& item) override;
+
+  void CreateMobileViewSidePanelCoordinator(const sidebar::SidebarItem& item);
+
+  base::flat_map<sidebar::MobileViewId,
+                 std::unique_ptr<MobileViewSidePanelCoordinator>>
+      coordinators_;
+  base::raw_ref<BrowserWindowInterface> browser_window_interface_;
+  base::ScopedObservation<sidebar::SidebarModel,
+                          sidebar::SidebarModel::Observer>
+      sidebar_model_observation_{this};
+};
+
+#endif  // BRAVE_BROWSER_UI_VIEWS_SIDE_PANEL_MOBILE_VIEW_MOBILE_VIEW_SIDE_PANEL_MANAGER_H_

--- a/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h
+++ b/browser/ui/views/side_panel/mobile_view/mobile_view_side_panel_manager.h
@@ -28,7 +28,7 @@ FORWARD_DECLARE_TEST(SidebarBrowserTestWithMobileViewFeature,
 class MobileViewSidePanelManager : public sidebar::SidebarModel::Observer {
  public:
   explicit MobileViewSidePanelManager(
-      BrowserWindowInterface* browser_window_interface);
+      BrowserWindowInterface& browser_window_interface);
 
   MobileViewSidePanelManager(const MobileViewSidePanelManager&) = delete;
   MobileViewSidePanelManager& operator=(const MobileViewSidePanelManager&) =

--- a/browser/ui/views/side_panel/sources.gni
+++ b/browser/ui/views/side_panel/sources.gni
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+brave_chrome_browser_ui_views_side_panel_public_deps =
+    [ "//brave/components/sidebar/browser" ]

--- a/chromium_src/chrome/browser/ui/browser_window/public/browser_window_features.h
+++ b/chromium_src/chrome/browser/ui/browser_window/public/browser_window_features.h
@@ -13,9 +13,12 @@
 #define BrowserWindowFeatures BrowserWindowFeatures_ChromiumImpl
 #define Init virtual Init
 #define InitPostBrowserViewConstruction virtual InitPostBrowserViewConstruction
+#define TearDownPreBrowserViewDestruction \
+  virtual TearDownPreBrowserViewDestruction
 
 #include "src/chrome/browser/ui/browser_window/public/browser_window_features.h"  // IWYU pragma: export
 
+#undef TearDownPreBrowserViewDestruction
 #undef InitPostBrowserViewConstruction
 #undef Init
 #undef BrowserWindowFeatures

--- a/chromium_src/chrome/browser/ui/views/side_panel/DEPS
+++ b/chromium_src/chrome/browser/ui/views/side_panel/DEPS
@@ -1,3 +1,4 @@
 include_rules = [
   "+brave/components/playlist/common",
+  "+brave/components/sidebar/browser",
 ]

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry_key.cc
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry_key.cc
@@ -1,0 +1,46 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/side_panel/side_panel_entry_key.h"
+
+#define SidePanelEntryKey SidePanelEntryKey_ChromiumImpl
+
+#include "src/chrome/browser/ui/views/side_panel/side_panel_entry_key.cc"
+
+#undef SidePanelEntryKey
+
+SidePanelEntryKey::SidePanelEntryKey(SidePanelEntryId id)
+    : SidePanelEntryKey_ChromiumImpl(id) {}
+
+SidePanelEntryKey::SidePanelEntryKey(SidePanelEntryId id,
+                                     extensions::ExtensionId extension_id)
+    : SidePanelEntryKey_ChromiumImpl(id, extension_id) {}
+
+SidePanelEntryKey::SidePanelEntryKey(SidePanelEntryId id,
+                                     sidebar::MobileViewId mobile_view_id)
+    : SidePanelEntryKey_ChromiumImpl(id), mobile_view_id_(mobile_view_id) {
+  CHECK_EQ(id, SidePanelEntryId::kMobileView);
+}
+
+SidePanelEntryKey::~SidePanelEntryKey() = default;
+
+SidePanelEntryKey::SidePanelEntryKey(const SidePanelEntryKey& other) = default;
+
+SidePanelEntryKey& SidePanelEntryKey::operator=(
+    const SidePanelEntryKey& other) = default;
+
+bool SidePanelEntryKey::operator==(const SidePanelEntryKey& other) const {
+  return SidePanelEntryKey_ChromiumImpl::operator==(other) &&
+         mobile_view_id_ == other.mobile_view_id();
+}
+
+auto SidePanelEntryKey::operator<=>(const SidePanelEntryKey& other) const {
+  if (id() == other.id() && id() == SidePanelEntryId::kMobileView) {
+    CHECK(mobile_view_id_.has_value() && other.mobile_view_id_.has_value());
+    return mobile_view_id_.value() <=> other.mobile_view_id_.value();
+  }
+
+  return SidePanelEntryKey_ChromiumImpl::operator<=>(other);
+}

--- a/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry_key.h
+++ b/chromium_src/chrome/browser/ui/views/side_panel/side_panel_entry_key.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_ENTRY_KEY_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_ENTRY_KEY_H_
+
+#define SidePanelEntryKey SidePanelEntryKey_ChromiumImpl
+
+#include "src/chrome/browser/ui/views/side_panel/side_panel_entry_key.h"  // // IWYU pragma: export
+
+#undef SidePanelEntryKey
+
+#include "brave/components/sidebar/browser/mobile_view_id.h"
+
+// Subclass for handling mobile view panel. As each mobile view panel item
+// should have unique key, its key is composed by using common type and unique
+// id.
+class SidePanelEntryKey : public SidePanelEntryKey_ChromiumImpl {
+ public:
+  explicit SidePanelEntryKey(SidePanelEntryId id);
+  SidePanelEntryKey(SidePanelEntryId id, extensions::ExtensionId extension_id);
+  SidePanelEntryKey(SidePanelEntryId id, sidebar::MobileViewId mobile_view_id);
+  ~SidePanelEntryKey() override;
+
+  SidePanelEntryKey(const SidePanelEntryKey& other);
+  SidePanelEntryKey& operator=(const SidePanelEntryKey& other);
+
+  bool operator==(const SidePanelEntryKey& other) const;
+  auto operator<=>(const SidePanelEntryKey& other) const;
+
+  std::optional<sidebar::MobileViewId> mobile_view_id() const {
+    return mobile_view_id_;
+  }
+
+ private:
+  std::optional<sidebar::MobileViewId> mobile_view_id_;
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_SIDE_PANEL_SIDE_PANEL_ENTRY_KEY_H_

--- a/components/sidebar/browser/BUILD.gn
+++ b/components/sidebar/browser/BUILD.gn
@@ -11,6 +11,7 @@ assert(toolkit_views)
 static_library("browser") {
   sources = [
     "constants.h",
+    "mobile_view_id.h",
     "pref_names.h",
     "sidebar_item.cc",
     "sidebar_item.h",

--- a/components/sidebar/browser/mobile_view_id.h
+++ b/components/sidebar/browser/mobile_view_id.h
@@ -1,0 +1,19 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_SIDEBAR_BROWSER_MOBILE_VIEW_ID_H_
+#define BRAVE_COMPONENTS_SIDEBAR_BROWSER_MOBILE_VIEW_ID_H_
+
+#include <string>
+
+#include "base/types/strong_alias.h"
+
+namespace sidebar {
+
+using MobileViewId = base::StrongAlias<class MobileViewIdTag, std::string>;
+
+}  // namespace sidebar
+
+#endif  // BRAVE_COMPONENTS_SIDEBAR_BROWSER_MOBILE_VIEW_ID_H_

--- a/components/sidebar/browser/sidebar_item.cc
+++ b/components/sidebar/browser/sidebar_item.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/sidebar/browser/sidebar_item.h"
 
+#include "brave/components/sidebar/common/features.h"
+
 namespace sidebar {
 
 // static
@@ -58,6 +60,14 @@ bool SidebarItem::IsValidItem() const {
   // WebType
   return url.is_valid() &&
          built_in_item_type == SidebarItem::BuiltInItemType::kNone;
+}
+
+bool SidebarItem::IsMobileViewItem() const {
+  if (!base::FeatureList::IsEnabled(sidebar::features::kSidebarMobileView)) {
+    return false;
+  }
+
+  return url.is_valid() && mobile_view;
 }
 
 }  // namespace sidebar

--- a/components/sidebar/browser/sidebar_item.h
+++ b/components/sidebar/browser/sidebar_item.h
@@ -54,6 +54,7 @@ struct SidebarItem {
   }
   bool is_web_type() const { return type == SidebarItem::Type::kTypeWeb; }
   bool IsValidItem() const;
+  bool IsMobileViewItem() const;
 
   bool operator==(const SidebarItem& item) const;
 
@@ -61,8 +62,14 @@ struct SidebarItem {
   Type type = Type::kTypeBuiltIn;
   BuiltInItemType built_in_item_type = BuiltInItemType::kNone;
   std::u16string title;
+
   // Set false to open this item in new tab.
   bool open_in_panel = false;
+
+  // TODO(simonhong): Remove this and migrate to |open_in_panel|.
+  // As mobile view feature can be toggled, |open_in_panel| flag
+  // should be preserved till this feature flag is removed.
+  bool mobile_view = false;
 };
 
 }  // namespace sidebar

--- a/components/sidebar/common/features.cc
+++ b/components/sidebar/common/features.cc
@@ -16,6 +16,11 @@ const base::FeatureParam<bool> kOpenOneShotLeoPanel{
     /*name=*/"open_one_shot_leo_panel",
     /*default_value=*/false};
 
+// Load sidebar item's url in the panel instead of loading it in the tab.
+BASE_FEATURE(kSidebarMobileView,
+             "SidebarMobileView",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 SidebarDefaultMode GetSidebarDefaultMode() {
    if (base::FeatureList::IsEnabled(kSidebarShowAlwaysOnStable)) {
      if (kOpenOneShotLeoPanel.Get()) {

--- a/components/sidebar/common/features.h
+++ b/components/sidebar/common/features.h
@@ -17,6 +17,8 @@ BASE_DECLARE_FEATURE(kSidebarShowAlwaysOnStable);
 // Whether to open the Leo panel only once.
 extern const base::FeatureParam<bool> kOpenOneShotLeoPanel;
 
+BASE_DECLARE_FEATURE(kSidebarMobileView);
+
 enum class SidebarDefaultMode {
   kOff = 0,
   kAlwaysOn,

--- a/patches/chrome-browser-ui-actions-chrome_action_id.h.patch
+++ b/patches/chrome-browser-ui-actions-chrome_action_id.h.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/actions/chrome_action_id.h b/chrome/browser/ui/actions/chrome_action_id.h
-index 99d3b60c63ef1a2953ce54ca53d9c244339a15b9..b0b277903b94058a898052ea748f0aa3be4ad457 100644
+index 99d3b60c63ef1a2953ce54ca53d9c244339a15b9..5534097b4641225486d35e8b9e728aaeadaaa16e 100644
 --- a/chrome/browser/ui/actions/chrome_action_id.h
 +++ b/chrome/browser/ui/actions/chrome_action_id.h
 @@ -519,6 +519,7 @@
    /* Side Panel items */ \
    E(kActionSidePanelShowAboutThisSite) \
    E(kActionSidePanelShowAssistant) \
-+  E(kActionSidePanelShowPlaylist) E(kActionSidePanelShowChatUI) \
++  E(kActionSidePanelShowPlaylist) E(kActionSidePanelShowChatUI) E(kActionSidePanelShowMobileView) \
    E(kActionSidePanelShowBookmarks, IDC_SHOW_BOOKMARK_SIDE_PANEL) \
    E(kActionSidePanelShowCustomizeChrome) \
    E(kActionSidePanelShowFeed) \

--- a/patches/chrome-browser-ui-views-side_panel-BUILD.gn.patch
+++ b/patches/chrome-browser-ui-views-side_panel-BUILD.gn.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/views/side_panel/BUILD.gn b/chrome/browser/ui/views/side_panel/BUILD.gn
-index e6cd05e1fd991b85b7671c125ee4882fb4f4bc83..3faf40e515295e152f1cdcbd26f95d40926147e5 100644
+index e6cd05e1fd991b85b7671c125ee4882fb4f4bc83..1ffe9aa1c08d3a0128fa8631db78753401fc42a7 100644
 --- a/chrome/browser/ui/views/side_panel/BUILD.gn
 +++ b/chrome/browser/ui/views/side_panel/BUILD.gn
 @@ -193,6 +193,7 @@ source_set("side_panel") {
      ]
      deps += [ "//chrome/common/extensions/api" ]
    }
-+  public_deps += [ "//brave/components/sidebar/browser" ]
++  import("//brave/browser/ui/views/side_panel/sources.gni") public_deps += brave_chrome_browser_ui_views_side_panel_public_deps
  
    allow_circular_includes_from = [
      "//chrome/browser/ui/views/toolbar",

--- a/patches/chrome-browser-ui-views-side_panel-BUILD.gn.patch
+++ b/patches/chrome-browser-ui-views-side_panel-BUILD.gn.patch
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/side_panel/BUILD.gn b/chrome/browser/ui/views/side_panel/BUILD.gn
+index e6cd05e1fd991b85b7671c125ee4882fb4f4bc83..3faf40e515295e152f1cdcbd26f95d40926147e5 100644
+--- a/chrome/browser/ui/views/side_panel/BUILD.gn
++++ b/chrome/browser/ui/views/side_panel/BUILD.gn
+@@ -193,6 +193,7 @@ source_set("side_panel") {
+     ]
+     deps += [ "//chrome/common/extensions/api" ]
+   }
++  public_deps += [ "//brave/components/sidebar/browser" ]
+ 
+   allow_circular_includes_from = [
+     "//chrome/browser/ui/views/toolbar",

--- a/patches/chrome-browser-ui-views-side_panel-side_panel_entry_id.h.patch
+++ b/patches/chrome-browser-ui-views-side_panel-side_panel_entry_id.h.patch
@@ -1,12 +1,12 @@
 diff --git a/chrome/browser/ui/views/side_panel/side_panel_entry_id.h b/chrome/browser/ui/views/side_panel/side_panel_entry_id.h
-index 34110251b5766f02fcaded443db1e4917a42dbb0..3cbaa6549e481e531ec5696ddddab58249b7518d 100644
+index 34110251b5766f02fcaded443db1e4917a42dbb0..8a6d82acfff36b03928590135b682558bda317d4 100644
 --- a/chrome/browser/ui/views/side_panel/side_panel_entry_id.h
 +++ b/chrome/browser/ui/views/side_panel/side_panel_entry_id.h
 @@ -30,6 +30,7 @@
    V(kSideSearch, kActionSidePanelShowSideSearch, "SideSearch")                \
    V(kLens, kActionSidePanelShowLens, "Lens")                                  \
    V(kAssistant, kActionSidePanelShowAssistant, "Assistant")                   \
-+  V(kPlaylist, kActionSidePanelShowPlaylist, "Playlist") V(kChatUI, kActionSidePanelShowChatUI, "ChatUI") \
++  V(kPlaylist, kActionSidePanelShowPlaylist, "Playlist") V(kChatUI, kActionSidePanelShowChatUI, "ChatUI") V(kMobileView, kActionSidePanelShowMobileView, "MobileView")\
    V(kAboutThisSite, kActionSidePanelShowAboutThisSite, "AboutThisSite")       \
    V(kCustomizeChrome, kActionSidePanelShowCustomizeChrome, "CustomizeChrome") \
    V(kSearchCompanion, kActionSidePanelShowSearchCompanion, "Companion")       \

--- a/patches/chrome-browser-ui-views-side_panel-side_panel_entry_key.h.patch
+++ b/patches/chrome-browser-ui-views-side_panel-side_panel_entry_key.h.patch
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/views/side_panel/side_panel_entry_key.h b/chrome/browser/ui/views/side_panel/side_panel_entry_key.h
+index a1af0c548bb277bb45eb4766e47b65ce90f6d027..6e7d2c107649fd1d8ce40e57e3461462cfa39551 100644
+--- a/chrome/browser/ui/views/side_panel/side_panel_entry_key.h
++++ b/chrome/browser/ui/views/side_panel/side_panel_entry_key.h
+@@ -17,7 +17,7 @@ class SidePanelEntryKey {
+   explicit SidePanelEntryKey(SidePanelEntryId id);
+   SidePanelEntryKey(SidePanelEntryId id, extensions::ExtensionId extension_id);
+   SidePanelEntryKey(const SidePanelEntryKey& other);
+-  ~SidePanelEntryKey();
++  virtual ~SidePanelEntryKey();
+ 
+   SidePanelEntryKey& operator=(const SidePanelEntryKey& other);
+   bool operator==(const SidePanelEntryKey& other) const;

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -697,6 +697,7 @@ if (!is_android) {
       "//base",
       "//brave/base/test:test_vendor_is_brave",
       "//brave/browser/brave_rewards",
+      "//brave/browser/ui/sidebar",
       "//brave/components/brave_ads/core/public:headers",
       "//brave/components/brave_rewards/content",
       "//chrome:packed_resources",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44958

This PR refactored the previous implementation (https://github.com/brave/brave-core/pull/21081) except UI to get review easier.

All implementations are behind kSidebarMobileView feature flag and it's disabled by default.
As this doesn't have UI, user can't add mobile view panel even flag is passed.

This PR subclassed SidePanelEntryKey to handle mobile view entry.
As each mobile view panel item should have unique key,
we use common type(`kMobileView`) and unique id(`MobileViewId`) for its SidePanelEntry key.

This PR added two important classes - `MobileViewSidePanelManager` and `MobileViewSidePanelCoordinator`.
As sidebar is per browser function, `BrowserWindowFeatures` owns `MobileViewSidePanelManager`.
It monitor's sidebar item add/deletion noti and create `MobileViewSidePanelCoordinator` for each mobile view panel item.

Another interface target `//brave/browser/ui/sidebar` is added as `//brave/browser/ui/views/side_panel` depends on it.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

## Submitter Checklist:

- [x] I confirm that no [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) and no other type of reviews are needed, or that I have [requested](https://github.com/brave/reviews/issues/new/choose) them
- [x] There is a [ticket](https://github.com/brave/brave-browser/issues) for my issue
- [x] Used Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- [x] Wrote a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- [ ] Squashed any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- [x] Added appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- [ ] Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- [x] Ran `git rebase master` (if needed)

## Reviewer Checklist:

- [ ] A security review [is not needed](https://github.com/brave/brave-browser/wiki/Security-reviews), or a link to one is included in the PR description
- [ ] New files have MPL-2.0 license header
- [ ] Adequate test coverage exists to prevent regressions
- [ ] Major classes, functions and non-trivial code blocks are well-commented
- [ ] Changes in component dependencies are properly reflected in `gn`
- [ ] Code follows the [style guide](https://chromium.googlesource.com/chromium/src/+/HEAD/styleguide/c++/c++.md)
- [ ] Test plan is specified in PR before merging

## After-merge Checklist:

- [ ] The associated issue milestone is set to the smallest version that the
  changes has landed on
- [ ] All relevant documentation has been updated, for instance:
  - [ ] https://github.com/brave/brave-browser/wiki/Deviations-from-Chromium-(features-we-disable-or-remove)
  - [ ] https://github.com/brave/brave-browser/wiki/Proxy-redirected-URLs
  - [ ] https://github.com/brave/brave-browser/wiki/Fingerprinting-Protections
  - [ ] https://github.com/brave/brave-browser/wiki/Brave%E2%80%99s-Use-of-Referral-Codes
  - [ ] https://github.com/brave/brave-browser/wiki/Web-Compatibility-Exceptions-in-Brave
  - [ ] https://github.com/brave/brave-browser/wiki/QA-Guide
  - [ ] https://github.com/brave/brave-browser/wiki/P3A

## Test Plan:

`SidebarBrowserTestWithMobileViewFeature`