### PR TITLE
Disable "Can't update Brave" notification on macOS

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -423,7 +423,9 @@ Config.prototype.buildArgs = function () {
     use_siso: false,
     use_libfuzzer: this.use_libfuzzer,
     enable_updater: this.isOfficialBuild(),
-    enable_update_notifications: this.isOfficialBuild(),
+    // Disable "Can't update Brave" notification on macOS until we have switched
+    // to Omaha 4 and have background updates:
+    enable_update_notifications: this.isOfficialBuild() && this.getTargetOS() !== 'mac',
     brave_services_production_domain: this.braveServicesProductionDomain,
     brave_services_staging_domain: this.braveServicesStagingDomain,
     brave_services_dev_domain: this.braveServicesDevDomain,


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/37427.

## Test plan

1. Advance the system clock by more than 8 weeks.
2. Start Brave and leave it running for 24 hours.
3. You should not get the notification shown in https://github.com/brave/brave-browser/issues/37427.