### PR TITLE
[ads] Fixes crash in AdsServiceImpl::PrefetchNewTabPageAdCallback (uplift to 1.78.x)

### DIFF
--- a/components/brave_ads/browser/BUILD.gn
+++ b/components/brave_ads/browser/BUILD.gn
@@ -91,9 +91,13 @@ static_library("browser") {
 source_set("unit_tests") {
   testonly = true
 
-  sources = [ "analytics/p3a/notification_ad_unittest.cc" ]
+  sources = [
+    "ad_units/new_tab_page_ad/new_tab_page_ad_prefetcher_unittest.cc",
+    "analytics/p3a/notification_ad_unittest.cc",
+  ]
 
   deps = [
+    ":test_support",
     "//base",
     "//base/test:test_support",
     "//brave/components/brave_ads/browser",

--- a/components/brave_ads/browser/ad_units/new_tab_page_ad/new_tab_page_ad_prefetcher_unittest.cc
+++ b/components/brave_ads/browser/ad_units/new_tab_page_ad/new_tab_page_ad_prefetcher_unittest.cc
@@ -1,0 +1,209 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.h"
+
+#include <memory>
+#include <optional>
+
+#include "brave/components/brave_ads/browser/ads_service_mock.h"
+#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_info.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+// npm run test -- brave_unit_tests --filter=BraveAds*
+
+namespace brave_ads {
+
+class BraveAdsNewTabPageAdPrefetcherTest : public ::testing::Test {
+ public:
+  BraveAdsNewTabPageAdPrefetcherTest()
+      : ads_service_(std::make_unique<AdsServiceMock>(/*delegate=*/nullptr)),
+        prefetcher_(std::make_unique<NewTabPageAdPrefetcher>(*ads_service_)) {}
+
+ protected:
+  AdsServiceMock& ads_service() const { return *ads_service_; }
+
+  NewTabPageAdPrefetcher& prefetcher() const { return *prefetcher_; }
+
+  void ResetPrefetcher() {
+    prefetcher_ = std::make_unique<NewTabPageAdPrefetcher>(*ads_service_);
+  }
+
+  NewTabPageAdInfo BuildNewTabPageAd() {
+    NewTabPageAdInfo ad;
+    ad.type = mojom::AdType::kNewTabPageAd;
+    ad.placement_id = "placement_id";
+    ad.creative_instance_id = "creative_instance_id";
+    ad.creative_set_id = "creative_set_id";
+    ad.campaign_id = "campaign_id";
+    ad.advertiser_id = "advertiser_id";
+    ad.segment = "segment";
+    ad.target_url = GURL("https://brave.com");
+    ad.company_name = "company_name";
+    ad.alt = "alt";
+    return ad;
+  }
+
+ private:
+  std::unique_ptr<AdsServiceMock> ads_service_;
+  std::unique_ptr<NewTabPageAdPrefetcher> prefetcher_;
+};
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest, NoAdWithoutPrefetch) {
+  // Act & Assert
+  EXPECT_FALSE(prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest, Prefetch) {
+  // Arrange
+  const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
+
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke(
+          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+            std::move(callback).Run(expected_ad);
+          }));
+
+  // Act
+  prefetcher().Prefetch();
+
+  // Assert
+  EXPECT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest, PrefetchFailed) {
+  // Arrange
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke([](MaybeServeNewTabPageAdCallback callback) {
+        std::move(callback).Run(/*ad=*/std::nullopt);
+      }));
+
+  // Act
+  prefetcher().Prefetch();
+
+  // Assert
+  EXPECT_FALSE(prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest, PrefetchInvalidAd) {
+  // Arrange
+  const NewTabPageAdInfo invalid_ad;
+  ASSERT_FALSE(invalid_ad.IsValid());
+
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke(
+          [&invalid_ad](MaybeServeNewTabPageAdCallback callback) {
+            std::move(callback).Run(invalid_ad);
+          }));
+
+  // Act
+  prefetcher().Prefetch();
+
+  // Assert
+  EXPECT_FALSE(prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest,
+       ShouldPrefetchAdAfterGettingPrefetchedAd) {
+  // Arrange
+  const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
+
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .Times(2)
+      .WillRepeatedly(::testing::Invoke(
+          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+            std::move(callback).Run(expected_ad);
+          }));
+
+  prefetcher().Prefetch();
+  ASSERT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
+
+  // Act
+  prefetcher().Prefetch();
+
+  // Assert
+  EXPECT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest,
+       ShouldNotPrefetchAdWhenAlreadyPrefetched) {
+  // Arrange
+  const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
+
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke(
+          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+            std::move(callback).Run(expected_ad);
+          }));
+
+  prefetcher().Prefetch();
+
+  // Act
+  prefetcher().Prefetch();
+
+  // Assert
+  EXPECT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest,
+       ShouldNotPrefetchAdWhenAnotherPrefetchIsInProgress) {
+  // Arrange
+  const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
+
+  MaybeServeNewTabPageAdCallback deferred_maybe_serve_ad_callback;
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke([&deferred_maybe_serve_ad_callback](
+                                      MaybeServeNewTabPageAdCallback callback) {
+        deferred_maybe_serve_ad_callback = std::move(callback);
+      }));
+
+  prefetcher().Prefetch();
+
+  // Act
+  prefetcher().Prefetch();
+  std::move(deferred_maybe_serve_ad_callback).Run(expected_ad);
+
+  // Assert
+  EXPECT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest, ShouldOnlyGetPrefetchedAdOnce) {
+  // Arrange
+  const NewTabPageAdInfo expected_ad = BuildNewTabPageAd();
+
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke(
+          [&expected_ad](MaybeServeNewTabPageAdCallback callback) {
+            std::move(callback).Run(expected_ad);
+          }));
+
+  prefetcher().Prefetch();
+  ASSERT_EQ(expected_ad, prefetcher().MaybeGetPrefetchedAd());
+
+  // Act & Assert
+  EXPECT_FALSE(prefetcher().MaybeGetPrefetchedAd());
+}
+
+TEST_F(BraveAdsNewTabPageAdPrefetcherTest, CancelPrefetch) {
+  // Arrange
+  MaybeServeNewTabPageAdCallback deferred_maybe_serve_ad_callback;
+  EXPECT_CALL(ads_service(), MaybeServeNewTabPageAd)
+      .WillOnce(::testing::Invoke([&deferred_maybe_serve_ad_callback](
+                                      MaybeServeNewTabPageAdCallback callback) {
+        deferred_maybe_serve_ad_callback = std::move(callback);
+      }));
+
+  // Act
+  prefetcher().Prefetch();
+  ResetPrefetcher();
+
+  // Assert
+  // Run the deferred callback and make sure no crash occurs
+  std::move(deferred_maybe_serve_ad_callback).Run(/*ad=*/std::nullopt);
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/browser/ads_service_impl.h
+++ b/components/brave_ads/browser/ads_service_impl.h
@@ -66,6 +66,7 @@ class BatAdsServiceFactory;
 class DeviceId;
 class ResourceComponent;
 struct NewTabPageAdInfo;
+class NewTabPageAdPrefetcher;
 
 class AdsServiceImpl final : public AdsService,
                              public bat_ads::mojom::BatAdsClient,
@@ -202,10 +203,6 @@ class AdsServiceImpl final : public AdsService,
   void NotificationAdTimedOut(const std::string& placement_id);
   void CloseAllNotificationAds();
 
-  // TODO(https://github.com/brave/brave-browser/issues/26192) Decouple new
-  // tab page ad business logic.
-  void PrefetchNewTabPageAdCallback(std::optional<base::Value::Dict> dict);
-
   // TODO(https://github.com/brave/brave-browser/issues/26193) Decouple open
   // new tab with ad business logic.
   void MaybeOpenNewTabWithAd();
@@ -272,6 +269,7 @@ class AdsServiceImpl final : public AdsService,
   void ParseAndSaveCreativeNewTabPageAds(
       base::Value::Dict dict,
       ParseAndSaveCreativeNewTabPageAdsCallback callback) override;
+  void MaybeServeNewTabPageAd(MaybeServeNewTabPageAdCallback callback) override;
   void TriggerNewTabPageAdEvent(
       const std::string& placement_id,
       const std::string& creative_instance_id,
@@ -457,9 +455,6 @@ class AdsServiceImpl final : public AdsService,
   std::map<std::string, std::unique_ptr<base::OneShotTimer>>
       notification_ad_timers_;
 
-  std::optional<NewTabPageAdInfo> prefetched_new_tab_page_ad_;
-  bool is_prefetching_new_tab_page_ad_ = false;
-
   std::string retry_opening_new_tab_for_ad_with_placement_id_;
 
   base::CancelableTaskTracker history_service_task_tracker_;
@@ -487,6 +482,8 @@ class AdsServiceImpl final : public AdsService,
   const std::unique_ptr<AdsTooltipsDelegate> ads_tooltips_delegate_;
 
   const std::unique_ptr<DeviceId> device_id_;
+
+  std::unique_ptr<NewTabPageAdPrefetcher> new_tab_page_ad_prefetcher_;
 
   const std::unique_ptr<BatAdsServiceFactory> bat_ads_service_factory_;
 

--- a/components/brave_ads/browser/ads_service_mock.h
+++ b/components/brave_ads/browser/ads_service_mock.h
@@ -60,6 +60,7 @@ class AdsServiceMock : public AdsService {
               MaybeGetPrefetchedNewTabPageAd,
               ());
   MOCK_METHOD(void, PrefetchNewTabPageAd, ());
+  MOCK_METHOD(void, MaybeServeNewTabPageAd, (MaybeServeNewTabPageAdCallback));
   MOCK_METHOD(void,
               TriggerNewTabPageAdEvent,
               (const std::string&,

--- a/components/brave_ads/core/browser/service/BUILD.gn
+++ b/components/brave_ads/core/browser/service/BUILD.gn
@@ -8,6 +8,8 @@ source_set("service") {
     "ads_service.cc",
     "ads_service.h",
     "ads_service_observer.h",
+    "new_tab_page_ad_prefetcher.cc",
+    "new_tab_page_ad_prefetcher.h",
   ]
 
   public_deps = [

--- a/components/brave_ads/core/browser/service/ads_service.h
+++ b/components/brave_ads/core/browser/service/ads_service.h
@@ -145,6 +145,11 @@ class AdsService : public KeyedService {
       base::Value::Dict dict,
       ParseAndSaveCreativeNewTabPageAdsCallback callback) = 0;
 
+  // Called to serve a new tab page ad. The callback takes one argument -
+  // `NewTabPageAdInfo` containing the info for the ad.
+  virtual void MaybeServeNewTabPageAd(
+      MaybeServeNewTabPageAdCallback callback) = 0;
+
   // Called when a user views or interacts with a new tab page ad to trigger a
   // `mojom_ad_event_type` event for the specified `placement_id` and
   // `creative_instance_id`. `placement_id` should be a 128-bit random GUID in

--- a/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.cc
+++ b/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.cc
@@ -1,0 +1,57 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "brave/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.h"
+
+#include "base/check.h"
+#include "brave/components/brave_ads/core/browser/service/ads_service.h"
+#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_info.h"
+
+namespace brave_ads {
+
+NewTabPageAdPrefetcher::NewTabPageAdPrefetcher(AdsService& ads_service)
+    : ads_service_(ads_service) {}
+
+NewTabPageAdPrefetcher::~NewTabPageAdPrefetcher() = default;
+
+std::optional<NewTabPageAdInfo> NewTabPageAdPrefetcher::MaybeGetPrefetchedAd() {
+  std::optional<NewTabPageAdInfo> ad;
+  if (prefetched_ad_) {
+    if (prefetched_ad_->IsValid()) {
+      ad = prefetched_ad_;
+    }
+
+    prefetched_ad_.reset();
+  }
+
+  return ad;
+}
+
+void NewTabPageAdPrefetcher::Prefetch() {
+  if (!prefetched_ad_ && !is_prefetching_) {
+    is_prefetching_ = true;
+
+    ads_service_->MaybeServeNewTabPageAd(
+        base::BindOnce(&NewTabPageAdPrefetcher::PrefetchCallback,
+                       weak_ptr_factory_.GetWeakPtr()));
+  }
+}
+
+void NewTabPageAdPrefetcher::PrefetchCallback(
+    base::optional_ref<const NewTabPageAdInfo> ad) {
+  CHECK(!prefetched_ad_);
+
+  if (!is_prefetching_) {
+    // `is_prefetching_` can be reset during shutdown, so fail gracefully.
+    return;
+  }
+  is_prefetching_ = false;
+
+  if (ad) {
+    prefetched_ad_ = *ad;
+  }
+}
+
+}  // namespace brave_ads

--- a/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.h
+++ b/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.h
@@ -1,0 +1,45 @@
+/* Copyright (c) 2025 The Brave Authors. All rights reserved.
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#ifndef BRAVE_COMPONENTS_BRAVE_ADS_CORE_BROWSER_SERVICE_NEW_TAB_PAGE_AD_PREFETCHER_H_
+#define BRAVE_COMPONENTS_BRAVE_ADS_CORE_BROWSER_SERVICE_NEW_TAB_PAGE_AD_PREFETCHER_H_
+
+#include <optional>
+
+#include "base/memory/raw_ref.h"
+#include "base/memory/weak_ptr.h"
+#include "base/types/optional_ref.h"
+#include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_info.h"
+
+namespace brave_ads {
+
+class AdsService;
+
+class NewTabPageAdPrefetcher {
+ public:
+  explicit NewTabPageAdPrefetcher(AdsService& ads_service);
+
+  NewTabPageAdPrefetcher(const NewTabPageAdPrefetcher&) = delete;
+  NewTabPageAdPrefetcher& operator=(const NewTabPageAdPrefetcher&) = delete;
+
+  ~NewTabPageAdPrefetcher();
+
+  void Prefetch();
+  std::optional<NewTabPageAdInfo> MaybeGetPrefetchedAd();
+
+ private:
+  void PrefetchCallback(base::optional_ref<const NewTabPageAdInfo> ad);
+
+  std::optional<NewTabPageAdInfo> prefetched_ad_;
+  bool is_prefetching_ = false;
+
+  const raw_ref<AdsService> ads_service_;
+
+  base::WeakPtrFactory<NewTabPageAdPrefetcher> weak_ptr_factory_{this};
+};
+
+}  // namespace brave_ads
+
+#endif  // BRAVE_COMPONENTS_BRAVE_ADS_CORE_BROWSER_SERVICE_NEW_TAB_PAGE_AD_PREFETCHER_H_

--- a/ios/browser/brave_ads/ads_service_impl_ios.h
+++ b/ios/browser/brave_ads/ads_service_impl_ios.h
@@ -31,7 +31,7 @@ namespace brave_ads {
 class Ads;
 class AdsClient;
 struct NewTabPageAdInfo;
-
+class NewTabPageAdPrefetcher;
 class AdsServiceImplIOS : public AdsService {
  public:
   explicit AdsServiceImplIOS(PrefService* prefs);
@@ -96,6 +96,7 @@ class AdsServiceImplIOS : public AdsService {
   void ParseAndSaveCreativeNewTabPageAds(
       base::Value::Dict dict,
       ParseAndSaveCreativeNewTabPageAdsCallback callback) override;
+  void MaybeServeNewTabPageAd(MaybeServeNewTabPageAdCallback callback) override;
   void TriggerNewTabPageAdEvent(
       const std::string& placement_id,
       const std::string& creative_instance_id,
@@ -171,13 +172,10 @@ class AdsServiceImplIOS : public AdsService {
   void ClearAdsData(ClearDataCallback callback, bool success);
   void ClearAdsDataCallback(ClearDataCallback callback);
 
-  // TODO(https://github.com/brave/brave-browser/issues/26192) Decouple new
-  // tab page ad business logic.
-  void PrefetchNewTabPageAdCallback(
-      base::optional_ref<const NewTabPageAdInfo> new_tab_page_ad);
   void OnParseAndSaveCreativeNewTabPageAdsCallback(
       ParseAndSaveCreativeNewTabPageAdsCallback callback,
       bool success);
+  void ResetNewTabPageAd();
 
   const raw_ptr<PrefService> prefs_ = nullptr;  // Not owned.
 
@@ -191,8 +189,7 @@ class AdsServiceImplIOS : public AdsService {
   mojom::BuildChannelInfoPtr mojom_build_channel_;
   mojom::WalletInfoPtr mojom_wallet_;
 
-  std::optional<NewTabPageAdInfo> prefetched_new_tab_page_ad_;
-  bool is_prefetching_new_tab_page_ad_ = false;
+  std::unique_ptr<NewTabPageAdPrefetcher> new_tab_page_ad_prefetcher_;
 
   std::unique_ptr<Ads> ads_;
 

--- a/ios/browser/brave_ads/ads_service_impl_ios.mm
+++ b/ios/browser/brave_ads/ads_service_impl_ios.mm
@@ -20,9 +20,11 @@
 #include "base/notimplemented.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
+#include "brave/components/brave_ads/core/browser/service/new_tab_page_ad_prefetcher.h"
 #include "brave/components/brave_ads/core/mojom/brave_ads.mojom.h"
 #include "brave/components/brave_ads/core/public/ad_units/new_tab_page_ad/new_tab_page_ad_info.h"
 #include "brave/components/brave_ads/core/public/ads.h"
+#include "brave/components/brave_ads/core/public/ads_callback.h"
 #include "brave/components/brave_ads/core/public/ads_client/ads_client.h"
 #include "brave/components/brave_ads/core/public/ads_constants.h"
 #include "brave/components/brave_ads/core/public/flags/flags_util.h"
@@ -43,7 +45,9 @@ AdsServiceImplIOS::AdsServiceImplIOS(PrefService* prefs)
       prefs_(prefs),
       file_task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
           {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
-           base::TaskShutdownBehavior::BLOCK_SHUTDOWN})) {
+           base::TaskShutdownBehavior::BLOCK_SHUTDOWN})),
+      new_tab_page_ad_prefetcher_(
+          std::make_unique<NewTabPageAdPrefetcher>(/*ads_service=*/*this)) {
   CHECK(prefs_);
 }
 
@@ -201,13 +205,7 @@ void AdsServiceImplIOS::PrefetchNewTabPageAd() {
     return;
   }
 
-  if (!prefetched_new_tab_page_ad_ && !is_prefetching_new_tab_page_ad_) {
-    is_prefetching_new_tab_page_ad_ = true;
-
-    ads_->MaybeServeNewTabPageAd(
-        base::BindOnce(&AdsServiceImplIOS::PrefetchNewTabPageAdCallback,
-                       weak_ptr_factory_.GetWeakPtr()));
-  }
+  new_tab_page_ad_prefetcher_->Prefetch();
 }
 
 std::optional<NewTabPageAdInfo>
@@ -216,20 +214,13 @@ AdsServiceImplIOS::MaybeGetPrefetchedNewTabPageAd() {
     return std::nullopt;
   }
 
-  std::optional<NewTabPageAdInfo> ad;
-  if (prefetched_new_tab_page_ad_ && prefetched_new_tab_page_ad_->IsValid()) {
-    ad = prefetched_new_tab_page_ad_;
-    prefetched_new_tab_page_ad_.reset();
-  }
-
-  return ad;
+  return new_tab_page_ad_prefetcher_->MaybeGetPrefetchedAd();
 }
 
 void AdsServiceImplIOS::OnFailedToPrefetchNewTabPageAd(
     const std::string& /*placement_id*/,
     const std::string& /*creative_instance_id*/) {
-  prefetched_new_tab_page_ad_.reset();
-  is_prefetching_new_tab_page_ad_ = false;
+  ResetNewTabPageAd();
 
   PurgeOrphanedAdEventsForType(mojom::AdType::kNewTabPageAd,
                                /*intentional*/ base::DoNothing());
@@ -256,6 +247,15 @@ void AdsServiceImplIOS::ParseAndSaveCreativeNewTabPageAds(
       base::BindOnce(
           &AdsServiceImplIOS::OnParseAndSaveCreativeNewTabPageAdsCallback,
           weak_ptr_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void AdsServiceImplIOS::MaybeServeNewTabPageAd(
+    MaybeServeNewTabPageAdCallback callback) {
+  if (!IsInitialized()) {
+    return std::move(callback).Run(/*ad=*/std::nullopt);
+  }
+
+  ads_->MaybeServeNewTabPageAd(std::move(callback));
 }
 
 void AdsServiceImplIOS::TriggerNewTabPageAdEvent(
@@ -473,8 +473,7 @@ void AdsServiceImplIOS::NotifyDidSolveAdaptiveCaptcha() {
 ///////////////////////////////////////////////////////////////////////////////
 
 void AdsServiceImplIOS::Shutdown() {
-  prefetched_new_tab_page_ad_.reset();
-  is_prefetching_new_tab_page_ad_ = false;
+  ResetNewTabPageAd();
 
   ads_.reset();
 }
@@ -542,23 +541,6 @@ void AdsServiceImplIOS::ClearAdsDataCallback(ClearDataCallback callback) {
   InitializeAds(std::move(callback));
 }
 
-void AdsServiceImplIOS::PrefetchNewTabPageAdCallback(
-    base::optional_ref<const NewTabPageAdInfo> new_tab_page_ad) {
-  CHECK(!prefetched_new_tab_page_ad_);
-
-  if (!is_prefetching_new_tab_page_ad_) {
-    // `is_prefetching_new_tab_page_ad_` can be reset during shutdown, so fail
-    // gracefully.
-    return;
-  }
-
-  is_prefetching_new_tab_page_ad_ = false;
-
-  if (new_tab_page_ad) {
-    prefetched_new_tab_page_ad_ = *new_tab_page_ad;
-  }
-}
-
 void AdsServiceImplIOS::OnParseAndSaveCreativeNewTabPageAdsCallback(
     ParseAndSaveCreativeNewTabPageAdsCallback callback,
     bool success) {
@@ -567,6 +549,11 @@ void AdsServiceImplIOS::OnParseAndSaveCreativeNewTabPageAdsCallback(
   }
 
   std::move(callback).Run(success);
+}
+
+void AdsServiceImplIOS::ResetNewTabPageAd() {
+  new_tab_page_ad_prefetcher_ =
+      std::make_unique<NewTabPageAdPrefetcher>(/*ads_service=*/*this);
 }
 
 }  // namespace brave_ads


### PR DESCRIPTION
Uplift of https://github.com/brave/brave-core/pull/28606
Resolves https://github.com/brave/brave-browser/issues/45295

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.