### PR TITLE
[Android] Yahoo phase 2

### DIFF
--- a/android/java/org/chromium/base/BravePreferenceKeys.java
+++ b/android/java/org/chromium/base/BravePreferenceKeys.java
@@ -96,6 +96,8 @@ public final class BravePreferenceKeys {
 
     public static final String DEFAULT_SEARCH_ENGINE_CHANGED = "default_search_engine_changed";
 
+    public static final String BRAVE_DEFAULT_SEARCH_ENGINE_MIGRATED_JP = "brave_default_search_engine_migrated_jp";
+
     /*
      * Checks if preference key is used in Brave.
      * It's no op currently. We might reconsider

--- a/android/java/org/chromium/base/BravePreferenceKeys.java
+++ b/android/java/org/chromium/base/BravePreferenceKeys.java
@@ -96,7 +96,8 @@ public final class BravePreferenceKeys {
 
     public static final String DEFAULT_SEARCH_ENGINE_CHANGED = "default_search_engine_changed";
 
-    public static final String BRAVE_DEFAULT_SEARCH_ENGINE_MIGRATED_JP = "brave_default_search_engine_migrated_jp";
+    public static final String BRAVE_DEFAULT_SEARCH_ENGINE_MIGRATED_JP =
+            "brave_default_search_engine_migrated_jp";
 
     /*
      * Checks if preference key is used in Brave.

--- a/android/java/org/chromium/chrome/browser/BraveRewardsOnboardingPagerAdapter.java
+++ b/android/java/org/chromium/chrome/browser/BraveRewardsOnboardingPagerAdapter.java
@@ -21,6 +21,7 @@ import org.chromium.base.ContextUtils;
 import org.chromium.base.Log;
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.profiles.ProfileManager;
+import org.chromium.chrome.browser.util.BraveConstants;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +31,6 @@ public class BraveRewardsOnboardingPagerAdapter extends PagerAdapter {
     private static final String TAG = "RewardsOnboarding";
     private boolean shouldShowMoreOptions;
     private TextView adsPerHourText;
-    private static final String JAPAN_COUNTRY_CODE = "JP";
     private String countryCode = BraveRewardsNativeWorker.getInstance().getCountryCode();
     private List<Integer> adsPerHourValues = Arrays.asList(0, 1, 2, 3, 4, 5, 10);
 
@@ -90,7 +90,7 @@ public class BraveRewardsOnboardingPagerAdapter extends PagerAdapter {
         List<String> headers = new ArrayList();
         headers.add(context.getResources().getString(R.string.welcome_to_brave_rewards));
         headers.add(context.getResources().getString(R.string.where_do_ads_show_up));
-        if (!countryCode.equals(JAPAN_COUNTRY_CODE)) {
+        if (!countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)) {
             headers.add(context.getResources().getString(R.string.giving_back_made_effortless));
         }
         headers.add(context.getResources().getString(R.string.say_thank_you_with_tips));
@@ -103,7 +103,7 @@ public class BraveRewardsOnboardingPagerAdapter extends PagerAdapter {
         List<String> texts = new ArrayList();
         texts.add(context.getResources().getString(R.string.welcome_to_brave_rewards_text));
         texts.add(context.getResources().getString(R.string.where_do_ads_show_up_text));
-        if (!countryCode.equals(JAPAN_COUNTRY_CODE)) {
+        if (!countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)) {
             texts.add(context.getResources().getString(R.string.giving_back_made_effortless_text));
         }
         texts.add(context.getResources().getString(R.string.say_thank_you_with_tips_text));
@@ -116,7 +116,7 @@ public class BraveRewardsOnboardingPagerAdapter extends PagerAdapter {
         List<Integer> images = new ArrayList();
         images.add(R.drawable.ic_onboarding_graphic_bat_ecosystem);
         images.add(R.drawable.ic_onboarding_graphic_android_brave_ads);
-        if (!countryCode.equals(JAPAN_COUNTRY_CODE)) {
+        if (!countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)) {
             images.add(R.drawable.ic_onboarding_graphic_auto_contribute);
         }
         images.add(R.drawable.ic_onboarding_graphic_tipping);

--- a/android/java/org/chromium/chrome/browser/app/BraveActivity.java
+++ b/android/java/org/chromium/chrome/browser/app/BraveActivity.java
@@ -1328,12 +1328,16 @@ public abstract class BraveActivity extends ChromeActivity
 
                     if (!isDefaultSearchEngineChanged
                             && countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)
-                            && templateUrlService.isDefaultSearchEngineGoogle()) {
+                            && templateUrlService.isDefaultSearchEngineGoogle()
+                            && !ChromeSharedPreferences.getInstance()
+                                    .readBoolean(BravePreferenceKeys.BRAVE_DEFAULT_SEARCH_ENGINE_MIGRATED_JP, false)) {
                         BraveSearchEngineUtils.setDSEPrefs(
                                 BraveSearchEngineUtils.getTemplateUrlByShortName(
                                         getCurrentProfile(), OnboardingPrefManager.YAHOO_JP),
                                 getCurrentProfile()
                                         .getPrimaryOtrProfile(/* createIfNeeded= */ true));
