### PR TITLE
Add iOS debug flag for enabling Screen Time by default

### DIFF
--- a/ios/brave-ios/App/Client.xcodeproj/xcshareddata/xcschemes/Debug (AppStore).xcscheme
+++ b/ios/brave-ios/App/Client.xcodeproj/xcshareddata/xcschemes/Debug (AppStore).xcscheme
@@ -101,6 +101,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-BREnableScreenTimeByDefault NO"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/ios/brave-ios/App/Client.xcodeproj/xcshareddata/xcschemes/Debug (No Core).xcscheme
+++ b/ios/brave-ios/App/Client.xcodeproj/xcshareddata/xcschemes/Debug (No Core).xcscheme
@@ -101,6 +101,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-BREnableScreenTimeByDefault NO"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/ios/brave-ios/App/Client.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
+++ b/ios/brave-ios/App/Client.xcodeproj/xcshareddata/xcschemes/Debug.xcscheme
@@ -101,6 +101,10 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "-BREnableScreenTimeByDefault NO"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "-com.apple.CoreData.SQLDebug 1"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -237,7 +237,8 @@ extension Preferences {
     /// Enables the Apple's Screen Time feature.
     public static let screenTimeEnabled = Option<Bool>(
       key: "privacy.screentime-toggle",
-      default: AppConstants.buildChannel != .release && !ProcessInfo.processInfo.isiOSAppOnVisionOS
+      default: Preferences.DebugFlag.enableScreenTimeByDefault
+        ?? (AppConstants.buildChannel != .release && !ProcessInfo.processInfo.isiOSAppOnVisionOS)
     )
 
   }

--- a/ios/brave-ios/Sources/Brave/Frontend/DebugFlag.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/DebugFlag.swift
@@ -17,6 +17,8 @@ extension Preferences {
     static let skipEduPopups = boolOrNil(for: "BRSkipEduPopups")
     /// Skips default browser, Brave VPN and other in-app callouts.
     static let skipNTPCallouts = boolOrNil(for: "BRSkipAppLaunchPopups")
+    /// Enables Screen Time by default
+    static let enableScreenTimeByDefault = boolOrNil(for: "BREnableScreenTimeByDefault")
 
     private static func boolOrNil(for key: String) -> Bool? {
       if AppConstants.buildChannel != .debug || prefs.object(forKey: key) == nil {


### PR DESCRIPTION
- ScreenTime enabled by default can crash on fresh launch in debug mode (presumably while loading symbols), adding to dev time. Example crash log:
``````
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Fatal error occured Error Domain=NSCocoaErrorDomain Code=4099 "The connection to service with pid 18586 named com.apple.ScreenTime.ScreenTimeWebExtension.viewservice was interrupted, but the message was sent over an additional proxy and therefore this proxy has become invalid." UserInfo={NSDebugDescription=The connection to service with pid 18586 named com.apple.ScreenTime.ScreenTimeWebExtension.viewservice was interrupted, additional proxy and therefore this proxy has become invalid.}'
*** First throw call stack:
(0x1a03392ec 0x19d7bda7c 0x19f635ea0 0x24169a76C 0x2416986e8 0x1a3746b50 0x1a3fee418 0x105944584 0x10595e064 0x10597ef38 0x105954548 0x105954484 0x1a02922b4 0x1a02900b0 0x1a02b4700 Ox1ecdf5190 0x1a2ed2240 0x1a2ed0470 0x1a332ea30 0x10d458a1c 0x10d458994 0x10d459838 0x1c6cb7ad8)
libc++abi: terminating due to uncaught exception of type NSException
``````

Resolves https://github.com/brave/brave-browser/issues/45255

### Testplan

- Verify debug flag is disabled by default & on exists in the Debug schemes
- Verify ScreenTime enabled by default logic remains the same when flag is not passed on launch