### PR TITLE
feat(wallet): Verified DApp Status

### DIFF
--- a/components/brave_wallet/browser/brave_wallet_constants.h
+++ b/components/brave_wallet/browser/brave_wallet_constants.h
@@ -1633,6 +1633,7 @@ inline constexpr webui::LocalizedString kLocalizedStrings[] = {
     {"braveWalletClearFilters", IDS_BRAVE_WALLET_CLEAR_FILTERS},
     {"braveWalletShowMore", IDS_BRAVE_WALLET_SHOW_MORE},
     {"braveWalletDetails", IDS_BRAVE_WALLET_DETAILS},
+    {"braveWalletVerified", IDS_BRAVE_WALLET_VERIFIED},
     {"braveWalletSwitchToShieldedAccount",
      IDS_BRAVE_WALLET_SWITCH_TO_SHIELDED_ACCOUNT},
     {"braveWalletShieldAccount", IDS_BRAVE_WALLET_SHIELD_ACCOUNT},

--- a/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.test.ts
+++ b/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.test.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import { renderHook, waitFor } from '@testing-library/react'
+
+// Utils
+import {
+  createMockStore,
+  renderHookOptionsWithMockStore
+} from '../../utils/test-utils'
+
+// Hooks
+import { useIsDAppVerified } from './use_is_dapp_verified'
+
+// Mocks
+import { mockUniswapOriginInfo } from '../../stories/mock-data/mock-origin-info'
+import { mockEthMainnet } from '../../stories/mock-data/mock-networks'
+
+describe('useIsDAppVerified hook', () => {
+  it('should return true when origin exists.', async () => {
+    // setup
+    const store = createMockStore(
+      {},
+      {
+        networks: [mockEthMainnet]
+      }
+    )
+    const renderOptions = renderHookOptionsWithMockStore(store)
+
+    const { result } = renderHook(
+      () =>
+        useIsDAppVerified({
+          ...mockUniswapOriginInfo
+        }),
+      renderOptions
+    )
+
+    // wait for query to complete
+    await waitFor(() => {
+      expect(result.current).toBeDefined()
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('should return false when origin does not exist.', async () => {
+    // setup
+    const store = createMockStore(
+      {},
+      {
+        networks: [mockEthMainnet]
+      }
+    )
+    const renderOptions = renderHookOptionsWithMockStore(store)
+
+    const { result } = renderHook(
+      () =>
+        useIsDAppVerified({
+          originSpec: 'https://unknown-dapp.com',
+          eTldPlusOne: 'unknown-dapp.com'
+        }),
+      renderOptions
+    )
+
+    // wait for query to complete
+    await waitFor(() => {
+      expect(result.current).toBeDefined()
+    })
+
+    expect(result.current).toBe(false)
+  })
+})

--- a/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.tsx
+++ b/components/brave_wallet_ui/common/hooks/use_is_dapp_verified.tsx
@@ -1,0 +1,20 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Types
+import { BraveWallet } from '../../constants/types'
+
+// Hooks
+import { useGetTopDappsQuery } from '../slices/api.slice'
+
+export const useIsDAppVerified = (originInfo: BraveWallet.OriginInfo) => {
+  // Queries
+  const { data: topDapps } = useGetTopDappsQuery()
+
+  return topDapps?.some((dapp) =>
+    dapp.website.startsWith(originInfo.originSpec)
+  )
+}
+export default useIsDAppVerified

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.style.ts
@@ -74,6 +74,7 @@ export const SiteURL = styled.span`
   text-align: left;
   color: ${leo.color.text.secondary};
   word-break: break-word;
+  margin-bottom: 6px;
 `
 
 export const FavIcon = styled.img<{ isReadyToConnect: boolean }>`
@@ -142,4 +143,14 @@ export const LinkIconCircle = styled.div`
 export const LinkIcon = styled(Icon)`
   --leo-icon-size: 16px;
   color: ${leo.color.white};
+`
+
+export const VerifiedIcon = styled(Icon).attrs({
+  name: 'verification-filled'
+})`
+  --leo-icon-size: 20px;
+  color: ${leo.color.purple[60]};
+  position: absolute;
+  bottom: -4px;
+  right: -2px;
 `

--- a/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
+++ b/components/brave_wallet_ui/components/extension/connect-with-site-panel/connect-with-site-header/connect-with-site-header.tsx
@@ -14,6 +14,9 @@ import { getLocale } from '../../../../../common/locale'
 // Components
 import { CreateSiteOrigin } from '../../../shared/create-site-origin/index'
 import { Tooltip } from '../../../shared/tooltip/index'
+import {
+  VerifiedLabel //
+} from '../../../shared/verified_label/verified_label'
 
 // Styled Components
 import {
@@ -29,13 +32,17 @@ import {
   BackIcon,
   GradientLine,
   LinkIconCircle,
-  LinkIcon
+  LinkIcon,
+  VerifiedIcon
 } from './connect-with-site-header.style'
 import { AccountCircle } from '../select-account-item/select-account-item.style'
 import { HorizontalSpace, Column, Row } from '../../../shared/style'
 
 // Hooks
 import { useAddressOrb } from '../../../../common/hooks/use-orb'
+import {
+  useIsDAppVerified //
+} from '../../../../common/hooks/use_is_dapp_verified'
 
 interface Props {
   originInfo: BraveWallet.OriginInfo
@@ -47,6 +54,9 @@ interface Props {
 
 export const ConnectWithSiteHeader = (props: Props) => {
   const { originInfo, address, isReadyToConnect, isScrolled, onBack } = props
+
+  // Hooks
+  const isDAppVerified = useIsDAppVerified(originInfo)
 
   // Memos
   const orb = useAddressOrb(address)
@@ -101,6 +111,7 @@ export const ConnectWithSiteHeader = (props: Props) => {
                   )}`}
                   isReadyToConnect={isReadyToConnect}
                 />
+                {isDAppVerified && <VerifiedIcon />}
               </Tooltip>
             </Row>
           )}
@@ -124,6 +135,7 @@ export const ConnectWithSiteHeader = (props: Props) => {
                     eTldPlusOne={originInfo.eTldPlusOne}
                   />
                 </SiteURL>
+                {isDAppVerified && <VerifiedLabel />}
               </Column>
             </Row>
           )}

--- a/components/brave_wallet_ui/components/extension/connections/connections.tsx
+++ b/components/brave_wallet_ui/components/extension/connections/connections.tsx
@@ -11,6 +11,11 @@ import { BraveWallet } from '../../../constants/types'
 // Queries
 import { useGetActiveOriginQuery } from '../../../common/slices/api.slice'
 
+// Hooks
+import {
+  useIsDAppVerified //
+} from '../../../common/hooks/use_is_dapp_verified'
+
 // Utils
 import { getLocale } from '$web-common/locale'
 
@@ -29,6 +34,7 @@ import {
 // Styled Components
 import { FavIcon } from './connections.style'
 import { Column, Text } from '../../shared/style'
+import { VerifiedLabel } from '../../shared/verified_label/verified_label'
 
 const CONNECTABLE_COIN_TYPES = [
   BraveWallet.CoinType.ETH,
@@ -39,6 +45,9 @@ export const Connections = () => {
   // Queries
   const { data: activeOrigin = { eTldPlusOne: '', originSpec: '' } } =
     useGetActiveOriginQuery()
+
+  // Hooks
+  const isDAppVerified = useIsDAppVerified(activeOrigin)
 
   return (
     <WalletPageWrapper
@@ -80,6 +89,7 @@ export const Connections = () => {
               eTldPlusOne={activeOrigin.eTldPlusOne}
             />
           </Text>
+          {isDAppVerified && <VerifiedLabel />}
         </Column>
         <Column
           gap='16px'

--- a/components/brave_wallet_ui/components/shared/verified_label/verified_label.tsx
+++ b/components/brave_wallet_ui/components/shared/verified_label/verified_label.tsx
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 The Brave Authors. All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import * as React from 'react'
+import Label from '@brave/leo/react/label'
+import Icon from '@brave/leo/react/icon'
+
+// Utils
+import { getLocale } from '../../../../common/locale'
+
+export const VerifiedLabel = () => {
+  return (
+    <Label color='purple'>
+      <div slot='icon-before'>
+        <Icon name='verification-filled' />
+      </div>
+      {getLocale('braveWalletVerified')}
+    </Label>
+  )
+}

--- a/components/brave_wallet_ui/stories/locale.ts
+++ b/components/brave_wallet_ui/stories/locale.ts
@@ -1527,6 +1527,7 @@ provideStrings({
   braveWalletClearFilters: 'Clear filters',
   braveWalletShowMore: 'Show more',
   braveWalletDetails: 'Details',
+  braveWalletVerified: 'Verified by DappRadar',
 
   // ZCash
   braveWalletSwitchToShieldedAccount: 'Switch to a shielded account',

--- a/components/resources/wallet_strings.grdp
+++ b/components/resources/wallet_strings.grdp
@@ -1163,6 +1163,7 @@
   <message name="IDS_BRAVE_WALLET_CLEAR_FILTERS" desc="Clear filters label">Clear filters</message>
   <message name="IDS_BRAVE_WALLET_SHOW_MORE" desc="Show more label">Show more</message>
   <message name="IDS_BRAVE_WALLET_DETAILS" desc="Details label">Details</message>
+  <message name="IDS_BRAVE_WALLET_VERIFIED" desc="Verified label">Verified by DappRadar</message>
   <message name="IDS_BRAVE_WALLET_SWITCH_TO_SHIELDED_ACCOUNT" desc="Switch to a shielded account button text">Switch to a shielded account</message>
   <message name="IDS_BRAVE_WALLET_SHIELD_ACCOUNT" desc="Shield account button text">Shield account</message>
   <message name="IDS_BRAVE_WALLET_ACCOUNT_NOT_SHIELDED_DESCRIPTION" desc="ZCash account not shielded description.">Currently this account supports transparent transactions which means they are visible to everyone on the blockchain.</message>


### PR DESCRIPTION
## Description 

Introduces a `Verified` badge and label to the Wallet `Connection` panels, when connecting to a DApp that exist in our `topDapps` list from `DAppRadar`

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/45507>
Security and privacy review: https://github.com/brave/reviews/issues/1926

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:
1. Go to https://app.uniswap.org/ and then open the Wallet `Panel`
2. Navigate to the `Connections` tab
3. You should see a `Verified` label
4. Click connect and wait for the `Connect` prompt
5. You should see a `Verified` label
6. Click `Next`, you should see the `Verified` check icon next to the site `FavIcon`
7. Now go to https://apeswap.finance/ and follow these same steps
8. You should not see any `Verified` labels

![Image](https://github.com/user-attachments/assets/0f77a293-6d6e-46b1-a593-f7176c273650) | ![Image](https://github.com/user-attachments/assets/f74f1702-cc9c-41a9-a3c1-8b8568c524f5) | ![Image](https://github.com/user-attachments/assets/0d15e383-805b-473b-9fd4-4782ea83a4bc)
--|--|--

https://github.com/user-attachments/assets/ce2f4971-d7a8-49fe-bd93-170a2259ff2a
