### PR TITLE
[iOS] Return correct credential for basic auth flow (uplift to 1.78.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebDelegate.swift
@@ -547,7 +547,7 @@ extension BrowserViewController {
     }
 
     do {
-      let credentials = try await Authenticator.handleAuthRequest(
+      let resolvedCredential = try await Authenticator.handleAuthRequest(
         self,
         credential: credential,
         protectionSpace: protectionSpace,
@@ -557,11 +557,11 @@ extension BrowserViewController {
       if BasicAuthCredentialsManager.validDomains.contains(host) {
         BasicAuthCredentialsManager.setCredential(
           origin: origin,
-          credential: credentials
+          credential: resolvedCredential
         )
       }
 
-      return credential
+      return resolvedCredential
     } catch {
       return nil
     }


### PR DESCRIPTION
Uplift of #28579
Resolves https://github.com/brave/brave-browser/issues/45325

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.