### PR TITLE
[iOS] - Fix playlist auto-download when adding an item

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
@@ -380,14 +380,8 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate,
               webLoaderFactory: LivePlaylistWebLoaderFactory()
             )
 
-            let newItem = (try? await mediaStreamer.loadMediaStreamingAsset(item)) ?? item
+            let newItem = try await mediaStreamer.loadMediaStreamingAsset(item)
             PlaylistManager.shared.autoDownload(item: newItem)
-
-            self.updatePlaylistURLBar(
-              tab: self.tabManager.selectedTab,
-              state: .existingItem,
-              item: newItem
-            )
           }
         } else {
           PlaylistManager.shared.autoDownload(item: item)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+Playlist.swift
@@ -364,15 +364,17 @@ extension BrowserViewController: PlaylistScriptHandlerDelegate,
     PlaylistP3A.recordUsage()
 
     let addItemToPlaylist = {
-      (item: PlaylistInfo, folderUUID: String?, completion: ((_ didAddItem: Bool) -> Void)?) in
-      PlaylistItem.addItem(item, folderUUID: folderUUID, cachedData: nil) { [weak self] in
+      [weak self] (
+        item: PlaylistInfo,
+        folderUUID: String?,
+        completion: ((_ didAddItem: Bool) -> Void)?
+      ) in
+      PlaylistItem.addItem(item, folderUUID: folderUUID, cachedData: nil) {
         guard let self = self else { return }
 
         if let url = URL(string: item.src), url.scheme == "blob" {
           // Spawn a WebView to load the non-blob asset
-          Task { @MainActor [weak self] in
-            guard let self = self else { return }
-
+          Task { @MainActor in
             let mediaStreamer = PlaylistMediaStreamer(
               playerView: self.view,
               webLoaderFactory: LivePlaylistWebLoaderFactory()

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -133,6 +133,7 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
     // This is due to a iFrames security
     item.pageSrc = tab.visibleURL?.absoluteString ?? item.pageSrc
     item.pageTitle = tab.title ?? item.pageTitle
+    item.lastPlayedOffset = 0.0
 
     Self.queue.async { [weak handler] in
       guard let handler = handler else { return }

--- a/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/UserContent/UserScripts/Scripts_Dynamic/ScriptHandlers/Paged/PlaylistScriptHandler.swift
@@ -131,20 +131,8 @@ class PlaylistScriptHandler: NSObject, TabContentScript, TabObserver {
 
     // Copy the item but use the web-view's title and location instead, if available
     // This is due to a iFrames security
-    item = PlaylistInfo(
-      name: item.name,
-      src: item.src,
-      pageSrc: tab.visibleURL?.absoluteString ?? item.pageSrc,
-      pageTitle: tab.title ?? item.pageTitle,
-      mimeType: item.mimeType,
-      duration: item.duration,
-      lastPlayedOffset: 0.0,
-      detected: item.detected,
-      dateAdded: item.dateAdded,
-      tagId: item.tagId,
-      order: item.order,
-      isInvisible: item.isInvisible
-    )
+    item.pageSrc = tab.visibleURL?.absoluteString ?? item.pageSrc
+    item.pageTitle = tab.title ?? item.pageTitle
 
     Self.queue.async { [weak handler] in
       guard let handler = handler else { return }

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -633,6 +633,10 @@ public class PlaylistManager: NSObject {
   }
 
   public func canAutoDownload(item: PlaylistInfo) -> Bool {
+    if let url = URL(string: item.src), url.scheme == "blob" {
+      return false
+    }
+
     let downloadType = PlayListDownloadType(
       rawValue: Preferences.Playlist.autoDownloadVideo.value
     )

--- a/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
+++ b/ios/brave-ios/Sources/Playlist/PlaylistManager.swift
@@ -632,24 +632,18 @@ public class PlaylistManager: NSObject {
     }
   }
 
-  public func autoDownload(item: PlaylistInfo) {
-    guard
-      let downloadType = PlayListDownloadType(
-        rawValue: Preferences.Playlist.autoDownloadVideo.value
-      )
-    else {
-      return
-    }
+  public func canAutoDownload(item: PlaylistInfo) -> Bool {
+    let downloadType = PlayListDownloadType(
+      rawValue: Preferences.Playlist.autoDownloadVideo.value
+    )
 
-    switch downloadType {
-    case .on:
+    // Only download when the preference is on OR when the preference is on Wifi
+    return downloadType == .on || downloadType == .wifi && DeviceInfo.hasWifiConnection()
+  }
+
+  public func autoDownload(item: PlaylistInfo) {
+    if canAutoDownload(item: item) {
       PlaylistManager.shared.download(item: item)
-    case .wifi:
-      if DeviceInfo.hasWifiConnection() {
-        PlaylistManager.shared.download(item: item)
-      }
-    case .off:
-      break
     }
   }
 


### PR DESCRIPTION
## Summary
- Cleanup Code
- Fix auto-download so it spawns an invisible WebView to download blobs items automatically in the background, when added


<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/44652


## Test Plan
- Add a 4K item from Youtube to playlist
- Wait a while (maybe wait about 10-20s? Depends on internet speed and size of item)
- Open Playlist
- The item should be downloaded already


## Screenshots
- We can see the `item` has a `src` with `blob:https://m.youtube.com/....`
- We can see the `newItem` has a `src` with `https://rr5---sn` and it downloads `newItem`:  `PlaylistManager.shared.autoDownload(item: newItem)`

<img width="971" alt="image" src="https://github.com/user-attachments/assets/e8a1975c-3063-49ec-bada-054dfd115487" />

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
