### PR TITLE
Remove unused and invalid namespaces from Windows ADMX

### DIFF
--- a/chromium_src/components/policy/tools/template_writers/writer_configuration.py
+++ b/chromium_src/components/policy/tools/template_writers/writer_configuration.py
@@ -8,7 +8,12 @@ import override_utils
 @override_utils.override_function(globals())
 def GetConfigurationForBuild(original_function, defines):
   base = original_function(defines)
-  return _merge_dicts(_BRAVE_VALUES, base)
+  merged = _merge_dicts(_BRAVE_VALUES, base)
+
+  # Remove Google.Policies namespace. Microsoft.Policies.Windows remains, as it is hardcoded in admx_writer.py.
+  merged.pop('admx_using_namespaces', None)
+
+  return merged
 
 _BRAVE_VALUES = {
   'build': 'brave',
@@ -22,9 +27,10 @@ _BRAVE_VALUES = {
       'reg_mandatory_key_name': 'Software\\Policies\\BraveSoftware\\Brave',
       'reg_recommended_key_name':
         'Software\\Policies\\BraveSoftware\\Brave\\Recommended',
-      'mandatory_category_path': ['Brave:Cat_Brave', 'brave'],
-      'recommended_category_path': ['Brave:Cat_Brave', 'brave_recommended'],
+      'mandatory_category_path': ['Cat_Brave', 'brave'],
+      'recommended_category_path': ['Cat_Brave', 'brave_recommended'],
       'category_path_strings': {
+        'Cat_Brave': 'Brave Software',
         'brave': 'Brave',
         'brave_recommended':
         'Brave - {doc_recommended}'
@@ -32,15 +38,7 @@ _BRAVE_VALUES = {
       'namespace': 'BraveSoftware.Policies.Brave',
     },
   },
-  # The string 'Brave' is defined in brave.adml for ADMX, but ADM doesn't
-  # support external references, so we define this map here.
-  'adm_category_path_strings': {
-    'Brave:Cat_Brave': 'Brave'
-  },
   'admx_prefix': 'brave',
-  'admx_using_namespaces': {
-    'Brave': 'BraveSoftware.Policies'  # prefix: namespace
-  },
   'linux_policy_path': '/etc/brave/policies/',
   'bundle_id': 'com.brave.ios.core',
 }

--- a/chromium_src/components/policy/tools/template_writers/writer_configuration.py
+++ b/chromium_src/components/policy/tools/template_writers/writer_configuration.py
@@ -44,5 +44,6 @@ _BRAVE_VALUES = {
 def _merge_dicts(src, dst):
     result = dict(dst)
     for k, v in src.items():
-        result[k] = _merge_dicts(v, dst.get(k, {})) if isinstance(v, dict) else v
+        result[k] = _merge_dicts(v, dst.get(k, {})) if isinstance(v,
+                                                                  dict) else v
     return result

--- a/chromium_src/components/policy/tools/template_writers/writer_configuration.py
+++ b/chromium_src/components/policy/tools/template_writers/writer_configuration.py
@@ -7,44 +7,42 @@ import override_utils
 
 @override_utils.override_function(globals())
 def GetConfigurationForBuild(original_function, defines):
-  base = original_function(defines)
-  merged = _merge_dicts(_BRAVE_VALUES, base)
+    base = original_function(defines)
+    merged = _merge_dicts(_BRAVE_VALUES, base)
 
-  # Remove Google.Policies namespace. Microsoft.Policies.Windows remains, as it is hardcoded in admx_writer.py.
-  merged.pop('admx_using_namespaces', None)
+    # Remove Google.Policies namespace. Microsoft.Policies.Windows remains, as it is hardcoded in admx_writer.py.
+    merged.pop('admx_using_namespaces', None)
 
-  return merged
+    return merged
+
 
 _BRAVE_VALUES = {
-  'build': 'brave',
-  'app_name': 'Brave',
-  'doc_url':
-    'https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy',
-  'frame_name': 'Brave Frame',
-  'webview_name': 'Brave WebView',
-  'win_config': {
-    'win': {
-      'reg_mandatory_key_name': 'Software\\Policies\\BraveSoftware\\Brave',
-      'reg_recommended_key_name':
-        'Software\\Policies\\BraveSoftware\\Brave\\Recommended',
-      'mandatory_category_path': ['Cat_Brave', 'brave'],
-      'recommended_category_path': ['Cat_Brave', 'brave_recommended'],
-      'category_path_strings': {
-        'Cat_Brave': 'Brave Software',
-        'brave': 'Brave',
-        'brave_recommended':
-        'Brave - {doc_recommended}'
-      },
-      'namespace': 'BraveSoftware.Policies.Brave',
+    'build': 'brave',
+    'app_name': 'Brave',
+    'doc_url': 'https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy',
+    'frame_name': 'Brave Frame',
+    'webview_name': 'Brave WebView',
+    'win_config': {
+        'win': {
+            'reg_mandatory_key_name': 'Software\\Policies\\BraveSoftware\\Brave',
+            'reg_recommended_key_name': 'Software\\Policies\\BraveSoftware\\Brave\\Recommended',
+            'mandatory_category_path': ['Cat_Brave', 'brave'],
+            'recommended_category_path': ['Cat_Brave', 'brave_recommended'],
+            'category_path_strings': {
+                'Cat_Brave': 'Brave Software',
+                'brave': 'Brave',
+                'brave_recommended': 'Brave - {doc_recommended}'
+            },
+            'namespace': 'BraveSoftware.Policies.Brave',
+        },
     },
-  },
-  'admx_prefix': 'brave',
-  'linux_policy_path': '/etc/brave/policies/',
-  'bundle_id': 'com.brave.ios.core',
+    'admx_prefix': 'brave',
+    'linux_policy_path': '/etc/brave/policies/',
+    'bundle_id': 'com.brave.ios.core',
 }
 
 def _merge_dicts(src, dst):
-  result = dict(dst)
-  for k, v in src.items():
-    result[k] = _merge_dicts(v, dst.get(k, {})) if isinstance(v, dict) else v
-  return result
+    result = dict(dst)
+    for k, v in src.items():
+        result[k] = _merge_dicts(v, dst.get(k, {})) if isinstance(v, dict) else v
+    return result


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves brave/brave-browser#42956

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

Windows policy writer configuration was importing an unused ADMX namespace, `BraveSoftware.Policies`, causing validation failures in external systems like Microsoft Intune. The Chrome equivalent `Google.Policies` is shared across multiple Google products to provide a parent `Google` policy category, but since Brave Software only distribute one policy bundle, we can safely define the `Brave Software` category here. We can also drop the ADM-specific category definition.

Some external systems just ignored the missing parent category, like Active Directory. After the change, it's rendered properly.

The `Google.Policies` category was also being imported. Most external systems already have this, so it rarely caused errors, but we should remove it anyway. `Microsoft.Policies.Windows` is probably safe to keep like Chrome, tons of other ADMX templates import it and there might be a good reason.

New bundle: [brave_policy_templates.zip](https://github.com/user-attachments/files/19620657/brave_policy_templates.zip)



<details>
<summary>Intune ingestion</summary>

![image](https://github.com/user-attachments/assets/f325a3ca-535e-406a-b42b-18708ff1f133)

</details>

<details>
<summary>Group Policy Editor before and after</summary>

![image](https://github.com/user-attachments/assets/ea5d5e20-e04a-493d-8fe6-59498068d590)

![image](https://github.com/user-attachments/assets/12701e3c-30b0-4532-95e4-c9f89787fcff)

</details>

<details>
<summary>ADM, ADMX, and en-US ADML diffs</summary>

```diff
@@ -1,6 +1,6 @@
-; brave version: 135.1.77.95
+; brave version: 135.1.79.0
 CLASS MACHINE
-  CATEGORY !!Brave:Cat_Brave
+  CATEGORY !!Cat_Brave
     CATEGORY !!brave
       KEYNAME "Software\Policies\BraveSoftware\Brave"

@@ -7098,7 +7098,7 @@
     END CATEGORY
   END CATEGORY

-  CATEGORY !!Brave:Cat_Brave
+  CATEGORY !!Cat_Brave
     CATEGORY !!brave_recommended
       KEYNAME "Software\Policies\BraveSoftware\Brave\Recommended"

@@ -7779,7 +7779,7 @@


 CLASS USER
-  CATEGORY !!Brave:Cat_Brave
+  CATEGORY !!Cat_Brave
     CATEGORY !!brave
       KEYNAME "Software\Policies\BraveSoftware\Brave"

@@ -14877,7 +14877,7 @@
     END CATEGORY
   END CATEGORY

-  CATEGORY !!Brave:Cat_Brave
+  CATEGORY !!Cat_Brave
     CATEGORY !!brave_recommended
       KEYNAME "Software\Policies\BraveSoftware\Brave\Recommended"

@@ -15560,7 +15560,7 @@
 [Strings]
 SUPPORTED_WIN7="Microsoft Windows 7 or later"
 SUPPORTED_WIN7_ONLY="Microsoft Windows 7"
-Brave:Cat_Brave="Brave"
+Cat_Brave="Brave Software"
 brave="Brave"
 brave_recommended="Brave - Default Settings (users can override)"
 Accessibility_Category="Accessibility settings"
```

```diff
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 <policyDefinitions revision="1.0" schemaVersion="1.0">
-  <!--brave version: 135.1.77.95-->
+  <!--brave version: 135.1.79.0-->
   <policyNamespaces>
     <target namespace="BraveSoftware.Policies.Brave" prefix="brave"/>
-    <using namespace="Google.Policies" prefix="Google"/>
-    <using namespace="BraveSoftware.Policies" prefix="Brave"/>
     <using namespace="Microsoft.Policies.Windows" prefix="windows"/>
   </policyNamespaces>
   <resources minRequiredRevision="1.0"/>
@@ -15,11 +13,12 @@
     </definitions>
   </supportedOn>
   <categories>
+    <category displayName="$(string.Cat_Brave)" name="Cat_Brave"/>
     <category displayName="$(string.brave)" name="brave">
-      <parentCategory ref="Brave:Cat_Brave"/>
+      <parentCategory ref="Cat_Brave"/>
     </category>
     <category displayName="$(string.brave_recommended)" name="brave_recommended">
-      <parentCategory ref="Brave:Cat_Brave"/>
+      <parentCategory ref="Cat_Brave"/>
     </category>
     <category displayName="$(string.Accessibility_group)" name="Accessibility">
       <parentCategory ref="brave"/>
```

```diff
@@ -1,12 +1,13 @@
 <?xml version="1.0"?>
 <policyDefinitionResources revision="1.0" schemaVersion="1.0">
-  <!--brave version: 135.1.77.95-->
+  <!--brave version: 135.1.79.0-->
   <displayName />
   <description />
   <resources>
   <stringTable>
   <string id="SUPPORTED_WIN7">Microsoft Windows 7 or later</string>
   <string id="SUPPORTED_WIN7_ONLY">Microsoft Windows 7</string>
+  <string id="Cat_Brave">Brave Software</string>
   <string id="brave">Brave</string>
   <string id="brave_recommended">Brave - Default Settings (users can override)</string>
   <string id="Accessibility_group">Accessibility settings</string>
```

</details>


