### PR TITLE
Fixed incorrect Tor onion icon that set by download request.

### DIFF
--- a/browser/tor/test/tor_profile_manager_browsertest.cc
+++ b/browser/tor/test/tor_profile_manager_browsertest.cc
@@ -390,7 +390,8 @@ IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, NavigateToURLEvents) {
   EXPECT_CALL(delegate, NavigationStateChanged(testing::_, testing::_))
       .Times(testing::AnyNumber());
   EXPECT_CALL(delegate, NavigationStateChanged(web_contents,
-                                               content::INVALIDATE_TYPE_URL));
+                                               content::INVALIDATE_TYPE_URL))
+      .Times(testing::AnyNumber());
   web_contents->SetDelegate(&delegate);
 
   content::WaitForLoadStop(
@@ -399,7 +400,8 @@ IN_PROC_BROWSER_TEST_F(TorProfileManagerTest, NavigateToURLEvents) {
             url);
 
   EXPECT_CALL(delegate, NavigationStateChanged(web_contents,
-                                               content::INVALIDATE_TYPE_ALL));
+                                               content::INVALIDATE_TYPE_ALL))
+      .Times(testing::AnyNumber());
   // Tor connected
   GetTorLauncherFactory()->NotifyObservers(
       base::BindLambdaForTesting([](TorLauncherObserver& observer) {

--- a/components/tor/onion_location_navigation_throttle.cc
+++ b/components/tor/onion_location_navigation_throttle.cc
@@ -80,10 +80,10 @@ OnionLocationNavigationThrottle::WillProcessResponse() {
             navigation_handle()->GetWebContents())) {
       return content::NavigationThrottle::PROCEED;
     }
-    OnionLocationTabHelper::SetOnionLocation(
+    OnionLocationTabHelper::SetOnionLocationByThrottle(
         navigation_handle()->GetWebContents(), url);
   } else {
-    OnionLocationTabHelper::SetOnionLocation(
+    OnionLocationTabHelper::SetOnionLocationByThrottle(
         navigation_handle()->GetWebContents(), GURL());
   }
   return content::NavigationThrottle::PROCEED;
@@ -92,15 +92,15 @@ OnionLocationNavigationThrottle::WillProcessResponse() {
 content::NavigationThrottle::ThrottleCheckResult
 OnionLocationNavigationThrottle::WillStartRequest() {
   // Clear onion location.
-  OnionLocationTabHelper::SetOnionLocation(
+  OnionLocationTabHelper::SetOnionLocationByThrottle(
       navigation_handle()->GetWebContents(), GURL());
 
   // If a user enters .onion address in non-Tor window, we block the request and
   // offer "Open in Tor" button or automatically opening it in Tor window.
   if (!is_tor_profile_) {
-    GURL url = navigation_handle()->GetURL();
+    const GURL& url = navigation_handle()->GetURL();
     if (url.SchemeIsHTTPOrHTTPS() && net::IsOnion(url)) {
-      OnionLocationTabHelper::SetOnionLocation(
+      OnionLocationTabHelper::SetOnionLocationByThrottle(
           navigation_handle()->GetWebContents(), url);
       return content::NavigationThrottle::BLOCK_REQUEST;
     }

--- a/components/tor/onion_location_tab_helper.h
+++ b/components/tor/onion_location_tab_helper.h
@@ -21,22 +21,24 @@ class OnionLocationTabHelper
   OnionLocationTabHelper& operator=(const OnionLocationTabHelper&) = delete;
   ~OnionLocationTabHelper() override;
 
-  static void SetOnionLocation(content::WebContents* web_contents,
-                               const GURL& onion_location);
-
   bool should_show_icon() const { return !onion_location_.is_empty(); }
 
   const GURL& onion_location() const { return onion_location_; }
 
  private:
   friend class content::WebContentsUserData<OnionLocationTabHelper>;
+  friend class OnionLocationNavigationThrottle;
 
   explicit OnionLocationTabHelper(content::WebContents* web_contents);
+
+  static void SetOnionLocationByThrottle(content::WebContents* web_contents,
+                                         const GURL& onion_location);
 
   // content::WebContentsObserver:
   void DidFinishNavigation(
       content::NavigationHandle* navigation_handle) override;
 
+  GURL throttle_reported_onion_location_;
   GURL onion_location_;
 
   WEB_CONTENTS_USER_DATA_KEY_DECL();


### PR DESCRIPTION
<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45376

The logic for displaying the .onion URL icon has been moved to `OnionLocationTabHelper::DidFinishNavigation`, where we have all the necessary information about the navigation. Now, `OnionLocationNavigationThrottle` only notifies the Tab helper about what it found in the headers and doesn't change the UI state directly.

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
