### PR TITLE
Call GetSuggestedAndDedupeTopics if it only has a single tab chunk (uplift to 1.78.x)

### DIFF
--- a/components/ai_chat/core/browser/engine/conversation_api_client.cc
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.cc
@@ -111,6 +111,8 @@ base::Value::List ConversationEventsToList(
            {ConversationEventType::GetSuggestedTopicsForFocusTabs,
             "suggestFocusTopics"},
            {ConversationEventType::DedupeTopics, "dedupeFocusTopics"},
+           {ConversationEventType::GetSuggestedAndDedupeTopicsForFocusTabs,
+            "suggestAndDedupeFocusTopics"},
            {ConversationEventType::GetFocusTabsForTopic, "classifyTabs"},
            {ConversationEventType::UploadImage, "uploadImage"}});
 

--- a/components/ai_chat/core/browser/engine/conversation_api_client.h
+++ b/components/ai_chat/core/browser/engine/conversation_api_client.h
@@ -66,6 +66,7 @@ class ConversationAPIClient {
     UploadImage,
     GetSuggestedTopicsForFocusTabs,
     DedupeTopics,
+    GetSuggestedAndDedupeTopicsForFocusTabs,
     GetFocusTabsForTopic,
     // TODO(petemill):
     // - Search in-progress?


### PR DESCRIPTION
Uplift of #28447
Resolves https://github.com/brave/brave-browser/issues/45100

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.