### PR TITLE
[cr135 follow up] Restores download button icon change for insecure downloads. (uplift to 1.78.x)

### DIFF
--- a/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc
+++ b/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc
@@ -1,0 +1,83 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.h"
+
+#include "chrome/browser/download/bubble/download_bubble_update_service.h"
+#include "chrome/browser/download/bubble/download_bubble_update_service_factory.h"
+#include "chrome/browser/download/download_ui_model.h"
+#include "components/vector_icons/vector_icons.h"
+
+#define DownloadToolbarUIController DownloadToolbarUIController_ChromiumImpl
+#include "src/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.cc"
+#undef DownloadToolbarUIController
+
+SkColor DownloadToolbarUIController_ChromiumImpl::GetIconColor(
+    bool is_dormant,
+    DownloadDisplay::IconActive active,
+    const ui::ColorProvider* color_provider) const {
+  return ::GetIconColor(is_dormant, active, color_provider);
+}
+
+SkColor DownloadToolbarUIController::GetIconColor(
+    bool is_dormant,
+    DownloadDisplay::IconActive active,
+    const ui::ColorProvider* color_provider) const {
+  // Apply active color only when download is completed and user doesn't
+  // interact with this button.
+  if (state_ == IconState::kComplete && active == IconActive::kActive) {
+    return color_provider->GetColor(kColorDownloadToolbarButtonActive);
+  }
+
+  // Otherwise, always use inactive color.
+  return color_provider->GetColor(kColorDownloadToolbarButtonInactive);
+}
+
+void DownloadToolbarUIController::UpdateIcon() {
+  DownloadToolbarUIController_ChromiumImpl::UpdateIcon();
+
+  if (!action_item_.get()) {
+    return;
+  }
+
+  auto* button = GetDownloadsButton(browser_view_);
+  if (!button) {
+    return;
+  }
+
+  // Use an exclamation point icon while there's an insecure download in the
+  // download models.
+  if (HasInsecureDownloads()) {
+    auto icon_color = browser_view_->GetColorProvider()->GetColor(
+        ui::kColorAlertMediumSeverityIcon);
+    button->SetIconEnabledColorsOverride(icon_color);
+    button->SetVectorIcon(vector_icons::kNotSecureWarningIcon);
+    const gfx::VectorIcon* new_icon = &vector_icons::kNotSecureWarningIcon;
+    const int icon_size = action_item_->GetImage().Size().height();
+    action_item_->SetImage(
+        ui::ImageModel::FromVectorIcon(*new_icon, icon_color, icon_size));
+  } else {
+    button->SetIconEnabledColorsOverride(std::nullopt);
+  }
+}
+
+bool DownloadToolbarUIController::HasInsecureDownloads() {
+  auto* update_service = DownloadBubbleUpdateServiceFactory::GetForProfile(
+      browser_view_->GetProfile());
+  if (!update_service || !update_service->IsInitialized()) {
+    return false;
+  }
+
+  std::vector<DownloadUIModel::DownloadUIModelPtr> all_models;
+  update_service->GetAllModelsToDisplay(all_models, /*web_app_id=*/nullptr,
+                                        /*force_backfill_download_items=*/true);
+
+  return std::ranges::any_of(all_models, [](const auto& model) {
+    return (model->GetInsecureDownloadStatus() ==
+                download::DownloadItem::InsecureDownloadStatus::BLOCK ||
+            model->GetInsecureDownloadStatus() ==
+                download::DownloadItem::InsecureDownloadStatus::WARN);
+  });
+}

--- a/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.h
+++ b/chromium_src/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.h
@@ -1,0 +1,47 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_UI_CONTROLLER_H_
+#define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_UI_CONTROLLER_H_
+
+#define DownloadToolbarUIController DownloadToolbarUIController_ChromiumImpl
+
+// Apply active color only when download is completed and user doesn't
+// interact with this button.
+#define UpdateIconDormant                                                      \
+  UpdateIconDormant();                                                         \
+                                                                               \
+ protected:                                                                    \
+  virtual SkColor GetIconColor(bool is_dormant,                                \
+                               DownloadDisplay::IconActive active,             \
+                               const ui::ColorProvider* color_provider) const; \
+  void UnUsed
+
+// Override to show warning icon in the toolbar when there's an insecure
+// download in progress.
+#define UpdateIcon virtual UpdateIcon
+
+#include "src/chrome/browser/ui/views/download/bubble/download_toolbar_ui_controller.h"  // IWYU pragma: export
+#undef UpdateIcon
+#undef UpdateIconDormant
+#undef DownloadToolbarUIController
+
+class DownloadToolbarUIController
+    : public DownloadToolbarUIController_ChromiumImpl {
+ public:
+  using DownloadToolbarUIController_ChromiumImpl::
+      DownloadToolbarUIController_ChromiumImpl;
+
+  SkColor GetIconColor(bool is_dormant,
+                       DownloadDisplay::IconActive active,
+                       const ui::ColorProvider* color_provider) const override;
+
+  void UpdateIcon() override;
+
+ private:
+  bool HasInsecureDownloads();
+};
+
+#endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_DOWNLOAD_BUBBLE_DOWNLOAD_TOOLBAR_UI_CONTROLLER_H_

