### PR TITLE
fix(iOS): Exclude brave search promotion in japan region (uplift to 1.78.x)

### DIFF
--- a/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
+++ b/ios/brave-ios/Sources/Brave/Frontend/Browser/Search/SearchSuggestionDataSource.swift
@@ -109,6 +109,10 @@ class SearchSuggestionDataSource {
       return false
     }
 
+    if let region = Locale.current.region?.identifier, region == "JP" {
+      return false
+    }
+
     let rightNow = Date()
     let nextShowDate = braveSearchPromotionLaunchDate.addingTimeInterval(
       AppConstants.isOfficialBuild


### PR DESCRIPTION
Uplift of #28789
Resolves https://github.com/brave/brave-browser/issues/45642

Pre-approval checklist: 
- [x] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.