### PR TITLE
[Tab Focus with Leo] Use cached suggested focus topics when there are no tab changes observed

### DIFF
--- a/browser/ai_chat/ai_chat_service_factory.cc
+++ b/browser/ai_chat/ai_chat_service_factory.cc
@@ -11,6 +11,7 @@
 
 #include "base/no_destructor.h"
 #include "brave/browser/ai_chat/ai_chat_utils.h"
+#include "brave/browser/ai_chat/tab_tracker_service_factory.h"
 #include "brave/browser/brave_browser_process.h"
 #include "brave/browser/misc_metrics/process_misc_metrics.h"
 #include "brave/browser/skus/skus_service_factory.h"
@@ -55,6 +56,7 @@ AIChatServiceFactory::AIChatServiceFactory()
               .Build()) {
   DependsOn(skus::SkusServiceFactory::GetInstance());
   DependsOn(ModelServiceFactory::GetInstance());
+  DependsOn(TabTrackerServiceFactory::GetInstance());
 }
 
 AIChatServiceFactory::~AIChatServiceFactory() = default;
@@ -73,6 +75,7 @@ AIChatServiceFactory::BuildServiceInstanceForBrowserContext(
 
   return std::make_unique<AIChatService>(
       ModelServiceFactory::GetForBrowserContext(context),
+      TabTrackerServiceFactory::GetForBrowserContext(context),
       std::move(credential_manager), user_prefs::UserPrefs::Get(context),
       (g_brave_browser_process->process_misc_metrics())
           ? g_brave_browser_process->process_misc_metrics()->ai_chat_metrics()

--- a/browser/ui/webui/tab_search/BUILD.gn
+++ b/browser/ui/webui/tab_search/BUILD.gn
@@ -19,6 +19,7 @@ source_set("browser_tests") {
     "//brave/browser/ai_chat",
     "//brave/components/ai_chat/core/browser",
     "//brave/components/ai_chat/core/browser:test_support",
+    "//brave/components/ai_chat/core/common/mojom",
     "//brave/components/resources:strings_grit",
     "//chrome/browser/ui",
     "//chrome/browser/ui:browser_navigator_params_headers",

--- a/browser/ui/webui/tab_search/tab_search_page_handler_browsertest.cc
+++ b/browser/ui/webui/tab_search/tab_search_page_handler_browsertest.cc
@@ -7,35 +7,50 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
+#include "base/functional/callback.h"
+#include "base/location.h"
 #include "base/memory/raw_ptr.h"
+#include "base/path_service.h"
+#include "base/run_loop.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/test/bind.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "brave/browser/ai_chat/ai_chat_service_factory.h"
+#include "brave/browser/ai_chat/tab_tracker_service_factory.h"
 #include "brave/components/ai_chat/core/browser/ai_chat_service.h"
 #include "brave/components/ai_chat/core/browser/constants.h"
 #include "brave/components/ai_chat/core/browser/engine/mock_engine_consumer.h"
+#include "brave/components/ai_chat/core/browser/tab_tracker_service.h"
 #include "brave/components/ai_chat/core/browser/types.h"
+#include "brave/components/ai_chat/core/common/mojom/tab_tracker.mojom.h"
+#include "brave/components/constants/brave_paths.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
 #include "chrome/browser/ui/browser_commands.h"
 #include "chrome/browser/ui/browser_list.h"
 #include "chrome/browser/ui/browser_tabstrip.h"
 #include "chrome/browser/ui/test/test_browser_closed_waiter.h"
+#include "chrome/browser/ui/webui/tab_search/tab_search.mojom-forward.h"
 #include "chrome/browser/ui/webui/tab_search/tab_search_ui.h"
 #include "chrome/common/webui_url_constants.h"
 #include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
 #include "components/grit/brave_components_strings.h"
 #include "content/public/browser/navigation_controller.h"
 #include "content/public/test/browser_test.h"
 #include "content/public/test/browser_test_utils.h"
+#include "content/public/test/content_mock_cert_verifier.h"
 #include "content/public/test/test_utils.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "net/dns/mock_host_resolver.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "ui/base/l10n/l10n_util.h"
+#include "ui/base/window_open_disposition.h"
 #include "url/gurl.h"
 #include "url/origin.h"
 
@@ -51,14 +66,65 @@ constexpr char kFooDotComTitle2[] = "foo.com 2";
 constexpr char kBarDotComTitle1[] = "bar.com 1";
 constexpr char kBarDotComTitle2[] = "bar.com 2";
 
+constexpr char kTopic[] = "topic";
+constexpr char kTopic2[] = "topic2";
+
 }  // namespace
 
 using testing::_;
 
+class TabChangeWaiter : ai_chat::mojom::TabDataObserver {
+ public:
+  explicit TabChangeWaiter(content::BrowserContext* context) {
+    auto* tracker_service =
+        ai_chat::TabTrackerServiceFactory::GetInstance()->GetForBrowserContext(
+            context);
+    tracker_service->AddObserver(receiver_.BindNewPipeAndPassRemote());
+  }
+
+  ~TabChangeWaiter() override = default;
+
+  void WaitForTabDataChanged(const std::vector<std::string>& titles) {
+    expected_titles_ = titles;
+    base::RunLoop run_loop;
+    quit_closure_ = run_loop.QuitClosure();
+    run_loop.Run();
+  }
+
+  void TabDataChanged(
+      std::vector<ai_chat::mojom::TabDataPtr> tab_data) override {
+    std::vector<std::string> titles;
+    for (const auto& tab : tab_data) {
+      titles.push_back(tab->title);
+    }
+
+    if (!quit_closure_ || titles != expected_titles_) {
+      return;
+    }
+    std::move(quit_closure_).Run();
+  }
+
+ private:
+  mojo::Receiver<ai_chat::mojom::TabDataObserver> receiver_{this};
+  std::vector<std::string> expected_titles_;
+  base::OnceClosure quit_closure_;
+};
+
 class TabSearchPageHandlerBrowserTest : public InProcessBrowserTest {
  public:
+  TabSearchPageHandlerBrowserTest()
+      : https_server_(net::EmbeddedTestServer::TYPE_HTTPS) {}
+
   void SetUpOnMainThread() override {
     InProcessBrowserTest::SetUpOnMainThread();
+
+    base::FilePath test_data_dir =
+        base::PathService::CheckedGet(brave::DIR_TEST_DATA);
+    mock_cert_verifier_.mock_cert_verifier()->set_default_result(net::OK);
+    https_server_.ServeFilesFromDirectory(test_data_dir);
+    host_resolver()->AddRule("*", "127.0.0.1");
+    EXPECT_TRUE(https_server_.Start());
+
     webui_contents_ = content::WebContents::Create(
         content::WebContents::CreateParams(browser()->profile()));
 
@@ -68,15 +134,29 @@ class TabSearchPageHandlerBrowserTest : public InProcessBrowserTest {
 
     // Finish loading after initializing.
     ASSERT_TRUE(content::WaitForLoadStop(webui_contents_.get()));
-
-    // Create another browser with the default profile.
-    chrome::NewEmptyWindow(profile1(), false);
   }
 
   void TearDownOnMainThread() override {
     webui_contents_.reset();
     InProcessBrowserTest::TearDownOnMainThread();
   }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    InProcessBrowserTest::SetUpCommandLine(command_line);
+    mock_cert_verifier_.SetUpCommandLine(command_line);
+  }
+
+  void SetUpInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::SetUpInProcessBrowserTestFixture();
+    mock_cert_verifier_.SetUpInProcessBrowserTestFixture();
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    InProcessBrowserTest::TearDownInProcessBrowserTestFixture();
+    mock_cert_verifier_.TearDownInProcessBrowserTestFixture();
+  }
+
+  const net::EmbeddedTestServer* https_server() const { return &https_server_; }
 
   TabSearchPageHandler* handler() {
     return webui_contents_->GetWebUI()
@@ -89,8 +169,11 @@ class TabSearchPageHandlerBrowserTest : public InProcessBrowserTest {
 
   void AppendTabWithTitle(Browser* browser,
                           const GURL& url,
-                          const std::string& title) {
-    chrome::AddTabAt(browser, url, -1, true);
+                          const std::string& title,
+                          ui_test_utils::BrowserTestWaitFlags wait_flags =
+                              ui_test_utils::BROWSER_TEST_NO_WAIT) {
+    ui_test_utils::NavigateToURLWithDisposition(
+        browser, url, WindowOpenDisposition::NEW_FOREGROUND_TAB, wait_flags);
     content::WebContents* web_contents =
         browser->tab_strip_model()->GetActiveWebContents();
     web_contents->UpdateTitleForEntry(
@@ -98,16 +181,135 @@ class TabSearchPageHandlerBrowserTest : public InProcessBrowserTest {
         base::UTF8ToUTF16(title));
   }
 
+  void TestGetSuggestedTopics(const std::vector<std::string>& expected_topics,
+                              tab_search::mojom::ErrorPtr expected_error,
+                              const base::Location& location = FROM_HERE) {
+    SCOPED_TRACE(location.ToString());
+    base::RunLoop run_loop;
+    handler()->GetSuggestedTopics(
+        base::BindLambdaForTesting([&](const std::vector<std::string>& topics,
+                                       tab_search::mojom::ErrorPtr error) {
+          EXPECT_EQ(topics, expected_topics);
+          EXPECT_EQ(error, expected_error);
+          run_loop.Quit();
+        }));
+    run_loop.Run();
+  }
+
+  ai_chat::AIChatService* service() {
+    return ai_chat::AIChatServiceFactory::GetForBrowserContext(profile1());
+  }
+
+  ai_chat::MockEngineConsumer* SetMockTabOrganizationEngine() {
+    service()->SetTabOrganizationEngineForTesting(
+        std::make_unique<testing::NiceMock<ai_chat::MockEngineConsumer>>());
+    auto* mock_engine = static_cast<ai_chat::MockEngineConsumer*>(
+        service()->GetTabOrganizationEngineForTesting());
+    ON_CALL(*mock_engine, GetModelName())
+        .WillByDefault(testing::ReturnRef(model_name_));
+    return mock_engine;
+  }
+
  protected:
   std::unique_ptr<content::WebContents> webui_contents_;
+
+ private:
+  net::EmbeddedTestServer https_server_;
+  content::ContentMockCertVerifier mock_cert_verifier_;
+  std::string model_name_ = ai_chat::kClaudeHaikuModelName;
 };
 
+IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest,
+                       GetSuggestedTopics_NewTab) {
+  auto* mock_engine = SetMockTabOrganizationEngine();
+  ASSERT_EQ(mock_engine, service()->GetTabOrganizationEngineForTesting());
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(_, _))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic}))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic2}));
+  TestGetSuggestedTopics({kTopic}, nullptr);
+
+  AppendTabWithTitle(
+      browser(), https_server()->GetURL("foo.com", "/simple.html"),
+      kFooDotComTitle1, ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  TestGetSuggestedTopics({kTopic2}, nullptr);
+  // Cached topics should be returned when nothing changed.
+  TestGetSuggestedTopics({kTopic2}, nullptr);
+}
+
+IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest,
+                       GetSuggestedTopics_TitleUpdated) {
+  auto* mock_engine = SetMockTabOrganizationEngine();
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(_, _))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic}))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic2}));
+
+  AppendTabWithTitle(
+      browser(), https_server()->GetURL("foo.com", "/simple.html"),
+      kFooDotComTitle1, ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  TestGetSuggestedTopics({kTopic}, nullptr);
+
+  TabChangeWaiter tab_change_waiter(profile1());
+  content::WebContents* web_contents =
+      browser()->tab_strip_model()->GetActiveWebContents();
+  web_contents->UpdateTitleForEntry(
+      web_contents->GetController().GetLastCommittedEntry(), u"New Title");
+  tab_change_waiter.WaitForTabDataChanged({"New Title"});
+  TestGetSuggestedTopics({kTopic2}, nullptr);
+}
+
+IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest,
+                       GetSuggestedTopics_TabClosed) {
+  auto* mock_engine = SetMockTabOrganizationEngine();
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(_, _))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic}))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic2}));
+
+  AppendTabWithTitle(
+      browser(), https_server()->GetURL("foo.com", "/simple.html"),
+      kFooDotComTitle1, ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  AppendTabWithTitle(
+      browser(), https_server()->GetURL("bar.com", "/simple.html"),
+      kBarDotComTitle1, ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  TestGetSuggestedTopics({kTopic}, nullptr);
+
+  TabChangeWaiter tab_change_waiter(profile1());
+  browser()->tab_strip_model()->CloseWebContentsAt(
+      browser()->tab_strip_model()->active_index(), TabCloseTypes::CLOSE_NONE);
+  tab_change_waiter.WaitForTabDataChanged({kFooDotComTitle1});
+  TestGetSuggestedTopics({kTopic2}, nullptr);
+}
+
+IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest,
+                       GetSuggestedTopics_Navigated) {
+  auto* mock_engine = SetMockTabOrganizationEngine();
+  EXPECT_CALL(*mock_engine, GetSuggestedTopics(_, _))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic}))
+      .WillOnce(
+          base::test::RunOnceCallback<1>(std::vector<std::string>{kTopic2}));
+
+  AppendTabWithTitle(
+      browser(), https_server()->GetURL("foo.com", "/simple.html"),
+      kFooDotComTitle1, ui_test_utils::BROWSER_TEST_WAIT_FOR_LOAD_STOP);
+  TestGetSuggestedTopics({kTopic}, nullptr);
+
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(
+      browser(), https_server()->GetURL("dog.com", "/simple.html")));
+  TestGetSuggestedTopics({kTopic2}, nullptr);
+}
+
 IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest, GetFocusTabs) {
+  // Create another browser with the default profile.
+  chrome::NewEmptyWindow(profile1(), false);
+
   // Test Engine's GetFocusTabs is called with expected tabs info and topic.
-  auto* ai_chat_service =
-      ai_chat::AIChatServiceFactory::GetForBrowserContext(profile1());
-  ai_chat_service->SetTabOrganizationEngineForTesting(
-      std::make_unique<ai_chat::MockEngineConsumer>());
+  auto* mock_engine = SetMockTabOrganizationEngine();
 
   BrowserList* browser_list = BrowserList::GetInstance();
   ASSERT_EQ(browser_list->size(), 2u);
@@ -146,11 +348,6 @@ IN_PROC_BROWSER_TEST_F(TabSearchPageHandlerBrowserTest, GetFocusTabs) {
   std::vector<std::string> mock_ret_tabs = {base::NumberToString(tab_id1),
                                             "100", "invalid",
                                             base::NumberToString(tab_id4)};
-  auto* mock_engine = static_cast<ai_chat::MockEngineConsumer*>(
-      ai_chat_service->GetTabOrganizationEngineForTesting());
-  std::string model_name = ai_chat::kClaudeHaikuModelName;
-  EXPECT_CALL(*mock_engine, GetModelName())
-      .WillOnce(testing::ReturnRef(model_name));
   EXPECT_CALL(*mock_engine, GetFocusTabs(expected_tabs, "topic", _))
       .WillOnce(base::test::RunOnceCallback<2>(mock_ret_tabs));
 

--- a/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
+++ b/chromium_src/chrome/browser/ui/webui/tab_search/tab_search_page_handler_unittest.cc
@@ -54,6 +54,9 @@ TEST_F(TabSearchPageHandlerTest, GetSuggestedTopics) {
       ai_chat::AIChatServiceFactory::GetForBrowserContext(profile());
   ai_chat_service->SetTabOrganizationEngineForTesting(
       std::make_unique<testing::NiceMock<ai_chat::MockEngineConsumer>>());
+  // Disable caching suggested topics, caching using tab tracker service is
+  // covered by TabSearchPageHandlerBrowserTest.
+  ai_chat_service->SetTabTrackerServiceForTesting(nullptr);
 
   ai_chat_service->SetCredentialManagerForTesting(
       std::make_unique<testing::NiceMock<MockAIChatCredentialManager>>(

--- a/components/ai_chat/core/browser/conversation_handler_unittest.cc
+++ b/components/ai_chat/core/browser/conversation_handler_unittest.cc
@@ -202,9 +202,9 @@ class ConversationHandlerUnitTest : public testing::Test {
     model_service_ = std::make_unique<ModelService>(&prefs_);
 
     ai_chat_service_ = std::make_unique<AIChatService>(
-        model_service_.get(), std::move(credential_manager), &prefs_, nullptr,
-        os_crypt_.get(), shared_url_loader_factory_, "",
-        temp_directory_.GetPath());
+        model_service_.get(), nullptr /* tab_tracker_service */,
+        std::move(credential_manager), &prefs_, nullptr, os_crypt_.get(),
+        shared_url_loader_factory_, "", temp_directory_.GetPath());
 
     conversation_ = mojom::Conversation::New(
         "uuid", "title", base::Time::Now(), false, std::nullopt, 0, 0, nullptr);

--- a/ios/browser/api/ai_chat/ai_chat_service_factory.mm
+++ b/ios/browser/api/ai_chat/ai_chat_service_factory.mm
@@ -62,9 +62,9 @@ std::unique_ptr<KeyedService> AIChatServiceFactory::BuildServiceInstanceFor(
       std::move(skus_service_getter), GetApplicationContext()->GetLocalState());
   ModelService* model_service = ModelServiceFactory::GetForProfile(profile);
   return std::make_unique<AIChatService>(
-      model_service, std::move(credential_manager),
-      user_prefs::UserPrefs::Get(context), ai_chat_metrics_.get(),
-      GetApplicationContext()->GetOSCryptAsync(),
+      model_service, nullptr /* tab_tracker_service */,
+      std::move(credential_manager), user_prefs::UserPrefs::Get(context),
+      ai_chat_metrics_.get(), GetApplicationContext()->GetOSCryptAsync(),
       context->GetSharedURLLoaderFactory(),
       version_info::GetChannelString(::GetChannel()), profile->GetStatePath());
 }


### PR DESCRIPTION
- Keep cached suggested topic in AIChatService.
- Add AIChatService as a observer to TabTrackerService to clear cached topics upon tab changes.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45003

Manual Test:
1. Open several HTTPS tabs and open tab focus UI
2. Once suggested topics loaded, create a focus window
3. Go back to the original window, suggested topics should be ready and no loading happened
4. Undo the creation by clicking undo in the UI in the original window
5. Open tab focus UI again, suggested topics should be ready and no loading happened
6. Create a new HTTPS tab, then open tab focus UI, suggested topics should start loading.
7. Navigate to another URL in a tab, then open tab focus UI, suggested topics should start loading.
8. Close a tab, then open tab focus UI, suggested topics should start loading.