### PR TITLE
[ads] Fixes p3a lands event is not triggered for RichNTT (uplift to 1.77.x)

### DIFF
--- a/browser/ui/BUILD.gn
+++ b/browser/ui/BUILD.gn
@@ -55,6 +55,7 @@ source_set("ui") {
     "//brave/browser/brave_adaptive_captcha",
     "//brave/browser/brave_ads",
     "//brave/browser/brave_rewards",
+    "//brave/browser/ntp_background",
     "//brave/browser/skus",
     "//brave/components/brave_shields/core/browser",
     "//brave/components/webcompat/core/common",
@@ -353,7 +354,6 @@ source_set("ui") {
 
     deps += [
       "//base",
-      "//brave/browser/ntp_background",
       "//brave/browser/profiles:util",
       "//brave/common",
       "//brave/components/constants",

--- a/browser/ui/webui/brave_web_ui_controller_factory.cc
+++ b/browser/ui/webui/brave_web_ui_controller_factory.cc
@@ -12,10 +12,10 @@
 #include "base/memory/ptr_util.h"
 #include "base/no_destructor.h"
 #include "brave/browser/brave_ads/ads_service_factory.h"
-#include "brave/browser/brave_browser_process.h"
 #include "brave/browser/brave_news/brave_news_controller_factory.h"
 #include "brave/browser/brave_rewards/rewards_util.h"
 #include "brave/browser/ethereum_remote_client/buildflags/buildflags.h"
+#include "brave/browser/ntp_background/view_counter_service_factory.h"
 #include "brave/browser/ui/webui/ads_internals/ads_internals_ui.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_page_ui.h"
 #include "brave/browser/ui/webui/brave_rewards/rewards_web_ui_utils.h"
@@ -156,9 +156,9 @@ WebUIController* NewWebUI(WebUI* web_ui, const GURL& url) {
     return new BraveNewTabUI(
         web_ui, url.host(),
         brave_ads::AdsServiceFactory::GetForProfile(profile),
-        g_browser_process->local_state(),
-        g_brave_browser_process->p3a_service(),
-        g_brave_browser_process->ntp_background_images_service());
+        ntp_background_images::ViewCounterServiceFactory::GetForProfile(
+            profile),
+        g_browser_process->local_state());
 #endif  // !BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(ENABLE_TOR)
   } else if (host == kTorInternalsHost) {

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.cc
@@ -34,11 +34,13 @@
 #include "brave/components/ntp_background_images/browser/ntp_custom_images_source.h"
 #include "brave/components/ntp_background_images/browser/ntp_p3a_helper.h"
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h"
+#include "brave/components/ntp_background_images/browser/view_counter_service.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/search_engines/template_url_service_factory.h"
 #include "chrome/browser/themes/theme_syncable_service.h"
 #include "chrome/common/pref_names.h"
 #include "components/grit/brave_components_resources.h"
+#include "components/prefs/pref_service.h"
 #include "components/strings/grit/components_strings.h"
 #include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/url_data_source.h"
@@ -75,13 +77,12 @@ std::string GetSearchWidgetDefaultHost(PrefService* local_state) {
 
 }  // namespace
 
-BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui,
-                             const std::string& name,
-                             brave_ads::AdsService* ads_service,
-                             PrefService* local_state,
-                             p3a::P3AService* p3a_service,
-                             ntp_background_images::NTPBackgroundImagesService*
-                                 ntp_background_images_service)
+BraveNewTabUI::BraveNewTabUI(
+    content::WebUI* web_ui,
+    const std::string& name,
+    brave_ads::AdsService* ads_service,
+    ntp_background_images::ViewCounterService* view_counter_service,
+    PrefService* local_state)
     : ui::MojoWebUIController(
           web_ui,
           true /* Needed for legacy non-mojom message handler */),
@@ -172,15 +173,13 @@ BraveNewTabUI::BraveNewTabUI(content::WebUI* web_ui,
   source->AddString("ntpNewTabTakeoverRichMediaUrl",
                     kNTPNewTabTakeoverRichMediaUrl);
 
-  std::unique_ptr<ntp_background_images::NTPP3AHelperImpl> ntp_p3a_helper;
-  if (g_brave_browser_process->p3a_service() != nullptr) {
-    ntp_p3a_helper = std::make_unique<ntp_background_images::NTPP3AHelperImpl>(
-        local_state, p3a_service, ntp_background_images_service,
-        profile->GetPrefs());
+  ntp_background_images::NTPP3AHelper* ntp_p3a_helper = nullptr;
+  if (view_counter_service != nullptr) {
+    ntp_p3a_helper = view_counter_service->GetP3AHelper();
   }
   rich_media_ad_event_handler_ = std::make_unique<
       ntp_background_images::NTPSponsoredRichMediaAdEventHandler>(
-      ads_service, std::move(ntp_p3a_helper));
+      ads_service, ntp_p3a_helper);
 }
 
 BraveNewTabUI::~BraveNewTabUI() = default;

--- a/browser/ui/webui/new_tab_page/brave_new_tab_ui.h
+++ b/browser/ui/webui/new_tab_page/brave_new_tab_ui.h
@@ -13,7 +13,6 @@
 #include "brave/components/brave_news/common/brave_news.mojom.h"
 #include "brave/components/brave_vpn/common/buildflags/buildflags.h"
 #include "chrome/browser/ui/webui/searchbox/realbox_handler.h"
-#include "components/prefs/pref_service.h"
 #include "content/public/browser/web_ui_controller.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
@@ -25,6 +24,8 @@
 #include "brave/components/brave_vpn/common/mojom/brave_vpn.mojom.h"  // nogncheck
 #endif
 
+class PrefService;
+
 namespace brave_ads {
 class AdsService;
 }  // namespace brave_ads
@@ -34,13 +35,9 @@ class BraveNewsController;
 }  // namespace brave_news
 
 namespace ntp_background_images {
-class NTPBackgroundImagesService;
 class NTPSponsoredRichMediaAdEventHandler;
+class ViewCounterService;
 }  // namespace ntp_background_images
-
-namespace p3a {
-class P3AService;
-}  // namespace p3a
 
 class BraveNewTabPageHandler;
 
@@ -50,10 +47,8 @@ class BraveNewTabUI : public ui::MojoWebUIController,
   BraveNewTabUI(content::WebUI* web_ui,
                 const std::string& name,
                 brave_ads::AdsService* ads_service,
-                PrefService* local_state,
-                p3a::P3AService* p3a_service,
-                ntp_background_images::NTPBackgroundImagesService*
-                    ntp_background_images_service);
+                ntp_background_images::ViewCounterService* view_counter_service,
+                PrefService* local_state);
   ~BraveNewTabUI() override;
   BraveNewTabUI(const BraveNewTabUI&) = delete;
   BraveNewTabUI& operator=(const BraveNewTabUI&) = delete;

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.cc
@@ -5,6 +5,8 @@
 
 #include "brave/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h"
 
