### PR TITLE
fix(wallet): Hide Edit Gas Buttons for Zcash Transactions

### DIFF
--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm-transaction-panel.tsx
@@ -453,7 +453,7 @@ export const ConfirmTransactionPanel = ({
         {selectedTab === 'transaction' ? (
           <TransactionInfo
             onToggleEditGas={
-              isSolanaTransaction || isBitcoinTransaction
+              isSolanaTransaction || isBitcoinTransaction || isZCashTransaction
                 ? undefined
                 : onToggleEditGas
             }
@@ -482,6 +482,9 @@ export const ConfirmTransactionPanel = ({
 
       <NetworkFeeRow>
         <PendingTransactionNetworkFeeAndSettings
+          showEditGas={
+            !isZCashTransaction && !isBitcoinTransaction && !isSolanaTransaction
+          }
           onToggleEditGas={onToggleEditGas}
           feeDisplayMode='fiat'
         />

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm_simulated_tx_panel.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/confirm_simulated_tx_panel.tsx
@@ -87,6 +87,8 @@ export const ConfirmSimulatedTransactionPanel = ({
   // custom hooks
   const {
     isSolanaTransaction,
+    isZCashTransaction,
+    isBitcoinTransaction,
     onEditAllowanceSave,
     transactionDetails,
     transactionsNetwork,
@@ -363,6 +365,11 @@ export const ConfirmSimulatedTransactionPanel = ({
             <NetworkFeeRow>
               <PendingTransactionNetworkFeeAndSettings
                 onToggleEditGas={onToggleEditGas}
+                showEditGas={
+                  !isZCashTransaction &&
+                  !isBitcoinTransaction &&
+                  !isSolanaTransaction
+                }
                 feeDisplayMode='fiat'
               />
             </NetworkFeeRow>

--- a/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
+++ b/components/brave_wallet_ui/components/extension/confirm-transaction-panel/swap.tsx
@@ -54,7 +54,10 @@ export function ConfirmSwapTransaction() {
     insufficientFundsError,
     insufficientFundsForGasError,
     onConfirm,
-    onReject
+    onReject,
+    isZCashTransaction,
+    isBitcoinTransaction,
+    isSolanaTransaction
   } = usePendingTransactions()
 
   // queries
@@ -137,6 +140,9 @@ export function ConfirmSwapTransaction() {
           onToggleAdvancedTransactionSettings
         }
         onToggleEditGas={onToggleEditGas}
+        showEditGas={
+          !isZCashTransaction && !isBitcoinTransaction && !isSolanaTransaction
+        }
       />
 
       <Column

--- a/components/brave_wallet_ui/components/extension/pending-transaction-network-fee/pending-transaction-network-fee.tsx
+++ b/components/brave_wallet_ui/components/extension/pending-transaction-network-fee/pending-transaction-network-fee.tsx
@@ -50,6 +50,7 @@ import {
 interface Props {
   onToggleEditGas?: () => void
   onToggleAdvancedTransactionSettings?: () => void
+  showEditGas: boolean
   feeDisplayMode?: 'fiat' | 'crypto'
   showNetworkLogo?: boolean
 }
@@ -57,6 +58,7 @@ interface Props {
 export const PendingTransactionNetworkFeeAndSettings: React.FC<Props> = ({
   onToggleAdvancedTransactionSettings,
   onToggleEditGas,
+  showEditGas,
   feeDisplayMode = 'fiat',
   showNetworkLogo
 }) => {
@@ -140,9 +142,11 @@ export const PendingTransactionNetworkFeeAndSettings: React.FC<Props> = ({
           ) : (
             <LoadingSkeleton width={38} />
           )}
-          <EditButton onClick={onToggleEditGas}>
-            {getLocale('braveWalletAllowSpendEditButton')}
-          </EditButton>
+          {showEditGas && (
+            <EditButton onClick={onToggleEditGas}>
+              {getLocale('braveWalletAllowSpendEditButton')}
+            </EditButton>
+          )}
         </NetworkFeeValue>
       </NetworkFeeContainer>
 


### PR DESCRIPTION
## Description 

Hides the `Edit Gas` buttons in the `Confirm Transaction` panels for `Zcash` transactions.

<!-- Add brave-browser issue below that this PR will resolve -->
Resolves <https://github.com/brave/brave-browser/issues/45748>

<!-- CI-related labels that can be applied to this PR:
* CI/run-audit-deps (1) - check for known npm/cargo vulnerabilities (audit_deps)
* CI/run-network-audit (1) - run network-audit
* CI/run-upstream-tests - run Chromium unit and browser tests on Linux and Windows (otherwise only on Linux)
* CI/run-linux-arm64, CI/run-macos-x64, CI/run-windows-arm64, CI/run-windows-x86 - run builds that would otherwise be skipped
* CI/skip - do not run CI builds (except noplatform)
* CI/skip-linux-x64, CI/skip-android, CI/skip-macos-arm64, CI/skip-ios, CI/skip-windows-x64 - skip CI builds for specific platforms
* CI/skip-upstream-tests - do not run Chromium unit, or browser tests (otherwise only on Linux)
* CI/skip-all-linters - do not run presubmit and lint checks
* CI/storybook-url (1) - deploy storybook and provide a unique URL for each build

(1) applied automatically when some files are changed (see: https://github.com/brave/brave-core/blob/master/.github/labeler.yml)
-->

<!--
## Checklist:

- Review design docs
  [Browser design principles](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/chrome_browser_design_principles.md)
  [Style guide](https://chromium.googlesource.com/chromium/src/+/main/styleguide/c++/c++.md)
  [Core principles](https://www.chromium.org/developers/core-principles/)
- Ensure there are (tests)[https://www.chromium.org/developers/testing/]. Unit test as much as possible (including edge cases), but also include browser tests covering high level functionality.
- Ensure that there are comments explaining what classes/methods are/do. The "why" is often more important than the "what" in comments. Also update any relevant docs (moving docs from wiki to brave-core if necessary).
- Request security or other review (third-party libraries, rust code, etc...) if applicable [security/privacy review is needed](https://github.com/brave/brave-browser/wiki/Security-reviews) [other review](https://github.com/brave/reviews/issues/new/choose)
  Also see [adding third-party libraries](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/adding_to_third_party.md) for general guidelines on using third party code
- Maks sure there is a [ticket](https://github.com/brave/brave-browser/issues) for your issue
- Use Github [auto-closing keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in the PR description above
- Write a good [PR/commit description](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
- Squash any review feedback or "fixup" commits before merge, so that history is a record of what happened in the repo, not your PR
- Add appropriate labels (`QA/Yes` or `QA/No`; `release-notes/include` or `release-notes/exclude`; `OS/...`) to the associated issue
- Checked the PR locally:
  * `npm run test -- brave_browser_tests`, `npm run test -- brave_unit_tests` [wiki](https://github.com/brave/brave-browser/wiki/Tests)
  * `npm run presubmit` [wiki](https://github.com/brave/brave-browser/wiki/Presubmit-checks), `npm run gn_check`, `npm run tslint`
- Run `git rebase master` (if needed)
-->

## Test Plan:

1. Open the `Wallet` and navigate to the `Send` screen
2. Create a `Zcash` transaction and wait for the `Confirmation` panel to show up
3. You should not see the `Edit` gas buttons.

Before:

![Screenshot 63](https://github.com/user-attachments/assets/349c8f99-269c-4e10-89d9-81fc32541aed)

After:

![Screenshot 64](https://github.com/user-attachments/assets/a8cbfadb-2489-41af-9351-fadcca26caaa)
