### PR TITLE
feat(iOS): Yahoo! JAPAN phase two

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -229,11 +229,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       if Preferences.Search.defaultEngineName.value == nil {
         AppState.shared.profile.searchEngines.searchEngineSetup()
         Preferences.Search.yahooJPPhaseOneCompleted.value = true
-      } else if !Preferences.Search.yahooJPPhaseOneCompleted.value {
+        Preferences.Search.yahooJPPhaseTwoCompleted.value = true
+      }
+      if !Preferences.Search.yahooJPPhaseOneCompleted.value {
         // Upgrade from existed version which has a DSE set. Need to insert Yahoo! JAPAN into
         // the correct position of the ordered search engines list
         AppState.shared.profile.searchEngines.updateYahooJPOrderIfNeeded()
         Preferences.Search.yahooJPPhaseOneCompleted.value = true
+      }
+      if !Preferences.Search.yahooJPPhaseTwoCompleted.value {
+        AppState.shared.profile.searchEngines.updateDSEToYahooJPIfNeeded()
+        Preferences.Search.yahooJPPhaseTwoCompleted.value = true
       }
     }
 

--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -217,6 +217,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       // Still need to insert Yahoo! JAPAN in the engine list during `InitialSearchEngines` initialization
       // but not override the current DSE value
       Preferences.Search.shouldOverrideDSEForJapanRegion.value = false
+    } else if Preferences.Search.yahooJPPhaseOneCompleted.value {
+      Preferences.Search.shouldOverrideDSEForJapanRegion.value = false
     }
 
     Preferences.General.isFirstLaunch.value = false

--- a/ios/brave-ios/Sources/Brave/Assets/SearchPlugins/yahoojp.xml
+++ b/ios/brave-ios/Sources/Brave/Assets/SearchPlugins/yahoojp.xml
@@ -11,7 +11,7 @@
   <Param name="appid" value="dj00aiZpPXVyZmc2WDgzWnA5SSZzPWNvbnN1bWVyc2VjcmV0Jng9MTE-"/>
   <Param name="fr" value="brave-mobile_ext"/>
 </Url>
-<Url type="text/html" method="GET" template="https://search.yahoo.co.jp/search/">
+<Url type="text/html" method="GET" template="https://search.yahoo.co.jp/search">
   <Param name="p" value="{searchTerms}"/>
   <Param name="ei" value="UTF-8"/>
   <Param name="fr" value="brave-mobile_ext"/>

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
@@ -116,6 +116,28 @@ public class SearchEngines {
     }
   }
 
+  /// Update DSE to Yahoo! JAPAN for Japan region if user's DSE is google for standard tabs
+  public func updateDSEToYahooJPIfNeeded() {
+    // match conditions:
+    // 1. in Japan region
+    // 2. DSE is google for standard tab
+    // 3. user has never picked a DSE for standard tab since version 1.77
+    guard let region = locale.region?.identifier,
+      initialSearchEngines.yahooJapanEnabledRegions.contains(region),
+      let dseStandard = defaultEngine(forType: .standard),
+      dseStandard.engineID == InitialSearchEngines.SearchEngineID.google.rawValue,
+      Preferences.Search.userPickedDSEName.value == nil
+    else { return }
+    DefaultEngineType.standard.option.value = InitialSearchEngines.SearchEngineID.yahoojp.rawValue
+    // Make sure Yahoo! JAPAN is at the first position of the list
+    if let oldIndex = orderedEngines.firstIndex(where: {
+      $0.engineID == InitialSearchEngines.SearchEngineID.yahoojp.rawValue
+    }) {
+      let yahooJP = orderedEngines.remove(at: oldIndex)
+      orderedEngines.insert(yahooJP, at: 0)
+    }
+  }
+
   /// If no engine type is specified this method returns search engine for regular browsing.
   func defaultEngine(forType engineType: DefaultEngineType) -> OpenSearchEngine? {
     if let name = engineType.option.value,

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -184,6 +184,11 @@ extension Preferences {
       key: "search.yahoo-jp-phase-one-completed",
       default: false
     )
+    /// Whether or not Yahoo! JAPAN search engine phase two has been completed
+    public static let yahooJPPhaseTwoCompleted = Option<Bool>(
+      key: "search.yahoo-jp-phase-two-completed",
+      default: false
+    )
     /// User picked DSE name for normal mode
     public static let userPickedDSEName = Option<String?>(
       key: "search.user-picked-dse-name",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44828
Resolves https://github.com/brave/brave-browser/issues/45037

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

# Test Plan for DSE Behavior in Version 1.78  

## 1. New Users on Version 1.78  
- Default Search Engine (DSE) is set to **Yahoo! JAPAN**.  

## 2. Upgrade from Version 1.77 to 1.78  
- **If the user did not modify the DSE in version 1.77:**  
  - If DSE was **Yahoo! JAPAN** → It remains **Yahoo! JAPAN** in 1.78.  
  - If DSE was **Google** → It changes to **Yahoo! JAPAN** in 1.78.  
  - If DSE was **any other search engine (excluding Google/Yahoo! JAPAN)** → It remains unchanged in 1.78.  

- **If the user modified the DSE in version 1.77:**  
  - The user's chosen DSE is respected in 1.78.  

## 3. Direct Upgrade from Version ≤ 1.76 to 1.78  
- If DSE was **Google** → It changes to **Yahoo! JAPAN** in 1.78.  
- If DSE was **any search engine other than Google** → It remains unchanged in 1.78.  

## 4. Upgrade Path: Version ≤ 1.76 → 1.77 → 1.78  
- If DSE was **Google** in 1.76:  
  - If the user **did not modify** DSE in 1.77 → It changes to **Yahoo! JAPAN** in 1.78.  
  - If the user **changed DSE to another search engine (e.g., DDG) in 1.77** → It remains as that search engine in 1.78.  
  - If the user **changed DSE to another search engine (e.g., DDG) and then back to Google in 1.77** → It remains **Google** in 1.78.  

- If DSE was **any search engine other than Google (e.g., DDG) in 1.76**:  
  - If the user **did not modify** DSE in 1.77 → It remains unchanged in 1.78.  