### PR TITLE
[canary] Adding tests for continuation types in B🚀

### DIFF
--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -5,11 +5,12 @@
 # You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import unittest
-from pathlib import PurePath, Path
+from pathlib import Path
 import shutil
-from datetime import datetime, timedelta
+from datetime import datetime
 
 import brockit
+from brockit import ApplyPatchesRecord
 
 from test.fake_chromium_src import FakeChromiumSrc
 
@@ -23,6 +24,11 @@ class BrockitTest(unittest.TestCase):
         self.fake_chromium_src.setup()
         self.fake_chromium_src.add_dep('v8')
         self.fake_chromium_src.add_dep('third_party/test1')
+
+        # Patch VERSION_UPGRADE_FILE to be under self.fake_chromium_src.brave
+        brockit.VERSION_UPGRADE_FILE = (self.fake_chromium_src.brave /
+                                        '.version_upgrade')
+
         self.addCleanup(self.fake_chromium_src.cleanup)
 
     def test_get_current_branch_upstream_name(self):
@@ -87,6 +93,266 @@ class BrockitTest(unittest.TestCase):
                                                '%a %b %d %H:%M:%S %Y')
         self.assertTrue(
             0 <= (before_update - timestamp_datetime).total_seconds() <= 10)
+
+    def test_requires_conflict_resolution(self):
+        """Test ApplyPatchesRecord.requires_conflict_resolution"""
+
+        # Case 1: No conflicts, no deleted files, no broken patches
+        record = ApplyPatchesRecord()
+        self.assertFalse(record.requires_conflict_resolution())
+
+        # Case 2: Conflicts present
+        record = ApplyPatchesRecord(files_with_conflicts=['file1'])
+        self.assertTrue(record.requires_conflict_resolution())
+
+        # Case 3: Deleted patches present
+        record = ApplyPatchesRecord(patches_to_deleted_files=['patch1'])
+        self.assertTrue(record.requires_conflict_resolution())
+
+        # Case 4: Broken patches present
+        record = ApplyPatchesRecord(broken_patches=['patch2'])
+        self.assertTrue(record.requires_conflict_resolution())
+
+        # Case 5: Multiple issues present
+        record = ApplyPatchesRecord(files_with_conflicts=['file1'],
+                                    patches_to_deleted_files=['patch1'],
+                                    broken_patches=['patch2'])
+        self.assertTrue(record.requires_conflict_resolution())
+
+    def test_stage_all_patches(self):
+        """Test ApplyPatchesRecord.stage_all_patches"""
+
+        # Step 1: Commit files to fake repositories
+        test_file_chromium = Path(
+            'chrome/common/extensions/api/test_file1.idl')
+        test_file_v8 = Path('v8/test_file2.cc')
+        test_file_third_party = Path('third_party/test1/test_file3.h')
+        unrelated_file = Path(
+            'chrome/common/extensions/api/unrelated_file.idl')
+
+        # Write and commit files to respective repositories
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_chromium, 'Initial content for Chromium file.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add test_file1.idl',
+                                      self.fake_chromium_src.chromium)
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_v8, 'Initial content for V8 file.',
+            self.fake_chromium_src.chromium / 'v8')
+        self.fake_chromium_src.commit('Add test_file2.cc',
+                                      self.fake_chromium_src.chromium / 'v8')
+
+        self.fake_chromium_src.write_and_stage_file(
+            test_file_third_party, 'Initial content for third_party file.',
+            self.fake_chromium_src.chromium / 'third_party/test1')
+        self.fake_chromium_src.commit(
+            'Add test_file3.h',
+            self.fake_chromium_src.chromium / 'third_party/test1')
+
+        # Add an unrelated file and commit it
+        self.fake_chromium_src.write_and_stage_file(
+            unrelated_file, 'Initial content for unrelated file.',
+            self.fake_chromium_src.chromium)
+        self.fake_chromium_src.commit('Add unrelated_file.idl',
+                                      self.fake_chromium_src.chromium)
+
+        # Step 2: Modify files directly using write_text
+        (self.fake_chromium_src.chromium /
+         test_file_chromium).write_text('Modified content for Chromium file.')
+        (self.fake_chromium_src.chromium / 'v8' /
+         test_file_v8).write_text('Modified content for V8 file.')
+        (self.fake_chromium_src.chromium / 'third_party/test1' /
+         test_file_third_party
+         ).write_text('Modified content for third_party file.')
+        (self.fake_chromium_src.chromium /
+         unrelated_file).write_text('Modified content for unrelated file.')
+
+        # Run update_patches to generate patches
+        self.fake_chromium_src.run_update_patches()
+
+        # Step 3: Create ApplyPatchesRecord and test stage_all_patches
+        record = ApplyPatchesRecord(
+            patch_files={
+                self.fake_chromium_src.chromium: [
+                    brockit.Patchfile(path=self.fake_chromium_src.
+                                      get_patchfile_path_for_source(
+                                          self.fake_chromium_src.chromium,
+                                          test_file_chromium))
+                ],
+                self.fake_chromium_src.chromium / 'v8': [
+                    brockit.Patchfile(path=self.fake_chromium_src.
+                                      get_patchfile_path_for_source(
+                                          self.fake_chromium_src.chromium /
+                                          'v8', test_file_v8))
+                ],
+                self.fake_chromium_src.chromium / 'third_party/test1': [
+                    brockit.Patchfile(
+                        path=self.fake_chromium_src.
+                        get_patchfile_path_for_source(
+                            self.fake_chromium_src.chromium /
+                            'third_party/test1', test_file_third_party))
+                ],
+            })
+
+        # Stage all patches
+        record.stage_all_patches()
+
+        # Verify that the listed patches are staged
+        staged_files = self.fake_chromium_src._run_git_command(
+            ['diff', '--cached', '--name-only'], self.fake_chromium_src.brave)
+        self.assertIn(
+            str(
+                self.fake_chromium_src.get_patchfile_path_for_source(
+                    self.fake_chromium_src.chromium, test_file_chromium)),
+            staged_files)
+        self.assertIn(
+            str(
+                self.fake_chromium_src.get_patchfile_path_for_source(
+                    self.fake_chromium_src.chromium / 'v8', test_file_v8)),
+            staged_files)
+        self.assertIn(
+            str(
+                self.fake_chromium_src.get_patchfile_path_for_source(
+                    self.fake_chromium_src.chromium / 'third_party/test1',
+                    test_file_third_party)), staged_files)
+
+        # Verify that unrelated patches are not staged
+        self.assertNotIn(
+            str(
+                self.fake_chromium_src.get_patchfile_path_for_source(
+                    self.fake_chromium_src.chromium, unrelated_file)),
+            staged_files)
+
+    def test_continuation_file_save_and_load(self):
+        """Test saving and loading of ContinuationFile."""
+        target_version = brockit.Version('135.0.7037.1')
+        working_version = brockit.Version('134.0.7036.0')
+        base_version = brockit.Version('134.0.7035.0')
+
+        # Create a ContinuationFile instance and save it
+        continuation = brockit.ContinuationFile(
+            target_version=target_version,
+            working_version=working_version,
+            base_version=base_version,
+            has_shown_advisory=True,
+            apply_record=None)
+        continuation.save()
+
+        # Load the continuation file with check=True
+        loaded_continuation = brockit.ContinuationFile.load(
+            target_version=target_version,
+            working_version=working_version,
+            check=True)
+        self.assertEqual(loaded_continuation.target_version, target_version)
+        self.assertEqual(loaded_continuation.working_version, working_version)
+        self.assertEqual(loaded_continuation.base_version, base_version)
+        self.assertTrue(loaded_continuation.has_shown_advisory)
+
+        # Load the continuation file with check=False
+        loaded_continuation_no_check = brockit.ContinuationFile.load(
+            target_version=target_version,
+            working_version=working_version,
+            check=False)
+        self.assertEqual(loaded_continuation_no_check.target_version,
+                         target_version)
+
+    def test_continuation_file_load_nonexistent(self):
+        """Test loading a nonexistent ContinuationFile."""
+        target_version = brockit.Version('135.0.7037.1')
+        working_version = brockit.Version('134.0.7036.0')
+
+        # Attempt to load a nonexistent continuation file with check=False
+        continuation = brockit.ContinuationFile.load(
+            target_version=target_version,
+            working_version=working_version,
+            check=False)
+        self.assertIsNone(continuation)
+
+        # Attempt to load a nonexistent continuation file with check=True
+        with self.assertRaises(FileNotFoundError):
+            brockit.ContinuationFile.load(target_version=target_version,
+                                          working_version=working_version,
+                                          check=True)
+
+    def test_continuation_file_load_version_mismatch(self):
+        """Test loading a ContinuationFile with mismatched versions."""
+        target_version = brockit.Version('135.0.7037.1')
+        working_version = brockit.Version('134.0.7036.0')
+        base_version = brockit.Version('134.0.7035.0')
+
+        # Create and save a ContinuationFile with specific versions
+        continuation = brockit.ContinuationFile(
+            target_version=brockit.Version(
+                '136.0.8000.0'),  # Different target version
+            working_version=brockit.Version('134.0.7036.0'),
+            base_version=base_version)
+        continuation.save()
+
+        # Attempt to load with mismatched target_version and check=False
+        loaded_continuation = brockit.ContinuationFile.load(
+            target_version=target_version,
+            working_version=working_version,
+            check=False)
+        self.assertIsNone(loaded_continuation)
+
+        # Attempt to load with mismatched target_version and check=True
+        with self.assertRaises(TypeError):
+            brockit.ContinuationFile.load(target_version=target_version,
+                                          working_version=working_version,
+                                          check=True)
+
+    def test_continuation_file_load_working_version_mismatch(self):
+        """Test loading a ContinuationFile with mismatched working versions."""
+        target_version = brockit.Version('135.0.7037.1')
+        working_version = brockit.Version('134.0.7036.0')
+        base_version = brockit.Version('134.0.7035.0')
+
+        # Create and save a ContinuationFile with specific versions
+        continuation = brockit.ContinuationFile(
+            target_version=target_version,
+            working_version=brockit.Version(
+                '134.0.5000.0'),  # Different working version
+            base_version=base_version)
+        continuation.save()
+
+        # Attempt to load with mismatched working_version and check=False
+        loaded_continuation = brockit.ContinuationFile.load(
+            target_version=target_version,
+            working_version=working_version,
+            check=False)
+        self.assertIsNone(loaded_continuation)
+
+        # Attempt to load with mismatched working_version and check=True
+        with self.assertRaises(TypeError):
+            brockit.ContinuationFile.load(target_version=target_version,
+                                          working_version=working_version,
+                                          check=True)
+
+    def test_continuation_file_clear(self):
+        """Test clearing the ContinuationFile."""
+        target_version = brockit.Version('135.0.7037.1')
+        working_version = brockit.Version('134.0.7036.0')
+        base_version = brockit.Version('134.0.7035.0')
+
+        # Create and save a ContinuationFile
+        continuation = brockit.ContinuationFile(
+            target_version=target_version,
+            working_version=working_version,
+            base_version=base_version)
+        continuation.save()
+
+        # Verify the file exists
+        self.assertTrue(brockit.VERSION_UPGRADE_FILE.exists())
+
+        # Clear the continuation file
+        brockit.ContinuationFile.clear()
+
+        # Verify the file no longer exists
+        self.assertFalse(brockit.VERSION_UPGRADE_FILE.exists())
+
+        # Check double delete is noop
+        brockit.ContinuationFile.clear()
 
 
 if __name__ == "__main__":

