### PR TITLE
[canary] Fix the decorators for B🚀 task interruptions

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -450,12 +450,12 @@ class BadOutcomeException(Exception):
         logging.warning(message)
 
 
-class TaskFailureException(Exception):
+class ActionNeededException(Exception):
     """An expected failure along the way that results on task termination."""
 
     def __init__(self, message: str):
         super().__init__(message)
-        logging.info(message)
+        console.log(message)
 
 class Task:
     """ Base class for all tasks in brockit.
@@ -1415,7 +1415,7 @@ class Upgrade(Versioned):
             self.target_version.get_googlesource_diff_link(self.base_version))
 
         if not ack_advisory and not self._prerun_checks():
-            raise TaskFailureException(
+            raise ActionNeededException(
                 '👋 (Address advisories and then rerun with '
                 '[bold cyan]--ack-advisory[/])')
 
@@ -1442,7 +1442,7 @@ class Upgrade(Versioned):
                     launch_vscode=launch_vscode)
                 if apply_record.requires_conflict_resolution():
                     # Manual resolution required.
-                    raise TaskFailureException(
+                    raise ActionNeededException(
                         '👋 (Address all sections with '
                         f'{ACTION_NEEDED_DECORATOR} above, and then rerun '
                         '[italic]🚀Brockit![/] with [bold cyan]--continue[/])'
@@ -2038,7 +2038,7 @@ def main():
             console.print(Markdown(__doc__))
         if args.command == 'show':
             show(args)
-    except (InvalidInputException, BadOutcomeException, TaskFailureException):
+    except (InvalidInputException, BadOutcomeException, ActionNeededException):
         return 1
 
     return 0


### PR DESCRIPTION
`ActionNeededException` is being used for cases where we have tasks interruptions usually require user input. This change fixes the use of `logging.info`, as that interferes with the status bar clearing.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->
