### PR TITLE
[iOS] Fix new tab page title in tab tray and fix restoration state (uplift to 1.78.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/TabExtensions.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/TabExtensions.swift
@@ -13,14 +13,12 @@ import Web
 
 extension Tab {
   var displayTitle: String {
-    if let displayTabTitle = fetchDisplayTitle(using: url, title: title) {
-      return displayTabTitle
+    if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false {
+      return Strings.Hotkey.newTabTitle
     }
 
-    // When picking a display title. Tabs with sessionData are pending a restore so show their old title.
-    // To prevent flickering of the display title. If a tab is restoring make sure to use its lastTitle.
-    if let url = self.url, InternalURL(url)?.isAboutHomeURL ?? false, !isRestoring {
-      return Strings.Hotkey.newTabTitle
+    if let displayTabTitle = fetchDisplayTitle(using: url, title: title) {
+      return displayTabTitle
     }
 
     if let url = self.url, !InternalURL.isValid(url: url),

--- a/ios/brave-ios/Sources/Web/WebKit/TabWKNavigationHandler.swift
+++ b/ios/brave-ios/Sources/Web/WebKit/TabWKNavigationHandler.swift
@@ -314,6 +314,7 @@ class TabWKNavigationHandler: NSObject, WKNavigationDelegate {
 
     // Set the committed url which will also set tab.visibleURL
     tab.committedURL = webView.url
+    tab.isRestoring = false
     tab.mimeType = pendingMIMEType
 
     pendingMIMEType = nil


### PR DESCRIPTION
Uplift of #28372
Resolves https://github.com/brave/brave-browser/issues/45006

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.