### PR TITLE
[ads] Enable "ShouldAlwaysRunBraveAdsService" and "ShouldAlwaysTriggerBraveSearchResultAdEvents" by default - 1.78.x

### DIFF
--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -18,7 +18,6 @@
 #include "brave/components/ai_rewriter/common/buildflags/buildflags.h"
 #include "brave/components/brave_ads/browser/ad_units/notification_ad/custom_notification_ad_feature.h"
 #include "brave/components/brave_ads/core/public/ad_units/notification_ad/notification_ad_feature.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_education/buildflags.h"
 #include "brave/components/brave_news/common/features.h"
@@ -837,26 +836,6 @@ const flags_ui::FeatureEntry::FeatureVariation kZCashFeatureVariations[] = {
           kOsDesktop | kOsAndroid,                                             \
           FEATURE_VALUE_TYPE(                                                  \
               brave_rewards::features::kPlatformCreatorDetectionFeature),      \
-      },                                                                       \
-      {                                                                        \
-          "brave-ads-should-always-run-brave-ads-service",                     \
-          "Should always run Brave Ads service",                               \
-          "Always run Brave Ads service to support triggering ad events when " \
-          "Brave Private Ads are disabled.",                                   \
-          kOsAll,                                                              \
-          FEATURE_VALUE_TYPE(                                                  \
-              brave_ads::kShouldAlwaysRunBraveAdsServiceFeature),              \
-      },                                                                       \
-      {                                                                        \
-          "brave-ads-should-always-trigger-search-result-ad-events",           \
-          "Should always trigger search result ad events",                     \
-          "Support triggering search result ad events if Brave Private Ads "   \
-          "are disabled. Requires "                                            \
-          "#brave-ads-should-always-run-brave-ads-service to be enabled.",     \
-          kOsAll,                                                              \
-          FEATURE_VALUE_TYPE(                                                  \
-              brave_ads::                                                      \
-                  kShouldAlwaysTriggerBraveSearchResultAdEventsFeature),       \
       },                                                                       \
       {                                                                        \
           "brave-ads-custom-push-notifications-ads",                           \

--- a/browser/about_flags.cc
+++ b/browser/about_flags.cc
@@ -848,15 +848,6 @@ const flags_ui::FeatureEntry::FeatureVariation kZCashFeatureVariations[] = {
               brave_ads::kShouldAlwaysRunBraveAdsServiceFeature),              \
       },                                                                       \
       {                                                                        \
-          "brave-ads-should-support-search-result-ads",                        \
-          "Support Search Result Ads feature",                                 \
-          "Should be used in combination with "                                \
-          "#brave-ads-should-always-trigger-search-result-ad-events and "      \
-          "#brave-ads-should-always-run-brave-ads-service",                    \
-          kOsAll,                                                              \
-          FEATURE_VALUE_TYPE(brave_ads::kShouldSupportSearchResultAdsFeature), \
-      },                                                                       \
-      {                                                                        \
           "brave-ads-should-always-trigger-search-result-ad-events",           \
           "Should always trigger search result ad events",                     \
           "Support triggering search result ad events if Brave Private Ads "   \

--- a/browser/brave_ads/ads_service_factory.cc
+++ b/browser/brave_ads/ads_service_factory.cc
@@ -108,7 +108,7 @@ AdsServiceFactory::BuildServiceInstanceForBrowserContext(
 }
 
 bool AdsServiceFactory::ServiceIsNULLWhileTesting() const {
-  return false;
+  return true;
 }
 
 }  // namespace brave_ads

--- a/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_tab_helper.cc
+++ b/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_tab_helper.cc
@@ -79,19 +79,10 @@ void CreativeSearchResultAdTabHelper::MaybeCreateForWebContents(
     return;
   }
 
