### PR TITLE
[canary] Use exceptions to communicate B🚀 failures

### DIFF
--- a/tools/cr/brockit_test.py
+++ b/tools/cr/brockit_test.py
@@ -80,6 +80,10 @@ class BrockitTest(unittest.TestCase):
             ['commit', '-m', 'Add pinslist file for testing'],
             self.fake_chromium_src.brave)
 
+        # Ensure there is an empty line at the end of the file before the update
+        self.assertTrue(test_pinslist_path.read_text().endswith('\n'),
+                        "File does not end with an empty line before update.")
+
         # Call the function to update the timestamp
         before_update = datetime.now()
         readable_timestamp = brockit._update_pinslist_timestamp()
@@ -93,6 +97,10 @@ class BrockitTest(unittest.TestCase):
                                                '%a %b %d %H:%M:%S %Y')
         self.assertTrue(
             0 <= (before_update - timestamp_datetime).total_seconds() <= 10)
+
+        # Ensure there is still an empty line at the end of the file after
+        self.assertTrue(test_pinslist_path.read_text().endswith('\n'),
+                        "File does not end with an empty line after update.")
 
     def test_requires_conflict_resolution(self):
         """Test ApplyPatchesRecord.requires_conflict_resolution"""

--- a/tools/cr/repository.py
+++ b/tools/cr/repository.py
@@ -66,7 +66,7 @@ class Repository:
         """Runs a git command on the repository.
         """
         if self.is_brave:
-            return terminal.run_git(*cmd)
+            return terminal.run_git(*cmd, no_trim=no_trim)
 
         return terminal.run_git('-C', self.from_brave(), *cmd, no_trim=no_trim)
 

--- a/tools/cr/repository_test.py
+++ b/tools/cr/repository_test.py
@@ -11,6 +11,7 @@ import repository
 from repository import Repository
 
 from test.fake_chromium_src import FakeChromiumSrc
+from unittest.mock import patch
 
 
 class RepositoryTest(unittest.TestCase):
@@ -95,6 +96,18 @@ class RepositoryTest(unittest.TestCase):
             Repository(self.fake_chromium_src.chromium /
                        "third_party/test1").run_git("rev-parse", "HEAD"),
         )
+
+    def test_run_git_no_trim(self):
+        """Test that no_trim is correctly passed to run_git."""
+        with patch("terminal.terminal.run_git") as mock_run_git:
+            # Call run_git with no_trim=True for brave repository
+            repository.brave.run_git("log", no_trim=True)
+            mock_run_git.assert_called_once_with("log", no_trim=True)
+
+            # Reset mock and call run_git with no_trim=False
+            mock_run_git.reset_mock()
+            repository.brave.run_git("log", no_trim=False)
+            mock_run_git.assert_called_once_with("log", no_trim=False)
 
     def test_unstage_all_changes(self):
         """Test unstage_all_changes and has_staged_changed."""


### PR DESCRIPTION
This PR changes the use of bool to signal success/failure when running `brockit` tasks, and replaces them with exceptions. The main issue with the use of return values is that it was not possible to use return values in every case. For instance, some failures were due to validations in the task constructor, that belong in there. This change will make testing these tasks a bit easier too.

Additionally, in this PR we include a fix to `Repository.run_git` where `no_trim` was not being passed to terminal when the repository was brave.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45596

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
