### PR TITLE
[canary] Adding `GitStatus` tests

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -179,6 +179,7 @@ import sys
 from typing import Optional, List, Dict
 
 from incendiary_error_handler import IncendiaryErrorHandler
+from git_status import GitStatus
 from patchfile import Patchfile
 import repository
 from repository import Repository, CHROMIUM_SRC_PATH
@@ -303,38 +304,6 @@ def _get_apply_patches_list():
         return json.loads(match.group(0))
 
     return None
-
-
-class GitStatus:
-    """Runs `git status` and provides a summary.
-    """
-
-    def __init__(self):
-        self.git_status = repository.brave.run_git('status', '--short')
-
-        # a list of all deleted files, regardless of their staged status.
-        self.deleted = []
-
-        # a list of all modified files, regardless of their staged status.
-        self.modified = []
-
-        # a list of all untracked files.
-        self.untracked = []
-
-        for line in self.git_status.splitlines():
-            [status, path] = line.lstrip().split(' ', 1)
-            if status == 'D':
-                self.deleted.append(path)
-            elif status == 'M':
-                self.modified.append(path)
-            elif status == '??':
-                self.untracked.append(path)
-
-    def has_deleted_patch_files(self):
-        return any(path.endswith('.patch') for path in self.deleted)
-
-    def has_untracked_patch_files(self):
-        return any(path.endswith('.patch') for path in self.untracked)
 
 
 @dataclass(frozen=True)

--- a/tools/cr/git_status.py
+++ b/tools/cr/git_status.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import repository
+
+
+class GitStatus:
+    """Runs `git status` and provides a summary.
+    """
+
+    def __init__(self):
+        self.git_status = repository.brave.run_git('status', '--short')
+
+        # a list of all deleted files, regardless of their staged status.
+        self.deleted = []
+
+        # a list of all modified files, regardless of their staged status.
+        self.modified = []
+
+        # a list of all untracked files.
+        self.untracked = []
+
+        for line in self.git_status.splitlines():
+            [status, path] = line.lstrip().split(' ', 1)
+            if status == 'D':
+                self.deleted.append(path)
+            elif status == 'M':
+                self.modified.append(path)
+            elif status == '??':
+                self.untracked.append(path)
+
+    def has_deleted_patch_files(self):
+        return any(path.endswith('.patch') for path in self.deleted)
+
+    def has_untracked_patch_files(self):
+        return any(path.endswith('.patch') for path in self.untracked)

--- a/tools/cr/git_status_test.py
+++ b/tools/cr/git_status_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+from pathlib import Path
+
+from test.fake_chromium_src import FakeChromiumSrc
+from git_status import GitStatus
+
+
+class GitStatusTest(unittest.TestCase):
+
+    def setUp(self):
+        """Set up a fake Chromium repository for testing."""
+        self.fake_chromium_src = FakeChromiumSrc()
+        self.fake_chromium_src.setup()
+        self.addCleanup(self.fake_chromium_src.cleanup)
+
+    def test_has_deleted_patch_files(self):
+        """Test has_deleted_patch_files method."""
+        self.assertFalse(GitStatus().has_deleted_patch_files())
+
+        # Create a patch file and commit it
+        patch_file = 'patches/test.patch'
+        self.fake_chromium_src.write_and_stage_file(
+            patch_file, 'Patch content', self.fake_chromium_src.brave)
+        self.fake_chromium_src.commit('Add test.patch',
+                                      self.fake_chromium_src.brave)
+
+        # Delete the patch file
+        self.fake_chromium_src.delete_file(patch_file,
+                                           self.fake_chromium_src.brave)
+
+        # Run GitStatus and verify the deleted patch file is detected
+        self.assertTrue(GitStatus().has_deleted_patch_files())
+
+    def test_has_untracked_patch_files(self):
+        """Test has_untracked_patch_files method."""
+        self.assertFalse(GitStatus().has_untracked_patch_files())
+
+        # Create a patch file but do not stage it
+        Path(self.fake_chromium_src.brave /
+             'test_untracked.patch').write_text('Untracked patch content')
+
+        # Run GitStatus and verify the untracked patch file is detected
+        self.assertTrue(GitStatus().has_untracked_patch_files())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cr/patchfile.py
+++ b/tools/cr/patchfile.py
@@ -6,7 +6,7 @@
 from dataclasses import dataclass, field, replace
 from enum import Enum, auto
 import logging
-from pathlib import PurePath
+from pathlib import PurePath, Path
 import re
 import subprocess
 from typing import Optional, NamedTuple


### PR DESCRIPTION
These change adds coverage to `GitStatus`. It also adds some extra tests for `Patchfile` completing the coverage for that type.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45234

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