+#include <utility>
+
 #include "brave/components/brave_ads/core/browser/service/ads_service.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/ntp_background_images/browser/ntp_p3a_helper.h"
@@ -13,8 +15,8 @@ namespace ntp_background_images {
 
 NTPSponsoredRichMediaAdEventHandler::NTPSponsoredRichMediaAdEventHandler(
     brave_ads::AdsService* ads_service,
-    std::unique_ptr<NTPP3AHelper> ntp_p3a_helper)
-    : ads_service_(ads_service), ntp_p3a_helper_(std::move(ntp_p3a_helper)) {}
+    NTPP3AHelper* ntp_p3a_helper)
+    : ads_service_(ads_service), ntp_p3a_helper_(ntp_p3a_helper) {}
 
 NTPSponsoredRichMediaAdEventHandler::~NTPSponsoredRichMediaAdEventHandler() =
     default;

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler.h
@@ -6,7 +6,6 @@
 #ifndef BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_SPONSORED_RICH_MEDIA_AD_EVENT_HANDLER_H_
 #define BRAVE_COMPONENTS_NTP_BACKGROUND_IMAGES_BROWSER_NTP_SPONSORED_RICH_MEDIA_AD_EVENT_HANDLER_H_
 
-#include <memory>
 #include <string>
 
 #include "brave/components/ntp_background_images/browser/mojom/ntp_background_images.mojom.h"
