### PR TITLE
AI Chat: Image Attachment UI Improvements

### DIFF
--- a/components/ai_chat/resources/page/components/input_box/index.tsx
+++ b/components/ai_chat/resources/page/components/input_box/index.tsx
@@ -52,6 +52,9 @@ function InputBox(props: InputBoxProps) {
   }
 
   const querySubmitted = React.useRef(false)
+  const attachmentWrapperRef = React.useRef<HTMLDivElement>(null)
+  const [attachmentWrapperHeight, setAttachmentWrapperHeight] =
+    React.useState(0)
 
   const handleSubmit = () => {
     querySubmitted.current = true
@@ -94,6 +97,21 @@ function InputBox(props: InputBoxProps) {
     }
   }
 
+  const updateAttachmentWrapperHeight = () => {
+    let { height } = attachmentWrapperRef?.current?.getBoundingClientRect() ?? {
+      height: 0
+    }
+    setAttachmentWrapperHeight(height)
+  }
+
+  React.useEffect(() => {
+    // Update the height of the attachment wrapper when
+    // pendingMessageImages changes.
+    if (props.context?.pendingMessageImages) {
+      updateAttachmentWrapperHeight()
+    }
+  }, [props.context.pendingMessageImages])
+
   return (
     <form className={styles.form}>
       {props.context.selectedActionType && (
@@ -106,14 +124,21 @@ function InputBox(props: InputBoxProps) {
         </div>
       )}
       {props.context.pendingMessageImages && (
-        <div className={styles.attachmentWrapper}>
-          {props.context.pendingMessageImages.map((img, i) =>
+        <div
+          className={classnames({
+            [styles.attachmentWrapper]: true,
+            [styles.attachmentWrapperScrollStyles]:
+              attachmentWrapperHeight >= 240
+          })}
+          ref={attachmentWrapperRef}
+        >
+          {props.context.pendingMessageImages.map((img, i) => (
             <UploadedImgItem
               key={img.filename}
               uploadedImage={img}
               removeImage={() => props.context.removeImage(i)}
             />
-          )}
+          ))}
         </div>
       )}
       <div

--- a/components/ai_chat/resources/page/components/input_box/style.module.scss
+++ b/components/ai_chat/resources/page/components/input_box/style.module.scss
@@ -125,9 +125,16 @@
 }
 
 .attachmentWrapper {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   padding: var(--leo-spacing-m) var(--leo-spacing-m) 0px var(--leo-spacing-m);
-  max-height: 300px;
+  max-height: 240px;
   overflow-y: auto;
-  gap: var(--leo-spacing-m);
+  gap: var(--leo-spacing-s);
+}
+
+.attachmentWrapperScrollStyles {
+  padding: var(--leo-spacing-m);
+  border-bottom: 1px solid var(--leo-color-divider-subtle);
 }

--- a/components/ai_chat/resources/page/components/uploaded_img_item/index.tsx
+++ b/components/ai_chat/resources/page/components/uploaded_img_item/index.tsx
@@ -6,6 +6,7 @@
 import * as React from 'react'
 import Button from '@brave/leo/react/button'
 import Icon from '@brave/leo/react/icon'
+import Tooltip from '@brave/leo/react/tooltip'
 
 // Types
 import * as Mojom from '../../../common/mojom'
@@ -43,8 +44,6 @@ export default function UploadedImgItem(props: Props) {
     return `${bytes.toFixed(2)} ${units[index]}`
   }, [props.uploadedImage.filesize])
 
-  const filenameParts = props.uploadedImage.filename.split('.')
-
   return (
     <div className={styles.itemWrapper}>
       <div className={styles.leftSide}>
@@ -53,12 +52,16 @@ export default function UploadedImgItem(props: Props) {
           src={dataUrl}
         />
         <div className={styles.imageInfo}>
-          <div className={styles.nameAndExtensionRow}>
+          <Tooltip
+            mode='mini'
+            text={props.uploadedImage.filename}
+          >
             <div className={styles.forEllipsis}>
-              <span className={styles.nameText}>{filenameParts[0]}</span>
+              <span className={styles.nameText}>
+                {props.uploadedImage.filename}
+              </span>
             </div>
-            <span className={styles.extensionText}>.{filenameParts[1]}</span>
-          </div>
+          </Tooltip>
           <span className={styles.sizeText}>{filesize}</span>
         </div>
       </div>

--- a/components/ai_chat/resources/page/components/uploaded_img_item/style.module.scss
+++ b/components/ai_chat/resources/page/components/uploaded_img_item/style.module.scss
@@ -18,7 +18,8 @@
 
 .image {
   width: 48px;
-  height: auto;
+  height: 48px;
+  object-fit: none;
   border-radius: var(--leo-radius-m);
   box-shadow: 0px var(--leo-elevation-xxs, 1px) 0px 0px
       var(--leo-color-elevation-primary, rgba(0, 0, 0, 0.05)),
@@ -39,28 +40,17 @@
   align-items: flex-start;
 }
 
-.nameAndExtensionRow {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
-}
-
 .forEllipsis {
   display: grid;
 }
 
 .nameText {
+  cursor: pointer;
   font: var(--leo-font-default-regular);
   color: var(--leo-color-text-primary);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.extensionText {
-  font: var(--leo-font-default-regular);
-  color: var(--leo-color-text-primary);
 }
 
 .sizeText {
@@ -69,5 +59,6 @@
 }
 
 .removeButton {
+  --leo-icon-color: var(--leo-color-icon-secondary);
   flex-grow: 0;
 }

--- a/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/style.module.scss
+++ b/components/ai_chat/resources/untrusted_conversation_frame/components/conversation_entries/style.module.scss
@@ -80,7 +80,10 @@
 }
 
 .uploadedImages {
-  max-height: 300px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: 240px;
   overflow-y: auto;
-  gap: var(--leo-spacing-m);
+  gap: var(--leo-spacing-s);
 }


### PR DESCRIPTION
## Description 

Minor Improvements to the AI Chat Image Attachment UI

- Fixes the `gap` spacing between image `attachments`
- Adds a `divider` line to the `attachment` wrapper when it is long enough to scroll
- Changes the `x` button icon to use `--leo-color-icon-secondary`
- Fixes the `ellipses` for long attachment names
- Adds a `tooltip` to display the full name if you hove over the attachment `name`
- Will now maintain size for the `thumbnail` and fill the entire thumbnail with the image.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/45672>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Open some article or website and then attach `screenshot` to get info about that article
2. After the screenshots have loaded, test and ensure the changes mentioned above are correct

![Screenshot 60](https://github.com/user-attachments/assets/f3b7323d-1aa8-4e21-b997-44d73fba57bd)

![Screenshot 61](https://github.com/user-attachments/assets/595375f5-40f8-47bb-b429-dc86dac80e31)

