### PR TITLE
[Bookmarks]: Only be default if title is exact match

### DIFF
--- a/components/omnibox/browser/brave_bookmark_provider.cc
+++ b/components/omnibox/browser/brave_bookmark_provider.cc
@@ -29,9 +29,7 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
 
   // We need to bump the relevance of the bookmark if we ever want it to rank
   // high enough to be the default match.
-  constexpr int kContainsQueryBump = 350;
-  // Note: This is in addition to the kContainsQueryBump.
-  constexpr int kExactTitleBump = 200;
+  constexpr int kExactTitleBump = 550;
 
   bool modified = false;
 
@@ -41,13 +39,12 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
       continue;
     }
 
-    // We only allow the bookmark to be the default match if the input is
-    // literally contained in the title or URL.
+    // We only allow the bookmark to be the default match if the input is an
+    // exact match for the bookmark title
     auto lower_description = base::ToLowerASCII(match.description);
-    auto bump_match =
-        base::Contains(base::ToLowerASCII(match.contents), lower_text) ||
-        base::Contains(lower_description, lower_text);
-    if (!bump_match) {
+    auto description_matches =
+        lower_description == base::ToLowerASCII(input.text());
+    if (!description_matches) {
       continue;
     }
 
@@ -70,17 +67,10 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
           ACMatchClassification(0, ACMatchClassification::URL)};
     }
 
-    // Additional bump if the title is an exact match - this helps people with
-    // short bookmark titles for jumping to pages (like "sa" for
-    // "chrome://settings/appearance")
-    if (lower_description == lower_text) {
-      match.relevance += kExactTitleBump;
-    }
-
     match.SetAllowedToBeDefault(input);
 
     modified = true;
-    match.relevance += kContainsQueryBump;
+    match.relevance += kExactTitleBump;
   }
 
   // If we modified any matches, notify listeners so the UI updates.

--- a/components/omnibox/browser/brave_bookmark_provider.cc
+++ b/components/omnibox/browser/brave_bookmark_provider.cc
@@ -42,9 +42,7 @@ void BraveBookmarkProvider::Start(const AutocompleteInput& input,
     // We only allow the bookmark to be the default match if the input is an
     // exact match for the bookmark title
     auto lower_description = base::ToLowerASCII(match.description);
-    auto description_matches =
-        lower_description == base::ToLowerASCII(input.text());
-    if (!description_matches) {
+    if (lower_description != lower_text) {
       continue;
     }
 

--- a/components/omnibox/browser/brave_bookmark_provider_unittest.cc
+++ b/components/omnibox/browser/brave_bookmark_provider_unittest.cc
@@ -123,24 +123,6 @@ TEST_F(BraveBookmarkProviderTest, ContainsQueryBumpsRelevance) {
   EXPECT_GT(provider_->matches()[0].relevance, 1199);
 }
 
-TEST_F(BraveBookmarkProviderTest, ExactTitleMatchBumpsRelevance) {
-  prefs()->SetBoolean(omnibox::kBookmarkSuggestionsEnabled, true);
-  client_.GetBookmarkModel()->AddURL(client_.GetBookmarkModel()->other_node(),
-                                     0, u"Hellow",
-                                     GURL("https://example.com/one"));
-  provider_->Start(CreateAutocompleteInput("Hello"), true);
-  EXPECT_EQ(provider_->matches().size(), 2u);
-
-  EXPECT_EQ(provider_->matches()[0].description, u"Hello");
-  EXPECT_TRUE(provider_->matches()[0].allowed_to_be_default_match);
-
-  EXPECT_EQ(provider_->matches()[1].description, u"Hellow");
-  EXPECT_TRUE(provider_->matches()[1].allowed_to_be_default_match);
-
-  EXPECT_GT(provider_->matches()[0].relevance,
-            provider_->matches()[1].relevance);
-}
-
 TEST_F(BraveBookmarkProviderTest, TitleOnlyMatchSetsURL) {
   prefs()->SetBoolean(omnibox::kBookmarkSuggestionsEnabled, true);
   provider_->Start(CreateAutocompleteInput("Hello"), true);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44961

This stops partial matches of the url/title from setting bookmarks as the default match. This probably wants uplifting to 1.78 which introduced the behavior

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->


## Test Plan

1. Create a bookmark (with short title)
2. Type the title
3. The bookmark should be the default match
4. Type part of the url
5. The bookmark should not be the default match
6. Type part of the title
7. The bookmark should not be the default match