### PR TITLE
Add notification permission for rewards 3.0

### DIFF
--- a/android/java/org/chromium/chrome/browser/notifications/BravePermissionUtils.java
+++ b/android/java/org/chromium/chrome/browser/notifications/BravePermissionUtils.java
@@ -29,7 +29,10 @@ import org.chromium.chrome.browser.notifications.channels.BraveChannelDefinition
 public class BravePermissionUtils {
     private static final String APP_PACKAGE = "app_package";
     private static final String APP_UID = "app_uid";
-    private static final int NOTIFICATION_PERMISSION_CODE = 123;
+    public static final int NOTIFICATION_PERMISSION_CODE = 123;
+
+    public static final String REWARDS_NOTIFICATION_PERMISSION_COUNT =
+            "rewards_notification_permission_count";
 
     public static boolean hasNotificationPermission(Context context) {
         return hasPermission(context, Manifest.permission.POST_NOTIFICATIONS);


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45135

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Test plan : 

**Note : **
This PR change is applicable exclusively to devices running Android 13 or later versions, as it is necessary to request notification permissions solely for devices operating on Android versions above 12.

Test1 : 
1. Install the updated version of Brave.
2. open rewards panel
3. System model to ask for notification permission should be shown
4. Tap `allow`
5. Verify the permission in notification settings

Test 2 : 
1. Install the updated version of Brave.
2. Open rewards panel
3. A system modal requesting notification permissions should appear
4. Select `Deny`
5. A snackbar will display a message prompting users to visit settings to enable notification permissions
6. Close the panel
7. Open rewards panel
8. A system modal requesting notification permissions should appear.
9. Select `Deny`
10. A snackbar will display a message prompting users to visit settings to enable notification permissions
11. Close the panel
12. Open rewards panel
13. If the Notification Rate Limits apply (meaning we can't show the system model anymore), a snackbar will appear, prompting users to visit settings to enable notification permissions.
14. Close the rewards panel
15. Open rewards panel
16. The system modal or snackbar should no longer appear, as the request is limited to three prompts.