### PR TITLE
Initialize Eip 6963 request provider on DidFinishLoad event

### DIFF
--- a/components/brave_wallet/renderer/js_ethereum_provider.cc
+++ b/components/brave_wallet/renderer/js_ethereum_provider.cc
@@ -133,6 +133,9 @@ void JSEthereumProvider::DidFinishLoad() {
     return;
   }
 
+  // These used to be called synchronously by `JSEthereumProvider::Install`
+  // which appeared to cause rare crashes with certain extensions' behavior. See
+  // https://github.com/brave/brave-browser/issues/45694 for details.
   BindRequestProviderListener();
   AnnounceProvider();
 }

--- a/components/brave_wallet/renderer/js_ethereum_provider.h
+++ b/components/brave_wallet/renderer/js_ethereum_provider.h
@@ -21,7 +21,7 @@
 #include "gin/wrappable.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
-#include "v8/include/v8.h"
+#include "v8/include/v8-forward.h"
 
 namespace brave_wallet {
 
@@ -82,6 +82,7 @@ class JSEthereumProvider final : public gin::Wrappable<JSEthereumProvider>,
   void WillReleaseScriptContext(v8::Local<v8::Context>,
                                 int32_t world_id) override;
   void DidDispatchDOMContentLoadedEvent() override;
+  void DidFinishLoad() override;
 
   bool EnsureConnected();
 


### PR DESCRIPTION
Resolves https://github.com/brave/brave-browser/issues/45109

Workaround to avoid creation v8 Function instance which causes leak of extension's script context into main world. In that scenario `isolate->GetIncumbentContext()` being not from main world causes bound event listener function to CHECK with world id mismatch error message
Created https://github.com/brave/brave-browser/issues/45694 for further research

<details><summary>Details</summary>
<p>

```
        brave_wallet::JSEthereumProvider::BindRequestProviderListener [0x00007FFA8C4D03BE+1150] (C:\work\brave-browser\src\brave\components\brave_wallet\renderer\js_ethereum_provider.cc:702)
        brave_wallet::JSEthereumProvider::Install [0x00007FFA8C4CFE0B+1611] (C:\work\brave-browser\src\brave\components\brave_wallet\renderer\js_ethereum_provider.cc:255)
        brave_wallet::BraveWalletRenderFrameObserver::DidClearWindowObject [0x00007FFA8C4F9CB0+512] (C:\work\brave-browser\src\brave\renderer\brave_wallet\brave_wallet_render_frame_observer.cc:109)
        content::RenderFrameImpl::DidClearWindowObject [0x00007FFA86DBBB69+937] (C:\work\brave-browser\src\content\renderer\render_frame_impl.cc:4205)
        blink::LocalFrameClientImpl::DispatchDidClearWindowObjectInMainWorld [0x00007FFA70B0C32D+317] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\local_frame_client_impl.cc:217)
        blink::FrameLoader::DispatchDidClearWindowObjectInMainWorld [0x00007FFA71AC5042+258] (C:\work\brave-browser\src\third_party\blink\renderer\core\loader\frame_loader.cc:1767)
        blink::LocalWindowProxy::Initialize [0x00007FFA6F857F37+2711] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\local_window_proxy.cc:225)
        blink::Frame::GetWindowProxy [0x00007FFA708EEDB0+160] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\frame.cc:282)
        blink::LocalFrame::WindowProxy [0x00007FFA7096BE99+25] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\local_frame.cc:1071)
        blink::ToV8ContextEvenIfDetached [0x00007FFA6F922C96+294] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\v8_binding_for_core.cc:739)
        blink::ToScriptStateImpl [0x00007FFA6F922A93+67] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\v8_binding_for_core.cc:688)
        blink::ToScriptStateForMainWorld [0x00007FFA6F923206+102] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\v8_binding_for_core.cc:790)
        blink::ScriptLoader::PrepareScript [0x00007FFA71FA5663+4211] (C:\work\brave-browser\src\third_party\blink\renderer\core\script\script_loader.cc:766)
        blink::ScriptLoader::DidNotifySubtreeInsertionsToDocument [0x00007FFA71FA3CB2+546] (C:\work\brave-browser\src\third_party\blink\renderer\core\script\script_loader.cc:185)
        blink::HTMLScriptElement::DidNotifySubtreeInsertionsToDocument [0x00007FFA70EB912C+140] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\html_script_element.cc:160)
        blink::ContainerNode::DidInsertNodeVector [0x00007FFA7284782B+1867] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\container_node.cc:397)
        blink::ContainerNode::AppendChild [0x00007FFA7284A837+583] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\container_node.cc:1199)
        blink::`anonymous namespace'::v8_node::AppendChildOperationCallbackForNonMainWorlds [0x00007FFA72F6DAB4+468] (C:\work\brave-browser\src\out\Component\gen\third_party\blink\renderer\bindings\core\v8\v8_node.cc:589)
        Builtins_CallApiCallbackGeneric [0x00007FFA6C38B5C0+192]
        Builtins_InterpreterEntryTrampoline [0x00007FFA6C389363+355]
        Builtins_InterpreterEntryTrampoline [0x00007FFA6C389363+355]
        Builtins_JSEntryTrampoline [0x00007FFA6C38585C+92]
        Builtins_JSEntry [0x00007FFA6C3853BF+255]
        v8::internal::`anonymous namespace'::Invoke [0x00007FFA69AD520F+5679] (C:\work\brave-browser\src\v8\src\execution\execution.cc:439)
        v8::internal::Execution::CallScript [0x00007FFA69AD6028+520] (C:\work\brave-browser\src\v8\src\execution\execution.cc:540)
        v8::Script::Run [0x00007FFA697349FB+1147] (C:\work\brave-browser\src\v8\src\api\api.cc:1967)
        blink::V8ScriptRunner::RunCompiledScript [0x00007FFA6F95121B+1195] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\v8_script_runner.cc:528)
        blink::V8ScriptRunner::CompileAndRunScript [0x00007FFA6F951E63+1731] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\v8_script_runner.cc:652)
        blink::ClassicScript::RunScriptOnScriptStateAndReturnValue [0x00007FFA71F5776D+221] (C:\work\brave-browser\src\third_party\blink\renderer\core\script\classic_script.cc:225)
        blink::`anonymous namespace'::WebScriptExecutor::Execute [0x00007FFA70A8EF25+165] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\pausable_script_executor.cc:152)
        blink::PausableScriptExecutor::ExecuteAndDestroySelf [0x00007FFA70A8ABE8+664] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\pausable_script_executor.cc:360)
        blink::PausableScriptExecutor::Run [0x00007FFA70A898E7+151] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\pausable_script_executor.cc:319)
        blink::PausableScriptExecutor::CreateAndRun [0x00007FFA70A89AB4+420] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\pausable_script_executor.cc:272)
        blink::LocalFrame::RequestExecuteScript [0x00007FFA7097D965+341] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\local_frame.cc:3136)
        blink::WebLocalFrameImpl::RequestExecuteScript [0x00007FFA70B5FFD5+261] (C:\work\brave-browser\src\third_party\blink\renderer\core\frame\web_local_frame_impl.cc:1118)
        extensions::ScriptInjection::InjectJs [0x00007FFA8C5BD92F+1119] (C:\work\brave-browser\src\extensions\renderer\script_injection.cc:315)
        extensions::ScriptInjection::Inject [0x00007FFA8C5BD10C+444] (C:\work\brave-browser\src\extensions\renderer\script_injection.cc:218)
        extensions::ScriptInjection::TryToInject [0x00007FFA8C5BCDA6+262] (C:\work\brave-browser\src\extensions\renderer\script_injection.cc:148)
        extensions::ScriptInjectionManager::TryToInject [0x00007FFA8C5C0862+98] (C:\work\brave-browser\src\extensions\renderer\script_injection_manager.cc:419)
        extensions::ScriptInjectionManager::HandleExecuteCode [0x00007FFA8C5C10BB+1067] (C:\work\brave-browser\src\extensions\renderer\script_injection_manager.cc:467)
        extensions::Dispatcher::ExecuteCode [0x00007FFA8C57C216+150] (C:\work\brave-browser\src\extensions\renderer\dispatcher.cc:952)
        extensions::ExtensionFrameHelper::ExecuteCode [0x00007FFA8C58736A+1626] (C:\work\brave-browser\src\extensions\renderer\extension_frame_helper.cc:496)
        extensions::mojom::LocalFrameStubDispatch::AcceptWithResponder [0x00007FFA89409A5B+555] (C:\work\brave-browser\src\out\Component\gen\extensions\common\mojom\frame.mojom.cc:1761)
        extensions::mojom::LocalFrameStub<mojo::RawPtrImplRefTraits<extensions::mojom::LocalFrame> >::AcceptWithResponder [0x00007FFA8C5885BC+60] (C:\work\brave-browser\src\out\Component\gen\extensions\common\mojom\frame.mojom.h:414)
        mojo::InterfaceEndpointClient::HandleValidatedMessage [0x00007FFB17EE4E17+1783] (C:\work\brave-browser\src\mojo\public\cpp\bindings\lib\interface_endpoint_client.cc:1006)
        mojo::MessageDispatcher::Accept [0x00007FFB17EEF2C2+306] (C:\work\brave-browser\src\mojo\public\cpp\bindings\lib\message_dispatcher.cc:43)
        mojo::InterfaceEndpointClient::HandleIncomingMessage [0x00007FFB17EE7538+184] (C:\work\brave-browser\src\mojo\public\cpp\bindings\lib\interface_endpoint_client.cc:724)
        IPC::ChannelAssociatedGroupController::AcceptOnEndpointThread [0x00007FFABE241B82+738] (C:\work\brave-browser\src\ipc\ipc_mojo_bootstrap.cc:1202)
        base::internal::Invoker<base::internal::FunctorTraits<void (IPC::ChannelAssociatedGroupController::*&&)(mojo::Message, IPC::(anonymous namespace)::ScopedUrgentMessageNotification),IPC::ChannelAssociatedGroupController *&&,mojo::Message &&,IPC::(anonymous  [0x00007FFABE2427FE+190] (C:\work\brave-browser\src\base\functional\bind_internal.h:973)
        base::OnceCallback<void ()>::Run [0x00007FFAAEB91ABD+141] (C:\work\brave-browser\src\base\functional\callback.h:156)
        base::TaskAnnotator::RunTaskImpl [0x00007FFAAEC7A504+340] (C:\work\brave-browser\src\base\task\common\task_annotator.cc:210)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl [0x00007FFAAECBCAC1+2337] (C:\work\brave-browser\src\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:456)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork [0x00007FFAAECBBEAA+394] (C:\work\brave-browser\src\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:332)
        base::MessagePumpDefault::Run [0x00007FFAAEBD7A8B+267] (C:\work\brave-browser\src\base\message_loop\message_pump_default.cc:43)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run [0x00007FFAAECBD94A+842] (C:\work\brave-browser\src\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:629)
        base::RunLoop::Run [0x00007FFAAEC38B10+528] (C:\work\brave-browser\src\base\run_loop.cc:136)
        content::RendererMain [0x00007FFA86DFCBAE+1758] (C:\work\brave-browser\src\content\renderer\renderer_main.cc:377)
        content::RunOtherNamedProcessTypeMain [0x00007FFA870094DF+767] (C:\work\brave-browser\src\content\app\content_main_runner_impl.cc:781)
        content::ContentMainRunnerImpl::Run [0x00007FFA8700A4CB+619] (C:\work\brave-browser\src\content\app\content_main_runner_impl.cc:1155)
        content::RunContentProcess [0x00007FFA870051CC+1740] (C:\work\brave-browser\src\content\app\content_main.cc:359)
        content::ContentMain [0x00007FFA870052E6+134] (C:\work\brave-browser\src\content\app\content_main.cc:372)
        ChromeMain [0x00007FFA88B31411+977] (C:\work\brave-browser\src\chrome\app\chrome_main.cc:222)
        MainDllLoader::Launch [0x00007FF670582377+1047] (C:\work\brave-browser\src\chrome\app\main_dll_loader_win.cc:201)
        wWinMain [0x00007FF6705819B5+2453] (C:\work\brave-browser\src\chrome\app\chrome_exe_main_win.cc:352)
        __scrt_common_main_seh [0x00007FF670655816+262] (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
        BaseThreadInitThunk [0x00007FFB39727374+20]
        RtlUserThreadStart [0x00007FFB3B21CC91+33]
[77168:63716:0425/184001.753:FATAL:third_party\blink\renderer\bindings\core\v8\binding_security.cc:215] Check failed: accessing_world.GetWorldId() == target_world.GetWorldId() (0 vs. 5)
        base::debug::CollectStackTrace [0x00007FFAAED4FBA5+21] (C:\work\brave-browser\src\base\debug\stack_trace_win.cc:326)
        base::debug::StackTrace::StackTrace [0x00007FFAAED2D33C+268] (C:\work\brave-browser\src\base\debug\stack_trace.cc:256)
        logging::LogMessage::Flush [0x00007FFAAEBC53D4+244] (C:\work\brave-browser\src\base\logging.cc:734)
        logging::LogMessage::~LogMessage [0x00007FFAAEBC5279+25] (C:\work\brave-browser\src\base\logging.cc:722)
        logging::`anonymous namespace'::CheckLogMessage::~CheckLogMessage [0x00007FFAAEB969EE+94] (C:\work\brave-browser\src\base\check.cc:195)
        logging::CheckNoreturnError::~CheckNoreturnError [0x00007FFAAEB964EB+11] (C:\work\brave-browser\src\base\check.cc:355)
        blink::BindingSecurity::ShouldAllowAccessToV8ContextInternal [0x00007FFA6F834E3F+223] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\binding_security.cc:215)
        blink::JSBasedEventListener::Invoke [0x00007FFA6F84CFDE+1294] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\js_based_event_listener.cc:120)
        blink::EventTarget::FireEventListeners [0x00007FFA702CC562+2434] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_target.cc:1094)
        blink::EventTarget::FireEventListeners [0x00007FFA702CB856+678] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_target.cc:1022)
        blink::EventTarget::DispatchEventInternal [0x00007FFA702CB341+49] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_target.cc:907)
        blink::EventTarget::dispatchEventForBindings [0x00007FFA702CB2AE+110] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_target.cc:891)
        blink::`anonymous namespace'::v8_event_target::DispatchEventOperationCallback [0x00007FFA72ED362A+426] (C:\work\brave-browser\src\out\Component\gen\third_party\blink\renderer\bindings\core\v8\v8_event_target.cc:180)
        Builtins_CallApiCallbackGeneric [0x00007FFA6C38B5C0+192]
        Builtins_InterpreterEntryTrampoline [0x00007FFA6C389363+355]
        Builtins_InterpreterEntryTrampoline [0x00007FFA6C389363+355]
        Builtins_JSEntryTrampoline [0x00007FFA6C38585C+92]
        Builtins_JSEntry [0x00007FFA6C3853BF+255]
        v8::internal::`anonymous namespace'::Invoke [0x00007FFA69AD520F+5679] (C:\work\brave-browser\src\v8\src\execution\execution.cc:439)
        v8::internal::Execution::Call [0x00007FFA69AD3A8B+331] (C:\work\brave-browser\src\v8\src\execution\execution.cc:530)
        v8::Function::Call [0x00007FFA697650AF+831] (C:\work\brave-browser\src\v8\src\api\api.cc:5444)
        blink::V8ScriptRunner::CallFunction [0x00007FFA6F954525+1445] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\v8_script_runner.cc:888)
        blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase,0,0>::CallInternal [0x00007FFA6F83CA9E+254] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\callback_invoke_helper.cc:142)
        blink::bindings::CallbackInvokeHelper<blink::CallbackInterfaceBase,0,0>::Call [0x00007FFA6F83C98D+13] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\callback_invoke_helper.cc:166)
        blink::V8EventListener::InvokeWithoutRunnabilityCheck [0x00007FFA72D0A84A+378] (C:\work\brave-browser\src\out\Component\gen\third_party\blink\renderer\bindings\core\v8\v8_event_listener.cc:119)
        blink::JSEventListener::InvokeInternal [0x00007FFA6F85457E+318] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\js_event_listener.cc:57)
        blink::JSBasedEventListener::Invoke [0x00007FFA6F84CF66+1174] (C:\work\brave-browser\src\third_party\blink\renderer\bindings\core\v8\js_based_event_listener.cc:160)
        blink::EventTarget::FireEventListeners [0x00007FFA702CC562+2434] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_target.cc:1094)
        blink::EventTarget::FireEventListeners [0x00007FFA702CB856+678] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_target.cc:1022)
        blink::NodeEventContext::HandleLocalEvents [0x00007FFA702D5152+338] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\node_event_context.cc:60)
        blink::EventDispatcher::DispatchEventAtBubbling [0x00007FFA72961228+200] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_dispatcher.cc:340)
        blink::EventDispatcher::Dispatch [0x00007FFA729608D3+1843] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_dispatcher.cc:275)
        blink::EventDispatcher::DispatchEvent [0x00007FFA7295FC08+232] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\events\event_dispatcher.cc:81)
        blink::Document::FinishedParsing [0x00007FFA728A8E2D+2413] (C:\work\brave-browser\src\third_party\blink\renderer\core\dom\document.cc:7497)
        blink::HTMLConstructionSite::FinishedParsing [0x00007FFA729D7546+214] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_construction_site.cc:775)
        blink::HTMLTreeBuilder::Finished [0x00007FFA72A914E6+214] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_tree_builder.cc:3188)
        blink::HTMLDocumentParser::end [0x00007FFA72A005F7+215] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_document_parser.cc:1087)
        blink::HTMLDocumentParser::AttemptToRunDeferredScriptsAndEnd [0x00007FFA729F1081+321] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_document_parser.cc:1097)
        blink::HTMLDocumentParser::PrepareToStopParsing [0x00007FFA729EFB2F+783] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_document_parser.cc:565)
        blink::HTMLDocumentParser::AttemptToEnd [0x00007FFA729F87AB+523] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_document_parser.cc:1122)
        blink::HTMLDocumentParser::PumpTokenizerIfPossible [0x00007FFA729F048B+1115] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_document_parser.cc:651)
        blink::HTMLDocumentParser::DeferredPumpTokenizerIfPossible [0x00007FFA729F18E5+1013] (C:\work\brave-browser\src\third_party\blink\renderer\core\html\parser\html_document_parser.cc:626)
        base::OnceCallback<void ()>::Run [0x00007FFA6F8907B0+144] (C:\work\brave-browser\src\base\functional\callback.h:156)
        WTF::ThreadCheckingCallbackWrapper<base::OnceCallback<void ()>,void ()>::Run [0x00007FFA6F8903EA+58] (C:\work\brave-browser\src\third_party\blink\renderer\platform\wtf\functional.h:228)
        base::OnceCallback<void ()>::Run [0x00007FFAAEB91ABD+141] (C:\work\brave-browser\src\base\functional\callback.h:156)
        base::TaskAnnotator::RunTaskImpl [0x00007FFAAEC7A504+340] (C:\work\brave-browser\src\base\task\common\task_annotator.cc:210)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl [0x00007FFAAECBCAC1+2337] (C:\work\brave-browser\src\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:456)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork [0x00007FFAAECBBEAA+394] (C:\work\brave-browser\src\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:332)
        base::MessagePumpDefault::Run [0x00007FFAAEBD7A8B+267] (C:\work\brave-browser\src\base\message_loop\message_pump_default.cc:43)
        base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run [0x00007FFAAECBD94A+842] (C:\work\brave-browser\src\base\task\sequence_manager\thread_controller_with_message_pump_impl.cc:629)
        base::RunLoop::Run [0x00007FFAAEC38B10+528] (C:\work\brave-browser\src\base\run_loop.cc:136)
        content::RendererMain [0x00007FFA86DFCBAE+1758] (C:\work\brave-browser\src\content\renderer\renderer_main.cc:377)
        content::RunOtherNamedProcessTypeMain [0x00007FFA870094DF+767] (C:\work\brave-browser\src\content\app\content_main_runner_impl.cc:781)
        content::ContentMainRunnerImpl::Run [0x00007FFA8700A4CB+619] (C:\work\brave-browser\src\content\app\content_main_runner_impl.cc:1155)
        content::RunContentProcess [0x00007FFA870051CC+1740] (C:\work\brave-browser\src\content\app\content_main.cc:359)
        content::ContentMain [0x00007FFA870052E6+134] (C:\work\brave-browser\src\content\app\content_main.cc:372)
        ChromeMain [0x00007FFA88B31411+977] (C:\work\brave-browser\src\chrome\app\chrome_main.cc:222)
        MainDllLoader::Launch [0x00007FF670582377+1047] (C:\work\brave-browser\src\chrome\app\main_dll_loader_win.cc:201)
        wWinMain [0x00007FF6705819B5+2453] (C:\work\brave-browser\src\chrome\app\chrome_exe_main_win.cc:352)
        __scrt_common_main_seh [0x00007FF670655816+262] (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
        BaseThreadInitThunk [0x00007FFB39727374+20]
        RtlUserThreadStart   ##[0x00007FFB3B21CC91+33]
```


</p>
</details> 


