### PR TITLE
fix(wallet): Hide Token Icons Stack on Android

### DIFF
--- a/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../../utils/rewards_utils'
 import { getLocale } from '../../../../common/locale'
 import { getEntitiesListFromEntityState } from '../../../utils/entities.utils'
+import { loadTimeData } from '../../../../common/loadTimeData'
 
 // hooks
 import { useOnClickOutside } from '../../../common/hooks/useOnClickOutside'
@@ -87,7 +88,6 @@ import {
   AccountMenuButton,
   AccountMenuIcon,
   AccountBalanceText,
-  AccountDescription,
   AccountNameWrapper,
   AccountButton,
   WarningIcon
@@ -127,6 +127,8 @@ export const AccountListItem = ({
 
   // selectors
   const isPanel = useSafeUISelector(UISelectors.isPanel)
+  const isAndroid = loadTimeData.getBoolean('isAndroid') || false
+
   // redux
   const isZCashShieldedTransactionsEnabled = useSafeWalletSelector(
     WalletSelectors.isZCashShieldedTransactionsEnabled
@@ -416,11 +418,16 @@ export const AccountListItem = ({
                     {reduceAddress(account.address)}
                   </Text>
                 )}
-                <AccountDescription>
+                <Text
+                  textSize='12px'
+                  isBold={false}
+                  textColor='secondary'
+                  textAlign='left'
+                >
                   {isRewardsAccount
                     ? getRewardsTokenDescription(externalProvider ?? null)
                     : getAccountTypeDescription(account.accountId)}
-                </AccountDescription>
+                </Text>
                 {showSyncWarning && (
                   <Row
                     justifyContent='flex-start'
@@ -441,7 +448,7 @@ export const AccountListItem = ({
 
             {!isDisconnectedRewardsAccount && (
               <Row width='unset'>
-                {!isPanel && !accountsFiatValue.isZero() ? (
+                {!isAndroid && !isPanel && !accountsFiatValue.isZero() ? (
                   tokensWithBalances.length ? (
                     <TokenIconsStack tokens={tokensWithBalances} />
                   ) : (

--- a/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
+++ b/components/brave_wallet_ui/components/desktop/account-list-item/style.ts
@@ -125,14 +125,6 @@ export const AccountBalanceText = styled(Text)`
   margin-right: 12px;
 `
 
-export const AccountDescription = styled.span`
-  font-family: Poppins;
-  font-size: 12px;
-  line-height: 16px;
-  font-weight: 400;
-  color: ${leo.color.text.secondary};
-`
-
 export const AccountNameWrapper = styled(Row)`
   @media screen and (max-width: ${layoutPanelWidth}px) {
     flex-direction: column;


### PR DESCRIPTION
## Description 

- Hides the `Token Icons Stack` on the `Accounts` list items for `Android`, similar as we do for the Wallet `Panel` to help with space.
- Fixes the Account `Description` position to the left.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/44949>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

1. Open the `Wallet` on and `Android` device.
2. Navigate to the `Accounts` page.
3. The `Token Icons Stack` should not be visible.
4. The Account `Description` should be aligned to the left.

![Screenshot 48](https://github.com/user-attachments/assets/a72fc5e5-9dc7-4f16-9ec3-43eb73c6e9cc)
