### PR TITLE
[CODEOWNERS]: Add @fallaciousreasoning as a CODEOWNER for Lit Mangling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,10 @@ chromium_src/**/extensions/**/*_features.json @brave/sec-team
 chromium_src/tools/json_schema_compiler/ @brave/sec-team
 common/extensions/api/ @brave/sec-team
 
+# Lit Mangling
+chromium_src/**/*.lit_mangler.ts @fallaciousreasoning
+tools/chromium_src/lit_mangler/ @fallaciousreasoning
+
 # Brave theme
 browser/themes @simonhong
 


### PR DESCRIPTION
I've been talking to @cdesouza-chromium about ways we can make rebasing the lit mangling stuff easier. One idea we came up with was to automatically update the snapshot tests when they fail and ping me for review when they get modified.