@@ -23,9 +22,8 @@ class NTPP3AHelper;
 class NTPSponsoredRichMediaAdEventHandler
     : public mojom::SponsoredRichMediaAdEventHandler {
  public:
-  NTPSponsoredRichMediaAdEventHandler(
-      brave_ads::AdsService* ads_service,
-      std::unique_ptr<NTPP3AHelper> ntp_p3a_helper);
+  NTPSponsoredRichMediaAdEventHandler(brave_ads::AdsService* ads_service,
+                                      NTPP3AHelper* ntp_p3a_helper);
 
   NTPSponsoredRichMediaAdEventHandler(
       const NTPSponsoredRichMediaAdEventHandler&) = delete;
@@ -55,7 +53,7 @@ class NTPSponsoredRichMediaAdEventHandler
 
   const raw_ptr<brave_ads::AdsService> ads_service_ = nullptr;  // Not owned.
 
-  std::unique_ptr<NTPP3AHelper> ntp_p3a_helper_;
+  const raw_ptr<NTPP3AHelper> ntp_p3a_helper_ = nullptr;  // Not owned.
 
   mojo::Receiver<mojom::SponsoredRichMediaAdEventHandler> receiver_{this};
 };

--- a/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler_unittest.cc
+++ b/components/ntp_background_images/browser/ntp_sponsored_rich_media_ad_event_handler_unittest.cc
@@ -29,23 +29,19 @@ class NTPSponsoredRichMediaAdEventHandlerTest : public testing::Test {
       bool should_record) {
     std::unique_ptr<NTPP3AHelperMock> ntp_p3a_helper =
         std::make_unique<NTPP3AHelperMock>();
-    raw_ptr<NTPP3AHelperMock> ntp_p3a_helper_ptr = ntp_p3a_helper.get();
 
     NTPSponsoredRichMediaAdEventHandler ad_event_handler(
-        /*ads_service=*/nullptr, std::move(ntp_p3a_helper));
+        /*ads_service=*/nullptr, ntp_p3a_helper.get());
 
     if (should_record) {
       EXPECT_CALL(
-          *ntp_p3a_helper_ptr,
+          *ntp_p3a_helper,
           RecordNewTabPageAdEvent(mojom_ad_event_type, kCreativeInstanceId));
     } else {
-      EXPECT_CALL(*ntp_p3a_helper_ptr, RecordNewTabPageAdEvent).Times(0);
+      EXPECT_CALL(*ntp_p3a_helper, RecordNewTabPageAdEvent).Times(0);
     }
     ad_event_handler.ReportRichMediaAdEvent(kPlacementId, kCreativeInstanceId,
                                             mojom_ad_event_type);
-
-    // Reset the `ntp_p3a_helper_ptr` to nullptr to avoid dangling pointer.
-    ntp_p3a_helper_ptr = nullptr;
   }
 
   void VerifyTriggerNewTabPageAdEventExpectation(

--- a/components/ntp_background_images/browser/view_counter_service.cc
+++ b/components/ntp_background_images/browser/view_counter_service.cc
@@ -519,6 +519,10 @@ void ViewCounterService::OnTabURLChanged(const GURL& url) {
   }
 }
 
+NTPP3AHelper* ViewCounterService::GetP3AHelper() const {
+  return ntp_p3a_helper_.get();
+}
+
 bool ViewCounterService::IsBrandedWallpaperActive() const {
   if (!GetCurrentBrandedWallpaperData()) {
     return false;

--- a/components/ntp_background_images/browser/view_counter_service.h
+++ b/components/ntp_background_images/browser/view_counter_service.h
@@ -117,6 +117,8 @@ class ViewCounterService : public KeyedService,
 
   void OnTabURLChanged(const GURL& url);
 
+  NTPP3AHelper* GetP3AHelper() const;
+
  private:
   // Sync with themeValues in brave_appearance_page.js
   enum ThemesOption {


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/28390
Resolves https://github.com/brave/brave-browser/issues/45035

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.