### PR TITLE
[iOS] - Fix Private Browsing Not working on Open Window

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -385,7 +385,13 @@ extension SceneDelegate {
         let urlString = userInfo[CSSearchableItemActivityIdentifier] as? String,
         let url = URL(string: urlString)
       {
-        scene.browserViewController?.switchToTabForURLOrOpen(url, isPrivileged: false)
+        let isPrivateBrowsing =
+          scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true
+        scene.browserViewController?.switchToTabForURLOrOpen(
+          url,
+          isPrivate: isPrivateBrowsing,
+          isPrivileged: false
+        )
         return
       }
     case ActivityType.newTab.identifier:
@@ -480,7 +486,13 @@ extension SceneDelegate {
         break
       }
 
-      scene.browserViewController?.switchToTabForURLOrOpen(url, isPrivileged: true)
+      let isPrivateBrowsing =
+        scene.browserViewController?.privateBrowsingManager.isPrivateBrowsing == true
+      scene.browserViewController?.switchToTabForURLOrOpen(
+        url,
+        isPrivate: isPrivateBrowsing,
+        isPrivileged: true
+      )
       return
     }
   }
@@ -613,8 +625,12 @@ extension SceneDelegate {
       urlToOpen = nil
     }
 
-    scene.userActivity = BrowserState.userActivity(for: windowId.uuidString, isPrivate: false)
-    BrowserState.setWindowInfo(for: scene.session, windowId: windowId.uuidString, isPrivate: false)
+    scene.userActivity = BrowserState.userActivity(for: windowId.uuidString, isPrivate: isPrivate)
+    BrowserState.setWindowInfo(
+      for: scene.session,
+      windowId: windowId.uuidString,
+      isPrivate: isPrivate
+    )
 
     // Create a browser instance
     let browserViewController = BrowserViewController(
@@ -665,7 +681,11 @@ extension SceneDelegate {
     if let urlToOpen = urlToOpen {
       DispatchQueue.main.async {
         browserViewController.loadViewIfNeeded()
-        browserViewController.switchToTabForURLOrOpen(urlToOpen, isPrivileged: false)
+        browserViewController.switchToTabForURLOrOpen(
+          urlToOpen,
+          isPrivate: isPrivate,
+          isPrivileged: false
+        )
       }
     }
 

--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -491,7 +491,7 @@ extension SceneDelegate {
       scene.browserViewController?.switchToTabForURLOrOpen(
         url,
         isPrivate: isPrivateBrowsing,
-        isPrivileged: true
+        isPrivileged: false
       )
       return
     }

--- a/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/SceneDelegate.swift
@@ -625,12 +625,8 @@ extension SceneDelegate {
       urlToOpen = nil
     }
 
-    scene.userActivity = BrowserState.userActivity(for: windowId.uuidString, isPrivate: isPrivate)
-    BrowserState.setWindowInfo(
-      for: scene.session,
-      windowId: windowId.uuidString,
-      isPrivate: isPrivate
-    )
+    scene.userActivity = BrowserState.userActivity(for: windowId.uuidString, isPrivate: false)
+    BrowserState.setWindowInfo(for: scene.session, windowId: windowId.uuidString, isPrivate: false)
 
     // Create a browser instance
     let browserViewController = BrowserViewController(

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BrowserViewController.swift
@@ -1905,7 +1905,7 @@ public class BrowserViewController: UIViewController {
     browser.tabManager.addTabsForURLs([url], zombie: false, isPrivate: isPrivate)
   }
 
-  public func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool = false, isPrivileged: Bool) {
+  public func switchToTabForURLOrOpen(_ url: URL, isPrivate: Bool, isPrivileged: Bool) {
     popToBVC(isAnimated: false)
 
     if let tab = tabManager.getTabForURL(url, isPrivate: isPrivate) {


### PR DESCRIPTION
## Info
- The `isPrivateBrowsing: Bool = false` causes bugs where the parameter is defaulted to false, and usage of the `openInNewTab` can accidentally not notice that it's false by default. This can cause incorrect usage of the function.

## Summary
- Remove `isPrivateBrowsing: Bool = false` for private browsing (removed default parameter). 
- Update all uses to explicitly specify private browsing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45389

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