--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.cc
@@ -5,8 +5,21 @@
 
 #include "chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h"
 
+#include "chrome/browser/ui/views/toolbar/pinned_toolbar_actions_container.h"
+#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
+
+#define UpdateIcon UpdateIcon_ChromiumImpl
 #include "src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.cc"
+#undef UpdateIcon
 
 bool PinnedActionToolbarButton::ShouldShowMenu() {
   return false;
+}
+
+void PinnedActionToolbarButton::UpdateIcon() {
+  if (HasIconEnabledColorsOverride() && action_engaged_) {
+    ToolbarButton::UpdateIcon();
+    return;
+  }
+  UpdateIcon_ChromiumImpl();
 }

--- a/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h
@@ -6,6 +6,8 @@
 #ifndef BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_ACTION_TOOLBAR_BUTTON_H_
 #define BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_ACTION_TOOLBAR_BUTTON_H_
 
+#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
+
 // We don't want to show context menu for pinned container buttons. For now we
 // only allow downloads button and we don't want to show any customization UI
 // elements yet.
@@ -13,7 +15,13 @@
   ShouldShowEphemerallyInToolbar(__VA_ARGS__); \
   bool ShouldShowMenu() override
 
+// Allow ToolbarButton's color override to persist.
+#define UpdateIcon           \
+  UpdateIcon_ChromiumImpl(); \
+  void UpdateIcon
+
 #include "src/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h"  // IWYU pragma: export
+#undef UpdateIcon
 #undef ShouldShowEphemerallyInToolbar
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_PINNED_ACTION_TOOLBAR_BUTTON_H_

--- a/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.cc
+++ b/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.cc
@@ -3,10 +3,11 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // you can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
+
 #include <utility>
 
 #include "brave/browser/ui/color/brave_color_id.h"
-#include "chrome/browser/ui/views/toolbar/toolbar_button.h"
 #include "ui/views/controls/highlight_path_generator.h"
 
 #define ToolbarButton ToolbarButton_ChromiumImpl
@@ -52,7 +53,25 @@ void ToolbarButton::InkDropRippleAnimationEnded(views::InkDropState state) {
   OnInkDropStateChanged(state);
 }
 
+void ToolbarButton::UpdateIcon() {
+  if (HasVectorIcons() && icon_enabled_colors_override_) {
+    UpdateIconsWithColors(
+        ui::TouchUiController::Get()->touch_ui() ? GetVectorTouchIcon()
+                                                 : GetVectorIcon(),
+        *icon_enabled_colors_override_, *icon_enabled_colors_override_,
+        *icon_enabled_colors_override_,
+        GetForegroundColor(ButtonState::STATE_DISABLED));
+    return;
+  }
+
+  ToolbarButton_ChromiumImpl::UpdateIcon();
+}
+
 void ToolbarButton::OnInkDropStateChanged(views::InkDropState state) {
+  if (icon_enabled_colors_override_) {
+    return UpdateIcon();
+  }
+
   // Use different color for icon when activated.
   activated_ = state == views::InkDropState::ACTIVATED;
 

--- a/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.h
+++ b/chromium_src/chrome/browser/ui/views/toolbar/toolbar_button.h
@@ -36,8 +36,17 @@ class ToolbarButton : public ToolbarButton_ChromiumImpl,
   using ToolbarButton_ChromiumImpl::ToolbarButton_ChromiumImpl;
   ~ToolbarButton() override;
 
+  // Override icon color for non-disabled button states.
+  void SetIconEnabledColorsOverride(std::optional<SkColor> color) {
+    icon_enabled_colors_override_ = color;
+  }
+  bool HasIconEnabledColorsOverride() const {
+    return icon_enabled_colors_override_.has_value();
+  }
+
   // ToolbarButton_ChromiumImpl overrides:
   void OnThemeChanged() override;
+  void UpdateIcon() override;
 
   virtual void OnInkDropStateChanged(views::InkDropState state);
 
@@ -47,6 +56,7 @@ class ToolbarButton : public ToolbarButton_ChromiumImpl,
   void InkDropRippleAnimationEnded(views::InkDropState state) override;
 
   bool activated_ = false;
+  std::optional<SkColor> icon_enabled_colors_override_;
 };
 
 #endif  // BRAVE_CHROMIUM_SRC_CHROME_BROWSER_UI_VIEWS_TOOLBAR_TOOLBAR_BUTTON_H_


### PR DESCRIPTION
Uplift of #28473
Resolves https://github.com/brave/brave-browser/issues/45159

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.