### PR TITLE
[canary] Adding `RepositoryTest`

### DIFF
--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python3
+# # Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+from unittest.mock import patch
+from pathlib import PurePath
+from repository import Repository
+from test.fake_chromium_repo import FakeChromiumRepo
+import os
+
+
+class RepositoryTest(unittest.TestCase):
+
+    def setUp(self):
+        """Set up a fake Chromium repository for testing."""
+        self.fake_repo = FakeChromiumRepo()
+        self.fake_repo.add_dep('v8')
+        self.fake_repo.add_dep('third_party/test1')
+        self.addCleanup(self.fake_repo.cleanup)
+
+        # Patch BRAVE_CORE_PATH and CHROMIUM_SRC_PATH
+        self.brave_patch = patch('repository.BRAVE_CORE_PATH',
+                                 PurePath(self.fake_repo.brave))
+        self.chromium_patch = patch('repository.CHROMIUM_SRC_PATH',
+                                    PurePath(self.fake_repo.chromium))
+        self.brave_patch.start()
+        self.chromium_patch.start()
+        self.addCleanup(self.brave_patch.stop)
+        self.addCleanup(self.chromium_patch.stop)
+
+        # Change the current working directory to the fake Chromium repo
+        self.original_cwd = os.getcwd()
+        os.chdir(self.fake_repo.brave)
+        self.addCleanup(os.chdir, self.original_cwd)
+
+    def test_chromium_repository(self):
+        repo = Repository.chromium()
+        self.assertEqual(repo.path, PurePath(self.fake_repo.chromium))
+        self.assertTrue(repo.is_chromium)
+        self.assertFalse(repo.is_brave)
+
+    def test_brave_repository(self):
+        repo = Repository.brave()
+        self.assertEqual(repo.path, PurePath(self.fake_repo.brave))
+        self.assertTrue(repo.is_brave)
+        self.assertFalse(repo.is_chromium)
+
+    def test_to_brave(self):
+        self.assertEqual(
+            Repository(self.fake_repo.chromium).to_brave(), PurePath('brave'))
+        self.assertEqual(
+            Repository(self.fake_repo.brave).to_brave(), PurePath('../brave'))
+        self.assertEqual(
+            Repository(self.fake_repo.chromium / 'v8').to_brave(),
+            PurePath('../brave'))
+        self.assertEqual(
+            Repository(
+                self.fake_repo.chromium / 'third_party/test1').to_brave(),
+            PurePath('../../brave'))
+
+    def test_from_brave(self):
+        self.assertEqual(
+            Repository(self.fake_repo.chromium).from_brave(), PurePath('../'))
+        self.assertEqual(
+            Repository(self.fake_repo.brave).from_brave(),
+            PurePath('../brave'))
+        self.assertEqual(
+            Repository(self.fake_repo.chromium / 'v8').from_brave(),
+            PurePath('../v8'))
+        self.assertEqual(
+            Repository(self.fake_repo.chromium /
+                       'third_party/test1').from_brave(),
+            PurePath('../third_party/test1'))
+        self.assertEqual(
+            Repository(self.fake_repo.chromium /
+                       'third_party/test1').from_brave('test_file.txt'),
+            PurePath('../third_party/test1/test_file.txt'))
+
+    def test_run_git(self):
+        """Test Repository.run_git by verifying the hash of the last commit."""
+        # Verify the hash of the last commit using Repository.run_git
+        self.assertEqual(
+            self.fake_repo.commit_empty("Empty commit in brave",
+                                        self.fake_repo.brave),
+            Repository.brave().run_git("rev-parse", "HEAD"),
+        )
+        self.assertEqual(
+            self.fake_repo.commit_empty("Empty commit in chromium",
+                                        self.fake_repo.chromium),
+            Repository.chromium().run_git("rev-parse", "HEAD"),
+        )
+        self.assertEqual(
+            self.fake_repo.commit_empty("Empty commit in v8",
+                                        self.fake_repo.chromium / "v8"),
+            Repository(self.fake_repo.chromium / "v8").run_git(
+                "rev-parse", "HEAD"),
+        )
+        self.assertEqual(
+            self.fake_repo.commit_empty(
+                "Empty commit in third_party/test1",
+                self.fake_repo.chromium / "third_party/test1"),
+            Repository(self.fake_repo.chromium / "third_party/test1").run_git(
+                "rev-parse", "HEAD"),
+        )
+
+    def test_unstage_all_changes(self):
+        """Test unstage_all_changes and has_staged_changed."""
+        # Create a new file and stage it
+        test_file = self.fake_repo.chromium / "test_file.txt"
+        test_file.write_text("Test content")
+        repo = Repository.chromium()
+        repo.run_git("add", str(test_file))
+
+        # Verify the file is staged and has_staged_changed returns True
+        staged_files = repo.run_git("diff", "--cached", "--name-only")
+        self.assertIn("test_file.txt", staged_files)
+        self.assertTrue(repo.has_staged_changed())
+
+        # Unstage all changes
+        repo.unstage_all_changes()
+
+        # Verify the file is no longer staged and has_staged_changed is false
+        staged_files_after = repo.run_git("diff", "--cached", "--name-only")
+        self.assertNotIn("test_file.txt", staged_files_after)
+        self.assertFalse(repo.has_staged_changed())
+
+    def test_get_commit_short_description(self):
+        """Test get_commit_short_description using the chromium repository."""
+        # Create an empty commit with a specific message
+        commit_message = "Test commit message"
+        commit_hash = self.fake_repo.commit_empty(commit_message,
+                                                  self.fake_repo.chromium)
+
+        # Verify the short description of the commit
+        repo = Repository.chromium()
+        short_description = repo.get_commit_short_description(commit_hash)
+        self.assertEqual(short_description, commit_message)
+
+    def test_git_commit(self):
+        """Test git_commit."""
+        repo = Repository.chromium()
+
+        # Case 1: Commit with staged changes
+        test_file = self.fake_repo.chromium / "test_file.txt"
+        test_file.write_text("Test content")
+        repo.run_git("add", str(test_file))
+        commit_message = "Add test_file.txt"
+        repo.git_commit(commit_message)
+
+        # Verify the commit message
+        last_commit_message = repo.get_commit_short_description()
+        self.assertEqual(last_commit_message, commit_message)
+
+        # Case 2: Commit with no staged changes
+        repo.git_commit("This should not create a commit")
+        # Verify that the last commit message remains unchanged
+        last_commit_message_after = repo.get_commit_short_description()
+        self.assertEqual(last_commit_message_after, commit_message)
+
+    def test_is_valid_git_reference(self):
+        """Test is_valid_git_reference using the chromium repository."""
+        repo = Repository.chromium()
+
+        # Create a valid commit and verify the reference
+        commit_message = "Valid commit"
+        valid_commit_hash = self.fake_repo.commit_empty(
+            commit_message, self.fake_repo.chromium)
+        self.assertTrue(repo.is_valid_git_reference(valid_commit_hash))
+
+        # Test an invalid reference
+        self.assertFalse(repo.is_valid_git_reference("invalid_reference"))
+
+    def test_last_changed(self):
+        """Test last_changed using the chromium repository."""
+        repo = Repository.chromium()
+
+        # Create and commit a file
+        self.fake_repo.commit_empty('empty #1', self.fake_repo.chromium)
+        file_commits = []
+        self.fake_repo.write_and_stage_file("test_file.txt", "Initial content",
+                                            self.fake_repo.chromium)
+        file_commits.append(
+            self.fake_repo.commit("Initial commit for test_file.txt",
+                                  self.fake_repo.chromium))
+        self.fake_repo.commit_empty('empty #2', self.fake_repo.chromium)
+
+        # Modify and commit the file again
+        self.fake_repo.commit_empty('empty #3', self.fake_repo.chromium)
+        self.fake_repo.write_and_stage_file("test_file.txt", "Updated content",
+                                            self.fake_repo.chromium)
+        file_commits.append(
+            self.fake_repo.commit("Updated test_file.txt",
+                                  self.fake_repo.chromium))
+        self.fake_repo.commit_empty('empty #4', self.fake_repo.chromium)
+
+        # Verify last_changed returns the latest commit hash for the file
+        last_changed_hash = repo.last_changed("test_file.txt")
+        self.assertEqual(last_changed_hash[:7], file_commits[-1][:7])
+
+        # Verify last_changed with a specific from_commit returns the correct
+        # hash
+        last_changed_from_initial = repo.last_changed(
+            "test_file.txt", from_commit=f'{file_commits[-1]}~1')
+        self.assertEqual(last_changed_from_initial[:7], file_commits[-2][:7])
+
+    def test_read_file(self):
+        """Test read_file, including reading multiple files."""
+        repo = Repository.chromium()
+
+        # Create and commit two files
+        self.fake_repo.write_and_stage_file("file1.txt", "Content of file 1\n",
+                                            self.fake_repo.chromium)
+        commit1 = self.fake_repo.commit("Add file1.txt",
+                                        self.fake_repo.chromium)
+
+        self.fake_repo.write_and_stage_file("file2.txt", "Content of file 2\n",
+                                            self.fake_repo.chromium)
+        commit2 = self.fake_repo.commit("Add file2.txt",
+                                        self.fake_repo.chromium)
+
+        # Test reading a single file
+        content_file1 = repo.read_file("file1.txt", commit=commit1)
+        self.assertEqual(content_file1, "Content of file 1\n")
+
+        # Test reading multiple files
+        content_files = repo.read_file("file1.txt",
+                                       "file2.txt",
+                                       commit=commit2)
+        self.assertIn("Content of file 1\n", content_files)
+        self.assertIn("Content of file 2\n", content_files)
+
+        # Test enforcing no_trim (ensure trailing newlines are preserved)
+        self.fake_repo.write_and_stage_file(
+            "file3.txt", "Content with trailing newline\n\n",
+            self.fake_repo.chromium)
+        commit3 = self.fake_repo.commit("Add file3.txt",
+                                        self.fake_repo.chromium)
+        content_file3 = repo.read_file("file3.txt", commit=commit3)
+        self.assertEqual(content_file3, "Content with trailing newline\n\n")
+
+    def test_current_branch(self):
+        """Test current_branch using the chromium repository."""
+        repo = Repository.chromium()
+
+        # Verify the default branch is "master" or "main"
+        current_branch = repo.current_branch()
+        self.assertIn(current_branch, ["master", "main"])
+
+        # Create and switch to a new branch
+        new_branch = "test-branch"
+        repo.run_git("checkout", "-b", new_branch)
+
+        # Verify the current branch is updated
+        self.assertEqual(repo.current_branch(), new_branch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import tempfile
+import subprocess
+from pathlib import Path
+from typing import List
+
+CHROME_VERSION_TEMPLATE: str = """MAJOR={major}
+MINOR={minor}
+BUILD={build}
+PATCH={patch}
+"""
+
+
+class FakeChromiumRepo:
+    """A fake Chromium repository for testing purposes."""
+
+    def __init__(self) -> None:
+        """Initializes the fake Chromium repository.
+
+        Creates a temporary directory and initializes a fake Chromium repository
+        with a `src` directory. Also creates a `brave` repository inside `src`.
+        """
+        self.temp_dir: tempfile.TemporaryDirectory = (
+            tempfile.TemporaryDirectory())
+        self.base_path: Path = Path(self.temp_dir.name)
+        self._init_repo(self.chromium)
+        self._init_repo(self.brave)  # Create the brave repository
+
+    @property
+    def chromium(self) -> Path:
+        """Returns the path to the Chromium source directory."""
+        return self.base_path / "src"
+
+    @property
+    def brave(self) -> Path:
+        """Returns the path to the Brave directory"""
+        return self.chromium / "brave"
+
+    def _run_git_command(self, command: List[str], cwd: Path) -> str:
+        """Runs a git command in the specified directory and returns the stdout.
+
+        Args:
+            command: The git command to execute as a list of strings.
+            cwd: The directory in which to run the command.
+
+        Returns:
+            The stdout output of the git command as a string.
+        """
+        return subprocess.check_output(command,
+                                       cwd=cwd,
+                                       stderr=subprocess.DEVNULL,
+                                       text=True).strip()
+
+    def _init_repo(self, path: Path) -> None:
+        """Initializes a git repository at the specified path.
+
+        Creates a `README.md` file, stages it, and makes an initial commit.
+
+        Args:
+            path: The path where the repository should be initialized.
+        """
+        path.mkdir(parents=True, exist_ok=True)
+        self._run_git_command(["git", "init"], path)
+        (path / "README.md").write_text(f"# Fake {path.name} repo\n")
+        self._run_git_command(["git", "add", "README.md"], path)
+        self._run_git_command(["git", "commit", "-m", "Initial commit"], path)
+
+    def add_repo(self, relative_path: str) -> None:
+        """Adds a new repository at the specified relative path.
+
+        Args:
+            relative_path: The relative path for the new repository.
+        """
+        repo_path: Path = self.chromium / relative_path
+        self._init_repo(repo_path)
+
+    def add_dep(self, relative_path: str) -> None:
+        """Adds a dependency as a git submodule.
+
+        Initializes a repository at the specified path and adds it as a
+        submodule to the main repository.
+
+        Args:
+            relative_path: The relative path of the dependency to add.
+        """
+        dep_path: Path = self.chromium / relative_path
+        self._init_repo(dep_path)
+        self._run_git_command(
+            ["git", "submodule", "add",
+             str(dep_path), relative_path], self.chromium)
+        self._run_git_command(
+            ["git", "commit", "-m", f"Add submodule {relative_path}"],
+            self.chromium)
+
+    def add_tag(self, version: str) -> None:
+        """Adds a git tag to the repository.
+
+        Creates a `VERSION` file with the specified version and commits it,
+        then tags the commit with the version.
+
+        Args:
+            version: The version string in the format `MAJOR.MINOR.BUILD.PATCH`.
+        """
+        major, minor, build, patch = version.split(".")
+        version_file: Path = self.chromium / "chrome" / "VERSION"
+        version_file.parent.mkdir(parents=True, exist_ok=True)
+        version_file.write_text(
+            CHROME_VERSION_TEMPLATE.format(major=major,
+                                           minor=minor,
+                                           build=build,
+                                           patch=patch))
+        self._run_git_command(["git", "add", str(version_file)], self.chromium)
+        self._run_git_command(["git", "commit", "-m", f"VERSION {version}"],
+                              self.chromium)
+        self._run_git_command(["git", "tag", version], self.chromium)
+
+    def commit_empty(self, commit_message: str, repo_path: Path) -> str:
+        """Creates an empty commit for a repository and returns a hash.
+
+        Args:
+            commit_message: The message to use for the empty commit.
+            repo_path: The repository path.
+
+        Returns:
+            The hash of the commit made.
+        """
+        self._run_git_command(
+            ["git", "commit", "--allow-empty", "-m", commit_message],
+            repo_path)
+        return self._run_git_command(["git", "rev-parse", "HEAD"], repo_path)
+
+    def commit(self, commit_message: str, repo_path: Path) -> str:
+        """Creates commit in the passed repository and returns a hash.
+
+        Args:
+            commit_message: The message to use for the commit.
+            repo_path: The repository path.
+
+        Returns:
+            The hash of the commit made.
+        """
+        self._run_git_command(["git", "commit", "-m", commit_message],
+                              repo_path)
+        return self._run_git_command(["git", "rev-parse", "HEAD"], repo_path)
+
+    def write_and_stage_file(self, relative_path: str, content: str,
+                             repo_path: Path) -> None:
+        """Writes content to a file and stages it in the specified repository.
+
+        Args:
+            relative_path: The relative path of the file to write.
+            content: The content to write to the file.
+            repo_path: The path to the repository.
+        """
+        file_path = repo_path / relative_path
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content)
+        self._run_git_command(["git", "add", str(file_path)], repo_path)
+
+    def cleanup(self) -> None:
+        """Cleans up the temporary directory used for the fake repository."""
+        self.temp_dir.cleanup()


### PR DESCRIPTION
This is the first of the test converage for B🚀. This also intrduces `FakeChromiumRepo`, which acts like a stand in for the chromium repo, and others. This is the place where we will emulate `npm run` functionalities for other parts of brockit.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45123

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
