### PR TITLE
[iOS] - Fix tab leaking causing audio to play in the background

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Brave Translate/BraveTranslateTabHelper.swift
@@ -78,7 +78,7 @@ class BraveTranslateTabHelper: NSObject {
     urlObserver = tab.webView?.observe(
       \.url,
       options: [.new],
-      changeHandler: { [weak self] _, change in
+      changeHandler: { [weak self, weak tab] _, change in
         guard let self = self, let url = change.newValue else { return }
         if self.url != url {
           self.url = url
@@ -87,7 +87,7 @@ class BraveTranslateTabHelper: NSObject {
           self.currentLanguageInfo.pageLanguage = nil
           self.translationTask = nil
 
-          if let delegate = self.delegate {
+          if let delegate = self.delegate, let tab = tab {
             delegate.updateTranslateURLBar(tab: tab, state: .unavailable)
             BraveTranslateScriptHandler.checkTranslate(tab: tab)
           }


### PR DESCRIPTION
## Summary
- Fix leak capturing tab strongly instead of weakly
- This fixes tab leaking causing audio to play in the background after tab is closed

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44938

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->


## Test Plan
1. For ALL tests below, enable Background Play from Settings (...) -> Media.

1. Visit Youtube.
2. Play a video
3. Open settings menu
4. Close the menu.
5. Close the tab
6. Audio MUST stop playing!
----

1. Enable Brave Translate (if not enabled)
2. Visit Youtube.
3. Play a video.
4. Close the tab.
5. Audio MUST stop playing!
----

1. Enable Brave Translate (if not enabled)
2. Visit Wikipedia.
3. Translate the page.
4. Visit Youtube.
5. Play a video.
7. Close the tab.
8. Audio MUST stop playing!