### PR TITLE
[ads] Fixes p3a lands event is not triggered for RichNTT (uplift to 1.78.x)

### DIFF
--- a/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
+++ b/browser/ui/webui/brave_new_tab_page_refresh/brave_new_tab_page_ui.cc
@@ -20,6 +20,7 @@
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/new_tab_page_initializer.h"
 #include "brave/browser/ui/webui/brave_new_tab_page_refresh/top_sites_facade.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h"
+#include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "chrome/browser/browser_process.h"
 #include "chrome/browser/ntp_tiles/chrome_most_visited_sites_factory.h"
 #include "chrome/browser/profiles/profile.h"
@@ -72,18 +73,15 @@ void BraveNewTabPageUI::BindInterface(
         ntp_background_images::mojom::SponsoredRichMediaAdEventHandler>
         receiver) {
   auto* profile = Profile::FromWebUI(web_ui());
-  std::unique_ptr<ntp_background_images::NTPP3AHelperImpl> ntp_p3a_helper;
-  if (g_brave_browser_process->p3a_service()) {
-    ntp_p3a_helper = std::make_unique<ntp_background_images::NTPP3AHelperImpl>(
-        g_browser_process->local_state(),
-        g_brave_browser_process->p3a_service(),
-        g_brave_browser_process->ntp_background_images_service(),
-        profile->GetPrefs());
+  ntp_background_images::NTPP3AHelper* ntp_p3a_helper = nullptr;
+  if (ntp_background_images::ViewCounterService* view_counter_service =
+          ntp_background_images::ViewCounterServiceFactory::GetForProfile(
+              profile)) {
+    ntp_p3a_helper = view_counter_service->GetP3AHelper();
   }
   rich_media_ad_event_handler_ = std::make_unique<
       ntp_background_images::NTPSponsoredRichMediaAdEventHandler>(
-      brave_ads::AdsServiceFactory::GetForProfile(profile),
-      std::move(ntp_p3a_helper));
+      brave_ads::AdsServiceFactory::GetForProfile(profile), ntp_p3a_helper);
   rich_media_ad_event_handler_->Bind(std::move(receiver));
 }
 

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -13,10 +13,10 @@
 #include "base/no_destructor.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"
 #include "brave/browser/brave_browser_features.h"
-#include "brave/browser/brave_browser_process.h"
 #include "brave/browser/brave_news/brave_news_controller_factory.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
+#include "brave/browser/ntp_background/view_counter_service_factory.h"
 #include "brave/browser/ui/webui/ads_internals/ads_internals_ui.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_page_ui.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_web_ui_utils.h"
@@ -161,9 +161,9 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
     return new BraveNewTabUI(
         web_ui, url.host(),
         brave_ads::AdsServiceFactory::GetForProfile(profile),
-        g_browser_process->local_state(),
-        g_brave_browser_process->p3a_service(),
-        g_brave_browser_process->ntp_background_images_service());
+        ntp_background_images::ViewCounterServiceFactory::GetForProfile(
+            profile),
+        g_browser_process->local_state());
 #endif  // !BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(ENABLE_TOR)
   } else if (host == kTorInternalsHost) {

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.h
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.h
@@ -13,7 +13,6 @@
 #include "brave/components/brave_news/common/brave_news.mojom.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/webui/searchbox/realbox_handler.h"
-#include "components/prefs/pref_service.h"
 #include "content/public/browser/web_ui_controller.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
@@ -25,18 +24,16 @@
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"  // nogncheck
 #endif  // BUILDFLAG(ENABLE_BRAVE_VPN)
 
+class PrefService;
+
 namespace brave_ads {
 class AdsService;
 }  // namespace brave_ads
 
 namespace ntp_background_images {
-class NTPBackgroundImagesService;
 class NTPSponsoredRichMediaAdEventHandler;
+class ViewCounterService;
 }  // namespace ntp_background_images
-
-namespace p3a {
-class P3AService;
-}  // namespace p3a
 
 class BraveNewTabPageHandler;
 
@@ -46,10 +43,8 @@ class BraveNewTabUI : public ui::MojoWebUIController,
   BraveNewTabUI(content::WebUI* web_ui,
                 const std::string& name,
                 brave_ads::AdsService* ads_service,
-                PrefService* local_state,
-                p3a::P3AService* p3a_service,
-                ntp_background_images::NTPBackgroundImagesService*
-                    ntp_background_images_service);
+                ntp_background_images::ViewCounterService* view_counter_service,
+                PrefService* local_state);
   ~BraveNewTabUI() override;
   BraveNewTabUI(const BraveNewTabUI&) = delete;
   BraveNewTabUI& operator=(const BraveNewTabUI&) = delete;

