### PR TITLE
Fixed crash when send tabs to desktop (uplift to 1.78.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.cc
@@ -23,7 +23,7 @@ void PinnedToolbarActionsContainer::UpdateActionState(actions::ActionId id,
 void PinnedToolbarActionsContainer::ShowActionEphemerallyInToolbar(
     actions::ActionId id,
     bool show) {
-  if (id != kActionShowDownloads) {
+  if (id != kActionShowDownloads && id != kActionSendTabToSelf) {
     return;
   }
   PinnedToolbarActionsContainer::ShowActionEphemerallyInToolbar_ChromiumImpl(

--- a/test/filters/browser_tests.filter
+++ b/test/filters/browser_tests.filter
@@ -1975,10 +1975,6 @@
 -RecentActivityBubbleDialogViewActionBrowserTest.HandlesActionFocusTab
 -RecentActivityBubbleDialogViewActionBrowserTest.HandlesActionReopenTab
 -SendTabToSelfBubbleTest.BubbleTriggersCorrectlyWhenPinned
--SendTabToSelfToolbarIconControllerTest.DisplayNewEntry
--SendTabToSelfToolbarIconControllerTest.ReplaceExistingEntry
--SendTabToSelfToolbarIconControllerTest.StorePendingNewEntryFromIncognitoBrowser
--SendTabToSelfToolbarIconControllerTest.StorePendingNewEntryFromWebApp
 
 # This test fails in CanvasImageSource::CreatePadded when checking
 # DCHECK(clip_rect.Contains(gfx::Rect(size_in_pixel))); when both clip_rect


### PR DESCRIPTION
Uplift of #28498
fix https://github.com/brave/brave-browser/issues/45198

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.