### PR TITLE
[iOS] Fix assigning nil values in TabBrowserData (uplift to 1.78.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/TabBrowserData.swift
@@ -561,9 +561,7 @@ extension Tab {
       return data.browserData?[keyPath: member]
     }
     set {
-      if let newValue {
-        data.browserData?[keyPath: member] = newValue
-      }
+      data.browserData?[keyPath: member] = newValue
     }
   }
 }


### PR DESCRIPTION
Uplift of #28510
Resolves https://github.com/brave/brave-browser/issues/45220

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.