### PR TITLE
[patches]: Make it possible to update only a specific patches with `update_patches`

### DIFF
--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -207,6 +207,8 @@ program
 
 program
   .command('update_patches')
+  .arguments('[filePaths...]')
+  .description("Updates all patches in the brave-core repo. If a filePath is provider, only that specific file will be updated.")
   .action(updatePatches)
 
 program

--- a/build/commands/scripts/updatePatches.js
+++ b/build/commands/scripts/updatePatches.js
@@ -48,7 +48,7 @@ function loadChromiumPathFilter(filePath) {
 chromiumPathFilter = loadChromiumPathFilter(
     path.join(config.braveCoreDir, 'build', 'update_patches_exclusions.cfg'))
 
-module.exports = function RunCommand (options) {
+module.exports = function RunCommand (filePaths, options) {
   config.update(options)
 
   const chromiumDir = config.srcDir
@@ -68,17 +68,17 @@ module.exports = function RunCommand (options) {
 
   Promise.all([
     // chromium
-    updatePatches(chromiumDir, patchDir, chromiumPathFilter),
+    updatePatches(chromiumDir, patchDir, filePaths, chromiumPathFilter),
     // v8
-    updatePatches(v8Dir, v8PatchDir),
+    updatePatches(v8Dir, v8PatchDir, filePaths),
     // third_party/catapult
-    updatePatches(catapultDir, catapultPatchDir),
+    updatePatches(catapultDir, catapultPatchDir, filePaths),
     // third_party/devtools-frontend/src
-    updatePatches(devtoolsFrontendDir, devtoolsFrontendPatchDir),
+    updatePatches(devtoolsFrontendDir, devtoolsFrontendPatchDir, filePaths),
     // third_party/tflite/src
-    updatePatches(tfliteDir, tflitePatchDir),
+    updatePatches(tfliteDir, tflitePatchDir, filePaths),
     // third_party/search_engines_data
-    updatePatches(searchEngineDataDir, searchEngineDataPatchDir),
+    updatePatches(searchEngineDataDir, searchEngineDataPatchDir, filePaths),
   ])
   .then(() => {
     console.log('Done.')


### PR DESCRIPTION
In this Slack thread I was formatting patches differently to everybody else:
https://bravesoftware.slack.com/archives/C7VLGSR55/p1744377996280649

because I'd changed some settings in my `.gitconfig` (since changed back) and I was using `git diff <file> > brave/patches/<patch-file>` to create the patches because I have modifications to upstream (like log statements and disabled `DCHECK`s for Wayland).

This PR makes it possible to only update a specific set of patches by passing in the paths of the files you want to update.

`npm run update_patches -- path/to/file1.ext path/to/file2.ext`

not passing in any paths has the same behavior as before, so this shouldn't have any effect on existing workflows.