### PR TITLE
fix(iOS): Fix Yahoo! JP Position in Quick Search List for  Phase 1 Via Upgrading 

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -214,8 +214,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       && !Preferences.Search.yahooJPPhaseOneCompleted.value
     {
       // Not a new install. DSE has been set previously.
+      // Still need to insert Yahoo! JAPAN in the engine list during `InitialSearchEngines` initialization
+      // but not override the current DSE value
       Preferences.Search.shouldOverrideDSEForJapanRegion.value = false
-      Preferences.Search.yahooJPPhaseOneCompleted.value = true
     }
 
     Preferences.General.isFirstLaunch.value = false
@@ -227,6 +228,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
       // was not set.
       if Preferences.Search.defaultEngineName.value == nil {
         AppState.shared.profile.searchEngines.searchEngineSetup()
+        Preferences.Search.yahooJPPhaseOneCompleted.value = true
+      } else if !Preferences.Search.yahooJPPhaseOneCompleted.value {
+        // Upgrade from existed version which has a DSE set. Need to insert Yahoo! JAPAN into
+        // the correct position of the ordered search engines list
+        AppState.shared.profile.searchEngines.updateYahooJPOrderIfNeeded()
         Preferences.Search.yahooJPPhaseOneCompleted.value = true
       }
     }

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchEngines.swift
@@ -74,6 +74,21 @@ public class SearchEngines {
     setInitialDefaultEngine(engine.legacyName ?? engine.rawValue)
   }
 
+  public func updateYahooJPOrderIfNeeded() {
+    guard let region = locale.region?.identifier,
+      initialSearchEngines.yahooJapanEnabledRegions.contains(region),
+      DefaultEngineType.standard.option.value
+        != InitialSearchEngines.SearchEngineID.yahoojp.rawValue
+    else { return }
+    // Move Yahoo! JP to the second position (after the DSE)
+    if let oldIndex = orderedEngines.firstIndex(where: {
+      $0.engineID == InitialSearchEngines.SearchEngineID.yahoojp.rawValue
+    }) {
+      let yahooJP = orderedEngines.remove(at: oldIndex)
+      orderedEngines.insert(yahooJP, at: 1)
+    }
+  }
+
   private var loadingStream: AsyncStream<Void>?
 
   public func loadSearchEngines() async {


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45072

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

# Test Plan:
1. Make sure device region is set to Japan
2. Download 1.76.x or older build
3. Open the app to make sure it has a DSE value (default should be Google)
4. Upgrade the build to a build has this PR changes
5. Open the app 
6. Observe Yahoo! JAPAN is at the top of the engine list for Standard Tab and Private Tab under All Settings/Search Engines
7. Observe Yahoo! JAPAN is the the top of the engine list under All Settings/Search Engines/Quick-Search Engines
8. open a NTP and start typing in the omnibox
9. Observe Yahoo! JAPAN is at the second position beside the DSE (Search icon -> Google -> Yahoo! JAPAN)
10. Go to All Settings/Search Engines/Quick-Search Engines and edit to move Bing a head of Yahoo! JAPAN.
11. open a NTP and start typing in the omnibox
12. Observe Yahoo! JAPAN is at the correct position (Search icon -> Google -> Bing -> Yahoo! JAPAN)
13. Do a fresh install with a build has this PR changes
14. open the app
15. observe Yahoo! JAPAN is the DSE for standard tab. Yahoo! JAPAN is at the top of the search engine list for both standard and private tab. Yahoo! JAPAN is the first search engine in the quick search bar right beside the search icon.

Note: The issue mentions the expected behaviours is Leo -> DSE -> Yahoo! JAPAN
Since Leo does not live in the quick search bar yet (will be introduced in this pr https://github.com/brave/brave-core/pull/27825). The correct expected behaviours is Search icon -> DSE -> Yahoo! JAPAN
