### PR TITLE
[iOS] Update `TabState.takeSnapshot` to allow for repeated callbacks

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Helpers/ScreenshotHelper.swift
@@ -37,8 +37,8 @@ class ScreenshotHelper {
       if !tab.canTakeSnapshot {
         return
       }
-      Task { @MainActor in
-        let image = await tab.takeSnapshot(rect: .null)
+      tab.takeSnapshot(rect: .null) { [weak tab] image in
+        guard let tab else { return }
         if let image = image {
           tab.browserData?.setScreenshot(image)
         } else {

--- a/ios/brave-ios/Sources/Web/AnyTabState.swift
+++ b/ios/brave-ios/Sources/Web/AnyTabState.swift
@@ -161,8 +161,8 @@ public class AnyTabState: TabState {
     tab.canTakeSnapshot
   }
 
-  public func takeSnapshot(rect: CGRect) async -> UIImage? {
-    await tab.takeSnapshot(rect: rect)
+  public func takeSnapshot(rect: CGRect, handler: @escaping (UIImage?) -> Void) {
+    tab.takeSnapshot(rect: rect, handler: handler)
   }
 
   public func createFullPagePDF() async throws -> Data? {

--- a/ios/brave-ios/Sources/Web/TabState.swift
+++ b/ios/brave-ios/Sources/Web/TabState.swift
@@ -189,8 +189,8 @@ public protocol TabState: AnyObject {
   /// Whether or not the TabState can be captured in a snapshot
   var canTakeSnapshot: Bool { get }
   /// Takes a snapshot of the web contents with the given rect. Pass in a `null` rect to capture
-  /// the entire page
-  func takeSnapshot(rect: CGRect) async -> UIImage?
+  /// the entire page. `handler` may be called more than once
+  func takeSnapshot(rect: CGRect, handler: @escaping (UIImage?) -> Void)
   /// Creates a full page PDF of the web contents
   func createFullPagePDF() async throws -> Data?
   /// Presents the find in page interaction using the provided text as an initial search query


### PR DESCRIPTION
There is a bug in WebKit where if you call `takeSnapshot` on the web view more than once it will break the integrity of the completion handlers. Chromium solves this by instead forcing a repeat closure to be passed in so this change will switch back to a standard closure based solution to match

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45407

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
