### PR TITLE
[iOS] Remove Data import from Tab

### DIFF
--- a/ios/brave-ios/Sources/Web/Tab.swift
+++ b/ios/brave-ios/Sources/Web/Tab.swift
@@ -6,7 +6,6 @@ import BraveCore
 import BraveStrings
 import CertificateUtilities
 import Combine
-import Data
 import FaviconModels
 import Foundation
 import Shared


### PR DESCRIPTION
This import isn't needed and can cause build failures if SPM builds Web before Data
