### PR TITLE
Fix change in Xcode's SDK where blob parsing would escape the entire URL (uplift to 1.78.x)

### DIFF
--- a/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
+++ b/ios/brave-ios/Sources/BraveShared/Extensions/URLExtensions.swift
@@ -187,24 +187,24 @@ extension URL {
   }
 
   public var strippingBlobURLAuth: URL {
-    if self.scheme == "blob",
-      var components = URLComponents(url: self, resolvingAgainstBaseURL: true)
-    {
-      components.scheme = nil
+    guard self.scheme == "blob" else { return self }
 
-      if let newURL = components.url {
-        if var newComponents = URLComponents(url: newURL, resolvingAgainstBaseURL: true) {
-          newComponents.user = nil
-          newComponents.password = nil
-          newComponents.scheme = newURL.scheme
+    let blobURLString = self.absoluteString.dropFirst("blob:".count)
 
-          if let url = newComponents.url, let result = URL(string: "blob:\(url.absoluteString)") {
-            return result
-          }
-        }
-      }
+    guard let innerURL = URL(string: String(blobURLString)),
+      var components = URLComponents(url: innerURL, resolvingAgainstBaseURL: true)
+    else {
+      return self
     }
-    return self
+
+    components.user = nil
+    components.password = nil
+
+    guard let cleanedInnerURL = components.url else {
+      return self
+    }
+
+    return URL(string: "blob:\(cleanedInnerURL.absoluteString)") ?? self
   }
 
   /// Matches what `window.origin` would return in javascript.


### PR DESCRIPTION
Uplift of #28445
Resolves https://github.com/brave/brave-browser/issues/45129

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.