### PR TITLE
[canary] Adding `brockit_test.py` to test B🚀

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -223,7 +223,7 @@ MINOR_VERSION_BUMP_ISSUE_TEMPLATE = """### Minor Chromium bump
 """
 
 
-def _get_current_branch_upstream_name():
+def _get_current_branch_upstream_name() -> Optional[str]:
     """Retrieves the name of the current branch's upstream.
     """
     try:
@@ -233,17 +233,14 @@ def _get_current_branch_upstream_name():
         return None
 
 
-def _update_pinslist_timestamp():
+def _update_pinslist_timestamp() -> str:
     """Updates the pinslist timestamp in the input_file_parsers.cc file for the
     version commit.
+
+    Returns:
+        The readable timestamp of the update into the file.
     """
-    try:
-        with open(PINSLIST_TIMESTAMP_FILE, "r", encoding="utf-8") as file:
-            content = file.read()
-    except FileNotFoundError:
-        logging.exception("ERROR: File %s not found. Aborting.",
-                          PINSLIST_TIMESTAMP_FILE)
-        sys.exit(1)
+    content = repository.brave.read_file(PINSLIST_TIMESTAMP_FILE)
 
     pattern = r"# Last updated:.*\nPinsListTimestamp\n[0-9]{10}\n"
     match = re.search(pattern, content, flags=re.DOTALL)
@@ -272,6 +269,8 @@ def _update_pinslist_timestamp():
     updated = repository.brave.run_git('diff', PINSLIST_TIMESTAMP_FILE)
     if updated == '':
         raise ValueError('Pinslist timestamp failed to update.')
+
+    return readable_timestamp
 
 
 def _is_gh_cli_logged_in():

--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env vpython3
+# Copyright (c) 2025 The Brave Authors. All rights reserved.
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import unittest
+from pathlib import PurePath, Path
+import shutil
+from datetime import datetime, timedelta
+
+import brockit
+
+from test.fake_chromium_src import FakeChromiumSrc
+
+
+class BrockitTest(unittest.TestCase):
+    """Test the patchfile generation and application."""
+
+    def setUp(self):
+        """Set up a fake Chromium repository for testing."""
+        self.fake_chromium_src = FakeChromiumSrc()
+        self.fake_chromium_src.setup()
+        self.fake_chromium_src.add_dep('v8')
+        self.fake_chromium_src.add_dep('third_party/test1')
+        self.addCleanup(self.fake_chromium_src.cleanup)
+
+    def test_get_current_branch_upstream_name(self):
+        """Test that the upstream branch name is correctly retrieved."""
+        # Create a remote for the Brave repository
+        self.fake_chromium_src.create_brave_remote()
+
+        # Set the upstream branch for the current branch
+        repo_path = self.fake_chromium_src.brave
+        self.fake_chromium_src._run_git_command(
+            ['checkout', '-b', 'test-branch'], repo_path)
+        self.fake_chromium_src._run_git_command(
+            ['push', '--set-upstream', 'origin', 'test-branch'], repo_path)
+
+        # Verify the upstream branch name
+        upstream_name = brockit._get_current_branch_upstream_name()
+        self.assertEqual(upstream_name, 'origin/test-branch')
+
+    def test_get_current_branch_upstream_name_no_upstream(self):
+        """Test when there's no upstream branch."""
+        # Create a branch without setting an upstream
+        repo_path = self.fake_chromium_src.brave
+        self.fake_chromium_src._run_git_command(
+            ['checkout', '-b', 'no-upstream-branch'], repo_path)
+
+        # Verify that _get_current_branch_upstream_name returns None
+        upstream_name = brockit._get_current_branch_upstream_name()
+        self.assertIsNone(upstream_name)
+
+    def test_update_pinslist_timestamp(self):
+        """Test that the pinslist timestamp is updated correctly."""
+        # Copy the file from the Chromium source directory to the test repo
+        original_pinslist_path = (
+            Path(__file__).parent.parent.parent /
+            'chromium_src/net/tools/transport_security_state_generator/'
+            'input_file_parsers.cc')
+        test_pinslist_path = (
+            self.fake_chromium_src.brave /
+            'chromium_src/net/tools/transport_security_state_generator/'
+            'input_file_parsers.cc')
+
+        test_pinslist_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(original_pinslist_path, test_pinslist_path)
+
+        # Stage and commit the file to the Brave fake repository
+        self.fake_chromium_src._run_git_command(
+            ['add', str(test_pinslist_path)], self.fake_chromium_src.brave)
+        self.fake_chromium_src._run_git_command(
+            ['commit', '-m', 'Add pinslist file for testing'],
+            self.fake_chromium_src.brave)
+
+        # Call the function to update the timestamp
+        before_update = datetime.now()
+        readable_timestamp = brockit._update_pinslist_timestamp()
+
+        # Verify that the timestamp is updated
+        updated_content = test_pinslist_path.read_text()
+        self.assertIn(f'# Last updated: {readable_timestamp}', updated_content)
+
+        # Verify that the readable timestamp is within a valid range
+        timestamp_datetime = datetime.strptime(readable_timestamp,
+                                               '%a %b %d %H:%M:%S %Y')
+        self.assertTrue(
+            0 <= (before_update - timestamp_datetime).total_seconds() <= 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/cr/test/fake_chromium_repo.py
+++ b/tools/cr/test/fake_chromium_repo.py
@@ -27,7 +27,7 @@ class FakeChromiumRepo:
         """
         self.temp_dir: tempfile.TemporaryDirectory = (
             tempfile.TemporaryDirectory())
-        self.base_path: Path = Path(self.temp_dir.name)
+        self.base_path: Path = Path(self.temp_dir.name) / 'workspace'
         self._init_repo(self.chromium)
         self._init_repo(self.brave)  # Create the brave repository
 
@@ -45,6 +45,11 @@ class FakeChromiumRepo:
     def brave_patches(self) -> Path:
         """Returns the path to the Brave patches directory."""
         return self.brave / 'patches'
+
+    @property
+    def remote(self) -> Path:
+        """Returns the path to the Brave directory"""
+        return self.base_path / 'remote'
 
     def _run_git_command(self,
                          command: List[str],
@@ -81,6 +86,20 @@ class FakeChromiumRepo:
         (path / 'README.md').write_text(f'# Fake {path.name} repo\n')
         self._run_git_command(['add', 'README.md'], path)
         self._run_git_command(['commit', '-m', 'Initial commit'], path)
+
+    def create_brave_remote(self) -> None:
+        """Creates a remote repository for Brave and sets it as the origin.
+
+        Initializes a git repository at the path returned by `self.remote` and
+        adds it as the `origin` remote for the Brave repository.
+        """
+        # Initialize the remote repository
+        self._init_repo(self.remote / 'brave')
+
+        # Add the remote as 'origin' for the Brave repository
+        self._run_git_command(
+            ['remote', 'add', 'origin',
+             str(self.remote / 'brave')], self.brave)
 
     def add_repo(self, relative_path: str) -> None:
         """Adds a new repository at the specified relative path.


### PR DESCRIPTION
This change introduces `brockit_test.py` which will be used to host most of the `brockit` tests.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45536


<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