--- a/browser/ui/webui/new_tab_takeover/android/BUILD.gn
+++ b/browser/ui/webui/new_tab_takeover/android/BUILD.gn
@@ -17,13 +17,10 @@ source_set("new_tab_takeover") {
 
   deps = [
     "//base",
-    "//brave/browser:browser_process",
     "//brave/browser/brave_ads:brave_ads",
-    "//brave/browser/ntp_background",
     "//brave/components/constants",
     "//brave/components/new_tab_takeover:new_tab_takeover_generated_resources",
     "//brave/components/ntp_background_images/browser",
-    "//chrome/browser:browser_process",
     "//chrome/browser:browser_public_dependencies",
     "//chrome/browser/profiles:profile",
     "//content/public/browser",
@@ -33,6 +30,7 @@ source_set("new_tab_takeover") {
   ]
 
   public_deps = [
+    "//brave/browser/ntp_background",
     "//brave/components/new_tab_takeover/mojom",
     "//brave/components/ntp_background_images/browser/mojom",
     "//mojo/public/cpp/bindings",

--- a/browser/ui/webui/new_tab_takeover/android/new_tab_takeover_ui_config.cc
+++ b/browser/ui/webui/new_tab_takeover/android/new_tab_takeover_ui_config.cc
@@ -9,14 +9,12 @@
 #include <utility>
 
 #include "brave/browser/brave_ads/ads_service_factory.h"
-#include "brave/browser/brave_browser_process.h"
-#include "brave/browser/ntp_background/ntp_p3a_helper_impl.h"
 #include "brave/browser/ntp_background/view_counter_service_factory.h"
 #include "brave/browser/ui/webui/new_tab_takeover/android/new_tab_takeover_ui.h"
 #include "brave/components/constants/webui_url_constants.h"
 #include "brave/components/ntp_background_images/browser/ntp_p3a_helper.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h"
-#include "chrome/browser/browser_process.h"
+#include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "content/public/browser/web_ui.h"
 #include "content/public/common/url_constants.h"
@@ -30,20 +28,17 @@ NewTabTakeoverUIConfig::CreateWebUIController(content::WebUI* web_ui,
                                               const GURL& url) {
   Profile* profile = Profile::FromWebUI(web_ui);
 
-  auto ntp_p3a_helper =
-      std::make_unique<ntp_background_images::NTPP3AHelperImpl>(
-          g_browser_process->local_state(),
-          g_brave_browser_process->p3a_service(),
-          g_brave_browser_process->ntp_background_images_service(),
-          profile->GetPrefs());
+  ntp_background_images::ViewCounterService* view_counter_service =
+      ntp_background_images::ViewCounterServiceFactory::GetForProfile(profile);
+  ntp_background_images::NTPP3AHelper* ntp_p3a_helper = nullptr;
+  if (view_counter_service != nullptr) {
+    ntp_p3a_helper = view_counter_service->GetP3AHelper();
+  }
 
   auto rich_media_ad_event_handler = std::make_unique<
       ntp_background_images::NTPSponsoredRichMediaAdEventHandler>(
-      brave_ads::AdsServiceFactory::GetForProfile(profile),
-      std::move(ntp_p3a_helper));
+      brave_ads::AdsServiceFactory::GetForProfile(profile), ntp_p3a_helper);
 
   return std::make_unique<NewTabTakeoverUI>(
-      web_ui,
-      ntp_background_images::ViewCounterServiceFactory::GetForProfile(profile),
-      std::move(rich_media_ad_event_handler));
+      web_ui, view_counter_service, std::move(rich_media_ad_event_handler));
 }

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.cc
@@ -17,8 +17,8 @@ namespace ntp_background_images {
 
 NTPSponsoredRichMediaAdEventHandler::NTPSponsoredRichMediaAdEventHandler(
     brave_ads::AdsService* ads_service,
-    std::unique_ptr<NTPP3AHelper> ntp_p3a_helper)
-    : ads_service_(ads_service), ntp_p3a_helper_(std::move(ntp_p3a_helper)) {}
+    NTPP3AHelper* ntp_p3a_helper)
+    : ads_service_(ads_service), ntp_p3a_helper_(ntp_p3a_helper) {}
 
 NTPSponsoredRichMediaAdEventHandler::~NTPSponsoredRichMediaAdEventHandler() =
     default;

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h
@@ -6,7 +6,6 @@
 #ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_SPONSORED_RICH_MEDIA_AD_EVENT_HANDLER_H_
 #define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_SPONSORED_RICH_MEDIA_AD_EVENT_HANDLER_H_
 
-#include <memory>
 #include <string>
 
 #include "brave/components/ntp_background_images/browser/mojom/ntp_background_images.mojom.h"
@@ -23,9 +22,8 @@ class NTPP3AHelper;
 class NTPSponsoredRichMediaAdEventHandler
     : public mojom::SponsoredRichMediaAdEventHandler {
  public:
-  NTPSponsoredRichMediaAdEventHandler(
-      brave_ads::AdsService* ads_service,
-      std::unique_ptr<NTPP3AHelper> ntp_p3a_helper);
+  NTPSponsoredRichMediaAdEventHandler(brave_ads::AdsService* ads_service,
+                                      NTPP3AHelper* ntp_p3a_helper);
 
   NTPSponsoredRichMediaAdEventHandler(
       const NTPSponsoredRichMediaAdEventHandler&) = delete;
@@ -50,7 +48,7 @@ class NTPSponsoredRichMediaAdEventHandler
 
   const raw_ptr<brave_ads::AdsService> ads_service_ = nullptr;  // Not owned.
 
-  std::unique_ptr<NTPP3AHelper> ntp_p3a_helper_;
+  const raw_ptr<NTPP3AHelper> ntp_p3a_helper_ = nullptr;  // Not owned.
 
   mojo::Receiver<mojom::SponsoredRichMediaAdEventHandler> receiver_{this};
 };

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler_unittest.cc
@@ -32,15 +32,14 @@ class NTPSponsoredRichMediaAdEventHandlerTest : public testing::Test {
 
     std::unique_ptr<NTPP3AHelperMock> ntp_p3a_helper =
         std::make_unique<NTPP3AHelperMock>();
-    raw_ptr<NTPP3AHelperMock> ntp_p3a_helper_ptr = ntp_p3a_helper.get();
 
-    NTPSponsoredRichMediaAdEventHandler ad_event_handler(
-        &ads_service, std::move(ntp_p3a_helper));
+    NTPSponsoredRichMediaAdEventHandler ad_event_handler(&ads_service,
+                                                         ntp_p3a_helper.get());
 
     if (should_metrics_fallback_to_p3a) {
       if (should_report) {
         EXPECT_CALL(
-            *ntp_p3a_helper_ptr,
+            *ntp_p3a_helper,
             RecordNewTabPageAdEvent(mojom_ad_event_type, kCreativeInstanceId));
 
         // `TriggerNewTabPageAdEvent` should be called because the ads service
@@ -48,7 +47,7 @@ class NTPSponsoredRichMediaAdEventHandlerTest : public testing::Test {
         // campaign should report using P3A.
         EXPECT_CALL(ads_service, TriggerNewTabPageAdEvent);
       } else {
-        EXPECT_CALL(*ntp_p3a_helper_ptr, RecordNewTabPageAdEvent).Times(0);
+        EXPECT_CALL(*ntp_p3a_helper, RecordNewTabPageAdEvent).Times(0);
         EXPECT_CALL(ads_service, TriggerNewTabPageAdEvent).Times(0);
       }
     } else {
@@ -60,15 +59,12 @@ class NTPSponsoredRichMediaAdEventHandlerTest : public testing::Test {
       } else {
         EXPECT_CALL(ads_service, TriggerNewTabPageAdEvent).Times(0);
       }
-      EXPECT_CALL(*ntp_p3a_helper_ptr, RecordNewTabPageAdEvent).Times(0);
+      EXPECT_CALL(*ntp_p3a_helper, RecordNewTabPageAdEvent).Times(0);
     }
 
     ad_event_handler.MaybeReportRichMediaAdEvent(
         kPlacementId, kCreativeInstanceId, should_metrics_fallback_to_p3a,
         mojom_ad_event_type);
-
-    // Reset the `ntp_p3a_helper_ptr` to nullptr to avoid dangling pointer.
-    ntp_p3a_helper_ptr = nullptr;
   }
 };
 

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -477,6 +477,10 @@ void ViewCounterService::OnTabURLChanged(const GURL& url) {
   }
 }
 
+NTPP3AHelper* ViewCounterService::GetP3AHelper() const {
+  return ntp_p3a_helper_.get();
+}
+
 bool ViewCounterService::CanShowSponsoredImages() const {
   NTPSponsoredImagesData* images_data = GetSponsoredImagesData();
   if (!images_data) {

--- a/components/ntp_background_images/browser/view_counter_service.h
+++ b/components/ntp_background_images/browser/view_counter_service.h
@@ -116,6 +116,8 @@ class ViewCounterService : public KeyedService,
 
   void OnTabURLChanged(const GURL& url);
 
+  NTPP3AHelper* GetP3AHelper() const;
+
  private:
   friend class ViewCounterServiceTest;
   friend class NTPBackgroundImagesServiceTest;


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/28390
Resolves https://github.com/brave/brave-browser/issues/45035

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.