### PR TITLE
[ads] Ads Settings can't be opened after disabling all ads options (uplift to 1.78.x)

### DIFF
--- a/components/brave_ads/browser/ads_service_impl.cc
+++ b/components/brave_ads/browser/ads_service_impl.cc
@@ -350,27 +350,16 @@ void AdsServiceImpl::GetDeviceIdAndMaybeStartBatAdsServiceCallback(
 }
 
 bool AdsServiceImpl::CanStartBatAdsService() const {
-  const bool user_has_opted_in_to_brave_news_ads =
-      UserHasOptedInToBraveNewsAds();
-  const bool user_has_opted_in_to_new_tab_page_ads =
-      UserHasOptedInToNewTabPageAds();
-  const bool user_has_opted_in_to_notification_ads =
-      UserHasOptedInToNotificationAds();
-  const bool user_has_opted_in_to_search_result_ads =
-      UserHasOptedInToSearchResultAds();
+  if (UserHasJoinedBraveRewards()) {
+    // Always start the service to update brave://ads-internals,
+    // brave://rewards, and brave://rewards-internals if the user has joined
+    // Brave Rewards, even if all ad units are opted out.
+    return true;
+  }
 
-  const bool should_start_for_non_rewards =
-      user_has_opted_in_to_brave_news_ads ||
-      (ShouldAlwaysRunService() && (user_has_opted_in_to_new_tab_page_ads ||
-                                    user_has_opted_in_to_search_result_ads));
-
-  const bool should_start_for_rewards =
-      UserHasJoinedBraveRewards() && (user_has_opted_in_to_brave_news_ads ||
-                                      user_has_opted_in_to_new_tab_page_ads ||
-                                      user_has_opted_in_to_notification_ads ||
-                                      user_has_opted_in_to_search_result_ads);
-
-  return should_start_for_non_rewards || should_start_for_rewards;
+  return UserHasOptedInToBraveNewsAds() ||
+         (ShouldAlwaysRunService() && (UserHasOptedInToNewTabPageAds() ||
+                                       UserHasOptedInToSearchResultAds()));
 }
 
 void AdsServiceImpl::MaybeStartBatAdsService() {


### PR DESCRIPTION
Uplift of #28765
Resolves https://github.com/brave/brave-browser/issues/45568

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.