-  if (!ShouldSupportSearchResultAds()) {
-    return;
-  }
-
   CreateForWebContents(web_contents);
 }
 
 bool CreativeSearchResultAdTabHelper::ShouldHandleCreativeAdEvents() const {
-  if (!ShouldSupportSearchResultAds()) {
-    // If the feature is disabled, we should not trigger creative ad events.
-    return false;
-  }
-
   if (ShouldAlwaysTriggerSearchResultAdEvents()) {
     // If the feature is enabled, we should always trigger creative ad events.
     return true;

--- a/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_tab_helper_browsertest.cc
+++ b/browser/brave_ads/creatives/search_result_ad/creative_search_result_ad_tab_helper_browsertest.cc
@@ -85,11 +85,6 @@ class ScopedTestingAdsServiceSetter {
 class BraveAdsCreativeSearchResultAdTabHelperTest
     : public CertVerifierBrowserTest {
  public:
-  BraveAdsCreativeSearchResultAdTabHelperTest() {
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldSupportSearchResultAdsFeature);
-  }
-
   void SetUpOnMainThread() override {
     CertVerifierBrowserTest::SetUpOnMainThread();
     mock_cert_verifier()->set_default_result(net::OK);

--- a/browser/brave_ads/services/bat_ads_service_factory_impl.cc
+++ b/browser/brave_ads/services/bat_ads_service_factory_impl.cc
@@ -36,10 +36,11 @@ mojo::Remote<bat_ads::mojom::BatAdsService> LaunchInProcessBatAdsService() {
   base::ThreadPool::CreateSingleThreadTaskRunner(
       {base::MayBlock(), base::WithBaseSyncPrimitives()},
       base::SingleThreadTaskRunnerThreadMode::DEDICATED)
-      ->PostTask(
+      ->PostDelayedTask(
           FROM_HERE,
           base::BindOnce(&BindInProcessBatAdsService,
-                         bat_ads_service_remote.BindNewPipeAndPassReceiver()));
+                         bat_ads_service_remote.BindNewPipeAndPassReceiver()),
+          base::Seconds(3));
   return bat_ads_service_remote;
 }
 

--- a/browser/net/brave_network_audit_allowed_lists.h
+++ b/browser/net/brave_network_audit_allowed_lists.h
@@ -63,18 +63,6 @@ inline constexpr auto kAllowedUrlPrefixes = std::to_array<std::string_view>({
     // Brave's Privacy-focused CDN
     "https://pcdn.brave.com/",
 
-    // Brave Rewards production
-    "https://api.rewards.brave.com/v1/cards",
-    "https://api.rewards.brave.com/v1/parameters",
-    "https://rewards.brave.com/publishers/prefix-list",
-    "https://grant.rewards.brave.com/v1/promotions",
-
-    // Brave Rewards staging & dev
-    "https://api.rewards.bravesoftware.com/v1/cards",
-    "https://api.rewards.bravesoftware.com/v1/parameters",
-    "https://rewards-stg.bravesoftware.com/publishers/prefix-list",
-    "https://grant.rewards.bravesoftware.com/v1/promotions",
-
     // p3a
     "https://p3a-creative.brave.com/",
     "https://p3a-json.brave.com/",

--- a/browser/net/brave_network_audit_browsertest.cc
+++ b/browser/net/brave_network_audit_browsertest.cc
@@ -17,11 +17,9 @@
 #include "base/test/scoped_run_loop_timeout.h"
 #include "base/test/test_timeouts.h"
 #include "base/time/time.h"
-#include "brave/browser/brave_rewards/rewards_service_factory.h"
 #include "brave/browser/net/brave_network_audit_allowed_lists.h"
 #include "brave/browser/net/brave_network_audit_test_helper.h"
 #include "brave/browser/ui/brave_browser.h"
-#include "brave/components/brave_rewards/content/rewards_service_impl.h"
 #include "brave/components/playlist/common/buildflags/buildflags.h"
 #include "chrome/browser/password_manager/profile_password_store_factory.h"
 #include "chrome/browser/profiles/profile.h"
@@ -79,18 +77,6 @@ class BraveNetworkAuditTest : public InProcessBrowserTest {
     InProcessBrowserTest::SetUpOnMainThread();
 
     ASSERT_TRUE(embedded_test_server()->Start());
-
-    // Create and start the Rewards service
-    rewards_service_ = static_cast<brave_rewards::RewardsServiceImpl*>(
-        brave_rewards::RewardsServiceFactory::GetForProfile(profile()));
-    base::RunLoop run_loop;
-    rewards_service_->StartProcessForTesting(run_loop.QuitClosure());
-    run_loop.Run();
-  }
-
-  void TearDownOnMainThread() override {
-    rewards_service_->Shutdown();
-    InProcessBrowserTest::TearDownOnMainThread();
   }
 
   void SetUpCommandLine(base::CommandLine* command_line) override {
@@ -115,18 +101,9 @@ class BraveNetworkAuditTest : public InProcessBrowserTest {
                           std::vector<std::string>());
   }
 
-  bool EnableBraveRewards() {
-    PrefService* pref_service = profile()->GetPrefs();
-    pref_service->SetInteger("brave.rewards.version", 7);
-    pref_service->SetBoolean("brave.rewards.enabled", true);
-    return pref_service->GetBoolean("brave.rewards.enabled");
-  }
-
   Profile* profile() { return browser()->profile(); }
 
  private:
-  raw_ptr<brave_rewards::RewardsServiceImpl, DanglingUntriaged>
-      rewards_service_ = nullptr;
   base::FilePath net_log_path_;
   base::FilePath audit_results_path_;
 
@@ -136,8 +113,7 @@ class BraveNetworkAuditTest : public InProcessBrowserTest {
 };
 
 // Loads brave://welcome first to simulate a first run and then loads another
-// URL, and finally enables brave rewards, waiting some time after each load to
-// allow gathering network requests.
+// URL, waiting some time after each load to allow gathering network requests.
 IN_PROC_BROWSER_TEST_F(BraveNetworkAuditTest, BasicTests) {
   // Load the Welcome page.
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("brave://welcome")));
@@ -163,11 +139,6 @@ IN_PROC_BROWSER_TEST_F(BraveNetworkAuditTest, BasicTests) {
   // Load a simple HTML page from the test server.
   GURL simple_url(embedded_test_server()->GetURL("/simple.html"));
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), simple_url));
-  WaitForTimeout(kMaxTimeoutPerLoadedURL);
-
-  // Finally, load brave://rewards and enable Brave Rewards.
-  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("brave://rewards")));
-  ASSERT_TRUE(EnableBraveRewards());
   WaitForTimeout(kMaxTimeoutPerLoadedURL);
 
   ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("brave://wallet")));

