### PR TITLE
[ads] Fix crash with AdsServiceImplIOS::ParseAndSaveCreativeNewTabPageAds on start (uplift to 1.77)

### DIFF
--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -220,13 +220,17 @@ void AdsServiceImplIOS::OnFailedToPrefetchNewTabPageAd(
 void AdsServiceImplIOS::ParseAndSaveCreativeNewTabPageAds(
     base::Value::Dict dict,
     ParseAndSaveCreativeNewTabPageAdsCallback callback) {
-  if (!IsInitialized()) {
+  if (task_queue_.should_queue()) {
     // TODO(https://github.com/brave/brave-browser/issues/44925): Transition
     // task queue to ads service layer. API calls are fired before the ads
     // service is initialized, we will follow up with a cross platform solution.
     return task_queue_.Add(base::BindOnce(
         &AdsServiceImplIOS::ParseAndSaveCreativeNewTabPageAds,
         weak_ptr_factory_.GetWeakPtr(), std::move(dict), std::move(callback)));
+  }
+
+  if (!IsInitialized()) {
+    return std::move(callback).Run(/*success*/ false);
   }
 
   ads_->ParseAndSaveCreativeNewTabPageAds(std::move(dict), std::move(callback));


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/28514
Resolves https://github.com/brave/brave-browser/issues/45219

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.