--- a/tools/cr/fake_chromium_repo_test.py
+++ b/tools/cr/fake_chromium_repo_test.py
@@ -22,164 +22,164 @@ class FakeChromiumRepoTest(unittest.TestCase):
 
     def test_add_repo(self):
         """Tests the add_repo method of FakeChromiumRepo."""
-        new_repo_path = "new_repo"
+        new_repo_path = 'new_repo'
         self.repo.add_repo(new_repo_path)
 
         # Verify the new repository exists
         new_repo_full_path = self.repo.chromium / new_repo_path
         self.assertTrue(new_repo_full_path.exists())
-        self.assertTrue((new_repo_full_path / ".git").exists())
+        self.assertTrue((new_repo_full_path / '.git').exists())
 
         # Verify the initial commit exists
-        log = self.repo._run_git_command(["log", "--oneline"],
+        log = self.repo._run_git_command(['log', '--oneline'],
                                          new_repo_full_path)
-        self.assertIn("Initial commit", log)
+        self.assertIn('Initial commit', log)
 
     def test_add_dep(self):
         """Tests the add_dep method of FakeChromiumRepo."""
-        dep_path = "third_party/dep_repo"
+        dep_path = 'third_party/dep_repo'
         self.repo.add_dep(dep_path)
 
         # Verify the dependency repository exists
         dep_full_path = self.repo.chromium / dep_path
         self.assertTrue(dep_full_path.exists())
-        self.assertTrue((dep_full_path / ".git").exists())
+        self.assertTrue((dep_full_path / '.git').exists())
 
         # Verify the submodule is added to the main repository
         submodule_config = self.repo._run_git_command([
-            "config", "--file", ".gitmodules", "--get",
-            f"submodule.{dep_path}.path"
+            'config', '--file', '.gitmodules', '--get',
+            f'submodule.{dep_path}.path'
         ], self.repo.chromium)
         self.assertEqual(submodule_config, dep_path)
 
         # Verify the submodule commit exists in the main repository
-        log = self.repo._run_git_command(["log", "--oneline"],
+        log = self.repo._run_git_command(['log', '--oneline'],
                                          self.repo.chromium)
-        self.assertIn(f"Add submodule {dep_path}", log)
+        self.assertIn(f'Add submodule {dep_path}', log)
 
     def test_add_tag(self):
         """Tests the add_tag method of FakeChromiumRepo."""
-        version = "1.2.3.4"
+        version = '1.2.3.4'
         self.repo.add_tag(version)
 
         # Verify the VERSION file exists with correct content
-        version_file = self.repo.chromium / "chrome" / "VERSION"
+        version_file = self.repo.chromium / 'chrome' / 'VERSION'
         self.assertTrue(version_file.exists())
-        with version_file.open("r") as f:
+        with version_file.open('r') as f:
             content = f.read()
-        self.assertIn("MAJOR=1", content)
-        self.assertIn("MINOR=2", content)
-        self.assertIn("BUILD=3", content)
-        self.assertIn("PATCH=4", content)
+        self.assertIn('MAJOR=1', content)
+        self.assertIn('MINOR=2', content)
+        self.assertIn('BUILD=3', content)
+        self.assertIn('PATCH=4', content)
 
         # Verify the tag exists in the repository
-        tags = self.repo._run_git_command(["tag"], self.repo.chromium)
+        tags = self.repo._run_git_command(['tag'], self.repo.chromium)
         self.assertIn(version, tags)
 
         # Verify the commit message for the tag
-        log = self.repo._run_git_command(["log", "-1", "--oneline"],
+        log = self.repo._run_git_command(['log', '-1', '--oneline'],
                                          self.repo.chromium)
-        self.assertIn(f"VERSION {version}", log)
+        self.assertIn(f'VERSION {version}', log)
 
     def test_commit(self):
         """Tests the commit method of FakeChromiumRepo."""
-        file_path = "test_file.txt"
-        content = "This is a test file."
+        file_path = 'test_file.txt'
+        content = 'This is a test file.'
         self.repo.write_and_stage_file(file_path, content, self.repo.chromium)
 
         # Commit the staged file
-        commit_message = "Add test_file.txt"
+        commit_message = 'Add test_file.txt'
         commit_hash = self.repo.commit(commit_message, self.repo.chromium)
 
         # Verify the commit exists in the repository
         short_hash = commit_hash[:7]
-        log = self.repo._run_git_command(["log", "--oneline"],
+        log = self.repo._run_git_command(['log', '--oneline'],
                                          self.repo.chromium)
         self.assertIn(commit_message, log)
         self.assertIn(short_hash, log)
 
     def test_commit_empty(self):
         """Tests the commit_empty method of FakeChromiumRepo."""
-        commit_message = "Empty commit for testing"
+        commit_message = 'Empty commit for testing'
         commit_hash = self.repo.commit_empty(commit_message,
                                              self.repo.chromium)
 
         # Verify the empty commit exists in the repository
         short_hash = commit_hash[:7]
-        log = self.repo._run_git_command(["log", "--oneline"],
+        log = self.repo._run_git_command(['log', '--oneline'],
                                          self.repo.chromium)
         self.assertIn(commit_message, log)
         self.assertIn(short_hash, log)
 
     def test_write_and_stage_file(self):
         """Tests the write_and_stage_file method of FakeChromiumRepo."""
-        file_path = "test_dir/test_file.txt"
-        content = "This is a test file."
+        file_path = 'test_dir/test_file.txt'
+        content = 'This is a test file.'
         self.repo.write_and_stage_file(file_path, content, self.repo.chromium)
 
         # Verify the file exists with the correct content
         full_file_path = self.repo.chromium / file_path
         self.assertTrue(full_file_path.exists())
-        with full_file_path.open("r") as f:
+        with full_file_path.open('r') as f:
             self.assertEqual(f.read(), content)
 
         # Verify the file is staged
         staged_files = self.repo._run_git_command(
-            ["diff", "--name-only", "--cached"], self.repo.chromium)
+            ['diff', '--name-only', '--cached'], self.repo.chromium)
         self.assertIn(file_path, staged_files)
 
     def test_update_brave_version(self):
         """Tests the update_brave_version method of FakeChromiumRepo."""
-        new_version = "1.2.3.4"
+        new_version = '1.2.3.4'
         commit_hash = self.repo.update_brave_version(new_version)
 
         # Verify the package.json file exists
-        package_json_path = self.repo.brave / "package.json"
+        package_json_path = self.repo.brave / 'package.json'
         self.assertTrue(package_json_path.exists())
 
         # Verify the version in package.json is updated
-        with package_json_path.open("r") as f:
+        with package_json_path.open('r') as f:
             package_data = json.load(f)
-        self.assertEqual(package_data["config"]["projects"]["chrome"]["tag"],
+        self.assertEqual(package_data['config']['projects']['chrome']['tag'],
                          new_version)
 
         # Verify the commit exists in the repository
         short_hash = commit_hash[:7]
-        log = self.repo._run_git_command(["log", "--oneline"], self.repo.brave)
-        self.assertIn(f"Update from Chromium N/A to Chromium {new_version}",
+        log = self.repo._run_git_command(['log', '--oneline'], self.repo.brave)
+        self.assertIn(f'Update from Chromium N/A to Chromium {new_version}',
                       log)
         self.assertIn(short_hash, log)
 
     def test_update_patches(self):
         """Tests the update_patches method of FakeChromiumRepo."""
         # Add a file to the Chromium repo and commit it
-        file_path_chromium = "modified_file_chromium.txt"
-        content_chromium = "This is a modified file in the Chromium repo."
+        file_path_chromium = 'modified_file_chromium.txt'
+        content_chromium = 'This is a modified file in the Chromium repo.'
         self.repo.write_and_stage_file(file_path_chromium, content_chromium,
                                        self.repo.chromium)
-        self.repo.commit("Add file to Chromium repo", self.repo.chromium)
+        self.repo.commit('Add file to Chromium repo', self.repo.chromium)
 
         # Add a file to another repo and commit it
-        repo_path = "test_repo"
+        repo_path = 'test_repo'
         self.repo.add_repo(repo_path)
-        file_path_repo = "modified_file_repo.txt"
-        content_repo = "This is a modified file in the test_repo."
+        file_path_repo = 'modified_file_repo.txt'
+        content_repo = 'This is a modified file in the test_repo.'
         self.repo.write_and_stage_file(file_path_repo, content_repo,
                                        self.repo.chromium / repo_path)
-        self.repo.commit("Add file to test_repo",
+        self.repo.commit('Add file to test_repo',
                          self.repo.chromium / repo_path)
 
         # Run update_patches on a clean tree (no patches should be produced)
         self.repo.run_update_patches()
         self.assertFalse(any(self.repo.brave_patches.iterdir()),
-                         "No patches should be produced for a clean tree.")
+                         'No patches should be produced for a clean tree.')
 
         # Modify the files without staging (leave the tree dirty)
-        new_content_chromium = "Modified content in Chromium repo."
+        new_content_chromium = 'Modified content in Chromium repo.'
         full_file_path_chromium = self.repo.chromium / file_path_chromium
         full_file_path_chromium.write_text(new_content_chromium)
 
-        new_content_repo = "Modified content in test_repo."
+        new_content_repo = 'Modified content in test_repo.'
         full_file_path_repo = self.repo.chromium / repo_path / file_path_repo
         full_file_path_repo.write_text(new_content_repo)
 
@@ -187,57 +187,56 @@ class FakeChromiumRepoTest(unittest.TestCase):
         self.repo.run_update_patches()
 
         # Check that the patchfile for test_repo is created
-        patch_file_name_repo = f"{file_path_repo.replace('/', '-')}.patch"
+        patch_file_name_repo = f'{file_path_repo.replace("/", "-")}.patch'
         patch_file_path_repo = (self.repo.brave_patches / repo_path /
                                 patch_file_name_repo)
         self.assertTrue(patch_file_path_repo.exists())
 
         # Check the patchfile for Chromium is created
         patch_file_name_chromium = (
-            f"{file_path_chromium.replace('/', '-')}.patch")
+            f'{file_path_chromium.replace("/", "-")}.patch')
         patch_file_path_chromium = (self.repo.brave_patches /
                                     patch_file_name_chromium)
         self.assertTrue(patch_file_path_chromium.exists())
 
         # Verify the patch file for the test_repo contains the correct diff
-        with patch_file_path_repo.open("r") as f:
+        with patch_file_path_repo.open('r') as f:
             patch_content_repo = f.read()
-        self.assertIn("diff --git a/", patch_content_repo)
-        self.assertIn("b/", patch_content_repo)
+        self.assertIn('diff --git a/', patch_content_repo)
+        self.assertIn('b/', patch_content_repo)
         self.assertIn(new_content_repo, patch_content_repo)
 
         # Verify the patch file for Chromium contains the correct diff
-        with patch_file_path_chromium.open("r") as f:
+        with patch_file_path_chromium.open('r') as f:
             patch_content_chromium = f.read()
-        self.assertIn("diff --git a/", patch_content_chromium)
-        self.assertIn("b/", patch_content_chromium)
+        self.assertIn('diff --git a/', patch_content_chromium)
+        self.assertIn('b/', patch_content_chromium)
         self.assertIn(new_content_chromium, patch_content_chromium)
 
     def test_run_apply_patches(self):
         """Tests the run_apply_patches method of FakeChromiumRepo."""
         # Add a file to the Chromium repo and commit it
-        file_path_chromium = "modified_file_chromium.txt"
-        content_chromium = "This is a modified file in the Chromium repo."
+        file_path_chromium = 'modified_file_chromium.txt'
+        content_chromium = 'This is a modified file in the Chromium repo.'
         self.repo.write_and_stage_file(file_path_chromium, content_chromium,
                                        self.repo.chromium)
-        self.repo.commit("Add file to Chromium repo", self.repo.chromium)
+        self.repo.commit('Add file to Chromium repo', self.repo.chromium)
 
         # Add a file to another repo and commit it
-        repo_path = "test_repo"
-        self.repo.add_repo(repo_path)
-        file_path_repo = "modified_file_repo.txt"
-        content_repo = "This is a modified file in the test_repo."
+        repo_path = 'test_repo'
+        file_path_repo = 'modified_file_repo.txt'
+        content_repo = 'This is a modified file in the test_repo.'
         self.repo.write_and_stage_file(file_path_repo, content_repo,
                                        self.repo.chromium / repo_path)
-        self.repo.commit("Add file to test_repo",
+        self.repo.commit('Add file to test_repo',
                          self.repo.chromium / repo_path)
 
         # Modify the files without staging (leave the tree dirty)
-        new_content_chromium = "Modified content in Chromium repo."
+        new_content_chromium = 'Modified content in Chromium repo.'
         full_file_path_chromium = self.repo.chromium / file_path_chromium
         full_file_path_chromium.write_text(new_content_chromium)
 
-        new_content_repo = "Modified content in test_repo."
+        new_content_repo = 'Modified content in test_repo.'
         full_file_path_repo = self.repo.chromium / repo_path / file_path_repo
         full_file_path_repo.write_text(new_content_repo)
 
@@ -245,26 +244,128 @@ class FakeChromiumRepoTest(unittest.TestCase):
         self.repo.run_update_patches()
 
         # Reset the changes to simulate a clean state
-        self.repo._run_git_command(["checkout", "."], self.repo.chromium)
-        self.repo._run_git_command(["checkout", "."],
+        self.repo._run_git_command(['checkout', '.'], self.repo.chromium)
+        self.repo._run_git_command(['checkout', '.'],
                                    self.repo.chromium / repo_path)
 
         # Run apply_patches to apply the patches
         self.repo.run_apply_patches()
 
         # Verify the changes from the patches are applied
-        with full_file_path_chromium.open("r") as f:
+        with full_file_path_chromium.open('r') as f:
             applied_content_chromium = f.read()
         self.assertEqual(applied_content_chromium, new_content_chromium)
 
-        with full_file_path_repo.open("r") as f:
+        with full_file_path_repo.open('r') as f:
             applied_content_repo = f.read()
         self.assertEqual(applied_content_repo, new_content_repo)
 
+    def test_run_apply_patches_with_failures(self):
+        """Tests run_apply_patches with conflict/corrupted patch failures."""
+        # Add a file to the Chromium repo and commit it
+
+        self.repo.write_and_stage_file('a.txt', 'contents of a.txt',
+                                       self.repo.chromium)
+        self.repo.write_and_stage_file('b.txt', 'contents of b.txt',
+                                       self.repo.chromium)
+        self.repo.write_and_stage_file('c.txt', 'contents of c.txt',
+                                       self.repo.chromium)
+        self.repo.commit('Adding files to chrome repo', self.repo.chromium)
+
+        self.repo.chromium.joinpath('a.txt').write_text(
+            'patched contents of a.txt')
+        self.repo.chromium.joinpath('b.txt').write_text(
+            'also patched contents of b.txt')
+
+        # Run update_patches to generate patches
+        self.repo.run_update_patches()
+
+        # Reset the changes to simulate a clean state
+        self.repo._run_git_command(['checkout', '.'], self.repo.chromium)
+
+        # Run apply_patches to apply the patches
+        apply_failures = self.repo.run_apply_patches()
+        self.assertEqual(len(apply_failures), 0)
+
+        # Reset the changes to simulate a clean state
+        self.repo._run_git_command(['checkout', '.'], self.repo.chromium)
+
+        # let's update these files to cause conflicts
+        self.repo.write_and_stage_file('a.txt', 'second contents of a.txt',
+                                       self.repo.chromium)
+        self.repo.write_and_stage_file('b.txt', 'second contents of b.txt',
+                                       self.repo.chromium)
+        self.repo.commit('Updating files to chrome repo', self.repo.chromium)
+
+        # Run apply_patches to apply the patches
+        apply_failures = self.repo.run_apply_patches()
+        self.assertEqual(len(apply_failures), 2)
+
+        # Check the values in apply_failures
+        failure = (next((f for f in apply_failures
+                         if f['patchPath'] == 'patches/b.txt.patch'), None))
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure['path'], 'b.txt')
+        self.assertEqual(failure['reason'], 'PATCH_CHANGED')
+
+        failure = (next((f for f in apply_failures
+                         if f['patchPath'] == 'patches/a.txt.patch'), None))
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure['path'], 'a.txt')
+        self.assertEqual(failure['reason'], 'PATCH_CHANGED')
+
+        # Reset the changes to simulate a clean state
+        self.repo._run_git_command(['checkout', '.'], self.repo.chromium)
+
+        # Commit the deletion of b.txt
+        self.repo.delete_file('b.txt', self.repo.chromium)
+        self.repo.commit('Delete b.txt', self.repo.chromium)
+
+        # Run apply_patches to apply the patches
+        apply_failures = self.repo.run_apply_patches()
+        self.assertEqual(len(apply_failures), 2)
+
+        # Check the values in apply_failures
+        failure = (next((f for f in apply_failures
+                         if f['patchPath'] == 'patches/b.txt.patch'), None))
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure['path'], 'b.txt')
+        self.assertEqual(failure['reason'], 'SRC_REMOVED')
+
+        failure = (next((f for f in apply_failures
+                         if f['patchPath'] == 'patches/a.txt.patch'), None))
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure['path'], 'a.txt')
+        self.assertEqual(failure['reason'], 'PATCH_CHANGED')
+
+        # Reset the changes to simulate a clean state
+        self.repo._run_git_command(['checkout', '.'], self.repo.chromium)
+
+        # Corrupt the patch file for a.txt
+        patch_file_a = self.repo.brave_patches / 'a.txt.patch'
+        patch_file_a.write_text('corrupted patch content')
+
+        # Run apply_patches to apply the patches
+        apply_failures = self.repo.run_apply_patches()
+        self.assertEqual(len(apply_failures), 2)
+
+        # Check the values in apply_failures
+        failure = (next((f for f in apply_failures
+                         if f['patchPath'] == 'patches/b.txt.patch'), None))
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure['path'], 'b.txt')
+        self.assertEqual(failure['reason'], 'SRC_REMOVED')
+
+        failure = (next((f for f in apply_failures
+                         if f['patchPath'] == 'patches/a.txt.patch'), None))
+        self.assertIsNotNone(failure)
+        self.assertEqual(failure['path'], None)
+        self.assertEqual(failure['reason'], 'PATCH_CHANGED')
+
     def test_delete_file(self):
         """Tests the delete_file method of FakeChromiumRepo."""
-        file_path = "test_dir/test_file.txt"
-        content = "This is a test file."
+        file_path = 'test_dir/test_file.txt'
+        content = 'This is a test file.'
 
         # Write and stage the file
         self.repo.write_and_stage_file(file_path, content, self.repo.chromium)
@@ -272,7 +373,7 @@ class FakeChromiumRepoTest(unittest.TestCase):
         self.assertTrue(full_file_path.exists())
 
         # Commit the file
-        self.repo.commit("Add test_file.txt", self.repo.chromium)
+        self.repo.commit('Add test_file.txt', self.repo.chromium)
 
         # Delete the file
         self.repo.delete_file(file_path, self.repo.chromium)
@@ -282,16 +383,18 @@ class FakeChromiumRepoTest(unittest.TestCase):
 
         # Verify the deletion is staged
         staged_files = self.repo._run_git_command(
-            ["diff", "--name-only", "--cached"], self.repo.chromium)
+            ['diff', '--name-only', '--cached'], self.repo.chromium)
         self.assertIn(file_path, staged_files)
 
         # Commit the deletion
-        self.repo.commit("Delete test_file.txt", self.repo.chromium)
+        self.repo.commit('Delete test_file.txt', self.repo.chromium)
 
         # Verify the deletion is committed
-        log = self.repo._run_git_command(["log", "--oneline"], self.repo.chromium)
-        self.assertIn("Delete test_file.txt", log)
+        self.assertIn(
+            'Delete test_file.txt',
+            self.repo._run_git_command(['log', '--oneline'],
+                                       self.repo.chromium))
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This change adds tests to the continuation data types in Brockit. It also adds some extra tests around the fake `apply_patches` that will be necessary for testing brockit.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45595

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
