### PR TITLE
Disable "Can't update Brave" notification on macOS (uplift to 1.78.x)

### DIFF
--- a/build/commands/lib/config.js
+++ b/build/commands/lib/config.js
@@ -423,7 +423,9 @@ Config.prototype.buildArgs = function () {
     use_siso: false,
     use_libfuzzer: this.use_libfuzzer,
     enable_updater: this.isOfficialBuild(),
-    enable_update_notifications: this.isOfficialBuild(),
+    // Disable "Can't update Brave" notification on macOS until we have switched
+    // to Omaha 4 and have background updates:
+    enable_update_notifications: this.isOfficialBuild() && this.getTargetOS() !== 'mac',
     brave_services_production_domain: this.braveServicesProductionDomain,
     brave_services_staging_domain: this.braveServicesStagingDomain,
     brave_services_dev_domain: this.braveServicesDevDomain,


### PR DESCRIPTION
Uplift of #28351
Resolves https://github.com/brave/brave-browser/issues/37427

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.