### PR TITLE
[canary] Fix milestone API call PR number portion (uplift to 1.79.x)

### DIFF
--- a/tools/cr/brockit.py
+++ b/tools/cr/brockit.py
@@ -705,7 +705,7 @@ class GitHubIssue(Versioned):
                 raise BadOutcomeException(
                     f'Failed to find milestone for branch {upstream_branch}')
 
-            pr_number = pr_url.split("/", 1)[-1]
+            pr_number = pr_url.rsplit('/', 1)[-1]
             terminal.run([
                 'gh', 'api', '-X', 'PATCH',
                 f'repos/brave/brave-core/issues/{pr_number}', '-F',


### PR DESCRIPTION
Uplift of #28791
Resolves https://github.com/brave/brave-browser/issues/45658

Pre-approval checklist: 
- [ ] You have tested your change on Nightly. 
- [ ] This contains text which needs to be translated. 
    - [ ] There are more than 7 days before the release. 
    - [ ] I've notified folks in #l10n on Slack that translations are needed. 
- [x] The PR milestones match the branch they are landing to. 


Pre-merge checklist: 
- [x] You have checked CI and the builds, lint, and tests all pass or are not related to your PR. 

Post-merge checklist: 
- [x] The associated issue milestone is set to the smallest version that the changes is landed on.