### PR TITLE
Fixed crash when toggling playlist panel while it's playing (uplift to 1.78.x)

### DIFF
--- a/browser/playlist/test/BUILD.gn
+++ b/browser/playlist/test/BUILD.gn
@@ -41,7 +41,10 @@ source_set("browser_tests") {
   if (is_android) {
     deps += [ "//chrome/test:test_support_ui_android" ]
   } else {
-    deps += [ "//chrome/test:test_support_ui" ]
+    deps += [
+      "//chrome/browser/ui/browser_window",
+      "//chrome/test:test_support_ui",
+    ]
   }
 }
 

--- a/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
+++ b/browser/ui/views/side_panel/playlist/playlist_side_panel_coordinator.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <string>
 
+#include "base/gtest_prod_util.h"
 #include "base/scoped_observation.h"
 #include "brave/browser/ui/views/side_panel/playlist/playlist_contents_wrapper.h"
 #include "brave/browser/ui/views/side_panel/playlist/playlist_side_panel_web_view.h"
@@ -18,6 +19,7 @@
 
 namespace playlist {
 class PlaylistUI;
+FORWARD_DECLARE_TEST(PlaylistBrowserTest, PanelToggleTestWhilePlaying);
 }  // namespace playlist
 
 class Browser;
@@ -71,6 +73,8 @@ class PlaylistSidePanelCoordinator
 
  private:
   friend class BrowserUserData<PlaylistSidePanelCoordinator>;
+  FRIEND_TEST_ALL_PREFIXES(playlist::PlaylistBrowserTest,
+                           PanelToggleTestWhilePlaying);
 
   void DestroyWebContentsIfNeeded();
 
@@ -78,6 +82,7 @@ class PlaylistSidePanelCoordinator
 
   raw_ptr<Browser> browser_ = nullptr;
 
+  bool is_audible_for_testing_ = false;
   std::unique_ptr<PlaylistContentsWrapper> contents_wrapper_;
 
   base::WeakPtr<PlaylistSidePanelWebView> side_panel_web_view_;


### PR DESCRIPTION
Uplift of #28485
fix https://github.com/brave/brave-browser/issues/45144

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.