+                        ChromeSharedPreferences.getInstance()
+                                .writeBoolean(BravePreferenceKeys.BRAVE_DEFAULT_SEARCH_ENGINE_MIGRATED_JP, true);
                     }
                 };
         templateUrlService.runWhenLoaded(onTemplateUrlServiceReady);

--- a/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
@@ -66,6 +66,7 @@ public class OnboardingPrefManager {
 
     public static final String BRAVE = "Brave";
     public static final String YANDEX = "Yandex";
+    public static final String YAHOO_JP = "yahoo.co.jp";
 
     private OnboardingPrefManager() {
         mSharedPreferences = ContextUtils.getAppSharedPreferences();

--- a/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/OnboardingPrefManager.java
@@ -66,7 +66,7 @@ public class OnboardingPrefManager {
 
     public static final String BRAVE = "Brave";
     public static final String YANDEX = "Yandex";
-    public static final String YAHOO_JP = "yahoo.co.jp";
+    public static final String YAHOO_JP = "Yahoo! JAPAN";
 
     private OnboardingPrefManager() {
         mSharedPreferences = ContextUtils.getAppSharedPreferences();

--- a/android/java/org/chromium/chrome/browser/onboarding/v2/HighlightDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/v2/HighlightDialogFragment.java
@@ -22,13 +22,13 @@ import android.widget.ImageView;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.ViewPager;
-import org.chromium.chrome.browser.util.BraveConstants;
 
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
 import org.chromium.chrome.browser.brave_stats.BraveStatsUtil;
 import org.chromium.chrome.browser.notifications.retention.RetentionNotificationUtil;
 import org.chromium.chrome.browser.onboarding.OnboardingPrefManager;
+import org.chromium.chrome.browser.util.BraveConstants;
 
 import java.util.Arrays;
 import java.util.List;
@@ -204,7 +204,8 @@ public class HighlightDialogFragment extends DialogFragment {
 
     private void checkAndOpenNtpPage() {
         String countryCode = Locale.getDefault().getCountry();
-        if (((BraveActivity) getActivity()) != null && countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)) {
+        if (((BraveActivity) getActivity()) != null
+                && countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)) {
             ((BraveActivity) getActivity()).openNewOrSelectExistingTab(NTP_TUTORIAL_PAGE);
         }
     }

--- a/android/java/org/chromium/chrome/browser/onboarding/v2/HighlightDialogFragment.java
+++ b/android/java/org/chromium/chrome/browser/onboarding/v2/HighlightDialogFragment.java
@@ -22,6 +22,7 @@ import android.widget.ImageView;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.viewpager.widget.ViewPager;
+import org.chromium.chrome.browser.util.BraveConstants;
 
 import org.chromium.chrome.R;
 import org.chromium.chrome.browser.app.BraveActivity;
@@ -203,7 +204,7 @@ public class HighlightDialogFragment extends DialogFragment {
 
     private void checkAndOpenNtpPage() {
         String countryCode = Locale.getDefault().getCountry();
-        if (((BraveActivity) getActivity()) != null && countryCode.equals("JP")) {
+        if (((BraveActivity) getActivity()) != null && countryCode.equals(BraveConstants.JAPAN_COUNTRY_CODE)) {
             ((BraveActivity) getActivity()).openNewOrSelectExistingTab(NTP_TUTORIAL_PAGE);
         }
     }

--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
@@ -55,7 +55,6 @@ public class BraveBaseSearchEngineAdapter extends BaseAdapter {
         Set<String> templateUrlSet = new HashSet<String>();
         Iterator<TemplateUrl> iterator = templateUrls.iterator();
         while (iterator.hasNext()) {
-            Log.e("brave_search", "templateUrl: " + iterator.next().getShortName());
             TemplateUrl templateUrl = iterator.next();
             if (!templateUrlSet.contains(templateUrl.getShortName())) {
                 templateUrlSet.add(templateUrl.getShortName());

--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
@@ -11,6 +11,8 @@ import android.widget.BaseAdapter;
 
 import org.chromium.components.search_engines.TemplateUrl;
 
+import org.chromium.base.Log;
+
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -53,6 +55,7 @@ public class BraveBaseSearchEngineAdapter extends BaseAdapter {
         Set<String> templateUrlSet = new HashSet<String>();
         Iterator<TemplateUrl> iterator = templateUrls.iterator();
         while (iterator.hasNext()) {
+            Log.e("brave_search", "templateUrl: " + iterator.next().getShortName());
             TemplateUrl templateUrl = iterator.next();
             if (!templateUrlSet.contains(templateUrl.getShortName())) {
                 templateUrlSet.add(templateUrl.getShortName());

--- a/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
+++ b/android/java/org/chromium/chrome/browser/search_engines/settings/BraveBaseSearchEngineAdapter.java
@@ -11,8 +11,6 @@ import android.widget.BaseAdapter;
 
 import org.chromium.components.search_engines.TemplateUrl;
 
-import org.chromium.base.Log;
-
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;

--- a/android/java/org/chromium/chrome/browser/util/BraveConstants.java
+++ b/android/java/org/chromium/chrome/browser/util/BraveConstants.java
@@ -27,6 +27,7 @@ public final class BraveConstants {
             "https://brave.com/privacy/browser/#brave-news";
 
     public static final String INDIA_COUNTRY_CODE = "IN";
+    public static final String JAPAN_COUNTRY_CODE = "JP";
 
     public static final String BRAVE_NEWS_PREFERENCES_TYPE = "BraveNewsPreferencesType";
 


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44915

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->


# Test Plan for DSE Behavior in Version 1.78  

## 1. New Users on Version 1.78  
- Default Search Engine (DSE) is set to **Yahoo! JAPAN**.  

## 2. Upgrade from Version 1.77 to 1.78  
- **If the user did not modify the DSE in version 1.77:**  
  - If DSE was **Yahoo! JAPAN** → It remains **Yahoo! JAPAN** in 1.78.  
  - If DSE was **any other search engine (excluding Google/Yahoo! JAPAN)** → It remains unchanged in 1.78.  

- **If the user modified the DSE in version 1.77:**  
  - The user's chosen DSE is respected in 1.78.  

## 3. Direct Upgrade from Version ≤ 1.76 to 1.78  
- If DSE was **Google** → It changes to **Yahoo! JAPAN** in 1.78.  
- If DSE was **any search engine other than Google** → It remains unchanged in 1.78.  

## 4. Upgrade Path: Version ≤ 1.76 → 1.77 → 1.78  
- If DSE was **Google** in 1.76:  
  - If the user **did not modify** DSE in 1.77 → It changes to **Yahoo! JAPAN** in 1.78.  
  - If the user **changed DSE to another search engine (e.g., DDG) in 1.77** → It remains as that search engine in 1.78.  
  - If the user **changed DSE to another search engine (e.g., DDG) and then back to Google in 1.77** → It remains **Google** in 1.78.  

- If DSE was **any search engine other than Google (e.g., DDG) in 1.76**:  
  - If the user **did not modify** DSE in 1.77 → It remains unchanged in 1.78.  
