### PR TITLE
[canary] Add milestones to uplift PRs by B🚀

### DIFF
--- a/tools/cr/versioning.py
+++ b/tools/cr/versioning.py
@@ -49,6 +49,13 @@ def read_chromium_version_file():
     return Version('{MAJOR}.{MINOR}.{BUILD}.{PATCH}'.format(**version_parts))
 
 
+def get_uplift_branch_name_from_package() -> str:
+    """Generates the name of the uplift branch from `package.json`.
+    """
+    version = load_package_file('HEAD')['version'].split('.')
+    return f'{version[0]}.{version[1]}.x'
+
+
 @total_ordering
 @dataclass(frozen=True)
 class Version:

--- a/tools/cr/versioning_test.py
+++ b/tools/cr/versioning_test.py
@@ -11,10 +11,12 @@ from unittest.mock import patch
 import repository
 from repository import Repository
 
-from versioning import load_package_file, read_chromium_version_file
+from versioning import (load_package_file, read_chromium_version_file,
+                        get_uplift_branch_name_from_package)
 from versioning import Version
 
 from test.fake_chromium_src import FakeChromiumSrc
+import json
 
 
 class VersioningTest(unittest.TestCase):
@@ -171,6 +173,20 @@ class VersioningTest(unittest.TestCase):
         version_2 = read_chromium_version_file()
         self.assertEqual(str(version_2), test_version_2)
         self.assertEqual(version_2.parts, (5, 6, 7, 8))
+
+    def test_get_uplift_branch_name_from_package(self):
+        """Test the result of get_uplift_branch_name_from_package."""
+        # Update the package.json file with a specific version
+        test_version = '1.2.3'
+        self.fake_chromium_src.write_and_stage_file(
+            'package.json', json.dumps({'version': test_version}),
+            self.fake_chromium_src.brave)
+        self.fake_chromium_src.commit('Update package.json',
+                                      self.fake_chromium_src.brave)
+
+        # Assert the uplift branch name is generated correctly
+        uplift_branch_name = get_uplift_branch_name_from_package()
+        self.assertEqual(uplift_branch_name, '1.2.x')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change lines up what the other uplift script already does, which is adding the milestones to the uplift PRs.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45305

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
