### PR TITLE
[canary] Add `Version` tests to B🚀

### DIFF
--- a/tools/cr/PRESUBMIT.py
+++ b/tools/cr/PRESUBMIT.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+"""Presubmit script for changes affecting tools/cr/
+
+See http://dev.chromium.org/developers/how-tos/depottools/presubmit-scripts
+for more details about the presubmit API built into depot_tools.
+"""
+
+PRESUBMIT_VERSION = '2.0.0'
+TEST_FILE_PATTERN = [r'.+_test.py$']
+
+
+def CheckTests(input_api, output_api):
+    # input_api.logging.debug('testing this output')
+    return input_api.canned_checks.RunUnitTestsInDirectory(
+        input_api, output_api, '.', files_to_check=TEST_FILE_PATTERN)

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -8,7 +8,7 @@ from pathlib import PurePath
 import subprocess
 from typing import Optional
 
-from terminal import console, terminal
+from terminal import terminal
 
 # The path to the brave/ directory.
 BRAVE_CORE_PATH = next(brave for brave in PurePath(__file__).parents
@@ -31,18 +31,6 @@ class Repository:
     # of a patch file, with chromium/src being ''.
     # e.g. "third_party/search_engines_data/resources"
     path: PurePath
-
-    @classmethod
-    def chromium(cls) -> "Repository":
-        """Returns the chromium/src repository.
-        """
-        return cls(PurePath(CHROMIUM_SRC_PATH))
-
-    @classmethod
-    def brave(cls) -> "Repository":
-        """Returns the brave/ repository.
-        """
-        return cls(BRAVE_CORE_PATH)
 
     @property
     def is_chromium(self) -> bool:
@@ -156,3 +144,10 @@ class Repository:
         """Gets the current branch name, or HEAD if not in any branch.
         """
         return self.run_git('rev-parse', '--abbrev-ref', 'HEAD')
+
+
+# An instance to the chromium repository.
+chromium = Repository(PurePath(CHROMIUM_SRC_PATH))
+
+# An instance to the brave repository.
+brave = Repository(PurePath(BRAVE_CORE_PATH))

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -1,81 +1,73 @@
-#!/usr/bin/env python3
+#!/usr/bin/env vpython3
 # # Copyright (c) 2025 The Brave Authors. All rights reserved.
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from pathlib import PurePath
 import unittest
 from unittest.mock import patch
-from pathlib import PurePath
+
+import repository
 from repository import Repository
+
 from test.fake_chromium_repo import FakeChromiumRepo
-import os
+from test.fake_chromium_src import FakeChromiumSrc
 
 
 class RepositoryTest(unittest.TestCase):
 
     def setUp(self):
         """Set up a fake Chromium repository for testing."""
-        self.fake_repo = FakeChromiumRepo()
-        self.fake_repo.add_dep('v8')
-        self.fake_repo.add_dep('third_party/test1')
-        self.addCleanup(self.fake_repo.cleanup)
-
-        # Patch BRAVE_CORE_PATH and CHROMIUM_SRC_PATH
-        self.brave_patch = patch('repository.BRAVE_CORE_PATH',
-                                 PurePath(self.fake_repo.brave))
-        self.chromium_patch = patch('repository.CHROMIUM_SRC_PATH',
-                                    PurePath(self.fake_repo.chromium))
-        self.brave_patch.start()
-        self.chromium_patch.start()
-        self.addCleanup(self.brave_patch.stop)
-        self.addCleanup(self.chromium_patch.stop)
-
-        # Change the current working directory to the fake Chromium repo
-        self.original_cwd = os.getcwd()
-        os.chdir(self.fake_repo.brave)
-        self.addCleanup(os.chdir, self.original_cwd)
+        self.fake_chromium_src = FakeChromiumSrc()
+        self.fake_chromium_src.setup()
+        self.fake_chromium_src.add_dep('v8')
+        self.fake_chromium_src.add_dep('third_party/test1')
+        self.addCleanup(self.fake_chromium_src.cleanup)
 
     def test_chromium_repository(self):
-        repo = Repository.chromium()
-        self.assertEqual(repo.path, PurePath(self.fake_repo.chromium))
-        self.assertTrue(repo.is_chromium)
-        self.assertFalse(repo.is_brave)
+        self.assertEqual(repository.chromium.path,
+                         PurePath(self.fake_chromium_src.chromium))
+        self.assertTrue(repository.chromium.is_chromium)
+        self.assertFalse(repository.chromium.is_brave)
 
     def test_brave_repository(self):
-        repo = Repository.brave()
-        self.assertEqual(repo.path, PurePath(self.fake_repo.brave))
-        self.assertTrue(repo.is_brave)
-        self.assertFalse(repo.is_chromium)
+        self.assertEqual(repository.brave.path,
+                         PurePath(self.fake_chromium_src.brave))
+        self.assertTrue(repository.brave.is_brave)
+        self.assertFalse(repository.brave.is_chromium)
 
     def test_to_brave(self):
         self.assertEqual(
-            Repository(self.fake_repo.chromium).to_brave(), PurePath('brave'))
+            Repository(self.fake_chromium_src.chromium).to_brave(),
+            PurePath('brave'))
         self.assertEqual(
-            Repository(self.fake_repo.brave).to_brave(), PurePath('../brave'))
-        self.assertEqual(
-            Repository(self.fake_repo.chromium / 'v8').to_brave(),
+            Repository(self.fake_chromium_src.brave).to_brave(),
             PurePath('../brave'))
         self.assertEqual(
-            Repository(
-                self.fake_repo.chromium / 'third_party/test1').to_brave(),
+            Repository(self.fake_chromium_src.chromium / 'v8').to_brave(),
+            PurePath('../brave'))
+        self.assertEqual(
+            Repository(self.fake_chromium_src.chromium /
+                       'third_party/test1').to_brave(),
             PurePath('../../brave'))
 
     def test_from_brave(self):
         self.assertEqual(
-            Repository(self.fake_repo.chromium).from_brave(), PurePath('../'))
+            Repository(self.fake_chromium_src.chromium).from_brave(),
+            PurePath('../'))
         self.assertEqual(
-            Repository(self.fake_repo.brave).from_brave(),
+            Repository(self.fake_chromium_src.brave).from_brave(),
             PurePath('../brave'))
         self.assertEqual(
-            Repository(self.fake_repo.chromium / 'v8').from_brave(),
+            Repository(self.fake_chromium_src.chromium / 'v8').from_brave(),
             PurePath('../v8'))
         self.assertEqual(
-            Repository(self.fake_repo.chromium /
+            Repository(self.fake_chromium_src.chromium /
                        'third_party/test1').from_brave(),
             PurePath('../third_party/test1'))
         self.assertEqual(
-            Repository(self.fake_repo.chromium /
+            Repository(self.fake_chromium_src.chromium /
                        'third_party/test1').from_brave('test_file.txt'),
             PurePath('../third_party/test1/test_file.txt'))
 
@@ -83,178 +75,185 @@ class RepositoryTest(unittest.TestCase):
         """Test Repository.run_git by verifying the hash of the last commit."""
         # Verify the hash of the last commit using Repository.run_git
         self.assertEqual(
-            self.fake_repo.commit_empty("Empty commit in brave",
-                                        self.fake_repo.brave),
-            Repository.brave().run_git("rev-parse", "HEAD"),
+            self.fake_chromium_src.commit_empty("Empty commit in brave",
+                                                self.fake_chromium_src.brave),
+            repository.brave.run_git("rev-parse", "HEAD"),
         )
         self.assertEqual(
-            self.fake_repo.commit_empty("Empty commit in chromium",
-                                        self.fake_repo.chromium),
-            Repository.chromium().run_git("rev-parse", "HEAD"),
+            self.fake_chromium_src.commit_empty(
+                "Empty commit in chromium", self.fake_chromium_src.chromium),
+            repository.chromium.run_git("rev-parse", "HEAD"),
         )
         self.assertEqual(
-            self.fake_repo.commit_empty("Empty commit in v8",
-                                        self.fake_repo.chromium / "v8"),
-            Repository(self.fake_repo.chromium / "v8").run_git(
+            self.fake_chromium_src.commit_empty(
+                "Empty commit in v8", self.fake_chromium_src.chromium / "v8"),
+            Repository(self.fake_chromium_src.chromium / "v8").run_git(
                 "rev-parse", "HEAD"),
         )
         self.assertEqual(
-            self.fake_repo.commit_empty(
+            self.fake_chromium_src.commit_empty(
                 "Empty commit in third_party/test1",
-                self.fake_repo.chromium / "third_party/test1"),
-            Repository(self.fake_repo.chromium / "third_party/test1").run_git(
-                "rev-parse", "HEAD"),
+                self.fake_chromium_src.chromium / "third_party/test1"),
+            Repository(self.fake_chromium_src.chromium /
+                       "third_party/test1").run_git("rev-parse", "HEAD"),
         )
 
     def test_unstage_all_changes(self):
         """Test unstage_all_changes and has_staged_changed."""
         # Create a new file and stage it
-        test_file = self.fake_repo.chromium / "test_file.txt"
+        test_file = self.fake_chromium_src.chromium / "test_file.txt"
         test_file.write_text("Test content")
-        repo = Repository.chromium()
-        repo.run_git("add", str(test_file))
+        repository.chromium.run_git("add", str(test_file))
 
         # Verify the file is staged and has_staged_changed returns True
-        staged_files = repo.run_git("diff", "--cached", "--name-only")
+        staged_files = repository.chromium.run_git("diff", "--cached",
+                                                   "--name-only")
         self.assertIn("test_file.txt", staged_files)
-        self.assertTrue(repo.has_staged_changed())
+        self.assertTrue(repository.chromium.has_staged_changed())
 
         # Unstage all changes
-        repo.unstage_all_changes()
+        repository.chromium.unstage_all_changes()
 
         # Verify the file is no longer staged and has_staged_changed is false
-        staged_files_after = repo.run_git("diff", "--cached", "--name-only")
+        staged_files_after = repository.chromium.run_git(
+            "diff", "--cached", "--name-only")
         self.assertNotIn("test_file.txt", staged_files_after)
-        self.assertFalse(repo.has_staged_changed())
+        self.assertFalse(repository.chromium.has_staged_changed())
 
     def test_get_commit_short_description(self):
         """Test get_commit_short_description using the chromium repository."""
         # Create an empty commit with a specific message
         commit_message = "Test commit message"
-        commit_hash = self.fake_repo.commit_empty(commit_message,
-                                                  self.fake_repo.chromium)
+        commit_hash = self.fake_chromium_src.commit_empty(
+            commit_message, self.fake_chromium_src.chromium)
 
         # Verify the short description of the commit
-        repo = Repository.chromium()
-        short_description = repo.get_commit_short_description(commit_hash)
+        short_description = repository.chromium.get_commit_short_description(
+            commit_hash)
         self.assertEqual(short_description, commit_message)
 
     def test_git_commit(self):
         """Test git_commit."""
-        repo = Repository.chromium()
 
         # Case 1: Commit with staged changes
-        test_file = self.fake_repo.chromium / "test_file.txt"
+        test_file = self.fake_chromium_src.chromium / "test_file.txt"
         test_file.write_text("Test content")
-        repo.run_git("add", str(test_file))
+        repository.chromium.run_git("add", str(test_file))
         commit_message = "Add test_file.txt"
-        repo.git_commit(commit_message)
+        repository.chromium.git_commit(commit_message)
 
         # Verify the commit message
-        last_commit_message = repo.get_commit_short_description()
+        last_commit_message = repository.chromium.get_commit_short_description(
+        )
         self.assertEqual(last_commit_message, commit_message)
 
         # Case 2: Commit with no staged changes
-        repo.git_commit("This should not create a commit")
+        repository.chromium.git_commit("This should not create a commit")
         # Verify that the last commit message remains unchanged
-        last_commit_message_after = repo.get_commit_short_description()
+        last_commit_message_after = (
+            repository.chromium.get_commit_short_description())
         self.assertEqual(last_commit_message_after, commit_message)
 
     def test_is_valid_git_reference(self):
         """Test is_valid_git_reference using the chromium repository."""
-        repo = Repository.chromium()
 
         # Create a valid commit and verify the reference
         commit_message = "Valid commit"
-        valid_commit_hash = self.fake_repo.commit_empty(
-            commit_message, self.fake_repo.chromium)
-        self.assertTrue(repo.is_valid_git_reference(valid_commit_hash))
+        valid_commit_hash = self.fake_chromium_src.commit_empty(
+            commit_message, self.fake_chromium_src.chromium)
+        self.assertTrue(
+            repository.chromium.is_valid_git_reference(valid_commit_hash))
 
         # Test an invalid reference
-        self.assertFalse(repo.is_valid_git_reference("invalid_reference"))
+        self.assertFalse(
+            repository.chromium.is_valid_git_reference("invalid_reference"))
 
     def test_last_changed(self):
         """Test last_changed using the chromium repository."""
-        repo = Repository.chromium()
-
         # Create and commit a file
-        self.fake_repo.commit_empty('empty #1', self.fake_repo.chromium)
+        self.fake_chromium_src.commit_empty('empty #1',
+                                            self.fake_chromium_src.chromium)
         file_commits = []
-        self.fake_repo.write_and_stage_file("test_file.txt", "Initial content",
-                                            self.fake_repo.chromium)
+        self.fake_chromium_src.write_and_stage_file(
+            "test_file.txt", "Initial content",
+            self.fake_chromium_src.chromium)
         file_commits.append(
-            self.fake_repo.commit("Initial commit for test_file.txt",
-                                  self.fake_repo.chromium))
-        self.fake_repo.commit_empty('empty #2', self.fake_repo.chromium)
+            self.fake_chromium_src.commit("Initial commit for test_file.txt",
+                                          self.fake_chromium_src.chromium))
+        self.fake_chromium_src.commit_empty('empty #2',
+                                            self.fake_chromium_src.chromium)
 
         # Modify and commit the file again
-        self.fake_repo.commit_empty('empty #3', self.fake_repo.chromium)
-        self.fake_repo.write_and_stage_file("test_file.txt", "Updated content",
-                                            self.fake_repo.chromium)
+        self.fake_chromium_src.commit_empty('empty #3',
+                                            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.write_and_stage_file(
+            "test_file.txt", "Updated content",
+            self.fake_chromium_src.chromium)
         file_commits.append(
-            self.fake_repo.commit("Updated test_file.txt",
-                                  self.fake_repo.chromium))
-        self.fake_repo.commit_empty('empty #4', self.fake_repo.chromium)
+            self.fake_chromium_src.commit("Updated test_file.txt",
+                                          self.fake_chromium_src.chromium))
+        self.fake_chromium_src.commit_empty('empty #4',
+                                            self.fake_chromium_src.chromium)
 
         # Verify last_changed returns the latest commit hash for the file
-        last_changed_hash = repo.last_changed("test_file.txt")
+        last_changed_hash = repository.chromium.last_changed("test_file.txt")
         self.assertEqual(last_changed_hash[:7], file_commits[-1][:7])
 
         # Verify last_changed with a specific from_commit returns the correct
         # hash
-        last_changed_from_initial = repo.last_changed(
+        last_changed_from_initial = repository.chromium.last_changed(
             "test_file.txt", from_commit=f'{file_commits[-1]}~1')
         self.assertEqual(last_changed_from_initial[:7], file_commits[-2][:7])
 
     def test_read_file(self):
         """Test read_file, including reading multiple files."""
-        repo = Repository.chromium()
-
         # Create and commit two files
-        self.fake_repo.write_and_stage_file("file1.txt", "Content of file 1\n",
-                                            self.fake_repo.chromium)
-        commit1 = self.fake_repo.commit("Add file1.txt",
-                                        self.fake_repo.chromium)
+        self.fake_chromium_src.write_and_stage_file(
+            "file1.txt", "Content of file 1\n",
+            self.fake_chromium_src.chromium)
+        commit1 = self.fake_chromium_src.commit(
+            "Add file1.txt", self.fake_chromium_src.chromium)
 
-        self.fake_repo.write_and_stage_file("file2.txt", "Content of file 2\n",
-                                            self.fake_repo.chromium)
-        commit2 = self.fake_repo.commit("Add file2.txt",
-                                        self.fake_repo.chromium)
+        self.fake_chromium_src.write_and_stage_file(
+            "file2.txt", "Content of file 2\n",
+            self.fake_chromium_src.chromium)
+        commit2 = self.fake_chromium_src.commit(
+            "Add file2.txt", self.fake_chromium_src.chromium)
 
         # Test reading a single file
-        content_file1 = repo.read_file("file1.txt", commit=commit1)
+        content_file1 = repository.chromium.read_file("file1.txt",
+                                                      commit=commit1)
         self.assertEqual(content_file1, "Content of file 1\n")
 
         # Test reading multiple files
-        content_files = repo.read_file("file1.txt",
-                                       "file2.txt",
-                                       commit=commit2)
+        content_files = repository.chromium.read_file("file1.txt",
+                                                      "file2.txt",
+                                                      commit=commit2)
         self.assertIn("Content of file 1\n", content_files)
         self.assertIn("Content of file 2\n", content_files)
 
         # Test enforcing no_trim (ensure trailing newlines are preserved)
-        self.fake_repo.write_and_stage_file(
+        self.fake_chromium_src.write_and_stage_file(
             "file3.txt", "Content with trailing newline\n\n",
-            self.fake_repo.chromium)
-        commit3 = self.fake_repo.commit("Add file3.txt",
-                                        self.fake_repo.chromium)
-        content_file3 = repo.read_file("file3.txt", commit=commit3)
+            self.fake_chromium_src.chromium)
+        commit3 = self.fake_chromium_src.commit(
+            "Add file3.txt", self.fake_chromium_src.chromium)
+        content_file3 = repository.chromium.read_file("file3.txt",
+                                                      commit=commit3)
         self.assertEqual(content_file3, "Content with trailing newline\n\n")
 
     def test_current_branch(self):
         """Test current_branch using the chromium repository."""
-        repo = Repository.chromium()
-
         # Verify the default branch is "master" or "main"
-        current_branch = repo.current_branch()
+        current_branch = repository.chromium.current_branch()
         self.assertIn(current_branch, ["master", "main"])
 
         # Create and switch to a new branch
         new_branch = "test-branch"
-        repo.run_git("checkout", "-b", new_branch)
+        repository.chromium.run_git("checkout", "-b", new_branch)
 
         # Verify the current branch is updated
-        self.assertEqual(repo.current_branch(), new_branch)
+        self.assertEqual(repository.chromium.current_branch(), new_branch)
 
 
 if __name__ == "__main__":

--- a/tools/cr/test/fake_chromium_src.py
+++ b/tools/cr/test/fake_chromium_src.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from pathlib import PurePath
+import os
+from unittest.mock import patch
+from test.fake_chromium_repo import FakeChromiumRepo
+
+import repository
+
+
+class FakeChromiumSrc(FakeChromiumRepo):
+    """Extends FakeChromiumRepo to manage repository patches."""
+
+    def __init__(self):
+        super().__init__()
+        self.brave_patch = patch('repository.BRAVE_CORE_PATH',
+                                 PurePath(self.brave))
+        self.chromium_patch = patch('repository.CHROMIUM_SRC_PATH',
+                                    PurePath(self.chromium))
+        self.original_cwd = None
+
+    def setup(self):
+        """Set up the fake repo and apply patches."""
+        self.brave_patch.start()
+        self.chromium_patch.start()
+
+        # Re-initialize the global instances in the repository module
+        repository.chromium = repository.Repository(PurePath(self.chromium))
+        repository.brave = repository.Repository(PurePath(self.brave))
+
+        # Change the current working directory to the fake Chromium repo
+        self.original_cwd = os.getcwd()
+        os.chdir(self.brave)
+
+    def cleanup(self):
+        """Clean up the fake repo, patches, and restore the working directory"""
+        self.brave_patch.stop()
+        self.chromium_patch.stop()
+        if self.original_cwd:
+            os.chdir(self.original_cwd)
+        super().cleanup()

--- a/tools/cr/versioning.py
+++ b/tools/cr/versioning.py
@@ -1,0 +1,103 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from dataclasses import dataclass
+from functools import total_ordering
+import json
+
+import repository
+
+# The path to the package.json file in brave-core
+PACKAGE_FILE = 'package.json'
+
+# The link to the Chromium source code.
+GOOGLESOURCE_LINK = 'https://chromium.googlesource.com/chromium/src'
+
+# Link with the log of changes between two versions.
+GOOGLESOURCE_LOG_LINK = (
+    f'{GOOGLESOURCE_LINK}'
+    '/+log/{from_version}..{to_version}?pretty=fuller&n=10000')
+
+# The file in Chromium with the version written in it.
+CHROMIUM_VERSION_FILE = 'chrome/VERSION'
+
+
+def load_package_file(branch):
+    """Retrieves the json content of package.json for a given revision
+
+  Args:
+    branch:
+      A branch or hash to load the file from.
+  """
+    package = repository.brave.read_file(PACKAGE_FILE, commit=branch)
+    return json.loads(package)
+
+
+def read_chromium_version_file():
+    """Retrieves the Chromium version from the VERSION file.
+
+    This function reads directly from git, as VERSION gets patched during
+    `apply_patches`.
+    """
+    version_parts = {}
+    file = repository.chromium.read_file(CHROMIUM_VERSION_FILE)
+    for line in file.splitlines():
+        key, value = line.strip().split('=')
+        version_parts[key] = value
+    return Version('{MAJOR}.{MINOR}.{BUILD}.{PATCH}'.format(**version_parts))
+
+
+@total_ordering
+@dataclass(frozen=True)
+class Version:
+    """A class to hold the version information.
+    """
+
+    # The version data in the format of 'MAJOR.MINOR.BUILD.PATCH'
+    value: str
+
+    def __post_init__(self):
+        if len(self.parts) != 4:
+            raise ValueError(
+                'Version required format: MAJOR.MINOR.BUILD.PATCH. '
+                f'version={self.value}')
+
+    def __str__(self):
+        return self.value
+
+    @property
+    def parts(self) -> tuple[int, int, int, int]:
+        """The version parts as integers."""
+        return tuple(map(int, self.value.split('.')))
+
+    @property
+    def major(self) -> int:
+        """The major version part.
+        """
+        return self.parts[0]
+
+    @classmethod
+    def from_git(cls, branch: str) -> "Version":
+        """Retrieves the version from the git repository.
+        """
+        return cls(
+            load_package_file(branch).get('config').get('projects').get(
+                'chrome').get('tag'))
+
+    def __eq__(self, other):
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self.parts == other.parts
+
+    def __lt__(self, other):
+        if not isinstance(other, Version):
+            return NotImplemented
+        return self.parts < other.parts
+
+    def get_googlesource_diff_link(self, from_version: "Version") -> str:
+        """Generates a link to the diff of the upgrade.
+        """
+        return GOOGLESOURCE_LOG_LINK.format(from_version=from_version,
+                                            to_version=self)

--- a/tools/cr/versioning_test.py
+++ b/tools/cr/versioning_test.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env vpython3
+# # Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from pathlib import PurePath
+import unittest
+from unittest.mock import patch
+
+import repository
+from repository import Repository
+
+from versioning import load_package_file, read_chromium_version_file
+from versioning import Version
+
+from test.fake_chromium_src import FakeChromiumSrc
+
+
+class VersioningTest(unittest.TestCase):
+
+    def setUp(self):
+        """Set up a fake Chromium repository for testing."""
+        self.fake_chromium_src = FakeChromiumSrc()
+        self.fake_chromium_src.setup()
+        self.addCleanup(self.fake_chromium_src.cleanup)
+
+    def test_load_package_file(self):
+        """Test that load_package_file loads the correct package.json."""
+        # Update the package.json file with a specific version
+        test_version_1 = "1.2.3.4"
+        v1 = self.fake_chromium_src.update_brave_version(test_version_1)
+
+        # Load the package.json file using load_package_file
+        loaded_package_1 = load_package_file("HEAD")
+
+        # Assert that the loaded version matches the first updated version
+        self.assertEqual(
+            loaded_package_1.get("config").get("projects").get("chrome").get(
+                "tag"),
+            test_version_1,
+        )
+
+        # Update the package.json file with a second version
+        test_version_2 = "2.3.4.5"
+        self.fake_chromium_src.update_brave_version(test_version_2)
+
+        loaded_package_2 = load_package_file("HEAD")
+        self.assertEqual(
+            loaded_package_2.get("config").get("projects").get("chrome").get(
+                "tag"),
+            test_version_2,
+        )
+
+        # Assert that the hash passed in is being used to load the file.
+        self.assertEqual(
+            loaded_package_1,
+            load_package_file(v1),
+        )
+
+    def test_version_parts(self):
+        """Test that Version.parts correctly splits the version string."""
+        version = Version("1.2.3.4")
+        self.assertEqual(version.parts, (1, 2, 3, 4))
+
+        version = Version("10.20.30.40")
+        self.assertEqual(version.parts, (10, 20, 30, 40))
+
+        with self.assertRaises(ValueError):
+            Version("1.2.3")  # Invalid version format
+
+        with self.assertRaises(ValueError):
+            Version("1.2.3.4.5")  # Invalid version format
+
+        with self.assertRaises(ValueError):
+            Version("asdfasdf")  # Invalid version format
+
+    def test_version_major(self):
+        """Test that Version.major correctly retrieves the major version."""
+        version = Version("1.2.3.4")
+        self.assertEqual(version.major, 1)
+
+        version = Version("10.20.30.40")
+        self.assertEqual(version.major, 10)
+
+        version = Version("0.1.2.3")
+        self.assertEqual(version.major, 0)
+
+    def test_version_comparisons(self):
+        """Test that Version comparisons work correctly."""
+        # Test equality
+        self.assertEqual(Version("1.2.3.4"), Version("1.2.3.4"))
+        self.assertNotEqual(Version("1.2.3.4"), Version("1.2.3.5"))
+
+        # Test less than
+        self.assertTrue(Version("1.2.3.4") < Version("1.2.3.5"))
+        self.assertTrue(Version("1.2.3.5") < Version("2.0.0.0"))
+        self.assertFalse(Version("2.0.0.0") < Version("1.2.3.4"))
+        self.assertFalse(Version("10.20.3.4") < Version("1.2.3.5"))
+        self.assertFalse(Version("1.20.3.4") < Version("1.2.3.5"))
+        self.assertFalse(Version("1.2.30.4") < Version("1.2.3.4"))
+        self.assertFalse(Version("1.2.3.40") < Version("1.2.3.4"))
+
+        # Test greater than (via __lt__)
+        self.assertTrue(Version("2.0.0.0") > Version("1.2.3.5"))
+        self.assertFalse(Version("1.2.3.4") > Version("1.2.3.4"))
+        self.assertTrue(Version("10.20.3.4") > Version("1.2.3.5"))
+        self.assertTrue(Version("1.20.3.4") > Version("1.2.3.5"))
+        self.assertTrue(Version("1.2.30.4") > Version("1.2.3.4"))
+        self.assertTrue(Version("1.2.3.40") > Version("1.2.3.4"))
+
+    def test_version_from_git(self):
+        """Test that Version.from_git retrieves the correct version."""
+        # Update the package.json file with a specific version
+        test_version_1 = "3.4.5.6"
+        commit_hash_1 = self.fake_chromium_src.update_brave_version(
+            test_version_1)
+
+        # Retrieve the version using Version.from_git with HEAD
+        version_1 = Version.from_git("HEAD")
+        self.assertEqual(str(version_1), test_version_1)
+        self.assertEqual(version_1.parts, (3, 4, 5, 6))
+
+        # Update the package.json file with another version
+        test_version_2 = "4.5.6.7"
+        commit_hash_2 = self.fake_chromium_src.update_brave_version(
+            test_version_2)
+
+        # Retrieve the version using Version.from_git with HEAD
+        version_2 = Version.from_git("HEAD")
+        self.assertEqual(str(version_2), test_version_2)
+        self.assertEqual(version_2.parts, (4, 5, 6, 7))
+
+        # Retrieve the version using Version.from_git with the first commit hash
+        version_1_again = Version.from_git(commit_hash_1)
+        self.assertEqual(str(version_1_again), test_version_1)
+        self.assertEqual(version_1_again.parts, (3, 4, 5, 6))
+
+        # Retrieve the second version using Version.from_git
+        version_2_again = Version.from_git(commit_hash_2)
+        self.assertEqual(str(version_2_again), test_version_2)
+        self.assertEqual(version_2_again.parts, (4, 5, 6, 7))
+
+    def test_get_googlesource_diff_link(self):
+        """Test the link generated by get_googlesource_diff_link."""
+        version_1 = Version("1.2.3.4")
+        version_2 = Version("2.3.4.5")
+
+        expected_link = ("https://chromium.googlesource.com/chromium/src"
+                         "/+log/1.2.3.4..2.3.4.5?pretty=fuller&n=10000")
+
+        self.assertEqual(version_2.get_googlesource_diff_link(version_1),
+                         expected_link)
+
+    def test_read_chromium_version_file(self):
+        """Test the result of read_chromium_version_file."""
+        # Add a tag with a specific version
+        test_version_1 = "1.2.3.4"
+        self.fake_chromium_src.add_tag(test_version_1)
+
+        # Read the version from the VERSION file
+        version_1 = read_chromium_version_file()
+        self.assertEqual(str(version_1), test_version_1)
+        self.assertEqual(version_1.parts, (1, 2, 3, 4))
+
+        # Add another tag with a different version
+        test_version_2 = "5.6.7.8"
+        self.fake_chromium_src.add_tag(test_version_2)
+
+        # Read the updated version from the VERSION file
+        version_2 = read_chromium_version_file()
+        self.assertEqual(str(version_2), test_version_2)
+        self.assertEqual(version_2.parts, (5, 6, 7, 8))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds tests for `Version` to `brockit`. For convenience, `Version` has been moved into its own module, and also a few other bits and pieces that were associated with it.

This change also touches a lot on `Repository`, because these two modules make heavy use of a common test machinery for the two. This means adjusting both tests to make better reuse of code.

Finally, `Repository.chromium()`/`Repository.brave()` are being changed into globals inside `repository`. This is to avoid instatiations on each use, and to follow the advise in
https://google.github.io/styleguide/pyguide.html#2174-decision regarding the use of `@classmethod`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45231

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
