### PR TITLE
[iOS] Update 'Block all Cookies' toggle to visible by default, update copy

### DIFF
--- a/components/brave_shields/core/common/features.cc
+++ b/components/brave_shields/core/common/features.cc
@@ -136,7 +136,11 @@ BASE_FEATURE(kCosmeticFilteringSyncLoad,
 // If the feature flag is on, we show the Block all Cookies toggle
 BASE_FEATURE(kBlockAllCookiesToggle,
              "BlockAllCookiesToggle",
+#if BUILDFLAG(IS_IOS)
+             base::FEATURE_ENABLED_BY_DEFAULT);
+#else
              base::FEATURE_DISABLED_BY_DEFAULT);
+#endif
 // when enabled, allow to select and block HTML elements
 BASE_FEATURE(kBraveShieldsElementPicker,
              "BraveShieldsElementPicker",

--- a/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
+++ b/ios/brave-ios/Sources/BraveStrings/BraveStrings.swift
@@ -3106,13 +3106,6 @@ extension Strings {
     value: "Blocks JavaScript (may break sites).",
     comment: ""
   )
-  public static let blockCookiesDescription = NSLocalizedString(
-    "BlockCookiesDescription",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "Prevents websites from storing information about your previous visits.\nThe \"Block all Cookies\" option has been deprecated. To learn how to force-enable this option, visit [our help page](https://github.com/brave/brave-browser/wiki/Block-all-cookies-global-Shields-setting)",
-    comment: ""
-  )
   public static let fingerprintingProtection = NSLocalizedString(
     "FingerprintingProtection",
     tableName: "BraveShared",
@@ -3222,7 +3215,7 @@ extension Strings {
     "BlockAllCookies",
     tableName: "BraveShared",
     bundle: .module,
-    value: "Block all Cookies",
+    value: "Block All Cookies",
     comment: "Title for setting to block all website cookies."
   )
   public static let blockAllCookiesAction = NSLocalizedString(
@@ -3232,19 +3225,19 @@ extension Strings {
     value: "Block All",
     comment: "block all cookies settings action title"
   )
-  public static let blockAllCookiesAlertInfo = NSLocalizedString(
-    "BlockAllCookiesAlertInfo",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "Blocking all Cookies will prevent some websites from working correctly.",
-    comment: "Information displayed to user when block all cookie is enabled."
-  )
   public static let blockAllCookiesAlertTitle = NSLocalizedString(
-    "BlockAllCookiesAlertTitle",
+    "blockAllCookiesAlertTitle",
     tableName: "BraveShared",
     bundle: .module,
-    value: "Block all Cookies?",
-    comment: "Title of alert displayed to user when block all cookie is enabled."
+    value: "Block All Cookies?",
+    comment: "Title of confirmation alert displayed to user when block all cookie toggle is enabled."
+  )
+  public static let blockAllCookiesDescription = NSLocalizedString(
+    "blockAllCookiesDescription",
+    tableName: "BraveShared",
+    bundle: .module,
+    value: "Shields already blocks 3rd-party cookies. This setting to block ALL cookies will remove existing cookies and site data, and could break websites.",
+    comment: "Description of confirmation alert displayed to user when block all cookie toggle is enabled."
   )
   public static let blockAllCookiesFailedAlertMsg = NSLocalizedString(
     "BlockAllCookiesFailedAlertMsg",
@@ -3252,20 +3245,6 @@ extension Strings {
     bundle: .module,
     value: "Failed to set the preference. Please try again.",
     comment: "Message of alert displayed to user when block all cookie operation fails"
-  )
-  public static let dontBlockCookies = NSLocalizedString(
-    "DontBlockCookies",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "Don't block cookies",
-    comment: "cookie settings option"
-  )
-  public static let cookieControl = NSLocalizedString(
-    "CookieControl",
-    tableName: "BraveShared",
-    bundle: .module,
-    value: "Cookie Control",
-    comment: "Cookie settings option title"
   )
   public static let neverShow = NSLocalizedString(
     "NeverShow",


### PR DESCRIPTION
- Update block all cookies toggle visibility feature flag to default to enabled for iOS only (`#block-all-cookies-toggle`). 
- Move 'Block all Cookies' toggle to 'Other Privacy Settings', update copy of alert & description.

Resolves https://github.com/brave/brave-browser/issues/45457

### Testplan

1. Verify `Block all Cookies` is visible by default in `Other Privacy Settings` section (in Settings > Shields & Privacy)
   - Assuming fresh install. Value of `block-all-cookies-toggle` in `brave://flags` should be enabled by default on iOS.
2. Verify description below toggle is `Shields already blocks 3rd-party cookies. This setting to block ALL cookies will remove existing cookies and site data, and could break websites.`
3. Tap to enable the toggle
4. Verify alert copy:
Title: `Block All Cookies?`
Description: `Shields already blocks 3rd-party cookies. This setting to block ALL cookies will remove existing cookies and site data, and could break websites.`
5. Verify `Block All` button title is red.

<img src="https://github.com/user-attachments/assets/b2295f60-ce81-4127-8016-3cf0791ca7ea" width="300">