### PR TITLE
Use tooltip size directly when calculating bounds (uplift to 1.78.x)

### DIFF
--- a/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
+++ b/browser/ui/views/brave_tooltips/brave_tooltip_popup.cc
@@ -277,13 +277,11 @@ gfx::Point BraveTooltipPopup::GetDefaultOriginForSize(const gfx::Size& size) {
 
 gfx::Rect BraveTooltipPopup::CalculateBounds(bool use_default_origin) {
   DCHECK(tooltip_view_);
-  gfx::Size size = tooltip_view_->size();
-  size.set_height(kTooltipSize.height());
-  DCHECK(!size.IsEmpty());
 
-  const gfx::Point origin =
-      use_default_origin ? GetDefaultOriginForSize(size) : widget_origin_;
-  return gfx::Rect(origin, size);
+  const gfx::Point origin = use_default_origin
+                                ? GetDefaultOriginForSize(kTooltipSize)
+                                : widget_origin_;
+  return gfx::Rect(origin, kTooltipSize);
 }
 
 void BraveTooltipPopup::RecomputeAlignment() {


### PR DESCRIPTION
Uplift of #28806
Resolves https://github.com/brave/brave-browser/issues/45561

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [ ] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [ ] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [ ] The associated issue milestone is set to the smallest version that the changes is landed on.