### PR TITLE
fix(iOS): Fix recent search from the recent search list only searches with default search engine

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/BrowserViewController/BVC+ToolbarDelegate.swift
@@ -778,8 +778,12 @@ extension BrowserViewController: TopToolbarDelegate {
 
   private func displayFavoritesController() {
     if favoritesController == nil {
+      let dse = profile.searchEngines.defaultEngine(
+        forType: privateBrowsingManager.isPrivateBrowsing ? .privateMode : .standard
+      )
       let favoritesController = FavoritesViewController(
         privateBrowsingManager: privateBrowsingManager,
+        defaultSearchEngine: dse,
         bookmarkAction: { [weak self] bookmark, action in
           self?.handleFavoriteAction(favorite: bookmark, action: action)
         },
@@ -803,13 +807,28 @@ extension BrowserViewController: TopToolbarDelegate {
             }
 
             switch searchType {
-            case .text, .website:
+            case .text:
               if let text = recentSearch.text {
                 self.topToolbar.setLocation(text, search: false)
                 self.topToolbar(self.topToolbar, didEnterText: text)
 
                 if shouldSubmitSearch {
                   submitSearch(text)
+                }
+              }
+            case .website:
+              if let text = recentSearch.text {
+                self.topToolbar.setLocation(text, search: false)
+                self.topToolbar(self.topToolbar, didEnterText: text)
+
+                if shouldSubmitSearch {
+                  if let urlString = recentSearch.websiteUrl,
+                    let url = URL(string: urlString)
+                  {
+                    finishEditingAndSubmit(url)
+                  } else {
+                    submitSearch(text)
+                  }
                 }
               }
             case .qrCode:

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -99,15 +99,20 @@ class FavoritesViewController: UIViewController {
   // Private Browsing
   var privateBrowsingManager: PrivateBrowsingManager
   private var privateModeCancellable: AnyCancellable?
+  
+  // Search Engines
+  private let defaultSearchEngine: OpenSearchEngine?
 
   init(
     privateBrowsingManager: PrivateBrowsingManager,
+    defaultSearchEngine: OpenSearchEngine?,
     bookmarkAction: @escaping (Favorite, BookmarksAction) -> Void,
     recentSearchAction: @escaping (RecentSearch?, Bool) -> Void
   ) {
     self.bookmarkAction = bookmarkAction
     self.recentSearchAction = recentSearchAction
     self.privateBrowsingManager = privateBrowsingManager
+    self.defaultSearchEngine = defaultSearchEngine
 
     super.init(nibName: nil, bundle: nil)
 
@@ -651,23 +656,31 @@ extension FavoritesViewController: NSFetchedResultsControllerDelegate {
         {
           let website =
             URL(string: websiteUrl)?.baseDomain ?? URL(string: websiteUrl)?.host ?? websiteUrl
+          var searchIsUsingDefaultEngine = false
+          if let dse = defaultSearchEngine,
+            dse.searchTemplate.contains(website)
+          {
+            searchIsUsingDefaultEngine = true
+          }
 
           let title = NSMutableAttributedString(
             string: text,
             attributes: [.font: UIFont.systemFont(ofSize: 15.0)]
           )
-          title.append(
-            NSAttributedString(
-              string: " \(Strings.recentSearchQuickSearchOnWebsite) ",
-              attributes: [.font: UIFont.systemFont(ofSize: 15.0, weight: .semibold)]
+          if !searchIsUsingDefaultEngine {
+            title.append(
+              NSAttributedString(
+                string: " \(Strings.recentSearchQuickSearchOnWebsite) ",
+                attributes: [.font: UIFont.systemFont(ofSize: 15.0, weight: .semibold)]
+              )
             )
-          )
-          title.append(
-            NSAttributedString(
-              string: website,
-              attributes: [.font: UIFont.systemFont(ofSize: 15.0)]
+            title.append(
+              NSAttributedString(
+                string: website,
+                attributes: [.font: UIFont.systemFont(ofSize: 15.0)]
+              )
             )
-          )
+          }
           cell.setAttributedTitle(title)
         } else if let websiteUrl = recentSearch.websiteUrl {
           cell.setTitle(websiteUrl)

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Favorites/FavoritesViewController.swift
@@ -99,7 +99,7 @@ class FavoritesViewController: UIViewController {
   // Private Browsing
   var privateBrowsingManager: PrivateBrowsingManager
   private var privateModeCancellable: AnyCancellable?
-  
+
   // Search Engines
   private let defaultSearchEngine: OpenSearchEngine?
 


### PR DESCRIPTION

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45384

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan

1. Enable recent search 
2. make a search from the omnibox with default search engine A
3. open a NTP and tap the omnibox 
4. observe `search query` appears in recent search list
5. change default search engine to B
6. open a NTP and tap the omnibox
7. observe `search query on A's base domain` appears in recent search list
8. make a search from the omnibox with default search engine B
9. open a NTP and tap the omnibox 
10. observe `search query` and `search query on A's base domain` appear in recent search
11. tap `search query` entry from the recent search list
12. observe browser will open a search with that search query using default search engine B
13. open a NTP and tap the omnibox
14. this time tap `search query on A's base domain`from the recent search list
15. observe browser will open a search with the search query using search engine A
16. change default search engine to C
17. open a NTP and tap the omnibox
18. observe `search query on A's base domain` and `search query on B's base domain` now appear in recent search. 
19. tap `search query on A's base domain` 
20. browser will open a search with that search query using search engine A
21. back to step  18 and tap `search query on B's base domain`
22. browser will open a search with that search query using search engine B
