### PR TITLE
[canary] Support JSON output with `npm run presubmit` (uplift to 1.78.x)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,5 +79,8 @@ xcuserdata
 # This is a temp file used by script/version_up.py
 .version_upgrade
 
+# A file that may be left behind in the CI after running presubmits
+.presubmit_results.json
+
 # buffer exclusion file generated locally during sync
 build/config/unsafe_buffers_paths.txt

--- a/build/commands/lib/util.js
+++ b/build/commands/lib/util.js
@@ -813,6 +813,11 @@ const util = {
     if (options.verbose) {
       args.push(...Array(options.verbose).fill('--verbose'))
     }
+    if (options.json) {
+      args.push('-j')
+      args.push(options.json)
+    }
+
     if (options.fix) {
       cmd_options.env.PRESUBMIT_FIX = '1'
     }

--- a/build/commands/scripts/commands.js
+++ b/build/commands/scripts/commands.js
@@ -246,6 +246,7 @@ program
     'semicolon-separated list files to run presubmit on')
   .option('--verbose [arg]', 'pass --verbose 2 for more debugging info', JSON.parse)
   .option('--fix', 'try to fix found issues automatically')
+  .option('--json <output>', 'An output file for a JSON report')
   .action(util.presubmit)
 
 program


### PR DESCRIPTION
Uplift of #28352
Resolves https://github.com/brave/brave-browser/issues/44994

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.