### PR TITLE
AI Chat: Move Open External Link Listener to Context

### DIFF
--- a/components/ai_chat/core/common/mojom/untrusted_frame.mojom
+++ b/components/ai_chat/core/common/mojom/untrusted_frame.mojom
@@ -29,7 +29,7 @@ interface ParentUIFrame {
   // and fixes centering the modal in the page view. The parent frame
   // then deals with whether to display the modal or to continue opening
   // the link.
-  SetOpeningExternalLinkURL(string url);
+  UserRequestedOpenGeneratedUrl(url.mojom.Url url);
 };
 
 // Browser-side handler for untrusted frame that handles rendering of

--- a/components/ai_chat/resources/page/stories/components_panel.tsx
+++ b/components/ai_chat/resources/page/stories/components_panel.tsx
@@ -9,6 +9,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import '@brave/leo/tokens/css/variables.css'
 import '$web-components/app.global.scss'
 import { getKeysForMojomEnum } from '$web-common/mojomUtils'
+import { Url } from 'gen/url/mojom/url.mojom.m.js'
 import { InferControlsFromArgs } from '../../../../../.storybook/utils'
 import * as Mojom from '../../common/mojom'
 import { ActiveChatContext, SelectedChatDetails } from '../state/active_chat_context'
@@ -486,6 +487,7 @@ type CustomArgs = {
   isGenerating: boolean
   showAttachments: boolean
   isNewConversation: boolean
+  generatedUrlToBeOpened: Url | undefined
 }
 
 const args: CustomArgs = {
@@ -520,6 +522,7 @@ const args: CustomArgs = {
   isGenerating: false,
   showAttachments: true,
   isNewConversation: false,
+  generatedUrlToBeOpened: undefined
 }
 
 const meta: Meta<CustomArgs> = {
@@ -546,6 +549,10 @@ const meta: Meta<CustomArgs> = {
     },
     deletingConversationId: {
       options: CONVERSATIONS.map(conversation => conversation.uuid),
+      control: { type: 'select' }
+    },
+    generatedUrlToBeOpened: {
+      options: [{ url: 'https://www.example.com' }],
       control: { type: 'select' }
     }
   },
@@ -687,6 +694,7 @@ function StoryContext(props: React.PropsWithChildren<{ args: CustomArgs, setArgs
     isCharLimitExceeded: inputText.length > 70,
     inputTextCharCountDisplay: `${inputText.length} / 70`,
     pendingMessageImages: null,
+    generatedUrlToBeOpened: options.args.generatedUrlToBeOpened,
     setInputText,
     setCurrentModel: () => { },
     switchToBasicModel,
@@ -705,7 +713,10 @@ function StoryContext(props: React.PropsWithChildren<{ args: CustomArgs, setArgs
     setShowAttachments: (show: boolean) => setArgs({ showAttachments: show }),
     showAttachments: options.args.showAttachments,
     removeImage: () => {},
-    uploadImage: (useMediaCapture: boolean) => {}
+    uploadImage: (useMediaCapture: boolean) => {},
+    setGeneratedUrlToBeOpened:
+      (url?: Url) => setArgs({ generatedUrlToBeOpened: url }),
+    setIgnoreExternalLinkWarning: () => { }
   }
 
   const conversationEntriesContext: UntrustedConversationContext = {

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/index.tsx
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/markdown_renderer/index.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 import Markdown from 'react-markdown'
 import type { Root, Element as HastElement } from 'hast'
+import { Url } from 'gen/url/mojom/url.mojom.m.js'
 
 import { visit } from 'unist-util-visit'
 
@@ -102,7 +103,9 @@ export function RenderLink(props: RenderLinkProps) {
 
   const handleLinkClicked = React.useCallback(() => {
     if (href && isLinkAllowed) {
-      context.parentUiFrame?.setOpeningExternalLinkURL(href)
+      const mojomUrl = new Url()
+      mojomUrl.url = href
+      context.parentUiFrame?.userRequestedOpenGeneratedUrl(mojomUrl)
     }
   }, [context, href])
 


### PR DESCRIPTION
## Description 

- Moves the open external link listener and logic into the `conversation_context`.
- Now uses `api.uiHandler.openURL(url)` instead of  `chrome.tabs` to open external links.
- Fixes `Storybook`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/45390>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. The `Open External Link` modal should continue to work as expected
2. `Storybook` should not be broken for `Leo AI`