### PR TITLE
Mirror upstream's macOS codesign requirements

### DIFF
--- a/build/mac/signing/internal_config.py
+++ b/build/mac/signing/internal_config.py
@@ -43,7 +43,7 @@ class InternalCodeSignConfig(ChromiumCodeSignConfig):
 
     @property
     def codesign_requirements_basic(self):
-        return 'and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists / and certificate leaf[field.1.2.840.113635.100.6.1.13] / exists */'  # pylint: disable=line-too-long
+        return 'and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = KL8N8XSYF4'  # pylint: disable=line-too-long
 
     @property
     def provisioning_profile_basename(self):


### PR DESCRIPTION
The previous original author @bridiver of the affected line said he only commented out some parts because they failed the signing process. Also, both Chrome and Edge have the subject part that is being added here.

Resolves https://github.com/brave/brave-browser/issues/45347.

# Test plan

Please check that Brave's DMG and PKG installers still work, ideally on a machine that has never seen Brave, and that Brave can be updated to and from versions with this change.