--- a/browser/net/brave_network_audit_rewards_browsertest.cc
+++ b/browser/net/brave_network_audit_rewards_browsertest.cc
@@ -1,0 +1,143 @@
+/* Copyright (c) 2021 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include <vector>
+
+#include "base/base_paths.h"
+#include "base/memory/raw_ptr.h"
+#include "base/path_service.h"
+#include "base/run_loop.h"
+#include "base/task/single_thread_task_runner.h"
+#include "base/test/scoped_run_loop_timeout.h"
+#include "brave/browser/brave_rewards/rewards_service_factory.h"
+#include "brave/browser/net/brave_network_audit_test_helper.h"
+#include "brave/components/brave_rewards/content/rewards_service_impl.h"
+#include "chrome/browser/profiles/profile.h"
+#include "chrome/browser/ui/browser.h"
+#include "chrome/test/base/in_process_browser_test.h"
+#include "chrome/test/base/ui_test_utils.h"
+#include "components/prefs/pref_service.h"
+#include "content/public/test/browser_test.h"
+#include "services/network/public/cpp/network_switches.h"
+
+namespace brave {
+
+namespace {
+
+// Max amount of time to wait after getting an URL loaded, in milliseconds. Note
+// that the value passed to --ui-test-action-timeout in //brave/package.json, as
+// part of the 'network-audit' script, must be big enough to accomodate this.
+//
+// In particular:
+//   --ui-test-action-timeout: should be greater than |kMaxTimeoutPerLoadedURL|.
+//   --test-launcher-timeout: should be able to fit the total sum of timeouts.
+constexpr int kMaxTimeoutPerLoadedURL = 30;
+
+void WaitForTimeout(int timeout) {
+  base::test::ScopedRunLoopTimeout file_download_timeout(
+      FROM_HERE, base::Seconds(kMaxTimeoutPerLoadedURL + 1));
+  base::RunLoop run_loop;
+  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
+      FROM_HERE, run_loop.QuitClosure(), base::Seconds(timeout));
+  run_loop.Run();
+}
+
+class BraveRewardsNetworkAuditTest : public InProcessBrowserTest {
+ public:
+  BraveRewardsNetworkAuditTest() = default;
+
+  BraveRewardsNetworkAuditTest(const BraveRewardsNetworkAuditTest&) = delete;
+  BraveRewardsNetworkAuditTest& operator=(const BraveRewardsNetworkAuditTest&) =
+      delete;
+
+  void SetUpOnMainThread() override {
+    InProcessBrowserTest::SetUpOnMainThread();
+
+    ASSERT_TRUE(embedded_test_server()->Start());
+
+    // Create and start the Rewards service
+    rewards_service_ = static_cast<brave_rewards::RewardsServiceImpl*>(
+        brave_rewards::RewardsServiceFactory::GetForProfile(profile()));
+    base::RunLoop run_loop;
+    rewards_service_->StartProcessForTesting(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  void TearDownOnMainThread() override {
+    rewards_service_->Shutdown();
+    InProcessBrowserTest::TearDownOnMainThread();
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    base::FilePath source_root_path =
+        base::PathService::CheckedGet(base::DIR_SRC_TEST_DATA_ROOT);
+
+    // Full log containing all the network requests.
+    net_log_path_ = source_root_path.AppendASCII("network_rewards_log.json");
+
+    // Log containing the results of the audit only.
+    audit_results_path_ =
+        source_root_path.AppendASCII("network_audit_rewards_results.json");
+
+    command_line->AppendSwitchPath(network::switches::kLogNetLog,
+                                   net_log_path_);
+    command_line->AppendSwitchASCII(network::switches::kNetLogCaptureMode,
+                                    "Everything");
+  }
+
+  void TearDownInProcessBrowserTestFixture() override {
+    // Before adding to this list, get approval from the security team.
+    VerifyNetworkAuditLog(
+        net_log_path_, audit_results_path_,
+        /*extra_allowed_prefixes=*/
+        {
+            // Brave Rewards production.
+            "https://api.rewards.brave.com/v1/cards",
+            "https://api.rewards.brave.com/v1/parameters",
+            "https://rewards.brave.com/publishers/prefix-list",
+            "https://grant.rewards.brave.com/v1/promotions",
+
+            // Brave Rewards staging & dev.
+            "https://api.rewards.bravesoftware.com/v1/cards",
+            "https://api.rewards.bravesoftware.com/v1/parameters",
+            "https://rewards-stg.bravesoftware.com/publishers/prefix-list",
+            "https://grant.rewards.bravesoftware.com/v1/promotions",
+
+            // Brave Ads production.
+            "https://geo.ads.brave.com/v1/getstate",
+            "https://static.ads.brave.com/v9/catalog",
+
+            // Brave Ads staging.
+            "https://geo.ads.bravesoftware.com/v1/getstate",
+            "https://static.ads.bravesoftware.com/v9/catalog",
+        });
+  }
+
+  bool EnableBraveRewards() {
+    PrefService* pref_service = profile()->GetPrefs();
+    pref_service->SetInteger("brave.rewards.version", 7);
+    pref_service->SetBoolean("brave.rewards.enabled", true);
+    return pref_service->GetBoolean("brave.rewards.enabled");
+  }
+
+  Profile* profile() { return browser()->profile(); }
+
+ private:
+  raw_ptr<brave_rewards::RewardsServiceImpl, DanglingUntriaged>
+      rewards_service_ = nullptr;
+  base::FilePath net_log_path_;
+  base::FilePath audit_results_path_;
+};
+
+IN_PROC_BROWSER_TEST_F(BraveRewardsNetworkAuditTest, BasicTests) {
+  // Load brave://rewards and enable Brave Rewards.
+  ASSERT_TRUE(ui_test_utils::NavigateToURL(browser(), GURL("brave://rewards")));
+  ASSERT_TRUE(EnableBraveRewards());
+  WaitForTimeout(kMaxTimeoutPerLoadedURL);
+}
+
+}  // namespace
+
+}  // namespace brave

--- a/browser/net/brave_network_audit_search_ad_browsertest.cc
+++ b/browser/net/brave_network_audit_search_ad_browsertest.cc
@@ -24,7 +24,6 @@
 #include "brave/browser/net/brave_network_audit_allowed_lists.h"
 #include "brave/browser/net/brave_network_audit_test_helper.h"
 #include "brave/browser/ui/brave_browser.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 #include "brave/components/constants/brave_paths.h"
 #include "chrome/browser/profiles/profile.h"
 #include "chrome/browser/ui/browser.h"
