### PR TITLE
Add patch to update proxy url for favicons (uplift to 1.78.x)

### DIFF
--- a/chromium_src/components/favicon/core/large_icon_service_impl.cc
+++ b/chromium_src/components/favicon/core/large_icon_service_impl.cc
@@ -1,0 +1,12 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "components/favicon/core/large_icon_service_impl.h"
+
+#define server_url_(URL) \
+  server_url_("https://favicons.proxy.brave.com/faviconV2")
+
+#include "src/components/favicon/core/large_icon_service_impl.cc"
+#undef server_url_


### PR DESCRIPTION
Uplift of #28197
Resolves https://github.com/brave/brave-browser/issues/42127

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.