### PR TITLE
[iOS] Remove shortcut button pref default value on iPad

### DIFF
--- a/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
+++ b/ios/brave-ios/App/iOS/Delegates/AppDelegate.swift
@@ -12,6 +12,7 @@ import BraveShields
 import BraveStore
 import BraveVPN
 import BraveWallet
+import BraveWidgetsModels
 import Combine
 import CoreSpotlight
 import Data
@@ -264,6 +265,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
       Preferences.Search.shouldShowSuggestionsOptIn.value =
         !AppState.shared.profile.searchEngines.isBraveSearchDefaultRegion
+
+      if UIDevice.isIpad {
+        Preferences.General.toolbarShortcutButton.value = WidgetShortcut.bookmarks.rawValue
+      }
     }
 
     if Preferences.URP.referralLookupOutstanding.value == nil {

--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Toolbars/UrlBar/TopToolbarView.swift
@@ -186,7 +186,7 @@ class TopToolbarView: UIView, ToolbarProtocol {
         options: .displayInline,
         children: [
           UIAction(
-            title: "Hide Shortcut Button",
+            title: Strings.ShortcutButton.hideButtonTitle,
             image: UIImage(braveSystemNamed: "leo.eye.off"),
             attributes: .destructive,
             handler: { _ in

--- a/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/ClientPreferences.swift
@@ -76,9 +76,9 @@ extension Preferences {
       default: false
     )
     /// Specifies whether the bookmark button is present on toolbar
-    static let toolbarShortcutButton = Option<Int?>(
+    public static let toolbarShortcutButton = Option<Int?>(
       key: "general.show-bookmark-toolbar-shortcut",
-      default: UIDevice.isIpad ? WidgetShortcut.bookmarks.rawValue : nil
+      default: nil
     )
     /// Controls whether or not media should continue playing in the background
     static let mediaAutoBackgrounding = Option<Bool>(

--- a/ios/brave-ios/Sources/Brave/Migration/Migration.swift
+++ b/ios/brave-ios/Sources/Brave/Migration/Migration.swift
@@ -28,6 +28,7 @@ public class Migration {
     Preferences.migrateHTTPSUpgradeLevel()
     Preferences.migrateBackgroundSponsoredImages()
     Preferences.migrateBookmarksButtonInToolbar()
+    Preferences.migrateShortcutsButtonOniPad()
 
     if Preferences.General.isFirstLaunch.value {
       if UIDevice.current.userInterfaceIdiom == .phone {
@@ -260,6 +261,11 @@ extension Preferences {
       key: "migration.bookmarks-button-in-toolbar",
       default: false
     )
+
+    static let migratedShortcutsButtonOniPad = Option<Bool>(
+      key: "migration.shortcuts-button-on-ipad",
+      default: false
+    )
   }
 
   /// Migrate a given key from `Prefs` into a specific option
@@ -424,6 +430,18 @@ extension Preferences {
     }
 
     Migration.migratedBookmarksButtonInToolbar.value = true
+  }
+
+  // Migrate new default nil value on iPads to bookmarks button since that was what was always
+  // showing on iPads until the default value was fixed
+  fileprivate class func migrateShortcutsButtonOniPad() {
+    guard !Migration.migratedShortcutsButtonOniPad.value, UIDevice.isIpad else { return }
+
+    if Preferences.General.toolbarShortcutButton.value == nil {
+      Preferences.General.toolbarShortcutButton.value = WidgetShortcut.bookmarks.rawValue
+    }
+
+    Migration.migratedShortcutsButtonOniPad.value = true
   }
 }
 


### PR DESCRIPTION
The `nil` value for this is being used to determine when to hide the shortcut button so we must explicitly set the value to bookmarks on first launch (and migration) for iPads to maintain the old default value

This change also fixes a missed hard-coded string to the localized version

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves https://github.com/brave/brave-browser/issues/45612

### Test plan

On iPad, Fresh install:
- Verify shortcut button is visible and set to bookmarks
- Disable the shortcut button either via settings or long-press on the shortcut button
- Force close & re-launch Brave, verify the shortcut button remains hidden

On iPad, migration from older version:
- Test setting the shortcut button to something explicitly via the settings then upgrade, verify setting is retained
- Test fresh install of older version, then migrate to current and verify bookmarks shortcut button is still visible, then disable shortcut button, force close & re-launch and verify shortcut button remains hidden

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