@@ -61,12 +60,7 @@ void WaitForTimeout(int timeout) {
 
 class BraveNetworkAuditSearchAdTest : public InProcessBrowserTest {
  public:
-  BraveNetworkAuditSearchAdTest() {
-    feature_list_.InitWithFeatures(
-        {brave_ads::kShouldAlwaysRunBraveAdsServiceFeature,
-         brave_ads::kShouldAlwaysTriggerBraveSearchResultAdEventsFeature},
-        {});
-  }
+  BraveNetworkAuditSearchAdTest() = default;
 
   BraveNetworkAuditSearchAdTest(const BraveNetworkAuditSearchAdTest&) = delete;
   BraveNetworkAuditSearchAdTest& operator=(

--- a/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler_unittest.cc
+++ b/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_handler_unittest.cc
@@ -10,7 +10,6 @@
 
 #include "base/check.h"
 #include "base/test/mock_callback.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/browser/ads_service_mock.h"
 #include "brave/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_constants.h"
 #include "brave/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_mojom_web_page_entities_extractor.h"
@@ -18,7 +17,6 @@
 #include "brave/components/brave_ads/content/browser/creatives/search_result_ad/creative_search_result_ad_test_constants.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ads_callback.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/blink/public/mojom/document_metadata/document_metadata.mojom.h"
@@ -37,11 +35,6 @@ constexpr char kDisallowedDomain[] = "https://brave.com";
 
 class BraveAdsCreativeSearchResultAdHandlerTest : public ::testing::Test {
  public:
-  BraveAdsCreativeSearchResultAdHandlerTest() {
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldSupportSearchResultAdsFeature);
-  }
-
   static void SimulateMaybeExtractCreativeAdPlacementIdsFromWebPageCallback(
       CreativeSearchResultAdHandler* creative_search_result_ad_handler,
       blink::mojom::WebPagePtr mojom_web_page) {
@@ -67,9 +60,7 @@ class BraveAdsCreativeSearchResultAdHandlerTest : public ::testing::Test {
   }
 
  protected:
-  AdsServiceMock ads_service_mock_{nullptr};
-
-  base::test::ScopedFeatureList scoped_feature_list_;
+  AdsServiceMock ads_service_mock_{/*delegate=*/nullptr};
 };
 
 TEST_F(BraveAdsCreativeSearchResultAdHandlerTest, Create) {

--- a/components/brave_ads/core/internal/account/account_util_unittest.cc
+++ b/components/brave_ads/core/internal/account/account_util_unittest.cc
@@ -9,12 +9,10 @@
 
 #include <cstddef>
 
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_constants.h"
 #include "brave/components/brave_ads/core/internal/ads_core/ads_core_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 namespace brave_ads {
 
@@ -153,28 +151,9 @@ TEST_F(BraveAdsAccountUtilTest,
   }
 }
 
-TEST_F(
-    BraveAdsAccountUtilTest,
-    DoNotAllowSearchResultAdDepositsForNonRewardsUserIfShouldNotAlwaysTriggerSearchResultAdEvents) {
+TEST_F(BraveAdsAccountUtilTest,
+       OnlyAllowSearchResultAdConversionDepositForNonRewardsUser) {
   // Arrange
-  test::DisableBraveRewards();
-
-  // Act & Assert
-  for (int i = 0; i < static_cast<int>(mojom::ConfirmationType::kMaxValue);
-       ++i) {
-    EXPECT_FALSE(IsAllowedToDeposit(test::kCreativeInstanceId,
-                                    mojom::AdType::kSearchResultAd,
-                                    static_cast<mojom::ConfirmationType>(i)));
-  }
-}
-
-TEST_F(
-    BraveAdsAccountUtilTest,
-    OnlyAllowSearchResultAdConversionDepositForNonRewardsUserIfShouldAlwaysTriggerSearchResultAdEvents) {
-  // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   // Act & Assert

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_non_rewards_test.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_non_rewards_test.cc
@@ -6,14 +6,12 @@
 #include "base/run_loop.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/search_result_ads/creative_search_result_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/permission_rules/permission_rules_test_util.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
 #include "brave/components/brave_ads/core/public/ads.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -24,9 +22,6 @@ class BraveAdsSearchResultAdForNonRewardsIntegrationTest
  protected:
   void SetUp() override {
     test::TestBase::SetUp(/*is_integration_test=*/true);
-
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
 
     test::ForcePermissionRules();
 
@@ -49,25 +44,10 @@ class BraveAdsSearchResultAdForNonRewardsIntegrationTest
                                         mojom_ad_event_type, callback.Get());
     run_loop.Run();
   }
-
-  base::test::ScopedFeatureList scoped_feature_list_;
 };
 
 TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
        DoNotTriggerViewedEvent) {
-  // Act & Assert
-  TriggerSearchResultAdEventAndVerifyExpectations(
-      test::BuildCreativeSearchResultAdWithConversion(
-          /*should_generate_random_uuids=*/true),
-      mojom::SearchResultAdEventType::kViewedImpression,
-      /*should_fire_event=*/false);
-}
-
-TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
-       DoNotTriggerViewedEventIfShouldNotAlwaysTriggerAdEvents) {
-  // Arrange
-  scoped_feature_list_.Reset();
-
   // Act & Assert
   TriggerSearchResultAdEventAndVerifyExpectations(
       test::BuildCreativeSearchResultAdWithConversion(
@@ -111,21 +91,6 @@ TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
   TriggerSearchResultAdEventAndVerifyExpectations(
       mojom_creative_ad.Clone(), mojom::SearchResultAdEventType::kClicked,
       /*should_fire_event=*/true);
-}
-
-TEST_F(BraveAdsSearchResultAdForNonRewardsIntegrationTest,
-       DoNotTriggerClickedEventIfShouldNotAlwaysTriggerAdEvents) {
-  // Arrange
-  scoped_feature_list_.Reset();
-
-  const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
-      test::BuildCreativeSearchResultAdWithConversion(
-          /*should_generate_random_uuids=*/true);
-
-  // Act & Assert
-  TriggerSearchResultAdEventAndVerifyExpectations(
-      mojom_creative_ad.Clone(), mojom::SearchResultAdEventType::kClicked,
-      /*should_fire_event=*/false);
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_rewards_test.cc
+++ b/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_for_rewards_test.cc
@@ -6,13 +6,11 @@
 #include "base/run_loop.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_handler.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/creatives/search_result_ads/creative_search_result_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/serving/permission_rules/permission_rules_test_util.h"
 #include "brave/components/brave_ads/core/public/ads.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -22,9 +20,6 @@ class BraveAdsSearchResultAdForRewardsIntegrationTest : public test::TestBase {
  protected:
   void SetUp() override {
     test::TestBase::SetUp(/*is_integration_test=*/true);
-
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
 
     test::ForcePermissionRules();
   }
@@ -45,8 +40,6 @@ class BraveAdsSearchResultAdForRewardsIntegrationTest : public test::TestBase {
                                         mojom_ad_event_type, callback.Get());
     run_loop.Run();
   }
-
-  base::test::ScopedFeatureList scoped_feature_list_;
 };
 
 TEST_F(BraveAdsSearchResultAdForRewardsIntegrationTest, TriggerViewedEvents) {

--- a/components/brave_ads/core/internal/ads_feature.cc
+++ b/components/brave_ads/core/internal/ads_feature.cc
@@ -15,14 +15,6 @@ bool ShouldAlwaysRunService() {
   return base::FeatureList::IsEnabled(kShouldAlwaysRunBraveAdsServiceFeature);
 }
 
-BASE_FEATURE(kShouldSupportSearchResultAdsFeature,
-             "ShouldSupportSearchResultAds",
-             base::FEATURE_ENABLED_BY_DEFAULT);
-
-bool ShouldSupportSearchResultAds() {
-  return base::FeatureList::IsEnabled(kShouldSupportSearchResultAdsFeature);
-}
-
 BASE_FEATURE(kShouldAlwaysTriggerBraveSearchResultAdEventsFeature,
              "ShouldAlwaysTriggerBraveSearchResultAdEvents",
              base::FEATURE_DISABLED_BY_DEFAULT);

--- a/components/brave_ads/core/internal/ads_feature.cc
+++ b/components/brave_ads/core/internal/ads_feature.cc
@@ -9,7 +9,7 @@ namespace brave_ads {
 
 BASE_FEATURE(kShouldAlwaysRunBraveAdsServiceFeature,
              "ShouldAlwaysRunBraveAdsService",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 bool ShouldAlwaysRunService() {
   return base::FeatureList::IsEnabled(kShouldAlwaysRunBraveAdsServiceFeature);
@@ -17,7 +17,7 @@ bool ShouldAlwaysRunService() {
 
 BASE_FEATURE(kShouldAlwaysTriggerBraveSearchResultAdEventsFeature,
              "ShouldAlwaysTriggerBraveSearchResultAdEvents",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
 bool ShouldAlwaysTriggerSearchResultAdEvents() {
   return base::FeatureList::IsEnabled(

--- a/components/brave_ads/core/internal/ads_feature_unittest.cc
+++ b/components/brave_ads/core/internal/ads_feature_unittest.cc
@@ -13,29 +13,31 @@
 namespace brave_ads {
 
 TEST(BraveAdsBraveAdsFeatureTest, ShouldAlwaysRunService) {
-  // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysRunBraveAdsServiceFeature);
-
   // Act & Assert
   EXPECT_TRUE(ShouldAlwaysRunService());
 }
 
 TEST(BraveAdsBraveAdsFeatureTest, ShouldNotAlwaysRunService) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(
+      kShouldAlwaysRunBraveAdsServiceFeature);
+
   // Act & Assert
   EXPECT_FALSE(ShouldAlwaysRunService());
 }
 
 TEST(BraveAdsBraveAdsFeatureTest, ShouldAlwaysTriggerSearchResultAdEvents) {
-  // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   // Act & Assert
   EXPECT_TRUE(ShouldAlwaysTriggerSearchResultAdEvents());
 }
 
 TEST(BraveAdsBraveAdsFeatureTest, ShouldNotAlwaysTriggerSearchResultAdEvents) {
+  // Arrange
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(
+      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
+
   // Act & Assert
   EXPECT_FALSE(ShouldAlwaysTriggerSearchResultAdEvents());
 }

--- a/components/brave_ads/core/internal/ads_feature_unittest.cc
+++ b/components/brave_ads/core/internal/ads_feature_unittest.cc
@@ -26,21 +26,6 @@ TEST(BraveAdsBraveAdsFeatureTest, ShouldNotAlwaysRunService) {
   EXPECT_FALSE(ShouldAlwaysRunService());
 }
 
-TEST(BraveAdsBraveAdsFeatureTest, ShouldSupportSearchResultAds) {
-  // Act & Assert
-  EXPECT_TRUE(ShouldSupportSearchResultAds());
-}
-
-TEST(BraveAdsBraveAdsFeatureTest, ShouldNotSupportSearchResultAds) {
-  // Arrange
-  base::test::ScopedFeatureList scoped_feature_list;
-  scoped_feature_list.InitAndDisableFeature(
-      kShouldSupportSearchResultAdsFeature);
-
-  // Act & Assert
-  EXPECT_FALSE(ShouldSupportSearchResultAds());
-}
-
 TEST(BraveAdsBraveAdsFeatureTest, ShouldAlwaysTriggerSearchResultAdEvents) {
   // Arrange
   const base::test::ScopedFeatureList scoped_feature_list(

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_for_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_for_rewards_unittest.cc
@@ -25,7 +25,6 @@
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_delegate_mock.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/search_result_ad/search_result_ad_feature.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -66,9 +65,6 @@ class BraveAdsSearchResultAdEventHandlerForRewardsTest : public test::TestBase {
   void SetUp() override {
     test::TestBase::SetUp();
 
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
     test::ForcePermissionRules();
 
     event_handler_.SetDelegate(&delegate_mock_);
@@ -106,8 +102,6 @@ class BraveAdsSearchResultAdEventHandlerForRewardsTest : public test::TestBase {
 
     VerifyCreativeSetConversionExpectation(expected_count);
   }
-
-  base::test::ScopedFeatureList scoped_feature_list_;
 
   SearchResultAdEventHandler event_handler_;
   ::testing::StrictMock<SearchResultAdEventHandlerDelegateMock> delegate_mock_;

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_non_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_non_rewards_unittest.cc
@@ -6,7 +6,6 @@
 #include "base/run_loop.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_builder.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_info.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
@@ -18,7 +17,6 @@
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_builder.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -30,13 +28,8 @@ class BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest
   void SetUp() override {
     test::TestBase::SetUp();
 
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
     test::DisableBraveRewards();
   }
-
-  base::test::ScopedFeatureList scoped_feature_list_;
 
   database::table::CreativeSetConversions
       creative_set_conversions_database_table_;
@@ -157,21 +150,6 @@ TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
           IsAllowedToFireAdEvent(mojom_creative_ad, mojom_ad_event_type));
     }
   }
-}
-
-TEST_F(
-    BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,
-    NotAllowedToFireClickedEventWithConversionIfShouldNotAlwaysTriggerAdEvents) {
-  // Arrange
-  scoped_feature_list_.Reset();
-
-  const mojom::CreativeSearchResultAdInfoPtr mojom_creative_ad =
-      test::BuildCreativeSearchResultAdWithConversion(
-          /*should_generate_random_uuids=*/true);
-
-  // Act & Assert
-  EXPECT_FALSE(IsAllowedToFireAdEvent(
-      mojom_creative_ad, mojom::SearchResultAdEventType::kClicked));
 }
 
 TEST_F(BraveAdsSearchResultAdEventHandlerUtilForNonRewardsTest,

--- a/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_rewards_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util_for_rewards_unittest.cc
@@ -6,7 +6,6 @@
 #include "base/run_loop.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_builder.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_info.h"
 #include "brave/components/brave_ads/core/internal/ad_units/search_result_ad/search_result_ad_test_util.h"
@@ -18,7 +17,6 @@
 #include "brave/components/brave_ads/core/internal/creatives/search_result_ads/creative_search_result_ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/ad_event_builder.h"
 #include "brave/components/brave_ads/core/internal/user_engagement/ad_events/search_result_ads/search_result_ad_event_handler_util.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -27,15 +25,6 @@ namespace brave_ads {
 class BraveAdsSearchResultAdEventHandlerUtilForRewardsTest
     : public test::TestBase {
  protected:
-  void SetUp() override {
-    test::TestBase::SetUp();
-
-    scoped_feature_list_.InitAndEnableFeature(
-        kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-  }
-
-  base::test::ScopedFeatureList scoped_feature_list_;
-
   database::table::CreativeSetConversions
       creative_set_conversions_database_table_;
 };

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_search_result_ad_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_search_result_ad_unittest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/test/scoped_feature_list.h"
 #include "base/time/time.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/creatives/conversions/creative_set_conversion_test_util.h"
@@ -16,7 +15,6 @@
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions_test_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_info.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -108,9 +106,6 @@ TEST_F(BraveAdsConversionsSearchResultAdTest,
 TEST_F(BraveAdsConversionsSearchResultAdTest,
        DoNotConvertViewedAdForNonRewardsUser) {
   // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,
@@ -128,13 +123,9 @@ TEST_F(BraveAdsConversionsSearchResultAdTest,
                              /*html=*/"");
 }
 
-TEST_F(
-    BraveAdsConversionsSearchResultAdTest,
-    ConvertClickedAdForNonRewardsUserIfShouldAlwaysTriggerSearchResultAdEvents) {
+TEST_F(BraveAdsConversionsSearchResultAdTest,
+       ConvertClickedAdForNonRewardsUser) {
   // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,
@@ -153,27 +144,6 @@ TEST_F(
   conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
                              /*html=*/"");
   run_loop.Run();
-}
-
-TEST_F(
-    BraveAdsConversionsSearchResultAdTest,
-    DoNotConvertClickedAdForNonRewardsUserIfShouldNotAlwaysTriggerSearchResultAdEvents) {
-  // Arrange
-  test::DisableBraveRewards();
-
-  const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,
-                                  /*should_generate_random_uuids=*/false);
-  test::BuildAndSaveCreativeSetConversion(ad.creative_set_id,
-                                          test::kMatchingUrlPattern,
-                                          /*observation_window=*/base::Days(3));
-
-  // We only record ad clicked and conversion events for non-Rewards users.
-  test::RecordAdEvent(ad, mojom::ConfirmationType::kClicked);
-
-  // Act & Assert
-  VerifyOnDidNotConvertAdExpectation();
-  conversions_->MaybeConvert(test::BuildDefaultConversionRedirectChain(),
-                             /*html=*/"");
 }
 
 }  // namespace brave_ads

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_search_result_ad_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_search_result_ad_util_unittest.cc
@@ -3,7 +3,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/ad_units/ad_test_util.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/common/test/time_test_util.h"
@@ -13,7 +12,6 @@
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/conversions_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_info.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
 
@@ -33,22 +31,6 @@ TEST_F(BraveAdsConversionsSearchResultAdUtilTest,
 
   // Act & Assert
   EXPECT_TRUE(IsAllowedToConvertAdEvent(ad_event));
-}
-
-TEST_F(
-    BraveAdsConversionsSearchResultAdUtilTest,
-    NotAllowedToConvertViewedAdEventForNonRewardsUserIfShouldNotAlwaysTriggerSearchResultAdEvents) {
-  // Arrange
-  test::DisableBraveRewards();
-
-  const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,
-                                  /*should_generate_random_uuids=*/false);
-  const AdEventInfo ad_event =
-      BuildAdEvent(ad, mojom::ConfirmationType::kViewedImpression,
-                   /*created_at=*/test::Now());
-
-  // Act & Assert
-  EXPECT_FALSE(IsAllowedToConvertAdEvent(ad_event));
 }
 
 TEST_F(BraveAdsConversionsSearchResultAdUtilTest,
@@ -116,9 +98,6 @@ TEST_F(BraveAdsConversionsSearchResultAdUtilTest,
 TEST_F(BraveAdsConversionsSearchResultAdUtilTest,
        NotAllowedToConvertViewedAdEventForNonRewardsUser) {
   // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,
@@ -131,28 +110,9 @@ TEST_F(BraveAdsConversionsSearchResultAdUtilTest,
   EXPECT_FALSE(IsAllowedToConvertAdEvent(ad_event));
 }
 
-TEST_F(
-    BraveAdsConversionsSearchResultAdUtilTest,
-    NotAllowedToConvertAdClickedEventForNonRewardsUserIfShouldNotAlwaysTriggerSearchResultAdEvents) {
+TEST_F(BraveAdsConversionsSearchResultAdUtilTest,
+       AllowedToConvertAdClickedEventForNonRewardsUser) {
   // Arrange
-  test::DisableBraveRewards();
-
-  const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,
-                                  /*should_generate_random_uuids=*/false);
-  const AdEventInfo ad_event = BuildAdEvent(
-      ad, mojom::ConfirmationType::kClicked, /*created_at=*/test::Now());
-
-  // Act & Assert
-  EXPECT_FALSE(IsAllowedToConvertAdEvent(ad_event));
-}
-
-TEST_F(
-    BraveAdsConversionsSearchResultAdUtilTest,
-    AllowedToConvertAdClickedEventForNonRewardsUserIfShouldAlwaysTriggerBraveSearchResultAdEvents) {
-  // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   const AdInfo ad = test::BuildAd(mojom::AdType::kSearchResultAd,

--- a/components/brave_ads/core/internal/user_engagement/conversions/conversions_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/conversions/conversions_unittest.cc
@@ -25,7 +25,6 @@
 #include "brave/components/brave_ads/core/internal/user_engagement/conversions/types/verifiable_conversion/verifiable_conversion_test_constants.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/ad_info.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 #include "url/gurl.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -526,9 +525,6 @@ TEST_F(BraveAdsConversionsTest, VerifiableConversion) {
 
 TEST_F(BraveAdsConversionsTest, FallbackToDefaultConversionForNonRewardsUser) {
   // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   NotifyResourceComponentDidChange(test::kCountryComponentManifestVersion,

--- a/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
+++ b/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util_unittest.cc
@@ -5,11 +5,9 @@
 
 #include "brave/components/brave_ads/core/internal/user_engagement/site_visit/site_visit_util.h"
 
-#include "base/test/scoped_feature_list.h"
 #include "brave/components/brave_ads/core/internal/common/test/test_base.h"
 #include "brave/components/brave_ads/core/internal/settings/settings_test_util.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 #include "net/http/http_status_code.h"
 
 // npm run test -- brave_unit_tests --filter=BraveAds*
@@ -169,19 +167,6 @@ TEST_F(
     BraveAdsSiteVisitUtilTest,
     DoNotAllowSearchResultAdPageLandIfNonRewardsUserAndOptedInToSearchResultAds) {
   // Arrange
-  test::DisableBraveRewards();
-
-  // Act & Assert
-  EXPECT_FALSE(IsAllowedToLandOnPage(mojom::AdType::kSearchResultAd));
-}
-
-TEST_F(
-    BraveAdsSiteVisitUtilTest,
-    DoNotAllowSearchResultAdPageLandIfNonRewardsUserAndOptedInToSearchResultAdsAndShouldAlwaysTriggerSearchResultAdEvents) {
-  // Arrange
-  const base::test::ScopedFeatureList scoped_feature_list(
-      kShouldAlwaysTriggerBraveSearchResultAdEventsFeature);
-
   test::DisableBraveRewards();
 
   // Act & Assert

--- a/components/brave_ads/core/public/ads_feature.h
+++ b/components/brave_ads/core/public/ads_feature.h
@@ -16,12 +16,6 @@ BASE_DECLARE_FEATURE(kShouldAlwaysRunBraveAdsServiceFeature);
 
 bool ShouldAlwaysRunService();
 
-// Set to `true` to support search result ads. `ShouldAlwaysRunService()` must
-// be set to `true`, otherwise this feature param will be ignored.
-BASE_DECLARE_FEATURE(kShouldSupportSearchResultAdsFeature);
-
-bool ShouldSupportSearchResultAds();
-
 // Set to `true` to always trigger search result ad events even if Brave Private
 // Ads are disabled. `ShouldAlwaysRunService()` must be set to `true`, otherwise
 // this feature param will be ignored.

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+TabWebPolicyDecider.swift
@@ -306,8 +306,7 @@ extension BrowserViewController: TabPolicyDecider {
 
           // Add Brave search result ads processing script
           // This script will process search result ads on the Brave search page.
-          .searchResultAd: BraveAds.shouldSupportSearchResultAds()
-            && BraveSearchManager.isValidURL(requestURL) && !isPrivateBrowsing,
+          .searchResultAd: BraveSearchManager.isValidURL(requestURL) && !isPrivateBrowsing,
         ])
       }
 

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/BraveSearchResultAdManager.swift
@@ -79,6 +79,5 @@ class BraveSearchResultAdManager: NSObject {
     isAggressiveAdsBlocking: Bool
   ) -> Bool {
     return !isPrivateBrowsing && !isAggressiveAdsBlocking && BraveSearchManager.isValidURL(url)
-      && BraveAds.shouldSupportSearchResultAds()
   }
 }

--- a/ios/browser/api/ads/brave_ads.h
+++ b/ios/browser/api/ads/brave_ads.h
@@ -60,9 +60,6 @@ OBJC_EXPORT
 /// disabled.
 + (BOOL)shouldAlwaysRunService;
 
-/// Returns `true` if search result ads are supported.
-+ (BOOL)shouldSupportSearchResultAds;
-
 /// Returns `true` if should show Sponsored Images & Videos option in settings.
 /// This function will be deprecated once Sponsored Video is available globally.
 - (BOOL)shouldShowSponsoredImagesAndVideosSetting;

--- a/ios/browser/api/ads/brave_ads.mm
+++ b/ios/browser/api/ads/brave_ads.mm
@@ -190,10 +190,6 @@ constexpr NSString* kAdsResourceComponentMetadataVersion = @".v1";
   return brave_ads::ShouldAlwaysRunService();
 }
 
-+ (BOOL)shouldSupportSearchResultAds {
-  return brave_ads::ShouldSupportSearchResultAds();
-}
-
 - (BOOL)shouldShowSponsoredImagesAndVideosSetting {
   const std::string country_code =
       brave_l10n::GetCountryCode(self->_localStatePrefService);

--- a/ios/browser/flags/about_flags.mm
+++ b/ios/browser/flags/about_flags.mm
@@ -7,7 +7,6 @@
 
 #include "base/strings/string_util.h"
 #include "brave/components/ai_chat/core/common/features.h"
-#include "brave/components/brave_ads/core/public/ads_feature.h"
 #include "brave/components/brave_component_updater/browser/features.h"
 #include "brave/components/brave_rewards/core/features.h"
 #include "brave/components/brave_shields/core/common/features.h"
@@ -241,26 +240,6 @@
           "do not share it unless asked to by Brave staff.",                   \
           flags_ui::kOsIos,                                                    \
           FEATURE_VALUE_TYPE(brave_rewards::features::kVerboseLoggingFeature), \
-      },                                                                       \
-      {                                                                        \
-          "brave-ads-should-always-run-brave-ads-service",                     \
-          "Should always run Brave Ads service",                               \
-          "Always run Brave Ads service to support triggering ad events when " \
-          "Brave Private Ads are disabled.",                                   \
-          flags_ui::kOsIos,                                                    \
-          FEATURE_VALUE_TYPE(                                                  \
-              brave_ads::kShouldAlwaysRunBraveAdsServiceFeature),              \
-      },                                                                       \
-      {                                                                        \
-          "brave-ads-should-always-trigger-search-result-ad-events",           \
-          "Should always trigger search result ad events",                     \
-          "Support triggering search result ad events if Brave Private Ads "   \
-          "are disabled. Requires "                                            \
-          "#brave-ads-should-always-run-brave-ads-service to be enabled.",     \
-          flags_ui::kOsIos,                                                    \
-          FEATURE_VALUE_TYPE(                                                  \
-              brave_ads::                                                      \
-                  kShouldAlwaysTriggerBraveSearchResultAdEventsFeature),       \
       })                                                                       \
   BRAVE_SHIELDS_FEATURE_ENTRIES                                                \
   BRAVE_NATIVE_WALLET_FEATURE_ENTRIES                                          \

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -686,6 +686,7 @@ if (!is_android) {
     sources = [
       "//brave/browser/net/brave_network_audit_allowed_lists.h",
       "//brave/browser/net/brave_network_audit_browsertest.cc",
+      "//brave/browser/net/brave_network_audit_rewards_browsertest.cc",
       "//brave/browser/net/brave_network_audit_search_ad_browsertest.cc",
       "//brave/browser/net/brave_network_audit_test_helper.cc",
       "//brave/browser/net/brave_network_audit_test_helper.h",


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/28286
Uplift of https://github.com/brave/brave-core/pull/28366
Resolves https://github.com/brave/brave-browser/issues/42433
Resolves https://github.com/brave/brave-browser/issues/45023

- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR.
- [x] You have tested your change on Nightly. 
- [x] The PR milestones match the branch they are landing to. 

After you merge: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.
