### PR TITLE
Allow for empty favicons for WebSources

### DIFF
--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/web_sources_event.test.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/web_sources_event.test.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import { render, screen } from '@testing-library/react'
+import WebSourcesEvent from './web_sources_event'
+
+test('WebSourcesEvent shows chrome-untrusted:// favicon URL as-is', () => {
+  render(
+    <WebSourcesEvent
+      sources={[
+        {
+          faviconUrl: { url:
+            'chrome-untrusted://resources/brave-icons/globe.svg' },
+          url: { url: 'https://example.com' },
+          title: 'Example Site'
+        }
+      ]}
+    />
+  )
+
+  const img = screen.getByRole('img')
+  expect(img).toHaveAttribute('src',
+      'chrome-untrusted://resources/brave-icons/globe.svg')
+})
+
+test('WebSourcesEvent sanitizes non-chrome-untrusted favicon URL', () => {
+  const faviconUrl = 'https://imgs.search.brave.com/favicon.ico'
+
+  render(
+    <WebSourcesEvent
+      sources={[
+        {
+          faviconUrl: { url: faviconUrl },
+          url: { url: 'https://example.com' },
+          title: 'Example Site'
+        }
+      ]}
+    />
+  )
+
+  const img = screen.getByRole('img')
+  expect(img).toHaveAttribute('src',
+      '//image?url=https%3A%2F%2Fimgs.search.brave.com%2Ffavicon.ico')
+})

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/web_sources_event.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/assistant_response/web_sources_event.tsx
@@ -24,11 +24,15 @@ function WebSource (props: { source: mojom.WebSource }) {
     context.uiHandler?.openURLFromResponse(source.url)
   }
 
+  const faviconSrc = source.faviconUrl.url.startsWith('chrome-untrusted://')
+    ? source.faviconUrl.url
+    : createSanitizedImageUrl(source.faviconUrl.url)
+
   const host = new URL(source.url.url).hostname
   return (
     <li>
       <a href={source.url.url} title={source.title} onClick={(e) => handleOpenSource(e, source)}>
-        <img src={createSanitizedImageUrl(source.faviconUrl.url)} />
+        <img src={faviconSrc} />
         {host}
       </a>
     </li>

--- a/ui/webui/resources/BUILD.gn
+++ b/ui/webui/resources/BUILD.gn
@@ -256,6 +256,7 @@ leo_icons = [
   "font-size.svg",
   "forward-15.svg",
   "fullscreen-on.svg",
+  "globe.svg",
   "google-color.svg",
   "graph.svg",
   "grid04.svg",


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45346

Here's an example of the new type of reply that can fetch URL content. And the WebSource which doesn't come with a favicon.

If an old client uses the new aichat side, it will not show the WebSource.

<img width="897" alt="Screenshot 2025-04-10 at 2 55 18 PM" src="https://github.com/user-attachments/assets/ee1e8bd4-71e4-4128-a951-f886970066b6" />

This is for URL fetching support on the server side. Which does not return a favicon

# Test Plan
Ask Leo something like:
In https://brianbondy.com/blog/188/can-confirm-hurt-100-hurts what did he eat?

Most of the time it should do a content search and give you the right answer. It should show a WebSource per the screenshot here.

Without this change, it should reply correctly, but no WebSource will be shown.


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
