### PR TITLE
[uplift script] Add new arg to copy `CI/*` labels (from the PR being uplifted)

### DIFF
--- a/script/uplift.py
+++ b/script/uplift.py
@@ -163,6 +163,10 @@ def parse_args():
         '--title',
         help='title to use (instead of inferring one from the first commit)',
         default=None)
+    parser.add_argument(
+        '--copy-ci-labels',
+        action='store_true',
+        help='copy the `CI/*` labels from the PR (if present)')
 
     return parser.parse_args()
 
@@ -231,6 +235,16 @@ def main():
             merged_at = str(response['merged_at']).strip()
             config.title = str(response['title']).strip()
             issues_fixed = parse_issues_fixed(response['body'])
+
+            # optionally copy the CI/* labels (ex: skip platform, etc)
+            if args.copy_ci_labels:
+                print('copying `CI/*` labels from PR...')
+                for label in response['labels']:
+                    if label != 'None':
+                        label_name = str(label['name'])
+                        if label_name.startswith("CI/"):
+                            print('adding label "' + label_name + '"')
+                            config.labels.append(label_name)
 
         except Exception as e:
             print(


### PR DESCRIPTION
Fixes https://github.com/brave/brave-browser/issues/45503

Example CLI usage (dry run w/ `-n`):
```
python3 script/uplift.py -n --uplift-using-pr='28703' --uplift-to='beta' --copy-ci-labels
```

CLI output from that run:
```
python3 script/uplift.py -n --uplift-using-pr='28703' --uplift-to='beta' --copy-ci-labels
copying `CI/*` labels from PR...
adding label "CI/skip-android"
adding label "CI/skip-macos-x64"
adding label "CI/skip-windows-x64"
adding label "CI/skip-macos-arm64"
adding label "CI/skip-teamcity"
pr was already merged at 2025-04-16T20:15:52Z; using "e973a630ec37906dd3e31ffe55aa8a0f81b1e15d" instead of "master"
branch "pr28703_ios-fix-cert-tests" exists; resetting to origin/ios-fix-cert-tests (81c40dd20128340633eb53adc360afcfe237c57d)

Creating branches...
###########################################################################################################################
NOTE: Commits are being detected by diffing "pr28703_ios-fix-cert-tests" against "e973a630ec37906dd3e31ffe55aa8a0f81b1e15d"
###########################################################################################################################
(beta) branch "pr28703_ios-fix-cert-tests_1.78.x" exists; resetting to origin/1.78.x
- picked 81c40dd2012 ([pr28703_ios-fix-cert-tests_1.78.x a702e26cf07] [iOS] Fix certificate unit tests running on iOS 18.4)
- squashed all commits into "09a64173f6d"
 with message: "Uplift of #28703 (squashed) to beta"

Pushing local branches to remote...
[INFO] would push the following local branches to remote: ['pr28703_ios-fix-cert-tests_1.78.x']

Creating the pull requests...
(beta) creating pull request
[INFO] would call `repo.pulls.post({'title': '[iOS] Fix certificate unit tests running on iOS 18.4 (uplift to 1.78.x)', 'head': 'pr28703_ios-fix-cert-tests_1.78.x', 'base': '1.78.x', 'body': "Uplift of #28703\nResolves https://github.com/brave/brave-browser/issues/45500\n\nPre-approval checklist: \n- [ ] You have tested your change on Nightly. \n- [ ] This contains text which needs to be translated. \n    - [ ] There are more than 7 days before the release. \n    - [ ] I've notified folks in #l10n on Slack that translations are needed. \n- [ ] The PR milestones match the branch they are landing to. \n\n\nPre-merge checklist: \n- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. \n\nPost-merge checklist: \n- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.", 'maintainer_can_modify': True})`
[INFO] would open PR in web browser
[INFO] would call `repo.pulls(1234).requested_reviewers.post({'team_reviewers': ['uplift-approvers']})`
[INFO] would call `repo.issues(1234).patch({'milestone': 431, 'assignees': ['bsclifton'], 'labels': ['CI/skip-android', 'CI/skip-macos-x64', 'CI/skip-windows-x64', 'CI/skip-macos-arm64', 'CI/skip-teamcity']})`

Done!
```

Next step would be: employees can wire up this argument to a Jenkins parameter (bool) in https://github.com/brave/devops/blob/master/jenkins/jobs/browser/brave-core-create-uplift-prs.yml

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
