### PR TITLE
[iOS] Update Playlist timestamp formatting when content over 1 hour long

### DIFF
--- a/ios/brave-ios/Sources/PlaylistUI/MediaScrubber.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/MediaScrubber.swift
@@ -39,7 +39,7 @@ struct MediaScrubber<Label: View>: View {
   @Environment(\.layoutDirection) private var layoutDirection
 
   private var currentValueLabel: Text {
-    return Text(.seconds(currentTime), format: .time(pattern: .minuteSecond))
+    return Text(.seconds(currentTime), format: .timestamp)
   }
 
   @ViewBuilder private var remainingTimeLabel: some View {
@@ -47,7 +47,7 @@ struct MediaScrubber<Label: View>: View {
     case .unknown:
       EmptyView()
     case .seconds(let duration):
-      Text(.seconds(currentTime - duration), format: .time(pattern: .minuteSecond))
+      Text(.seconds(currentTime - duration), format: .timestamp)
     case .indefinite:
       Text(Strings.Playlist.liveIndicator)
     }
@@ -55,7 +55,7 @@ struct MediaScrubber<Label: View>: View {
 
   private var durationLabel: Text {
     if case .seconds(let duration) = duration {
-      return Text(.seconds(duration), format: .time(pattern: .minuteSecond))
+      return Text(.seconds(duration), format: .timestamp)
     }
     return Text("")
   }
@@ -202,7 +202,7 @@ struct DefaultMediaScrubberLabel: View {
 
   var body: some View {
     HStack {
-      Text(.seconds(currentTime), format: .time(pattern: .minuteSecond))
+      Text(.seconds(currentTime), format: .timestamp)
       Spacer()
       switch duration {
       case .unknown:
@@ -214,9 +214,9 @@ struct DefaultMediaScrubberLabel: View {
         } label: {
           Group {
             if isShowingTotalTime {
-              Text(.seconds(duration), format: .time(pattern: .minuteSecond))
+              Text(.seconds(duration), format: .timestamp)
             } else {
-              Text(.seconds(currentTime - duration), format: .time(pattern: .minuteSecond))
+              Text(.seconds(currentTime - duration), format: .timestamp)
             }
           }
           .transition(.move(edge: .trailing).combined(with: .opacity))
@@ -245,6 +245,12 @@ private struct MediaScrubberPreview: View {
       MediaScrubber(
         currentTime: $currentTime,
         duration: .seconds(1000),
+        isScrubbing: $isScrubbing
+      )
+      .padding()
+      MediaScrubber(
+        currentTime: $currentTime,
+        duration: .seconds(3600),
         isScrubbing: $isScrubbing
       )
       .padding()

--- a/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlayerView.swift
@@ -353,7 +353,7 @@ struct CompactMediaScrubberLabel: View {
   var duration: PlayerModel.ItemDuration
 
   private var currentValueLabel: Text {
-    return Text(.seconds(currentTime), format: .time(pattern: .minuteSecond))
+    return Text(.seconds(currentTime), format: .timestamp)
   }
 
   var body: some View {
@@ -361,7 +361,7 @@ struct CompactMediaScrubberLabel: View {
       currentValueLabel
       if case .seconds(let duration) = duration {
         Text(verbatim: "/")  // FIXME: Does this need some sort of localization?
-        Text(.seconds(currentTime - duration), format: .time(pattern: .minuteSecond))
+        Text(.seconds(currentTime - duration), format: .timestamp)
       }
     }
     .font(.caption2)

--- a/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/PlaylistItemView.swift
@@ -57,7 +57,7 @@ struct PlaylistItemView: View {
           switch duration {
           case .seconds(let duration):
             if duration > 0 {
-              Text(.seconds(duration), format: .time(pattern: .minuteSecond))
+              Text(.seconds(duration), format: .timestamp)
             } else {
               EmptyView()
             }

--- a/ios/brave-ios/Sources/PlaylistUI/TimestampFormatStyle.swift
+++ b/ios/brave-ios/Sources/PlaylistUI/TimestampFormatStyle.swift
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import Foundation
+
+/// Formats a Duration dynamically based on if the value is over an hour.
+struct TimestampFormatStyle: FormatStyle {
+  func format(_ value: Duration) -> String {
+    let pattern: Duration.TimeFormatStyle.Pattern
+    if abs(value.components.seconds) >= (60 * 60) {
+      pattern = .hourMinuteSecond
+    } else {
+      pattern = .minuteSecond
+    }
+    return value.formatted(.time(pattern: pattern))
+  }
+}
+
+extension FormatStyle where Self == TimestampFormatStyle {
+  static var timestamp: TimestampFormatStyle {
+    .init()
+  }
+}


### PR DESCRIPTION
This replaces the hardcoded minute second formatting used on the scrubber to dynamically include the hour if the duration is 60 minutes or longer

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45033

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
